### PR TITLE
fix: include closed tasks in progress bar completion count

### DIFF
--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/overview-timeline.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/overview-timeline.tsx
@@ -185,7 +185,7 @@ export function OverviewTimeline({
 
   // Task stats
   const taskStats = useMemo(() => {
-    const done = tasks.filter((t) => t.status === "done").length;
+    const done = tasks.filter((t) => t.status === "done" || t.status === "closed").length;
     const inProgress = tasks.filter((t) => t.status === "in_progress").length;
     const toVerify = tasks.filter((t) => t.status === "to_verify").length;
     const open = tasks.filter((t) => t.status === "open" || t.status === "assigned").length;

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/task-list-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/task-list-view.tsx
@@ -95,7 +95,7 @@ export function TaskListView({ tasks, projectUuid, proposalUuids, onSelectTask }
   // Aggregate stats
   const stats = useMemo(() => {
     const total = tasks.length;
-    const done = tasks.filter((t) => t.status === "done").length;
+    const done = tasks.filter((t) => t.status === "done" || t.status === "closed").length;
     let acTotal = 0;
     let acPassed = 0;
     let acRequired = 0;

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -39,7 +39,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           },
         },
         tasks: {
-          where: { status: "done" },
+          where: { status: { in: ["done", "closed"] } },
           select: { uuid: true },
         },
       },


### PR DESCRIPTION
Closes #120

Progress bars at project and group level only counted `done` tasks as completed, but `closed` tasks still counted toward the total. So if you close a task instead of marking it done, progress goes *down* — which is confusing.

## What changed

- **`src/app/api/projects/route.ts`** — Prisma query now filters `status: { in: ["done", "closed"] }` instead of just `"done"`
- **`overview-timeline.tsx`** — task stats count `done || closed`
- **`task-list-view.tsx`** — same fix for the task list aggregate

This matches what `project.service.ts` already does (line 255):
```ts
const tasksDone = (taskStatusMap.get("done") || 0) + (taskStatusMap.get("closed") || 0);
```

## Test

1. Create a project with tasks
2. Close some tasks (not mark as done)
3. Progress bar should reflect closed tasks as completed