### PR TITLE
docs: v0.6.6 release blog and landing quickstart redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ## What's New
 
+**[v0.6.6](https://chorus-ai.dev/blog/chorus-v0.6.6-release/)** — npm one-click install (`npx @chorus-aidlc/chorus`), document export (MD/PDF/Word), proposal revoke, faster agent checkin with work status at a glance.
+
 **[v0.6.2](https://chorus-ai.dev/blog/chorus-v0.6.2-release/)** — Embedded PGlite mode (zero-dependency deployment), structured logging with Pino, stateless MCP for horizontal scaling, default port changed to 8637.
 
 **[v0.6.1](https://chorus-ai.dev/blog/chorus-v0.6.1-release/)** — `/yolo` skill: full-auto AI-DLC pipeline (Idea → Proposal → Execute → Verify) with Agent Team parallel execution.

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,6 +26,8 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ## 最近更新
 
+**[v0.6.6](https://chorus-ai.dev/zh/blog/chorus-v0.6.6-release/)** — npm 一键安装（`npx @chorus-aidlc/chorus`）、文档导出（MD/PDF/Word）、Proposal 撤回、优化 Agent Checkin 快速获取工作状态。
+
 **[v0.6.2](https://chorus-ai.dev/zh/blog/chorus-v0.6.2-release/)** — 嵌入式 PGlite 模式（零依赖部署）、Pino 结构化日志、无状态 MCP 支持水平扩展、默认端口改为 8637。
 
 **[v0.6.1](https://chorus-ai.dev/zh/blog/chorus-v0.6.1-release/)** — `/yolo` 技能：全自动 AI-DLC 流水线（Idea → Proposal → Execute → Verify），支持 Agent Team 并行执行。

--- a/packages/landing/src/components/Quickstart.astro
+++ b/packages/landing/src/components/Quickstart.astro
@@ -9,83 +9,49 @@ interface Props {
 const { lang } = Astro.props;
 
 const dockerHubUrl = "https://hub.docker.com/repository/docker/chorusaidlc/chorus-app/general";
-const githubUrl = "https://github.com/Chorus-AIDLC/chorus";
-
-const composeYml = `services:
-  app:
-    image: chorusaidlc/chorus-app:latest
-    ports: ["8637:8637"]
-    environment:
-      - NEXTAUTH_SECRET=change-me-to-a-random-secret
-      - DEFAULT_USER=admin@example.com
-      - DEFAULT_PASSWORD=changeme
-    volumes:
-      - chorus-data:/app/data
-volumes:
-  chorus-data:`;
+const npxCmd = "npx @chorus-aidlc/chorus";
 ---
 
-<div class="quickstart" id="quickstart">
-  <div class="quickstart-card">
-    <div class="quickstart-header">
-      <span class="quickstart-badge">{t(lang, 'quickstart.badge')}</span>
+<section class="quickstart" id="quickstart">
+  <div class="qs-inner">
+    <div class="qs-left">
+      <div class="qs-label">{t(lang, 'quickstart.badge')}</div>
+      <h2>{t(lang, 'quickstart.title')}</h2>
+      <p class="qs-subtitle">{t(lang, 'quickstart.subtitle')}</p>
+      <div class="qs-platforms">
+        <span class="qs-platform">macOS ARM</span>
+        <span class="qs-platform">Linux x86</span>
+        <span class="qs-platform">Linux ARM</span>
+      </div>
+      <p class="qs-docker">{t(lang, 'quickstart.docker').split('<a>')[0]}<a href={dockerHubUrl} target="_blank" rel="noopener noreferrer">{t(lang, 'quickstart.docker').match(/<a>(.*?)<\/a>/)?.[1] ?? 'Docker Hub'}</a>{t(lang, 'quickstart.docker').split('</a>')[1] ?? ''}</p>
     </div>
-    <h2>{t(lang, 'quickstart.title')}</h2>
-    <p>{t(lang, 'quickstart.subtitle').split('<a>')[0]}<a href={dockerHubUrl}>{t(lang, 'quickstart.subtitle').match(/<a>(.*?)<\/a>/)?.[1] ?? 'Docker Hub'}</a>{t(lang, 'quickstart.subtitle').split('</a>')[1] ?? ''}</p>
-    <div class="qs-steps">
-      <div class="qs-step">
-        <div class="qs-num">1</div>
-        <div class="qs-content">
-          <p>{t(lang, 'quickstart.step1').split('<code>')[0]}<code>{t(lang, 'quickstart.step1').match(/<code>(.*?)<\/code>/)?.[1] ?? 'docker-compose.yml'}</code>{t(lang, 'quickstart.step1').split('</code>')[1] ?? ''}</p>
-          <div class="qs-code-wrap">
-            <button class="qs-copy" title="Copy" data-code={composeYml}>
-              <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="7" height="7" rx="1"/><path d="M5 11H4a1 1 0 01-1-1V4a1 1 0 011-1h6a1 1 0 011 1v1"/></svg>
+    <div class="qs-right">
+      <div class="qs-terminal">
+        <div class="qs-terminal-bar">
+          <span class="qs-dot"></span>
+          <span class="qs-dot"></span>
+          <span class="qs-dot"></span>
+        </div>
+        <div class="qs-terminal-body">
+          <div class="qs-line">
+            <span class="qs-prompt">$</span>
+            <span class="qs-cmd">npx</span> @chorus-aidlc/chorus
+            <button class="qs-copy" title="Copy" data-code={npxCmd}>
+              <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="8" width="6" height="6" rx="1"/><path d="M4 10H3.5a1 1 0 01-1-1V3.5a1 1 0 011-1H9a1 1 0 011 1V4"/></svg>
             </button>
-            <pre class="qs-code"><span class="qs-comment"># docker-compose.yml</span>{`
-services:
-  app:
-    `}<span class="qs-flag">image</span>: chorusaidlc/chorus-app:<span class="qs-env">latest</span>{`
-    `}<span class="qs-flag">ports</span>: [<span class="qs-env">"8637:8637"</span>]{`
-    `}<span class="qs-flag">environment</span>:{`
-      - NEXTAUTH_SECRET=`}<span class="qs-env">change-me-to-a-random-secret</span>{`
-      - DEFAULT_USER=`}<span class="qs-env">admin@example.com</span>{`
-      - DEFAULT_PASSWORD=`}<span class="qs-env">changeme</span>{`
-    `}<span class="qs-flag">volumes</span>:{`
-      - chorus-data:/app/data
-`}<span class="qs-flag">volumes</span>:{`
-  chorus-data:`}</pre>
+          </div>
+          <div class="qs-output">
+            <span class="qs-ok">&#10003;</span> {t(lang, 'quickstart.output1')}<br>
+            <span class="qs-ok">&#10003;</span> {t(lang, 'quickstart.output2')}<br>
+            <span class="qs-ok">&#10003;</span> {t(lang, 'quickstart.output3')}<br>
+            <br>
+            <span class="qs-ready">&#9654;</span> <a href="http://localhost:8637" class="qs-url" target="_blank" rel="noopener noreferrer">http://localhost:8637</a>
           </div>
         </div>
       </div>
-      <div class="qs-step">
-        <div class="qs-num">2</div>
-        <div class="qs-content">
-          <p>{t(lang, 'quickstart.step2')}</p>
-          <div class="qs-code-wrap">
-            <button class="qs-copy" title="Copy" data-code="docker compose up -d">
-              <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="7" height="7" rx="1"/><path d="M5 11H4a1 1 0 01-1-1V4a1 1 0 011-1h6a1 1 0 011 1v1"/></svg>
-            </button>
-            <pre class="qs-code"><span class="qs-cmd">docker compose</span> up -d</pre>
-          </div>
-        </div>
-      </div>
-      <div class="qs-step">
-        <div class="qs-num">3</div>
-        <div class="qs-content">
-          <p>{t(lang, 'quickstart.step3').split('<a>')[0]}<a href="http://localhost:8637">{t(lang, 'quickstart.step3').match(/<a>(.*?)<\/a>/)?.[1] ?? 'http://localhost:8637'}</a>{t(lang, 'quickstart.step3').split('</a>')[1] ?? ''}</p>
-          <div class="qs-arch">
-            <span class="qs-arch-tag">linux/amd64</span>
-            <span class="qs-arch-tag">linux/arm64</span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="qs-footer">
-      <a href={dockerHubUrl} class="qs-link qs-link-primary">{t(lang, 'quickstart.dockerHub')}</a>
-      <a href={githubUrl} class="qs-link qs-link-outline">{t(lang, 'quickstart.github')}</a>
     </div>
   </div>
-</div>
+</section>
 
 <script>
   document.querySelectorAll('.qs-copy').forEach(btn => {
@@ -93,10 +59,10 @@ services:
       const code = (btn as HTMLElement).dataset.code || '';
       navigator.clipboard.writeText(code).then(() => {
         btn.classList.add('copied');
-        btn.innerHTML = '<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 8 7 11 12 5"/></svg>';
+        btn.innerHTML = '<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 7 6 10 11 4"/></svg>';
         setTimeout(() => {
           btn.classList.remove('copied');
-          btn.innerHTML = '<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="7" height="7" rx="1"/><path d="M5 11H4a1 1 0 01-1-1V4a1 1 0 011-1h6a1 1 0 011 1v1"/></svg>';
+          btn.innerHTML = '<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="8" width="6" height="6" rx="1"/><path d="M4 10H3.5a1 1 0 01-1-1V3.5a1 1 0 011-1H9a1 1 0 011 1V4"/></svg>';
         }, 2000);
       });
     });
@@ -105,144 +71,165 @@ services:
 
 <style>
   .quickstart {
-    max-width: 800px; margin: 0 auto;
-    padding: 0 32px 80px;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 32px 20px;
   }
-  .quickstart-card {
-    background: var(--text-primary);
-    border-radius: 20px;
-    padding: 48px;
-    position: relative;
-    overflow: hidden;
+  .qs-inner {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+    align-items: center;
   }
-  .quickstart-card::before {
-    content: '';
-    position: absolute; top: 0; right: 0;
-    width: 200px; height: 200px;
-    background: radial-gradient(circle, rgba(198,122,82,0.15), transparent 70%);
+  .qs-label {
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--primary);
+    margin-bottom: 12px;
   }
-  .quickstart-header {
-    display: flex; align-items: center; gap: 12px;
-    margin-bottom: 8px;
+  .qs-left h2 {
+    font-size: clamp(28px, 4vw, 38px);
+    font-weight: 800;
+    letter-spacing: -0.8px;
+    line-height: 1.15;
+    margin-bottom: 16px;
   }
-  .quickstart-badge {
+  .qs-subtitle {
+    font-size: 16px;
+    color: var(--text-secondary);
+    line-height: 1.7;
+    margin-bottom: 20px;
+  }
+  .qs-platforms {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+  }
+  .qs-platform {
     padding: 4px 12px;
     border-radius: 6px;
-    font-size: 12px; font-weight: 700;
-    background: rgba(198,122,82,0.2);
-    color: var(--primary-light);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
+    font-size: 12px;
+    font-weight: 600;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    background: rgba(198,122,82,0.08);
+    color: var(--primary-dark);
+    border: 1px solid rgba(198,122,82,0.15);
   }
-  .quickstart-card h2 {
-    font-size: 28px; font-weight: 800;
-    color: #fff;
-    margin-bottom: 8px;
-  }
-  .quickstart-card > p {
-    font-size: 15px;
-    color: rgba(255,255,255,0.5);
-    margin-bottom: 28px;
-  }
-  .quickstart-card > p a {
-    color: var(--primary-light);
-    text-decoration: none;
-  }
-  .quickstart-card > p a:hover { text-decoration: underline; }
-  .qs-steps {
-    display: flex; flex-direction: column; gap: 20px;
-  }
-  .qs-step {
-    display: flex; gap: 16px; align-items: flex-start;
-  }
-  .qs-num {
-    width: 28px; height: 28px;
-    border-radius: 8px;
-    background: var(--primary);
-    color: #fff;
-    display: flex; align-items: center; justify-content: center;
-    font-size: 13px; font-weight: 700;
-    flex-shrink: 0;
-    margin-top: 2px;
-  }
-  .qs-content { flex: 1; }
-  .qs-content p {
+  .qs-docker {
     font-size: 14px;
-    color: rgba(255,255,255,0.6);
-    margin-bottom: 8px;
+    color: var(--text-tertiary);
+    line-height: 1.6;
   }
-  .qs-content p a {
+  .qs-docker a {
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .qs-docker a:hover { text-decoration: underline; }
+
+  /* Terminal */
+  .qs-terminal {
+    background: #1a1a2e;
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow:
+      0 20px 60px rgba(0,0,0,0.15),
+      0 0 0 1px rgba(255,255,255,0.05) inset;
+  }
+  .qs-terminal-bar {
+    display: flex;
+    gap: 7px;
+    padding: 14px 18px;
+    background: rgba(255,255,255,0.04);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .qs-dot {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.12);
+  }
+  .qs-dot:first-child { background: #ff5f57; }
+  .qs-dot:nth-child(2) { background: #febc2e; }
+  .qs-dot:nth-child(3) { background: #28c840; }
+  .qs-terminal-body {
+    padding: 20px 22px 24px;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 13.5px;
+    line-height: 1.8;
+  }
+  .qs-line {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: rgba(255,255,255,0.8);
+    margin-bottom: 16px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .qs-prompt {
+    color: #28c840;
+    font-weight: 700;
+    user-select: none;
+  }
+  .qs-cmd {
+    color: #7dd3fc;
+  }
+  .qs-copy {
+    margin-left: auto;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.1);
+    color: rgba(255,255,255,0.4);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+    flex-shrink: 0;
+  }
+  .qs-copy:hover {
+    background: rgba(255,255,255,0.12);
+    color: rgba(255,255,255,0.7);
+  }
+  .qs-copy:global(.copied) {
+    background: var(--green);
+    border-color: var(--green);
+    color: #fff;
+  }
+  .qs-output {
+    color: rgba(255,255,255,0.45);
+    font-size: 12.5px;
+    line-height: 2;
+  }
+  .qs-ok {
+    color: #28c840;
+  }
+  .qs-ready {
+    color: var(--primary);
+  }
+  .qs-url {
     color: #7dd3fc;
     text-decoration: none;
   }
-  .qs-content p a:hover { text-decoration: underline; }
-  .qs-content code {
-    color: rgba(255,255,255,0.8);
+  .qs-url:hover {
+    text-decoration: underline;
   }
-  .qs-code-wrap { position: relative; }
-  .qs-code {
-    background: rgba(0,0,0,0.35);
-    border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 10px;
-    padding: 14px 18px;
-    font-family: 'SF Mono', 'Fira Code', monospace;
-    font-size: 13px;
-    color: rgba(255,255,255,0.8);
-    line-height: 1.7;
-    overflow-x: auto;
-    white-space: pre;
-    margin: 0;
+
+  @media (max-width: 900px) {
+    .qs-inner {
+      grid-template-columns: 1fr;
+      gap: 36px;
+    }
+    .quickstart { padding: 0 20px 60px; }
   }
-  .qs-code :global(.qs-cmd) { color: #7dd3fc; }
-  .qs-code :global(.qs-flag) { color: #a78bfa; }
-  .qs-code :global(.qs-env) { color: #86efac; }
-  .qs-code :global(.qs-comment) { color: rgba(255,255,255,0.3); }
-  .qs-copy {
-    position: absolute; top: 10px; right: 10px;
-    width: 32px; height: 32px;
-    border-radius: 6px;
-    background: rgba(255,255,255,0.08);
-    border: 1px solid rgba(255,255,255,0.12);
-    color: rgba(255,255,255,0.5);
-    cursor: pointer;
-    display: flex; align-items: center; justify-content: center;
-    transition: all 0.2s;
-    z-index: 1;
+  @media (max-width: 480px) {
+    .quickstart { padding: 0 16px 40px; }
+    .qs-terminal-body { padding: 16px; font-size: 12px; }
   }
-  .qs-copy:hover { background: rgba(255,255,255,0.15); color: rgba(255,255,255,0.8); }
-  .qs-copy:global(.copied) { background: var(--green); border-color: var(--green); color: #fff; }
-  .qs-arch {
-    display: flex; gap: 6px; margin-top: 12px;
-  }
-  .qs-arch-tag {
-    padding: 3px 10px;
-    border-radius: 5px;
-    font-size: 11px; font-weight: 600;
-    font-family: 'SF Mono', 'Fira Code', monospace;
-    background: rgba(255,255,255,0.06);
-    color: rgba(255,255,255,0.45);
-    border: 1px solid rgba(255,255,255,0.08);
-  }
-  .qs-footer {
-    margin-top: 28px;
-    display: flex; gap: 12px; flex-wrap: wrap;
-  }
-  .qs-link {
-    display: inline-flex; align-items: center; gap: 6px;
-    padding: 8px 18px;
-    border-radius: 8px;
-    font-size: 13px; font-weight: 600;
-    text-decoration: none;
-    transition: all 0.2s;
-  }
-  .qs-link-primary {
-    background: var(--primary); color: #fff;
-  }
-  .qs-link-primary:hover { background: var(--primary-dark); }
-  .qs-link-outline {
-    background: rgba(255,255,255,0.06);
-    border: 1px solid rgba(255,255,255,0.15);
-    color: rgba(255,255,255,0.7);
-  }
-  .qs-link-outline:hover { border-color: var(--primary); color: var(--primary-light); }
 </style>

--- a/packages/landing/src/content/blog/chorus-v0.6.6-release.md
+++ b/packages/landing/src/content/blog/chorus-v0.6.6-release.md
@@ -1,0 +1,93 @@
+---
+title: "Chorus v0.6.6: One npx, Zero Setup"
+description: "No Docker, no database, no config files. Just npx and a browser. Plus: export your docs."
+date: 2026-04-23
+lang: en
+postSlug: chorus-v0.6.6-release
+---
+
+# Chorus v0.6.6: One npx, Zero Setup
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.6.6 is out. Two things in this release: npm install that actually works everywhere, and document export so your content isn't trapped inside Chorus.
+
+---
+
+## How many people did the install scare off?
+
+You tell a colleague about Chorus. They say "sure, I'll try it." Then you start explaining: install Docker, pull the image, set up compose, configure environment variables...
+
+They haven't opened a terminal yet, and you've already lost half their interest.
+
+v0.6.2 added PGlite as an embedded database and swapped Redis for an in-memory event bus with automatic fallback. Three containers down to one. But "install Docker" was still a prerequisite. For someone who just wants a quick look at what Chorus does, Docker itself is the barrier.
+
+---
+
+## Now npx is all you need
+
+```bash
+npx @chorus-aidlc/chorus
+```
+
+No Docker. No database config. No docker-compose.yml. npx pulls the package, PGlite runs PostgreSQL in-process, migrations run automatically. Open a browser and you're in. 
+
+This works because Chorus runs entirely on WASM and pure JS with zero native C/C++ dependencies. macOS ARM, Linux x86/ARM — npx just works, no build toolchain needed.
+
+For production, Docker Compose with standalone PostgreSQL + Redis is still the recommended setup, especially for multi-agent concurrency. But "just trying it out" shouldn't require any prerequisites.
+
+---
+
+## Community ask: get your docs out
+
+In [Issue #195](https://github.com/Chorus-AIDLC/Chorus/issues/195#issuecomment-4286676685), @songyitao1991 raised a practical point:
+
+> Project delivery always involves client sign-off. You need milestone PRDs and technical docs. Chorus is great for AI-driven development, but it can't produce the traditional deliverables clients expect for review and approval.
+
+Fair point. If AI-generated documents can only be viewed inside Chorus, they're intermediate artifacts in a closed system, not deliverable assets.
+
+v0.6.6 adds document export in three formats:
+
+- **Markdown**: with YAML frontmatter, ready to drop into any docs platform
+- **PDF**: bundled CJK + emoji fonts, Mermaid diagrams rendered as PNG, works out of the box
+- **Word**: syntax-highlighted code blocks, for people who prefer Word over Markdown
+
+Export is available on document detail pages, document list pages, and the proposal editor. Draft documents inside proposals can be exported before approval — no need to wait for sign-off to get the content out.
+
+---
+
+## Other changes
+
+- **Proposal revoke**: Approved proposals can now be revoked. Code going sideways? Revoke the proposal, fix it, resubmit. Revoke cascade-closes materialized tasks and deletes generated documents, resetting to draft. An impact preview dialog prevents accidental triggers.
+- **Checkin API overhaul**: Agents get the full picture in one call — project-grouped idea tracker, unread notification summary, ready to pick up where they left off.
+- **Onboarding improvements**: Back navigation across the Copy Key / Install Plugin / Test Connection steps. No more 5-minute timeout waiting for agent connection — SSE listens indefinitely. A copyable checkin prompt on the waiting screen means new users don't have to dig through docs.
+- **Auto review reminder**: Sub-agents now get a review + verify reminder after task completion. No more manual nudging to submit for verification.
+
+---
+
+## Upgrade
+
+npm users:
+```bash
+npx @chorus-aidlc/chorus@latest
+# or install globally
+npm install -g @chorus-aidlc/chorus
+```
+
+Docker users:
+```bash
+docker compose up -d --pull always
+```
+
+Don't forget to update the Chorus Plugin — the new onboarding flow and review reminders depend on it:
+
+```bash
+# Inside Claude Code
+/plugin marketplace update chorus-plugins
+```
+
+v0.6.6 is on [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.6) and [npm](https://www.npmjs.com/package/@chorus-aidlc/chorus).
+
+Questions or feedback? [GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) or [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions).
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.6.6](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.6)

--- a/packages/landing/src/content/blog/zh-chorus-v0.6.6-release.md
+++ b/packages/landing/src/content/blog/zh-chorus-v0.6.6-release.md
@@ -1,0 +1,93 @@
+---
+title: "Chorus v0.6.6: npx 一键启动"
+description: "Docker 都不用装了。一行 npx 本地跑 Chorus，文档还能导出带走。"
+date: 2026-04-23
+lang: zh
+postSlug: chorus-v0.6.6-release
+---
+
+# Chorus v0.6.6: npx 一键启动
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.6.6 来了。这个版本做了两件事：npm 一键安装本地运行，文档支持导出带走。
+
+---
+
+## 安装劝退了多少人
+
+你跟同事安利 Chorus，对方说"行，我试试"。然后你开始解释：先装 Docker，拉镜像，配 compose，跑起来之后还要配环境变量……
+
+对方还没打开终端，兴趣已经凉了一半。
+
+v0.6.2 加了 PGlite 内嵌数据库，Redis 也换成了内存事件总线自动降级，三个容器缩到一个。但"装 Docker"这个前置条件还在。对于只想快速看一眼 Chorus 长什么样的人来说，Docker 本身就是门槛。
+
+---
+
+## 现在 npx 就够了
+
+```bash
+npx @chorus-aidlc/chorus
+```
+
+不用装 Docker，不用配数据库，不用写 docker-compose.yml。npx 拉包，PGlite 内嵌 PostgreSQL，自动跑 migration，打开浏览器就能用。
+
+能做到这一点，是因为 Chorus 全栈基于 WASM 和纯 JS，不依赖任何原生 C/C++ 模块。macOS ARM、Linux x86/ARM 都能直接跑，不跟编译环境较劲。
+
+正式用的话，Docker Compose 依然是推荐的生产部署方式，独立 PostgreSQL + Redis 更适合多 Agent 并发。但"先跑起来看看"这件事，不应该需要任何前置准备。
+
+---
+
+## 社区要的：把文档带出去
+
+[Issue #195](https://github.com/Chorus-AIDLC/Chorus/issues/195#issuecomment-4286676685) 里 @songyitao1991 提了一个很实际的场景：
+
+> 项目交付必然有与客户确认的环节，需要有一份阶段性的 PRD 和技术文档。Chorus 能够利用 AI 进行规范完整的开发，但不能很好地服务于项目交付，不能阶段性地形成传统的文档性资料与客户进行沟通确认。
+
+说得对。AI 生成的文档如果只能在 Chorus 里看，那它就是个封闭系统的中间产物，不是可交付的资产。
+
+v0.6.6 加了文档导出，三种格式：
+
+- **Markdown**：带 YAML frontmatter，可以直接丢进任何文档系统
+- **PDF**：内置 CJK + emoji 字体，Mermaid 图表渲染成 PNG，开箱即用
+- **Word**：代码块带语法高亮，方便不习惯 Markdown 的人阅读
+
+在文档详情页、文档列表页、Proposal 编辑页都能导出。Proposal 里的文档草稿也能在审批前导出预览，不用等审批通过才能拿到内容。
+
+---
+
+## 其他改动
+
+- **Proposal 撤回**：审批通过的 Proposal 现在可以撤回。发现代码写歪了也不用着急，撤回 Proposal 改完再来。撤回会级联关闭已创建的 Task、删除已生成的 Document，状态回到草稿。操作前有影响预览，不会误触。
+- **Checkin API 重构**：Agent 上线一秒获悉工作全貌，按项目分组的 Idea 追踪器、未读通知摘要一次返回，直接接上之前的工作。
+- **Onboarding 优化**：复制 API Key、安装插件、测试连接三步都可以返回上一步了。等待 Agent 连接不再有 5 分钟超时，SSE 会一直监听。等待页面还加了可复制的 checkin prompt，新人不用翻文档找命令。
+- **完成后自动提醒 Review**：Sub-agent 完成 Task 后会自动收到 Review + Verify 提醒，不再需要人工提醒它提交验证。
+
+---
+
+## 升级
+
+npm 用户：
+```bash
+npx @chorus-aidlc/chorus@latest
+# 或全局安装
+npm install -g @chorus-aidlc/chorus
+```
+
+Docker 用户：
+```bash
+docker compose up -d --pull always
+```
+
+别忘了同步更新 Chorus Plugin，新版本的 Onboarding 流程和 Review 提醒都依赖插件更新：
+
+```bash
+# Claude Code 内执行
+/plugin marketplace update chorus-plugins
+```
+
+v0.6.6 已发布到 [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.6) 和 [npm](https://www.npmjs.com/package/@chorus-aidlc/chorus)。
+
+有问题或反馈？[GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) 或 [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions)。
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.6.6](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.6)

--- a/packages/landing/src/i18n/translations/en.json
+++ b/packages/landing/src/i18n/translations/en.json
@@ -191,12 +191,15 @@
     ]
   },
   "quickstart": {
-    "badge": "Docker",
-    "title": "Run Chorus in 60 Seconds",
-    "subtitle": "Pre-built image on <a>Docker Hub</a>. No external database needed — embedded PGlite included.",
-    "step1": "Create a <code>docker-compose.yml</code>",
-    "step2": "Start it",
-    "step3": "Open <a>http://localhost:8637</a> and log in with your DEFAULT_USER credentials",
+    "badge": "Quick Start",
+    "title": "One Command, Zero Setup",
+    "subtitle": "No Docker, no database, no config files. Embedded PGlite handles everything.",
+    "step1": "Run this in your terminal",
+    "step2": "Open <a>http://localhost:8637</a> and log in — that's it",
+    "output1": "Installing @chorus-aidlc/chorus...",
+    "output2": "Running migrations...",
+    "output3": "Chorus is ready",
+    "docker": "Need production deployment? See <a>Docker Hub</a> for Docker Compose setup.",
     "dockerHub": "Docker Hub",
     "github": "GitHub"
   },

--- a/packages/landing/src/i18n/translations/zh.json
+++ b/packages/landing/src/i18n/translations/zh.json
@@ -191,12 +191,15 @@
     ]
   },
   "quickstart": {
-    "badge": "Docker",
-    "title": "60 秒跑起来",
-    "subtitle": "镜像已发布到 <a>Docker Hub</a>，内置数据库，无需额外依赖。",
-    "step1": "创建 <code>docker-compose.yml</code>",
-    "step2": "一键启动",
-    "step3": "打开 <a>http://localhost:8637</a>，用 DEFAULT_USER 登录",
+    "badge": "Quick Start",
+    "title": "一行命令，直接跑",
+    "subtitle": "不用装 Docker，不用配数据库。内置 PGlite，开箱即用。",
+    "step1": "在终端里执行",
+    "step2": "打开 <a>http://localhost:8637</a> 登录即可",
+    "output1": "Installing @chorus-aidlc/chorus...",
+    "output2": "Running migrations...",
+    "output3": "Chorus is ready",
+    "docker": "生产环境部署？前往 <a>Docker Hub</a> 查看 Docker Compose 方式。",
     "dockerHub": "Docker Hub",
     "github": "GitHub"
   },

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -23,12 +23,12 @@ const lang = 'en' as const;
   <Pipeline lang={lang} />
   <ReversedConversation lang={lang} />
   <Features lang={lang} />
+  <Quickstart lang={lang} />
   <Integration lang={lang} />
   <Showcase lang={lang} />
   <Agents lang={lang} />
   <Workflow lang={lang} />
   <Stats lang={lang} />
-  <Quickstart lang={lang} />
   <Cta lang={lang} />
   <Footer lang={lang} />
 </Layout>

--- a/packages/landing/src/pages/zh/index.astro
+++ b/packages/landing/src/pages/zh/index.astro
@@ -24,12 +24,12 @@ const lang = 'zh' as const;
   <Pipeline lang={lang} />
   <ReversedConversation lang={lang} />
   <Features lang={lang} />
+  <Quickstart lang={lang} />
   <Integration lang={lang} />
   <Showcase lang={lang} />
   <Agents lang={lang} />
   <Workflow lang={lang} />
   <Stats lang={lang} />
-  <Quickstart lang={lang} />
   <Cta lang={lang} />
   <Footer lang={lang} />
 </Layout>


### PR DESCRIPTION
## Summary
- Add bilingual (zh/en) v0.6.6 release blog posts — npm one-click install as primary, document export as secondary
- Redesign landing Quickstart section: replace Docker 3-step flow with npx terminal mockup, two-column layout
- Move Quickstart above Integration for better visual flow (terminal dark bg bridges into Integration dark section)
- Update README What's New for v0.6.6 in both en/zh
- Docker Hub linked as secondary option for production deployment

## Changed files
| File | Change |
|------|--------|
| `packages/landing/src/content/blog/zh-chorus-v0.6.6-release.md` | New: Chinese release blog |
| `packages/landing/src/content/blog/chorus-v0.6.6-release.md` | New: English release blog |
| `packages/landing/src/components/Quickstart.astro` | Redesign: npx terminal mockup, two-column layout |
| `packages/landing/src/i18n/translations/en.json` | Update quickstart i18n keys |
| `packages/landing/src/i18n/translations/zh.json` | Update quickstart i18n keys |
| `packages/landing/src/pages/index.astro` | Move Quickstart before Integration |
| `packages/landing/src/pages/zh/index.astro` | Move Quickstart before Integration |
| `README.md` | Add v0.6.6 to What's New |
| `README.zh.md` | Add v0.6.6 to What's New |

## Test plan
- [x] Landing dev server renders correctly (en + zh)
- [x] Quickstart terminal copy button works
- [x] Responsive layout verified at 1440px and mobile widths
- [x] Blog frontmatter postSlug matches between zh/en versions

Generated with [Claude Code](https://claude.com/claude-code)