### PR TITLE
feat: refactor checkin API with idea tracker and notification summary

### DIFF
--- a/public/chorus-plugin/bin/on-session-start.sh
+++ b/public/chorus-plugin/bin/on-session-start.sh
@@ -52,50 +52,23 @@ if command -v jq >/dev/null 2>&1; then
     "$API" state-set "agent_roles" "$_ROLES"
   fi
 
-  # Cache first assignment's projectUuid for Stop hook (to scope to_verify task lookup)
-  _PROJECT_UUID=$(echo "$CHECKIN_RESULT" | jq -r '
-    (.assignments.tasks[0].project.uuid // .assignments.ideas[0].project.uuid) // empty
-  ' 2>/dev/null) || true
-  if [ -n "$_PROJECT_UUID" ]; then
-    "$API" state-set "project_uuid" "$_PROJECT_UUID"
-  fi
 fi
 
 # Build context for Claude (additionalContext)
 CONTEXT="# Chorus Plugin — Active
 
-Chorus is connected at ${CHORUS_URL}.
-Session lifecycle hooks are enabled: SubagentStart, SubagentStop, TeammateIdle, TaskCompleted.
+Chorus is connected at ${CHORUS_URL}. Session lifecycle hooks are enabled.
 
-## Checkin Result
+## Checkin
 
 ${CHECKIN_RESULT}
 
-## Session Management — IMPORTANT
+## Quick Reference
 
-The Chorus Plugin **fully automates** Chorus session lifecycle:
-- Sub-agent spawn → Chorus session auto-created (or reused) + session UUID and workflow auto-injected into sub-agent context
-- Teammate idle → Chorus session heartbeat (automatic)
-- Sub-agent stop → auto checkout all tasks + Chorus session closed
-
-**Do NOT call chorus_create_session or chorus_close_session for sub-agents.** The plugin handles this.
-When spawning sub-agents, just pass Chorus TASK UUIDs in the prompt. Session UUID + workflow are auto-injected by SubagentStart hook.
-
-For your own session (if you are a Developer agent working directly, not via sub-agents):
-call chorus_list_sessions() first, then reopen or create as needed.
-
-To link a Claude Code task to a Chorus task, include \`chorus:task:<uuid>\` in the task description.
-
-## Notifications
-
-When you or your sub-agents receive @mentions or other notifications:
-- \`chorus_get_notifications()\` — fetches unread notifications and **auto-marks them as read**
-- \`chorus_get_notifications({ autoMarkRead: false })\` — peek without marking read
-- No need to call \`chorus_mark_notification_read\` separately after reading
-
-## Project Groups
-
-Projects are organized into Project Groups. Before creating a new project, call \`chorus_get_project_groups()\` to see existing groups and pass the \`groupUuid\` to \`chorus_admin_create_project()\` to assign the project to the correct group. Creating a project without specifying a group puts it in Ungrouped."
+- **Idea Tracker**: Shows up to 10 most recently updated ideas. Use chorus_get_ideas() for full list.
+- **Sessions**: Auto-managed by hooks. Do NOT call chorus_create_session/chorus_close_session for sub-agents. See /chorus:develop.
+- **Notifications**: chorus_get_notifications() fetches and auto-marks read. See /chorus.
+- **Project Groups**: chorus_get_project_groups() before creating projects. See /chorus."
 
 # Check for existing state (resumed session)
 MAIN_SESSION=$("$API" state-get "main_session_uuid" 2>/dev/null) || true
@@ -104,39 +77,6 @@ if [ -n "$MAIN_SESSION" ]; then
 
 Resuming with existing Chorus session: ${MAIN_SESSION}"
   "$API" mcp-tool "chorus_session_heartbeat" "$(printf '{"sessionUuid":"%s"}' "$MAIN_SESSION")" >/dev/null 2>&1 || true
-fi
-
-# Plan A: Session discovery for sub-agents
-SESSIONS_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus/sessions"
-if [ -d "$SESSIONS_DIR" ]; then
-  SESSION_FILES=$(ls "$SESSIONS_DIR"/*.json 2>/dev/null) || true
-  if [ -n "$SESSION_FILES" ]; then
-    SESSION_LIST="
-
-## Pre-assigned Chorus Sessions
-
-The following Chorus sessions were auto-created by the plugin for sub-agents.
-If you are a sub-agent, find your session by matching your agent name:
-"
-    for f in $SESSION_FILES; do
-      BASENAME=$(basename "$f" .json)
-      if command -v jq &>/dev/null; then
-        S_UUID=$(jq -r '.sessionUuid // empty' "$f" 2>/dev/null) || true
-        S_NAME=$(jq -r '.agentName // empty' "$f" 2>/dev/null) || true
-      else
-        S_UUID=$(grep -o '"sessionUuid":"[^"]*"' "$f" 2>/dev/null | cut -d'"' -f4) || true
-        S_NAME="$BASENAME"
-      fi
-      if [ -n "$S_UUID" ]; then
-        SESSION_LIST="${SESSION_LIST}
-- **${S_NAME:-$BASENAME}**: sessionUuid = \`${S_UUID}\`"
-      fi
-    done
-    SESSION_LIST="${SESSION_LIST}
-
-Use your session UUID with \`chorus_session_checkin_task\`, \`chorus_report_work\`, etc."
-    CONTEXT="${CONTEXT}${SESSION_LIST}"
-  fi
 fi
 
 # Build user-visible message

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -21,6 +21,7 @@ import * as projectGroupService from "@/services/project-group.service";
 import * as mentionService from "@/services/mention.service";
 import * as searchService from "@/services/search.service";
 import * as sessionService from "@/services/session.service";
+import * as checkinService from "@/services/checkin.service";
 import { prisma } from "@/lib/prisma";
 
 export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
@@ -331,93 +332,12 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_checkin",
     {
-      description: "Agent check-in. Returns agent identity (including owner/master info), roles, assigned work, and pending counts. Recommended at session start.",
+      description:
+        "Agent check-in. Returns agent identity (owner, roles, persona), a project-grouped idea tracker with derived statuses and proposal/task counts, and up to 5 recent unread notifications (auto-marked read). Recommended at session start.",
       inputSchema: z.object({}),
     },
     async () => {
-      // Update last active time and get Agent info (query by UUID)
-      const agent = await prisma.agent.update({
-        where: { uuid: auth.actorUuid },
-        data: { lastActiveAt: new Date() },
-        select: {
-          uuid: true,
-          name: true,
-          roles: true,
-          persona: true,
-          systemPrompt: true,
-          ownerUuid: true,
-          owner: { select: { uuid: true, name: true, email: true } },
-        },
-      });
-
-      // Get pending Ideas and Tasks
-      const { ideas, tasks } = await assignmentService.getMyAssignments(auth, auth.projectUuids);
-
-      // Get unread notification count
-      const unreadNotificationCount = await notificationService.getUnreadCount(
-        auth.companyUuid,
-        auth.type,
-        auth.actorUuid
-      );
-
-      // Build default persona (if no custom persona is set)
-      const defaultPersonas: Record<string, string> = {
-        pm: `你是一个经验丰富的产品经理 Agent。你的职责是：
-- 分析用户需求，提炼核心问题
-- 将模糊的想法转化为清晰的 PRD
-- 合理拆分任务，估算工作量（以 Agent 小时为单位）
-- 识别风险和依赖关系
-- 与团队保持沟通，推动项目进展
-
-工作风格：务实、注重细节、善于沟通`,
-        developer: `你是一个专业的开发者 Agent。你的职责是：
-- 理解任务需求，编写高质量代码
-- 遵循项目的代码规范和架构约定
-- 完成任务后及时报告进度
-- 遇到问题主动沟通，不做假设
-
-工作风格：严谨、高效、注重代码质量`,
-      };
-
-      // Determine the effective persona
-      let effectivePersona = agent.persona;
-      if (!effectivePersona && agent.roles.length > 0) {
-        effectivePersona = defaultPersonas[agent.roles[0]] || null;
-      }
-
-      // Emit agent_checkin notification to owner on first checkin
-      if (agent.ownerUuid) {
-        await notificationService.emitAgentCheckinIfFirst({
-          companyUuid: auth.companyUuid,
-          agentUuid: agent.uuid,
-          agentName: agent.name,
-          ownerUuid: agent.ownerUuid,
-        });
-      }
-
-      const result = {
-        checkinTime: new Date().toISOString(),
-        agent: {
-          uuid: agent.uuid,
-          name: agent.name,
-          roles: agent.roles,
-          persona: effectivePersona,
-          systemPrompt: agent.systemPrompt,
-          owner: agent.owner ? { uuid: agent.owner.uuid, name: agent.owner.name, email: agent.owner.email } : null,
-        },
-        assignments: {
-          ideas: ideas.filter(i => ["assigned", "in_progress"].includes(i.status)),
-          tasks: tasks.filter(t => ["assigned", "in_progress"].includes(t.status)),
-        },
-        pending: {
-          ideasCount: ideas.length,
-          tasksCount: tasks.length,
-        },
-        notifications: {
-          unreadCount: unreadNotificationCount,
-        },
-      };
-
+      const result = await checkinService.buildCheckinResponse(auth);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       };

--- a/src/services/__tests__/checkin.service.test.ts
+++ b/src/services/__tests__/checkin.service.test.ts
@@ -1,0 +1,539 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Mocks (hoisted) =====
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    agent: {
+      update: vi.fn(),
+    },
+    idea: {
+      findMany: vi.fn(),
+    },
+    proposal: {
+      findMany: vi.fn(),
+    },
+    task: {
+      findMany: vi.fn(),
+    },
+    project: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const { mockNotificationService } = vi.hoisted(() => ({
+  mockNotificationService: {
+    list: vi.fn(),
+    markRead: vi.fn(),
+    emitAgentCheckinIfFirst: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/event-bus", () => ({ eventBus: { emitChange: vi.fn(), emit: vi.fn() } }));
+vi.mock("@/services/notification.service", () => mockNotificationService);
+
+import { buildCheckinResponse } from "@/services/checkin.service";
+import type { AuthContext } from "@/types/auth";
+
+// ===== Test fixtures =====
+
+const COMPANY_UUID = "company-1111-1111-1111-111111111111";
+const AGENT_UUID = "agent-2222-2222-2222-222222222222";
+const OWNER_UUID = "owner-3333-3333-3333-333333333333";
+const PROJECT_A = "project-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PROJECT_B = "project-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const now = new Date("2026-04-23T10:00:00Z");
+
+const auth: AuthContext = {
+  type: "agent",
+  companyUuid: COMPANY_UUID,
+  actorUuid: AGENT_UUID,
+  ownerUuid: OWNER_UUID,
+  roles: ["developer"],
+};
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: AGENT_UUID,
+    name: "Dev Agent",
+    roles: ["developer"],
+    persona: null,
+    systemPrompt: null,
+    ownerUuid: OWNER_UUID,
+    owner: { uuid: OWNER_UUID, name: "Owner User", email: "owner@example.com" },
+    ...overrides,
+  };
+}
+
+function makeIdea(
+  uuid: string,
+  projectUuid: string,
+  status: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    uuid,
+    title: `Idea ${uuid}`,
+    status,
+    elaborationStatus: null,
+    projectUuid,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function emptyNotifications() {
+  return { notifications: [], total: 0, unreadCount: 0 };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.agent.update.mockResolvedValue(makeAgent());
+  mockPrisma.idea.findMany.mockResolvedValue([]);
+  mockPrisma.proposal.findMany.mockResolvedValue([]);
+  mockPrisma.task.findMany.mockResolvedValue([]);
+  mockPrisma.project.findMany.mockResolvedValue([]);
+  mockNotificationService.list.mockResolvedValue(emptyNotifications());
+  mockNotificationService.markRead.mockResolvedValue({});
+  mockNotificationService.emitAgentCheckinIfFirst.mockResolvedValue(true);
+});
+
+// ===== Agent info =====
+
+describe("buildCheckinResponse — agent info", () => {
+  it("returns agent identity with owner", async () => {
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.agent.uuid).toBe(AGENT_UUID);
+    expect(result.agent.name).toBe("Dev Agent");
+    expect(result.agent.roles).toEqual(["developer"]);
+    expect(result.agent.owner).toEqual({
+      uuid: OWNER_UUID,
+      name: "Owner User",
+      email: "owner@example.com",
+    });
+  });
+
+  it("returns custom persona when set", async () => {
+    mockPrisma.agent.update.mockResolvedValue(makeAgent({ persona: "custom-persona" }));
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.agent.persona).toBe("custom-persona");
+  });
+
+  it("returns null persona when agent has none", async () => {
+    mockPrisma.agent.update.mockResolvedValue(makeAgent({ persona: null }));
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.agent.persona).toBeNull();
+  });
+
+  it("returns null owner when agent has none", async () => {
+    mockPrisma.agent.update.mockResolvedValue(makeAgent({ ownerUuid: null, owner: null }));
+
+    const result = await buildCheckinResponse({ ...auth, ownerUuid: undefined });
+
+    expect(result.agent.owner).toBeNull();
+    expect(mockNotificationService.emitAgentCheckinIfFirst).not.toHaveBeenCalled();
+  });
+
+  it("emits first-checkin notification when owner is present", async () => {
+    await buildCheckinResponse(auth);
+
+    expect(mockNotificationService.emitAgentCheckinIfFirst).toHaveBeenCalledWith({
+      companyUuid: COMPANY_UUID,
+      agentUuid: AGENT_UUID,
+      agentName: "Dev Agent",
+      ownerUuid: OWNER_UUID,
+    });
+  });
+
+  it("sets checkinTime to an ISO string", async () => {
+    const result = await buildCheckinResponse(auth);
+    expect(result.checkinTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ===== Idea tracker =====
+
+describe("buildCheckinResponse — ideaTracker", () => {
+  it("returns empty tracker when agent has no assigned ideas", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([]);
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.ideaTracker).toEqual({});
+  });
+
+  it("queries ideas assigned to agent OR agent's owner", async () => {
+    await buildCheckinResponse(auth);
+
+    const call = mockPrisma.idea.findMany.mock.calls[0][0];
+    expect(call.where.OR).toEqual([
+      { assigneeType: "agent", assigneeUuid: AGENT_UUID },
+      { assigneeType: "user", assigneeUuid: OWNER_UUID },
+    ]);
+    expect(call.where.status).toEqual({ not: "closed" });
+    expect(call.where.companyUuid).toBe(COMPANY_UUID);
+  });
+
+  it("queries only agent condition when owner is absent", async () => {
+    await buildCheckinResponse({ ...auth, ownerUuid: undefined });
+
+    const call = mockPrisma.idea.findMany.mock.calls[0][0];
+    expect(call.where.OR).toEqual([{ assigneeType: "agent", assigneeUuid: AGENT_UUID }]);
+  });
+
+  it("groups ideas by project with project name", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("idea-a1", PROJECT_A, "open"),
+      makeIdea("idea-a2", PROJECT_A, "elaborating", { elaborationStatus: "validating" }),
+      makeIdea("idea-b1", PROJECT_B, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([
+      { uuid: PROJECT_A, name: "Project A" },
+      { uuid: PROJECT_B, name: "Project B" },
+    ]);
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.ideaTracker[PROJECT_A].name).toBe("Project A");
+    expect(result.ideaTracker[PROJECT_A].ideas).toHaveLength(2);
+    expect(result.ideaTracker[PROJECT_B].name).toBe("Project B");
+    expect(result.ideaTracker[PROJECT_B].ideas).toHaveLength(1);
+  });
+
+  it("emits derived status for each idea", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("idea-todo", PROJECT_A, "open"),
+      makeIdea("idea-research", PROJECT_A, "elaborating", { elaborationStatus: "validating" }),
+      makeIdea("idea-answer", PROJECT_A, "elaborating", { elaborationStatus: "pending_answers" }),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const result = await buildCheckinResponse(auth);
+
+    const byUuid = Object.fromEntries(result.ideaTracker[PROJECT_A].ideas.map((i) => [i.uuid, i]));
+    expect(byUuid["idea-todo"].status).toBe("todo");
+    expect(byUuid["idea-research"].status).toBe("in_progress");
+    expect(byUuid["idea-answer"].status).toBe("human_conduct_required");
+  });
+
+  it("filters out ideas with derivedStatus=done", async () => {
+    const doneProposal = "proposal-done";
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("idea-active", PROJECT_A, "open"),
+      makeIdea("idea-done", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: doneProposal, status: "approved", inputUuids: ["idea-done"], createdAt: now },
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: doneProposal, status: "done" },
+      { proposalUuid: doneProposal, status: "done" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.ideaTracker[PROJECT_A].ideas.map((i) => i.uuid)).toEqual(["idea-active"]);
+  });
+
+  it("excludes closed ideas at the query level", async () => {
+    // The Prisma query filter (not: "closed") is responsible for excluding closed ideas.
+    // Verify that filter is actually on the query so it can't regress silently.
+    await buildCheckinResponse(auth);
+    const call = mockPrisma.idea.findMany.mock.calls[0][0];
+    expect(call.where.status).toEqual({ not: "closed" });
+  });
+
+  it("computes proposals count across pending + approved", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "elaborated")]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "proposal-p", status: "pending", inputUuids: ["idea-1"], createdAt: now },
+      { uuid: "proposal-a", status: "approved", inputUuids: ["idea-1"], createdAt: now },
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "proposal-a", status: "open" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const result = await buildCheckinResponse(auth);
+
+    const idea = result.ideaTracker[PROJECT_A].ideas[0];
+    expect(idea.proposals).toBe(2);
+    expect(idea.tasks).toBe(1);
+  });
+
+  it("reports 0 tasks when idea has no approved proposal", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "elaborated")]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "proposal-p", status: "pending", inputUuids: ["idea-1"], createdAt: now },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const result = await buildCheckinResponse(auth);
+
+    const idea = result.ideaTracker[PROJECT_A].ideas[0];
+    expect(idea.proposals).toBe(1);
+    expect(idea.tasks).toBe(0);
+  });
+
+  it("uses the latest approved proposal for task counting", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "elaborated")]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      {
+        uuid: "proposal-new",
+        status: "approved",
+        inputUuids: ["idea-1"],
+        createdAt: new Date("2026-03-01T00:00:00Z"),
+      },
+      {
+        uuid: "proposal-old",
+        status: "approved",
+        inputUuids: ["idea-1"],
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "proposal-new", status: "open" },
+      { proposalUuid: "proposal-new", status: "in_progress" },
+      { proposalUuid: "proposal-old", status: "done" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const result = await buildCheckinResponse(auth);
+
+    const idea = result.ideaTracker[PROJECT_A].ideas[0];
+    expect(idea.proposals).toBe(2);
+    expect(idea.tasks).toBe(2);
+  });
+
+  it("ignores proposal inputUuids that point to ideas outside the tracked set", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "elaborated")]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      {
+        uuid: "proposal-x",
+        status: "approved",
+        inputUuids: ["idea-1", "idea-unrelated"],
+        createdAt: now,
+      },
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([{ proposalUuid: "proposal-x", status: "open" }]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.ideaTracker[PROJECT_A].ideas[0].proposals).toBe(1);
+  });
+
+  it("skips task query when no approved proposals are in scope", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "open")]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    await buildCheckinResponse(auth);
+
+    expect(mockPrisma.task.findMany).not.toHaveBeenCalled();
+  });
+
+  it("falls back to empty name when project not found", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "open")]);
+    mockPrisma.project.findMany.mockResolvedValue([]);
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.ideaTracker[PROJECT_A].name).toBe("");
+  });
+
+  it("tolerates proposals with non-array inputUuids", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "elaborated")]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "p-bad", status: "approved", inputUuids: "oops", createdAt: now },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const result = await buildCheckinResponse(auth);
+
+    const idea = result.ideaTracker[PROJECT_A].ideas[0];
+    expect(idea.proposals).toBe(0);
+    expect(idea.tasks).toBe(0);
+  });
+
+  it("runs exactly 3 entity queries when there are approved proposals", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([makeIdea("idea-1", PROJECT_A, "elaborated")]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "p-1", status: "approved", inputUuids: ["idea-1"], createdAt: now },
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([{ proposalUuid: "p-1", status: "open" }]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    await buildCheckinResponse(auth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.proposal.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.project.findMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===== Notifications =====
+
+describe("buildCheckinResponse — notifications", () => {
+  it("returns empty recent list when no unread notifications", async () => {
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.notifications.recent).toEqual([]);
+    expect(result.notifications.unread).toBe(0);
+    expect(mockNotificationService.markRead).not.toHaveBeenCalled();
+  });
+
+  it("returns top 5 unread in slim format and marks them as read", async () => {
+    mockNotificationService.list.mockResolvedValue({
+      notifications: [
+        {
+          uuid: "notif-1",
+          action: "mentioned",
+          entityType: "task",
+          entityTitle: "Fix bug X",
+          actorName: "Alice",
+          createdAt: "2026-04-23T09:00:00.000Z",
+        },
+        {
+          uuid: "notif-2",
+          action: "task_assigned",
+          entityType: "task",
+          entityTitle: "Ship feature Y",
+          actorName: "Bob",
+          createdAt: "2026-04-23T08:30:00.000Z",
+        },
+      ],
+      total: 2,
+      unreadCount: 7,
+    });
+
+    const result = await buildCheckinResponse(auth);
+
+    expect(result.notifications.recent).toEqual([
+      {
+        uuid: "notif-1",
+        action: "mentioned",
+        entity: "task",
+        title: "Fix bug X",
+        actor: "Alice",
+        at: "2026-04-23T09:00:00.000Z",
+      },
+      {
+        uuid: "notif-2",
+        action: "task_assigned",
+        entity: "task",
+        title: "Ship feature Y",
+        actor: "Bob",
+        at: "2026-04-23T08:30:00.000Z",
+      },
+    ]);
+    expect(mockNotificationService.markRead).toHaveBeenCalledTimes(2);
+    expect(mockNotificationService.markRead).toHaveBeenCalledWith(
+      "notif-1",
+      COMPANY_UUID,
+      "agent",
+      AGENT_UUID,
+    );
+    // unread = total unread (7) - marked (2)
+    expect(result.notifications.unread).toBe(5);
+  });
+
+  it("passes readFilter=unread and take=5 to notification list", async () => {
+    await buildCheckinResponse(auth);
+
+    expect(mockNotificationService.list).toHaveBeenCalledWith({
+      companyUuid: COMPANY_UUID,
+      recipientType: "agent",
+      recipientUuid: AGENT_UUID,
+      readFilter: "unread",
+      take: 5,
+    });
+  });
+
+  it("tolerates markRead failures without throwing — failed marks are not subtracted", async () => {
+    mockNotificationService.list.mockResolvedValue({
+      notifications: [
+        {
+          uuid: "notif-1",
+          action: "mentioned",
+          entityType: "task",
+          entityTitle: "T",
+          actorName: "A",
+          createdAt: "2026-04-23T09:00:00.000Z",
+        },
+        {
+          uuid: "notif-stale",
+          action: "mentioned",
+          entityType: "task",
+          entityTitle: "T",
+          actorName: "A",
+          createdAt: "2026-04-23T08:59:00.000Z",
+        },
+      ],
+      total: 2,
+      unreadCount: 3,
+    });
+    mockNotificationService.markRead.mockImplementation(async (uuid: string) => {
+      if (uuid === "notif-stale") throw new Error("stale");
+      return {};
+    });
+
+    const result = await buildCheckinResponse(auth);
+
+    // 3 unread - 1 successfully marked = 2 remaining
+    expect(result.notifications.unread).toBe(2);
+    expect(result.notifications.recent).toHaveLength(2);
+  });
+
+  it("never reports negative unread (clamped at 0)", async () => {
+    mockNotificationService.list.mockResolvedValue({
+      notifications: [
+        {
+          uuid: "notif-1",
+          action: "mentioned",
+          entityType: "task",
+          entityTitle: "T",
+          actorName: "A",
+          createdAt: "2026-04-23T09:00:00.000Z",
+        },
+      ],
+      total: 1,
+      // unreadCount stale/racey: fewer than what we just marked
+      unreadCount: 0,
+    });
+
+    const result = await buildCheckinResponse(auth);
+    expect(result.notifications.unread).toBe(0);
+  });
+});
+
+// ===== Empty state sanity =====
+
+describe("buildCheckinResponse — empty state", () => {
+  it("returns a well-formed response with no assignments or notifications", async () => {
+    const result = await buildCheckinResponse(auth);
+
+    expect(result).toEqual({
+      checkinTime: expect.any(String),
+      agent: {
+        uuid: AGENT_UUID,
+        name: "Dev Agent",
+        roles: ["developer"],
+        persona: null,
+        systemPrompt: null,
+        owner: { uuid: OWNER_UUID, name: "Owner User", email: "owner@example.com" },
+      },
+      ideaTracker: {},
+      notifications: { unread: 0, recent: [] },
+    });
+  });
+});

--- a/src/services/checkin.service.ts
+++ b/src/services/checkin.service.ts
@@ -1,0 +1,305 @@
+// src/services/checkin.service.ts
+// Checkin service — builds the agent checkin response with ideaTracker + notifications.
+// Uses an agent-centric batch (3 queries + project-name lookup) to avoid per-project N+1.
+
+import { prisma } from "@/lib/prisma";
+import type { AuthContext } from "@/types/auth";
+import { computeDerivedStatus } from "@/services/idea.service";
+import type { DerivedIdeaStatus } from "@/services/idea.service";
+import * as notificationService from "@/services/notification.service";
+
+// ===== Response shape =====
+
+export interface CheckinAgentInfo {
+  uuid: string;
+  name: string;
+  roles: string[];
+  persona: string | null;
+  systemPrompt: string | null;
+  owner: { uuid: string; name: string | null; email: string | null } | null;
+}
+
+export interface CheckinIdea {
+  uuid: string;
+  title: string;
+  status: DerivedIdeaStatus;
+  proposals: number;
+  tasks: number;
+}
+
+export interface CheckinProject {
+  name: string;
+  ideas: CheckinIdea[];
+}
+
+export interface CheckinNotification {
+  uuid: string;
+  action: string;
+  entity: string;
+  title: string;
+  actor: string;
+  at: string;
+}
+
+export interface CheckinResponse {
+  checkinTime: string;
+  agent: CheckinAgentInfo;
+  ideaTracker: Record<string, CheckinProject>;
+  notifications: {
+    unread: number;
+    recent: CheckinNotification[];
+  };
+}
+
+// ===== Service method =====
+
+/**
+ * Build the full checkin response for the current agent auth context.
+ *
+ * Side effects:
+ *   - Updates agent.lastActiveAt
+ *   - Emits first-checkin notification to owner (once per agent lifetime)
+ *   - Marks the 5 returned recent notifications as read
+ */
+export async function buildCheckinResponse(auth: AuthContext): Promise<CheckinResponse> {
+  // Update lastActiveAt + fetch agent info
+  const agent = await prisma.agent.update({
+    where: { uuid: auth.actorUuid },
+    data: { lastActiveAt: new Date() },
+    select: {
+      uuid: true,
+      name: true,
+      roles: true,
+      persona: true,
+      systemPrompt: true,
+      ownerUuid: true,
+      owner: { select: { uuid: true, name: true, email: true } },
+    },
+  });
+
+  // Build idea tracker and fetch notification summary in parallel
+  const [ideaTracker, notifications] = await Promise.all([
+    buildIdeaTracker(auth),
+    buildNotificationSummary(auth),
+  ]);
+
+  // First-checkin notification to owner (fire-and-forget style, but await to surface errors)
+  if (agent.ownerUuid) {
+    await notificationService.emitAgentCheckinIfFirst({
+      companyUuid: auth.companyUuid,
+      agentUuid: agent.uuid,
+      agentName: agent.name,
+      ownerUuid: agent.ownerUuid,
+    });
+  }
+
+  return {
+    checkinTime: new Date().toISOString(),
+    agent: {
+      uuid: agent.uuid,
+      name: agent.name,
+      roles: agent.roles,
+      persona: agent.persona,
+      systemPrompt: agent.systemPrompt,
+      owner: agent.owner
+        ? { uuid: agent.owner.uuid, name: agent.owner.name, email: agent.owner.email }
+        : null,
+    },
+    ideaTracker,
+    notifications,
+  };
+}
+
+// ===== Idea tracker (agent-centric 3-query batch) =====
+
+async function buildIdeaTracker(auth: AuthContext): Promise<Record<string, CheckinProject>> {
+  // Q1: Ideas assigned to the agent OR to the agent's owner.
+  // Exclude legacy "closed" status (terminal) — elaborated/completed/etc. still flow to
+  // ideaTracker so the agent sees downstream proposal/task work.
+  const assigneeConditions: Array<{ assigneeType: string; assigneeUuid: string }> = [
+    { assigneeType: "agent", assigneeUuid: auth.actorUuid },
+  ];
+  if (auth.ownerUuid) {
+    assigneeConditions.push({ assigneeType: "user", assigneeUuid: auth.ownerUuid });
+  }
+
+  const rawIdeas = await prisma.idea.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      OR: assigneeConditions,
+      status: { not: "closed" },
+    },
+    select: {
+      uuid: true,
+      title: true,
+      status: true,
+      elaborationStatus: true,
+      projectUuid: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  if (rawIdeas.length === 0) return {};
+
+  const ideaUuidSet = new Set(rawIdeas.map((i) => i.uuid));
+  const projectUuidSet = new Set(rawIdeas.map((i) => i.projectUuid));
+  const projectUuids = [...projectUuidSet];
+
+  // Q2: Pending + approved proposals in those projects, filtered in-memory by inputUuids overlap.
+  // Scoping by projectUuid keeps the fetch small; JSON overlap filtering in Prisma is awkward.
+  const rawProposals = await prisma.proposal.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      projectUuid: { in: projectUuids },
+      status: { in: ["pending", "approved"] },
+      inputType: "idea",
+    },
+    select: {
+      uuid: true,
+      status: true,
+      inputUuids: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  // Map ideaUuid → { proposalCount, latestApproved, hasPending }
+  const ideaProposalCount = new Map<string, number>();
+  const ideaHasPending = new Set<string>();
+  const ideaLatestApproved = new Map<string, { uuid: string; createdAt: Date }>();
+
+  for (const proposal of rawProposals) {
+    const inputUuids = proposal.inputUuids as unknown;
+    if (!Array.isArray(inputUuids)) continue;
+    for (const ideaUuid of inputUuids) {
+      if (typeof ideaUuid !== "string" || !ideaUuidSet.has(ideaUuid)) continue;
+      ideaProposalCount.set(ideaUuid, (ideaProposalCount.get(ideaUuid) ?? 0) + 1);
+      if (proposal.status === "pending") {
+        ideaHasPending.add(ideaUuid);
+      } else if (proposal.status === "approved") {
+        const existing = ideaLatestApproved.get(ideaUuid);
+        if (!existing || proposal.createdAt > existing.createdAt) {
+          ideaLatestApproved.set(ideaUuid, { uuid: proposal.uuid, createdAt: proposal.createdAt });
+        }
+      }
+    }
+  }
+
+  const approvedProposalUuids = [
+    ...new Set([...ideaLatestApproved.values()].map((p) => p.uuid)),
+  ];
+
+  // Q3: Tasks on the approved proposals
+  const proposalToTaskStatuses = new Map<string, string[]>();
+  if (approvedProposalUuids.length > 0) {
+    const tasks = await prisma.task.findMany({
+      where: {
+        companyUuid: auth.companyUuid,
+        proposalUuid: { in: approvedProposalUuids },
+      },
+      select: { proposalUuid: true, status: true },
+    });
+
+    for (const task of tasks) {
+      if (!task.proposalUuid) continue;
+      const statuses = proposalToTaskStatuses.get(task.proposalUuid) ?? [];
+      statuses.push(task.status);
+      proposalToTaskStatuses.set(task.proposalUuid, statuses);
+    }
+  }
+
+  // Q4: Project names (only for projects that have surviving ideas)
+  const projects = await prisma.project.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      uuid: { in: projectUuids },
+    },
+    select: { uuid: true, name: true },
+  });
+  const projectNames = new Map(projects.map((p) => [p.uuid, p.name]));
+
+  // Compute derivedStatus + group by project, filter out "done", cap at 10 ideas
+  const MAX_IDEAS = 10;
+  const tracker: Record<string, CheckinProject> = {};
+  let count = 0;
+
+  for (const idea of rawIdeas) {
+    if (count >= MAX_IDEAS) break;
+
+    const latestApproved = ideaLatestApproved.get(idea.uuid);
+    const taskStatuses = latestApproved
+      ? proposalToTaskStatuses.get(latestApproved.uuid) ?? []
+      : [];
+
+    const { derivedStatus } = computeDerivedStatus({
+      ideaStatus: idea.status,
+      elaborationStatus: idea.elaborationStatus,
+      hasPendingProposal: ideaHasPending.has(idea.uuid),
+      hasApprovedProposal: !!latestApproved,
+      taskStatuses,
+    });
+
+    if (derivedStatus === "done") continue;
+
+    const projectUuid = idea.projectUuid;
+    if (!tracker[projectUuid]) {
+      tracker[projectUuid] = {
+        name: projectNames.get(projectUuid) ?? "",
+        ideas: [],
+      };
+    }
+
+    tracker[projectUuid].ideas.push({
+      uuid: idea.uuid,
+      title: idea.title,
+      status: derivedStatus,
+      proposals: ideaProposalCount.get(idea.uuid) ?? 0,
+      tasks: taskStatuses.length,
+    });
+    count++;
+  }
+
+  return tracker;
+}
+
+// ===== Notification summary (fetch 5 unread, mark read) =====
+
+async function buildNotificationSummary(auth: AuthContext): Promise<CheckinResponse["notifications"]> {
+  const list = await notificationService.list({
+    companyUuid: auth.companyUuid,
+    recipientType: auth.type,
+    recipientUuid: auth.actorUuid,
+    readFilter: "unread",
+    take: 5,
+  });
+
+  const recent: CheckinNotification[] = list.notifications.map((n) => ({
+    uuid: n.uuid,
+    action: n.action,
+    entity: n.entityType,
+    title: n.entityTitle,
+    actor: n.actorName,
+    at: n.createdAt,
+  }));
+
+  // Mark the fetched items as read. Errors (e.g. stale UUID) should not fail checkin.
+  let markedCount = 0;
+  if (recent.length > 0) {
+    const results = await Promise.all(
+      recent.map((n) =>
+        notificationService
+          .markRead(n.uuid, auth.companyUuid, auth.type, auth.actorUuid)
+          .then(() => true)
+          .catch(() => false),
+      ),
+    );
+    markedCount = results.filter(Boolean).length;
+  }
+
+  return {
+    unread: Math.max(0, list.unreadCount - markedCount),
+    recent,
+  };
+}

--- a/src/services/idea.service.ts
+++ b/src/services/idea.service.ts
@@ -655,6 +655,9 @@ export interface IdeaWithDerivedStatus {
   badgeHint: BadgeHint;
   createdAt: Date;
   updatedAt: Date;
+  projectUuid: string;
+  proposalCount: number;
+  taskCount: number;
 }
 
 /**
@@ -696,14 +699,16 @@ export async function getIdeasWithDerivedStatus(
   });
 
   // Build ideaUuid → latest approved Proposal mapping
-  // Also track which ideas have a pending proposal
+  // Also track which ideas have a pending proposal and count pending+approved per idea
   const ideaToLatestApproved = new Map<string, { uuid: string; createdAt: Date }>();
   const ideasWithPendingProposal = new Set<string>();
+  const ideaProposalCounts = new Map<string, number>();
 
   for (const proposal of proposals) {
     const inputUuids = proposal.inputUuids as string[];
     if (!Array.isArray(inputUuids)) continue;
     for (const ideaUuid of inputUuids) {
+      ideaProposalCounts.set(ideaUuid, (ideaProposalCounts.get(ideaUuid) ?? 0) + 1);
       if (proposal.status === "pending") {
         ideasWithPendingProposal.add(ideaUuid);
       } else if (proposal.status === "approved") {
@@ -763,6 +768,9 @@ export async function getIdeasWithDerivedStatus(
       badgeHint,
       createdAt: idea.createdAt,
       updatedAt: idea.updatedAt,
+      projectUuid,
+      proposalCount: ideaProposalCounts.get(idea.uuid) ?? 0,
+      taskCount: taskStatuses.length,
     };
   });
 }


### PR DESCRIPTION
## Summary
- Replace bloated `assignments`/`pending` response with project-grouped `ideaTracker` (derivedStatus, proposal/task counts, capped at 10 most recently updated ideas)
- Add 5-item notification summary with auto-mark-read in checkin response
- Extract checkin logic into `src/services/checkin.service.ts` with agent-centric 3+1 query batch (no per-project N+1)
- Slim `on-session-start.sh`: remove ~60 lines of redundant static docs, dead `_PROJECT_UUID` extraction, and legacy session file discovery; replace with compact Quick Reference

## Changed files
| File | Change |
|------|--------|
| `src/services/checkin.service.ts` | New service with `buildCheckinResponse()` — ideaTracker + notification summary |
| `src/services/__tests__/checkin.service.test.ts` | 27 unit tests covering grouping, filtering, notifications, edge cases |
| `src/mcp/tools/public.ts` | `chorus_checkin` handler delegates to checkinService, inline logic removed |
| `src/services/idea.service.ts` | `IdeaWithDerivedStatus` extended with proposalCount/taskCount/projectUuid |
| `public/chorus-plugin/bin/on-session-start.sh` | Static docs → 4-line Quick Reference; removed dead code and legacy session discovery |

## Test plan
- [x] 27 new unit tests pass (`pnpm test -- src/services/__tests__/checkin.service.test.ts`)
- [x] Existing idea service tests unaffected (47 pass)
- [x] `npx tsc --noEmit` clean
- [x] `bash -n` syntax check passes on shell script
- [x] Manually verified checkin via MCP on local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)