### PR TITLE
fix: skip already-closed tasks during proposal revoke

### DIFF
--- a/src/services/proposal.service.ts
+++ b/src/services/proposal.service.ts
@@ -777,7 +777,7 @@ export async function approveProposal(
 export async function getMaterializedEntities(companyUuid: string, proposalUuid: string) {
   const [tasks, documents] = await Promise.all([
     prisma.task.findMany({
-      where: { companyUuid, proposalUuid },
+      where: { companyUuid, proposalUuid, status: { not: "closed" } },
       select: { uuid: true, title: true, status: true },
       orderBy: { createdAt: "asc" },
     }),
@@ -814,7 +814,7 @@ export async function revokeProposal(
   // 2. Find all materialized Tasks and Documents before the transaction
   const [tasksToClose, docsToDelete] = await Promise.all([
     prisma.task.findMany({
-      where: { proposalUuid: proposal.uuid },
+      where: { proposalUuid: proposal.uuid, status: { not: "closed" } },
       select: { uuid: true, title: true },
     }),
     prisma.document.findMany({


### PR DESCRIPTION
## Summary
- Filter out `status: closed` tasks in `revokeProposal()` and `getMaterializedEntities()`
- Prevents stale resource accumulation on repeated revoke cycles

## Changed files
| File | Change |
|------|--------|
| `src/services/proposal.service.ts` | Added `status: { not: "closed" }` to task queries in both functions |

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 1298 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)