### PR TITLE
fix: count closed tasks in progress bar

### DIFF
--- a/src/services/__tests__/project.service.test.ts
+++ b/src/services/__tests__/project.service.test.ts
@@ -386,7 +386,31 @@ describe("listProjectsWithStats", () => {
       where: {
         companyUuid,
         projectUuid: { in: [project1.uuid, project2.uuid] },
-        status: "done",
+        status: { in: ["done", "closed"] },
+      },
+      _count: true,
+    });
+  });
+
+  it("should count closed tasks as completed (done + closed)", async () => {
+    const project = makeProject({ uuid: "project-0000-0000-0000-000000000001" });
+
+    mockPrisma.project.findMany.mockResolvedValue([project]);
+    mockPrisma.project.count.mockResolvedValue(1);
+    // groupBy returns combined count of done + closed tasks
+    mockPrisma.task.groupBy.mockResolvedValue([
+      { projectUuid: "project-0000-0000-0000-000000000001", _count: 7 },
+    ]);
+
+    const result = await listProjectsWithStats({ companyUuid, skip: 0, take: 20 });
+
+    expect(result.projects[0].tasksDone).toBe(7);
+    expect(mockPrisma.task.groupBy).toHaveBeenCalledWith({
+      by: ["projectUuid"],
+      where: {
+        companyUuid,
+        projectUuid: { in: [project.uuid] },
+        status: { in: ["done", "closed"] },
       },
       _count: true,
     });

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -200,7 +200,7 @@ export async function listProjectsWithStats({ companyUuid, skip, take }: Project
   const projectUuids = projects.map((p) => p.uuid);
   const doneCounts = await prisma.task.groupBy({
     by: ["projectUuid"],
-    where: { companyUuid, projectUuid: { in: projectUuids }, status: "done" },
+    where: { companyUuid, projectUuid: { in: projectUuids }, status: { in: ["done", "closed"] } },
     _count: true,
   });
   const doneMap = new Map(doneCounts.map((d) => [d.projectUuid, d._count]));


### PR DESCRIPTION
## Summary
- `listProjectsWithStats` only counted `status: "done"` tasks for progress bars, missing `closed` tasks
- Changed Prisma query to `status: { in: ["done", "closed"] }` to align with `getProjectStats` and `project-group.service`
- Added unit test verifying closed tasks are counted

## Changed files
| File | Change |
|------|--------|
| `src/services/project.service.ts` | Query filter: `"done"` → `{ in: ["done", "closed"] }` |
| `src/services/__tests__/project.service.test.ts` | Updated assertion + new test for closed counting |

## Test plan
- [x] `pnpm test` — 59 files, 1292 passed, 0 failed
- [x] `npx tsc --noEmit` — clean

Generated with [Claude Code](https://claude.com/claude-code)