### PR TITLE
fix: allow reassigning already-assigned tasks

### DIFF
--- a/src/services/__tests__/task.service.test.ts
+++ b/src/services/__tests__/task.service.test.ts
@@ -482,7 +482,7 @@ describe("claimTask", () => {
     expect(result.status).toBe("assigned");
     expect(mockPrisma.task.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { uuid: TASK_UUID, status: "open" },
+        where: { uuid: TASK_UUID, status: { in: ["open", "assigned"] } },
         data: expect.objectContaining({
           status: "assigned",
           assigneeType: "agent",
@@ -492,7 +492,34 @@ describe("claimTask", () => {
     );
   });
 
-  it("throws AlreadyClaimedError when task is not open (Prisma P2025)", async () => {
+  it("reassigns an already-assigned task to a different agent", async () => {
+    const reassigned = {
+      ...rawTask({ status: "assigned", assigneeType: "agent", assigneeUuid: "a2" }),
+      project: { uuid: PROJECT_UUID, name: "Test Project" },
+    };
+    mockPrisma.task.update.mockResolvedValue(reassigned);
+
+    const result = await claimTask({
+      taskUuid: TASK_UUID,
+      companyUuid: COMPANY_UUID,
+      assigneeType: "agent",
+      assigneeUuid: "a2",
+      assignedByUuid: "user-123",
+    });
+
+    expect(result.status).toBe("assigned");
+    expect(mockPrisma.task.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: TASK_UUID, status: { in: ["open", "assigned"] } },
+        data: expect.objectContaining({
+          assigneeType: "agent",
+          assigneeUuid: "a2",
+        }),
+      }),
+    );
+  });
+
+  it("throws AlreadyClaimedError when task is not open or assigned (Prisma P2025)", async () => {
     mockPrisma.task.update.mockRejectedValue({ code: "P2025" });
 
     await expect(

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -596,7 +596,7 @@ export async function claimTask({
 }: TaskClaimParams): Promise<TaskResponse> {
   try {
     const task = await prisma.task.update({
-      where: { uuid: taskUuid, status: "open" },
+      where: { uuid: taskUuid, status: { in: ["open", "assigned"] } },
       data: {
         status: "assigned",
         assigneeType,


### PR DESCRIPTION
Closes #12 (reassign part — button layout is a separate CSS issue)

## What's wrong

`claimTask()` in `task.service.ts` only matches tasks with `status: "open"`:

```ts
where: { uuid: taskUuid, status: "open" }
```

But the UI-side check in `actions.ts` allows both `open` and `assigned`:

```ts
if (task.status !== "open" && task.status !== "assigned") {
  return { success: false, error: "Task is not available for claiming" };
}
```

So when you try to reassign a task that's already assigned to someone, the UI says "go ahead" but the service layer says "nope" — Prisma can't find a matching row and throws P2025, which becomes `AlreadyClaimedError`.

## Fix

```ts
where: { uuid: taskUuid, status: { in: ["open", "assigned"] } }
```

Now reassigning works. If the task is in any other status (in_progress, to_verify, done, closed), it still correctly rejects.

## Tests

- Updated existing test assertion to match the new where filter
- Added a new test case: "reassigns an already-assigned task to a different agent"
- All 81 tests pass