### PR TITLE
docs: add v0.6.1 release blog post and blog skill

### DIFF
--- a/.claude/skills/blog/SKILL.md
+++ b/.claude/skills/blog/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: blog
+description: Write release blog posts for Chorus — problem-first narrative, bilingual (zh/en), following the project's editorial style.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.1.0"
+  category: content
+---
+
+# Chorus Blog Post
+
+Write bilingual (zh/en) release blog posts for the Chorus landing site.
+
+## Prerequisites
+
+- You know what version / feature to write about (user will tell you, or check recent CHANGELOG / git log)
+- Existing blog posts live in `packages/landing/src/content/blog/`
+- Naming convention: `zh-chorus-vX.Y.Z-release.md` (Chinese), `chorus-vX.Y.Z-release.md` (English)
+
+## Editorial Style
+
+These rules come from the project owner. Follow them strictly.
+
+### Narrative structure
+
+1. **Open from the reader's pain point, not the feature.** Don't start with "we released X." Start with the problem the reader is living with. Describe the scenario vividly so they recognize themselves in it.
+2. **One line to introduce the solution.** After the pain point lands, say what this version does in one sentence.
+3. **Break down the supporting mechanisms.** Explain the layers / building blocks that make the solution work. Order them by the flow the user experiences, not by importance.
+4. **Industry context as supporting evidence, not the opening.** If there are relevant industry trends (e.g., new tools from Anthropic, competitor features), reference them to validate the direction. But they go in the middle or late section, never the lead.
+5. **Converge to a conclusion.** Tie the pieces back together. The punchline should echo the opening pain point: "this is why you can now do X."
+
+### Tone and voice
+
+- **Don't speak for the reader.** Never write "you probably think X" or "you definitely feel Y." Describe the situation, let readers identify with it on their own.
+- **Casual, not corporate.** Write like you're explaining to a sharp colleague, not writing a press release. No marketing speak, no filler adjectives.
+- **No em dashes (——) in Chinese.** Use commas, periods, or sentence breaks instead.
+- **Chinese should read like Chinese.** Not translated-from-English. Spoken rhythm, natural phrasing.
+- **English should read like English.** Not translated-from-Chinese. Prefer short punchy sentences. Avoid "materialize," "leverage," "utilize" — use plain words.
+- **Logical consistency matters.** The owner will catch contradictions immediately. If you say "we had X from day one," make sure that's actually true. If something was added in a specific version, say so.
+- **No filler.** If one sentence covers it, don't stretch it to three.
+
+### Title
+
+- Include the version number: `Chorus vX.Y.Z: <hook>`
+- The hook is the real title. It should make someone want to click.
+- Can mix Chinese and English, use slang, be playful.
+- Examples:
+  - "Chorus v0.6.1: 你的时间比 Token 贵，/yolo it！"
+  - "Chorus v0.6.0: 给你的 Agent 团队派个监工"
+
+### Frontmatter
+
+```markdown
+---
+title: "Chorus vX.Y.Z: <hook>"
+description: "<1-2 sentences, written as a question or provocation, not a summary>"
+date: YYYY-MM-DD
+lang: zh  # or en
+postSlug: chorus-vX.Y.Z-release
+---
+```
+
+- `description` should hook the reader, not summarize the post. A question or a challenge works well.
+- `postSlug` must be the same for both zh and en versions so they link together.
+
+## Steps
+
+### 1. Gather context
+
+```bash
+# Find the version's CHANGELOG entry
+# Read recent commits if needed
+# Read the relevant feature code / skill docs to understand what was built
+```
+
+Understand the feature deeply before writing. Read the code, the skill docs, the PR descriptions. Don't write from summaries alone.
+
+### 2. Draft the Chinese version first
+
+Write `zh-chorus-vX.Y.Z-release.md`. Chinese is the primary version, not a translation.
+
+**Present the draft to the user for review.** Expect multiple rounds of feedback on:
+- Narrative structure (what goes first, what to cut)
+- Tone (too stiff, too corporate, too presumptuous)
+- Logical consistency
+- Title and description
+
+**Do NOT proceed to the English version until the Chinese version is approved.**
+
+### 3. Write the English version
+
+Write `chorus-vX.Y.Z-release.md`. This is NOT a literal translation. Rewrite for an English-speaking audience:
+- Same structure and arguments
+- Natural English phrasing and rhythm
+- Adapt metaphors and references that don't cross language boundaries
+
+### 4. Self-review checklist
+
+Before presenting each version:
+
+- [ ] Opens from pain point, not feature announcement
+- [ ] Doesn't speak for the reader ("you probably think...")
+- [ ] No em dashes in Chinese version
+- [ ] No translation-smell in either language
+- [ ] Title has version number + hook
+- [ ] Description is a hook, not a summary
+- [ ] All factual claims are accurate (which version introduced what)
+- [ ] No logical contradictions between sections
+- [ ] No filler paragraphs — every section earns its space
+- [ ] `postSlug` matches between zh and en versions

--- a/packages/landing/src/content/blog/chorus-v0.6.1-release.md
+++ b/packages/landing/src/content/blog/chorus-v0.6.1-release.md
@@ -1,0 +1,107 @@
+---
+title: "Chorus v0.6.1: Your Time Costs More Than Tokens. /yolo it!"
+description: "Still reviewing every Claude Code plan line by line? /yolo lets agents review each other so you don't have to."
+date: 2026-04-13
+lang: en
+postSlug: chorus-v0.6.1-release
+---
+
+# Chorus v0.6.1: Your Time Costs More Than Tokens. /yolo it!
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.6.1 is here! This release does one thing: break you out of review-every-Claude-Code-plan hell.
+
+---
+
+## Review Hell
+
+If you've ever used Claude Code to build a full feature, you know the loop. Hand it a task, wait for it to finish, review the plan, spot something wrong, send it back, review again, confirm it's fine, hand it the next task. Repeat. Repeat. Repeat.
+
+The agent writes code. You review full-time.
+
+Tokens are cheap, but the real bottleneck is you. Every plan needs your eyes. Every output needs your sign-off. One moment of inattention and a flawed design slips through. No matter how many agents you run in parallel, they're all stuck behind your single-threaded review bandwidth.
+
+This isn't a model problem. The model is smart enough. It's a harness problem: there's no quality gate between the agent and you, so you have no choice but to watch every step yourself.
+
+Today Chorus fills that gap, so you can `/yolo`.
+
+---
+
+## /yolo: One Prompt, Start to Finish
+
+v0.6.1 adds a new command to the Chorus Claude Code plugin:
+
+```
+/yolo Add dark mode to the project with automatic system preference detection
+```
+
+One sentence in, the agent runs the entire pipeline automatically: Idea → Elaboration → Proposal → Review → Task breakdown → Parallel execution → Verification → Done. It won't ask you a single question along the way.
+
+Sounds reckless, but `/yolo` isn't flying blind. It can go full-auto because the Chorus workflow has three layers of guardrails backing it up.
+
+---
+
+## Layer 1: Elaboration — Surface the Assumptions
+
+After receiving your one-liner, the agent doesn't jump straight into writing a plan. It enters an Elaboration phase first, generating a set of key questions: Which browsers need support? Should data be persisted? What are the performance targets?
+
+In the normal workflow, a human answers these. In `/yolo` mode the agent answers them itself, reasoning from the original prompt to pick the most sensible options.
+
+The value here isn't the accuracy of the answers. It's that the agent's assumptions are now explicit and on the record. Every self-answered question is logged in the Chorus audit trail. What did the agent assume? Why did it pick A over B? All traceable. If the final delivery is off, you trace back to Elaboration and pinpoint where the assumption diverged, instead of staring at code trying to guess what the agent was thinking.
+
+Full automation doesn't mean black box.
+
+## Layer 2: Proposal — Think Before You Code
+
+After Elaboration, the agent still doesn't start writing code. It produces a full Proposal: tech design documents, task breakdown, dependency DAG, and acceptance criteria for every task.
+
+The proposal isn't free-form text. It's structured: Documents carry the technical design, Tasks define units of work, Acceptance Criteria define what "done" looks like. Once approved, these turn directly into executable work items. The agent doesn't need to re-interpret its own plan.
+
+When nobody is in the loop to course-correct in real time, the quality of the plan determines the quality of everything downstream. A bad Proposal plus five agents executing in parallel just amplifies the mistake five times over. That's why `/yolo` is actually most careful at this step: get the planning right, then let it rip.
+
+## Layer 3: Reviewer — Let Agents Review Agents
+
+The Proposal doesn't get rubber-stamped. A `proposal-reviewer` kicks in automatically. It checks whether API contracts are consistent with upstream and downstream consumers, whether task granularity makes sense, whether acceptance criteria are actually testable. Problems? Rejected with specific BLOCKERs. The agent fixes them and resubmits. The reviewer reviews again. Up to three rounds. If it still doesn't pass, it escalates to a human.
+
+Same thing after task execution. A `task-reviewer` checks whether the code actually meets acceptance criteria. Doesn't pass? Sent back for another round. Same three-round cap.
+
+All that review work you used to do yourself? An agent handles the bulk of it now. Interface mismatches, unmet criteria, dependency cycles — these mechanical checks no longer cost your attention. By the time something reaches you, it's already survived a round of adversarial review. You just make the final call.
+
+Review isn't gone. It's just not your job anymore.
+
+---
+
+## The Industry Is Converging
+
+Last week Anthropic shipped two things worth reading side by side.
+
+**[Advisor Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool)** lets Sonnet consult Opus mid-execution. One does the work, the other checks the work. Essentially a higher-tier reviewer for agents. This solves the same class of problem as Chorus's Review Agent, except Advisor operates at the model level (within a single API call) while Chorus's Reviewer operates at the workflow level (separate process, separate context, review results permanently archived).
+
+**[UltraPlan](https://code.claude.com/docs/en/ultraplan)** has Claude Code generate a full implementation plan in the cloud. Humans comment on sections, request revisions, iterate until satisfied, then execute. This solves the same problem as Chorus's Proposal mechanism, except Chorus's Proposals are structured (Document + Task DAG + AC) and turn directly into executable work items upon approval.
+
+One is "someone watching while you execute." The other is "think it through before you start." The industry's view on agent workflows is converging: **execute fast, but plan carefully; automate deep, but never skip review.**
+
+---
+
+## So, /yolo
+
+Elaboration surfaces the assumptions. Proposal locks down the plan. Reviewer guards the quality. Stack all three and full automation stops being reckless. It becomes something you can actually trust.
+
+`/yolo` isn't "we finally built full automation." It's "we finally have the guardrails to pull it off." Your time shouldn't be spent reviewing agent output line by line.
+
+Ctrl+C to bail out any time. Everything created so far stays in Chorus. Pick up with `/develop` or `/review` to take over manually. If a task fails review repeatedly (three-round cap), the pipeline doesn't stall. It flags the task for human intervention and keeps going.
+
+---
+
+## Try It
+
+```
+/yolo whatever feature you want
+```
+
+v0.6.1 is on [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.1). `/yolo` ships as a [Chorus Plugin](https://github.com/Chorus-AIDLC/Chorus/tree/main/public/chorus-plugin) skill. Make sure to upgrade the plugin to v0.7.0. Your API key needs all three roles: `pm_agent`, `admin_agent`, `developer_agent`.
+
+Questions or feedback? [GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) or [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions).
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.6.1](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.1)

--- a/packages/landing/src/content/blog/zh-chorus-v0.6.1-release.md
+++ b/packages/landing/src/content/blog/zh-chorus-v0.6.1-release.md
@@ -1,0 +1,107 @@
+---
+title: "Chorus v0.6.1: 你的时间比 Token 贵，/yolo it！"
+description: "还在逐行 review Claude Code 的输出？/yolo 让 Agent 自己审自己，把你从 review 地狱里捞出来。"
+date: 2026-04-13
+lang: zh
+postSlug: chorus-v0.6.1-release
+---
+
+# Chorus v0.6.1: 你的时间比 Token 贵，/yolo it！
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.6.1 来了！这个版本就做一件事：把你从无尽的 review Claude Code plan 地狱里捞出来。
+
+---
+
+## Review 地狱
+
+用 Claude Code 写过完整功能的人都熟悉这个循环：给一个任务，等它做完，review plan，发现不对，打回去，改完再看，确认没问题，给下一个。再来一遍。再来一遍。
+
+Agent 在写代码，你在全职 review。
+
+Token 烧了一堆，但真正的瓶颈是你。每个 plan 要看，每段输出要审，稍微一走神就可能放过一个有问题的设计。Agent 的并行能力再强，也被卡在你一个人的 review 带宽上。
+
+这不是模型的问题。模型够聪明。这是 harness 的问题：Agent 和你之间缺一道质量关卡，所以只能靠人肉盯着。
+
+今天 Chorus 来补这道关卡了，让你敢于 `/yolo`。
+
+---
+
+## /yolo：一句话，从需求到交付
+
+v0.6.1 给 Chorus 的 Claude Code 插件加了一条新命令：
+
+```
+/yolo 给项目加一个暗色模式，支持系统偏好自动切换
+```
+
+一句话进去，Agent 自动走完 Idea → Elaboration → Proposal → Review → 拆 Task → 并行开发 → 验证 → 完工。中间不问你一句话。
+
+听起来很莽，但 `/yolo` 不是蒙眼狂奔。它之所以敢全自动，是因为 Chorus 的工作流里有三层机制在兜底。
+
+---
+
+## 第一层：Elaboration，先把需求聊透
+
+Agent 拿到你的一句话之后，不会直接开始写方案。它先进入 Elaboration 阶段，生成一组关键问题：要支持哪些浏览器？数据要不要持久化？性能指标是多少？
+
+正常流程里这些问题由人类回答。`/yolo` 模式下 Agent 自问自答，根据原始 prompt 推理出最合理的答案。
+
+这一步的价值不在于答案有多准确，而在于它把 Agent 的假设摊到了明面上。所有自问自答全部记录在 Chorus 的审计链里。Agent 假设了什么、为什么选 A 不选 B，都能查到。交付的东西不对？回溯到 Elaboration 就能定位偏差出在哪，不用对着最终代码猜 Agent 到底在想什么。
+
+全自动不等于黑箱。
+
+## 第二层：Proposal，先想清楚再动手
+
+Elaboration 之后，Agent 不是直接开始写代码，而是输出一份完整的 Proposal：技术文档、Task 拆分、依赖关系 DAG、每个 Task 的验收标准。
+
+方案不是一段自由文本，而是结构化的：Document 承载技术设计，Task 定义工作单元，Acceptance Criteria 定义验收条件。审批通过后这些数据直接变成可执行的工作项，Agent 不需要再"理解"一遍自己写的计划。
+
+没有人在旁边实时纠偏的时候，方案的质量直接决定后面所有 Task 的质量。Proposal 写歪了，五个 Agent 并行开发只会把错误放大五倍。所以 `/yolo` 在这一步反而是最慎重的：动手之前的功夫做足了，后面才敢放手跑。
+
+## 第三层：Reviewer，让 Agent 审 Agent
+
+Proposal 写完不是直接批准，`proposal-reviewer` 会自动介入。它检查接口定义和上下游对不对得上，Task 拆分粒度合不合理，验收标准是不是可测试的。不行？打回来附上具体的 BLOCKER，Agent 自己改。改完再提交，reviewer 再审。最多三轮，三轮还过不了自动上报人类。
+
+Task 开发完成后也一样。`task-reviewer` 检查代码实现是否满足验收标准，不满足同样打回重做，同样三轮上限。
+
+之前那些你亲自干的 review 工作，现在有个 Agent 替你扛了大头。接口对不对、标准满没满足、依赖画没画反，这些机械性检查不再消耗你的注意力。等内容递到你手上，已经过了一轮对抗性审查，你只需要做最终判断。
+
+不是不 review 了，是 review 的主力换人了。
+
+---
+
+## 行业在收敛到同一个方向
+
+上周 Anthropic 发布了两个东西，放在一起看很有意思。
+
+**[Advisor Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool)** 让 Sonnet 干活的时候随时请教 Opus。干活的归干活，把关的归把关。本质上就是给 Agent 配了一个段位更高的 reviewer。这跟 Chorus 的 Review Agent 解决的是同一类问题，区别在于 Advisor 是模型级别的（一次 API 调用内部完成），Chorus 的 Reviewer 是工作流级别的（独立进程、独立上下文、审查结果永久存档）。
+
+**[UltraPlan](https://code.claude.com/docs/en/ultraplan)** 让 Claude Code 在云端先生成完整的实施计划，人类逐段评论、反复迭代，满意了再执行。这跟 Chorus 的 Proposal 机制解决同一个问题，区别在于 Chorus 的 Proposal 是结构化的（Document + Task DAG + AC），审批后直接实体化成工作项。
+
+一个是"执行时有人看着"，一个是"动手前先想清楚"。行业对 Agent 工作流的认知正在收敛：**执行要快，但规划要慎重；自动化要深，但审查不能省。**
+
+---
+
+## 所以，/yolo
+
+Elaboration 把假设摊开，Proposal 把方案想透，Reviewer 把质量守住。三层叠在一起，全自动就不再是"莽"，而是"有底气"。
+
+`/yolo` 不是"我们终于做了全自动"，而是"我们终于有底气做全自动了"。你的时间不该花在逐行 review Agent 的输出上。
+
+Ctrl+C 随时中断，所有已创建的实体都在 Chorus 里，用 `/develop` 或 `/review` 手动接管。某个 Task 反复过不了审（三轮上限），流水线不会卡死，标记为需要人工介入然后继续推进其他 Task。
+
+---
+
+## 试试看
+
+```
+/yolo 你想要的任何功能描述
+```
+
+v0.6.1 已发布到 [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.1)。`/yolo` 作为 [Chorus Plugin](https://github.com/Chorus-AIDLC/Chorus/tree/main/public/chorus-plugin) 技能发布，安装后在 Claude Code 里直接使用。注意插件需要升级到 v0.7.0 版本，API Key 需要同时拥有 `pm_agent`、`admin_agent`、`developer_agent` 三个角色。
+
+有问题或反馈？[GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) 或 [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions)。
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.6.1](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.1)


### PR DESCRIPTION
## Summary
- Add v0.6.1 release blog post in both Chinese and English
- Add `/blog` skill for writing future release blog posts

## Changed files
| File | Change |
|------|--------|
| `packages/landing/src/content/blog/zh-chorus-v0.6.1-release.md` | Chinese blog post |
| `packages/landing/src/content/blog/chorus-v0.6.1-release.md` | English blog post |
| `.claude/skills/blog/SKILL.md` | Blog writing skill with editorial guidelines |

Generated with [Claude Code](https://claude.com/claude-code)