### PR TITLE
feat: log all MCP tool calls including business rejections

### DIFF
--- a/src/mcp/__tests__/tool-logger.test.ts
+++ b/src/mcp/__tests__/tool-logger.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { truncateParams, extractErrorText } from "../tools/tool-logger";
+import type { AgentAuthContext } from "@/types/auth";
+
+// Mock logger — vi.hoisted ensures fns exist before vi.mock runs
+const { mockDebug, mockWarn, mockError } = vi.hoisted(() => ({
+  mockDebug: vi.fn(),
+  mockWarn: vi.fn(),
+  mockError: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    child: () => ({
+      debug: mockDebug,
+      warn: mockWarn,
+      error: mockError,
+    }),
+  },
+}));
+
+// Import after mock so enableToolCallLogging gets the mocked logger
+import { enableToolCallLogging } from "../tools/tool-logger";
+
+// Minimal McpServer stub
+function createMockServer() {
+  const tools = new Map<string, { config: unknown; handler: Function }>();
+  return {
+    registerTool: vi.fn((name: string, config: unknown, handler: Function) => {
+      tools.set(name, { config, handler });
+    }),
+    _tools: tools,
+    async callTool(name: string, params: Record<string, unknown>) {
+      const entry = tools.get(name);
+      if (!entry) throw new Error(`Tool ${name} not registered`);
+      return entry.handler(params, {});
+    },
+  };
+}
+
+const mockAuth: AgentAuthContext = {
+  type: "agent",
+  companyUuid: "company-1",
+  actorUuid: "agent-1",
+  agentName: "Test Agent",
+  roles: ["developer_agent"],
+};
+
+describe("tool-logger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("truncateParams", () => {
+    it("keeps short strings intact", () => {
+      const result = truncateParams({ taskUuid: "abc-123", title: "Short" });
+      expect(result).toEqual({ taskUuid: "abc-123", title: "Short" });
+    });
+
+    it("truncates strings longer than 500 characters", () => {
+      const longString = "A".repeat(600);
+      const result = truncateParams({ content: longString });
+      const truncated = result.content as string;
+      expect(truncated.length).toBeLessThan(600);
+      expect(truncated).toContain("...");
+      expect(truncated.startsWith("A".repeat(250))).toBe(true);
+      expect(truncated.endsWith("A".repeat(250))).toBe(true);
+    });
+
+    it("does not truncate exactly 500 character strings", () => {
+      const exact = "B".repeat(500);
+      const result = truncateParams({ content: exact });
+      expect(result.content).toBe(exact);
+    });
+
+    it("passes through non-string values unchanged", () => {
+      const result = truncateParams({ count: 42, flag: true, nested: { a: 1 } });
+      expect(result).toEqual({ count: 42, flag: true, nested: { a: 1 } });
+    });
+  });
+
+  describe("extractErrorText", () => {
+    it("extracts text from MCP error result", () => {
+      const result = {
+        isError: true,
+        content: [{ type: "text", text: "Task already claimed" }],
+      };
+      expect(extractErrorText(result)).toBe("Task already claimed");
+    });
+
+    it("joins multiple text content items", () => {
+      const result = {
+        isError: true,
+        content: [
+          { type: "text", text: "Error 1." },
+          { type: "text", text: "Error 2." },
+        ],
+      };
+      expect(extractErrorText(result)).toBe("Error 1. Error 2.");
+    });
+
+    it("returns undefined for non-object input", () => {
+      expect(extractErrorText(null)).toBeUndefined();
+      expect(extractErrorText("string")).toBeUndefined();
+    });
+
+    it("returns undefined when no text content", () => {
+      const result = { isError: true, content: [{ type: "image", data: "..." }] };
+      expect(extractErrorText(result)).toBeUndefined();
+    });
+  });
+
+  describe("enableToolCallLogging", () => {
+    it("logs successful calls at debug level", async () => {
+      const server = createMockServer();
+      enableToolCallLogging(server as unknown as Parameters<typeof enableToolCallLogging>[0], mockAuth);
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: '{"uuid":"t-1"}' }],
+      });
+      server.registerTool("chorus_get_task", {}, handler);
+
+      await server.callTool("chorus_get_task", { taskUuid: "t-1" });
+
+      expect(mockDebug).toHaveBeenCalledOnce();
+      const [logObj, msg] = mockDebug.mock.calls[0];
+      expect(msg).toBe("MCP tool call");
+      expect(logObj.tool).toBe("chorus_get_task");
+      expect(logObj.agent).toEqual({ uuid: "agent-1", name: "Test Agent" });
+      expect(logObj.params).toEqual({ taskUuid: "t-1" });
+      expect(typeof logObj.durationMs).toBe("number");
+    });
+
+    it("logs business rejections at warn level", async () => {
+      const server = createMockServer();
+      enableToolCallLogging(server as unknown as Parameters<typeof enableToolCallLogging>[0], mockAuth);
+
+      const handler = vi.fn().mockResolvedValue({
+        isError: true,
+        content: [{ type: "text", text: "Task already claimed" }],
+      });
+      server.registerTool("chorus_claim_task", {}, handler);
+
+      await server.callTool("chorus_claim_task", { taskUuid: "t-1" });
+
+      expect(mockWarn).toHaveBeenCalledOnce();
+      const [logObj, msg] = mockWarn.mock.calls[0];
+      expect(msg).toBe("MCP tool business rejection");
+      expect(logObj.tool).toBe("chorus_claim_task");
+      expect(logObj.error).toBe("Task already claimed");
+      expect(typeof logObj.durationMs).toBe("number");
+    });
+
+    it("logs unhandled exceptions at error level and re-throws", async () => {
+      const server = createMockServer();
+      enableToolCallLogging(server as unknown as Parameters<typeof enableToolCallLogging>[0], mockAuth);
+
+      const thrownError = new Error("DB connection failed");
+      const handler = vi.fn().mockRejectedValue(thrownError);
+      server.registerTool("chorus_create_tasks", {}, handler);
+
+      await expect(
+        server.callTool("chorus_create_tasks", { projectUuid: "p-1" })
+      ).rejects.toThrow("DB connection failed");
+
+      expect(mockError).toHaveBeenCalledOnce();
+      const [logObj, msg] = mockError.mock.calls[0];
+      expect(msg).toBe("MCP tool unhandled exception");
+      expect(logObj.tool).toBe("chorus_create_tasks");
+      expect(logObj.err).toBe(thrownError);
+    });
+
+    it("truncates long params in logs", async () => {
+      const server = createMockServer();
+      enableToolCallLogging(server as unknown as Parameters<typeof enableToolCallLogging>[0], mockAuth);
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+      });
+      server.registerTool("chorus_pm_create_idea", {}, handler);
+
+      const longContent = "X".repeat(600);
+      await server.callTool("chorus_pm_create_idea", {
+        projectUuid: "p-1",
+        content: longContent,
+      });
+
+      expect(mockDebug).toHaveBeenCalledOnce();
+      const logObj = mockDebug.mock.calls[0][0];
+      expect(logObj.params.projectUuid).toBe("p-1");
+      expect((logObj.params.content as string).length).toBeLessThan(600);
+      expect((logObj.params.content as string)).toContain("...");
+    });
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,7 @@ import { registerPmTools } from "./tools/pm";
 import { registerDeveloperTools } from "./tools/developer";
 import { registerAdminTools } from "./tools/admin";
 import { registerSessionTools } from "./tools/session";
+import { enableToolCallLogging } from "./tools/tool-logger";
 import { enablePresence } from "./tools/presence";
 import type { AgentAuthContext } from "@/types/auth";
 
@@ -16,6 +17,9 @@ export function createMcpServer(auth: AgentAuthContext): McpServer {
     name: "chorus",
     version: "1.0.0",
   });
+
+  // Enable tool-call logging (must be before enablePresence so it wraps the outermost layer)
+  enableToolCallLogging(server, auth);
 
   // Enable presence event emission for all tools (must be called before registerTool calls)
   enablePresence(server, auth);

--- a/src/mcp/tools/tool-logger.ts
+++ b/src/mcp/tools/tool-logger.ts
@@ -1,0 +1,98 @@
+// src/mcp/tools/tool-logger.ts
+// Central MCP tool-call logging wrapper.
+// Intercepts all registerTool handlers to log business rejections (warn)
+// and successful calls (debug). Must be called BEFORE enablePresence in server.ts
+// so it wraps the outermost layer and captures the final result.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AgentAuthContext } from "@/types/auth";
+import logger from "@/lib/logger";
+
+const toolLogger = logger.child({ module: "mcp-tool" });
+
+const MAX_STRING_LENGTH = 500;
+const TRUNCATE_EDGE = 250;
+
+/** Truncate long string values in params to prevent log bloat. */
+function truncateParams(params: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === "string" && value.length > MAX_STRING_LENGTH) {
+      result[key] = `${value.slice(0, TRUNCATE_EDGE)}...${value.slice(-TRUNCATE_EDGE)}`;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/** Extract error text from an MCP tool result with isError: true. */
+function extractErrorText(result: unknown): string | undefined {
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "content" in result &&
+    Array.isArray((result as { content: unknown[] }).content)
+  ) {
+    const texts = (result as { content: Array<{ type: string; text?: string }> }).content
+      .filter((c) => c.type === "text" && typeof c.text === "string")
+      .map((c) => c.text);
+    return texts.length > 0 ? texts.join(" ") : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Wraps a McpServer to log all tool calls.
+ * - Business rejections (isError: true) → warn
+ * - Successful calls → debug
+ * - Unhandled exceptions → error + re-throw
+ *
+ * Call BEFORE enablePresence so this wrapper is the outermost layer.
+ */
+export function enableToolCallLogging(server: McpServer, auth: AgentAuthContext): void {
+  const agent = { uuid: auth.actorUuid, name: auth.agentName || "Unknown Agent" };
+  const originalRegisterTool = server.registerTool.bind(server);
+
+  server.registerTool = function (name: string, config: unknown, handler: unknown) {
+    const originalHandler = handler as (params: Record<string, unknown>, extra: unknown) => Promise<unknown>;
+
+    const wrappedHandler = async (params: Record<string, unknown>, extra: unknown) => {
+      const start = Date.now();
+      let result: unknown;
+
+      try {
+        result = await originalHandler(params, extra);
+      } catch (err) {
+        const durationMs = Date.now() - start;
+        toolLogger.error(
+          { tool: name, agent, params: truncateParams(params), err, durationMs },
+          "MCP tool unhandled exception"
+        );
+        throw err;
+      }
+
+      const durationMs = Date.now() - start;
+
+      if (typeof result === "object" && result !== null && (result as { isError?: boolean }).isError) {
+        const errorText = extractErrorText(result);
+        toolLogger.warn(
+          { tool: name, agent, params: truncateParams(params), error: errorText, durationMs },
+          "MCP tool business rejection"
+        );
+      } else {
+        toolLogger.debug(
+          { tool: name, agent, params: truncateParams(params), durationMs },
+          "MCP tool call"
+        );
+      }
+
+      return result;
+    };
+
+    return originalRegisterTool(name, config as Parameters<typeof originalRegisterTool>[1], wrappedHandler as Parameters<typeof originalRegisterTool>[2]);
+  } as typeof server.registerTool;
+}
+
+// Exported for testing
+export { truncateParams, extractErrorText };


### PR DESCRIPTION
## Summary
- Central `enableToolCallLogging` wrapper intercepts all MCP tool handlers (same `registerTool` override pattern as `presence.ts`)
- Business rejections (`isError: true`) logged at `warn` level with tool name, agent info, truncated params, error content, and duration
- Successful calls logged at `debug` level (visible when `LOG_LEVEL=debug`)
- Unhandled exceptions logged at `error` level then re-thrown (preserves existing behavior)
- Long string params (>500 chars) auto-truncated to `first250...last250`

## Changed files
| File | Change |
|------|--------|
| `src/mcp/tools/tool-logger.ts` | New — `enableToolCallLogging` wrapper, `truncateParams`, `extractErrorText` |
| `src/mcp/server.ts` | Import + call `enableToolCallLogging` before `enablePresence` |
| `src/mcp/__tests__/tool-logger.test.ts` | New — 12 unit tests covering success/warn/error/truncation |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm test` — 59 files, 1291 tests passed, 0 failed
- [x] New test file: 12 tests all passing

Resolves #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)