### PR TITLE
fix: make chorus.mjs startup hoist-safe under bun/yarn global install

### DIFF
--- a/chorus.mjs
+++ b/chorus.mjs
@@ -17,6 +17,25 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
+// Dependency resolution (hoist-safe — see issue #214)
+// ---------------------------------------------------------------------------
+// Use import.meta.resolve so the correct copy of each dependency is found
+// regardless of how the user's package manager laid out node_modules
+// (nested, hoisted to global root, yarn classic link, etc.).
+
+function resolveOrDie(specifier) {
+  try {
+    return fileURLToPath(import.meta.resolve(specifier));
+  } catch {
+    console.error(`\nERROR: cannot resolve dependency "${specifier}".`);
+    console.error(`This usually means your package manager hoisted deps in an`);
+    console.error(`unexpected layout. Try reinstalling with npm, or see`);
+    console.error(`https://github.com/Chorus-AIDLC/Chorus/issues/214 for context.`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // CLI argument parsing (zero dependencies)
 // ---------------------------------------------------------------------------
 
@@ -149,15 +168,12 @@ async function main() {
     // Start embedded PGlite
     console.log(`Starting embedded PostgreSQL (PGlite) on port ${PGLITE_PORT}...`);
 
-    const serverScript = join(
-      __dirname,
-      "node_modules",
-      "@electric-sql",
-      "pglite-socket",
-      "dist",
-      "scripts",
-      "server.js"
-    );
+    // @electric-sql/pglite-socket does not expose `./dist/scripts/server.js`
+    // via the "exports" field, so we resolve the package entry (which IS
+    // exported) and derive the sibling server.js path. This remains
+    // hoist-safe — see issue #214.
+    const pgliteSocketEntry = resolveOrDie("@electric-sql/pglite-socket");
+    const serverScript = resolve(dirname(pgliteSocketEntry), "scripts", "server.js");
 
     pgliteProcess = fork(serverScript, [
       `--db=${join(dataDir, "pglite")}`,
@@ -166,7 +182,13 @@ async function main() {
     ], { stdio: "ignore", detached: false });
 
     pgliteProcess.on("error", (err) => {
-      console.error("PGlite process error:", err.message);
+      // MODULE_NOT_FOUND is unreachable after the resolveOrDie fix above, but
+      // guard against regressions (see issue #214).
+      if (err.code === "MODULE_NOT_FOUND") {
+        console.error(`PGlite server script unreachable: ${err.message}`);
+      } else {
+        console.error("PGlite process error:", err.message);
+      }
       process.exit(1);
     });
 
@@ -191,9 +213,9 @@ async function main() {
 
   // 3. Run database migrations
   console.log("Running database migrations...");
-  const prismaPath = join(__dirname, "node_modules", ".bin", "prisma");
+  const prismaBin = resolveOrDie("prisma/build/index.js");
   try {
-    execSync(`"${prismaPath}" migrate deploy`, {
+    execSync(`"${process.execPath}" "${prismaBin}" migrate deploy`, {
       cwd: __dirname,
       stdio: "inherit",
       env: { ...process.env },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The Agent Harness for AI-Human Collaboration — session lifecycle, task state, sub-agent orchestration, observability, and failure recovery",
   "homepage": "https://github.com/Chorus-AIDLC/Chorus",
   "repository": {
@@ -25,9 +25,7 @@
     ".next/standalone/",
     "prisma/schema.prisma",
     "prisma/migrations/",
-    "prisma.config.ts",
-    "node_modules/@electric-sql/",
-    "node_modules/dotenv/"
+    "prisma.config.ts"
   ],
   "scripts": {
     "dev": "next dev --turbopack --port 8637",

--- a/scripts/prepack-pglite.mjs
+++ b/scripts/prepack-pglite.mjs
@@ -1,14 +1,16 @@
 /**
- * Dereference pnpm symlinks before npm pack.
+ * Dereference pnpm symlinks inside .next/standalone/ before npm pack.
  *
  * pnpm uses a content-addressable store with symlinks in node_modules/.
  * npm pack follows symlinks for `files` entries, but the resulting tarball
  * contains the pnpm .pnpm/ directory structure which breaks when installed
- * elsewhere. This script replaces symlinks with real copies in two places:
+ * elsewhere. This script replaces symlinks with real copies inside the
+ * Next.js standalone directory, then also copies the static assets and
+ * public/ folder next to standalone/server.js.
  *
- * 1. Root node_modules/ — PGlite and dotenv packages needed at runtime
- * 2. .next/standalone/node_modules/ — ALL pnpm symlinks that Next.js
- *    standalone traced as runtime dependencies
+ * Root node_modules/ is NOT touched — runtime deps are resolved via
+ * import.meta.resolve in chorus.mjs, so the user's package manager owns
+ * installation (see issue #214 for context).
  */
 
 import {
@@ -35,30 +37,7 @@ function derefSymlink(target) {
   return true;
 }
 
-// --- 1. Root node_modules: explicit packages ---
-
-console.log("Dereferencing root node_modules packages...");
-const rootPackages = [
-  "node_modules/@electric-sql/pglite",
-  "node_modules/@electric-sql/pglite-socket",
-  "node_modules/dotenv",
-];
-
-for (const pkg of rootPackages) {
-  const target = join(process.cwd(), pkg);
-  if (derefSymlink(target)) {
-    console.log(`  deref: ${pkg}`);
-  } else {
-    try {
-      lstatSync(target);
-      console.log(`  ok:    ${pkg}`);
-    } catch {
-      console.log(`  skip:  ${pkg} (not found)`);
-    }
-  }
-}
-
-// --- 2. Standalone node_modules: walk and dereference all symlinks ---
+// --- 1. Standalone node_modules: walk and dereference all symlinks ---
 
 console.log("Dereferencing .next/standalone/node_modules symlinks...");
 const standaloneNm = join(process.cwd(), ".next", "standalone", "node_modules");
@@ -100,7 +79,7 @@ function walkAndDeref(dir) {
 walkAndDeref(standaloneNm);
 console.log(`  dereferenced ${derefCount} symlinks`);
 
-// --- 3. Remove the now-orphaned .pnpm directory ---
+// --- 2. Remove the now-orphaned .pnpm directory ---
 
 const pnpmDir = join(standaloneNm, ".pnpm");
 try {
@@ -110,7 +89,7 @@ try {
   // ignore
 }
 
-// --- 4. Copy static assets and public/ into standalone directory ---
+// --- 3. Copy static assets and public/ into standalone directory ---
 // Next.js standalone server.js expects .next/static/ and public/ relative
 // to its own directory (.next/standalone/), but `next build` outputs them
 // at the project root. Docker does this via COPY; we do it here for npm.


### PR DESCRIPTION
## Summary

Resolves #214 — users running `bun install -g @chorus-aidlc/chorus && chorus` hit misleading errors (`PGlite failed to start within 15 seconds` on macOS, `/bin/sh: .../.bin/prisma: not found` on Linux). Same root cause: `chorus.mjs` hardcoded `__dirname/node_modules/...` for runtime dependency access, and bun/yarn classic hoist deps to the upper global `node_modules`, leaving those paths empty. npm/npx happened to work because they preserve the bundled `node_modules` shipped inside the tarball.

This PR makes startup resolution hoist-agnostic and cleans up the related bundling shim.

## Changed files

| File | Change |
|------|--------|
| `chorus.mjs` | Add `resolveOrDie(specifier)` helper using `import.meta.resolve`. Replace hardcoded path for `@electric-sql/pglite-socket/scripts/server.js` (derived from the package entry because its `exports` field only exposes `.`). Replace `.bin/prisma` invocation with `process.execPath` + resolved `prisma/build/index.js`. Add `MODULE_NOT_FOUND` branch in `pgliteProcess.on("error")` as a regression guard. |
| `package.json` | Remove `node_modules/@electric-sql/` and `node_modules/dotenv/` from `files[]` — the runtime resolver finds them via normal dependency resolution now. Bump version 0.6.6 → 0.6.7. |
| `scripts/prepack-pglite.mjs` | Drop root-level `rootPackages` deref loop; keep `.next/standalone/` walk (Next.js standalone still needs deref'd symlinks). Rewrite the opening docstring to reflect standalone-only scope. |

## Test plan

Packed a local tarball (`npm pack` → `chorus-aidlc-chorus-0.6.7.tgz`) and smoke-verified all four global install paths with isolated HTTP + PGlite ports:

| Install method | HTTP port | PGlite port | Banner `Chorus v0.6.7` | `PGlite ready` | `Migrations completed` | `curl /` |
|---|---|---|---|---|---|---|
| `bun install -g <tgz>` | 3101 | 5501 | yes | yes | yes | 200 |
| `npm install -g <tgz>` | 3102 | 5502 | yes | yes | yes | 200 |
| `yarn global add file:<tgz>` (classic) | 3103 | 5503 | yes | yes | yes | 200 |
| `npx --package=<tgz> chorus` | 3104 | 5504 | yes | yes | yes | 200 |

- `grep -E '\\.bin/prisma: not found\|failed to start within 15'` across all 4 logs → 0 matches
- Port 5433 killed + verified empty before each run (avoids the `waitForTcp` false-positive seen during root-cause analysis)
- Confirmed bun global layout: `/home/user/.bun/install/global/node_modules/@chorus-aidlc/chorus/` has **no `node_modules/` subdirectory**; deps all hoisted. `resolveOrDie` handles it.
- All globals uninstalled at end; ports freed.

- [x] Manual smoke across bun/npm/yarn/npx
- [x] `node chorus.mjs --version` / `--help` fast-path still exit 0
- [ ] CI green

## Notes

- Windows support is a separate issue (Prisma binary). Intentionally out of scope.
- CI matrix for bun/yarn smoke is a follow-up — this PR is the minimum fix.
- Implementation detail: tech design proposed `resolveOrDie("@electric-sql/pglite-socket/dist/scripts/server.js")`, but that specifier raises `ERR_PACKAGE_PATH_NOT_EXPORTED` against the package's actual `exports` field. Adjusted to resolve the package entry and derive the sibling `scripts/server.js` — same hoist-safety, compatible with the package's export surface.

Generated with [Claude Code](https://claude.com/claude-code)