### PR TITLE
fix: prevent duplicate notification DB writes in multi-container deployments

### DIFF
--- a/src/lib/__tests__/event-bus.test.ts
+++ b/src/lib/__tests__/event-bus.test.ts
@@ -353,6 +353,142 @@ describe('eventBus', () => {
     expect(parsed.data).toEqual(event);
   });
 
+  it('tags Redis-relayed events with _remote: true', async () => {
+    let messageHandler: ((channel: string, message: string) => void) | null = null;
+
+    const mockSub = {
+      ...mockRedis.mockSubscriber,
+      on: vi.fn((event, handler) => {
+        if (event === 'message') {
+          messageHandler = handler;
+        }
+      }),
+    };
+
+    mockRedis.isRedisEnabled.mockReturnValue(true);
+    mockRedis.getRedisPublisher.mockReturnValue(mockRedis.mockPublisher);
+    mockRedis.getRedisSubscriber.mockReturnValue(mockSub);
+
+    vi.resetModules();
+    mockRedis.isRedisEnabled.mockReturnValue(true);
+    mockRedis.getRedisPublisher.mockReturnValue(mockRedis.mockPublisher);
+    mockRedis.getRedisSubscriber.mockReturnValue(mockSub);
+
+    const { eventBus } = await import('../event-bus');
+    // Singleton may already be connected from a prior test — reset and reconnect
+    // so the fresh mock subscriber's `on("message", ...)` handler is registered.
+    await eventBus.disconnect();
+    await eventBus.connect();
+
+    const listener = vi.fn();
+    eventBus.on('change', listener);
+
+    const event: RealtimeEvent = {
+      companyUuid: 'comp-1',
+      projectUuid: 'proj-1',
+      entityType: 'task',
+      entityUuid: 'remote-task-1',
+      action: 'created',
+    };
+
+    const envelope = JSON.stringify({
+      _origin: 'other-instance-id',
+      channel: 'change',
+      data: event,
+    });
+
+    if (messageHandler) {
+      (messageHandler as (channel: string, message: string) => void)('chorus:events', envelope);
+    }
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const received = listener.mock.calls[0][0];
+    expect(received).toMatchObject(event);
+    expect(received._remote).toBe(true);
+
+    // Original envelope data must not be mutated
+    expect((event as RealtimeEvent & { _remote?: boolean })._remote).toBeUndefined();
+
+    eventBus.off('change', listener);
+  });
+
+  it('does not add _remote to locally emitted events', async () => {
+    mockRedis.isRedisEnabled.mockReturnValue(false);
+    mockRedis.getRedisPublisher.mockReturnValue(null);
+    mockRedis.getRedisSubscriber.mockReturnValue(null);
+
+    vi.resetModules();
+    mockRedis.isRedisEnabled.mockReturnValue(false);
+    mockRedis.getRedisPublisher.mockReturnValue(null);
+    mockRedis.getRedisSubscriber.mockReturnValue(null);
+
+    const { eventBus } = await import('../event-bus');
+
+    const listener = vi.fn();
+    eventBus.on('change', listener);
+
+    const event: RealtimeEvent = {
+      companyUuid: 'comp-1',
+      projectUuid: 'proj-1',
+      entityType: 'task',
+      entityUuid: 'local-task-1',
+      action: 'created',
+    };
+
+    eventBus.emitChange(event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const received = listener.mock.calls[0][0];
+    expect(received).toEqual(event);
+    expect(received).not.toHaveProperty('_remote');
+
+    eventBus.off('change', listener);
+  });
+
+  it('does not add _remote when relayed data is a primitive', async () => {
+    let messageHandler: ((channel: string, message: string) => void) | null = null;
+
+    const mockSub = {
+      ...mockRedis.mockSubscriber,
+      on: vi.fn((event, handler) => {
+        if (event === 'message') {
+          messageHandler = handler;
+        }
+      }),
+    };
+
+    mockRedis.isRedisEnabled.mockReturnValue(true);
+    mockRedis.getRedisPublisher.mockReturnValue(mockRedis.mockPublisher);
+    mockRedis.getRedisSubscriber.mockReturnValue(mockSub);
+
+    vi.resetModules();
+    mockRedis.isRedisEnabled.mockReturnValue(true);
+    mockRedis.getRedisPublisher.mockReturnValue(mockRedis.mockPublisher);
+    mockRedis.getRedisSubscriber.mockReturnValue(mockSub);
+
+    const { eventBus } = await import('../event-bus');
+    await eventBus.disconnect();
+    await eventBus.connect();
+
+    const listener = vi.fn();
+    eventBus.on('ping', listener);
+
+    const envelope = JSON.stringify({
+      _origin: 'other-instance-id',
+      channel: 'ping',
+      data: 'hello',
+    });
+
+    if (messageHandler) {
+      (messageHandler as (channel: string, message: string) => void)('chorus:events', envelope);
+    }
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toBe('hello');
+
+    eventBus.off('ping', listener);
+  });
+
   it('ignores malformed Redis messages', async () => {
     let messageHandler: ((channel: string, message: string) => void) | null = null;
 

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -72,8 +72,13 @@ class ChorusEventBus extends EventEmitter {
         const envelope: RedisEnvelope = JSON.parse(message);
         // Skip messages we published ourselves — already delivered locally
         if (envelope._origin === this._instanceId) return;
-        // Emit locally using the original channel name for cross-instance delivery
-        super.emit(envelope.channel, envelope.data);
+        // Tag cross-instance payloads so listeners can distinguish them
+        // from local emits (e.g., skip duplicate DB writes on relayed events)
+        const data =
+          envelope.data !== null && typeof envelope.data === "object"
+            ? { ...(envelope.data as Record<string, unknown>), _remote: true }
+            : envelope.data;
+        super.emit(envelope.channel, data);
       } catch {
         // Ignore malformed messages
       }

--- a/src/services/__tests__/notification-listener.test.ts
+++ b/src/services/__tests__/notification-listener.test.ts
@@ -685,6 +685,26 @@ describe("notification-listener", () => {
     });
   });
 
+  describe("_remote flag (Redis relay deduplication)", () => {
+    it("should call handleActivity for local events (no _remote flag)", async () => {
+      const event = makeEvent({ action: "assigned", targetType: "task" });
+      mockState.activityHandler!(event);
+      // Let the fire-and-forget promise resolve
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockNotificationService.createBatch).toHaveBeenCalled();
+    });
+
+    it("should NOT call handleActivity when event has _remote: true", async () => {
+      const event = { ...makeEvent({ action: "assigned", targetType: "task" }), _remote: true };
+      mockState.activityHandler!(event);
+      // Wait to ensure no async work happens
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockNotificationService.createBatch).not.toHaveBeenCalled();
+      // Also verify no prisma lookups happened — confirms early return
+      expect(mockPrisma.task.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
   describe("recipient resolution edge cases", () => {
     it("should handle comment_added excluding comment author", async () => {
       mockPrisma.task.findUnique.mockResolvedValue({

--- a/src/services/notification-listener.ts
+++ b/src/services/notification-listener.ts
@@ -544,7 +544,10 @@ export async function handleActivity(event: ActivityEvent): Promise<void> {
 }
 
 // Subscribe to activity events
-eventBus.on("activity", (event: ActivityEvent) => {
+eventBus.on("activity", (event: ActivityEvent & { _remote?: boolean }) => {
+  // Skip events relayed from other instances via Redis — the originating
+  // instance already created notifications, so processing again would duplicate.
+  if (event._remote) return;
   // Fire-and-forget — don't block the activity creation flow
   handleActivity(event);
 });


### PR DESCRIPTION
## Summary
- Tag Redis-relayed EventBus events with `_remote: true` so listeners can distinguish local vs cross-instance events
- notification-listener skips `handleActivity()` for remote events, preventing N-duplicate notifications when running N containers
- SSE notification delivery (`notification:*` events) still propagates via Redis for real-time push

## Changed files
| File | Change |
|------|--------|
| `src/lib/event-bus.ts` | Redis subscriber tags re-emitted data with `_remote: true` |
| `src/lib/__tests__/event-bus.test.ts` | 3 new tests: remote-object, local-emit, remote-primitive |
| `src/services/notification-listener.ts` | Early return when `event._remote` is truthy |
| `src/services/__tests__/notification-listener.test.ts` | 2 new tests: local and remote activity event paths |

## Test plan
- [x] Unit tests for EventBus _remote flag (3 tests)
- [x] Unit tests for notification-listener remote skip (2 tests)
- [x] Full test suite: 1355 passed, 1 skipped, 0 failures
- [x] `npx tsc --noEmit` clean

Generated with [Claude Code](https://claude.com/claude-code)