### PR TITLE
feat: add post-completion reviewer+verify reminder via SubagentStart injection

### DIFF
--- a/public/chorus-plugin/bin/on-subagent-start.sh
+++ b/public/chorus-plugin/bin/on-subagent-start.sh
@@ -44,7 +44,7 @@ AGENT_TYPE=$(echo "$EVENT" | jq -r '.agent_type // .agentType // empty' 2>/dev/n
 
 # Skip non-worker agent types (read-only agents don't need sessions)
 case "$(printf '%s' "$AGENT_TYPE" | tr '[:upper:]' '[:lower:]')" in
-  explore|plan|haiku|claude-code-guide|statusline-setup)
+  explore|plan|haiku|claude-code-guide|statusline-setup|chorus:proposal-reviewer|chorus:task-reviewer)
     exit 0
     ;;
 esac
@@ -228,6 +228,16 @@ The plugin manages session lifecycle (heartbeat, close). Do NOT call chorus_crea
    chorus_report_criteria_self_check({ taskUuid: \"<TASK_UUID>\", criteria: [{ uuid: \"<CRITERION_UUID>\", devStatus: \"passed\", devEvidence: \"...\" }] })
 5. Check out: chorus_session_checkout_task({ sessionUuid: \"${SESSION_UUID}\", taskUuid: \"<TASK_UUID>\" })
 6. Submit: chorus_submit_for_verify({ taskUuid: \"<TASK_UUID>\", summary: \"...\" })
+
+**IMPORTANT — include this in your final response to the main agent:**
+When you finish and return your summary, you MUST end it with:
+\`\`\`
+[Chorus post-completion] Task '<TASK_TITLE>' (<TASK_UUID>) submitted for verify.
+Next steps for main agent:
+1. REVIEW — spawn a task-reviewer agent to check code quality
+2. VERIFY — if you have admin_agent role, mark acceptance criteria and call chorus_admin_verify_task; otherwise, stop and ask the user to review and verify this task
+\`\`\`
+This ensures the main agent knows to run review and verification.
 
 Replace <TASK_UUID> with the actual Chorus task UUID from your prompt.${OWNER_SECTION}"
 

--- a/public/chorus-plugin/bin/on-subagent-stop.sh
+++ b/public/chorus-plugin/bin/on-subagent-stop.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # on-subagent-stop.sh — SubagentStop hook
 # Triggered when a sub-agent (teammate) exits.
-# Plan D: Auto-checkout from all checked-in tasks, then close the Chorus session.
-# Cleans up state and session files.
+# Auto-checkout from all checked-in tasks, close the Chorus session,
+# clean up state files, and auto-verify if admin AC all passed.
 #
-# Output: JSON with systemMessage (user) + additionalContext (Claude)
+# NOTE: SubagentStop does NOT support additionalContext in Claude Code's
+# hookSpecificOutput schema, and systemMessage only reaches the UI —
+# not the main agent's LLM context. All agent-facing reminders must go
+# through SubagentStart workflow injection instead.
 
 set -euo pipefail
 
@@ -43,7 +46,7 @@ if [ -z "$SESSION_UUID" ]; then
   exit 0
 fi
 
-# === Plan D: Auto-checkout from all checked-in tasks ===
+# === Auto-checkout from all checked-in tasks ===
 CHECKOUT_COUNT=0
 SESSION_DETAIL=$("$API" mcp-tool "chorus_get_session" "$(printf '{"sessionUuid":"%s"}' "$SESSION_UUID")" 2>/dev/null) || true
 
@@ -92,13 +95,8 @@ if [ -n "$AGENT_ID" ] && [ -f "${CLAIMED_DIR}/${AGENT_ID}" ]; then
   rm -f "${CLAIMED_DIR}/${AGENT_ID}"
 fi
 
-# === Auto-dispatch: discover unblocked tasks ===
-UNBLOCKED_INFO=""
+# === Auto-verify: if admin marked all AC, verify the task automatically ===
 if [ "$CLOSE_OK" = true ] && [ -n "$SESSION_DETAIL" ]; then
-  # Extract projectUuid from the session's checked-out tasks or session detail
-  PROJECT_UUID=""
-
-  # Try to get projectUuid from the tasks we just checked out
   FIRST_TASK_UUID=$(echo "$SESSION_DETAIL" | jq -r '
     (.checkins // .sessionTaskCheckins // [])[] | .taskUuid // empty
   ' 2>/dev/null | head -1) || true
@@ -106,109 +104,47 @@ if [ "$CLOSE_OK" = true ] && [ -n "$SESSION_DETAIL" ]; then
   if [ -n "$FIRST_TASK_UUID" ]; then
     TASK_DETAIL=$("$API" mcp-tool "chorus_get_task" "$(printf '{"taskUuid":"%s"}' "$FIRST_TASK_UUID")" 2>/dev/null) || true
     if [ -n "$TASK_DETAIL" ]; then
-      PROJECT_UUID=$(echo "$TASK_DETAIL" | jq -r '.project.uuid // empty' 2>/dev/null) || true
-    fi
-  fi
+      TASK_STATUS=$(echo "$TASK_DETAIL" | jq -r '.status // empty' 2>/dev/null) || true
 
-  if [ -n "$PROJECT_UUID" ]; then
-    UNBLOCKED_RESULT=$("$API" mcp-tool "chorus_get_unblocked_tasks" "$(printf '{"projectUuid":"%s"}' "$PROJECT_UUID")" 2>/dev/null) || true
-    if [ -n "$UNBLOCKED_RESULT" ]; then
-      UNBLOCKED_COUNT=$(echo "$UNBLOCKED_RESULT" | jq -r '.total // 0' 2>/dev/null) || true
-      if [ "${UNBLOCKED_COUNT:-0}" -gt 0 ]; then
-        UNBLOCKED_SUMMARY=$(echo "$UNBLOCKED_RESULT" | jq -r '
-          .tasks[] | "- [\(.status)] \(.title) (uuid: \(.uuid), priority: \(.priority))"
-        ' 2>/dev/null) || true
-        UNBLOCKED_INFO="
-=== UNBLOCKED TASKS (ready for assignment) ===
-${UNBLOCKED_COUNT} task(s) are now unblocked and ready to be claimed/assigned:
-${UNBLOCKED_SUMMARY}
+      if [ "$TASK_STATUS" = "to_verify" ]; then
+        AGENT_ROLES=$("$API" state-get "agent_roles" 2>/dev/null) || true
+        IS_ADMIN="false"
+        case ",$AGENT_ROLES," in
+          *,admin_agent,*) IS_ADMIN="true" ;;
+        esac
 
-Use chorus_get_unblocked_tasks for full details. Consider assigning these to available agents."
-      fi
-    fi
-  fi
-fi
+        if [ "$IS_ADMIN" = "true" ]; then
+          AC_TOTAL=$(echo "$TASK_DETAIL" | jq -r '.acceptanceSummary.required // 0' 2>/dev/null) || true
+          ADMIN_PASSED=$(echo "$TASK_DETAIL" | jq -r '.acceptanceSummary.requiredPassed // 0' 2>/dev/null) || true
 
-# === Verify reminder: check if sub-agent's task(s) need admin verification ===
-VERIFY_INFO=""
-if [ -n "${TASK_DETAIL:-}" ]; then
-  TASK_STATUS=$(echo "$TASK_DETAIL" | jq -r '.status // empty' 2>/dev/null) || true
-  TASK_TITLE=$(echo "$TASK_DETAIL" | jq -r '.title // empty' 2>/dev/null) || true
-
-  if [ "$TASK_STATUS" = "to_verify" ]; then
-    AGENT_ROLES=$("$API" state-get "agent_roles" 2>/dev/null) || true
-    IS_ADMIN="false"
-    case ",$AGENT_ROLES," in
-      *,admin_agent,*) IS_ADMIN="true" ;;
-    esac
-
-    if [ "$IS_ADMIN" = "true" ]; then
-      AC_TOTAL=$(echo "$TASK_DETAIL" | jq -r '.acceptanceSummary.required // 0' 2>/dev/null) || true
-      ADMIN_PASSED=$(echo "$TASK_DETAIL" | jq -r '.acceptanceSummary.requiredPassed // 0' 2>/dev/null) || true
-      DEV_PASSED=$(echo "$TASK_DETAIL" | jq -r '
-        [.acceptanceCriteriaItems[]? | select(.required == true and .devStatus == "passed")] | length
-      ' 2>/dev/null) || true
-
-      # Downstream dependencies
-      DEPENDED_BY_COUNT=$(echo "$TASK_DETAIL" | jq -r '.dependedBy | length // 0' 2>/dev/null) || true
-      DOWNSTREAM_NOTE=""
-      if [ "${DEPENDED_BY_COUNT:-0}" -gt 0 ]; then
-        DEPENDED_BY_LIST=$(echo "$TASK_DETAIL" | jq -r '.dependedBy[] | "  - \(.title) (\(.status))"' 2>/dev/null) || true
-        DOWNSTREAM_NOTE=" Verifying will unblock ${DEPENDED_BY_COUNT} downstream task(s):
-${DEPENDED_BY_LIST}"
-      fi
-
-      # Case 1: Admin already marked all AC → auto-verify
-      if [ "${AC_TOTAL:-0}" -gt 0 ] && [ "$AC_TOTAL" = "$ADMIN_PASSED" ]; then
-        VERIFY_RESULT=$("$API" mcp-tool "chorus_admin_verify_task" \
-          "$(printf '{"taskUuid":"%s"}' "$FIRST_TASK_UUID")" 2>/dev/null) || true
-        VERIFY_OK=$(echo "$VERIFY_RESULT" | jq -r '.status // empty' 2>/dev/null) || true
-        if [ "$VERIFY_OK" = "done" ]; then
-          VERIFY_INFO="
-=== AUTO-VERIFIED ===
-Task '${TASK_TITLE}' (${FIRST_TASK_UUID}) — admin AC all passed, auto-verified to done.${DOWNSTREAM_NOTE}"
+          if [ "${AC_TOTAL:-0}" -gt 0 ] && [ "$AC_TOTAL" = "$ADMIN_PASSED" ]; then
+            "$API" mcp-tool "chorus_admin_verify_task" \
+              "$(printf '{"taskUuid":"%s"}' "$FIRST_TASK_UUID")" \
+              >/dev/null 2>&1 || true
+          fi
         fi
 
-      # Case 2: Dev self-check all passed, admin not reviewed → remind
-      elif [ "${AC_TOTAL:-0}" -gt 0 ] && [ "${DEV_PASSED:-0}" = "$AC_TOTAL" ]; then
-        VERIFY_INFO="
-=== VERIFY NEEDED ===
-Task '${TASK_TITLE}' (${FIRST_TASK_UUID}) — dev self-check passed all ${AC_TOTAL} required criteria (admin: ${ADMIN_PASSED}/${AC_TOTAL}). Please review with chorus_get_task, mark AC with chorus_mark_acceptance_criteria, then chorus_admin_verify_task.${DOWNSTREAM_NOTE}"
-
-      # Case 3: Dev self-check incomplete → warn
-      elif [ "${AC_TOTAL:-0}" -gt 0 ]; then
-        VERIFY_INFO="
-=== VERIFY WARNING ===
-Task '${TASK_TITLE}' (${FIRST_TASK_UUID}) — dev self-check INCOMPLETE (${DEV_PASSED}/${AC_TOTAL}). Work may be unfinished. Review with chorus_get_task, consider chorus_admin_reopen_task.${DOWNSTREAM_NOTE}"
-
-      # Case 4: No structured AC → generic reminder
-      else
-        VERIFY_INFO="
-=== VERIFY NEEDED ===
-Task '${TASK_TITLE}' (${FIRST_TASK_UUID}) is in to_verify status. Please review and call chorus_admin_verify_task or chorus_admin_reopen_task.${DOWNSTREAM_NOTE}"
+        # Cache project_uuid for other hooks
+        PROJECT_UUID=$(echo "$TASK_DETAIL" | jq -r '.project.uuid // empty' 2>/dev/null) || true
+        if [ -n "$PROJECT_UUID" ]; then
+          "$API" state-set "project_uuid" "$PROJECT_UUID" 2>/dev/null || true
+        fi
       fi
-    fi
-
-    # Cache project_uuid for Stop hook
-    if [ -n "$PROJECT_UUID" ]; then
-      "$API" state-set "project_uuid" "$PROJECT_UUID" 2>/dev/null || true
     fi
   fi
 fi
 
-# === Output ===
+# === Output (UI-only, not visible to main agent LLM) ===
 DISPLAY_NAME="${AGENT_NAME:-${AGENT_ID:0:8}}"
 if [ "$CLOSE_OK" = true ]; then
   USER_MSG="Chorus session closed: '${DISPLAY_NAME}'"
   if [ "$CHECKOUT_COUNT" -gt 0 ]; then
     USER_MSG="${USER_MSG} (auto-checkout ${CHECKOUT_COUNT} task(s))"
   fi
-  # VERIFY_INFO is only in CONTEXT_MSG (for Claude), not USER_MSG (for human)
-  CONTEXT_MSG="Chorus session ${SESSION_UUID} for sub-agent '${DISPLAY_NAME}' closed. ${CHECKOUT_COUNT} task(s) auto-checked-out. State and session file cleaned up.${VERIFY_INFO}${UNBLOCKED_INFO}"
-  "$API" hook-output "$USER_MSG" "$CONTEXT_MSG" "SubagentStop"
+  "$API" hook-output "$USER_MSG" "" "SubagentStop"
 else
   "$API" hook-output \
     "Chorus: failed to close session for '${DISPLAY_NAME}'" \
-    "WARNING: Failed to close Chorus session ${SESSION_UUID} for sub-agent '${DISPLAY_NAME}'. State cleaned up locally." \
+    "" \
     "SubagentStop"
 fi


### PR DESCRIPTION
## Summary
- SubagentStop hook's `additionalContext` and `systemMessage` never reach the main agent's LLM context (confirmed by reading Claude Code source: `hookSpecificOutput` schema has no `SubagentStop` entry, and `systemMessage` only renders as UI attachment)
- Move post-completion reminders into **SubagentStart** workflow injection — subagents now include a `[Chorus post-completion]` block in their final response with review + verify steps (role-aware: admin self-verifies, non-admin asks user)
- Skip reviewer agents (`chorus:proposal-reviewer`, `chorus:task-reviewer`) in SubagentStart to avoid injecting dev workflow into read-only reviewers
- Clean up SubagentStop: remove dead text output (unblocked tasks query, verify reminders), keep only side-effects (auto-checkout, close session, state cleanup, auto-verify)

## Changed files
| File | Change |
|------|--------|
| `public/chorus-plugin/bin/on-subagent-start.sh` | Add reviewer skip list, inject post-completion reminder block into workflow |
| `public/chorus-plugin/bin/on-subagent-stop.sh` | Remove dead text output, keep side-effect logic only |

## Test plan
- [x] E2E: spawned dev subagent — post-completion block appears in subagent return summary
- [x] E2E: spawned chorus:task-reviewer — SubagentStart correctly skipped, no session created
- [x] `bash -n` passes on both scripts
- [x] `pnpm test` — 1354 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)