### PR TITLE
release: merge develop → main (v0.7.5 reviewer turn budget + chorus.mjs hoist fix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/chorus.mjs
+++ b/chorus.mjs
@@ -17,6 +17,25 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
+// Dependency resolution (hoist-safe — see issue #214)
+// ---------------------------------------------------------------------------
+// Use import.meta.resolve so the correct copy of each dependency is found
+// regardless of how the user's package manager laid out node_modules
+// (nested, hoisted to global root, yarn classic link, etc.).
+
+function resolveOrDie(specifier) {
+  try {
+    return fileURLToPath(import.meta.resolve(specifier));
+  } catch {
+    console.error(`\nERROR: cannot resolve dependency "${specifier}".`);
+    console.error(`This usually means your package manager hoisted deps in an`);
+    console.error(`unexpected layout. Try reinstalling with npm, or see`);
+    console.error(`https://github.com/Chorus-AIDLC/Chorus/issues/214 for context.`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // CLI argument parsing (zero dependencies)
 // ---------------------------------------------------------------------------
 
@@ -149,15 +168,12 @@ async function main() {
     // Start embedded PGlite
     console.log(`Starting embedded PostgreSQL (PGlite) on port ${PGLITE_PORT}...`);
 
-    const serverScript = join(
-      __dirname,
-      "node_modules",
-      "@electric-sql",
-      "pglite-socket",
-      "dist",
-      "scripts",
-      "server.js"
-    );
+    // @electric-sql/pglite-socket does not expose `./dist/scripts/server.js`
+    // via the "exports" field, so we resolve the package entry (which IS
+    // exported) and derive the sibling server.js path. This remains
+    // hoist-safe — see issue #214.
+    const pgliteSocketEntry = resolveOrDie("@electric-sql/pglite-socket");
+    const serverScript = resolve(dirname(pgliteSocketEntry), "scripts", "server.js");
 
     pgliteProcess = fork(serverScript, [
       `--db=${join(dataDir, "pglite")}`,
@@ -166,7 +182,13 @@ async function main() {
     ], { stdio: "ignore", detached: false });
 
     pgliteProcess.on("error", (err) => {
-      console.error("PGlite process error:", err.message);
+      // MODULE_NOT_FOUND is unreachable after the resolveOrDie fix above, but
+      // guard against regressions (see issue #214).
+      if (err.code === "MODULE_NOT_FOUND") {
+        console.error(`PGlite server script unreachable: ${err.message}`);
+      } else {
+        console.error("PGlite process error:", err.message);
+      }
       process.exit(1);
     });
 
@@ -191,9 +213,9 @@ async function main() {
 
   // 3. Run database migrations
   console.log("Running database migrations...");
-  const prismaPath = join(__dirname, "node_modules", ".bin", "prisma");
+  const prismaBin = resolveOrDie("prisma/build/index.js");
   try {
-    execSync(`"${prismaPath}" migrate deploy`, {
+    execSync(`"${process.execPath}" "${prismaBin}" migrate deploy`, {
       cwd: __dirname,
       stdio: "inherit",
       env: { ...process.env },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The Agent Harness for AI-Human Collaboration — session lifecycle, task state, sub-agent orchestration, observability, and failure recovery",
   "homepage": "https://github.com/Chorus-AIDLC/Chorus",
   "repository": {
@@ -25,9 +25,7 @@
     ".next/standalone/",
     "prisma/schema.prisma",
     "prisma/migrations/",
-    "prisma.config.ts",
-    "node_modules/@electric-sql/",
-    "node_modules/dotenv/"
+    "prisma.config.ts"
   ],
   "scripts": {
     "dev": "next dev --turbopack --port 8637",

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/agents/proposal-reviewer.md
+++ b/public/chorus-plugin/agents/proposal-reviewer.md
@@ -2,7 +2,7 @@
 description: "Review submitted Chorus proposals for quality — check document completeness, task granularity, AC alignment, and cross-task dependencies. Spawn after chorus_pm_submit_proposal."
 model: inherit
 color: red
-maxTurns: 15
+maxTurns: 20
 disallowedTools:
   - Agent
   - ExitPlanMode
@@ -16,6 +16,7 @@ criticalSystemReminder_EXPERIMENTAL: >
   Classify every finding as BLOCKER (blocks implementation) or NOTE (non-blocking). Pseudocode mismatches and cross-doc wording differences are always NOTE.
   You MUST end with VERDICT: PASS, VERDICT: PASS WITH NOTES, or VERDICT: FAIL. Has BLOCKERs → FAIL. Only NOTEs → PASS WITH NOTES. Nothing → PASS.
   If this is Round 2+, focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs.
+  Turn budget rule: When ≤3 turns remain in your budget, STOP reading files immediately and post your current findings as a comment via chorus_add_comment. Incomplete findings posted are strictly better than no comment at all.
   Do NOT rubber-stamp. Your value is in finding what the PM missed.
   Be efficient: batch all data gathering first, then produce one final comment.
 ---
@@ -36,6 +37,8 @@ You will receive a proposalUuid. Your job is to fetch and review the full propos
 === REVIEW PROCEDURE ===
 
 **Efficiency rule:** Gather ALL data in Steps 1-2 before analyzing. Do not alternate between fetching and writing conclusions. Batch your tool calls.
+
+**Turn budget rule: When ≤3 turns remain in your budget, STOP reading files immediately and post your current findings as a comment via chorus_add_comment. Incomplete findings posted are strictly better than no comment at all.**
 
 **Step 1: Gather context**
 ```
@@ -93,7 +96,7 @@ VERDICT decision: has BLOCKERs → FAIL. Only NOTEs → PASS WITH NOTES. Nothing
 
 You may receive the current review round number in your context.
 - **Round 1**: Full review, normal strictness.
-- **Round 2+**: Focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs on areas not flagged in previous rounds. If all previous BLOCKERs are resolved, VERDICT: PASS (or PASS WITH NOTES if old NOTEs remain).
+- **Round 2+**: Focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs on areas not flagged in previous rounds. If all previous BLOCKERs are resolved, VERDICT: PASS (or PASS WITH NOTES if old NOTEs remain). Round 1 already did the full-depth draft review. Round 2+ only re-reads the proposal drafts and comments to confirm each previous BLOCKER is addressed — fetch `chorus_get_proposal` and `chorus_get_comments`, diff against the previous round, and stop. No Read/Glob on project files.
 
 === RECOGNIZE YOUR OWN RATIONALIZATIONS ===
 - "The proposal looks well-structured" — structure is not substance.

--- a/public/chorus-plugin/agents/task-reviewer.md
+++ b/public/chorus-plugin/agents/task-reviewer.md
@@ -2,7 +2,7 @@
 description: "Review submitted Chorus tasks — verify implementation against AC and proposal documents. Spawn after chorus_submit_for_verify."
 model: inherit
 color: red
-maxTurns: 20
+maxTurns: 25
 disallowedTools:
   - Agent
   - ExitPlanMode
@@ -16,6 +16,7 @@ criticalSystemReminder_EXPERIMENTAL: >
   Classify every finding as BLOCKER (blocks correctness: build/test failure, AC not implemented, semantic contradiction) or NOTE (non-blocking: pseudocode mismatch, wording difference, style suggestion).
   You MUST end with VERDICT: PASS, VERDICT: PASS WITH NOTES, or VERDICT: FAIL. Has BLOCKERs → FAIL. Only NOTEs → PASS WITH NOTES. Nothing → PASS.
   If this is Round 2+, focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs.
+  Turn budget rule: When ≤3 turns remain in your budget, STOP reading files AND stop running bash/tests immediately and post your current findings as a comment via chorus_add_comment. Incomplete findings posted are strictly better than no comment at all.
   Do NOT confirm — find what's wrong. Be efficient: batch data gathering, then one final comment.
 ---
 
@@ -49,6 +50,8 @@ You will receive a taskUuid. Your job is to fetch the task, its AC, and the prop
 === REVIEW PROCEDURE ===
 
 **Efficiency rule:** Gather ALL context in Steps 1-2 before verifying. Batch your tool calls — do not alternate between fetching and writing conclusions.
+
+**Turn budget rule:** When ≤3 turns remain in your budget, STOP reading files AND stop running bash/tests immediately and post your current findings as a comment via chorus_add_comment. Incomplete findings posted are strictly better than no comment at all.
 
 **Step 1: Gather context**
 ```
@@ -111,7 +114,7 @@ VERDICT decision: has BLOCKERs → FAIL. Only NOTEs → PASS WITH NOTES. Nothing
 
 You may receive the current review round number in your context.
 - **Round 1**: Full review, normal strictness.
-- **Round 2+**: Focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs on areas not flagged in previous rounds. If all previous BLOCKERs are resolved, VERDICT: PASS (or PASS WITH NOTES if old NOTEs remain).
+- **Round 2+**: Focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs on areas not flagged in previous rounds. If all previous BLOCKERs are resolved, VERDICT: PASS (or PASS WITH NOTES if old NOTEs remain). Round 1 already did the full-depth review. Round 2+ should only re-read the specific files and re-run the specific tests/commands tied to previous BLOCKERs — do not re-scan unrelated code, do not rerun the full test suite, and do not probe new areas. Trusting the developer's diff summary without targeted re-verification is the "verification avoidance" anti-pattern.
 
 === RECOGNIZE YOUR OWN RATIONALIZATIONS ===
 - "The code looks correct based on my reading" — reading is not verification. Run it.

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.4"
+  version: "0.7.5"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.4"
+  version: "0.7.5"
   category: project-management
   mcp_server: chorus
 ---
@@ -225,6 +225,8 @@ Find the most recent comment containing `VERDICT:` and act on it:
 - **VERDICT: PASS** — All AC verified, no issues. Proceed to admin verification.
 - **VERDICT: PASS WITH NOTES** — All AC verified, minor notes. Proceed to admin verification (notes are non-blocking).
 - **VERDICT: FAIL** — BLOCKERs found. Do NOT verify. Fix the BLOCKERs listed in the reviewer's comment, then resubmit.
+
+If no new `VERDICT:` comment appears after the reviewer returns, it exhausted its `maxTurns` budget before posting. Respawn it ONCE with a concise-budget hint in the prompt: *"Stay within turn budget. Skip deep verification. Fetch task/proposal/comments, run only the core tests, and post your VERDICT comment within the first 12 turns."* If the second attempt still produces no VERDICT, review manually using the checklist and proceed.
 
 ### Step 9: Handle Review Feedback
 

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.4"
+  version: "0.7.5"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.4"
+  version: "0.7.5"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.7.4
+version: 0.7.5
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.4"
+  version: "0.7.5"
   category: project-management
   mcp_server: chorus
 ---
@@ -69,8 +69,9 @@ When reviewing proposals or tasks, prefer spawning an independent reviewer sub-a
    - **VERDICT: PASS** — No issues found. Approve (proposals) or mark AC passed and verify (tasks).
    - **VERDICT: PASS WITH NOTES** — Minor non-blocking notes. Still approve/verify. Notes are informational.
    - **VERDICT: FAIL** — BLOCKERs found. Reject (proposals) or reopen (tasks). Fix the specific BLOCKERs listed in the comment before resubmitting.
-3. **Track rounds.** Count existing VERDICT comments before spawning. After 3 rounds of FAIL on the same item, stop the loop and escalate to human review.
-4. **Fallback.** If the reviewer is unavailable (e.g., agent type not registered, sub-agent spawn fails), review the item yourself using the quality checklists in the workflows below.
+3. **No new VERDICT comment?** The reviewer exhausted its `maxTurns` budget before posting. Respawn it ONCE with an explicit prompt like: *"Stay within your turn budget. Skip deep source verification — batch all MCP fetches up front, skim for obvious BLOCKERs only, and reserve your last few turns to post the VERDICT comment."* If the second attempt also fails to post, review manually using the checklists below.
+4. **Track rounds.** Count existing VERDICT comments before spawning. After 3 rounds of FAIL on the same item, stop the loop and escalate to human review.
+5. **Fallback.** If the reviewer is unavailable (e.g., agent type not registered, sub-agent spawn fails), review the item yourself using the quality checklists in the workflows below.
 
 ---
 

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.4"
+  version: "0.7.5"
   category: project-management
   mcp_server: chorus
 ---
@@ -288,6 +288,8 @@ After `chorus_pm_submit_proposal`, the PostToolUse hook injects context instruct
           Proposal UUID: <uuid>"
    ```
 
+4. **No new VERDICT comment after reviewer returns?** The reviewer exhausted its `maxTurns` budget. Respawn it ONCE with a concise-budget hint: *"Stay within turn budget. Skip deep source verification. Fetch proposal + comments + idea only, skim for obvious BLOCKERs, and post your VERDICT within the first 10 turns."* If the second attempt still produces no VERDICT, treat the proposal as PASS WITH NOTES and proceed — the pipeline cannot loop forever on a silent reviewer.
+
 ---
 
 ### Phase 3: Task Execution (Wave-Based)
@@ -414,6 +416,8 @@ ESCALATE: "Task '{title}' failed review after {maxRounds} rounds.
 ```
 
 Continue with remaining tasks -- do not halt the entire pipeline for one stuck task.
+
+**No new VERDICT comment after the task-reviewer returns?** It exhausted its `maxTurns` budget. Respawn it ONCE with a concise-budget hint: *"Stay within turn budget. Skip deep verification. Fetch task/proposal/comments, run only the core tests, and post your VERDICT within the first 12 turns."* If the second attempt also produces no VERDICT, treat as PASS WITH NOTES and proceed — do not loop indefinitely.
 
 ---
 

--- a/scripts/prepack-pglite.mjs
+++ b/scripts/prepack-pglite.mjs
@@ -1,14 +1,16 @@
 /**
- * Dereference pnpm symlinks before npm pack.
+ * Dereference pnpm symlinks inside .next/standalone/ before npm pack.
  *
  * pnpm uses a content-addressable store with symlinks in node_modules/.
  * npm pack follows symlinks for `files` entries, but the resulting tarball
  * contains the pnpm .pnpm/ directory structure which breaks when installed
- * elsewhere. This script replaces symlinks with real copies in two places:
+ * elsewhere. This script replaces symlinks with real copies inside the
+ * Next.js standalone directory, then also copies the static assets and
+ * public/ folder next to standalone/server.js.
  *
- * 1. Root node_modules/ — PGlite and dotenv packages needed at runtime
- * 2. .next/standalone/node_modules/ — ALL pnpm symlinks that Next.js
- *    standalone traced as runtime dependencies
+ * Root node_modules/ is NOT touched — runtime deps are resolved via
+ * import.meta.resolve in chorus.mjs, so the user's package manager owns
+ * installation (see issue #214 for context).
  */
 
 import {
@@ -35,30 +37,7 @@ function derefSymlink(target) {
   return true;
 }
 
-// --- 1. Root node_modules: explicit packages ---
-
-console.log("Dereferencing root node_modules packages...");
-const rootPackages = [
-  "node_modules/@electric-sql/pglite",
-  "node_modules/@electric-sql/pglite-socket",
-  "node_modules/dotenv",
-];
-
-for (const pkg of rootPackages) {
-  const target = join(process.cwd(), pkg);
-  if (derefSymlink(target)) {
-    console.log(`  deref: ${pkg}`);
-  } else {
-    try {
-      lstatSync(target);
-      console.log(`  ok:    ${pkg}`);
-    } catch {
-      console.log(`  skip:  ${pkg} (not found)`);
-    }
-  }
-}
-
-// --- 2. Standalone node_modules: walk and dereference all symlinks ---
+// --- 1. Standalone node_modules: walk and dereference all symlinks ---
 
 console.log("Dereferencing .next/standalone/node_modules symlinks...");
 const standaloneNm = join(process.cwd(), ".next", "standalone", "node_modules");
@@ -100,7 +79,7 @@ function walkAndDeref(dir) {
 walkAndDeref(standaloneNm);
 console.log(`  dereferenced ${derefCount} symlinks`);
 
-// --- 3. Remove the now-orphaned .pnpm directory ---
+// --- 2. Remove the now-orphaned .pnpm directory ---
 
 const pnpmDir = join(standaloneNm, ".pnpm");
 try {
@@ -110,7 +89,7 @@ try {
   // ignore
 }
 
-// --- 4. Copy static assets and public/ into standalone directory ---
+// --- 3. Copy static assets and public/ into standalone directory ---
 // Next.js standalone server.js expects .next/static/ and public/ relative
 // to its own directory (.next/standalone/), but `next build` outputs them
 // at the project root. Docker does this via COPY; we do it here for npm.


### PR DESCRIPTION
## Summary

Release merge — 2 commits from develop to main.

## Commits included

| SHA | Title |
|-----|-------|
| 676f7d6 | fix(plugin): give reviewers more turn budget + hard stop rule (v0.7.5) (#217) |
| fe0f515 | fix: make chorus.mjs startup hoist-safe under bun/yarn global install (#216) |

## Highlights

**#217 — Plugin v0.7.5**
- `proposal-reviewer`: `maxTurns` 15 → 20, turn-budget hard rule, Round 2+ narrow scope
- `task-reviewer`: `maxTurns` 20 → 25, same rules (Round 2+ allows re-running BLOCKER-tied tests)
- Plugin skills (`review`, `develop`, `yolo`) instruct callers to respawn reviewer once with budget hint if no VERDICT comment appears

**#216 — chorus.mjs hoist-safe startup** for bun/yarn global install

## Test plan

- [x] Both PRs merged on develop with CI green
- [x] PR #217 end-to-end tested via /yolo corner-case run (proposal-reviewer caught planted BLOCKERs; Round 2+ narrow-scope rule held; task-reviewer caught a real cwd-coupling bug in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)