### PR TITLE
fix: resolve oidcSub unique constraint violation on default login

### DIFF
--- a/prisma/migrations/20260415120454_user_oidcsub_compound_unique/migration.sql
+++ b/prisma/migrations/20260415120454_user_oidcsub_compound_unique/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[companyUuid,oidcSub]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "User_oidcSub_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_companyUuid_oidcSub_key" ON "User"("companyUuid", "oidcSub");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,7 +43,7 @@ model User {
   uuid        String   @unique @default(uuid())
   companyUuid String
   company     Company  @relation(fields: [companyUuid], references: [uuid])
-  oidcSub     String   @unique    // OIDC subject
+  oidcSub     String   // OIDC subject
   email       String?
   name        String?
   avatarUrl   String?
@@ -51,6 +51,7 @@ model User {
 
   ownedAgents Agent[]
 
+  @@unique([companyUuid, oidcSub])
   @@index([companyUuid])
 }
 

--- a/src/app/api/auth/me/__tests__/route.test.ts
+++ b/src/app/api/auth/me/__tests__/route.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockPrisma = vi.hoisted(() => ({
+  user: { findFirst: vi.fn() },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+import { GET } from "@/app/api/auth/me/route";
+
+const companyUuid = "company-0000-0000-0000-000000000001";
+const userUuid = "user-0000-0000-0000-000000000001";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url"
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.fakesig`;
+}
+
+function makeRequest(token: string): NextRequest {
+  return new NextRequest(new URL("http://localhost:3000/api/auth/me"), {
+    headers: { authorization: `Bearer ${token}` },
+  });
+}
+
+const mockUser = {
+  uuid: userUuid,
+  email: "user@test.com",
+  name: "Test User",
+  companyUuid,
+  company: { uuid: companyUuid, name: "Test Company" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/auth/me", () => {
+  it("should find user by userUuid when present in token", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+
+    const res = await GET(makeRequest(makeJwt({ userUuid, companyUuid })));
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
+    expect(json.data.user.uuid).toBe(userUuid);
+    expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: userUuid },
+      })
+    );
+  });
+
+  it("should fallback to oidcSub+companyUuid when no userUuid", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+
+    const res = await GET(
+      makeRequest(
+        makeJwt({ oidcSub: "oidc-sub-123", companyUuid })
+      )
+    );
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
+    expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { oidcSub: "oidc-sub-123", companyUuid },
+      })
+    );
+  });
+
+  it("should use sub field as oidcSub fallback (raw OIDC token)", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+
+    const res = await GET(
+      makeRequest(makeJwt({ sub: "raw-oidc-sub", companyUuid }))
+    );
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
+    expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { oidcSub: "raw-oidc-sub", companyUuid },
+      })
+    );
+  });
+
+  it("should query without companyUuid when not in token", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+
+    const res = await GET(
+      makeRequest(makeJwt({ oidcSub: "oidc-sub-123" }))
+    );
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
+    expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { oidcSub: "oidc-sub-123" },
+      })
+    );
+  });
+
+  it("should return 401 when no authorization header", async () => {
+    const req = new NextRequest(
+      new URL("http://localhost:3000/api/auth/me")
+    );
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.success).toBe(false);
+    expect(res.status).toBe(401);
+  });
+
+  it("should return 401 when token has no user identifier", async () => {
+    const res = await GET(makeRequest(makeJwt({ companyUuid })));
+    const json = await res.json();
+
+    expect(json.success).toBe(false);
+    expect(res.status).toBe(401);
+  });
+
+  it("should return 401 when user not found in DB", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(makeJwt({ userUuid })));
+    const json = await res.json();
+
+    expect(json.success).toBe(false);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -38,15 +38,18 @@ export async function GET(request: NextRequest) {
     // Our JWT format has: userUuid, companyUuid, email, oidcSub, etc.
     // Also support raw OIDC tokens which have: sub, email
     const userUuid = payload.userUuid as string | undefined;
+    const companyUuid = payload.companyUuid as string | undefined;
     const oidcSub = (payload.oidcSub || payload.sub) as string | undefined;
 
     if (!userUuid && !oidcSub) {
       return errors.unauthorized("Token missing user identifier");
     }
 
-    // Find user - prefer userUuid, fallback to oidcSub (query by UUID)
+    // Find user - prefer userUuid, fallback to oidcSub+companyUuid
     const user = await prisma.user.findFirst({
-      where: userUuid ? { uuid: userUuid } : { oidcSub: oidcSub },
+      where: userUuid
+        ? { uuid: userUuid }
+        : { oidcSub, ...(companyUuid ? { companyUuid } : {}) },
       select: {
         uuid: true,
         email: true,

--- a/src/services/__tests__/user.service.test.ts
+++ b/src/services/__tests__/user.service.test.ts
@@ -7,6 +7,7 @@ const mockPrisma = vi.hoisted(() => ({
     findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    upsert: vi.fn(),
   },
   company: {
     findFirst: vi.fn(),
@@ -202,7 +203,7 @@ describe("findOrCreateDefaultUser", () => {
     const company = makeCompany();
     const user = makeUser();
     mockPrisma.company.findFirst.mockResolvedValue(company);
-    mockPrisma.user.findFirst.mockResolvedValue(user);
+    mockPrisma.user.upsert.mockResolvedValue(user);
 
     const result = await findOrCreateDefaultUser("user@test.com");
 
@@ -218,8 +219,7 @@ describe("findOrCreateDefaultUser", () => {
     const company = makeCompany();
     mockPrisma.company.findFirst.mockResolvedValue(null);
     mockPrisma.company.create.mockResolvedValue(company);
-    mockPrisma.user.findFirst.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue(makeUser());
+    mockPrisma.user.upsert.mockResolvedValue(makeUser());
 
     await findOrCreateDefaultUser("user@newdomain.com");
 
@@ -234,49 +234,65 @@ describe("findOrCreateDefaultUser", () => {
     );
   });
 
-  it("should return existing user in company", async () => {
+  it("should return existing user via upsert", async () => {
     const company = makeCompany();
     const user = makeUser();
     mockPrisma.company.findFirst.mockResolvedValue(company);
-    mockPrisma.user.findFirst.mockResolvedValue(user);
+    mockPrisma.user.upsert.mockResolvedValue(user);
 
     const result = await findOrCreateDefaultUser("user@test.com");
 
     expect(result.uuid).toBe(userUuid);
-    expect(mockPrisma.user.create).not.toHaveBeenCalled();
-  });
-
-  it("should create new user when not found", async () => {
-    const company = makeCompany();
-    mockPrisma.company.findFirst.mockResolvedValue(company);
-    mockPrisma.user.findFirst.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue(makeUser());
-
-    const result = await findOrCreateDefaultUser("newuser@test.com");
-
-    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+    expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: {
-          email: "newuser@test.com",
-          name: "newuser",
-          oidcSub: "default_user",
-          companyUuid,
+        where: {
+          companyUuid_oidcSub: {
+            companyUuid,
+            oidcSub: "default_user@test.com",
+          },
         },
       })
     );
   });
 
-  it("should extract name from email", async () => {
+  it("should upsert user with per-email oidcSub", async () => {
     const company = makeCompany();
     mockPrisma.company.findFirst.mockResolvedValue(company);
-    mockPrisma.user.findFirst.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue(makeUser({ name: "john.doe" }));
+    mockPrisma.user.upsert.mockResolvedValue(makeUser());
+
+    await findOrCreateDefaultUser("newuser@test.com");
+
+    expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          companyUuid_oidcSub: {
+            companyUuid,
+            oidcSub: "default_newuser@test.com",
+          },
+        },
+        create: {
+          email: "newuser@test.com",
+          name: "newuser",
+          oidcSub: "default_newuser@test.com",
+          companyUuid,
+        },
+        update: {
+          email: "newuser@test.com",
+        },
+      })
+    );
+  });
+
+  it("should extract name from email in create", async () => {
+    const company = makeCompany();
+    mockPrisma.company.findFirst.mockResolvedValue(company);
+    mockPrisma.user.upsert.mockResolvedValue(makeUser({ name: "john.doe" }));
 
     await findOrCreateDefaultUser("john.doe@test.com");
 
-    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+    expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ name: "john.doe" }),
+        create: expect.objectContaining({ name: "john.doe" }),
       })
     );
   });
@@ -284,7 +300,7 @@ describe("findOrCreateDefaultUser", () => {
   it("should handle lowercase domain conversion", async () => {
     const company = makeCompany();
     mockPrisma.company.findFirst.mockResolvedValue(company);
-    mockPrisma.user.findFirst.mockResolvedValue(makeUser());
+    mockPrisma.user.upsert.mockResolvedValue(makeUser());
 
     await findOrCreateDefaultUser("User@TEST.COM");
 

--- a/src/services/__tests__/user.service.test.ts
+++ b/src/services/__tests__/user.service.test.ts
@@ -310,6 +310,43 @@ describe("findOrCreateDefaultUser", () => {
       })
     );
   });
+
+  it("should be idempotent for repeated calls with same email", async () => {
+    const company = makeCompany();
+    const user = makeUser();
+    mockPrisma.company.findFirst.mockResolvedValue(company);
+    mockPrisma.user.upsert.mockResolvedValue(user);
+
+    const [result1, result2] = await Promise.all([
+      findOrCreateDefaultUser("user@test.com"),
+      findOrCreateDefaultUser("user@test.com"),
+    ]);
+
+    expect(result1.uuid).toBe(result2.uuid);
+    // Both calls use upsert with the same compound key — no constraint violation
+    expect(mockPrisma.user.upsert).toHaveBeenCalledTimes(2);
+    for (const call of mockPrisma.user.upsert.mock.calls) {
+      expect(call[0].where).toEqual({
+        companyUuid_oidcSub: {
+          companyUuid,
+          oidcSub: "default_user@test.com",
+        },
+      });
+    }
+  });
+
+  it("should generate different oidcSub for different emails in same company", async () => {
+    const company = makeCompany();
+    mockPrisma.company.findFirst.mockResolvedValue(company);
+    mockPrisma.user.upsert.mockResolvedValue(makeUser());
+
+    await findOrCreateDefaultUser("alice@test.com");
+    await findOrCreateDefaultUser("bob@test.com");
+
+    const calls = mockPrisma.user.upsert.mock.calls;
+    expect(calls[0][0].where.companyUuid_oidcSub.oidcSub).toBe("default_alice@test.com");
+    expect(calls[1][0].where.companyUuid_oidcSub.oidcSub).toBe("default_bob@test.com");
+  });
 });
 
 // ===== getUserByUuid =====

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -155,54 +155,40 @@ export async function findOrCreateDefaultUser(email: string) {
     });
   }
 
-  // Look for existing user by email in that company
-  let user = await prisma.user.findFirst({
-    where: {
-      email,
-      companyUuid: company.uuid,
-    },
-    select: {
-      id: true,
-      uuid: true,
-      email: true,
-      name: true,
-      oidcSub: true,
-      companyUuid: true,
-      company: {
-        select: {
-          uuid: true,
-          name: true,
-        },
+  const oidcSub = `default_${email.toLowerCase()}`;
+  const userSelect = {
+    id: true,
+    uuid: true,
+    email: true,
+    name: true,
+    oidcSub: true,
+    companyUuid: true,
+    company: {
+      select: {
+        uuid: true,
+        name: true,
       },
     },
-  });
+  } as const;
 
-  if (user) {
-    return user;
-  }
-
-  // Create new user
-  user = await prisma.user.create({
-    data: {
+  // Upsert to handle concurrent requests safely
+  const user = await prisma.user.upsert({
+    where: {
+      companyUuid_oidcSub: {
+        companyUuid: company.uuid,
+        oidcSub,
+      },
+    },
+    update: {
+      email,
+    },
+    create: {
       email,
       name: email.split("@")[0],
-      oidcSub: "default_user",
+      oidcSub,
       companyUuid: company.uuid,
     },
-    select: {
-      id: true,
-      uuid: true,
-      email: true,
-      name: true,
-      oidcSub: true,
-      companyUuid: true,
-      company: {
-        select: {
-          uuid: true,
-          name: true,
-        },
-      },
-    },
+    select: userSelect,
   });
 
   return user;


### PR DESCRIPTION
## Summary
- Change `oidcSub` from global `@unique` to compound `@@unique([companyUuid, oidcSub])` to support multi-company scenarios
- Replace hardcoded `oidcSub: "default_user"` with per-email value `"default_" + email` to avoid collisions
- Replace `findFirst` + `create` with `upsert` in `findOrCreateDefaultUser` to handle concurrent login requests safely
- Add `companyUuid` to the fallback oidcSub query in `/api/auth/me` to match new compound unique constraint

Resolves #161

## Changed files
| File | Change |
|------|--------|
| `prisma/schema.prisma` | `oidcSub @unique` → `@@unique([companyUuid, oidcSub])` |
| `src/services/user.service.ts` | `findOrCreateDefaultUser`: upsert with per-email oidcSub |
| `src/app/api/auth/me/route.ts` | Fallback query adds `companyUuid` filter |
| `src/services/__tests__/user.service.test.ts` | Updated tests for upsert logic |
| `prisma/migrations/.../migration.sql` | Drop old index, create compound unique index |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 1270 tests pass
- [x] Migration applied successfully to local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)