### PR TITLE
feat: unify page container max-width to 1200px

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -114,6 +114,7 @@ export default function DashboardLayout({
     pathname === "/settings" ||
     pathname.startsWith("/project-groups");
   const isProjectContext = currentProjectUuid && !isGlobalPage;
+  const isFullWidthPage = pathname.match(/^\/projects\/[a-f0-9-]{36}\/tasks(\/|$)/);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { checkSession(); }, []);
@@ -502,7 +503,7 @@ export default function DashboardLayout({
       {/* SSE: project pages get project-scoped events, /projects and /project-groups get company-wide, /settings gets none */}
       {isProjectContext && currentProjectUuid ? (
         <RealtimeProvider projectUuid={currentProjectUuid}>
-          <main className="flex-1 flex flex-col overflow-auto pt-14 md:pt-0"><PageTransition>{children}</PageTransition></main>
+          <main className="flex-1 flex flex-col overflow-auto pt-14 md:pt-0"><div className={`mx-auto w-full flex-1 flex flex-col ${isFullWidthPage ? "" : "max-w-[1200px]"}`}><PageTransition>{children}</PageTransition></div></main>
           <PixelCanvasWidget
             projectUuid={currentProjectUuid}
             projectName={currentProject?.name || ""}
@@ -510,10 +511,10 @@ export default function DashboardLayout({
         </RealtimeProvider>
       ) : pathname === "/projects" || pathname.startsWith("/project-groups") ? (
         <RealtimeProvider>
-          <main className="flex-1 flex flex-col overflow-auto pt-14 md:pt-0"><PageTransition>{children}</PageTransition></main>
+          <main className="flex-1 flex flex-col overflow-auto pt-14 md:pt-0"><div className={`mx-auto w-full flex-1 flex flex-col ${isFullWidthPage ? "" : "max-w-[1200px]"}`}><PageTransition>{children}</PageTransition></div></main>
         </RealtimeProvider>
       ) : (
-        <main className="flex-1 flex flex-col overflow-auto pt-14 md:pt-0"><PageTransition>{children}</PageTransition></main>
+        <main className="flex-1 flex flex-col overflow-auto pt-14 md:pt-0"><div className={`mx-auto w-full flex-1 flex flex-col ${isFullWidthPage ? "" : "max-w-[1200px]"}`}><PageTransition>{children}</PageTransition></div></main>
       )}
     </div>
     <Toaster position={isMobile ? "top-center" : "top-right"} closeButton={!isMobile} />

--- a/src/app/(dashboard)/projects/[uuid]/proposals/new/page.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/new/page.tsx
@@ -45,7 +45,7 @@ export default async function NewProposalPage({ params, searchParams }: PageProp
 
   return (
     <div className="p-8">
-      <div className="mx-auto max-w-3xl">
+      <div>
         <h1 className="mb-6 text-2xl font-semibold text-[#2C2C2C]">
           {t("proposals.createProposal")}
         </h1>

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -700,11 +700,9 @@ export default function ProjectsPage() {
   if (loading) {
     return (
       <div className="bg-[#FAF8F4] p-4 md:px-8 md:py-6">
-        <div className="mx-auto max-w-[1200px]">
           <p className="text-sm text-[#6B6B6B]">
             {t("projects.loadingProjects")}
           </p>
-        </div>
       </div>
     );
   }
@@ -713,7 +711,6 @@ export default function ProjectsPage() {
     <>
       <DragDropContext onDragEnd={handleDragEnd}>
         <div className="bg-[#FAF8F4] p-4 md:px-8 md:py-6">
-        <div className="mx-auto max-w-[1200px]">
           {/* Header */}
           <div className="mb-4 md:mb-6">
             <div className="flex items-center justify-between">
@@ -941,7 +938,6 @@ export default function ProjectsPage() {
               </Button>
             </div>
           )}
-        </div>
         </div>
       </DragDropContext>
 


### PR DESCRIPTION
## Summary
- Add `max-w-[1200px] mx-auto` wrapper in dashboard layout for all pages
- Tasks/kanban page excluded (full-width for multi-column layout)
- Remove per-page max-width from projects list (`max-w-[1200px]`) and proposals/new (`max-w-3xl`)

## Changed files
| File | Change |
|------|--------|
| `src/app/(dashboard)/layout.tsx` | Add `isFullWidthPage` check; wrap `<PageTransition>` in max-w container (3 places) |
| `src/app/(dashboard)/projects/page.tsx` | Remove 2x `max-w-[1200px] mx-auto` wrappers (loading + main) |
| `src/app/(dashboard)/projects/[uuid]/proposals/new/page.tsx` | Remove `max-w-3xl mx-auto` |

## Test plan
- [x] TypeScript type check passes
- [x] Playwright: widescreen (1600px) → container 1200px centered
- [x] Playwright: tasks page → full width (no max-w constraint)
- [x] Playwright: mobile (375px) → full width, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)