### PR TITLE
fix(plugin): clarify reviewer spawn PE and VERDICT handling (v0.7.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "author": {
     "name": "Chorus-AIDLC"
   },
@@ -12,13 +12,13 @@
     "enableProposalReviewer": {
       "type": "boolean",
       "title": "Enable Proposal Reviewer",
-      "description": "Auto-spawn chorus:proposal-reviewer after submitting a proposal. Adds independent quality review but increases token usage.",
+      "description": "Prompt the agent to spawn chorus:proposal-reviewer after submitting a proposal. Adds independent quality review but increases token usage.",
       "default": true
     },
     "enableTaskReviewer": {
       "type": "boolean",
       "title": "Enable Task Reviewer",
-      "description": "Auto-spawn chorus:task-reviewer after submitting a task for verification. Adds independent code review but increases token usage.",
+      "description": "Prompt the agent to spawn chorus:task-reviewer after submitting a task for verification. Adds independent code review but increases token usage.",
       "default": true
     },
     "maxProposalReviewRounds": {

--- a/public/chorus-plugin/bin/on-post-submit-for-verify.sh
+++ b/public/chorus-plugin/bin/on-post-submit-for-verify.sh
@@ -50,8 +50,13 @@ ACTION REQUIRED: Spawn the \`chorus:task-reviewer\` agent to perform an independ
 Example:
   Agent({ subagent_type: \"chorus:task-reviewer\", prompt: \"Review task ${TASK_UUID}. Max review rounds: ${MAX_ROUNDS}. First, read existing comments to count previous VERDICTs and determine your round number. If max > 0 and your round exceeds max, skip the review and post a comment saying the limit was reached — human decision needed. Otherwise, proceed with review. Post your VERDICT as a comment on the task.\" })
 
-The reviewer is read-only and will post its VERDICT as a comment on the task. The result is advisory — the admin makes the final verification decision.
+The reviewer is read-only and will post its VERDICT as a comment on the task.
 
-IMPORTANT: Run the reviewer synchronously (do NOT set run_in_background). Wait for its VERDICT before proceeding with admin verification."
+After the reviewer completes, read comments and find the most recent \`VERDICT:\` line:
+- **VERDICT: PASS** — All AC verified, no issues. Proceed to mark AC and call chorus_admin_verify_task.
+- **VERDICT: PASS WITH NOTES** — All AC verified, minor non-blocking notes. Still proceed to verify.
+- **VERDICT: FAIL** — BLOCKERs found. Do NOT verify. Reopen the task (chorus_admin_reopen_task) and fix the BLOCKERs.
+
+IMPORTANT: Run the reviewer synchronously (do NOT set run_in_background). Wait for its VERDICT before proceeding."
 
 "$API" hook-output "" "$CONTEXT" "PostToolUse"

--- a/public/chorus-plugin/bin/on-post-submit-proposal.sh
+++ b/public/chorus-plugin/bin/on-post-submit-proposal.sh
@@ -50,8 +50,13 @@ ACTION REQUIRED: Spawn the \`chorus:proposal-reviewer\` agent to perform an inde
 Example:
   Agent({ subagent_type: \"chorus:proposal-reviewer\", prompt: \"Review proposal ${PROPOSAL_UUID}. Max review rounds: ${MAX_ROUNDS}. First, read existing comments to count previous VERDICTs and determine your round number. If max > 0 and your round exceeds max, skip the review and post a comment saying the limit was reached — human decision needed. Otherwise, proceed with review. Post your VERDICT as a comment on the proposal.\" })
 
-The reviewer is read-only and will post its VERDICT as a comment on the proposal. The result is advisory — you make the final approval decision.
+The reviewer is read-only and will post its VERDICT as a comment on the proposal.
 
-IMPORTANT: Run the reviewer synchronously (do NOT set run_in_background). Wait for its VERDICT before proceeding with approval."
+After the reviewer completes, read comments and find the most recent \`VERDICT:\` line:
+- **VERDICT: PASS** — No issues found. Proceed to approve (chorus_admin_approve_proposal).
+- **VERDICT: PASS WITH NOTES** — Minor non-blocking notes. Still proceed to approve.
+- **VERDICT: FAIL** — BLOCKERs found. Do NOT approve. Reject the proposal (chorus_pm_reject_proposal), fix BLOCKERs, and resubmit.
+
+IMPORTANT: Run the reviewer synchronously (do NOT set run_in_background). Wait for its VERDICT before proceeding."
 
 "$API" hook-output "" "$CONTEXT" "PostToolUse"

--- a/public/chorus-plugin/bin/on-subagent-start.sh
+++ b/public/chorus-plugin/bin/on-subagent-start.sh
@@ -234,8 +234,9 @@ When you finish and return your summary, you MUST end it with:
 \`\`\`
 [Chorus post-completion] Task '<TASK_TITLE>' (<TASK_UUID>) submitted for verify.
 Next steps for main agent:
-1. REVIEW — spawn a task-reviewer agent to check code quality
-2. VERIFY — if you have admin_agent role, mark acceptance criteria and call chorus_admin_verify_task; otherwise, stop and ask the user to review and verify this task
+1. REVIEW — spawn chorus:task-reviewer agent, then read its VERDICT comment
+2. ACT ON VERDICT: PASS/PASS WITH NOTES → mark AC passed + verify task. FAIL → reopen task and fix BLOCKERs.
+3. If no admin_agent role, stop and ask the user to review and verify this task
 \`\`\`
 This ensures the main agent knows to run review and verification.
 

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.3"
+  version: "0.7.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -279,7 +279,7 @@ If it fails, check: API Key correct (`cho_` prefix)? URL reachable? Claude Code 
 
 ### 5. Review Agent Configuration
 
-The plugin includes two independent review agents that auto-trigger after proposal submission and task verification. Both are **enabled by default**.
+The plugin includes two independent review agents. After proposal submission or task verification, a PostToolUse hook injects context instructing the main agent to spawn the reviewer. The main agent must spawn it manually — it is NOT auto-launched. Both are **enabled by default**.
 
 | Setting | Controls | Default |
 |---------|----------|---------|
@@ -301,7 +301,7 @@ To disable, reconfigure the plugin via `/plugin` settings or manually edit `~/.c
 }
 ```
 
-When enabled, reviewers run as read-only sub-agents and post a VERDICT comment (PASS/FAIL/PARTIAL) on the proposal/task. Results are advisory — they do not block approval or verification. Disabling reduces token usage but removes the independent quality gate.
+When enabled, reviewers run as read-only sub-agents and post a VERDICT comment on the proposal/task. Three possible outcomes: **PASS** (no issues), **PASS WITH NOTES** (minor non-blocking notes), or **FAIL** (BLOCKERs found). Results are advisory — they do not block approval or verification. Disabling reduces token usage but removes the independent quality gate.
 
 ---
 

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -214,7 +214,7 @@ chorus_submit_for_verify({
 
 > `to_verify` does NOT unblock downstream tasks — only `done` (after admin verification) does.
 
-> **Review Agent:** After `chorus_submit_for_verify`, the Chorus plugin's PostToolUse hook injects context instructing you to spawn `chorus:task-reviewer` — an independent, read-only review agent. You MUST spawn it yourself (it is NOT auto-launched). **Run it in foreground** (do NOT set `run_in_background: true`) — wait for the VERDICT before proceeding. The reviewer posts a VERDICT comment on the task.
+> **Review Agent:** After `chorus_submit_for_verify`, the Chorus plugin's PostToolUse hook injects context instructing you to spawn `chorus:task-reviewer` — an independent, read-only review agent. You MUST spawn it yourself (it is NOT auto-launched). **Run it in foreground** (do NOT set `run_in_background`) — wait for the VERDICT before proceeding. The reviewer posts a VERDICT comment on the task.
 
 After the reviewer completes, read its VERDICT:
 ```

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.3"
+  version: "0.7.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -214,18 +214,31 @@ chorus_submit_for_verify({
 
 > `to_verify` does NOT unblock downstream tasks — only `done` (after admin verification) does.
 
-> **Review Agent:** After `chorus_submit_for_verify`, the Chorus plugin's PostToolUse hook will suggest spawning `chorus:task-reviewer` — an independent, read-only review agent. Follow the suggestion to get an adversarial review before admin verification. The reviewer posts a VERDICT comment on the task. Its result is advisory (does not block verification).
+> **Review Agent:** After `chorus_submit_for_verify`, the Chorus plugin's PostToolUse hook injects context instructing you to spawn `chorus:task-reviewer` — an independent, read-only review agent. You MUST spawn it yourself (it is NOT auto-launched). The reviewer posts a VERDICT comment on the task.
+
+After the reviewer completes, read its VERDICT:
+```
+chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+```
+Find the most recent comment containing `VERDICT:` and act on it:
+
+- **VERDICT: PASS** — All AC verified, no issues. Proceed to admin verification.
+- **VERDICT: PASS WITH NOTES** — All AC verified, minor notes. Proceed to admin verification (notes are non-blocking).
+- **VERDICT: FAIL** — BLOCKERs found. Do NOT verify. Fix the BLOCKERs listed in the reviewer's comment, then resubmit.
 
 ### Step 9: Handle Review Feedback
 
-If reopened (verification failed), **all acceptance criteria are reset to pending**.
+If the reviewer returns **FAIL**, or the task is reopened after verification:
+
+**All acceptance criteria are reset to pending** when a task is reopened.
 
 1. Check feedback:
    ```
    chorus_get_task({ taskUuid: "<task-uuid>" })
    chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
    ```
-2. Checkin again, fix issues, report fixes, resubmit.
+2. Fix every BLOCKER listed in the reviewer's FAIL comment.
+3. Checkin again, fix issues, report fixes, resubmit.
 
 ### Step 10: Task Complete
 

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -214,7 +214,7 @@ chorus_submit_for_verify({
 
 > `to_verify` does NOT unblock downstream tasks — only `done` (after admin verification) does.
 
-> **Review Agent:** After `chorus_submit_for_verify`, the Chorus plugin's PostToolUse hook injects context instructing you to spawn `chorus:task-reviewer` — an independent, read-only review agent. You MUST spawn it yourself (it is NOT auto-launched). The reviewer posts a VERDICT comment on the task.
+> **Review Agent:** After `chorus_submit_for_verify`, the Chorus plugin's PostToolUse hook injects context instructing you to spawn `chorus:task-reviewer` — an independent, read-only review agent. You MUST spawn it yourself (it is NOT auto-launched). **Run it in foreground** (do NOT set `run_in_background: true`) — wait for the VERDICT before proceeding. The reviewer posts a VERDICT comment on the task.
 
 After the reviewer completes, read its VERDICT:
 ```

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.3"
+  version: "0.7.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.3"
+  version: "0.7.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.7.3
+version: 0.7.4
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.3"
+  version: "0.7.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -65,7 +65,10 @@ Key responsibilities:
 When reviewing proposals or tasks, prefer spawning an independent reviewer sub-agent over reviewing manually:
 
 1. **Try the reviewer first.** Spawn `chorus:proposal-reviewer` (for proposals) or `chorus:task-reviewer` (for tasks) as a read-only sub-agent. It posts a VERDICT comment with detailed findings.
-2. **Act on the VERDICT.** Read the reviewer's comment, then approve/reject (proposals) or verify/reopen (tasks) based on its findings. VERDICT: FAIL is advisory — you make the final call.
+2. **Read the VERDICT.** After the reviewer completes, call `chorus_get_comments` and find the most recent comment containing `VERDICT:`. There are exactly three possible outcomes:
+   - **VERDICT: PASS** — No issues found. Approve (proposals) or mark AC passed and verify (tasks).
+   - **VERDICT: PASS WITH NOTES** — Minor non-blocking notes. Still approve/verify. Notes are informational.
+   - **VERDICT: FAIL** — BLOCKERs found. Reject (proposals) or reopen (tasks). Fix the specific BLOCKERs listed in the comment before resubmitting.
 3. **Track rounds.** Count existing VERDICT comments before spawning. After 3 rounds of FAIL on the same item, stop the loop and escalate to human review.
 4. **Fallback.** If the reviewer is unavailable (e.g., agent type not registered, sub-agent spawn fails), review the item yourself using the quality checklists in the workflows below.
 
@@ -204,7 +207,10 @@ chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
 
 #### B2.5: Independent Review
 
-Spawn `chorus:task-reviewer` per the [Review Strategy](#review-strategy) above. Read its VERDICT comment before proceeding.
+Spawn `chorus:task-reviewer` per the [Review Strategy](#review-strategy) above. After it completes, read its VERDICT:
+
+- **VERDICT: PASS** or **PASS WITH NOTES** → proceed to B3 (mark AC) and B4 (verify).
+- **VERDICT: FAIL** → skip to B4 and **reopen** the task. Do NOT mark AC as passed.
 
 #### B3: Mark Acceptance Criteria
 

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -64,7 +64,7 @@ Key responsibilities:
 
 When reviewing proposals or tasks, prefer spawning an independent reviewer sub-agent over reviewing manually:
 
-1. **Try the reviewer first.** Spawn `chorus:proposal-reviewer` (for proposals) or `chorus:task-reviewer` (for tasks) as a read-only sub-agent. **Run it in foreground** (do NOT set `run_in_background: true`) — you must wait for the VERDICT before proceeding. It posts a VERDICT comment with detailed findings.
+1. **Try the reviewer first.** Spawn `chorus:proposal-reviewer` (for proposals) or `chorus:task-reviewer` (for tasks) as a read-only sub-agent. **Run it in foreground** (do NOT set `run_in_background`) — you must wait for the VERDICT before proceeding. It posts a VERDICT comment with detailed findings.
 2. **Read the VERDICT.** After the reviewer completes, call `chorus_get_comments` and find the most recent comment containing `VERDICT:`. There are exactly three possible outcomes:
    - **VERDICT: PASS** — No issues found. Approve (proposals) or mark AC passed and verify (tasks).
    - **VERDICT: PASS WITH NOTES** — Minor non-blocking notes. Still approve/verify. Notes are informational.

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -64,7 +64,7 @@ Key responsibilities:
 
 When reviewing proposals or tasks, prefer spawning an independent reviewer sub-agent over reviewing manually:
 
-1. **Try the reviewer first.** Spawn `chorus:proposal-reviewer` (for proposals) or `chorus:task-reviewer` (for tasks) as a read-only sub-agent. It posts a VERDICT comment with detailed findings.
+1. **Try the reviewer first.** Spawn `chorus:proposal-reviewer` (for proposals) or `chorus:task-reviewer` (for tasks) as a read-only sub-agent. **Run it in foreground** (do NOT set `run_in_background: true`) — you must wait for the VERDICT before proceeding. It posts a VERDICT comment with detailed findings.
 2. **Read the VERDICT.** After the reviewer completes, call `chorus_get_comments` and find the most recent comment containing `VERDICT:`. There are exactly three possible outcomes:
    - **VERDICT: PASS** — No issues found. Approve (proposals) or mark AC passed and verify (tasks).
    - **VERDICT: PASS WITH NOTES** — Minor non-blocking notes. Still approve/verify. Notes are informational.
@@ -142,7 +142,7 @@ chorus_get_comments({ targetType: "proposal", targetUuid: "<proposal-uuid>" })
 
 #### A3.5: Independent Review
 
-Spawn `chorus:proposal-reviewer` per the [Review Strategy](#review-strategy) above. Read its VERDICT comment before proceeding.
+Spawn `chorus:proposal-reviewer` per the [Review Strategy](#review-strategy) above — foreground, not background. Read its VERDICT comment before proceeding.
 
 #### A4: Approve or Reject
 
@@ -207,7 +207,7 @@ chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
 
 #### B2.5: Independent Review
 
-Spawn `chorus:task-reviewer` per the [Review Strategy](#review-strategy) above. After it completes, read its VERDICT:
+Spawn `chorus:task-reviewer` per the [Review Strategy](#review-strategy) above — foreground, not background. After it completes, read its VERDICT:
 
 - **VERDICT: PASS** or **PASS WITH NOTES** → proceed to B3 (mark AC) and B4 (verify).
 - **VERDICT: FAIL** → skip to B4 and **reopen** the task. Do NOT mark AC as passed.

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -242,13 +242,13 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    ```
    chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
    ```
-   After this call, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST spawn it yourself — it is NOT auto-launched.
+   After this call, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST spawn it yourself in **foreground** (do NOT set `run_in_background: true`) — it is NOT auto-launched.
 
 ---
 
 ### Phase 2: Proposal Review Loop
 
-After `chorus_pm_submit_proposal`, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST manually spawn it as a read-only sub-agent. Wait for it to complete, then:
+After `chorus_pm_submit_proposal`, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST manually spawn it as a read-only sub-agent in **foreground** (do NOT set `run_in_background: true`). Wait for it to complete, then:
 
 1. **Read the reviewer's VERDICT:**
    ```
@@ -371,7 +371,8 @@ for each task in wave_tasks:
     # Sub-agent may have failed; skip or handle
     continue
 
-  # 2. Spawn task-reviewer (hook injects context — you must spawn it yourself)
+  # 2. Spawn task-reviewer in FOREGROUND (hook injects context — you must spawn it yourself)
+  #    Do NOT set run_in_background — you need the VERDICT before proceeding
   Agent({ subagent_type: "chorus:task-reviewer", prompt: "Review task <task-uuid>..." })
 
   # 3. Read task-reviewer VERDICT

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.3"
+  version: "0.7.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -242,13 +242,13 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    ```
    chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
    ```
-   The PostToolUse hook will auto-spawn `chorus:proposal-reviewer`. Do NOT manually spawn it.
+   After this call, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST spawn it yourself — it is NOT auto-launched.
 
 ---
 
 ### Phase 2: Proposal Review Loop
 
-After `chorus_pm_submit_proposal`, the PostToolUse hook auto-spawns `chorus:proposal-reviewer` as a read-only sub-agent. Wait for it to complete, then:
+After `chorus_pm_submit_proposal`, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST manually spawn it as a read-only sub-agent. Wait for it to complete, then:
 
 1. **Read the reviewer's VERDICT:**
    ```
@@ -279,7 +279,7 @@ After `chorus_pm_submit_proposal`, the PostToolUse hook auto-spawns `chorus:prop
      ```
      chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
      ```
-     The hook spawns the reviewer again for Round 2.
+     After resubmission, the hook injects context again — spawn the reviewer yourself for Round 2.
 
 3. **Max rounds:** Loop up to `maxProposalReviewRounds` (from plugin config, default 3). If exhausted:
    ```
@@ -323,7 +323,7 @@ loop:
   # 4. Wait for all sub-agents to complete
   #    Each sub-agent follows the /develop workflow:
   #    claim -> in_progress -> develop -> report -> self-check AC -> submit_for_verify
-  #    PostToolUse hook auto-spawns task-reviewer after submit_for_verify
+  #    PostToolUse hook injects context — main agent must spawn task-reviewer after submit_for_verify
 
   # 5. Proceed to Phase 4 (verification) for this wave
   wave += 1
@@ -350,11 +350,11 @@ for each task in unblocked:
   chorus_report_criteria_self_check({ taskUuid: "<task-uuid>", criteria: [...] })
   chorus_submit_for_verify({ taskUuid: "<task-uuid>", summary: "..." })
 
-  # PostToolUse hook still triggers task-reviewer
+  # PostToolUse hook injects context — you must spawn task-reviewer yourself
   # Proceed to Phase 4 verification for this task before moving to next
 ```
 
-The fallback is slower (sequential, not parallel) but still completes the pipeline. All reviewer hooks and verification work the same way.
+The fallback is slower (sequential, not parallel) but still completes the pipeline. The PostToolUse hook injects reviewer instructions the same way in both modes — you must always spawn the reviewer manually.
 
 ---
 
@@ -371,13 +371,16 @@ for each task in wave_tasks:
     # Sub-agent may have failed; skip or handle
     continue
 
-  # 2. Read task-reviewer VERDICT
-  comments = chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
-  # Find most recent VERDICT comment
+  # 2. Spawn task-reviewer (hook injects context — you must spawn it yourself)
+  Agent({ subagent_type: "chorus:task-reviewer", prompt: "Review task <task-uuid>..." })
 
-  # 3. Act on VERDICT
-  if VERDICT is PASS or PASS WITH NOTES:
-    # Mark all AC as passed
+  # 3. Read task-reviewer VERDICT
+  comments = chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+  # Find the most recent comment containing "VERDICT:"
+
+  # 4. Act on VERDICT — three possible outcomes:
+  if VERDICT is "PASS":
+    # All AC verified, no issues. Mark AC and verify.
     chorus_mark_acceptance_criteria({
       taskUuid: "<task-uuid>",
       criteria: [
@@ -388,7 +391,13 @@ for each task in wave_tasks:
     chorus_admin_verify_task({ taskUuid: "<task-uuid>" })
     # Task is now "done" -- unblocks dependents
 
-  if VERDICT is FAIL:
+  if VERDICT is "PASS WITH NOTES":
+    # All AC verified, minor non-blocking notes. Still mark AC and verify.
+    chorus_mark_acceptance_criteria({ ... })
+    chorus_admin_verify_task({ taskUuid: "<task-uuid>" })
+
+  if VERDICT is "FAIL":
+    # BLOCKERs found. Do NOT verify. Reopen for rework.
     chorus_admin_reopen_task({ taskUuid: "<task-uuid>" })
     # Task returns to "open", will be picked up in next wave
 ```

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -242,13 +242,13 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    ```
    chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
    ```
-   After this call, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST spawn it yourself in **foreground** (do NOT set `run_in_background: true`) — it is NOT auto-launched.
+   After this call, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST spawn it yourself in **foreground** (do NOT set `run_in_background`) — it is NOT auto-launched.
 
 ---
 
 ### Phase 2: Proposal Review Loop
 
-After `chorus_pm_submit_proposal`, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST manually spawn it as a read-only sub-agent in **foreground** (do NOT set `run_in_background: true`). Wait for it to complete, then:
+After `chorus_pm_submit_proposal`, the PostToolUse hook injects context instructing you to spawn `chorus:proposal-reviewer`. You MUST manually spawn it as a read-only sub-agent in **foreground** (do NOT set `run_in_background`). Wait for it to complete, then:
 
 1. **Read the reviewer's VERDICT:**
    ```


### PR DESCRIPTION
## Summary
- Replace all "auto-spawn/auto-trigger" PE with explicit "hook injects context, you MUST spawn manually" language across all plugin skills and hook scripts
- Add structured VERDICT handling instructions (PASS / PASS WITH NOTES / FAIL → specific action) to every consumer: develop, yolo, review skills and both PostToolUse hooks
- Fix incorrect `PARTIAL` verdict label → `PASS WITH NOTES` in chorus/SKILL.md
- Fix "Auto-spawn" wording in plugin.json userConfig descriptions
- Bump plugin version to 0.7.4

## Changed files
| File | Change |
|------|--------|
| `public/chorus-plugin/skills/yolo/SKILL.md` | 6 places: auto-spawn → manual spawn; Phase 4 pseudocode now has 3 explicit VERDICT branches |
| `public/chorus-plugin/skills/develop/SKILL.md` | Step 8: expanded from 1 vague line to full VERDICT handling with 3 outcomes |
| `public/chorus-plugin/skills/review/SKILL.md` | Review Strategy + B2.5: added 3 VERDICT outcomes and actions |
| `public/chorus-plugin/skills/chorus/SKILL.md` | "auto-trigger" → manual spawn; PARTIAL → PASS WITH NOTES |
| `public/chorus-plugin/bin/on-post-submit-for-verify.sh` | Added 3-line VERDICT guide after reviewer spawn |
| `public/chorus-plugin/bin/on-post-submit-proposal.sh` | Same VERDICT guide for proposal reviewer |
| `public/chorus-plugin/bin/on-subagent-start.sh` | Sub-agent template now includes VERDICT→action mapping |
| `public/chorus-plugin/.claude-plugin/plugin.json` | "Auto-spawn" → "Prompt agent to spawn"; version 0.7.4 |
| `.claude-plugin/marketplace.json` | Version 0.7.4 |
| `*/SKILL.md` (idea, proposal, quick-dev) | Version bump only |

## Test plan
- [ ] Run YOLO workflow — verify supervisor spawns task-reviewer instead of assuming it auto-triggered
- [ ] Verify reviewer VERDICT is correctly parsed (PASS → verify, FAIL → reopen)
- [ ] `/plugin update chorus@chorus-plugins` picks up 0.7.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)