### PR TITLE
feat: add CLI entry and npm publishing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,14 @@ packages/chorus-cdk/lib/*.d.ts
 # Chorus plugin state
 .chorus/
 
+# Chorus CLI data directory
+.chorus-data/
+
 # PGlite local dev database
 .pglite/
+
+# npm pack output
+*.tgz
 
 #demo
 dev-story-demo/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,46 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ---
 
+## Quick Start
+
+Run Chorus locally with two commands — no database, no Docker, no config files needed.
+
+```bash
+npm install -g @chorus-aidlc/chorus
+chorus
+```
+
+That's it. Chorus starts with an embedded PostgreSQL (PGlite), runs migrations automatically, and opens at **http://localhost:8637**.
+
+Default login: `admin@chorus.local` / `chorus`
+
+### Options
+
+```bash
+# Custom port
+chorus --port 3000
+
+# Custom data directory (default: ~/.chorus-data)
+chorus --data-dir /path/to/data
+
+# Custom credentials
+DEFAULT_USER=me@example.com DEFAULT_PASSWORD=secret chorus
+
+# Use an external PostgreSQL instead of embedded PGlite
+DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
+```
+
+### Other deployment options
+
+| Method | Command |
+|--------|---------|
+| **npm** (simplest) | `npm i -g @chorus-aidlc/chorus && chorus` |
+| **Docker (standalone)** | [`docker compose -f docker-compose.local.yml up`](#quick-start-with-docker-recommended) |
+| **Docker (full stack)** | [`docker compose up`](#quick-start-with-docker-recommended) (PostgreSQL + Redis + Chorus) |
+| **AWS CDK** | [Deploy to AWS](#deploy-to-aws) |
+
+---
+
 ## Screenshots
 
 ### Proposal — AI Agent Generates Plans in Real Time

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,6 +40,46 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ---
 
+## 快速开始
+
+两条命令在本地运行 Chorus——无需数据库、无需 Docker、无需配置文件。
+
+```bash
+npm install -g @chorus-aidlc/chorus
+chorus
+```
+
+Chorus 会自动启动内嵌 PostgreSQL (PGlite)、执行数据库迁移，然后在 **http://localhost:8637** 提供服务。
+
+默认登录账号：`admin@chorus.local` / `chorus`
+
+### 参数选项
+
+```bash
+# 自定义端口
+chorus --port 3000
+
+# 自定义数据目录（默认：~/.chorus-data）
+chorus --data-dir /path/to/data
+
+# 自定义登录账号
+DEFAULT_USER=me@example.com DEFAULT_PASSWORD=secret chorus
+
+# 使用外部 PostgreSQL（跳过内嵌 PGlite）
+DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
+```
+
+### 其他部署方式
+
+| 方式 | 命令 |
+|------|------|
+| **npm**（最简单） | `npm i -g @chorus-aidlc/chorus && chorus` |
+| **Docker（单镜像）** | [`docker compose -f docker-compose.local.yml up`](#docker-一键启动推荐) |
+| **Docker（完整版）** | [`docker compose up`](#docker-一键启动推荐)（PostgreSQL + Redis + Chorus） |
+| **AWS CDK** | [部署到 AWS](#部署到-aws) |
+
+---
+
 ## 界面预览
 
 ### Proposal——AI Agent 实时生成计划

--- a/chorus.mjs
+++ b/chorus.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+import { execSync, fork } from "node:child_process";
+import { randomBytes, createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing (zero dependencies)
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+function getArg(long, short) {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === long || args[i] === short) {
+      return args[i + 1] ?? true;
+    }
+    if (args[i].startsWith(`${long}=`)) {
+      return args[i].slice(long.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function hasFlag(long, short) {
+  return args.includes(long) || args.includes(short);
+}
+
+// --help / --version fast paths
+if (hasFlag("--help", "-h")) {
+  const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
+  process.stdout.write(`
+Chorus v${pkg.version} — AI Agent & Human collaboration platform
+
+USAGE
+  chorus [options]
+
+OPTIONS
+  -p, --port <port>        HTTP server port             (default: 8637, env: PORT)
+  -d, --data-dir <path>    Data directory for PGlite    (default: ~/.chorus-data, env: CHORUS_DATA_DIR)
+      --hostname <host>    Bind address                 (default: 0.0.0.0, env: HOSTNAME)
+  -h, --help               Show this help message
+  -v, --version            Show version number
+
+ENVIRONMENT VARIABLES
+  DATABASE_URL             External PostgreSQL URL (skips embedded PGlite)
+  REDIS_URL                Redis URL for multi-instance pub/sub
+  DEFAULT_USER             Auto-create login user email
+  DEFAULT_PASSWORD         Auto-create login user password
+  NEXTAUTH_SECRET          Session signing secret (auto-generated if unset)
+  COOKIE_SECURE            Set to "true" for HTTPS deployments
+
+EXAMPLES
+  chorus                                     # Start with defaults
+  chorus --port 3000                         # Custom port
+  chorus --data-dir /var/lib/chorus          # Custom data directory
+  DATABASE_URL=postgres://... chorus         # Use external PostgreSQL
+`);
+  process.exit(0);
+}
+
+if (hasFlag("--version", "-v")) {
+  const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
+  process.stdout.write(`${pkg.version}\n`);
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const port = Number(getArg("--port", "-p") ?? process.env.PORT ?? 8637);
+const dataDir = resolve(
+  getArg("--data-dir", "-d") ?? process.env.CHORUS_DATA_DIR ?? join(homedir(), ".chorus-data")
+);
+const hostname = getArg("--hostname") ?? process.env.HOSTNAME ?? "0.0.0.0";
+const PGLITE_PORT = 5433;
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function waitForTcp(host, tcpPort, maxRetries = 30, intervalMs = 500) {
+  return new Promise((resolve, reject) => {
+    let attempt = 0;
+    function tryConnect() {
+      attempt++;
+      const socket = createConnection({ host, port: tcpPort });
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        if (attempt >= maxRetries) {
+          reject(
+            new Error(`PGlite failed to start within ${(maxRetries * intervalMs) / 1000} seconds.`)
+          );
+        } else {
+          setTimeout(tryConnect, intervalMs);
+        }
+      });
+    }
+    tryConnect();
+  });
+}
+
+function ensureSecret() {
+  const secretPath = join(dataDir, ".secret");
+  if (process.env.NEXTAUTH_SECRET) return;
+  if (existsSync(secretPath)) {
+    process.env.NEXTAUTH_SECRET = readFileSync(secretPath, "utf8").trim();
+    return;
+  }
+  const secret = createHash("sha256")
+    .update(randomBytes(32))
+    .digest("hex");
+  writeFileSync(secretPath, secret, { mode: 0o600 });
+  process.env.NEXTAUTH_SECRET = secret;
+}
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+let pgliteProcess = null;
+
+async function main() {
+  // 1. Ensure data directory
+  mkdirSync(join(dataDir, "pglite"), { recursive: true });
+
+  // 2. Determine database mode
+  const useExternalDb = !!process.env.DATABASE_URL;
+
+  if (!useExternalDb) {
+    // Start embedded PGlite
+    console.log(`Starting embedded PostgreSQL (PGlite) on port ${PGLITE_PORT}...`);
+
+    const serverScript = join(
+      __dirname,
+      "node_modules",
+      "@electric-sql",
+      "pglite-socket",
+      "dist",
+      "scripts",
+      "server.js"
+    );
+
+    pgliteProcess = fork(serverScript, [
+      `--db=${join(dataDir, "pglite")}`,
+      `--port=${PGLITE_PORT}`,
+      "--max-connections=10",
+    ], { stdio: "ignore", detached: false });
+
+    pgliteProcess.on("error", (err) => {
+      console.error("PGlite process error:", err.message);
+      process.exit(1);
+    });
+
+    try {
+      await waitForTcp("localhost", PGLITE_PORT);
+    } catch (err) {
+      console.error(`\nERROR: ${err.message}`);
+      console.error(`\nPossible causes:`);
+      console.error(`  - Port ${PGLITE_PORT} is already in use`);
+      console.error(`  - Corrupt data in ${join(dataDir, "pglite")}/`);
+      process.exit(1);
+    }
+
+    console.log(`PGlite ready on port ${PGLITE_PORT}.`);
+    process.env.DATABASE_URL = `postgresql://postgres:postgres@localhost:${PGLITE_PORT}/postgres?sslmode=disable`;
+  }
+
+  // Disable Redis (single-instance in-memory EventBus)
+  if (!process.env.REDIS_URL) {
+    process.env.REDIS_URL = "";
+  }
+
+  // 3. Run database migrations
+  console.log("Running database migrations...");
+  const prismaPath = join(__dirname, "node_modules", ".bin", "prisma");
+  try {
+    execSync(`"${prismaPath}" migrate deploy`, {
+      cwd: __dirname,
+      stdio: "inherit",
+      env: { ...process.env },
+    });
+  } catch {
+    console.error("ERROR: Database migration failed.");
+    process.exit(1);
+  }
+  console.log("Migrations completed.");
+
+  // 4. Generate NEXTAUTH_SECRET if needed
+  ensureSecret();
+
+  // 5. Set server environment
+  process.env.PORT = String(port);
+  process.env.HOSTNAME = hostname;
+  process.env.NODE_ENV = "production";
+  if (!process.env.LOG_LEVEL) {
+    process.env.LOG_LEVEL = "info";
+  }
+  if (!process.env.COOKIE_SECURE) {
+    process.env.COOKIE_SECURE = "false";
+  }
+  if (!process.env.DEFAULT_USER) {
+    process.env.DEFAULT_USER = "admin@chorus.local";
+  }
+  if (!process.env.DEFAULT_PASSWORD) {
+    process.env.DEFAULT_PASSWORD = "chorus";
+  }
+
+  // 6. Print banner
+  const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
+  console.log("");
+  console.log(`  Chorus v${pkg.version}`);
+  console.log("");
+  console.log(`  URL:       http://${hostname === "0.0.0.0" ? "localhost" : hostname}:${port}`);
+  console.log(`  Data:      ${dataDir}`);
+  console.log(`  Database:  ${useExternalDb ? "external PostgreSQL" : "PGlite (embedded)"}`);
+  console.log(`  Redis:     ${process.env.REDIS_URL ? "connected" : "disabled (in-memory EventBus)"}`);
+  console.log(`  Login:     ${process.env.DEFAULT_USER} / ${process.env.DEFAULT_PASSWORD}`);
+  console.log("");
+
+  // 7. Ensure static assets are accessible inside standalone directory
+  // next build puts .next/static/ and public/ at the project root, but
+  // standalone/server.js expects them relative to its own directory.
+  // prepack copies them for npm distribution; here we symlink for local dev.
+  const standaloneDir = join(__dirname, ".next", "standalone");
+  const staticLink = join(standaloneDir, ".next", "static");
+  const publicLink = join(standaloneDir, "public");
+  const staticSrc = join(__dirname, ".next", "static");
+  const publicSrc = join(__dirname, "public");
+
+  if (!existsSync(staticLink) && existsSync(staticSrc)) {
+    symlinkSync(staticSrc, staticLink);
+  }
+  if (!existsSync(publicLink) && existsSync(publicSrc)) {
+    symlinkSync(publicSrc, publicLink);
+  }
+
+  // 8. Start Next.js standalone server
+  process.chdir(standaloneDir);
+  await import(join(standaloneDir, "server.js"));
+}
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown
+// ---------------------------------------------------------------------------
+
+let shuttingDown = false;
+
+function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log("\nShutting down...");
+  if (pgliteProcess && !pgliteProcess.killed) {
+    pgliteProcess.kill("SIGTERM");
+    setTimeout(() => {
+      if (pgliteProcess && !pgliteProcess.killed) {
+        pgliteProcess.kill("SIGKILL");
+      }
+      process.exit(0);
+    }, 3000);
+  } else {
+    process.exit(0);
+  }
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("exit", () => {
+  if (pgliteProcess && !pgliteProcess.killed) {
+    pgliteProcess.kill("SIGKILL");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  if (pgliteProcess) pgliteProcess.kill("SIGTERM");
+  process.exit(1);
+});

--- a/chorus.mjs
+++ b/chorus.mjs
@@ -50,7 +50,8 @@ USAGE
 OPTIONS
   -p, --port <port>        HTTP server port             (default: 8637, env: PORT)
   -d, --data-dir <path>    Data directory for PGlite    (default: ~/.chorus-data, env: CHORUS_DATA_DIR)
-      --hostname <host>    Bind address                 (default: 0.0.0.0, env: HOSTNAME)
+      --hostname <host>    Bind address                 (default: 0.0.0.0)
+      --pglite-port <port> Embedded PGlite port         (default: 5433, env: CHORUS_PGLITE_PORT)
   -h, --help               Show this help message
   -v, --version            Show version number
 
@@ -85,8 +86,8 @@ const port = Number(getArg("--port", "-p") ?? process.env.PORT ?? 8637);
 const dataDir = resolve(
   getArg("--data-dir", "-d") ?? process.env.CHORUS_DATA_DIR ?? join(homedir(), ".chorus-data")
 );
-const hostname = getArg("--hostname") ?? process.env.HOSTNAME ?? "0.0.0.0";
-const PGLITE_PORT = 5433;
+const hostname = getArg("--hostname") ?? "0.0.0.0";
+const PGLITE_PORT = Number(getArg("--pglite-port") ?? process.env.CHORUS_PGLITE_PORT ?? 5433);
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -232,7 +233,10 @@ async function main() {
   console.log(`  Data:      ${dataDir}`);
   console.log(`  Database:  ${useExternalDb ? "external PostgreSQL" : "PGlite (embedded)"}`);
   console.log(`  Redis:     ${process.env.REDIS_URL ? "connected" : "disabled (in-memory EventBus)"}`);
-  console.log(`  Login:     ${process.env.DEFAULT_USER} / ${process.env.DEFAULT_PASSWORD}`);
+  const maskedPassword = process.env.DEFAULT_PASSWORD === "chorus"
+    ? "chorus"
+    : "****";
+  console.log(`  Login:     ${process.env.DEFAULT_USER} / ${maskedPassword}`);
   console.log("");
 
   // 7. Ensure static assets are accessible inside standalone directory
@@ -294,6 +298,6 @@ process.on("exit", () => {
 
 main().catch((err) => {
   console.error("Fatal error:", err);
-  if (pgliteProcess) pgliteProcess.kill("SIGTERM");
+  if (pgliteProcess && !pgliteProcess.killed) pgliteProcess.kill("SIGTERM");
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,27 @@
 {
-  "name": "chorus",
+  "name": "@chorus-aidlc/chorus",
   "version": "0.6.2",
+  "description": "The Agent Harness for AI-Human Collaboration — session lifecycle, task state, sub-agent orchestration, observability, and failure recovery",
+  "homepage": "https://github.com/Chorus-AIDLC/Chorus",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Chorus-AIDLC/Chorus.git"
+  },
+  "keywords": ["agent-harness", "ai-dlc", "mcp", "agent-orchestration", "session-lifecycle", "task-dag"],
   "license": "AGPL-3.0",
   "packageManager": "pnpm@9.15.0",
+  "bin": {
+    "chorus": "chorus.mjs"
+  },
+  "files": [
+    "chorus.mjs",
+    ".next/standalone/",
+    "prisma/schema.prisma",
+    "prisma/migrations/",
+    "prisma.config.ts",
+    "node_modules/@electric-sql/",
+    "node_modules/dotenv/"
+  ],
   "scripts": {
     "dev": "next dev --turbopack --port 8637",
     "dev:local": "bash scripts/dev-local.sh",
@@ -33,7 +52,8 @@
     "landing:preview": "pnpm --filter chorus-landing run preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepack": "pnpm build && node scripts/prepack-pglite.mjs"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.4.4",
@@ -82,7 +102,8 @@
     "sonner": "^2.0.7",
     "streamdown": "^2.4.0",
     "tailwind-merge": "^3.4.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "prisma": "^7.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
@@ -97,7 +118,6 @@
     "eslint": "^9",
     "eslint-config-next": "^15.5.11",
     "pino-pretty": "^13.1.3",
-    "prisma": "^7.0.0",
     "shadcn": "^3.8.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      prisma:
+        specifier: ^7.0.0
+        version: 7.3.0(@types/react@19.2.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -186,9 +189,6 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
-      prisma:
-        specifier: ^7.0.0
-        version: 7.3.0(@types/react@19.2.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       shadcn:
         specifier: ^3.8.4
         version: 3.8.4(@types/node@22.19.8)(typescript@5.9.3)

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -57,21 +57,9 @@ fi
 echo "  version: ${PKG_VERSION}"
 echo ""
 
-# --- 2. Build ---
+# --- 2. Pack (triggers prepack: build + dereference + copy static) ---
 
-echo "[2/6] Building..."
-pnpm build
-echo ""
-
-# --- 3. Prepack (dereference symlinks + copy static assets) ---
-
-echo "[3/6] Running prepack..."
-node scripts/prepack-pglite.mjs
-echo ""
-
-# --- 4. Pack and inspect ---
-
-echo "[4/6] Packing tarball..."
+echo "[2/4] Packing tarball (runs prepack automatically)..."
 TARBALL=$(npm pack --pack-destination /tmp/ 2>&1 | tail -1)
 TARBALL_PATH="/tmp/${TARBALL}"
 TARBALL_SIZE=$(du -h "$TARBALL_PATH" | cut -f1)
@@ -79,9 +67,9 @@ echo "  tarball: ${TARBALL}"
 echo "  size:    ${TARBALL_SIZE}"
 echo ""
 
-# --- 5. Smoke test ---
+# --- 3. Smoke test ---
 
-echo "[5/6] Smoke test..."
+echo "[3/4] Smoke test..."
 INSTALL_DIR=$(mktemp -d)
 npm install --prefix "$INSTALL_DIR" "$TARBALL_PATH" --no-save 2>/dev/null
 
@@ -103,9 +91,9 @@ echo "  chorus --version: ${INSTALLED_VERSION} ✓"
 rm -rf "$INSTALL_DIR"
 echo ""
 
-# --- 6. Publish ---
+# --- 4. Publish ---
 
-echo "[6/6] Publishing..."
+echo "[4/4] Publishing..."
 if [[ "$DRY_RUN" == true ]]; then
   echo "  DRY RUN — skipping actual publish"
   echo ""

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish @chorus-aidlc/chorus to npm
+# Usage:
+#   ./scripts/npm-publish.sh           # publish current version
+#   ./scripts/npm-publish.sh --dry-run # test without publishing
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+PKG_NAME=$(node -e "console.log(require('./package.json').name)")
+PKG_VERSION=$(node -e "console.log(require('./package.json').version)")
+
+echo "========================================="
+echo "  Publishing ${PKG_NAME}@${PKG_VERSION}"
+echo "========================================="
+echo ""
+
+# --- 1. Pre-flight checks ---
+
+echo "[1/6] Pre-flight checks..."
+
+if ! command -v npm &>/dev/null; then
+  echo "ERROR: npm not found" >&2
+  exit 1
+fi
+
+if [[ "$DRY_RUN" == false ]]; then
+  if ! npm whoami &>/dev/null; then
+    echo "ERROR: Not logged in to npm. Run 'npm login' first." >&2
+    exit 1
+  fi
+  NPM_USER=$(npm whoami)
+  echo "  npm user: ${NPM_USER}"
+fi
+
+# Check for uncommitted changes
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "WARNING: Uncommitted changes detected."
+  echo "  Consider committing before publishing."
+  if [[ "$DRY_RUN" == false ]]; then
+    read -rp "  Continue anyway? [y/N] " confirm
+    if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+      echo "Aborted."
+      exit 1
+    fi
+  fi
+fi
+
+echo "  version: ${PKG_VERSION}"
+echo ""
+
+# --- 2. Build ---
+
+echo "[2/6] Building..."
+pnpm build
+echo ""
+
+# --- 3. Prepack (dereference symlinks + copy static assets) ---
+
+echo "[3/6] Running prepack..."
+node scripts/prepack-pglite.mjs
+echo ""
+
+# --- 4. Pack and inspect ---
+
+echo "[4/6] Packing tarball..."
+TARBALL=$(npm pack --pack-destination /tmp/ 2>&1 | tail -1)
+TARBALL_PATH="/tmp/${TARBALL}"
+TARBALL_SIZE=$(du -h "$TARBALL_PATH" | cut -f1)
+echo "  tarball: ${TARBALL}"
+echo "  size:    ${TARBALL_SIZE}"
+echo ""
+
+# --- 5. Smoke test ---
+
+echo "[5/6] Smoke test..."
+INSTALL_DIR=$(mktemp -d)
+npm install --prefix "$INSTALL_DIR" "$TARBALL_PATH" --no-save 2>/dev/null
+
+CHORUS_BIN="${INSTALL_DIR}/node_modules/.bin/chorus"
+if [[ ! -x "$CHORUS_BIN" ]]; then
+  echo "ERROR: chorus binary not found after install" >&2
+  rm -rf "$INSTALL_DIR"
+  exit 1
+fi
+
+INSTALLED_VERSION=$("$CHORUS_BIN" --version 2>/dev/null)
+if [[ "$INSTALLED_VERSION" != "$PKG_VERSION" ]]; then
+  echo "ERROR: Version mismatch. Expected ${PKG_VERSION}, got ${INSTALLED_VERSION}" >&2
+  rm -rf "$INSTALL_DIR"
+  exit 1
+fi
+
+echo "  chorus --version: ${INSTALLED_VERSION} ✓"
+rm -rf "$INSTALL_DIR"
+echo ""
+
+# --- 6. Publish ---
+
+echo "[6/6] Publishing..."
+if [[ "$DRY_RUN" == true ]]; then
+  echo "  DRY RUN — skipping actual publish"
+  echo ""
+  echo "  To publish for real:"
+  echo "    ./scripts/npm-publish.sh"
+  echo ""
+  echo "  Or manually:"
+  echo "    npm publish --access public"
+else
+  npm publish --access public
+  echo ""
+  echo "========================================="
+  echo "  Published ${PKG_NAME}@${PKG_VERSION}"
+  echo "========================================="
+  echo ""
+  echo "  Install:  npm install -g ${PKG_NAME}"
+  echo "  Run:      chorus"
+  echo "  npx:      npx ${PKG_NAME}"
+fi
+
+# Cleanup
+rm -f "$TARBALL_PATH"

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -25,7 +25,7 @@ echo ""
 
 # --- 1. Pre-flight checks ---
 
-echo "[1/6] Pre-flight checks..."
+echo "[1/4] Pre-flight checks..."
 
 if ! command -v npm &>/dev/null; then
   echo "ERROR: npm not found" >&2

--- a/scripts/prepack-pglite.mjs
+++ b/scripts/prepack-pglite.mjs
@@ -1,0 +1,131 @@
+/**
+ * Dereference pnpm symlinks before npm pack.
+ *
+ * pnpm uses a content-addressable store with symlinks in node_modules/.
+ * npm pack follows symlinks for `files` entries, but the resulting tarball
+ * contains the pnpm .pnpm/ directory structure which breaks when installed
+ * elsewhere. This script replaces symlinks with real copies in two places:
+ *
+ * 1. Root node_modules/ — PGlite and dotenv packages needed at runtime
+ * 2. .next/standalone/node_modules/ — ALL pnpm symlinks that Next.js
+ *    standalone traced as runtime dependencies
+ */
+
+import {
+  cpSync,
+  lstatSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+
+function derefSymlink(target) {
+  let stat;
+  try {
+    stat = lstatSync(target);
+  } catch {
+    return false;
+  }
+  if (!stat.isSymbolicLink()) return false;
+
+  const realPath = realpathSync(target);
+  rmSync(target, { force: true });
+  cpSync(realPath, target, { recursive: true, dereference: true });
+  return true;
+}
+
+// --- 1. Root node_modules: explicit packages ---
+
+console.log("Dereferencing root node_modules packages...");
+const rootPackages = [
+  "node_modules/@electric-sql/pglite",
+  "node_modules/@electric-sql/pglite-socket",
+  "node_modules/dotenv",
+];
+
+for (const pkg of rootPackages) {
+  const target = join(process.cwd(), pkg);
+  if (derefSymlink(target)) {
+    console.log(`  deref: ${pkg}`);
+  } else {
+    try {
+      lstatSync(target);
+      console.log(`  ok:    ${pkg}`);
+    } catch {
+      console.log(`  skip:  ${pkg} (not found)`);
+    }
+  }
+}
+
+// --- 2. Standalone node_modules: walk and dereference all symlinks ---
+
+console.log("Dereferencing .next/standalone/node_modules symlinks...");
+const standaloneNm = join(process.cwd(), ".next", "standalone", "node_modules");
+let derefCount = 0;
+
+function walkAndDeref(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    // Skip the .pnpm directory itself — we only want to deref the top-level
+    // package symlinks that point into .pnpm/
+    if (entry.name === ".pnpm") continue;
+
+    let stat;
+    try {
+      stat = lstatSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isSymbolicLink()) {
+      if (derefSymlink(fullPath)) {
+        derefCount++;
+      }
+    } else if (stat.isDirectory() && entry.name.startsWith("@")) {
+      // Scoped packages: walk one level deeper
+      walkAndDeref(fullPath);
+    }
+  }
+}
+
+walkAndDeref(standaloneNm);
+console.log(`  dereferenced ${derefCount} symlinks`);
+
+// --- 3. Remove the now-orphaned .pnpm directory ---
+
+const pnpmDir = join(standaloneNm, ".pnpm");
+try {
+  rmSync(pnpmDir, { recursive: true, force: true });
+  console.log("  removed .pnpm directory");
+} catch {
+  // ignore
+}
+
+// --- 4. Copy static assets and public/ into standalone directory ---
+// Next.js standalone server.js expects .next/static/ and public/ relative
+// to its own directory (.next/standalone/), but `next build` outputs them
+// at the project root. Docker does this via COPY; we do it here for npm.
+
+const standaloneDir = join(process.cwd(), ".next", "standalone");
+
+console.log("Copying static assets into standalone directory...");
+const staticSrc = join(process.cwd(), ".next", "static");
+const staticDst = join(standaloneDir, ".next", "static");
+cpSync(staticSrc, staticDst, { recursive: true });
+console.log("  copied .next/static/");
+
+const publicSrc = join(process.cwd(), "public");
+const publicDst = join(standaloneDir, "public");
+cpSync(publicSrc, publicDst, { recursive: true });
+console.log("  copied public/");
+
+console.log("Prepack complete.");


### PR DESCRIPTION
## Summary
- Add `chorus.mjs` CLI entry script — pure Node.js startup orchestration (PGlite → migrate → Next.js standalone server)
- Add `scripts/prepack-pglite.mjs` — dereference pnpm symlinks + copy static assets into standalone for npm distribution
- Add `scripts/npm-publish.sh` — build → pack → smoke test → publish workflow
- Configure `package.json` for npm: `bin`, `files`, `prepack`, prisma moved to deps, metadata
- Add Quick Start section to README (en/zh) with install + usage instructions

## Changed files
| File | Change |
|------|--------|
| `chorus.mjs` | New — CLI entry: arg parsing, PGlite startup, migration, server launch, graceful shutdown |
| `scripts/prepack-pglite.mjs` | New — dereference pnpm symlinks in root + standalone node_modules, copy .next/static + public |
| `scripts/npm-publish.sh` | New — 6-step publish script with pre-flight checks and smoke test |
| `package.json` | Add bin/files/prepack/repository/keywords, move prisma to deps, rename to @chorus-aidlc/chorus |
| `README.md` | Add Quick Start section with install command and options table |
| `README.zh.md` | Add 快速开始 section (Chinese mirror) |
| `.gitignore` | Add .chorus-data/, *.tgz |

## Test plan
- [x] `npm pack` produces valid tarball (14.1MB, 2130 files)
- [x] Global install → `chorus` command starts PGlite + migrations → HTTP 200
- [x] `chorus --help` and `chorus --version` output correctly
- [x] `--port`, `--data-dir` parameters work
- [x] Data persists across restart (no pending migrations on second start)
- [x] Playwright test: login page renders, default credentials work
- [x] Graceful shutdown kills PGlite child process

Generated with [Claude Code](https://claude.com/claude-code)