### PR TITLE
feat: strengthen reviewer PE with integration checkpoint and hallucination checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/packages/openclaw-plugin/skills/proposal/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal/SKILL.md
@@ -379,6 +379,8 @@ Good tasks are:
 - **Sized** — 1-8 story points (hours of agent work)
 - **Ordered** — Use `dependsOnDraftUuids` to express execution order in the DAG
 - **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC
+- **Integration checkpoints** — For DAGs with 4+ tasks, include at least one integration checkpoint task at a convergence point whose AC requires end-to-end execution of preceding modules together
+- **Hallucination-aware** — When tasks involve external dependencies, note in the task description that developers should verify specifics (API signatures, CLI flags, config keys, model IDs, etc.) against official docs rather than relying on LLM memory
 
 ### Task Granularity
 

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/agents/proposal-reviewer.md
+++ b/public/chorus-plugin/agents/proposal-reviewer.md
@@ -62,6 +62,7 @@ For each task draft, check:
 - **Coverage**: Cross-reference task AC against document requirements. Any requirements with NO corresponding AC?
 - **Dependencies**: Is the DAG correct? Can each task start once its dependencies are done?
 - **Integration checkpoints**: For DAGs with 4+ tasks, at least one task must be an integration checkpoint whose AC requires end-to-end execution of preceding modules together. If missing, classify as BLOCKER — without integration verification, module-level passes do not guarantee the system works.
+- **Hallucination risk**: Task descriptions and AC may contain LLM-fabricated specifics (SDK versions, API paths, CLI flags). Flag as NOTE — same rule as Step 2.
 
 **Step 4: Cross-check**
 - Do tasks cover ALL requirements from the documents?

--- a/public/chorus-plugin/agents/proposal-reviewer.md
+++ b/public/chorus-plugin/agents/proposal-reviewer.md
@@ -52,6 +52,7 @@ For each document draft, check:
 - **Specificity**: Are requirements testable? "Should handle errors gracefully" is not testable.
 - **Tech feasibility**: Does the architecture make sense? Missing auth, race conditions, no error handling?
 - **Module contracts**: If multiple tasks share interfaces, are return formats, error patterns, and call points defined?
+- **Hallucination risk**: Flag any specific external detail that looks like it could be LLM-fabricated (API signatures, model IDs, SDK versions, CLI flags, config keys, endpoint paths, etc.) as NOTE. The PM is an LLM — it confidently invents plausible-looking specifics.
 
 **Step 3: Review task drafts**
 
@@ -60,6 +61,7 @@ For each task draft, check:
 - **AC quality**: Each criterion must be objectively verifiable by a different agent. "Shows details" is BAD. "Displays order ID, customer name, and status badge" is GOOD.
 - **Coverage**: Cross-reference task AC against document requirements. Any requirements with NO corresponding AC?
 - **Dependencies**: Is the DAG correct? Can each task start once its dependencies are done?
+- **Integration checkpoints**: For DAGs with 4+ tasks, at least one task must be an integration checkpoint whose AC requires end-to-end execution of preceding modules together. If missing, classify as BLOCKER — without integration verification, module-level passes do not guarantee the system works.
 
 **Step 4: Cross-check**
 - Do tasks cover ALL requirements from the documents?

--- a/public/chorus-plugin/agents/task-reviewer.md
+++ b/public/chorus-plugin/agents/task-reviewer.md
@@ -84,6 +84,8 @@ A broken build or failing tests is an automatic FAIL. Test results are context, 
 
 Pick 2-3 probes that fit the specific task: boundary values, missing fields, error paths, or concurrency. Run them — don't just describe what you would check.
 
+**Hallucination check**: Flag anything that looks like it could be LLM-fabricated as NOTE — API signatures, CLI flags, config keys, model IDs, endpoint URLs, package names, or any external detail the developer likely wrote from memory rather than referencing docs.
+
 === FINDING CLASSIFICATION ===
 
 Every finding MUST be classified as one of:
@@ -115,6 +117,7 @@ You may receive the current review round number in your context.
 - "The code looks correct based on my reading" — reading is not verification. Run it.
 - "The developer's tests already pass" — the developer is an LLM. Verify independently.
 - "This AC is probably met" — probably is not verified. Find the specific code and check.
+- "The API call looks right" — for tasks involving external API/SDK calls, request execution evidence (run logs, test output, or error messages). If the developer provides none and you cannot run it yourself, flag as NOTE.
 
 === OUTPUT FORMAT (REQUIRED) ===
 

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -327,6 +327,8 @@ Good tasks are:
 - **Sized** — 1-8 story points (hours of agent work)
 - **Ordered** — Use `dependsOnDraftUuids` / `dependsOnTaskUuids` to express execution order
 - **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC
+- **Integration checkpoints** — For DAGs with 4+ tasks, include at least one integration checkpoint task at a convergence point whose AC requires end-to-end execution of preceding modules together
+- **Hallucination-aware** — When tasks involve external dependencies, note in the task description that developers should verify specifics (API signatures, CLI flags, config keys, model IDs, etc.) against official docs rather than relying on LLM memory
 
 ### Task Granularity
 

--- a/public/skill/proposal-chorus/SKILL.md
+++ b/public/skill/proposal-chorus/SKILL.md
@@ -305,6 +305,8 @@ Good tasks are:
 - **Sized** — 1-8 story points (hours of agent work)
 - **Ordered** — Use `dependsOnDraftUuids` / `dependsOnTaskUuids` to express execution order
 - **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC
+- **Integration checkpoints** — For DAGs with 4+ tasks, include at least one integration checkpoint task at a convergence point whose AC requires end-to-end execution of preceding modules together
+- **Hallucination-aware** — When tasks involve external dependencies, note in the task description that developers should verify specifics (API signatures, CLI flags, config keys, model IDs, etc.) against official docs rather than relying on LLM memory
 
 ### Task Granularity
 


### PR DESCRIPTION
## Summary
- Proposal reviewer: added **integration checkpoint** check (BLOCKER) — DAGs with 4+ tasks must include an e2e verification task
- Proposal reviewer: added **hallucination risk** check (NOTE) — flags potentially LLM-fabricated details in documents (API signatures, model IDs, SDK versions, etc.)
- Task reviewer: added **hallucination flag** for suspicious hardcoded constants (NOTE)
- Task reviewer: added **execution evidence** request for API/SDK tasks in rationalizations section
- All 3 proposal skill docs updated with new task writing guidelines (integration checkpoints + hallucination-aware)
- Plugin version bumped to 0.7.1

## Changed files
| File | Change |
|------|--------|
| `public/chorus-plugin/agents/proposal-reviewer.md` | Integration checkpoint BLOCKER + hallucination NOTE in Step 2/3 |
| `public/chorus-plugin/agents/task-reviewer.md` | Hallucination NOTE in Step 6 + execution evidence in rationalizations |
| `public/chorus-plugin/skills/proposal/SKILL.md` | 2 new task writing guidelines |
| `public/skill/proposal-chorus/SKILL.md` | Same 2 guidelines |
| `packages/openclaw-plugin/skills/proposal/SKILL.md` | Same 2 guidelines |
| `public/chorus-plugin/.claude-plugin/plugin.json` | 0.7.0 → 0.7.1 |
| `.claude-plugin/marketplace.json` | 0.7.0 → 0.7.1 |

## Test plan
- [x] Created test project with 5-task proposal missing integration checkpoint + fake model IDs
- [x] Proposal reviewer correctly flagged missing integration checkpoint as BLOCKER
- [x] Proposal reviewer correctly flagged "gpt-4-turbo" and "OpenAI SDK v5.2" as hallucination NOTE
- [x] All additions are concise (1-2 sentences each, no context bloat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)