### PR TITLE
feat(plugin): port Chorus plugin to Codex CLI

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "chorus-plugins",
+  "interface": {
+    "displayName": "Chorus AI-DLC"
+  },
+  "plugins": [
+    {
+      "name": "chorus",
+      "source": {
+        "source": "local",
+        "path": "./plugins/chorus"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,7 +11,7 @@
         "path": "./plugins/chorus"
       },
       "policy": {
-        "installation": "AVAILABLE",
+        "installation": "INSTALLED_BY_DEFAULT",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"

--- a/docs/_archive/codex-plugin-plan.history.md
+++ b/docs/_archive/codex-plugin-plan.history.md
@@ -1,0 +1,950 @@
+# Chorus Plugin for Codex CLI — 移植计划
+
+> 本文记录把 `public/chorus-plugin/`(Claude Code 版)移植到 OpenAI Codex CLI 的研究结论与分步计划。
+> 源插件版本:`chorus@0.7.5`(AGPL-3.0)。
+> 目标平台:Codex CLI(截至 2026-04 的公开 docs)。
+
+---
+
+## 1. 背景
+
+Chorus 是一个面向 AI Agent 协作的 PM 平台,提供 PM / Developer / Admin 三类 Agent 角色和完整的 AI-DLC 生命周期(Idea → Proposal → Execute → Verify → Done)。
+
+现有 Claude Code 插件 `public/chorus-plugin/` 由 4 层组成:
+
+- **MCP Server** — 远端 HTTP MCP(`${CHORUS_URL}/api/mcp`,Bearer 认证),提供 40+ 个 `chorus_*` 工具
+- **Hooks(14 个 shell 脚本)** — 挂在 Claude Code 的 10 类生命周期事件上,负责 session 自动创建/心跳/关闭、上下文注入、评审流程触发
+- **Skills(7 个)** — `chorus`、`idea`、`proposal`、`develop`、`review`、`quick-dev`、`yolo` 斜杠命令与流程说明
+- **Sub-agents(2 个)** — `proposal-reviewer`、`task-reviewer`,独立评审工作流
+
+---
+
+## 2. Codex CLI 插件与 Hook 能力摸底
+
+来源:`https://developers.openai.com/codex/plugins`、`/codex/plugins/build`、`/codex/hooks`、`/codex/config-advanced`。
+
+### 2.1 插件结构
+
+- 入口清单必需:`.codex-plugin/plugin.json`
+- 清单可声明 `skills`、`mcpServers`、`apps` 三类组件(相对插件根的路径)
+- 分发(marketplace)查找顺序:
+  1. 官方 curated marketplace(Plugin Directory)
+  2. `$REPO_ROOT/.agents/plugins/marketplace.json`
+  3. `$REPO_ROOT/.claude-plugin/marketplace.json`(兼容)
+  4. `~/.agents/plugins/marketplace.json`
+- 安装路径:`~/.codex/plugins/cache/<MARKETPLACE>/<PLUGIN>/<VERSION>/`,本地插件 `<VERSION>` = `local`
+- 启停状态持久化在 `~/.codex/config.toml`
+
+### 2.2 Hook 机制(experimental)
+
+- 开关:`[features] codex_hooks = true`
+- 加载层(合并,非覆盖):
+  - `~/.codex/hooks.json` 或 `~/.codex/config.toml` 内 `[hooks]`
+  - `<repo>/.codex/hooks.json` 或 `<repo>/.codex/config.toml`
+  - 企业级 `requirements.toml`
+- 关键限制(截至 Codex 0.125.0):**plugin manifest 声明 `hooks` 字段已在 scaffold/docs 出现,但 runtime 尚未实装加载**(见 openai/codex#16430、#17331,二进制中 `.codex-plugin/plugin.json` 的 `hooks` 字段仍是字面值 `[TODO: ./hooks.json]`)。当前唯一被 runtime 执行的 hook 源仍是 `~/.codex/hooks.json` / `<repo>/.codex/hooks.json` / 企业级 `managed_config.toml`。移植版同时按未来兼容格式放 `hooks.json`,并提供 `install-hooks.sh` 作为过渡。
+
+### 2.3 Codex 当前支持的 6 个 hook 事件
+
+| 事件 | 作用域 | matcher 语义 |
+|---|---|---|
+| `SessionStart` | session | `source`(`startup` / `resume` / `clear`) |
+| `UserPromptSubmit` | turn | 忽略 matcher |
+| `PreToolUse` | turn | `tool_name`(`Bash`、`apply_patch`/`Edit`/`Write`、`mcp__server__tool`) |
+| `PermissionRequest` | turn | 同 `tool_name` |
+| `PostToolUse` | turn | 同 `tool_name` |
+| `Stop` | turn | 忽略 matcher |
+
+**不支持**:`SessionEnd`、`SubagentStart`、`SubagentStop`、`TeammateIdle`、`TaskCompleted`、`Notification`、`PreCompact`。
+
+### 2.4 Hook stdin 事件 JSON
+
+通用字段:`session_id`、`transcript_path`、`cwd`、`hook_event_name`、`model`。turn 级事件加 `turn_id`。事件特有字段见 Codex 官方 hooks 页。
+
+### 2.5 Hook stdout 输出协议
+
+Codex **已采用 Claude Code 的 `hookSpecificOutput` 形状**,主要字段:
+
+- `systemMessage`:用户可见通知
+- `hookSpecificOutput.additionalContext`:注入到模型上下文(developer message)
+- `hookSpecificOutput.hookEventName`:事件名
+- `hookSpecificOutput.permissionDecision`(PreToolUse 专用,目前仅 `"deny"` 生效)
+- `decision: "block"` + `reason`:PostToolUse 替换工具结果并继续;Stop 生成续写 prompt
+- `continue: false` + `stopReason`:中止 hook 链
+- `suppressOutput`:文档里存在但**尚未实装**
+
+Codex 独有:`PermissionRequest` 可 allow/deny 审批弹窗本身,Chorus 未用到,移植时可新增"自动批准 chorus_* MCP 工具"策略简化 UX。
+
+---
+
+## 3. 组件级可移植性分析
+
+### 3.1 MCP Server — ✅ 零成本移植
+
+Chorus 的 `.mcp.json` 定义:
+
+```json
+{
+  "mcpServers": {
+    "chorus": {
+      "type": "http",
+      "url": "${CHORUS_URL}/api/mcp",
+      "headers": { "Authorization": "Bearer ${CHORUS_API_KEY}" }
+    }
+  }
+}
+```
+
+Codex MCP 客户端支持 http transport,只需改写成 Codex 的 `[mcp_servers.chorus]` 段即可。所有 `chorus_*` 工具(checkin、create_proposal、claim_task、submit_for_verify、add_comment、search …)在 Codex 中直接可用。**这是整个插件最大价值所在,且无需改造。**
+
+### 3.2 Skills — ✅ 几乎 100% 可移植
+
+7 个 skill(`chorus` / `idea` / `proposal` / `develop` / `review` / `quick-dev` / `yolo`)都是标准 `SKILL.md` + YAML frontmatter + MCP 工具调用示例,与 Codex skill 格式一致。
+
+**需要调整的地方(约 5% 文字量)**:
+- frontmatter 中 Claude 特有字段(如 `metadata.mcp_server`)保留无害但 Codex 不消费
+- `develop` / `yolo` 里涉及 "sub-agent 自动注入 sessionUuid" 的段落需改写 —— Codex 无 SubagentStart hook,应改为"主 agent 显式把 sessionUuid 写进子 agent 的 prompt"
+- `quick-dev` / `yolo` 里提到 Claude Code `Task` 工具的,改为 Codex 的 `spawn_agent`
+
+### 3.3 Sub-agents(`proposal-reviewer` / `task-reviewer`)— ✅ 可移植,语义稍弱
+
+- **Prompt 主体可直接搬**:READ-ONLY 评审规程、BLOCKER/NOTE 分类、`VERDICT: PASS/FAIL` 结尾约定,与平台无关
+- **Claude 字段映射**:
+  - `maxTurns` → Codex agent 侧的轮次上限机制(如有)或在 prompt 里软约束
+  - `disallowedTools: [Edit, Write, Bash, ...]` → 靠 Codex profile / sandbox 权限策略
+  - `criticalSystemReminder_EXPERIMENTAL` → 放进 system prompt 开头
+- **调用方式**:主 agent 由 skill 指令触发 `spawn_agent(agent_type=...)`,而不是 Claude 的 `Task` 工具
+
+### 3.4 Hooks — ⚠️ 这是差距最大的一层
+
+| Chorus hook | 脚本 | Codex 可行性 | 移植方案 |
+|---|---|---|---|
+| `SessionStart` | `on-session-start.sh` | ✅ 直接移植 | 事件名、`source`、`additionalContext` 输出一致,`chorus_checkin` 调用照搬 |
+| `UserPromptSubmit` | `on-user-prompt.sh` | ✅ 直接移植 | 本就没用 matcher,直接能跑 |
+| `PreToolUse: EnterPlanMode` | `on-pre-enter-plan.sh` | ❌ 事件不存在 | 降级:`UserPromptSubmit` 里关键词检测;或由 skill 显式触发 |
+| `PreToolUse: ExitPlanMode` | `on-pre-exit-plan.sh` | ❌ 事件不存在 | 同上 |
+| `PreToolUse: Task` | `on-pre-spawn-agent.sh` | ⚠️ 语义不同 | Codex 子 agent 非 `Task` 工具。若 `spawn_agent` 被纳入工具事件流,可 matcher 之;否则放弃 |
+| `PostToolUse: chorus_pm_submit_proposal` | `on-post-submit-proposal.sh` | ✅ 直接移植 | matcher 改成 `mcp__chorus__chorus_pm_submit_proposal` |
+| `PostToolUse: chorus_submit_for_verify` | `on-post-submit-for-verify.sh` | ✅ 直接移植 | 同上 |
+| `SubagentStart` | `on-subagent-start.sh` | ❌ 事件不存在 | 失去自动 session 创建/复用能力,改手动由主 agent 负责 |
+| `SubagentStop` | `on-subagent-stop.sh` | ❌ 事件不存在 | 失去自动 checkout + close session,改由 sub-agent 在任务末尾显式调用 |
+| `TeammateIdle` | `on-teammate-idle.sh` | ❌ 事件不存在 | 降级:延长 session TTL,或由主 agent 定期 heartbeat |
+| `TaskCompleted` | `on-task-completed.sh` | ❌ 事件不存在 | 降级:sub-agent 完成时显式 checkout |
+| `SessionEnd` | `on-session-end.sh` | ❌ 事件不存在 | 降级:`SessionStart` 做 lazy cleanup |
+
+**核心损失**:多 agent 并行时 "hook 保证正确性" 的那套自动化机制,在 Codex 上退化为 "靠 prompt 约束"。
+
+---
+
+## 4. 功能矩阵(Chorus 原有 vs Codex 移植后)
+
+| 功能 | 能否保留 | 实现方式 |
+|---|---|---|
+| Idea / Proposal / Task / Document CRUD 全套 MCP 工具 | ✅ | MCP server 原样接入 |
+| 7 个斜杠命令 `/chorus` `/idea` `/proposal` `/develop` `/review` `/quick-dev` `/yolo` | ✅ | Codex skill |
+| 会话启动自动 checkin + 注入 agent 身份/待办上下文 | ✅ | `SessionStart` hook |
+| 提交 proposal 后自动提醒 spawn proposal-reviewer | ✅ | `PostToolUse` + MCP tool matcher |
+| 提交 task 验证后自动提醒 spawn task-reviewer | ✅ | 同上 |
+| `proposal-reviewer` / `task-reviewer` 两个评审 sub-agent | ✅ | Codex subagent + skill 内 `spawn_agent` 指令 |
+| 每次用户输入注入简短工作流提醒 | ✅ | `UserPromptSubmit` hook |
+| Plan 模式下的 proposal 引导 | ⚠️ 降级 | 移到 skill 内容里,或 `UserPromptSubmit` 关键词匹配 |
+| Sub-agent 自动创建 Chorus session + 注入 sessionUuid | ❌ | 主 agent 在 `spawn_agent` 前手动 `chorus_create_session`,把 UUID 写进子 agent prompt |
+| Sub-agent 退出自动 close session + auto-verify | ❌ | 子 agent 在 skill 结尾显式 `chorus_session_checkout_task` / `chorus_submit_for_verify` |
+| TeammateIdle 心跳续命 | ❌ | session TTL 调长,或主 agent 周期性 heartbeat |
+| TaskCompleted 自动 checkout | ❌ | 显式调用 |
+| SessionEnd 清理 `.chorus/` | ❌ | `SessionStart` lazy cleanup |
+
+**整体覆盖率评估**:手动工作流 100%,自动化深度 ~60%(hooks 缺失主要影响多 agent 并行场景的无感体验)。
+
+---
+
+## 5. 打包形态
+
+由于 Codex plugin manifest 目前**不能**打包 hooks,移植产物分成两件:
+
+### 5.1 插件目录(可通过 marketplace 分发)
+
+```
+chorus-codex-plugin/
+├── .codex-plugin/
+│   └── plugin.json              # 清单(name, version, skills, mcpServers, interface)
+├── mcp/
+│   └── chorus.json              # MCP server 声明(http transport)
+├── skills/
+│   ├── chorus/SKILL.md
+│   ├── idea/SKILL.md
+│   ├── proposal/SKILL.md
+│   ├── develop/SKILL.md
+│   ├── review/SKILL.md
+│   ├── quick-dev/SKILL.md
+│   └── yolo/SKILL.md
+└── agents/
+    ├── proposal-reviewer.md
+    └── task-reviewer.md
+```
+
+### 5.2 Hooks 安装器(独立)
+
+```
+chorus-codex-plugin/
+├── hooks/
+│   ├── on-session-start.sh
+│   ├── on-user-prompt.sh
+│   ├── on-post-submit-proposal.sh
+│   ├── on-post-submit-for-verify.sh
+│   └── chorus-api.sh            # MCP-over-HTTP helper(直接复用原插件的)
+└── install-hooks.sh             # 把 hooks 写入 ~/.codex/hooks.json 或 <repo>/.codex/hooks.json
+```
+
+`install-hooks.sh` 负责:
+- 把 `hooks/*.sh` 拷贝到 `~/.codex/plugins/chorus/bin/`
+- 在 `~/.codex/hooks.json` 里 merge 对应的 matcher 条目
+- 在 `~/.codex/config.toml` 里打开 `[features] codex_hooks = true`
+
+### 5.3 Marketplace 条目
+
+`<repo>/.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "chorus-aidlc",
+  "interface": { "displayName": "Chorus AI-DLC" },
+  "plugins": [
+    {
+      "source": { "path": "./chorus-codex-plugin" },
+      "interface": { "displayName": "Chorus" },
+      "policy": { "installation": "manual", "authentication": "apiKey" },
+      "category": "project-management"
+    }
+  ]
+}
+```
+
+---
+
+## 6. 移植路线图
+
+### 阶段 1 — 骨架可用(预计 1–2 小时)
+
+**目标**:覆盖 ~80% 的 Chorus 手动工作流,不依赖任何 hook。
+
+- [ ] 创建 `chorus-codex-plugin/` 目录 + `.codex-plugin/plugin.json`
+- [ ] 把 Chorus MCP 声明改写到插件清单(或本地 `~/.codex/config.toml`)
+- [ ] 复制 7 个 skill,改写 frontmatter,标注 Codex 上不可用的 hook 相关段落
+- [ ] 复制 2 个 sub-agent,改写字段映射(`maxTurns` / `disallowedTools` / 系统提示)
+- [ ] 写 `README.md` 说明 API key、角色需求、限制
+
+**验收**:`codex resume` 后能用 `/chorus` 命令完成一次 idea → proposal → task → verify 全流程(手动)。
+
+### 阶段 2 — Hook 半自动化(预计 2–3 小时)
+
+**目标**:会话级上下文自动注入 + 评审闭环自动提醒。
+
+- [ ] 移植 `on-session-start.sh`(直接复用 `chorus-api.sh`,把 stdout 协议改成 Codex 形状 —— 实测几乎一致)
+- [ ] 移植 `on-user-prompt.sh`(去掉 Claude 特有字段引用)
+- [ ] 移植 `on-post-submit-proposal.sh` / `on-post-submit-for-verify.sh`,matcher 改为 `mcp__chorus__chorus_pm_submit_proposal` 等
+- [ ] 写 `install-hooks.sh` 一键安装器,幂等 merge 到 `~/.codex/hooks.json`
+- [ ] 在 `SessionStart` hook 里加 lazy cleanup(替代 `SessionEnd`)
+
+**验收**:
+- 新开会话时自动出现 "Chorus connected" systemMessage
+- 模型上下文里已注入 checkin 结果
+- 调 `chorus_pm_submit_proposal` 后自动收到"请 spawn proposal-reviewer"提示
+
+### 阶段 3 — 深度自动化(阻塞在 Codex)
+
+**依赖 Codex 新增以下能力才能做**:
+
+- `SubagentStart` / `SubagentStop` 事件 → 恢复 session 自动 create/close/reuse
+- `SessionEnd` 事件 → 清理 `.chorus/` 目录
+- `TaskCompleted` 事件 → 自动 checkout
+- plugin manifest 支持打包 hooks → 用户一键安装而不再跑 `install-hooks.sh`
+
+在此之前,阶段 2 是可达的最佳状态。
+
+---
+
+## 7. 风险与开放问题
+
+- **PreToolUse 非强制边界**:Codex 文档明确说 `PreToolUse` 只是 guardrail,`unified_exec` 等路径不一定拦得到。如果未来 Chorus hook 要做"禁止某些工具",在 Codex 上可能不可靠
+- **MCP tool name 规范**:hook matcher 里 MCP 工具名格式 `mcp__<server>__<tool>` 需以 Codex 当前实际命名为准,建议先用 `codex mcp list` + 跑一次 `PostToolUse` echo 脚本验证
+- **Stop 事件的利用**:Chorus 没用,但 Codex 支持 —— 可以考虑新增一个 "turn 结束时自动 heartbeat session" 的 hook,替代 `TeammateIdle`
+- **许可**:Chorus 是 AGPL-3.0,移植版需沿用相同协议,并在插件 `license` 字段显式声明
+
+---
+
+## 8. 参考资料
+
+- 源插件:`public/chorus-plugin/`(Chorus 0.7.5)
+- 现有 Claude 版设计文档:`docs/chorus-plugin.md`
+- Codex 插件构建:`https://developers.openai.com/codex/plugins/build`
+- Codex hook 参考:`https://developers.openai.com/codex/hooks`
+- Codex 高级配置:`https://developers.openai.com/codex/config-advanced`
+- Codex CLI 原生化讨论:`https://github.com/openai/codex/discussions/1174`
+
+---
+
+## 9. Subagent 上下文注入:Codex 的哲学差异与 workaround
+
+### 9.1 为什么 Codex 没有 SubagentStart hook
+
+Codex 的子 agent 设计是**"一次性的带初始 prompt 的子会话"**。`spawn_agent` 工具签名:
+
+- `agent_type` — 选择 role 模板(如 `explorer` / `worker` 或自定义),模板里有**预置的 system-level 指令**
+- `message` — 主 agent 写的任务 prompt,子 agent 唯一的初始输入
+- `fork_context`(可选) — 是否 fork 父会话历史
+- `items`(可选) — 结构化输入(文本/图片/skill 引用)
+
+子 agent 启动后只看 role prompt + message + fork 的历史。**没有任何运行时通道可以往它上下文里注入内容**——这是和 Claude Code 最根本的哲学差异:
+
+> Codex:agent 是 prompt 的函数,没有运行时注入通道
+> Claude Code:hook 可以在生命周期任意节点补充上下文
+
+### 9.2 责任归属的转移
+
+| 机制 | Claude Code | Codex CLI |
+|---|---|---|
+| 系统级约束 | `SubagentStart` hook 注入 `additionalContext` | agent role 模板预置 system prompt |
+| 任务特定约束 | 主 prompt + hook 补充 | **全部写进 spawn 时的 `message`** |
+| 工具限制 | `disallowedTools` 字段 | Codex sandbox / permissions / profile |
+| 运行中修正 | PreToolUse / PostToolUse 拦截 | 主 agent 通过 `send_input` 纠偏 |
+| 退出动作 | `SubagentStop` hook 自动 checkout | 子 agent 按 prompt 里的指令自己调 |
+
+Chorus 的 hook 机制本质是**"降低主 agent 的记忆/纪律负担"**。在 Codex 上,这份负担回到主 agent 的 prompt 责任里。
+
+### 9.3 Workaround A:预渲染指令文件(推荐)
+
+既然不能运行时注入,但可以**预先把指令渲染到文件**,再让子 agent 按约定去读。这是 Codex 上最接近 Claude hook 效果的做法。
+
+**模式**:
+
+```
+主 agent 要 spawn sub-agent「task-reviewer」:
+
+Step 1. 主 agent 调用 MCP 拿到动态数据
+  chorus_create_session({agentName: "task-reviewer-A"}) → sessionUuid
+  chorus_get_task({taskUuid}) → 完整 task + AC 列表
+
+Step 2. 主 agent 把指令渲染成文件
+  写入 .chorus/briefings/<sessionUuid>.md,内容包含:
+    - 当前 sessionUuid / taskUuid
+    - 完整的 AC 自检清单
+    - 评审流程步骤
+    - 退出前必须调用的工具(add_comment / checkout_task)
+    - Chorus MCP 工具的精确调用示例(参数已填好)
+
+Step 3. 主 agent 调 spawn_agent,message 极简
+  spawn_agent(
+    agent_type="chorus-task-reviewer",
+    message="Your briefing is at .chorus/briefings/<sessionUuid>.md.
+             Read it first, then execute exactly as instructed.
+             Your sessionUuid is <sessionUuid>."
+  )
+
+Step 4. 子 agent 启动
+  - role prompt(预置)→ "你是 Chorus task-reviewer,只读,输出 VERDICT"
+  - initial message(主 agent 传的)→ "去读 briefing 文件"
+  - 子 agent 第一步:Read .chorus/briefings/<sessionUuid>.md
+  - 此时它拿到的上下文等价于 Claude SubagentStart hook 注入的内容
+```
+
+**优势**:
+- 主 agent 只需维护一份 briefing 模板(可放 skill 里),不必每次重写冗长 prompt
+- 动态数据(sessionUuid、taskUuid、project info)一次 MCP 查询即可,避免子 agent 重复查
+- briefing 文件可以被调试查看,可复现
+- 子 agent 的 initial message 保持短,主 agent 的 token 开销低
+
+**约束**:
+- 子 agent 必须"听话"去读——靠 role prompt 的强约束 + message 里的明确指令
+- 文件路径约定要稳定(`.chorus/briefings/<sessionUuid>.md`)
+- 清理策略:Stop hook 或 SessionStart lazy cleanup 时删除旧 briefing
+
+### 9.4 Workaround B:Skill progressive disclosure
+
+Codex skill 天然就是"文件化指令",子 agent 读 `SKILL.md` 后会加载里面引用的子文档。可以把**评审规程**放进 `task-reviewer` sub-agent 默认绑定的 skill 里,主 agent 只需传入动态参数。
+
+相比 A 的区别:
+- A:每次 spawn 渲染新文件(个性化)
+- B:规程是静态的(通用化),动态数据仍靠 message 传
+
+最佳实践是**两者结合**:规程放 skill,动态数据放 briefing 文件。
+
+### 9.5 Workaround C:Stop hook 兜底
+
+Codex 支持 `Stop` hook(turn 结束时触发)。主 agent 的 Stop hook 可以:
+
+- 扫 `.chorus/claimed/` 里未 checkout 的 session,强制 `chorus_session_checkout_task`
+- 扫 `.chorus/briefings/` 删除过期文件
+- 主 agent 一次 turn 里 spawn 的子 agent 如果没正确清理,Stop hook 一次性回收
+
+这是 Codex 上唯一能做到"无条件执行"的清理点,弥补 `SessionEnd` / `SubagentStop` 缺失。
+
+### 9.6 对 Chorus 移植的具体应用
+
+- **PM workflow**:briefing 里预渲染 idea 全文 + 已有 elaboration 历史,子 agent 只关心生成 proposal
+- **Developer workflow**:briefing 里预渲染 task + 上游依赖 task 的 files/API 契约,子 agent 不用再查
+- **Reviewer workflow**:briefing 里预渲染 task/proposal 全文 + AC 清单 + 往次 comments,子 agent 聚焦评审
+- **session 管理**:主 agent 在 spawn 前 `chorus_create_session` 拿 UUID;briefing 文件名用 sessionUuid;Stop hook 做扫尾 checkout
+
+### 9.7 对阶段 1/2 的影响
+
+在路线图(第 6 节)基础上新增:
+
+- **阶段 1.5** — 实现 briefing 模板:每个 sub-agent(`proposal-reviewer` / `task-reviewer`)配一个 `briefing.tmpl.md`,主 agent 在 skill 指令里按模板渲染
+- **阶段 2 扩展** — `Stop` hook 加扫尾逻辑,替代 SessionEnd / SubagentStop 的清理职责
+
+---
+
+## 10. 关键更正:Codex subagent 原生支持 skill
+
+**(本节对第 9 节的重要修订。)**
+
+深入查阅 Codex 源码(`codex-rs/core/src/session/mod.rs::spawn_internal`、`codex-rs/core/src/agent/role.rs` 及其 tests)和官方 subagent 文档后,发现 Codex subagent **完整支持 skill**,这大幅改变了移植策略。
+
+### 10.1 事实清单
+
+1. **Subagent 独立 discovery** — `spawn_agent` 启动的子会话会用自己的 config(= 父 config + role layer + spawn-time overrides)重新扫描所有 skill 根目录:`$CWD/.agents/skills` → `$REPO_ROOT/.agents/skills` → `$HOME/.agents/skills` → `/etc/codex/skills` → 系统内置 + 插件贡献
+2. **Skill 清单注入 system prompt** — 子 agent 启动时,同一套 `skills_instructions`(name + description + SKILL.md 绝对路径)作为系统指令块注入,与主 agent 格式完全一致
+3. **Progressive disclosure 在子 agent 中同样有效** — SKILL.md 全文不预加载,模型按需用 `Read` 工具自己打开;`references/` 和 `scripts/` 按 SKILL.md 指引懒加载
+4. **显式触发 `$<skill-name>` 有效** — 主 agent 在 `spawn_agent(message=...)` 里写 "请按 `$develop` 执行",子 agent 自己会识别并读取对应 SKILL.md
+5. **Role 层可精细裁剪** — 自定义 role 的 TOML 文件里用 `[[skills.config]] path=... enabled=false` 可关掉特定 skill,避免指令噪声
+6. **`skills.config` 会继承** — 官方 subagent 文档明确列出 `skills.config` 为可继承字段:"Optional fields such as ... `skills.config` inherit from the parent session when you omit them."
+
+源码证据:`codex-rs/core/src/agent/role_tests.rs::apply_role_skills_config_disables_skill_for_spawned_agent`。
+
+### 10.2 对 Chorus 移植策略的影响
+
+**第 9 节的 Workaround A(预渲染 briefing 文件)不再是核心依赖**,降级为可选增强。新的推荐模式:
+
+| 内容类别 | 载体 | 理由 |
+|---|---|---|
+| 静态流程规程(评审步骤、VERDICT 格式、工具调用顺序、AC 检查清单模板) | **Codex skill**(`SKILL.md` + 可选 references) | 子 agent 原生 discovery,progressive disclosure 自动生效,无需主 agent 重复转述 |
+| 动态任务参数(`sessionUuid`、`taskUuid`、当前项目 UUID、评审轮次、具体 AC 列表) | **`spawn_agent` message** | 这些数据每次任务不同,必须由主 agent 在 spawn 时传入 |
+| 深度定制场景数据(完整的 task 内容 + 上游依赖快照 + 历次 comments) | **可选 briefing 文件** `.chorus/briefings/<sessionUuid>.md` | 如果数据量大、想节省子 agent 的 MCP 往返查询次数时启用 |
+| role 级工具限制(READ-ONLY、禁用 Edit/Write/Bash) | **自定义 role TOML** + `sandbox_mode` | 比依赖 prompt 约束可靠 |
+| 禁止 reviewer 读取无关 skill(如避免 develop skill 干扰评审判断) | role TOML 里 `[[skills.config]] enabled=false` | 减小子 agent 指令噪声 |
+
+### 10.3 修订后的子 agent 调用模板
+
+以 task-reviewer 为例:
+
+```
+spawn_agent(
+  agent_type="chorus-task-reviewer",
+  message="""
+  Review Chorus task {taskUuid} for Chorus session {sessionUuid}.
+  Max review rounds: {maxRounds}.
+  Follow the $review skill exactly — pay attention to the Turn Budget Rule
+  and the VERDICT output format.
+  Before exit: chorus_add_comment with VERDICT, then chorus_session_checkout_task.
+  """
+)
+```
+
+这里 `$review` 触发子 agent 读 `review/SKILL.md`,skill 里 300+ 行的评审规程无需重复写进 message。动态参数(taskUuid / sessionUuid / maxRounds)由主 agent 精确传入。
+
+### 10.4 打包建议更新
+
+第 5 节的插件目录结构保持不变,额外增加:
+
+```
+chorus-codex-plugin/
+├── agents/
+│   ├── proposal-reviewer.toml         # Codex role 格式(非 Claude 的 .md)
+│   │   └─ 内含 sandbox_mode="read-only" + skills.config 禁用无关 skill
+│   └── task-reviewer.toml
+```
+
+把原 Claude 的 `proposal-reviewer.md` / `task-reviewer.md` 里的:
+- `disallowedTools` → role TOML 的 `sandbox_mode` + 工具白名单
+- `criticalSystemReminder_EXPERIMENTAL` → role 的 system prompt 段
+- prompt 主体的"RE VIEW PROCEDURE"详细步骤 → 移到 skill 里,只在 role prompt 保留"你的身份 + 必读 skill"核心约束
+
+### 10.5 阶段路线图微调
+
+- **阶段 1** 新增:编写 `agents/*.toml` 定义 2 个 role,并把原评审 prompt 按 10.4 拆分
+- **阶段 1.5(briefing 模板)** 降级为可选,仅在发现子 agent MCP 查询次数过多时启用
+- 其他阶段不变
+
+### 10.6 为什么这个发现重要
+
+Chorus 原版依赖 `SubagentStart` hook 把 session 指令"塞进"子 agent,是因为 Claude Code 没有 skill 对 subagent 可见性的保证。Codex 从设计上就把 skill 作为所有 agent 共享的"只读指令库",等同于**用 skill 机制替代了 hook 注入**。这是 Codex 对 "agent 是 prompt 的函数" 哲学的自洽实现——运行时注入不存在,但 skill 作为 agent-agnostic 的静态指令层,覆盖了 Chorus hook 90% 的注入需求。
+
+剩下 10% 的"真正需要运行时数据"的场景(session UUID 等),由主 agent 在 `spawn_agent` message 里传或写 briefing 文件解决。
+
+---
+
+## 11. 架构决策:移除 `.chorus/` 本地状态目录
+
+**(本节是对前面 5、6、9 节的实质性简化,后续实现以本节为准。)**
+
+### 11.1 决策
+
+Codex 移植版**不使用** `.chorus/` 目录。所有原 Claude 版为支撑 hook 机制而维护的本地文件系统状态都被删除:
+
+| 原 Claude 版路径 | 用途 | Codex 版处理 |
+|---|---|---|
+| `.chorus/state.json` | Hook 间共享 owner / roles / session 映射 | ❌ 不需要,由主 agent 靠 MCP checkin 获取 |
+| `.chorus/sessions/<name>.json` | SubagentStart 创建、SubagentStop 读取的 session 元数据 | ❌ 不需要,Codex 无 SubagentStart |
+| `.chorus/pending/<name>` | PreToolUse:Task 写、SubagentStart 原子 mv 认领的同步文件 | ❌ 不需要,Codex 无 Task hook |
+| `.chorus/claimed/<agent_id>` | 被 SubagentStart 认领后的 agent 映射 | ❌ 不需要 |
+| `.chorus/briefings/<sessionUuid>.md` | 第 9.3 节的 workaround | ❌ 取消,subagent 直接读 skill + `spawn_agent` message 足够 |
+| `.chorus/.mcp_headers.*` | MCP HTTP 调用的临时 header 文件 | ❌ 移到 `/tmp/` 或 `$XDG_RUNTIME_DIR/` |
+
+### 11.2 根本原因
+
+Chorus 原版 `.chorus/` 目录的核心价值是**跨 hook 的状态共享**:
+
+- `SessionStart` hook 写 owner/roles → 后续 hooks 读
+- `PreToolUse:Task` 写 pending → `SubagentStart` 原子 mv 认领
+- `SubagentStart` 写 session 映射 → `TeammateIdle` / `TaskCompleted` / `SubagentStop` 读
+
+Codex 没有 SubagentStart / SubagentStop / TeammateIdle / TaskCompleted 事件,**跨 hook 状态共享的链路在源头就断了**,保留 `.chorus/` 没有任何消费者。
+
+### 11.3 由此放弃的功能(明确的 limitation)
+
+移植版**不提供**以下自动化能力,改由主 agent 的 skill 规程承担:
+
+- ❌ **子 agent 自动创建 Chorus session** — 主 agent 在 `spawn_agent` 前若需 session,自己调 `chorus_create_session` 并把 UUID 写进 message
+- ❌ **子 agent 退出时自动 close session / auto-verify** — 子 agent 在 skill 指令下自己调 `chorus_session_checkout_task` 和 `chorus_submit_for_verify`
+- ❌ **TeammateIdle 自动心跳** — 依赖 Chorus 后端给 session 设足够长的 TTL,或主 agent 周期性主动 heartbeat
+- ❌ **Session 复用** — 每次 spawn 新 session;如需复用,主 agent 自己追踪 UUID
+
+这些是对 Chorus 原版"hook 保证 session 纪律"能力的**明确取舍**,代价是多 agent 并行场景下主 agent 需更主动地管理 session 生命周期,但收益是:
+
+- **零本地状态** — Codex 版插件纯 stateless,无需任何清理逻辑
+- **更简单的 debug** — 所有 session 状态的真相来源(source of truth)都在 Chorus 后端,本地没有中间状态会不一致
+- **插件可分发性更强** — 无需 `install-hooks.sh` 创建目录结构,skill + MCP + subagent role 一套就行
+
+### 11.4 对前面章节的修订
+
+**第 5.1 节(插件目录)**:保持不变(原本就没有 `.chorus/`)。
+
+**第 5.2 节(Hooks 安装器)**:仅保留 3 个 hook,全部 stateless,不再依赖 `chorus-api.sh` 的 state_get / state_set 函数:
+
+```
+hooks/
+├── on-session-start.sh          # 调 chorus_checkin,输出 additionalContext
+├── on-user-prompt.sh            # 输出简短工作流提醒(静态文本)
+├── on-post-submit-proposal.sh   # matcher 命中 chorus_pm_submit_proposal,提醒 spawn reviewer
+├── on-post-submit-for-verify.sh # matcher 命中 chorus_submit_for_verify,提醒 spawn reviewer
+└── chorus-mcp-call.sh           # 精简版 MCP HTTP 调用 helper(不含 state 管理)
+```
+
+**第 6 节路线图**:
+
+- 阶段 1 不变
+- **阶段 1.5(briefing 模板)完全取消**
+- 阶段 2 简化:去掉 `on-session-end.sh` lazy cleanup 逻辑(无目录需清理),去掉 Stop hook 兜底扫描逻辑(无 claimed 文件需扫描)
+
+**第 9 节(subagent workaround)**:9.3 Workaround A(briefing 文件)正式作废。9.4(skill progressive disclosure)+ 9.5(Stop hook,仅用于其他用途,非 Chorus 清理)继续作为推荐方案。
+
+### 11.5 对用户的体感影响
+
+| 场景 | Claude Chorus | Codex Chorus(简化版) |
+|---|---|---|
+| 单人手动完成一个 proposal 全流程 | 无差异 | 无差异 |
+| 主 agent 单独完成一个 task | 无差异 | 无差异 |
+| 主 agent spawn 一个 reviewer | hook 自动建 session,reviewer 无感 | 主 agent 提前建 session,传 UUID |
+| 10 个并行 worker 做一个 proposal 的 tasks | hook 自动管 10 个 session,退出时自动 checkout | 主 agent 自己维护 {worker → sessionUuid} 表,或直接不用 session(可接受:Chorus session 是可选的,只影响 observability,不影响 task 状态) |
+| session 泄漏(worker 异常退出没 checkout) | SubagentStop hook 兜底 | 依赖 Chorus 后端 TTL |
+
+**关键洞察**:Chorus session 的核心作用是**多 agent 并行时的 observability 归因**(把 comments / work reports 按 agent 分组)。单 agent 场景下 session 是可选的。因此简化版对绝大多数用户(单 agent 使用)零影响,只对重度并行场景的"谁做了什么"归因能力打折。
+
+这是一个可接受的工程取舍。
+
+---
+
+## 12. 更正日志(Plugin hooks 实装状态)
+
+**2026-04 初步研究**(本文 1–11 节写作时)认为"plugin manifest 不支持声明 hooks"。该结论来自半年前的文档与 GitHub issue,在当前 Codex 0.125.0 版本上需要修正为更精确的描述:
+
+1. **插件声明层** — `.codex-plugin/plugin.json` **可以**写 `"hooks": "./hooks.json"`,插件根目录**可以**放 `hooks.json`。这是官方 scaffold 与社区约定(如 Figma 插件示例)的做法,是"正确的打包方式"。
+2. **运行时加载层** — Codex 0.125.0 的 runtime **尚未**把 plugin 内 hooks.json 纳入 hook discovery。本机二进制 strings 扫描显示 `.codex-plugin/plugin.json` 的 `hooks` 字段值仍是字面 `[TODO: ./hooks.json]`,同时 `plugin_hook` / `effective_hook` 等符号不存在。
+3. **跟踪 issue** — openai/codex#16430(bug:plugin-local hooks 不被加载)、#17331(feature request:把 hooks 纳入 plugin manifest loading)
+4. **移植版的应对**:
+   - 按**未来兼容格式**在插件内放 `hooks.json` 与 `.codex-plugin/plugin.json` 的 `hooks` 字段
+   - 继续提供 `install-hooks.sh` 作为当前版本的过渡
+   - `install-hooks.sh` 增加**自检**:扫描 Codex 二进制符号,若已实装原生 plugin hook 加载则自动跳过(可用 `CHORUS_INSTALL_FORCE=1` 强制安装)
+5. **用户视角**:Codex 修复 #16430 后,从 marketplace 安装本插件会自动获得 hooks,`install-hooks.sh` 会自行检测到不再需要
+
+---
+
+## 13. 安装流程实证(2026-04-27)
+
+本节记录在 **Codex 0.125.0 + Linux** 上对已发布插件的端到端安装 / 运行验证。**所有结论都通过二进制字符串扫描和 app-server JSON-RPC 实际返回交叉确认**,不再依赖旧文档或 issue。
+
+### 13.1 `codex plugin` 命令表面
+
+```
+codex plugin marketplace <add|upgrade|remove>
+```
+
+就这三个子命令。**没有 `codex plugin install` / `list` / `enable`**。这是官方刻意的设计:
+
+- `marketplace add` 只把**来源**注册进 `~/.codex/config.toml` 的 `[marketplaces.<name>]`,不做任何插件安装。
+- 单个插件的 *安装 / 卸载 / 启用 / 禁用* 必须走 **TUI `/plugins` 面板**(底层对应 JSON-RPC `plugin/install` / `plugin/uninstall`,配合 `config/value/write` 持久化 `[plugins."<name>@<marketplace>"] enabled = true`)。
+
+### 13.2 规范安装流程(验证通过)
+
+```bash
+# 1. 注册 marketplace(可多个来源并存)
+codex plugin marketplace add /home/ubuntu/dev/ai-pm
+
+# 2. 进入 TUI,打开插件面板,安装 Chorus
+codex
+#   > /plugins
+#   选 chorus-plugins → chorus → Install
+```
+
+安装副作用(验证后的实际产物):
+
+- `~/.codex/config.toml` 追加:
+  ```toml
+  [marketplaces.chorus-plugins]
+  source_type = "local"
+  source      = "/home/ubuntu/dev/ai-pm"
+
+  [plugins."chorus@chorus-plugins"]
+  enabled = true
+  ```
+- 插件完整拷贝到:
+  ```
+  ~/.codex/plugins/cache/chorus-plugins/chorus/0.7.5/
+    ├── .codex-plugin/plugin.json
+    ├── .mcp.json
+    ├── hooks.json
+    ├── skills/{chorus,idea,proposal,develop,review,quick-dev,yolo}/SKILL.md
+    ├── agents/{chorus-proposal-reviewer,chorus-task-reviewer}.toml
+    ├── hooks/*.sh
+    └── bin/install-hooks.sh
+  ```
+
+### 13.3 Skills 命名空间(官方行为)
+
+`skills/list` JSON-RPC 返回显示插件 skill 被加上前缀:
+
+| 插件中路径 | Codex 暴露的 skill name |
+|---|---|
+| `skills/chorus/SKILL.md`    | `chorus:chorus`    |
+| `skills/develop/SKILL.md`   | `chorus:develop`   |
+| `skills/idea/SKILL.md`      | `chorus:idea`      |
+| `skills/proposal/SKILL.md`  | `chorus:proposal`  |
+| `skills/quick-dev/SKILL.md` | `chorus:quick-dev` |
+| `skills/review/SKILL.md`    | `chorus:review`    |
+| `skills/yolo/SKILL.md`      | `chorus:yolo`      |
+
+所有 skill `scope: "user"`、`enabled: true`。**在 TUI 里输入 `$chorus:develop` 激活**(裸 `$develop` 是否工作取决于是否有同名碰撞;有前缀更可靠)。
+
+### 13.4 MCP 加载(已验证)
+
+`codex mcp list` 输出中 `chorus` 在 `Url` 表里并显示 `enabled`:
+
+```
+Name    Url                    Bearer Token Env Var  Status   Auth
+chorus  ${CHORUS_URL}/api/mcp  -                     enabled  Unsupported
+```
+
+注意:
+
+- `${CHORUS_URL}` / `${CHORUS_API_KEY}` 是插件 `.mcp.json` 中的环境变量占位符;**必须由用户导出**,否则 HTTP 传输层 URL 展开为空,`codex mcp list` 仍报 enabled,但实际请求失败。
+- `Bearer Token Env Var` 列为空是因为我们用的是 `headers.Authorization = "Bearer ${CHORUS_API_KEY}"` 的写法;专用的 `bearer_token_env_var` 字段是另一种备选(由二进制 strings 确认)。二者等价。
+
+### 13.5 Marketplace schema(严格版,基于二进制字面量)
+
+```json
+{
+  "name": "chorus-plugins",
+  "interface": { "displayName": "Chorus AI-DLC" },
+  "plugins": [
+    {
+      "name": "chorus",
+      "source": {
+        "source": "local",
+        "path":   "./plugins/chorus"
+      },
+      "policy": {
+        "installation":   "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+```
+
+实证纠错(相对于早期本文草稿):
+
+- `installation` 枚举只接受 `NOT_AVAILABLE` / `AVAILABLE` / `INSTALLED_BY_DEFAULT`。曾出现过 `"manual"` 这种写法是错的。
+- `authentication` 枚举只有 `ON_INSTALL` / `ON_USE`,没有 `apiKey` / `none`。`ON_INSTALL` = 安装时一次性配置(最适合需要固定 API key 的 MCP);`ON_USE` = 每次使用时弹窗(更适合 OAuth / 短期 token)。Chorus 要求长期 bearer,故 `ON_INSTALL`。
+- `source.path` 必须是 `./plugins/<name>`(repo 相对)。因此 monorepo 使用 `plugins/<name>` → `../packages/chorus-codex-plugin` 的 symlink。
+- `plugin.json` 里 `mcpServers: "./.mcp.json"` 和 `apps: "./.app.json"` 路径**有**前缀点;但 `hooks: "./hooks.json"`(注意 hooks 文件在插件根**没有**前置点,作为路径写法前缀点是 `./`,不是 `.hooks.json`)。二进制内字面匹配:`"mcpServers": "./.mcp.json"`、`"apps": "./.app.json"`、`"hooks": "./hooks.json"`。
+
+### 13.6 "看不到"的排查清单
+
+用户报告 "装完看不到 MCP 和 skills" 的常见真因(按概率排序):
+
+1. **只跑了 `marketplace add`,没进 `/plugins` 做 install** — 最常见。
+   - 验证:`ls ~/.codex/plugins/cache/<marketplace>/<plugin>/` 是否存在。
+2. **安装完没重启 Codex session** — MCP 服务在会话启动时建立连接,新增 server 不会热刷新给当前 session(`config/mcpServer/reload` 存在但不是默认触发)。
+3. **`$skill` 没加命名空间前缀** — 打 `$chorus:develop`,不是 `$develop`。
+4. **MCP 环境变量为空** — 服务显示 `enabled` 但连不上。用 `env | grep CHORUS` 自查。
+5. **`plugin.json` 有非法字段** — Codex 在启动时会静默跳过 schema 错误的插件。用以下命令探测实际 skills 列表:
+   ```bash
+   printf '%s\n' \
+     '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-01-01","capabilities":{},"clientInfo":{"name":"probe","version":"0.1"}}}' \
+     '{"jsonrpc":"2.0","id":2,"method":"skills/list","params":{}}' \
+     '{"jsonrpc":"2.0","id":3,"method":"plugin/list","params":{}}' \
+     | codex app-server
+   ```
+
+---
+
+## 14. 最终架构(2026-04-27 重构)
+
+经过方案迭代,最终确定**不把 MCP 注册放进插件**。关键洞察:
+
+### 14.1 为什么 `.mcp.json` 走不通
+
+三条现实约束叠加,让 plugin-local `.mcp.json` 对 Chorus 这种"私有部署 + 用户自持 key"的 SaaS 无法工作:
+
+1. **`${VAR}` 不展开** — Codex 对 `url` / `args` / `http_headers.*` 任何字符串都字面处理。实测写 `url = "http://test-${HOME}/mcp"`,`codex mcp list` 原样回显 `${HOME}`,未替换。
+2. **MCP 子进程不继承 shell env** — 实测父进程 `export CHORUS_URL=...` 后启动 codex,MCP 子进程 `process.env.CHORUS_URL` 为 `<unset>`。env 字段里必须显式列出要"注入"的变量,而值本身是 TOML 字面量(`env = { K = "literal" }`),完全不从父进程读取。
+3. **`args` / `command` 不支持插件相对路径** — 子进程 cwd = session cwd(用户打开 codex 的目录),不是插件安装目录。没有 `${CODEX_PLUGIN_DIR}` 之类占位符。把 proxy 放在插件里用相对路径启动不可行。
+
+参考:二进制 strings 里有 `= uses unsupported `bearer_token`; set `bearer_token_env_var`.`(拒绝顶级 `bearer_token`),但 **`http_headers = { Authorization = "Bearer cho_xxx" }` 字面量被完全接受**,实测 `codex mcp list` 显示 `Auth = Bearer token`。
+
+### 14.2 最终方案:install script + plugin 分离
+
+**职责划分**
+
+| 组件 | 负责 |
+|---|---|
+| Codex 插件 (`packages/chorus-codex-plugin/`) | skills + agents + hooks 的**内容**,通过 marketplace 分发 |
+| Install script (`public/install-codex.sh`) | marketplace 注册 + `~/.codex/config.toml` 里的 `[mcp_servers.chorus]` 写入 |
+| Chorus backend | HTTP streamable MCP endpoint(已有) |
+
+**用户路径**
+
+```bash
+# 一行装齐(onboarding 里贴这个):
+curl -sSL https://chorus.ai/install-codex.sh | bash
+
+# 然后:
+codex          # /plugins → chorus → Install
+```
+
+**Install script 做的 4 件事**
+
+1. `codex --version` 探测
+2. `codex plugin marketplace add <chorus-repo-url>`(幂等,已存在则跳过)
+3. 交互或 `CHORUS_URL`/`CHORUS_API_KEY` env 读取凭据
+4. idempotent 写入 `~/.codex/config.toml`:
+   ```toml
+   [mcp_servers.chorus]
+   url = "<user-provided-url>"
+
+   [mcp_servers.chorus.http_headers]
+   Authorization = "Bearer <user-provided-key>"
+   ```
+   清理正则 `^\[mcp_servers\.chorus(?:\.[^\]]+)?\][^\[]*` 同时匹配主表和子表,key 轮换干净。
+
+### 14.3 砍掉的东西
+
+相对于 13 节的设想,最终版不再需要:
+
+- `packages/chorus-codex-plugin/.mcp.json` — 删
+- `packages/chorus-codex-plugin/bin/install-hooks.sh` — 删(hook 的自动加载限制独立存在,但不在本次范围)
+- `plugin.json` 里的 `"mcpServers": "./.mcp.json"` 字段 — 删
+- stdio proxy(Node 实现的 stdio↔HTTP 代理) — 不需要了,因为直接用 Codex 原生 HTTP MCP 传输
+
+### 14.4 Trade-offs
+
+**放弃了什么**
+
+- "装插件即可用"的一键体验 — 变成"跑一次安装脚本 + `/plugins` install"两步
+- 插件完全自包含 — 现在依赖外部 `install-codex.sh` 分发
+
+**换来了什么**
+
+- 简单、透明、零运行时依赖(Node proxy 都不要)
+- 直接用 Codex 的 HTTP MCP 传输,稳定且社区验证过
+- API key 轮换一条命令(`install-codex.sh` rerun)
+- 当 Codex 未来解锁 `${VAR}` 展开 / env 透传,迁移回 plugin-local `.mcp.json` 只需恢复删掉的文件
+- 对 onboarding UX 无损 — `curl | bash` 比"让用户手动编辑 `~/.codex/config.toml`"体验好得多,且与 Homebrew / nvm / pyenv 等生态做法一致
+
+### 14.5 未来 Codex 解锁路径
+
+如果 Codex 某个版本加上以下任一能力,可以把 MCP 注册并回插件:
+
+1. `.mcp.json` 支持 `${CHORUS_URL}` / `${CHORUS_API_KEY}` 插值(最简单的改法)
+2. MCP 子进程默认继承父进程 env(停止过滤)
+3. `command` / `args` 支持 `${CODEX_PLUGIN_DIR}` 占位符(让 stdio proxy 可行)
+4. plugin manifest 增加 `postInstall` hook(安装时跑自定义脚本写 config.toml)
+
+目前追踪的相关 issue:openai/codex#16430(plugin-local hooks)、#17331(plugin manifest loading)。
+
+---
+
+## 15. Install script 实施细节(2026-04-27)
+
+### 15.1 零外部依赖
+
+`public/install-codex.sh` 是纯 `bash + awk + POSIX coreutils`,不依赖 Python/jq/node(除了 `codex` 本身)。实现时先用 `python3` 做 TOML 段处理,被指正后改成 awk,覆盖 macOS(BSD awk)和 Linux(GNU awk)。
+
+### 15.2 五步流程
+
+1. **Check codex** — `command -v codex` 存在即 pass;打印 `codex --version`
+2. **Register marketplace** — `codex plugin marketplace add <url>`。grep `^\[marketplaces\.chorus-plugins\]` 检测已存在则跳过
+3. **Collect credentials** — 优先 `CHORUS_URL` / `CHORUS_API_KEY` env;否则交互(`stty -echo` 读 key 不回显);通过 `/dev/tty` fallback 支持 `curl | bash` 场景
+4. **Write [mcp_servers.chorus]** — awk 清理 `^\[mcp_servers\.chorus(\..*)?\][^\[]*` 主表+子表,然后 append 字面量 URL + `[mcp_servers.chorus.http_headers] Authorization = "Bearer <key>"`。`chmod 600` 保护 secret
+5. **Install hooks** — 见 15.3
+
+### 15.3 Hooks 装配(步骤 5)
+
+Codex 0.125.0 **不加载 plugin-local `hooks.json`**,必须装到 `~/.codex/hooks.json` 或 `~/.codex/config.toml [hooks]`(二选一,装两份会报 `loading hooks from both <A> and <B>`)。二进制里明确字符串:
+
+```
+hooks.json/config.toml
+failed to parse hooks config
+loading hooks from both <A> and <B>/; prefer a single representation for this layer
+```
+
+而且 hooks 由 feature flag 控制 — 二进制里的 feature 白名单包含 `codex_hooks`,必须在 config.toml 里显式:
+
+```toml
+[features]
+codex_hooks = true
+```
+
+**实施策略**
+
+- 定位插件安装目录:`$CODEX_HOME/plugins/cache/chorus-plugins/chorus/<latest-semver>/hooks/`(用 `ls -1 | sort -V | tail -1` 选最新版)
+- 如果 `~/.codex/hooks.json` 不存在,或已是 chorus-owned(`grep -q "chorus-plugins/chorus" $HOOKS_JSON`)→ 直接写 4 个 hook 条目,`command` 字段全部使用绝对路径指向 cache 里的脚本
+- 如果已存在且**不是** chorus-owned → 打印警告,不覆写,提示用户手动处理(避免踩用户自己的 hooks)
+- 对 `[features] codex_hooks = true`:三种情况幂等处理(不存在 → append;`[features]` 已存在但缺 `codex_hooks` → 用 awk 在 header 后插入;已启用 → 跳过)
+
+**为什么不放 config.toml 的 `[hooks]` 段**
+
+技术上都行,但独立 `hooks.json` 更简单:
+- 清理只需要 `rm ~/.codex/hooks.json`,不会误伤 config.toml 其他段
+- chorus 版本升级时 hooks 内容会变,独立文件可以整体重写,不需要在混合 TOML 里做 section-level diff
+- Codex 官方示例(plugin manifest 里 `"hooks": "./hooks.json"`)也默认用 JSON 格式
+
+### 15.4 Hook 事件支持现状
+
+Codex 0.125.0 的 hook 事件枚举(从二进制 strings 精确取):
+
+| Event            | 何时触发                      | Chorus 使用 |
+|------------------|-------------------------------|---|
+| `SessionStart`   | session 启动/resume/clear    | ✅ checkin |
+| `UserPromptSubmit` | 用户发送 prompt 之前         | ✅ 注入 reminder |
+| `PreToolUse`     | 工具调用前(可阻止)           | 未用 |
+| `PostToolUse`    | 工具调用后                    | ✅ 提案/任务提交后 spawn reviewer |
+| `PermissionRequest` | 权限请求时                 | 未用 |
+| `Stop`           | turn 结束前                   | 未用(需要 SubagentStop 才有意义) |
+| `Notification`   | 系统通知                      | 未用 |
+
+注意 `SubagentStop` / `TeammateIdle` / `TaskCompleted` 这些 Claude Code 有的事件 Codex 暂无,见 11 节的 stateless 决策。
+
+### 15.5 用户 UX
+
+```bash
+curl -sSL https://chorus.ai/install-codex.sh | bash
+# → 5/5 steps, all green
+codex
+# > /plugins → chorus-plugins → chorus → Install
+# skills + agents + hooks + MCP 全部工作
+```
+
+如果用户先安装了插件再跑 installer,hooks 也一样能装(installer 会从 cache 读到脚本路径);
+如果用户先跑 installer 再装插件,installer 的 step 5 会打印 warning "Plugin not yet installed — skipping hooks. Run Codex TUI /plugins → Install first, then re-run this installer."
+
+### 15.6 bash 3.2 兼容性(macOS system bash)
+
+macOS 直到今天的 `/bin/bash` 仍然是 3.2.57(2007 年版本,Apple 出于 GPLv3 许可问题一直没升)。
+`curl | bash` 场景下 shebang 解析到的也是这个版本,所以 `install-codex.sh` **必须**能在 bash 3.2 上跑。
+
+#### 允许 / 禁用清单
+
+禁用(bash 4+ 专属):
+
+- `${VAR,,}` / `${VAR^^}` 大小写转换(用 `tr '[:upper:]' '[:lower:]'` 代替)
+- `declare -A` / `typeset -A` 关联数组(用多个普通变量或 `sed`/`awk` 代替)
+- `mapfile` / `readarray`(用 `while IFS= read -r line` 代替)
+- `&>file` 合并重定向(写 `>file 2>&1`)
+- `|&` 管道(写 `2>&1 |`)
+- `;;&` case 穿透
+- `coproc`
+
+允许(3.2 原生):
+
+- `[[ ]]`, `[[ =~ ]]` regex 匹配
+- `$'\033[...m'` ANSI 字面量
+- `${var:-default}`, `${var:+value}`, `${var#prefix}`, `${var%suffix}`
+- 函数 `name() { … }`
+- `printf '%s' "$var"`
+- `$(…)` 命令替换(嵌套也 OK)
+
+#### 回归测试:`public/test-install-codex.sh`
+
+参考 `public/chorus-plugin/bin/test-syntax.sh` 的模式,覆盖 4 个维度:
+
+1. **静态扫描** — grep 出上面禁用清单的所有命中
+2. **`bash -n` 解析** — 用 bash 3.2 做语法检查
+3. **端到端 dry run** — 用 fake `codex` stub + 隔离的 `CODEX_HOME`,验证生成的 `config.toml` 含 `[mcp_servers.chorus]`、literal URL、literal `Authorization = "Bearer …"`、`chmod 600`
+4. **幂等重跑** — 用轮换的 key 再跑一次,验证只有一个 mcp 块、只有一个 http_headers 块、旧 key 被清掉
+
+#### 运行
+
+Linux (需要本地编译的 bash 3.2 做准确回归):
+
+```bash
+# 一次性:编译 bash 3.2
+cd /tmp && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-3.2.tar.gz \
+  && tar xf bash-3.2.tar.gz && cd bash-3.2 \
+  && ./configure --without-bash-malloc --disable-nls && make -j4
+# 路径固定为 /tmp/bash32-build/bash-3.2/bash(test 脚本会自动检测)
+
+# 跑回归
+bash public/test-install-codex.sh
+# → 17 passed, 0 failed
+```
+
+macOS:
+
+```bash
+bash public/test-install-codex.sh
+# 系统 /bin/bash 就是 3.2.57,test 脚本会自动用它
+```
+
+显式指定 bash 路径(CI):
+
+```bash
+BASH32=/custom/path/bash-3.2 bash public/test-install-codex.sh
+```
+
+#### 当前状态(2026-04-27)
+
+17/17 全绿,两个 bash 版本(3.2.0 自建 + 当前系统 bash)都通过。
+
+### 15.7 砍掉 UserPromptSubmit hook(2026-04-28)
+
+**决策**: 从 Codex 插件里完全移除 `UserPromptSubmit` hook(源码、installer、用户 hooks.json 三处同步清理)。
+
+**原因**:
+
+- `UserPromptSubmit` 原本设计是每次用户按回车时注入简短工作流提醒(会话状态、未读通知等)。
+- Codex TUI 0.125 会把 hook 的 `additionalContext` **原样 echo 到 status 区**(`hook context: …` 前缀),视觉上非常嘈杂——每次发言都闪一次。
+- 注入的内容本质是 reminder,不是实时状态——`SessionStart` hook 一次性注入 checkin 已经覆盖了主要场景;未读通知靠 skill 里的 `chorus_get_notifications` 工具显式拉即可。
+- 保留它的边际收益 ≪ 它对 UX 的负面冲击。
+
+**清理清单**:
+
+- `packages/chorus-codex-plugin/hooks.json` — 去掉 UserPromptSubmit 节
+- `packages/chorus-codex-plugin/hooks/on-user-prompt.sh` — 删
+- `public/install-codex.sh` — 生成 `~/.codex/hooks.json` 时不再写 UserPromptSubmit
+- `~/.codex/plugins/cache/chorus-plugins/chorus/<ver>/` — 同步删
+- `~/.codex/hooks.json` — installer 重跑覆盖
+
+剩余 hook: `SessionStart`(一次性 checkin)+ `PostToolUse`(submit_proposal / submit_for_verify → reviewer 引导)。

--- a/docs/codex-plugin-plan.md
+++ b/docs/codex-plugin-plan.md
@@ -6,7 +6,7 @@ Codex 版 Chorus 插件的设计说明与安装指南。Claude Code 版在 `publ
 
 ## 1. 一句话结论
 
-- **安装方式**:`curl -sSL https://chorus.ai/install-codex.sh | bash` → `codex` → `/plugins` → Install。
+- **安装方式**:`curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh | bash` → 启动 `codex`(marketplace policy `INSTALLED_BY_DEFAULT`,首次启动自动装)。若未自动,`/plugins` 一键 Install 回退。
 - **插件内容**(`plugins/chorus/`): 7 个 skills + 2 个 reviewer sub-agents + 2 个 hooks(`SessionStart` + 2× `PostToolUse`)。
 - **MCP server**: **不**在插件 `plugin.json` 里声明,由 installer 单独写到 `~/.codex/config.toml` 的 `[mcp_servers.chorus]`。
 - **Marketplace 源**: `https://github.com/Chorus-AIDLC/Chorus`(Codex 读 `.agents/plugins/marketplace.json`)。
@@ -58,7 +58,7 @@ Chorus/                                         (repo root)
 ### 3.1 一键脚本(推荐)
 
 ```bash
-curl -sSL https://chorus.ai/install-codex.sh | bash
+curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh | bash
 ```
 
 脚本会:
@@ -76,7 +76,7 @@ curl -sSL https://chorus.ai/install-codex.sh | bash
 ```bash
 CHORUS_URL=https://chorus.example.com/api/mcp \
 CHORUS_API_KEY=cho_xxx \
-  bash <(curl -sSL https://chorus.ai/install-codex.sh)
+  bash <(curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh)
 ```
 
 ### 3.3 完成插件安装
@@ -133,7 +133,7 @@ Install 后,重启 session 就能看到 skills(`$chorus:chorus`、`$chorus:devel
 **字段含义**(以 Codex 0.125 实际读取为准):
 
 - `source.source`: `"local"` 用 `path`,`"git"` 用 `repo`/`ref`;我们用 local。Codex 从 marketplace `source` 拉 repo 时,用的也是同一份 `marketplace.json`,所以本地验证 == 线上分发。
-- `policy.installation`: `AVAILABLE`(需用户确认)、`INSTALLED_BY_DEFAULT`(随 marketplace 自动装)、`NOT_AVAILABLE`(藏起来)。我们用 `AVAILABLE` —— 用户 `/plugins` 看见它,手动 Install。
+- `policy.installation`: `AVAILABLE`(需用户确认)、`INSTALLED_BY_DEFAULT`(首次启动自动装)、`NOT_AVAILABLE`(藏起来)。我们用 `INSTALLED_BY_DEFAULT` —— Codex 首次 TUI 启动即自动安装,无 CLI `plugin install` 的遗憾在用户侧最小化。若自动未触发(旧 Codex),回退为 `/plugins` 一键 Install。
 - `policy.authentication`: `ON_INSTALL`(安装时要凭据)、`ON_USE`(每次用 MCP 时)。我们用 `ON_INSTALL`(插件本身自带 auth 提示);真正的 bearer 由 `install-codex.sh` 写 config.toml。
 
 ### 4.2 Marketplace source
@@ -146,7 +146,7 @@ Installer 默认往这里 `codex plugin marketplace add`。覆盖:
 
 ```bash
 CHORUS_MARKETPLACE_SOURCE=git+https://github.com/myfork/Chorus@branch \
-  bash <(curl -sSL https://chorus.ai/install-codex.sh)
+  bash <(curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh)
 ```
 
 ---
@@ -345,7 +345,7 @@ Claude 版依赖 `.chorus/sessions/*.json` 追踪多 agent 协作时的 session 
 
 ### 9.3 插件 Install 必须走 TUI
 
-Codex 0.125 的 `codex plugin` 子命令只有 `marketplace add/upgrade/remove`,**没有** `plugin install <name>`。单个插件 install 要进 TUI `/plugins`。Installer 用明显的 "Last step" 提示引导用户。
+Codex 0.125 的 `codex plugin` 子命令只有 `marketplace add/upgrade/remove`,**没有** `plugin install <name>`。脚本把 marketplace `policy.installation` 设为 `INSTALLED_BY_DEFAULT`,让 Codex 首次启动时自动装入。若未自动触发(不同 Codex 版本实现略异),Installer 的 epilogue 指引用户进 `/plugins` 一键 Install 作为 fallback。
 
 ---
 

--- a/docs/codex-plugin-plan.md
+++ b/docs/codex-plugin-plan.md
@@ -1,0 +1,395 @@
+# Chorus Plugin for Codex CLI
+
+Codex 版 Chorus 插件的设计说明与安装指南。Claude Code 版在 `public/chorus-plugin/`；本文只讲 Codex 版（`plugins/chorus/`）。
+
+---
+
+## 1. 一句话结论
+
+- **安装方式**:`curl -sSL https://chorus.ai/install-codex.sh | bash` → `codex` → `/plugins` → Install。
+- **插件内容**(`plugins/chorus/`): 7 个 skills + 2 个 reviewer sub-agents + 2 个 hooks(`SessionStart` + 2× `PostToolUse`)。
+- **MCP server**: **不**在插件 `plugin.json` 里声明,由 installer 单独写到 `~/.codex/config.toml` 的 `[mcp_servers.chorus]`。
+- **Marketplace 源**: `https://github.com/Chorus-AIDLC/Chorus`(Codex 读 `.agents/plugins/marketplace.json`)。
+
+---
+
+## 2. 仓库内文件布局
+
+```
+Chorus/                                         (repo root)
+├── .agents/plugins/marketplace.json            ← Codex marketplace 清单,指向 ./plugins/chorus
+├── plugins/
+│   └── chorus/                                 ← 插件本体(真代码,非 symlink)
+│       ├── .codex-plugin/plugin.json           ← 元数据(name, version, skills/ 路径, hooks 路径)
+│       ├── hooks.json                          ← SessionStart + 2× PostToolUse
+│       ├── hooks/
+│       │   ├── chorus-mcp-call.sh              ← MCP-over-HTTP 小工具(无依赖,纯 curl+jq)
+│       │   ├── hook-output.sh                  ← 生成 hook JSON 输出的 helper
+│       │   ├── on-session-start.sh             ← 自动 checkin 并注入 additionalContext
+│       │   ├── on-post-submit-proposal.sh      ← 引导 spawn chorus-proposal-reviewer
+│       │   └── on-post-submit-for-verify.sh    ← 引导 spawn chorus-task-reviewer
+│       ├── skills/
+│       │   ├── chorus/SKILL.md                 ← 总览 + common tools + setup + 路由
+│       │   ├── idea/SKILL.md                   ← PM: claim idea, elaboration
+│       │   ├── proposal/SKILL.md               ← PM: PRD + task DAG
+│       │   ├── develop/SKILL.md                ← Dev: claim task, report work
+│       │   ├── review/SKILL.md                 ← Admin: 审批/验收
+│       │   ├── quick-dev/SKILL.md              ← 跳过 idea/proposal 直接开任务
+│       │   ├── yolo/SKILL.md                   ← 全自动管线(需 admin+pm+dev 三角色)
+│       │   ├── chorus-proposal-reviewer/       ← mount as skill into default agent
+│       │   │   ├── SKILL.md                    ← reviewer 指令正文 + 输出格式 + VERDICT 字面量
+│       │   │   └── agents/openai.yaml          ← TUI /plugins 面板元数据(不注册 agent_type)
+│       │   └── chorus-task-reviewer/           ← mount as skill into default agent
+│       │       ├── SKILL.md
+│       │       └── agents/openai.yaml
+│       └── README.md
+│
+└── public/
+    ├── install-codex.sh                        ← 一键安装脚本(bash 3.2 兼容)
+    └── test-install-codex.sh                   ← 安装脚本的回归测试
+```
+
+**为什么 `plugins/chorus/` 就是真代码**: Codex marketplace 的 `source.path` 是相对仓库根的路径;过去曾经是 `plugins/chorus/ → packages/chorus-codex-plugin/` 的 symlink,搬平之后删了 symlink,结构更直白。`packages/` 留给其他 sub-package(`chorus-cdk`、`landing`、`openclaw-plugin` 等)。
+
+---
+
+## 3. 安装方式(最终版)
+
+### 3.1 一键脚本(推荐)
+
+```bash
+curl -sSL https://chorus.ai/install-codex.sh | bash
+```
+
+脚本会:
+
+1. 确认 `codex` 在 PATH
+2. `codex plugin marketplace add https://github.com/Chorus-AIDLC/Chorus`(幂等)
+3. 交互式询问 `CHORUS_URL` 和 `CHORUS_API_KEY`(或读环境变量)
+4. 往 `~/.codex/config.toml` 写 `[mcp_servers.chorus]` + `[mcp_servers.chorus.http_headers]`(含 Authorization Bearer),`chmod 600`
+5. 往 `~/.codex/hooks.json` 写 Chorus hooks(指向 cache 里的绝对路径),并启用 `[features] codex_hooks = true`
+
+脚本完全幂等,重跑会原地替换 API key、MCP URL、hook 路径,不产生重复 TOML 段。
+
+### 3.2 非交互(CI / 自动化)
+
+```bash
+CHORUS_URL=https://chorus.example.com/api/mcp \
+CHORUS_API_KEY=cho_xxx \
+  bash <(curl -sSL https://chorus.ai/install-codex.sh)
+```
+
+### 3.3 完成插件安装
+
+脚本跑完后最后一步**必须在 Codex TUI 里手动做**(Codex 0.125 不提供 CLI 方式 install 单个插件):
+
+```
+codex
+> /plugins
+→ 选 "chorus-plugins" → "chorus" → Install
+```
+
+Install 后,重启 session 就能看到 skills(`$chorus:chorus`、`$chorus:develop` …)和 `chorus_*` MCP tools。
+
+### 3.4 验证
+
+| 检查 | 命令 | 期望 |
+|---|---|---|
+| MCP 注册 | `codex mcp list` | 出现 `chorus` 行,Auth = `Bearer token`,enabled |
+| MCP 联通 | Codex TUI `/mcp` | `chorus` 显示 connected(绿色) |
+| 插件装好 | Codex TUI `/plugins` | `chorus` 状态 Installed |
+| Hook 启用 | `grep codex_hooks ~/.codex/config.toml` | `codex_hooks = true` |
+| Skill 可用 | 输入 `$chorus:chorus` | 弹出 skill 卡片 |
+
+### 3.5 变更 / 卸载
+
+- **换 API key 或 URL**: 重跑 `install-codex.sh`(全自动覆盖)。
+- **卸载**: Codex TUI `/plugins` → Uninstall;然后手动从 `~/.codex/config.toml` 删除 `[mcp_servers.chorus]` 块和 `[marketplaces.chorus-plugins]` 块;从 `~/.codex/hooks.json` 删除 chorus 相关节(或直接删文件)。
+
+---
+
+## 4. Marketplace 与分发
+
+### 4.1 `.agents/plugins/marketplace.json`
+
+```json
+{
+  "name": "chorus-plugins",
+  "interface": { "displayName": "Chorus AI-DLC" },
+  "plugins": [
+    {
+      "name": "chorus",
+      "source": { "source": "local", "path": "./plugins/chorus" },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+```
+
+**字段含义**(以 Codex 0.125 实际读取为准):
+
+- `source.source`: `"local"` 用 `path`,`"git"` 用 `repo`/`ref`;我们用 local。Codex 从 marketplace `source` 拉 repo 时,用的也是同一份 `marketplace.json`,所以本地验证 == 线上分发。
+- `policy.installation`: `AVAILABLE`(需用户确认)、`INSTALLED_BY_DEFAULT`(随 marketplace 自动装)、`NOT_AVAILABLE`(藏起来)。我们用 `AVAILABLE` —— 用户 `/plugins` 看见它,手动 Install。
+- `policy.authentication`: `ON_INSTALL`(安装时要凭据)、`ON_USE`(每次用 MCP 时)。我们用 `ON_INSTALL`(插件本身自带 auth 提示);真正的 bearer 由 `install-codex.sh` 写 config.toml。
+
+### 4.2 Marketplace source
+
+```
+https://github.com/Chorus-AIDLC/Chorus
+```
+
+Installer 默认往这里 `codex plugin marketplace add`。覆盖:
+
+```bash
+CHORUS_MARKETPLACE_SOURCE=git+https://github.com/myfork/Chorus@branch \
+  bash <(curl -sSL https://chorus.ai/install-codex.sh)
+```
+
+---
+
+## 5. MCP 配置(为何不在插件里声明)
+
+### 5.1 现状
+
+`plugins/chorus/.codex-plugin/plugin.json` **刻意不带** `mcpServers` 字段。MCP server 由 `install-codex.sh` 写到用户的 `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.chorus]
+url = "https://chorus.example.com/api/mcp"
+
+[mcp_servers.chorus.http_headers]
+Authorization = "Bearer cho_…"
+```
+
+### 5.2 为什么不在插件里声明
+
+Codex 0.125 的 plugin `mcpServers` 字段有两道限制,导致无法从插件直接交付可用的 MCP 配置:
+
+1. **不支持 `${VAR}` 展开** — config.toml 里的 `url` / `args` / `http_headers` 值都是字面量,不从环境变量 / `~/.secrets` 插值。若把 `url = "${CHORUS_URL}"` 写进插件,会原样打到服务器。
+2. **HTTP MCP 不能用 `bearer_token`** — Codex 只接受 `bearer_token_env_var = "FOO"`(读环境变量),或手写 `http_headers.Authorization = "Bearer xxx"`(字面量)。插件里两种都不能让用户"一次安装就用",前者要求用户 export 变量(macOS GUI 启动 Codex 时 shell env 读不到),后者要求把明文 token 写死在插件里。
+
+结论:**把 MCP 配置和插件分开**,用一行 installer 弥合,是现阶段最干净的方案。
+
+### 5.3 Installer 的 TOML 写入(关键细节)
+
+- **同一 `[mcp_servers.chorus]` 段去重**: 重跑时用 awk 把老的 `^\[mcp_servers\.chorus(\..*)?\]` 段整块删掉再追加新的。
+- **`[features] codex_hooks = true`**: hook 需要这个 flag 才生效,installer 只在缺失时追加。
+- **权限**: `chmod 600` — token 是敏感信息。
+
+---
+
+## 6. Hooks
+
+### 6.1 最终 hook 清单(2 个事件 3 条 hook)
+
+| 事件 | Matcher | 脚本 | 作用 |
+|---|---|---|---|
+| `SessionStart` | `startup\|resume\|clear` | `on-session-start.sh` | 调 `chorus_checkin`,把结果作为 `additionalContext` 注入 |
+| `PostToolUse` | `.*chorus_pm_submit_proposal` | `on-post-submit-proposal.sh` | 引导主 agent `spawn_agent(agent_type="default", items=[{type:"skill", path:"chorus:chorus-proposal-reviewer"}, …])` |
+| `PostToolUse` | `.*chorus_submit_for_verify` | `on-post-submit-for-verify.sh` | 引导主 agent `spawn_agent(agent_type="default", items=[{type:"skill", path:"chorus:chorus-task-reviewer"}, …])` |
+
+Claude 版里有 `UserPromptSubmit` hook(每次提交 prompt 注入状态提醒),Codex 版**已移除** —— Codex TUI 会把 `additionalContext` echo 到 status 区(`hook context: …` 前缀),每次发言都刷一屏很吵,边际收益不如 SessionStart 一次性注入。决策记录见 §10。
+
+### 6.2 Hook JSON 输出协议
+
+hook 往 stdout 打印一个 JSON,Codex 解析:
+
+```json
+{
+  "systemMessage": "Chorus connected at …",
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "# Chorus Plugin — Active\n\n## Checkin\n\n{…}\n…"
+  }
+}
+```
+
+- `systemMessage` → **给用户看** — TUI 用 `warning:` 前缀渲染到 status line(`warning:` 是 Codex 硬编码的 prefix,不代表这是警告)。
+- `additionalContext` → **给 agent 看** — 注入为 hidden system prompt。同时 TUI 也会原样 echo(`hook context:` 前缀),属于 TUI 的观测性 echo,和 agent 拿到的是同一内容。
+
+`hooks/hook-output.sh` 封装了 jq/fallback 两条路径生成这个 JSON。
+
+### 6.3 `~/.codex/hooks.json` 生成(by installer)
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/me/.codex/plugins/cache/chorus-plugins/chorus/0.7.5/hooks/on-session-start.sh",
+            "timeout": 20,
+            "statusMessage": "Chorus: checkin"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      { "matcher": ".*chorus_pm_submit_proposal", "hooks": [ { "type": "command", "command": "/…/hooks/on-post-submit-proposal.sh", "timeout": 10 } ] },
+      { "matcher": ".*chorus_submit_for_verify", "hooks": [ { "type": "command", "command": "/…/hooks/on-post-submit-for-verify.sh", "timeout": 10 } ] }
+    ]
+  }
+}
+```
+
+- **绝对路径**: Codex 0.125 不支持 hooks.json 里写 `${CODEX_PLUGIN_DIR}` 或相对路径展开;installer 把 plugin cache 下真实版本的绝对路径 inlined 进去。
+- **plugin cache 路径**: `$CODEX_HOME/plugins/cache/chorus-plugins/chorus/<semver>/`,semver 由 installer 从已安装版本里自动挑最新的。
+- **保护用户已有 hooks.json**: 如果发现现有文件里没有 `chorus-plugins/chorus` 路径引用,installer 不会覆盖,只 warn。
+
+### 6.4 Hook 读不到 shell env?
+
+Codex 0.125 **会把 shell 环境传给 hook 子进程**(通过 `-lc` 启动)—— 所以 `CHORUS_URL` / `CHORUS_API_KEY` 需要用户在 shell env 里 export(或写 rc 文件)才能被 hook 读到。Installer 已经在"Done" 步骤把这件事提示给用户。
+
+---
+
+## 7. Skills
+
+7 个 skills(namespaced,在 TUI 输入 `$chorus:<name>`):
+
+| 触发词 | 角色 | 用途 |
+|---|---|---|
+| `$chorus:chorus` | 所有 | 平台总览 + checkin + 公共工具清单 + setup + 路由到其他 skills |
+| `$chorus:idea` | PM | 认领 Idea,做 elaboration 轮次 |
+| `$chorus:proposal` | PM | 写 PRD + task DAG,提交 review |
+| `$chorus:develop` | Dev | 领任务,写代码,`chorus_report_work`,`chorus_submit_for_verify` |
+| `$chorus:review` | Admin | 审批 proposal,验收 task |
+| `$chorus:quick-dev` | Admin | 跳过 Idea/Proposal,直接创建任务 → 执行 → 验收 |
+| `$chorus:yolo` | Admin+PM+Dev(三合一) | 从一句话 prompt 自动跑完 AI-DLC 全流程 |
+
+Skill 来源: 基于 `public/chorus-plugin/skills/*/SKILL.md` 移植,替换 Claude Code 特有概念:
+
+- `/skill-name` → `$chorus:skill-name`
+- `Task` 工具(Claude Code spawn agent)→ `spawn_agent` 工具(Codex)
+- Hooks 描述从"自动触发"改为"advisory context,由主 agent 显式 `spawn_agent` 触发"
+
+---
+
+## 8. Reviewer Sub-Agents
+
+两个只读 sub-agent,实际上**就是两个特殊的 skill** —— 在其 skill 目录下放 `agents/openai.yaml` 后,Codex 把 skill name 注册为一个可用的 `agent_type`。由 `PostToolUse` hook 注入的 additionalContext 建议主 agent 用 `spawn_agent(agent_type="...")` 启动。
+
+### Codex 的 subagent 注册机制(重要)
+
+Codex 0.125 的 `spawn_agent` 工具 **只接受三个内置 `agent_type`**: `default`、`explorer`、`worker`。传自定义值(比如 `chorus-proposal-reviewer`)会直接报 `unknown agent_type`。
+
+**这意味着**: 我们的 "reviewer" 不是一个真正的自定义 agent 类型, 而是一个**通过 skill 挂载的角色**。工作流:
+
+1. `plugins/chorus/skills/chorus-proposal-reviewer/` 里放完整的 reviewer 指令(SKILL.md 的正文就是 prompt)
+2. 同目录下的 `agents/openai.yaml` **只负责 TUI `/plugins` 面板里的显示元数据** (`display_name`、`short_description`、`default_prompt`), 并不会把 skill "注册" 成一个 agent_type
+3. spawn 时这样调用, 把 skill 当内容喂给 default agent:
+
+   ```
+   spawn_agent(
+     agent_type="default",
+     items=[
+       { type: "skill", name: "Chorus Proposal Reviewer", path: "chorus:chorus-proposal-reviewer" },
+       { type: "text",  text: "Review proposal <uuid>. Post VERDICT comment." }
+     ]
+   )
+   ```
+
+`items` 数组的第一个条目把 skill 文件作为结构化 context 注入新 agent 的对话; 第二个条目是实际任务指令。Codex `spawn_agent` 工具描述里列了 `Input item type: text, image, local_image, skill, or mention` —— `skill` 就是这用法。
+
+**路径语法**: `chorus:chorus-proposal-reviewer`(小写 namespace)或 `Chorus:chorus-proposal-reviewer`(Pascal, 与 plugin displayName 对齐)。如果一种不通就换另一种 —— 从 TUI `/plugins` 面板看 skill 显示为什么前缀为准。
+
+**为什么曾经以为 `agents/*.toml` 或 `agents/openai.yaml` 会注册 agent_type**: 那是从 Codex system skills 的目录结构(`skill-creator/agents/openai.yaml` 等)反推出的错误假设。实际上 `agents/openai.yaml` 只是 UI 元数据, 和 agent_type 注册无关。sparkly 2026-04-28 由用户实测纠正。
+
+### 两个 reviewer
+
+| Agent | 触发时机 | 写作模式 | 三种结论 |
+|---|---|---|---|
+| `chorus-proposal-reviewer` | `chorus_pm_submit_proposal` 后 | 只读(只能读 + 评论) | PASS / PASS WITH NOTES / FAIL |
+| `chorus-task-reviewer` | `chorus_submit_for_verify` 后 | 只读 | 同上 |
+
+结论发为 `chorus_add_comment` 写到 proposal/task 上。reviewer 的意见是**咨询性**的,不阻断 Admin 的审批动作。
+
+### 线程槽位纪律(重要)
+
+Codex 限制**每条根线程最多 6 个并发 subagent 线程**(`agent thread limit reached (max 6)`)。关键坑: `completed` 状态**不会**释放槽位, 只有 `close_agent(id)` 会。
+
+`$yolo` 这种长链路会连续 spawn 多个 reviewer / worker, 每次 `wait_agent` 返回后必须立即 `close_agent`, 否则第 7 次 spawn 必爆。这条纪律写进 hook 提示和 `$yolo` skill 正文里。
+
+### VERDICT 字面量(重要)
+
+reviewer 输出末尾必须是这三个字符串之一, 不能换同义词("APPROVE"、"OK"不行):
+
+- `VERDICT: PASS`
+- `VERDICT: PASS WITH NOTES`
+- `VERDICT: FAIL`
+
+SKILL.md 里写明了这一要求, 但 LLM 有时候会"创造"新 verdict。hook 注入的 additionalContext 也用同样字面量, 降低漂移概率。主 agent 读 VERDICT 时用正则 `^VERDICT: (PASS|PASS WITH NOTES|FAIL)$` 严格匹配, 其他值按 FAIL 处理(保守)。
+
+---
+
+## 9. 已知限制(明确不做)
+
+### 9.1 没有 `.chorus/` 本地状态目录
+
+Claude 版依赖 `.chorus/sessions/*.json` 追踪多 agent 协作时的 session lifecycle。Codex 版**不落盘任何文件**:
+
+- Codex 不提供 `SubagentStart` / `SubagentStop` / `TeammateIdle` 事件,无法可靠地在 subagent 启动/结束时做 session checkin/checkout。
+- 无法自动维护 session 元数据。
+
+代价: 主 agent 用 `spawn_agent` spawn worker 时,**可选**手动 `chorus_create_session` + 把 `sessionUuid` 传进 worker 初始 prompt,worker 结束后主 agent `chorus_close_session`。不做也能工作 —— 只是丢失 per-worker 观测性。
+
+### 9.2 MCP tool 是 session-start snapshot
+
+`codex resume --last` 不会重新发现新注册的 MCP server。第一次装完 Chorus 后必须起**新 session**(不要 `--resume`)才能看到 `chorus_*` 工具。
+
+### 9.3 插件 Install 必须走 TUI
+
+Codex 0.125 的 `codex plugin` 子命令只有 `marketplace add/upgrade/remove`,**没有** `plugin install <name>`。单个插件 install 要进 TUI `/plugins`。Installer 用明显的 "Last step" 提示引导用户。
+
+---
+
+## 10. 设计决策日志
+
+| 日期 | 决策 | 原因 |
+|---|---|---|
+| 2026-04-27 | `plugin.json` 里不放 `mcpServers` | config.toml 不展开 `${VAR}`,bearer token 也不从 env 读取 |
+| 2026-04-27 | 砍掉 `.mcp.json` 方案 | 同上 |
+| 2026-04-27 | 不放 stdio proxy,选 HTTP MCP + installer 写 config.toml | 用户 UX 上最少动作 |
+| 2026-04-27 | Installer 纯 bash + awk,不依赖 python/node | macOS 自带 bash 3.2 都要跑得通 |
+| 2026-04-27 | Installer 支持 `curl \| bash` | `exec < /dev/tty` 重新接回交互输入 |
+| 2026-04-28 | 砍掉 `UserPromptSubmit` hook | TUI echo 太吵,边际收益不值 |
+| 2026-04-28 | `plugins/chorus/` 存真代码,不再 symlink 到 `packages/` | 直观,与 marketplace.json 的 `./plugins/chorus` 路径一致 |
+| 2026-04-28 | 修 `chorus-mcp-call.sh` 的 `${2:-{}}` parse bug | bash parser 把字面量 `{}` 在 `${:-…}` 里多吃一个 `}`,JSON 多括号服务器报 `-32700 Parse error` |
+| 2026-04-28 | `CHORUS_URL` 语义统一为"完整 MCP endpoint" | installer/hook 之前不一致,双拼成 `…/api/mcp/api/mcp` |
+| 2026-04-28 | Reviewer 从 `.toml` 改为 skill 目录 + `agents/openai.yaml` | Codex 根本不读 `agents/*.toml`,首次 spawn 报 `unknown agent_type`。真正的注册机制是 skill 目录下放 `agents/openai.yaml` |
+| 2026-04-28 | **更正**: `agents/openai.yaml` **不会**注册 agent_type | 实测 `spawn_agent(agent_type="chorus-proposal-reviewer")` 仍报 unknown。Codex 只有 default/explorer/worker 三种内置 role。正确做法:`agent_type="default"` + `items=[{type:"skill",path:"chorus:chorus-proposal-reviewer"}]` |
+| 2026-04-28 | 所有 `spawn_agent` 后强制 `close_agent` | `completed` 不释放槽位,长链路必撞 max 6 |
+| 2026-04-28 | VERDICT 字面量三选一硬性写进 SKILL + hook | LLM 常自创"APPROVE"导致 grep 失败 |
+
+---
+
+## 11. 回归测试
+
+```bash
+bash public/test-install-codex.sh
+```
+
+4 维 17 项断言:
+
+1. **静态扫描** — 拒绝 bash 4+ 专属语法(`${VAR,,}`、`declare -A`、`mapfile`、`&>`、`|&`、`;;&`)
+2. **`bash -n` 解析** — 用 target bash 做语法检查,默认优先 `$BASH32` → `/tmp/bash32-build/bash-3.2/bash` → `/bin/bash`(macOS 3.2.57) → PATH 上的 `bash`
+3. **端到端 dry run** — fake `codex` stub + 隔离 `CODEX_HOME`,校验生成的 `[mcp_servers.chorus]` + `http_headers` + literal URL + literal Bearer + mode 600
+4. **幂等重跑** — 轮换 key,校验唯一 mcp block / 唯一 http_headers block / 旧 key 被清除
+
+---
+
+## 12. 历史文档
+
+本文的演进过程(15 个章节的研究日志,从"为什么 `.mcp.json` 走不通"一路推到最终方案)归档在:
+
+```
+docs/_archive/codex-plugin-plan.history.md
+```
+
+如需考古请看那里;日常维护只读本文。

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "chorus",
+  "version": "0.7.5",
+  "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
+  "author": {
+    "name": "Chorus-AIDLC"
+  },
+  "homepage": "https://github.com/Chorus-AIDLC/Chorus",
+  "repository": "https://github.com/Chorus-AIDLC/Chorus",
+  "license": "AGPL-3.0",
+  "keywords": [
+    "chorus",
+    "ai-dlc",
+    "project-management",
+    "multi-agent",
+    "collaboration"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks.json",
+  "interface": {
+    "displayName": "Chorus",
+    "shortDescription": "Chorus AI-DLC collaboration platform for Codex",
+    "longDescription": "Chorus plugin for Codex CLI — seven skills spanning the AI-DLC lifecycle (Idea → Proposal → Task → Verify → Done), two read-only reviewer subagents, and session-aware hooks. The Chorus MCP server is installed separately via the install script at https://chorus.ai/install-codex.sh (which also adds this plugin's marketplace).",
+    "developerName": "Chorus-AIDLC",
+    "category": "Productivity"
+  }
+}

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Chorus",
     "shortDescription": "Chorus AI-DLC collaboration platform for Codex",
-    "longDescription": "Chorus plugin for Codex CLI — seven skills spanning the AI-DLC lifecycle (Idea → Proposal → Task → Verify → Done), two read-only reviewer subagents, and session-aware hooks. The Chorus MCP server is installed separately via the install script at https://chorus.ai/install-codex.sh (which also adds this plugin's marketplace).",
+    "longDescription": "Chorus plugin for Codex CLI — seven skills spanning the AI-DLC lifecycle (Idea → Proposal → Task → Verify → Done), two read-only reviewer subagents, and session-aware hooks. The Chorus MCP server is installed separately via the install script at https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh (which also adds this plugin's marketplace).",
     "developerName": "Chorus-AIDLC",
     "category": "Productivity"
   }

--- a/plugins/chorus/README.md
+++ b/plugins/chorus/README.md
@@ -19,7 +19,7 @@ Chorus AI-DLC collaboration platform plugin for OpenAI Codex CLI, ported from th
 ### One-shot installer (recommended)
 
 ```bash
-curl -sSL https://chorus.ai/install-codex.sh | bash
+curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh | bash
 ```
 
 The installer:
@@ -41,7 +41,7 @@ Re-run at any time to rotate the API key — existing `[mcp_servers.chorus*]` se
 ```
 codex
 > /plugins
-→ chorus-plugins → chorus → Install
+→ chorus (INSTALLED_BY_DEFAULT; one-click Install if auto-install does not fire)
 ```
 
 That copies the plugin (skills + agents + hooks) into `~/.codex/plugins/cache/chorus-plugins/chorus/<version>/` and flips `[plugins."chorus@chorus-plugins"] enabled = true` in your config.
@@ -59,7 +59,7 @@ Inside Codex, type `$chorus` (or any of `$idea` / `$proposal` / `$develop` / `$r
 ```bash
 CHORUS_URL="https://chorus.example.com/api/mcp" \
 CHORUS_API_KEY="cho_..." \
-  bash <(curl -sSL https://chorus.ai/install-codex.sh)
+  bash <(curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh)
 ```
 
 `CHORUS_MARKETPLACE_SOURCE` can also be overridden (e.g. to a fork URL or local clone path).
@@ -80,7 +80,7 @@ Then register the marketplace and install:
 
 ```bash
 codex plugin marketplace add https://github.com/Chorus-AIDLC/Chorus
-codex   # /plugins → chorus → Install
+codex   # plugin auto-installs on first launch; use /plugins to confirm
 ```
 
 ## What's different from the Claude Code version

--- a/plugins/chorus/README.md
+++ b/plugins/chorus/README.md
@@ -1,0 +1,129 @@
+# Chorus Plugin for Codex CLI
+
+Chorus AI-DLC collaboration platform plugin for OpenAI Codex CLI, ported from the Claude Code plugin (`public/chorus-plugin/`). See `docs/codex-plugin-plan.md` at the repo root for the full research and design notes.
+
+- **Version**: 0.7.5
+- **License**: AGPL-3.0
+- **Upstream**: https://github.com/Chorus-AIDLC/Chorus
+
+## What this plugin provides
+
+- **7 skills** — `$chorus`, `$idea`, `$proposal`, `$develop`, `$review`, `$quick-dev`, `$yolo` — driving every stage of the AI-DLC lifecycle
+- **2 read-only reviewer subagents** — `chorus-proposal-reviewer`, `chorus-task-reviewer`
+- **4 session-aware hooks** — session start checkin, per-turn reminders, and PostToolUse reviewer nudges after proposal/task submission
+
+> The Chorus **MCP server** is configured separately — see *Installation* below. Codex's plugin runtime doesn't expand `${VAR}` in `.mcp.json` and doesn't pass the user's shell env through to MCP subprocesses, so we don't ship an `.mcp.json` in this plugin. Instead, the install script writes a proper `[mcp_servers.chorus]` section to `~/.codex/config.toml` with a literal URL + `Authorization: Bearer <key>` header.
+
+## Installation
+
+### One-shot installer (recommended)
+
+```bash
+curl -sSL https://chorus.ai/install-codex.sh | bash
+```
+
+The installer:
+
+1. Verifies `codex` is in `PATH`
+2. Registers the **chorus-plugins** marketplace (`codex plugin marketplace add …`)
+3. Prompts for your **Chorus URL** and **API key** (or reads them from `CHORUS_URL` / `CHORUS_API_KEY` env)
+4. Writes `[mcp_servers.chorus]` + `[mcp_servers.chorus.http_headers]` to `~/.codex/config.toml` (`chmod 600`, backed up once to `config.toml.chorus-bak`)
+5. Installs session hooks: writes `~/.codex/hooks.json` (absolute paths into the plugin cache) and sets `[features] codex_hooks = true`
+
+Codex 0.125.0 doesn't load plugin-local `hooks.json` automatically yet, so the installer wires them up into `~/.codex/hooks.json`. If you already have a non-Chorus `hooks.json`, the installer skips this step with a warning and tells you how to merge entries manually.
+
+Then finish with `/plugins` inside the Codex TUI.
+
+Re-run at any time to rotate the API key — existing `[mcp_servers.chorus*]` sections are wiped and re-written idempotently.
+
+### Finish inside Codex
+
+```
+codex
+> /plugins
+→ chorus-plugins → chorus → Install
+```
+
+That copies the plugin (skills + agents + hooks) into `~/.codex/plugins/cache/chorus-plugins/chorus/<version>/` and flips `[plugins."chorus@chorus-plugins"] enabled = true` in your config.
+
+### Verify
+
+```bash
+codex mcp list    # look for 'chorus' row with Auth = 'Bearer token'
+```
+
+Inside Codex, type `$chorus` (or any of `$idea` / `$proposal` / `$develop` / `$review` / `$quick-dev` / `$yolo`) to activate a skill. Skills are namespaced; the fully qualified names are `chorus:<skill>` (e.g. `chorus:develop`).
+
+### Non-interactive install (CI / scripted)
+
+```bash
+CHORUS_URL="https://chorus.example.com/api/mcp" \
+CHORUS_API_KEY="cho_..." \
+  bash <(curl -sSL https://chorus.ai/install-codex.sh)
+```
+
+`CHORUS_MARKETPLACE_SOURCE` can also be overridden (e.g. to a fork URL or local clone path).
+
+### Manual (if you'd rather not run the installer)
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.chorus]
+url = "https://chorus.example.com/api/mcp"
+
+[mcp_servers.chorus.http_headers]
+Authorization = "Bearer cho_your_key_here"
+```
+
+Then register the marketplace and install:
+
+```bash
+codex plugin marketplace add https://github.com/Chorus-AIDLC/Chorus
+codex   # /plugins → chorus → Install
+```
+
+## What's different from the Claude Code version
+
+The Codex port is intentionally **stateless** — no `.chorus/` directory is used anywhere. This is driven by Codex's hook model, which lacks `SubagentStart`, `SubagentStop`, `TeammateIdle`, `SessionEnd`, and `TaskCompleted` events.
+
+Consequences:
+
+- ❌ Sub-agent sessions are **not** auto-created by the plugin. The main agent creates/closes Chorus sessions manually when per-worker observability is desired.
+- ❌ No auto-checkout on sub-agent exit — workers must explicitly call `chorus_session_checkout_task` in their skill-driven workflow, and the main agent calls `chorus_close_session` after `spawn_agent` returns.
+- ❌ No idle-heartbeat hook — rely on Chorus backend session TTL, or have the main agent call `chorus_session_heartbeat` periodically.
+- ✅ Everything else works: all 40+ MCP tools over the HTTP transport, all skills, both reviewer subagents, and 4 of the most valuable hooks.
+
+For single-agent use the UX is identical to the Claude version. For heavy parallel-worker use, the main agent carries more session-management responsibility (documented in `$develop` skill).
+
+Full design rationale and binary-level schema research: `docs/codex-plugin-plan.md` at the repo root.
+
+## Skills cheat sheet
+
+| Skill | Purpose |
+|---|---|
+| `$chorus` | Platform overview, setup, common tools, routing to other skills |
+| `$idea` | Claim ideas, run elaboration rounds |
+| `$proposal` | Draft PRD + task DAG, submit for approval |
+| `$develop` | Claim tasks, implement, report work, submit for verification (includes multi-worker patterns) |
+| `$review` | Admin: approve/reject proposals, verify tasks (includes reviewer-agent spawning) |
+| `$quick-dev` | Skip Idea→Proposal flow for small tasks |
+| `$yolo` | Full-auto AI-DLC pipeline from natural-language prompt to done |
+
+## Subagents
+
+- `chorus-proposal-reviewer` — read-only review of submitted proposals
+- `chorus-task-reviewer` — read-only review of completed tasks (can run tests/builds in read-only shell)
+
+Both are invoked by the main agent via `spawn_agent(agent_type=..., message=...)` and waited on via `wait_agent([id])`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `chorus` not in `codex mcp list` | Did you run `install-codex.sh`? It writes `[mcp_servers.chorus]` into `~/.codex/config.toml`. |
+| `chorus` is listed but tools don't work | URL or token wrong. Re-run `install-codex.sh` to update; the installer overwrites idempotently. |
+| Plugin (`/plugins` menu) is empty | The `marketplace add` step didn't run. Re-run `install-codex.sh`, or manually `codex plugin marketplace add https://github.com/Chorus-AIDLC/Chorus`. |
+| Skills don't show in `$<name>` autocomplete | Restart the Codex session. Skills are loaded at session start from `~/.codex/plugins/cache/chorus-plugins/chorus/*/skills/`. |
+| Hooks don't fire | Did the installer's step 5 run? Check `~/.codex/hooks.json` exists and `grep codex_hooks ~/.codex/config.toml` shows `true`. Re-run `install-codex.sh` to (re)install hooks. Codex 0.125.0 doesn't load plugin-local `hooks.json` directly; the installer bridges it into `~/.codex/hooks.json`. |
+| Need to rotate API key | Just re-run `install-codex.sh` and enter the new key when prompted. |

--- a/plugins/chorus/hooks.json
+++ b/plugins/chorus/hooks.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/on-session-start.sh",
+            "timeout": 20,
+            "statusMessage": "Chorus: checkin"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*chorus_pm_submit_proposal",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/on-post-submit-proposal.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": ".*chorus_submit_for_verify",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/on-post-submit-for-verify.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# chorus-mcp-call.sh — Stateless MCP-over-HTTP helper for Codex hooks.
+#
+# Usage:
+#   chorus-mcp-call.sh TOOL_NAME '<json_arguments>'
+#
+# Environment:
+#   CHORUS_URL      — Full Chorus MCP endpoint URL
+#                     (e.g., https://chorus.example.com/api/mcp).
+#                     If only a host is provided (no path), /api/mcp is
+#                     appended automatically for backward compatibility.
+#   CHORUS_API_KEY  — Agent API key (cho_xxx)
+#
+# Writes MCP tool result text to stdout. Exits non-zero on error.
+# No filesystem state — Codex port is stateless (no .chorus/ directory).
+
+set -euo pipefail
+
+if [ -z "${CHORUS_URL:-}" ] || [ -z "${CHORUS_API_KEY:-}" ]; then
+  echo "chorus-mcp-call: CHORUS_URL or CHORUS_API_KEY not set" >&2
+  exit 1
+fi
+
+TOOL_NAME="${1:?tool name required}"
+# NOTE: avoid `${2:-{}}` — bash mis-parses the literal `{}` inside the
+# parameter expansion and produces `{}}` (an extra `}`), which makes the
+# server return -32700 "Parse error: Invalid JSON". Assign plainly instead.
+ARGS="${2-}"
+if [ -z "$ARGS" ]; then
+  ARGS='{}'
+fi
+
+# Derive the MCP endpoint URL. Accept both:
+#   1) Full endpoint:  https://host/api/mcp   (preferred, installer writes this)
+#   2) Bare host:      https://host            (legacy — auto-append /api/mcp)
+_url="${CHORUS_URL%/}"
+case "$_url" in
+  http://*/*|https://*/*)
+    # Has a path segment beyond the host → assume it's already the full endpoint.
+    _rest="${_url#http*://}"
+    _rest="${_rest#*/}"
+    if [ -n "$_rest" ]; then
+      MCP_URL="$_url"
+    else
+      MCP_URL="${_url}/api/mcp"
+    fi
+    ;;
+  *)
+    MCP_URL="${_url}/api/mcp"
+    ;;
+esac
+AUTH="Authorization: Bearer ${CHORUS_API_KEY}"
+ACCEPT="Accept: application/json, text/event-stream"
+CT="Content-Type: application/json"
+
+INIT=$(cat <<JSON
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.7.5"}}}
+JSON
+)
+
+HEADERS_FILE=$(mktemp)
+trap 'rm -f "$HEADERS_FILE"' EXIT
+
+curl -s -S -X POST -H "$AUTH" -H "$CT" -H "$ACCEPT" -D "$HEADERS_FILE" \
+  -d "$INIT" "$MCP_URL" >/dev/null || { echo "MCP initialize failed" >&2; exit 2; }
+
+SESSION_ID=$(grep -i '^mcp-session-id:' "$HEADERS_FILE" 2>/dev/null | tr -d '\r' | awk '{print $2}') || true
+SESSION_HEADER=()
+if [ -n "$SESSION_ID" ]; then
+  SESSION_HEADER=(-H "Mcp-Session-Id: ${SESSION_ID}")
+fi
+
+# Fire 'initialized' notification (no reply expected)
+curl -s -S -X POST -H "$AUTH" -H "$CT" -H "$ACCEPT" "${SESSION_HEADER[@]}" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  "$MCP_URL" >/dev/null || true
+
+# Call the tool
+CALL=$(printf '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"%s","arguments":%s}}' "$TOOL_NAME" "$ARGS")
+
+RAW=$(curl -s -S -X POST -H "$AUTH" -H "$CT" -H "$ACCEPT" "${SESSION_HEADER[@]}" \
+  -d "$CALL" "$MCP_URL" 2>/dev/null) || { echo "MCP tool call failed" >&2; exit 3; }
+
+# Streamable transport may return SSE framing; strip 'data: ' prefix if present
+if printf '%s' "$RAW" | head -1 | grep -q '^event:\|^data:'; then
+  RAW=$(printf '%s' "$RAW" | sed -n 's/^data: //p' | head -1)
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  printf '%s' "$RAW" | jq -r '.result.content[0].text // .result // .'
+else
+  printf '%s\n' "$RAW"
+fi

--- a/plugins/chorus/hooks/hook-output.sh
+++ b/plugins/chorus/hooks/hook-output.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# hook-output.sh — shared helper to emit Codex hook JSON output.
+#
+# Usage:
+#   hook_output "<systemMessage>" "<additionalContext>" "<hookEventName>"
+
+hook_output() {
+  local sm="${1:-}"
+  local ac="${2:-}"
+  local hen="${3:-}"
+  if command -v jq >/dev/null 2>&1; then
+    if [ -n "$ac" ]; then
+      jq -n --arg sm "$sm" --arg ac "$ac" --arg hen "$hen" \
+        '{systemMessage:$sm, hookSpecificOutput:{hookEventName:$hen, additionalContext:$ac}}'
+    else
+      jq -n --arg sm "$sm" '{systemMessage:$sm}'
+    fi
+  else
+    # Fallback: minimal JSON escaping of sm and ac
+    local sm_esc="${sm//\\/\\\\}"
+    sm_esc="${sm_esc//\"/\\\"}"
+    sm_esc="${sm_esc//$'\n'/\\n}"
+    if [ -n "$ac" ]; then
+      local ac_esc="${ac//\\/\\\\}"
+      ac_esc="${ac_esc//\"/\\\"}"
+      ac_esc="${ac_esc//$'\n'/\\n}"
+      printf '{"systemMessage":"%s","hookSpecificOutput":{"hookEventName":"%s","additionalContext":"%s"}}\n' \
+        "$sm_esc" "$hen" "$ac_esc"
+    else
+      printf '{"systemMessage":"%s"}\n' "$sm_esc"
+    fi
+  fi
+}

--- a/plugins/chorus/hooks/on-post-submit-for-verify.sh
+++ b/plugins/chorus/hooks/on-post-submit-for-verify.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# on-post-submit-for-verify.sh — Codex PostToolUse hook for chorus_submit_for_verify.
+#
+# Reminds the main agent to spawn chorus-task-reviewer.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./hook-output.sh
+source "${DIR}/hook-output.sh"
+
+EVENT=""
+if [ ! -t 0 ]; then EVENT=$(cat); fi
+
+TASK_UUID=""
+if command -v jq >/dev/null 2>&1 && [ -n "$EVENT" ]; then
+  TASK_UUID=$(echo "$EVENT" | jq -r '
+    (.tool_response.content[0].text // "") as $t
+    | ($t | fromjson? // {}) as $tj
+    | ($tj.taskUuid // $tj.uuid // .tool_input.taskUuid // empty)
+  ' 2>/dev/null) || true
+fi
+
+CTX="[Chorus — Task Submitted for Verification]
+Task ${TASK_UUID:-<uuid>} has been submitted for verification.
+
+ACTION REQUIRED: Spawn the \`chorus-task-reviewer\` sub-agent to verify implementation against AC before admin verification.
+
+How to spawn (Codex correct syntax — the reviewer is a SKILL, not a built-in agent_type):
+  spawn_agent(
+    agent_type=\"default\",
+    items=[
+      { type: \"skill\", name: \"Chorus Task Reviewer\", path: \"chorus:chorus-task-reviewer\" },
+      { type: \"text\",  text: \"Review Chorus task ${TASK_UUID:-<uuid>}. Max review rounds: 3. Post VERDICT as a comment.\" }
+    ]
+  )
+  wait_agent([reviewer_id])
+  close_agent(reviewer_id)    # IMPORTANT: release the thread slot (max 6 concurrent; completed != closed)
+
+Why \`agent_type=\\\"default\\\"\` not \`agent_type=\\\"chorus-task-reviewer\\\"\`: Codex 0.125 only ships three built-in roles (default / explorer / worker). Custom review personas are loaded by mounting the skill into a default agent via \`items\`. If \`chorus:chorus-task-reviewer\` is rejected, try the namespaced form \`Chorus:chorus-task-reviewer\` or look up the exact skill path in the TUI \`/plugins\` panel.
+
+The reviewer is read-only (read-only sandbox) and posts its VERDICT as a comment. After it returns, read comments:
+- **VERDICT: PASS / PASS WITH NOTES** — Mark AC and call \`chorus_admin_verify_task\`.
+- **VERDICT: FAIL** — Do NOT verify. Call \`chorus_admin_reopen_task\`, fix BLOCKERs, resubmit."
+
+hook_output "" "$CTX" "PostToolUse"

--- a/plugins/chorus/hooks/on-post-submit-proposal.sh
+++ b/plugins/chorus/hooks/on-post-submit-proposal.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# on-post-submit-proposal.sh — Codex PostToolUse hook for chorus_pm_submit_proposal.
+#
+# Reminds the main agent to spawn chorus-proposal-reviewer.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./hook-output.sh
+source "${DIR}/hook-output.sh"
+
+EVENT=""
+if [ ! -t 0 ]; then EVENT=$(cat); fi
+
+# Try to extract proposal UUID from tool_response; fall back to tool_input.
+PROPOSAL_UUID=""
+if command -v jq >/dev/null 2>&1 && [ -n "$EVENT" ]; then
+  PROPOSAL_UUID=$(echo "$EVENT" | jq -r '
+    (.tool_response.content[0].text // "") as $t
+    | ($t | fromjson? // {}) as $tj
+    | ($tj.proposalUuid // $tj.uuid // .tool_input.proposalUuid // empty)
+  ' 2>/dev/null) || true
+fi
+
+CTX="[Chorus — Proposal Submitted for Review]
+Proposal ${PROPOSAL_UUID:-<uuid>} has been submitted.
+
+ACTION REQUIRED: Spawn the \`chorus-proposal-reviewer\` sub-agent to perform an independent quality review before admin approval.
+
+How to spawn (Codex correct syntax — the reviewer is a SKILL, not a built-in agent_type):
+  spawn_agent(
+    agent_type=\"default\",
+    items=[
+      { type: \"skill\", name: \"Chorus Proposal Reviewer\", path: \"chorus:chorus-proposal-reviewer\" },
+      { type: \"text\",  text: \"Review proposal ${PROPOSAL_UUID:-<uuid>}. Max review rounds: 3. First read existing comments to determine round number; post VERDICT as a comment.\" }
+    ]
+  )
+  wait_agent([reviewer_id])
+  close_agent(reviewer_id)    # IMPORTANT: release the thread slot (max 6 concurrent; completed != closed)
+
+Why \`agent_type=\\\"default\\\"\` not \`agent_type=\\\"chorus-proposal-reviewer\\\"\`: Codex 0.125 only ships three built-in roles (default / explorer / worker). Custom review personas are loaded by mounting the skill into a default agent via \`items\`. If \`chorus:chorus-proposal-reviewer\` is rejected, try the namespaced form \`Chorus:chorus-proposal-reviewer\` or look up the exact skill path in the TUI \`/plugins\` panel.
+
+The reviewer is read-only and posts its VERDICT as a comment on the proposal. Read comments after it returns, find the most recent \`VERDICT:\` line:
+- **VERDICT: PASS** — No issues. Proceed to \`chorus_admin_approve_proposal\`.
+- **VERDICT: PASS WITH NOTES** — Minor notes. Still approve.
+- **VERDICT: FAIL** — BLOCKERs found. Do NOT approve. Reject with \`chorus_pm_reject_proposal\`, fix, resubmit."
+
+hook_output "" "$CTX" "PostToolUse"

--- a/plugins/chorus/hooks/on-session-start.sh
+++ b/plugins/chorus/hooks/on-session-start.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# on-session-start.sh — Codex SessionStart hook.
+#
+# Calls chorus_checkin via MCP and injects the result as additionalContext
+# (developer message) into the session. Stateless — no local files written.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./hook-output.sh
+source "${DIR}/hook-output.sh"
+
+# Consume stdin event JSON (we don't need its fields for SessionStart).
+if [ ! -t 0 ]; then cat > /dev/null; fi
+
+if [ -z "${CHORUS_URL:-}" ] || [ -z "${CHORUS_API_KEY:-}" ]; then
+  hook_output \
+    "Chorus plugin: not configured (set CHORUS_URL and CHORUS_API_KEY)" \
+    "Chorus environment not configured. Set CHORUS_URL and CHORUS_API_KEY to enable Chorus integration." \
+    "SessionStart"
+  exit 0
+fi
+
+CHECKIN=$("${DIR}/chorus-mcp-call.sh" chorus_checkin '{}' 2>/dev/null) || {
+  hook_output \
+    "Chorus: connection failed (${CHORUS_URL})" \
+    "WARNING: Unable to reach Chorus at ${CHORUS_URL}. MCP tools may still work if reachable during the session." \
+    "SessionStart"
+  exit 0
+}
+
+CTX="# Chorus Plugin — Active (Codex port)
+
+Chorus is connected at ${CHORUS_URL}. MCP tools are available under the \`chorus\` server.
+
+## Checkin
+
+${CHECKIN}
+
+## Quick Reference
+
+- **Sessions are optional**: the Codex port does NOT auto-create Chorus sessions for sub-agents. If you spawn workers via \`spawn_agent\` and want per-worker observability, create a session manually with \`chorus_create_session\` before spawning and \`chorus_close_session\` after the worker returns. Otherwise skip session tools entirely.
+- **Notifications**: \`chorus_get_notifications()\` fetches and auto-marks read.
+- **Skills**: use \`\$chorus\`, \`\$idea\`, \`\$proposal\`, \`\$develop\`, \`\$review\`, \`\$quick-dev\`, or \`\$yolo\` to load the stage-specific workflow.
+- **Reviewer sub-agents**: mount the reviewer skill into a default sub-agent — \`spawn_agent(agent_type=\"default\", items=[{type:\"skill\", path:\"chorus:chorus-proposal-reviewer\"}, {type:\"text\", text:\"Review proposal <uuid>.\"}])\` after \`chorus_pm_submit_proposal\`; same pattern with \`chorus:chorus-task-reviewer\` after \`chorus_submit_for_verify\`. Codex 0.125 only ships three built-in roles (default / explorer / worker) — custom agent_types like \`chorus-proposal-reviewer\` will be rejected. Remember \`close_agent\` after \`wait_agent\`; completed ≠ closed, 6 concurrent max."
+
+hook_output "Chorus connected at ${CHORUS_URL}" "$CTX" "SessionStart"

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: chorus-proposal-reviewer
+description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, audits PRD/task drafts against the originating Idea, and posts a structured VERDICT comment. Invoke by mounting this skill into a default sub-agent via spawn_agent(agent_type="default", items=[{ type: "skill", path: "chorus:chorus-proposal-reviewer", ... }, { type: "text", text: "Review proposal <uuid>. Max review rounds: 3." }]).'
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+  short-description: Adversarial Chorus proposal reviewer
+---
+
+# Chorus Proposal Reviewer
+
+CRITICAL: READ-ONLY proposal review. You CANNOT edit, write, create files, or run Bash commands (sandbox enforces this).
+
+Keep your comment output under 800 characters. PASS items: names only. NOTE items: one-line description. BLOCKER items: evidence + expected/actual.
+
+Classify every finding as BLOCKER (blocks implementation) or NOTE (non-blocking). Pseudocode mismatches and cross-doc wording differences are always NOTE.
+
+You MUST end with exactly one of these three literal strings (grep-able):
+
+- `VERDICT: PASS`
+- `VERDICT: PASS WITH NOTES`
+- `VERDICT: FAIL`
+
+Has BLOCKERs → FAIL. Only NOTEs → PASS WITH NOTES. Nothing → PASS. Do NOT invent other verdicts like "APPROVE" or "OK" — automation greps for the three exact strings.
+
+If this is Round 2+, focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs.
+
+Turn budget rule: When ≤3 turns remain, STOP reading and post current findings as a comment via `chorus_add_comment`. Incomplete posted findings beat no comment.
+
+Do NOT rubber-stamp. Your value is finding what the PM missed. Be efficient: batch all data gathering first, then produce one final comment.
+
+You are a proposal review specialist. The PM who wrote this is an LLM — it produces plausible-looking proposals with systematic blind spots.
+
+Two failure patterns to avoid:
+
+- **Rubber-stamping**: skimming and writing "PASS" without checking substance.
+- **Surface-level approval**: seeing a well-structured PRD and assuming tasks match, missing requirements gaps, vague AC, or wrong dependencies.
+
+=== DO NOT MODIFY THE PROJECT ===
+
+Strictly prohibited:
+
+- Creating, modifying, or deleting any files
+- Running any shell commands (Bash is disabled)
+- Installing dependencies or packages
+
+=== WHAT YOU RECEIVE ===
+
+A proposalUuid. Your job is to fetch and review the full proposal.
+
+=== REVIEW PROCEDURE ===
+
+**Efficiency rule**: Gather ALL data in Steps 1-2 before analyzing. Do not alternate between fetching and writing conclusions. Batch tool calls.
+
+**Step 1: Gather context**
+
+```
+chorus_get_proposal({ proposalUuid: "<uuid>" })
+chorus_get_comments({ targetType: "proposal", targetUuid: "<uuid>" })
+chorus_get_idea({ ideaUuid: "<idea-uuid>" })
+chorus_get_elaboration({ ideaUuid: "<idea-uuid>" })
+```
+
+**Step 2: Review documents**
+
+For each document draft, check:
+
+- **Completeness**: Does the PRD cover functional, non-functional, error scenarios, and edge cases?
+- **Specificity**: Are requirements testable? "Should handle errors gracefully" is not testable.
+- **Tech feasibility**: Does the architecture make sense? Missing auth, race conditions, no error handling?
+- **Module contracts**: If tasks share interfaces, are return formats, error patterns, and call points defined?
+- **Hallucination risk**: Flag specific external details (API signatures, model IDs, SDK versions, CLI flags, config keys, endpoint paths) that look LLM-fabricated as NOTE.
+
+**Step 3: Review task drafts**
+
+For each task draft, check:
+
+- **Granularity**: Each task cohesive, independently testable. 2-10 AC items is the sweet spot.
+- **AC quality**: Objectively verifiable by a different agent. "Shows details" is BAD. "Displays order ID, customer name, status badge" is GOOD.
+- **Coverage**: Any requirements with NO corresponding AC?
+- **Dependencies**: Is the DAG correct? Missing dependencies? Circular?
+
+**Step 4: Cross-reference**
+
+- Each requirement in PRD → at least one task AC covers it
+- Each task AC → traceable back to a requirement
+- No orphan tasks, no orphan requirements
+
+=== RECOGNIZE YOUR OWN RATIONALIZATIONS ===
+
+- "The proposal looks well-structured" — structure is not substance.
+- "The PM probably considered this" — the PM is an LLM. Check it yourself.
+- "There are enough tasks" — count is not coverage. Map requirements to tasks.
+
+=== OUTPUT FORMAT (REQUIRED) ===
+
+```
+### Review Summary
+
+**PASS (N):** Check-1 name, Check-2 name, ...
+
+**NOTE (M):**
+- Note-1: [one-line description]
+- Note-2: [one-line description]
+
+**BLOCKER (K):**
+### Blocker-1: name
+**Evidence:** [specific finding]
+**Expected:** [what should be there]
+**Actual:** [what is there or what is missing]
+
+VERDICT: PASS
+```
+
+(or `VERDICT: PASS WITH NOTES` / `VERDICT: FAIL` — exact literal, no other variants)
+
+PASS items: names only. NOTE items: one-line descriptions. BLOCKER items: full evidence. Total output under 800 characters. No preamble, no summary paragraph.
+
+=== POSTING RESULTS ===
+
+Post as a single comment:
+
+```
+chorus_add_comment({
+  targetType: "proposal",
+  targetUuid: "<proposal-uuid>",
+  content: "<your review>"
+})
+```

--- a/plugins/chorus/skills/chorus-proposal-reviewer/agents/openai.yaml
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Chorus Proposal Reviewer"
+  short_description: "Read-only adversarial reviewer for Chorus proposals — posts a VERDICT comment"
+  default_prompt: "You are the Chorus proposal reviewer. Review the proposal at the UUID given to you. Follow the SKILL.md procedure. Post exactly one VERDICT comment and stop."

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: chorus-task-reviewer
+description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance criteria plus originating proposal documents via MCP, independently verifies the implementation, and posts a structured VERDICT comment. Invoke by mounting this skill into a default sub-agent via spawn_agent(agent_type="default", items=[{ type: "skill", path: "chorus:chorus-task-reviewer", ... }, { type: "text", text: "Review task <uuid>. Max review rounds: 3." }]).'
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+  short-description: Adversarial Chorus task reviewer
+---
+
+# Chorus Task Reviewer
+
+CRITICAL: READ-ONLY task review. You CANNOT edit, write, or create files in the project (sandbox enforces this).
+
+Bash is READ-ONLY: only test/build commands, cat, grep, ls, find, git diff/log/show. No git writes, no rm/mv/cp, no file writes.
+
+Keep your comment output under 800 characters. PASS items: names only. NOTE items: one-line description. BLOCKER items: command + output + evidence.
+
+Classify every finding as BLOCKER (blocks correctness: build/test failure, AC not implemented, semantic contradiction) or NOTE (non-blocking: pseudocode mismatch, wording difference, style suggestion).
+
+You MUST end with exactly one of these three literal strings (grep-able):
+
+- `VERDICT: PASS`
+- `VERDICT: PASS WITH NOTES`
+- `VERDICT: FAIL`
+
+Has BLOCKERs → FAIL. Only NOTEs → PASS WITH NOTES. Nothing → PASS. Do NOT invent other verdicts like "APPROVE" or "OK" — automation greps for the three exact strings.
+
+If Round 2+, focus ONLY on whether previous BLOCKERs were fixed. Do NOT introduce new NOTEs.
+
+Turn budget rule: When ≤3 turns remain, STOP reading AND running bash, post current findings as a comment via `chorus_add_comment`. Incomplete posted findings beat no comment.
+
+Do NOT confirm — find what's wrong. Be efficient: batch data gathering, then one final comment.
+
+You are a task review specialist. The developer is an LLM — its self-tests may be circular (testing mocks, not behavior).
+
+Two failure patterns to avoid:
+
+- **Verification avoidance**: reading code, narrating what you would test, writing "PASS," never running anything.
+- **Seduced by the first 80%**: seeing passing tests + clean code, missing that AC are superficially met, implementation diverges from proposal docs, or edge cases silently fail.
+
+=== DO NOT MODIFY THE PROJECT ===
+
+Strictly prohibited:
+
+- Creating, modifying, or deleting any files IN THE PROJECT DIRECTORY
+- Installing dependencies or packages
+- Running git write operations (add, commit, push, checkout, reset)
+
+=== BASH PERMISSIONS ===
+
+**Allowed (read-only + test/build commands)**:
+
+- Project test/build/lint commands (`pnpm test`, `pytest`, `make test`, `cargo test`)
+- `cat` / `head` / `tail` / `wc` / `diff`
+- `grep` / `rg` / `ls` / `find`
+- `git diff` / `git log` / `git show`
+
+**Strictly forbidden**:
+
+- `git add` / `git commit` / `git push` / `git checkout` / `git reset`
+- `rm` / `mv` / `cp` / `echo >` / `cat >` / `tee` / `sed -i`
+- Package install (`npm install`, `pnpm add`, `pip install`, …)
+- `curl -X POST/PUT/DELETE`
+
+=== WHAT YOU RECEIVE ===
+
+A taskUuid. Your job: fetch the task, its AC, and the proposal documents, then independently verify the implementation.
+
+=== REVIEW PROCEDURE ===
+
+**Step 1: Gather context**
+
+```
+chorus_get_task({ taskUuid: "<uuid>" })
+chorus_get_comments({ targetType: "task", targetUuid: "<uuid>" })
+chorus_get_proposal({ proposalUuid: "<task.proposalUuid>" })
+```
+
+**Step 2: Run tests/builds**
+
+Run the project's declared test/build/lint commands. Record command + exit code + relevant output.
+
+**Step 3: Verify each acceptance criterion**
+
+For each AC item:
+
+- Find the code/test that implements it. Cite file paths.
+- If the AC says "shows X", grep for evidence that X is rendered/returned.
+- If the AC says "handles Y error", find the test that triggers Y.
+- Circular self-tests (test mocks the module it tests) → NOTE or BLOCKER depending on severity.
+
+**Step 4: Cross-reference with proposal docs**
+
+- Implementation matches PRD wording / pseudocode (structural match, not exact match — pseudocode mismatches are NOTE).
+- Module contracts match what other tasks expect.
+- No silent divergence.
+
+=== RECOGNIZE YOUR OWN RATIONALIZATIONS ===
+
+- "Tests pass, looks fine" — read the test, not just the result.
+- "The code is clean" — clean code can still not meet AC.
+- "I'd trust this" — don't. Verify.
+
+=== OUTPUT FORMAT (REQUIRED) ===
+
+```
+### Review Summary
+
+**PASS (N):** AC-1, AC-2, ...
+
+**NOTE (M):**
+- Note-1: [one-line]
+
+**BLOCKER (K):**
+### Blocker-1: name
+**Command:** `pnpm test foo.test.ts`
+**Output:** [relevant failure line]
+**Expected:** [what AC requires]
+**Actual:** [what happened]
+
+VERDICT: PASS
+```
+
+(or `VERDICT: PASS WITH NOTES` / `VERDICT: FAIL` — exact literal, no other variants)
+
+Total output under 800 characters. No preamble, no summary paragraph.
+
+=== POSTING RESULTS ===
+
+```
+chorus_add_comment({
+  targetType: "task",
+  targetUuid: "<task-uuid>",
+  content: "<your review>"
+})
+```

--- a/plugins/chorus/skills/chorus-task-reviewer/agents/openai.yaml
+++ b/plugins/chorus/skills/chorus-task-reviewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Chorus Task Reviewer"
+  short_description: "Read-only adversarial reviewer for Chorus tasks — runs tests, posts a VERDICT comment"
+  default_prompt: "You are the Chorus task reviewer. Review the task at the UUID given to you. Follow the SKILL.md procedure. Post exactly one VERDICT comment and stop."

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -57,7 +57,7 @@ The checkin response includes **owner/master information** for the agent:
 
 #### Project Filtering
 
-Results can be filtered by project(s) using optional HTTP headers in your `.mcp.json` configuration:
+Results can be filtered by project(s) using optional HTTP headers on the Chorus MCP server. Add them to the `[mcp_servers.chorus.http_headers]` block in `~/.codex/config.toml`:
 
 | Header | Format | Example |
 |--------|--------|---------|
@@ -72,31 +72,24 @@ Results can be filtered by project(s) using optional HTTP headers in your `.mcp.
 
 **Affected tools**: `chorus_checkin`, `chorus_get_my_assignments`
 
-**Example `.mcp.json`**:
-```json
-{
-  "mcpServers": {
-    "chorus": {
-      "type": "http",
-      "url": "http://localhost:8637/api/mcp",
-      "headers": {
-        "Authorization": "Bearer cho_xxx",
-        "X-Chorus-Project": "project-uuid-1,project-uuid-2"
-      }
-    }
-  }
-}
+**Example (`~/.codex/config.toml`)**:
+```toml
+[mcp_servers.chorus]
+url = "<BASE_URL>/api/mcp"
+
+[mcp_servers.chorus.http_headers]
+Authorization = "Bearer cho_xxx"
+X-Chorus-Project = "project-uuid-1,project-uuid-2"
 ```
 
-### Session (Sub-Agents Only)
+### Session (Optional, Codex Port)
 
-The Chorus Plugin **fully automates** session lifecycle. Sub-agents only need to:
+The Codex port is **intentionally stateless**: it does NOT auto-create, heartbeat, or close Chorus sessions. Codex's hook surface has no `SubagentStart` / `SubagentStop` event, so lifecycle cannot be automated reliably. Sessions are optional bookkeeping you may use when running multiple workers in parallel:
 
-1. `chorus_session_checkin_task` — before starting work on a task
-2. `chorus_session_checkout_task` — when done with a task
-3. Pass `sessionUuid` to `chorus_update_task` and `chorus_report_work`
+- Single-agent work — skip session tools entirely. Task state, comments, and work reports all function fully without a `sessionUuid`.
+- Multi-agent work via `spawn_agent` — the Team Lead manually calls `chorus_create_session` before spawning workers, passes `sessionUuid` in each worker's initial message, and calls `chorus_close_session` after `wait_agent` returns.
 
-Main agent / Team Lead: no session needed — call tools without `sessionUuid`. See `/develop` for details.
+See `$develop` for the multi-worker pattern.
 
 ### Project Groups
 
@@ -241,14 +234,14 @@ Codex CLI reads MCP config from `~/.codex/config.toml` (global) or `<repo>/.code
 
 ```toml
 [mcp_servers.chorus]
-type = "http"
 url = "<BASE_URL>/api/mcp"
 
-[mcp_servers.chorus.headers]
+[mcp_servers.chorus.http_headers]
 Authorization = "Bearer <your-api-key>"
 ```
 
-> Alternatively, if this plugin is installed via the marketplace, the MCP server is declared in `mcp.json` at the plugin root and Codex registers it automatically — you still need to set `CHORUS_URL` and `CHORUS_API_KEY` as environment variables.
+> The transport is inferred from the `url` key — there is no `type = "http"` field in Codex's MCP schema. The header table key is `http_headers`, not `headers`.
+> Easier path: run `curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh | bash` and it will write this block for you (plus the hook wrapper).
 
 Restart Codex CLI after configuration.
 
@@ -283,7 +276,7 @@ The plugin includes two independent review agents. After proposal submission or 
 | `enableProposalReviewer` | Spawn `chorus-proposal-reviewer` after `chorus_pm_submit_proposal` | `true` (enabled) |
 | `enableTaskReviewer` | Spawn `chorus-task-reviewer` after `chorus_submit_for_verify` | `true` (enabled) |
 
-To disable in the Codex port, remove or disable the corresponding `PostToolUse` hook in `~/.codex/hooks.json` (see `install-hooks.sh` in the plugin root). Alternatively, the main agent can choose not to spawn the reviewer when the hook's `additionalContext` suggests it.
+To disable in the Codex port, delete (or comment out) the matching `PostToolUse` entry in `~/.codex/hooks.json` — the installer writes three entries: one `SessionStart` and two `PostToolUse` (`chorus_pm_submit_proposal`, `chorus_submit_for_verify`). Alternatively, the main agent can simply ignore the `additionalContext` the hook injects and skip spawning the reviewer.
 
 When enabled, reviewers run as read-only sub-agents and post a VERDICT comment on the proposal/task. Three possible outcomes: **PASS** (no issues), **PASS WITH NOTES** (minor non-blocking notes), or **FAIL** (BLOCKERs found). Results are advisory — they do not block approval or verification. Disabling reduces token usage but removes the independent quality gate.
 

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: chorus
+description: Chorus AI Agent collaboration platform — overview, common tools, setup, and routing to stage-specific skills. (Codex port)
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Chorus Skill
+
+Chorus is a work collaboration platform for AI Agents, enabling multiple Agents (PM, Developer, Admin) and humans to collaborate on the same platform.
+
+This is the **core skill** — it covers the platform overview, shared tools, and setup. For stage-specific workflows, use the dedicated skills listed in [Skill Routing](#skill-routing) below.
+
+---
+
+## Overview
+
+### AI-DLC Workflow
+
+Chorus follows the **AI-DLC (AI Development Life Cycle)** workflow:
+
+```
+Idea --> Proposal --> [Document + Task] --> Execute --> Verify --> Done
+ ^         ^              ^                   ^          ^         ^
+Human    PM Agent     PM Agent           Dev Agent    Admin     Admin
+creates  analyzes     drafts PRD         codes &      reviews   closes
+         & plans      & tasks            reports      & verifies
+```
+
+### Three Roles
+
+| Role | Responsibility | MCP Tools |
+|------|---------------|-----------|
+| **PM Agent** | Analyze Ideas, create Proposals (PRD + Task drafts), manage documents | Public + `chorus_pm_*` + `chorus_*_idea` |
+| **Developer Agent** | Claim Tasks, write code, report work, submit for verification | Public + `chorus_*_task` + `chorus_report_work` |
+| **Admin Agent** | Create projects/ideas, approve/reject proposals, verify tasks, manage lifecycle | Public + `chorus_admin_*` + PM + Developer tools |
+
+---
+
+## Common Tools (All Roles)
+
+All Agent roles can use the following tools for querying information and collaboration.
+
+### Checkin
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_checkin` | Call at session start: get Agent persona, role, current assignments, pending work counts, and unread notification count |
+
+The checkin response includes **owner/master information** for the agent:
+- `agent.owner`: `{ uuid, name, email }` or `null` — the human user who owns this agent
+- Use the owner info to know who to @mention for confirmations and approvals
+
+#### Project Filtering
+
+Results can be filtered by project(s) using optional HTTP headers in your `.mcp.json` configuration:
+
+| Header | Format | Example |
+|--------|--------|---------|
+| `X-Chorus-Project` | Single UUID or comma-separated UUIDs | `project-uuid-1` or `uuid1,uuid2,uuid3` |
+| `X-Chorus-Project-Group` | Group UUID | `group-uuid-here` |
+
+**Behavior**:
+- **No header**: Returns all projects (default, backward compatible)
+- **X-Chorus-Project**: Returns only specified project(s)
+- **X-Chorus-Project-Group**: Returns all projects in the group
+- **Priority**: `X-Chorus-Project-Group` takes precedence if both headers are provided
+
+**Affected tools**: `chorus_checkin`, `chorus_get_my_assignments`
+
+**Example `.mcp.json`**:
+```json
+{
+  "mcpServers": {
+    "chorus": {
+      "type": "http",
+      "url": "http://localhost:8637/api/mcp",
+      "headers": {
+        "Authorization": "Bearer cho_xxx",
+        "X-Chorus-Project": "project-uuid-1,project-uuid-2"
+      }
+    }
+  }
+}
+```
+
+### Session (Sub-Agents Only)
+
+The Chorus Plugin **fully automates** session lifecycle. Sub-agents only need to:
+
+1. `chorus_session_checkin_task` — before starting work on a task
+2. `chorus_session_checkout_task` — when done with a task
+3. Pass `sessionUuid` to `chorus_update_task` and `chorus_report_work`
+
+Main agent / Team Lead: no session needed — call tools without `sessionUuid`. See `/develop` for details.
+
+### Project Groups
+
+Projects can be organized into **Project Groups** — a single-level grouping that lets you categorize related projects together.
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_get_project_groups` | List all project groups with project counts |
+| `chorus_get_project_group` | Get a single project group by UUID with its projects list |
+| `chorus_get_group_dashboard` | Get aggregated dashboard stats for a project group |
+
+### Project & Activity
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_list_projects` | List all projects (paginated, with entity counts) |
+| `chorus_get_project` | Get project details |
+| `chorus_get_activity` | Get project activity stream (paginated) |
+
+### Ideas
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_get_ideas` | List project Ideas (filterable by status, paginated) |
+| `chorus_get_idea` | Get a single Idea's details |
+| `chorus_get_available_ideas` | Get claimable Ideas (status=open) |
+
+### Documents
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide) |
+| `chorus_get_document` | Get a single document's content |
+
+### Proposals
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_get_proposals` | List project Proposals (filterable by status: pending, approved, rejected) |
+| `chorus_get_proposal` | Get a single Proposal's details, including documentDrafts and taskDrafts |
+
+### Tasks
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_list_tasks` | List project Tasks (filterable by status/priority/proposalUuids, paginated) |
+| `chorus_get_task` | Get a single Task's details and context |
+| `chorus_get_available_tasks` | Get claimable Tasks (status=open, optional proposalUuids filter) |
+| `chorus_get_unblocked_tasks` | Get tasks ready to start — all dependencies resolved (done/closed). `to_verify` is NOT considered resolved. |
+
+**Proposal filtering** — `chorus_list_tasks`, `chorus_get_available_tasks`, and `chorus_get_unblocked_tasks` all accept an optional `proposalUuids` parameter (array of proposal UUID strings).
+
+### Assignments
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_get_my_assignments` | Get all Ideas and Tasks claimed by you |
+
+### Comments
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_add_comment` | Add a comment to an idea/proposal/task/document |
+| `chorus_get_comments` | Get the comment list for a target (paginated) |
+
+**Parameters for `chorus_add_comment`:**
+- `targetType`: `"idea"` / `"proposal"` / `"task"` / `"document"`
+- `targetUuid`: Target UUID
+- `content`: Comment content (Markdown)
+
+### Elaboration
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_answer_elaboration` | Submit answers for an elaboration round on an Idea |
+| `chorus_get_elaboration` | Get the full elaboration state for an Idea (rounds, questions, answers, summary) |
+
+### @Mentions
+
+Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName](type:uuid)` where type is `user` or `agent`.
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_search_mentionables` | Search for users and agents that can be @mentioned |
+
+**Mention workflow:**
+1. Search: `chorus_search_mentionables({ query: "yifei" })`
+2. Write: `@[Yifei](user:uuid-here)` in your content
+3. Mentioned users/agents automatically receive a notification
+
+**When to @mention:**
+- **Elaboration completion** — confirm understanding with the answerer before validating (see `/idea`)
+- **Proposal creation/update** — notify stakeholders when submitting
+- **Task submission** — notify PM/owner for significant decisions
+- **Blocking issues** — notify relevant person for human input
+
+### Search
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_search` | Search across tasks, ideas, proposals, documents, projects, and project groups |
+
+**Parameters:**
+- `query`: Search query string
+- `scope`: `"global"` (default) / `"group"` / `"project"`
+- `scopeUuid`: Project group UUID (when scope=group) or project UUID (when scope=project)
+- `entityTypes`: Array of entity types to search (default: all types)
+
+### Notifications
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_get_notifications` | Get your notifications (default: unread only, auto-marks as read) |
+| `chorus_mark_notification_read` | Mark a single notification or all notifications as read |
+
+**Recommended workflow:**
+1. `chorus_checkin()` — check `notifications.unreadCount`
+2. If > 0, call `chorus_get_notifications()` — auto-marks as read
+3. To peek without marking: `chorus_get_notifications({ autoMarkRead: false })`
+
+---
+
+## Setup
+
+### 1. Obtain API Key
+
+API Keys must be created manually by the user in the Chorus Web UI.
+
+**Ask the user to:**
+1. Open the Chorus settings page (e.g., `http://localhost:8637/settings`)
+2. Click **Create API Key**
+3. Enter Agent name, select role (Developer / PM / Admin)
+4. Click create and **immediately copy the key** (shown only once)
+
+**Security notes:**
+- Each Agent should have its own API Key with the minimum required role
+- API Keys should not be committed to version control
+
+### 2. MCP Server Configuration
+
+Codex CLI reads MCP config from `~/.codex/config.toml` (global) or `<repo>/.codex/config.toml` (per-project). Add:
+
+```toml
+[mcp_servers.chorus]
+type = "http"
+url = "<BASE_URL>/api/mcp"
+
+[mcp_servers.chorus.headers]
+Authorization = "Bearer <your-api-key>"
+```
+
+> Alternatively, if this plugin is installed via the marketplace, the MCP server is declared in `mcp.json` at the plugin root and Codex registers it automatically — you still need to set `CHORUS_URL` and `CHORUS_API_KEY` as environment variables.
+
+Restart Codex CLI after configuration.
+
+### 3. Verify Connection
+
+```
+chorus_checkin()
+```
+
+If it fails, check: API Key correct (`cho_` prefix)? URL reachable? Codex CLI restarted?
+
+### 4. Role-Specific Tool Access
+
+| Tool Prefix | Developer | PM | Admin |
+|-------------|-----------|------|-------|
+| `chorus_get_*` / `chorus_list_*` | Yes | Yes | Yes |
+| `chorus_checkin` | Yes | Yes | Yes |
+| `chorus_add_comment` / `chorus_get_comments` | Yes | Yes | Yes |
+| `chorus_claim_task` / `chorus_release_task` | Yes | No | Yes |
+| `chorus_update_task` / `chorus_submit_for_verify` | Yes | No | Yes |
+| `chorus_report_work` | Yes | No | Yes |
+| `chorus_claim_idea` / `chorus_release_idea` | No | Yes | Yes |
+| `chorus_pm_*` | No | Yes | Yes |
+| `chorus_admin_*` | No | No | Yes |
+
+### 5. Review Agent Configuration
+
+The plugin includes two independent review agents. After proposal submission or task verification, a PostToolUse hook injects context instructing the main agent to spawn the reviewer. The main agent must spawn it manually — it is NOT auto-launched. Both are **enabled by default**.
+
+| Setting | Controls | Default |
+|---------|----------|---------|
+| `enableProposalReviewer` | Spawn `chorus-proposal-reviewer` after `chorus_pm_submit_proposal` | `true` (enabled) |
+| `enableTaskReviewer` | Spawn `chorus-task-reviewer` after `chorus_submit_for_verify` | `true` (enabled) |
+
+To disable in the Codex port, remove or disable the corresponding `PostToolUse` hook in `~/.codex/hooks.json` (see `install-hooks.sh` in the plugin root). Alternatively, the main agent can choose not to spawn the reviewer when the hook's `additionalContext` suggests it.
+
+When enabled, reviewers run as read-only sub-agents and post a VERDICT comment on the proposal/task. Three possible outcomes: **PASS** (no issues), **PASS WITH NOTES** (minor non-blocking notes), or **FAIL** (BLOCKERs found). Results are advisory — they do not block approval or verification. Disabling reduces token usage but removes the independent quality gate.
+
+---
+
+## Execution Rules
+
+1. **Always check in first** — Call `chorus_checkin()` at session start
+2. **Sessions are optional (Codex port)** — Codex port does not auto-create sessions. Single-agent work: skip session tools entirely. Multi-agent work via `spawn_agent`: the main agent calls `chorus_create_session` before spawning workers, passes `sessionUuid` in the worker's initial message, and calls `chorus_close_session` after the worker returns. Task state, work reports, and comments all function fully without a session — sessions only add per-worker observability.
+3. **Stay in your role** — Only use tools available to your role
+4. **Report progress** — Use `chorus_report_work` or `chorus_add_comment`
+5. **Follow the lifecycle** — Ideas flow through Proposals to Tasks; don't skip steps
+6. **Set up task dependency DAG** — Use `dependsOnDraftUuids` in task drafts to express execution order
+7. **Verify before claiming** — Check available items before claiming
+8. **Document decisions** — Add comments explaining your reasoning
+9. **Respect the review process** — Submit work for verification; don't assume it's done until Admin verifies
+10. **Interactive questions** — For confirmations/choices, send a plain-text question; Codex currently does not ship a structured radio-button tool in default mode
+11. **Verify sub-agent tasks (admin team lead)** — After a worker spawned via `spawn_agent` returns, check if its task is `to_verify` and mount the reviewer skill into a default sub-agent: `spawn_agent(agent_type="default", items=[{type:"skill", path:"chorus:chorus-task-reviewer"}, {type:"text", text:"Review task <uuid>."}])`. Codex 0.125 only ships three built-in roles (default / explorer / worker); custom agent_types are rejected. Tasks in `to_verify` do NOT unblock downstream — only `done` does.
+
+---
+
+## Status Lifecycle Reference
+
+### Idea Status Flow
+```
+open --> elaborating --> proposal_created --> completed
+  \                                            /
+   \--> closed <------------------------------/
+```
+
+### Task Status Flow
+```
+open --> assigned --> in_progress --> to_verify --> done
+  \                                                 /
+   \--> closed <-----------------------------------/
+         ^                    |
+         |                    v
+         +--- (reopen) -- in_progress
+```
+
+### Proposal Status Flow
+```
+draft --> pending --> approved
+                 \-> rejected --> revised --> pending ...
+approved --> draft  (via revoke — cascade-closes tasks, deletes documents)
+```
+
+---
+
+## Skill Routing
+
+This is the core overview skill. For stage-specific workflows, use:
+
+| Stage | Skill | Description |
+|-------|-------|-------------|
+| **Full Auto** | `/yolo` | Full-auto AI-DLC pipeline — from prompt to done. Automates Idea → Proposal → Execute → Verify with adversarial reviewers |
+| **Quick Dev** | `/quick-dev` | Skip Idea→Proposal, create tasks directly, execute, and verify |
+| **Ideation** | `/idea` | Claim Ideas, run elaboration rounds, prepare for proposal |
+| **Planning** | `/proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
+| **Development** | `/develop` | Claim Tasks, report work, (optional) session management, sub-agent spawn patterns |
+| **Review** | `/review` | Approve/reject Proposals, verify Tasks, project governance |
+
+### Getting Started
+
+1. Call `chorus_checkin()` to learn your role and assignments
+2. Based on your role, use the appropriate skill:
+   - **Full Auto** → `/yolo` — give a prompt, agent handles everything (requires all 3 roles: admin + pm + developer)
+   - PM Agent → `/idea` then `/proposal`
+   - Developer Agent → `/develop`
+   - Admin Agent → `/review` (also has access to all PM and Developer tools)

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -1,0 +1,431 @@
+---
+name: develop
+description: Chorus Development workflow — claim tasks, report work, and spawn sub-agent workers for parallel execution. (Codex port)
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Develop Skill
+
+This skill covers the **Development** stage of the AI-DLC workflow: claiming Tasks, writing code, reporting progress, submitting for verification, and managing sessions for sub-agent observability.
+
+---
+
+## Overview
+
+Developer Agents take Tasks created by PM Agents (via `/proposal`) and turn them into working code. Each task follows:
+
+```
+claim --> in_progress --> report work --> self-check AC --> submit for verify --> Admin /review
+```
+
+For multi-agent parallel execution, the main agent uses Codex's `spawn_agent` tool to launch worker sub-agents. Sessions are optional in the Codex port — multi-agent observability requires the main agent to create sessions manually and pass `sessionUuid` to workers.
+
+---
+
+## Tools
+
+**Task Lifecycle:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_claim_task` | Claim an open task (open -> assigned) |
+| `chorus_release_task` | Release a claimed task (assigned -> open) |
+| `chorus_update_task` | Update task status (in_progress / to_verify) |
+| `chorus_submit_for_verify` | Submit task for admin verification with summary |
+
+**Work Reporting:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_report_work` | Report progress or completion (writes comment + records activity, with optional status update) |
+
+**Acceptance Criteria:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_report_criteria_self_check` | Report self-check results (passed/failed + optional evidence) on structured acceptance criteria |
+
+**Session (optional, main agent manages):**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_session_checkin_task` | Checkin to a task before starting work |
+| `chorus_session_checkout_task` | Checkout from a task when work is done |
+
+Main agent (when coordinating workers for observability): call `chorus_create_session` before spawning workers, pass the returned `sessionUuid` to the worker via `spawn_agent` message, and call `chorus_session_checkout_task` + `chorus_close_session` after the worker finishes.
+Workers: receive `sessionUuid` in their initial prompt and pass it to `chorus_update_task` and `chorus_report_work` for attribution.
+No session needed: everything still works — task status, reports, comments — you just lose per-worker attribution in the UI.
+
+**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+
+---
+
+## Workflow
+
+### Step 1: Check In
+
+```
+chorus_checkin()
+```
+
+Review your persona, current assignments, and pending work counts.
+
+### Step 1.5: Get Your Session (Codex port: main agent explicit)
+
+**Codex port does not auto-create sessions.** Two scenarios:
+
+- **Single-agent work (main agent)**: skip session entirely. Call task tools without `sessionUuid`.
+- **Multi-agent work (worker spawned via `spawn_agent`)**: the main agent should have created a session and passed `sessionUuid` in your initial prompt. Use it for every `chorus_update_task`, `chorus_report_work`, `chorus_session_checkin_task`, `chorus_session_checkout_task` call. If the main agent forgot to pass one and you still need observability, you MAY call `chorus_create_session` yourself — but coordinate with the main agent to avoid duplicates.
+
+### Step 2: Find Work
+
+```
+chorus_get_available_tasks({ projectUuid: "<project-uuid>" })
+```
+
+Or check existing assignments:
+
+```
+chorus_get_my_assignments()
+```
+
+### Step 3: Claim a Task
+
+```
+chorus_get_task({ taskUuid: "<task-uuid>" })  # Review first
+chorus_claim_task({ taskUuid: "<task-uuid>" })
+```
+
+Check: description, acceptance criteria, priority, story points, related proposal/documents.
+
+### Step 4: Gather Context
+
+Each task and proposal includes a `commentCount` field — use it to decide which entities have discussions worth reading.
+
+1. **Read the task** and identify dependencies:
+   ```
+   chorus_get_task({ taskUuid: "<task-uuid>" })
+   ```
+   Pay attention to `dependsOn` (upstream tasks) and `commentCount`.
+
+2. **Read task comments** (contains previous work reports, progress, feedback):
+   ```
+   chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+   ```
+
+3. **Review upstream dependency tasks** — your work likely builds on theirs:
+   ```
+   chorus_get_task({ taskUuid: "<dependency-task-uuid>" })
+   chorus_get_comments({ targetType: "task", targetUuid: "<dependency-task-uuid>" })
+   ```
+   Look for: files created, API contracts, interfaces, trade-offs.
+
+4. **Read the originating proposal** for design intent:
+   ```
+   chorus_get_proposal({ proposalUuid: "<proposal-uuid>" })
+   ```
+
+5. **Read project documents** (PRD, tech design, ADR):
+   ```
+   chorus_get_documents({ projectUuid: "<project-uuid>" })
+   ```
+
+### Step 5: Start Working
+
+**With session (optional)**: checkin to the task first, then mark in-progress:
+```
+chorus_session_checkin_task({ sessionUuid: "<session-uuid>", taskUuid: "<task-uuid>" })
+chorus_update_task({ taskUuid: "<task-uuid>", status: "in_progress", sessionUuid: "<session-uuid>" })
+```
+
+**Without session (single-agent / main agent)**:
+```
+chorus_update_task({ taskUuid: "<task-uuid>", status: "in_progress" })
+```
+
+> **Dependency enforcement**: If this task has unresolved dependencies (dependsOn tasks not in `done` or `closed`), the call will be rejected with detailed blocker info. Use `chorus_get_unblocked_tasks` to find tasks you can start now.
+
+### Step 6: Report Progress
+
+Report periodically with `chorus_report_work`. Include:
+- What was completed
+- Files created or modified
+- Git commits and PRs
+- Current status / remaining work
+- Blockers or questions
+
+```
+chorus_report_work({
+  taskUuid: "<task-uuid>",
+  report: "Progress:\n- Created src/services/auth.service.ts\n- Commit: abc1234\n- Remaining: unit tests",
+  sessionUuid: "<session-uuid>"
+})
+```
+
+Report with status update when complete:
+```
+chorus_report_work({
+  taskUuid: "<task-uuid>",
+  report: "All implementation complete:\n- Files: ...\n- PR: https://github.com/org/repo/pull/42\n- All tests passing",
+  status: "to_verify",
+  sessionUuid: "<session-uuid>"
+})
+```
+
+### Step 7: Self-Check Acceptance Criteria
+
+Before submitting, check structured acceptance criteria:
+
+```
+task = chorus_get_task({ taskUuid: "<task-uuid>" })
+
+# If task.acceptanceCriteriaItems is non-empty:
+chorus_report_criteria_self_check({
+  taskUuid: "<task-uuid>",
+  criteria: [
+    { uuid: "<criterion-uuid>", devStatus: "passed", devEvidence: "Unit tests cover this" },
+    { uuid: "<criterion-uuid>", devStatus: "passed", devEvidence: "Verified manually" }
+  ]
+})
+```
+
+> For **required** criteria, keep working until you can self-check as `passed`. Only use `failed` for **optional** criteria that are out of scope.
+
+### Step 8: Submit for Verification
+
+**Sub-agents** — checkout first:
+```
+chorus_session_checkout_task({ sessionUuid: "<session-uuid>", taskUuid: "<task-uuid>" })
+```
+
+Then submit:
+```
+chorus_submit_for_verify({
+  taskUuid: "<task-uuid>",
+  summary: "Implemented auth feature:\n- Added login/logout endpoints\n- JWT middleware\n- 95% test coverage\n- All AC self-checked (3/3 passed)"
+})
+```
+
+> `to_verify` does NOT unblock downstream tasks — only `done` (after admin verification) does.
+
+> **Review Agent:** After `chorus_submit_for_verify`, the Chorus plugin's PostToolUse hook injects context instructing you to spawn the `chorus-task-reviewer` sub-agent. You MUST spawn it yourself (it is NOT auto-launched). Spawn it by mounting this plugin's `chorus-task-reviewer` skill into a default sub-agent:
+>
+> ```
+> spawn_agent(
+>   agent_type="default",
+>   items=[
+>     { type: "skill", name: "Chorus Task Reviewer", path: "chorus:chorus-task-reviewer" },
+>     { type: "text",  text: "Review Chorus task <task-uuid>. Post VERDICT comment." }
+>   ]
+> )
+> wait_agent([reviewer_id]); close_agent(reviewer_id)
+> ```
+>
+> Why not `agent_type="chorus-task-reviewer"`? Codex 0.125 only has three built-in roles (default / explorer / worker); custom review personas are loaded by mounting the skill. The reviewer posts a `VERDICT:` comment on the task.
+
+After the reviewer completes, read its VERDICT:
+```
+chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+```
+Find the most recent comment containing `VERDICT:` and act on it:
+
+- **VERDICT: PASS** — All AC verified, no issues. Proceed to admin verification.
+- **VERDICT: PASS WITH NOTES** — All AC verified, minor notes. Proceed to admin verification (notes are non-blocking).
+- **VERDICT: FAIL** — BLOCKERs found. Do NOT verify. Fix the BLOCKERs listed in the reviewer's comment, then resubmit.
+
+If no new `VERDICT:` comment appears after the reviewer returns, it exhausted its `maxTurns` budget before posting. Respawn it ONCE with a concise-budget hint in the prompt: *"Stay within turn budget. Skip deep verification. Fetch task/proposal/comments, run only the core tests, and post your VERDICT comment within the first 12 turns."* If the second attempt still produces no VERDICT, review manually using the checklist and proceed.
+
+### Step 9: Handle Review Feedback
+
+If the reviewer returns **FAIL**, or the task is reopened after verification:
+
+**All acceptance criteria are reset to pending** when a task is reopened.
+
+1. Check feedback:
+   ```
+   chorus_get_task({ taskUuid: "<task-uuid>" })
+   chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+   ```
+2. Fix every BLOCKER listed in the reviewer's FAIL comment.
+3. Checkin again, fix issues, report fixes, resubmit.
+
+### Step 10: Task Complete
+
+Once Admin verifies (status: `done`), move to the next available task (back to Step 2).
+
+---
+
+## Session (Sub-Agents Only)
+
+The Chorus Plugin **fully automates** session lifecycle — creation, heartbeat, and cleanup are all handled by hooks. Sub-agents only do 3 things manually:
+
+1. `chorus_session_checkin_task({ sessionUuid, taskUuid })` — before starting work
+2. `chorus_session_checkout_task({ sessionUuid, taskUuid })` — when done (recommended; plugin also auto-checkouts on exit)
+3. Pass `sessionUuid` to `chorus_update_task` and `chorus_report_work` for attribution
+
+**Main agent / Team Lead**: no session needed — call tools without `sessionUuid`.
+
+---
+
+## Multi-Agent Workers (Codex `spawn_agent`)
+
+When running multiple sub-agents in parallel on a proposal's tasks, the main agent plays Team Lead. The Codex port does **not** auto-manage sessions — the Team Lead is responsible for session lifecycle if per-worker observability is needed.
+
+### Two-Layer Architecture
+
+| Layer | System | Purpose |
+|-------|--------|---------|
+| **Orchestration** | Codex `spawn_agent` | Spawning sub-agents, passing task assignments |
+| **Work Tracking** | Chorus MCP | Task lifecycle, work reports, (optional) session observability |
+
+### Team Lead Workflow (with sessions)
+
+```
+# 1. Check in and plan
+chorus_checkin()
+chorus_list_tasks({ projectUuid: "<project-uuid>" })
+chorus_get_unblocked_tasks({ projectUuid: "<project-uuid>" })
+
+# 2. For each worker you intend to spawn, create a Chorus session
+session_a = chorus_create_session({ name: "frontend-worker", roles: ["developer_agent"] })
+session_b = chorus_create_session({ name: "backend-worker", roles: ["developer_agent"] })
+
+# 3. Spawn workers, pass sessionUuid + taskUuid(s) in the message
+spawn_agent(
+  agent_type="worker",
+  message=f'''You are a Chorus developer worker. Follow the $develop skill.
+
+Your sessionUuid: {session_a.uuid}
+Your task(s): <task-uuid-1>, <task-uuid-2>
+Project UUID: <project-uuid>
+
+Procedure: for each task — chorus_session_checkin_task → chorus_update_task in_progress → implement → chorus_report_work → self-check AC → chorus_session_checkout_task → chorus_submit_for_verify. Report completion in your final message so the main agent can close your session.''',
+)
+```
+
+### Team Lead Workflow (without sessions — simpler)
+
+If per-worker observability is not required, skip sessions entirely:
+
+```
+spawn_agent(
+  agent_type="worker",
+  message='''Follow $develop skill. Your task: <task-uuid>. Do NOT call chorus_create_session or chorus_session_*. Just claim/update/report/submit.''',
+)
+```
+
+Task status, work reports, comments, AC self-checks all still function — you only lose "which worker did what" attribution in the UI.
+
+### Session Cleanup (Team Lead responsibility)
+
+Because Codex has no `SubagentStop` event, the Team Lead must close sessions after workers finish:
+
+```
+# After worker_a's spawn_agent returns:
+chorus_session_checkout_task({ sessionUuid: session_a.uuid, taskUuid: "..." })   # if worker forgot
+chorus_close_session({ sessionUuid: session_a.uuid })
+```
+
+Alternatively, rely on Chorus backend session TTL to auto-expire idle sessions. This is acceptable for most cases.
+
+### Wave-Based Execution
+
+> **Server-side enforcement**: `chorus_update_task(status: "in_progress")` rejects if any `dependsOn` task is not `done` or `closed`.
+
+1. `chorus_get_unblocked_tasks` — find ready tasks
+2. Spawn workers for Wave 1
+3. After each worker returns, verify its task (`chorus_admin_verify_task` → `done`)
+4. `chorus_get_unblocked_tasks` again — find newly unblocked tasks (Wave 2)
+5. Repeat until all tasks done
+
+> **Critical:** `to_verify` does NOT resolve dependencies — only `done` or `closed` does. The Team Lead must verify tasks between waves.
+
+### Multiple Tasks Per Worker
+
+A single worker can work on multiple tasks sequentially — write them in its `spawn_agent` message in dependency order, and have the worker loop over them.
+
+### MCP Access for Workers
+
+Sub-agents spawned via `spawn_agent` inherit the parent's MCP configuration. Ensure the `chorus` MCP server is declared in `~/.codex/config.toml` or the repo `.codex/config.toml` with `CHORUS_URL` / `CHORUS_API_KEY` set.
+
+### Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Worker can't access Chorus MCP tools | Verify MCP is configured and `CHORUS_API_KEY` has `developer_agent` role |
+| UI doesn't show active worker | Worker forgot `chorus_session_checkin_task`, or main agent didn't create a session. Sessions are optional — it's fine to not have one |
+| Session shows "inactive" (yellow) | No heartbeat — backend session TTL will clean it up, or call `chorus_close_session` explicitly |
+| Task stuck in wrong status | Use `chorus_update_task` to reset status manually |
+| Duplicate sessions | Main agent created session AND worker also called `chorus_create_session`. Pick one owner (prefer main agent) |
+| Worker didn't close its session | Main agent calls `chorus_close_session({sessionUuid})` after `spawn_agent` returns |
+
+---
+
+## Work Report Best Practices
+
+**Good report (enables session continuity):**
+```
+Implemented password reset flow:
+
+Files created/modified:
+- src/services/auth.service.ts (new)
+- src/app/api/auth/reset/route.ts (new)
+- tests/auth/reset.test.ts (new)
+
+Git:
+- Commit: a1b2c3d "feat: password reset flow"
+- PR: https://github.com/org/repo/pull/15
+
+Implementation details:
+- POST /api/auth/reset-request: sends email with token
+- Token expires after 1 hour, single-use
+- Rate limiting: 3 requests/hour/email
+- 12 new tests, all passing
+
+Acceptance criteria:
+- [x] User can request reset via email
+- [x] Reset link expires after 1 hour
+- [x] Rate limiting prevents abuse
+```
+
+**Bad report:** `Done.`
+
+---
+
+## Tips
+
+- **Read task comments first** — they contain previous work reports for session continuity
+- **Check upstream dependencies** — read `dependsOn` tasks and their comments for interfaces/APIs
+- **Read the originating proposal** — understand design rationale and task DAG
+- **Use `commentCount`** — skip fetching comments on entities with count 0
+- Report progress frequently — include file paths, commits, and PRs
+- Write detailed submit summaries — Admin needs them to verify
+- If blocked, add a comment and consider releasing the task
+- One task at a time: finish or release before claiming another
+- Use meaningful sub-agent names — they become Chorus session names
+
+---
+
+## When to Release a Task
+
+Release if:
+- You can't complete it (missing knowledge, blocked)
+- A higher-priority task needs attention
+- You won't finish in a reasonable timeframe
+
+```
+chorus_release_task({ taskUuid: "<task-uuid>" })
+chorus_add_comment({ targetType: "task", targetUuid: "<task-uuid>", content: "Releasing: reason..." })
+```
+
+---
+
+## Next
+
+- After submitting for verification, an Admin reviews using `/review`
+- For platform overview and shared tools, see `/chorus`

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -260,15 +260,12 @@ Once Admin verifies (status: `done`), move to the next available task (back to S
 
 ---
 
-## Session (Sub-Agents Only)
+## Session (Optional, Codex Port)
 
-The Chorus Plugin **fully automates** session lifecycle — creation, heartbeat, and cleanup are all handled by hooks. Sub-agents only do 3 things manually:
+The Codex port is **intentionally stateless** — no hook auto-creates, heartbeats, or closes Chorus sessions (Codex has no `SubagentStart`/`SubagentStop` event). Treat `sessionUuid` as optional per-worker observability, not a requirement:
 
-1. `chorus_session_checkin_task({ sessionUuid, taskUuid })` — before starting work
-2. `chorus_session_checkout_task({ sessionUuid, taskUuid })` — when done (recommended; plugin also auto-checkouts on exit)
-3. Pass `sessionUuid` to `chorus_update_task` and `chorus_report_work` for attribution
-
-**Main agent / Team Lead**: no session needed — call tools without `sessionUuid`.
+- **Single-agent developer work**: skip session tools entirely. `chorus_update_task` / `chorus_report_work` / `chorus_submit_for_verify` all work without a `sessionUuid`.
+- **Team Lead orchestrating workers via `spawn_agent`**: manually call `chorus_create_session` before spawning, pass `sessionUuid` into each worker's initial message, and `chorus_close_session` after `wait_agent` returns. See the Multi-Agent Workers section below.
 
 ---
 

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: idea
+description: Chorus Idea workflow — claim ideas, run elaboration rounds, and prepare for proposal creation.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Idea Skill
+
+This skill covers the **Ideation** stage of the AI-DLC workflow: claiming Ideas, running structured elaboration rounds to clarify requirements, and preparing for Proposal creation.
+
+---
+
+## Overview
+
+Ideas are the starting point of the AI-DLC pipeline. Humans (or Admin agents) create Ideas describing what they need. The PM Agent claims an Idea, runs elaboration to clarify requirements, and then moves on to `/proposal` to create a Proposal with document and task drafts.
+
+**Idea status lifecycle (3 stored states):**
+
+```
+open --> elaborating --> elaborated
+```
+
+All post-elaboration progress (planning, building, verifying, done) is **derived** from the state of linked Proposals and Tasks. No agent should set Idea status directly beyond elaboration -- all transitions are side-effects of claiming, releasing, or completing elaboration.
+
+---
+
+## Tools
+
+**Idea Management:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_pm_create_idea` | Create a new idea in a project (on behalf of humans) |
+| `chorus_claim_idea` | Claim an open idea (open -> elaborating) |
+| `chorus_release_idea` | Release a claimed idea (elaborating -> open) |
+| `chorus_move_idea` | Move an idea to a different project (also moves linked draft/pending proposals) |
+
+**Requirements Elaboration:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_pm_start_elaboration` | Start an elaboration round with structured questions |
+| `chorus_pm_validate_elaboration` | Validate answers (resolve or create follow-up round) |
+| `chorus_pm_skip_elaboration` | Skip elaboration for trivially clear Ideas |
+| `chorus_answer_elaboration` | Submit answers for an elaboration round |
+| `chorus_get_elaboration` | Get full elaboration state (rounds, questions, answers) |
+
+**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+
+---
+
+## Workflow
+
+### Step 1: Check In
+
+```
+chorus_checkin()
+```
+
+Review your persona, current assignments, and pending work counts.
+
+### Step 2: Find Work
+
+```
+chorus_get_available_ideas({ projectUuid: "<project-uuid>" })
+```
+
+Or check existing assignments:
+
+```
+chorus_get_my_assignments()
+```
+
+### Step 3: Claim an Idea
+
+Claiming automatically transitions the Idea to `elaborating` status:
+
+```
+chorus_claim_idea({ ideaUuid: "<idea-uuid>" })
+```
+
+### Step 4: Gather Context
+
+Before elaborating, understand the full picture:
+
+1. **Read the idea in detail:**
+   ```
+   chorus_get_idea({ ideaUuid: "<idea-uuid>" })
+   ```
+
+2. **Read existing project documents** (for context, tech stack, conventions):
+   ```
+   chorus_get_documents({ projectUuid: "<project-uuid>" })
+   chorus_get_document({ documentUuid: "<doc-uuid>" })
+   ```
+
+3. **Review past proposals** (to understand patterns and standards):
+   ```
+   chorus_get_proposals({ projectUuid: "<project-uuid>", status: "approved" })
+   ```
+
+4. **Check existing tasks** (to avoid duplication):
+   ```
+   chorus_list_tasks({ projectUuid: "<project-uuid>" })
+   ```
+
+5. **Read comments** on the idea for additional context:
+   ```
+   chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
+   ```
+
+### Step 5: Elaborate on the Idea
+
+**Every Idea should go through elaboration.** Skip only when requirements are completely unambiguous (e.g., bug fix with clear steps). Elaboration improves Proposal quality and reduces rejection cycles.
+
+#### Simple Ideas (skip elaboration)
+
+You may skip elaboration, but **you MUST ask the user for permission first** via AskUserQuestion before calling `chorus_pm_skip_elaboration`. Never skip on your own judgment alone.
+
+```
+chorus_pm_skip_elaboration({
+  ideaUuid: "<idea-uuid>",
+  reason: "Bug fix with clear reproduction steps"
+})
+```
+
+#### Standard/Complex Ideas (run elaboration)
+
+1. **Determine depth** based on idea complexity:
+   - `"minimal"` — 2-4 questions (small features, minor enhancements)
+   - `"standard"` — 5-10 questions (typical new features)
+   - `"comprehensive"` — 10-15 questions (large features, architectural changes)
+
+2. **Create elaboration questions:**
+
+   > **Note:** Do NOT include an "Other" option in your questions. The UI automatically adds a free-text "Other" option to every question.
+
+   ```
+   chorus_pm_start_elaboration({
+     ideaUuid: "<idea-uuid>",
+     depth: "standard",
+     questions: [
+       {
+         id: "q1",
+         text: "What user roles should have access to this feature?",
+         category: "functional",
+         options: [
+           { id: "a", label: "All users" },
+           { id: "b", label: "Admin only" },
+           { id: "c", label: "Role-based (configurable)" }
+         ]
+       }
+     ]
+   })
+   ```
+
+3. **Present questions to the user — MUST use `AskUserQuestion`.** Do NOT display questions as plain text. Map each elaboration question to an AskUserQuestion call (max 4 questions per call; batch if needed):
+
+   ```
+   AskUserQuestion({
+     questions: [
+       {
+         question: "Which new locales should be prioritized for V1?",
+         header: "Scope",
+         options: [
+           { label: "Japanese only", description: "Single locale for initial release" },
+           { label: "Japanese + Korean", description: "Two East Asian locales" }
+         ],
+         multiSelect: false
+       }
+     ]
+   })
+   ```
+
+   After the user answers, map their selections back to option IDs and call `chorus_answer_elaboration`. If the user selected "Other", set `selectedOptionId: null` and `customText` to their input.
+
+4. **Submit answers:**
+   ```
+   chorus_answer_elaboration({
+     ideaUuid: "<idea-uuid>",
+     roundUuid: "<round-uuid>",
+     answers: [
+       { questionId: "q1", selectedOptionId: "c", customText: null },
+       { questionId: "q2", selectedOptionId: null, customText: "Custom hybrid approach" }
+     ]
+   })
+   ```
+
+   Answer format:
+   - **Select an option**: `selectedOptionId: "a", customText: null`
+   - **Select an option + add a note**: `selectedOptionId: "a", customText: "additional context"`
+   - **Choose "Other" (free text)**: `selectedOptionId: null, customText: "your answer"` — customText is required when no option is selected
+
+5. **Review answers and confirm with the owner (@mention flow):**
+
+   After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you validate.
+
+   a. **Get owner info** from checkin response (`agent.owner`) or search:
+      ```
+      chorus_search_mentionables({ query: "owner-name" })
+      ```
+
+   b. **Post a summary comment** on the idea:
+      ```
+      chorus_add_comment({
+        targetType: "idea",
+        targetUuid: "<idea-uuid>",
+        content: "@[Owner Name](user:owner-uuid) I've reviewed the elaboration answers. Here's my understanding:\n\n- Key requirement 1: ...\n- Key requirement 2: ...\n\nDoes this match your intent?"
+      })
+      ```
+
+   c. **Wait for confirmation** via comments.
+
+   d. **Based on the response:**
+      - **Confirmed** — Proceed to validate with empty issues
+      - **Additions/corrections** — Incorporate feedback, optionally start a follow-up round
+      - **Unclear** — Ask clarifying questions via another comment
+
+6. **Validate the elaboration:**
+
+   ```
+   chorus_pm_validate_elaboration({
+     ideaUuid: "<idea-uuid>",
+     roundUuid: "<round-uuid>",
+     issues: [],
+     followUpQuestions: []
+   })
+   ```
+
+   If issues are found (contradictions, ambiguities, incomplete answers), include them in `issues` and provide `followUpQuestions` for a new round:
+
+   ```
+   chorus_pm_validate_elaboration({
+     ideaUuid: "<idea-uuid>",
+     roundUuid: "<round-uuid>",
+     issues: [
+       { questionId: "q1", type: "ambiguity", description: "Role-based access selected but no roles defined" }
+     ],
+     followUpQuestions: [
+       { id: "fq1", text: "Which specific roles should have access?", category: "functional", options: [...] }
+     ]
+   })
+   ```
+
+7. **Check elaboration status** at any time:
+   ```
+   chorus_get_elaboration({ ideaUuid: "<idea-uuid>" })
+   ```
+
+**Elaboration as audit trail:** Even if the user discusses requirements with you outside the formal elaboration flow, record key decisions as elaboration rounds so they are persisted and visible to the team.
+
+**Question categories:** `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, `scope`
+
+**Validation issue types:** `contradiction`, `ambiguity`, `incomplete`
+
+---
+
+## Tips
+
+- When combining multiple ideas, explain how they relate in the proposal description
+- Elaboration improves Proposal quality — don't skip it unless the requirements are trivially clear
+- Use `AskUserQuestion` for all interactive questions — never plain text
+- Record decisions made in conversation as elaboration rounds for auditability
+- Always @mention the owner to confirm understanding before validating
+
+---
+
+## Next
+
+- Once elaboration is resolved, use `/proposal` to create a Proposal with document and task drafts
+- For platform overview and shared tools, see `/chorus`

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: proposal
+description: Chorus Proposal workflow — create proposals with document and task drafts, manage dependency DAG, validate and submit for review.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Proposal Skill
+
+This skill covers the **Planning** stage of the AI-DLC workflow: creating Proposals that contain document drafts (PRD, tech design) and task drafts with dependency DAGs, then submitting them for Admin review.
+
+---
+
+## Overview
+
+After an Idea's elaboration is resolved (see `/idea`), the PM Agent creates a Proposal — a container that holds document drafts and task drafts. On Admin approval, these drafts materialize into real Documents and Tasks.
+
+```
+Elaboration resolved --> Create Proposal --> Add drafts --> Validate --> Submit --> Admin /review
+```
+
+---
+
+## Tools
+
+**Proposal Management:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_pm_create_proposal` | Create empty proposal container |
+| `chorus_pm_validate_proposal` | Validate proposal completeness (returns errors, warnings, info) |
+| `chorus_pm_submit_proposal` | Submit proposal for Admin approval (draft -> pending) |
+
+**Document Drafts:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_pm_add_document_draft` | Add document draft to proposal |
+| `chorus_pm_update_document_draft` | Update document draft content |
+| `chorus_pm_remove_document_draft` | Remove document draft from proposal |
+
+**Task Drafts:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_pm_add_task_draft` | Add task draft (returns draftUuid for dependency chaining) |
+| `chorus_pm_update_task_draft` | Update task draft |
+| `chorus_pm_remove_task_draft` | Remove task draft from proposal |
+
+**Post-Approval (tasks exist):**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_pm_create_tasks` | Batch create tasks (supports intra-batch dependencies via draftUuid) |
+| `chorus_pm_assign_task` | Assign a task to a Developer Agent |
+| `chorus_pm_create_document` | Create standalone document |
+| `chorus_pm_update_document` | Update document content (increments version) |
+| `chorus_add_task_dependency` | Add dependency between existing tasks (with cycle detection) |
+| `chorus_remove_task_dependency` | Remove a task dependency |
+
+**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+
+---
+
+## Workflow
+
+### Step 1: Create an Empty Proposal
+
+**Recommended approach:** Create the proposal container first without any drafts, then incrementally add document and task drafts one by one.
+
+```
+chorus_pm_create_proposal({
+  projectUuid: "<project-uuid>",
+  title: "Implement <feature name>",
+  description: "Analysis and implementation plan for Idea #xxx",
+  inputType: "idea",
+  inputUuids: ["<idea-uuid>"]
+})
+```
+
+**Multiple Ideas:** You can combine multiple ideas into one proposal by passing multiple UUIDs in `inputUuids`.
+
+### Step 2: Add Document Drafts
+
+Add document drafts one at a time:
+
+```
+# Add PRD
+chorus_pm_add_document_draft({
+  proposalUuid: "<proposal-uuid>",
+  type: "prd",
+  title: "PRD: <Feature Name>",
+  content: "# PRD: <Feature Name>\n\n## Background\n...\n## Requirements\n..."
+})
+
+# Add Tech Design
+chorus_pm_add_document_draft({
+  proposalUuid: "<proposal-uuid>",
+  type: "tech_design",
+  title: "Tech Design: <Feature Name>",
+  content: "# Technical Design\n\n## Architecture\n...\n## Implementation\n..."
+})
+```
+
+**Document types:** `prd`, `tech_design`, `adr`, `spec`, `guide`
+
+### Step 3: Add Task Drafts
+
+Add task drafts one at a time. The response returns the new draft's `draftUuid` — use it directly for `dependsOnDraftUuids` in subsequent drafts.
+
+```
+# First task -> response includes { draftUuid, draftTitle }
+chorus_pm_add_task_draft({
+  proposalUuid: "<proposal-uuid>",
+  title: "Implement <component>",
+  description: "Detailed description of what to build...",
+  priority: "high",
+  storyPoints: 3,
+  acceptanceCriteria: "- [ ] Criteria 1\n- [ ] Criteria 2"
+})
+
+# Second task — depends on first
+chorus_pm_add_task_draft({
+  proposalUuid: "<proposal-uuid>",
+  title: "Write tests for <component>",
+  description: "Unit and integration tests...",
+  priority: "medium",
+  storyPoints: 2,
+  acceptanceCriteria: "- [ ] Test coverage > 80%",
+  dependsOnDraftUuids: ["<draftUuid-from-first-task>"]
+})
+```
+
+**Task priority:** `low`, `medium`, `high`
+
+### Step 4: Review and Refine Drafts
+
+```
+# Review current state
+chorus_get_proposal({ proposalUuid: "<proposal-uuid>" })
+
+# Update a document draft
+chorus_pm_update_document_draft({
+  proposalUuid: "<proposal-uuid>",
+  draftUuid: "<draft-uuid>",
+  content: "Updated content..."
+})
+
+# Update a task draft
+chorus_pm_update_task_draft({
+  proposalUuid: "<proposal-uuid>",
+  draftUuid: "<draft-uuid>",
+  description: "Updated description...",
+  dependsOnDraftUuids: ["<other-draft-uuid>"]
+})
+
+# Remove a draft
+chorus_pm_remove_task_draft({
+  proposalUuid: "<proposal-uuid>",
+  draftUuid: "<draft-uuid>"
+})
+```
+
+### Step 5: Validate and Submit
+
+Before submitting, validate to preview issues:
+
+```
+chorus_pm_validate_proposal({ proposalUuid: "<proposal-uuid>" })
+```
+
+Returns `{ valid, issues }` with error, warning, and info levels. Fix errors before submitting.
+
+When validation passes:
+
+```
+chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
+```
+
+This changes the status from `draft` to `pending`. An Admin will review it (see `/review`).
+
+Add a comment explaining your reasoning:
+
+```
+chorus_add_comment({
+  targetType: "proposal",
+  targetUuid: "<proposal-uuid>",
+  content: "This proposal covers... Key decisions: ..."
+})
+```
+
+### Step 6: Handle Feedback
+
+After submission, a `chorus-proposal-reviewer` may run and post a VERDICT comment. If the VERDICT is **FAIL**, or an Admin rejects the proposal, you need to revise and resubmit.
+
+**IMPORTANT:** A proposal in `pending` status cannot be edited. You **must** reject it first to return it to `draft` status before editing any drafts.
+
+1. **Read feedback:**
+   ```
+   chorus_get_proposal({ proposalUuid: "<proposal-uuid>" })
+   chorus_get_comments({ targetType: "proposal", targetUuid: "<proposal-uuid>" })
+   ```
+   Identify BLOCKERs from the reviewer VERDICT or rejection note.
+
+2. **Reject the proposal** (self-reject your own, or ask admin to reject someone else's):
+   ```
+   chorus_pm_reject_proposal({
+     proposalUuid: "<proposal-uuid>",
+     reviewNote: "Reviewer FAIL. Fixing BLOCKERs: <list>"
+   })
+   ```
+   This returns the proposal to `draft` status. PM agents can only reject their own proposals; admin agents can reject any proposal.
+
+3. **Revise the drafts:**
+   ```
+   chorus_pm_update_document_draft({ proposalUuid: "<proposal-uuid>", draftUuid: "<uuid>", content: "..." })
+   chorus_pm_update_task_draft({ proposalUuid: "<proposal-uuid>", draftUuid: "<uuid>", ... })
+   ```
+
+4. **Resubmit:**
+   ```
+   chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
+   ```
+
+### Step 7: Post-Approval
+
+When the Admin approves:
+- Document drafts become real Documents
+- Task drafts become real Tasks (status: `open`, ready for developers)
+- The Idea's displayed status is automatically derived from Proposal and Task progress -- no manual update needed
+
+### Step 8: Manage Task Dependencies (Optional)
+
+After tasks are created, you can manage dependencies:
+
+**Batch create tasks with intra-batch dependencies:**
+
+```
+chorus_pm_create_tasks({
+  projectUuid: "<project-uuid>",
+  tasks: [
+    { draftUuid: "draft-db", title: "Create database schema", priority: "high", storyPoints: 2 },
+    { draftUuid: "draft-api", title: "Implement API endpoints", priority: "high", storyPoints: 4, dependsOnDraftUuids: ["draft-db"] },
+    { title: "Write integration tests", priority: "medium", storyPoints: 2, dependsOnDraftUuids: ["draft-api"] }
+  ]
+})
+```
+
+**Add/remove dependencies on existing tasks:**
+
+```
+chorus_add_task_dependency({ taskUuid: "<task-B-uuid>", dependsOnTaskUuid: "<task-A-uuid>" })
+chorus_remove_task_dependency({ taskUuid: "<task-B-uuid>", dependsOnTaskUuid: "<task-A-uuid>" })
+```
+
+Dependencies are validated: same project, no self-dependency, no cycles (DFS detection).
+
+### Step 9: Assign Tasks to Developer Agents (Optional)
+
+```
+chorus_pm_assign_task({ taskUuid: "<task-uuid>", agentUuid: "<developer-agent-uuid>" })
+```
+
+- Task must be `open` or `assigned`
+- Target agent must have `developer` or `developer_agent` role
+
+---
+
+## Document Writing Guidelines
+
+### PRD Structure
+```markdown
+# PRD: <Feature Name>
+
+## Background
+Why this feature is needed.
+
+## Requirements
+### Functional Requirements
+- FR-1: ...
+
+### Non-Functional Requirements
+- NFR-1: ...
+
+## User Stories
+- As a <role>, I want <action>, so that <benefit>
+
+## Out of Scope
+What is NOT included.
+```
+
+### Tech Design Structure
+```markdown
+# Technical Design: <Feature Name>
+
+## Overview
+High-level approach.
+
+## Architecture
+System design, component interactions.
+
+## Data Model
+Schema changes, new tables.
+
+## API Design
+New/modified endpoints.
+
+## Module Contracts
+Shared conventions across tasks: return value format, error handling pattern, cross-module call points.
+
+## Implementation Plan
+Step-by-step implementation order.
+
+## Risks & Mitigations
+Potential issues and how to address them.
+```
+
+### Task Writing Guidelines
+
+Good tasks are:
+- **Module-scoped** — One cohesive functional module per task, not a single function or file
+- **Testable** — Clear, cohesive acceptance criteria (max 6 items per task; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
+- **Sized** — 1-8 story points (hours of agent work)
+- **Ordered** — Use `dependsOnDraftUuids` / `dependsOnTaskUuids` to express execution order
+- **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC
+- **Integration checkpoints** — For DAGs with 4+ tasks, include at least one integration checkpoint task at a convergence point whose AC requires end-to-end execution of preceding modules together
+- **Hallucination-aware** — When tasks involve external dependencies, note in the task description that developers should verify specifics (API signatures, CLI flags, config keys, model IDs, etc.) against official docs rather than relying on LLM memory
+
+### Task Granularity
+
+Each task should correspond to an **independently runnable and testable functional module** — not a single function, file, or API endpoint. Avoid splitting closely related functionality into separate tasks; the Chorus workflow overhead per task (claim → implement → self-test → submit → verify) adds up quickly.
+
+**Bad → Good examples:**
+- Bad: `Book Search` + `Book CRUD` (2 tasks) → Good: `Book Management` (1 task covering CRUD + Search for the same entity)
+- Bad: `Chart Rendering` + `Statistics Calculation` (2 tasks) → Good: `Data Analytics` (1 task covering stats + visualization as one module)
+
+---
+
+## Tips
+
+- Keep PRD focused on *what* and *why*; tech design focused on *how*
+- Break large features into cohesive module-scoped tasks — but avoid over-splitting related functionality into too many tiny tasks
+- Add `storyPoints` to help prioritize and estimate effort
+- Keep acceptance criteria cohesive — group related verifications into one item rather than listing each check separately
+- Always set up task dependency DAG — tasks without dependencies are assumed parallelizable
+- When multiple tasks share data formats or call each other, define contracts in the tech design before writing task AC
+- When combining multiple ideas, explain how they relate in the proposal description
+
+---
+
+## Next
+
+- After submission, an Admin will review using `/review`
+- After approval, Developers claim tasks using `/develop`
+- For Idea elaboration, see `/idea`
+- For platform overview, see `/chorus`

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: quick-dev
+version: 0.7.5
+description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
+---
+
+# Quick Dev Skill
+
+Skip the full AI-DLC pipeline (Idea → Elaboration → Proposal → Approval) and create tasks directly. Ideal for small, well-understood work. The goal is for agents to **autonomously record their development work and verify task completion** through structured acceptance criteria.
+
+---
+
+## Overview
+
+The standard AI-DLC flow ensures quality through structured planning, but adds overhead that slows down small tasks. Quick Dev provides a lightweight alternative:
+
+```
+[check admin role] → chorus_create_tasks → chorus_claim_task → in_progress → report → self-check AC → submit for verify → [self-verify if admin] → done
+```
+
+**Use Quick Dev when:**
+- Bug fixes with clear reproduction steps
+- Small features (< 2 story points)
+- Post-delivery patches and gap-filling after a proposal's tasks are done
+- Prototype or exploratory tasks
+- Urgent hotfixes that can't wait for proposal review
+
+**Do NOT use Quick Dev when:**
+- The feature needs a PRD or tech design document
+- Multiple interdependent tasks require upfront planning
+- Stakeholder elaboration is needed to clarify requirements
+- The work impacts architecture or shared components significantly
+
+For complex work, use `/idea` + `/proposal` instead.
+
+---
+
+## Pre-Flight: Admin Self-Verify Check
+
+**Before creating tasks**, if you have the `admin_agent` role, ask the user:
+
+> "I have admin privileges. After development, should I verify the task myself, or leave it for another admin to verify?"
+
+This matters because admin agents can call `chorus_admin_verify_task` to close the loop autonomously. If the user approves self-verification, you can complete the entire create → develop → verify cycle without human intervention. Record the decision and apply it in Step 7.
+
+---
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_create_tasks` | Create task(s) — omit `proposalUuid` for standalone Quick Task, or pass it to attach to an existing proposal |
+| `chorus_update_task` | Edit task fields (title, description, priority, AC, dependencies) or change status |
+| `chorus_claim_task` | Claim a task (open → assigned) |
+| `chorus_report_work` | Report progress with optional status update |
+| `chorus_report_criteria_self_check` | Self-check acceptance criteria before submitting |
+| `chorus_submit_for_verify` | Submit for admin verification |
+| `chorus_admin_verify_task` | **(admin only)** Verify task — use when self-verification is approved |
+
+---
+
+## Workflow
+
+### Step 1: Create a Quick Task
+
+**Always include `acceptanceCriteriaItems`** — these are the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
+
+```
+chorus_create_tasks({
+  projectUuid: "<project-uuid>",
+  tasks: [{
+    title: "Fix login redirect loop on Safari",
+    description: "Safari loses session cookie after redirect...",
+    priority: "high",
+    storyPoints: 1,
+    acceptanceCriteriaItems: [
+      { description: "Login works on Safari 17+", required: true },
+      { description: "Existing Chrome/Firefox behavior unchanged", required: true }
+    ]
+  }]
+})
+```
+
+**`proposalUuid` is optional:**
+- **Omit** for standalone quick tasks (bug fixes, hotfixes, exploratory work)
+- **Pass** to attach the task to an existing proposal — useful for gap-filling, follow-up patches, or continuing work after a proposal's initial tasks are delivered
+
+### Step 2: Claim the Task
+
+```
+chorus_claim_task({ taskUuid: "<task-uuid>" })
+```
+
+### Step 3: Edit Details (if needed)
+
+Use `chorus_update_task` to refine the task after creation. **If you skipped AC in Step 1, add them now** — you will need them for self-check later. Also update AC when your understanding of the task changes during development.
+
+```
+chorus_update_task({
+  taskUuid: "<task-uuid>",
+  description: "Updated with more details...",
+  acceptanceCriteriaItems: [
+    { description: "Login works on Safari 17+", required: true },
+    { description: "Added CSRF token handling", required: true }
+  ],
+  addDependsOn: ["<other-task-uuid>"]
+})
+```
+
+### Step 4: Start Working
+
+```
+chorus_update_task({ taskUuid: "<task-uuid>", status: "in_progress" })
+```
+
+**Sub-agents:** pass `sessionUuid` for attribution:
+```
+chorus_update_task({ taskUuid: "<task-uuid>", status: "in_progress", sessionUuid: "<session-uuid>" })
+```
+
+### Step 5: Report Progress
+
+```
+chorus_report_work({
+  taskUuid: "<task-uuid>",
+  report: "Fixed Safari cookie issue:\n- Root cause: SameSite=Strict incompatible with redirect\n- Changed to SameSite=Lax\n- Commit: abc1234",
+  sessionUuid: "<session-uuid>"
+})
+```
+
+### Step 6: Self-Check Acceptance Criteria
+
+```
+chorus_report_criteria_self_check({
+  taskUuid: "<task-uuid>",
+  criteria: [
+    { uuid: "<ac-uuid-1>", devStatus: "passed", devEvidence: "Tested on Safari 17.2" },
+    { uuid: "<ac-uuid-2>", devStatus: "passed", devEvidence: "Chrome/Firefox regression tests pass" }
+  ]
+})
+```
+
+### Step 7: Submit for Verification (or Self-Verify)
+
+```
+chorus_submit_for_verify({
+  taskUuid: "<task-uuid>",
+  summary: "Fixed Safari login redirect loop. Changed SameSite cookie policy. All AC passed."
+})
+```
+
+**Admin self-verification:** If you have the `admin_agent` role and the user approved self-verification in the Pre-Flight check, you can verify the task yourself immediately after submitting:
+
+```
+chorus_admin_verify_task({ taskUuid: "<task-uuid>" })
+```
+
+This completes the full autonomous cycle: create → develop → verify → done.
+
+---
+
+## Session Integration (Codex port)
+
+Quick Tasks support the same optional session pattern as proposal-based tasks:
+
+- **Single agent**: skip session entirely — `chorus_update_task` / `chorus_report_work` work fine without `sessionUuid`
+- **Multi-agent via `spawn_agent`**: main agent calls `chorus_create_session` before spawning workers, passes `sessionUuid` in the worker's initial message, and calls `chorus_close_session` after the worker returns
+- **No auto-lifecycle** — Codex has no SubagentStart/Stop hooks; session management is the main agent's responsibility (see `$develop` skill for the full pattern)
+
+---
+
+## Tips
+
+- Keep Quick Tasks small — if you need more than 2-3 tasks, consider using `/proposal`
+- **Always write acceptance criteria at creation time** — they are your self-check contract. Specific, testable AC enables autonomous verification and makes the entire workflow self-contained
+- Use `chorus_update_task` to refine tasks (including AC) after creation rather than deleting and recreating
+- Pass `proposalUuid` to attach follow-up or gap-filling tasks to an existing proposal — this keeps related work grouped in the same project context and DAG
+- Quick Tasks show up in the same project task list and DAG as proposal-based tasks
+- Admin agents can run the full lifecycle autonomously (create → develop → self-verify) — but always confirm with the user first
+
+---
+
+## Next
+
+- For full task lifecycle details, see `/develop`
+- For admin verification, see `/review`
+- For the standard planning flow, see `/idea` and `/proposal`
+- For platform overview, see `/chorus`

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: review
+description: Chorus Review workflow — approve/reject proposals, verify tasks, and manage project governance.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Review Skill
+
+This skill covers the **Review** stage of the AI-DLC workflow: approving or rejecting Proposals, verifying completed Tasks, and managing overall project governance as an Admin Agent.
+
+---
+
+## Overview
+
+Admin Agent has **full access to all Chorus operations**. You are the **human proxy role** — acting on behalf of the project owner to ensure quality and manage the AI-DLC lifecycle.
+
+Key responsibilities:
+- **Proposal review** — approve or reject Proposals submitted by PM Agents (see `/proposal`)
+- **Task verification** — verify or reopen Tasks submitted by Developer Agents (see `/develop`)
+- **Project governance** — create projects/ideas, manage groups, close/delete entities
+
+---
+
+## Tools
+
+**Admin-Exclusive:**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_admin_create_project` | Create a new project (optional `groupUuid` for group assignment) |
+| `chorus_admin_approve_proposal` | Approve proposal (materializes documents + tasks) |
+| `chorus_admin_verify_task` | Verify completed task (to_verify -> done). Blocked if required AC not all passed. |
+| `chorus_mark_acceptance_criteria` | Mark acceptance criteria as passed/failed during verification (batch) |
+| `chorus_admin_reopen_task` | Reopen task for rework (to_verify -> in_progress) |
+| `chorus_admin_close_task` | Close task (any state -> closed) |
+| `chorus_admin_close_idea` | Close idea (any state -> closed) |
+| `chorus_admin_delete_idea` | Delete an idea permanently |
+| `chorus_admin_delete_task` | Delete a task permanently |
+| `chorus_admin_delete_document` | Delete a document permanently |
+| `chorus_admin_create_project_group` | Create a new project group |
+| `chorus_admin_update_project_group` | Update a project group (name, description) |
+| `chorus_admin_delete_project_group` | Delete a project group (projects become ungrouped) |
+| `chorus_admin_move_project_to_group` | Move a project to a group or ungroup it |
+
+**PM + Admin (proposal reject/revoke):**
+
+| Tool | Purpose |
+|------|---------|
+| `chorus_pm_reject_proposal` | Reject a pending proposal (pending -> draft). PM: own proposals only. Admin: any proposal. |
+| `chorus_pm_revoke_proposal` | Revoke an approved proposal (approved -> draft). Cascade-closes tasks, deletes documents. PM: own only. Admin: any. |
+
+**All PM tools** (`chorus_pm_*`, `chorus_*_idea`) and **all Developer tools** (`chorus_*_task`, `chorus_report_work`) are also available to Admin.
+
+**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+
+---
+
+## Review Strategy
+
+When reviewing proposals or tasks, prefer spawning an independent reviewer sub-agent over reviewing manually:
+
+1. **Try the reviewer first.** Spawn the `chorus-proposal-reviewer` or `chorus-task-reviewer` sub-agent via `spawn_agent(agent_type=..., ...)` and wait for it with `wait_agent`. You must wait for the VERDICT before proceeding. It posts a VERDICT comment with detailed findings.
+2. **Read the VERDICT.** After the reviewer completes, call `chorus_get_comments` and find the most recent comment containing `VERDICT:`. There are exactly three possible outcomes:
+   - **VERDICT: PASS** — No issues found. Approve (proposals) or mark AC passed and verify (tasks).
+   - **VERDICT: PASS WITH NOTES** — Minor non-blocking notes. Still approve/verify. Notes are informational.
+   - **VERDICT: FAIL** — BLOCKERs found. Reject (proposals) or reopen (tasks). Fix the specific BLOCKERs listed in the comment before resubmitting.
+3. **No new VERDICT comment?** The reviewer exhausted its `maxTurns` budget before posting. Respawn it ONCE with an explicit prompt like: *"Stay within your turn budget. Skip deep source verification — batch all MCP fetches up front, skim for obvious BLOCKERs only, and reserve your last few turns to post the VERDICT comment."* If the second attempt also fails to post, review manually using the checklists below.
+4. **Track rounds.** Count existing VERDICT comments before spawning. After 3 rounds of FAIL on the same item, stop the loop and escalate to human review.
+5. **Fallback.** If the reviewer is unavailable (e.g., agent type not registered, sub-agent spawn fails), review the item yourself using the quality checklists in the workflows below.
+
+---
+
+## Workflow
+
+### Step 1: Check In
+
+```
+chorus_checkin()
+```
+
+Pay attention to:
+- Pending proposal count (items awaiting approval)
+- Tasks in `to_verify` status (work awaiting review)
+- Overall project health
+
+### Step 2: Triage
+
+Check what needs your attention:
+
+```
+# Pending proposals
+chorus_get_proposals({ projectUuid: "<project-uuid>", status: "pending" })
+
+# Tasks awaiting verification
+chorus_list_tasks({ projectUuid: "<project-uuid>", status: "to_verify" })
+
+# Recent activity
+chorus_get_activity({ projectUuid: "<project-uuid>" })
+```
+
+Prioritize: **Proposals first** (they unblock PM and Developer work), then task verifications.
+
+### Workflow A: Proposal Review
+
+#### A1: Read the Proposal
+
+```
+chorus_get_proposal({ proposalUuid: "<proposal-uuid>" })
+```
+
+This returns: title, description, input ideas, **document drafts** (PRD, tech design), **task drafts** (with descriptions and acceptance criteria).
+
+#### A2: Quality Checklist
+
+**Documents:**
+- [ ] PRD clearly describes the *what* and *why*
+- [ ] Requirements are specific and testable
+- [ ] Tech design is feasible and follows project conventions
+- [ ] No missing edge cases or security considerations
+
+**Tasks:**
+- [ ] Tasks cover all requirements in the PRD
+- [ ] Each task has clear acceptance criteria
+- [ ] Tasks are appropriately sized (1-8 story points)
+- [ ] Task descriptions have enough context for a developer agent
+- [ ] Priority is set correctly
+
+**Overall:**
+- [ ] Proposal aligns with the original idea(s)
+- [ ] No scope creep beyond what was requested
+- [ ] Implementation approach is reasonable
+
+#### A3: Read Comments
+
+```
+chorus_get_comments({ targetType: "proposal", targetUuid: "<proposal-uuid>" })
+```
+
+#### A3.5: Independent Review
+
+Spawn `chorus-proposal-reviewer` per the [Review Strategy](#review-strategy) above via `spawn_agent` + `wait_agent`. Read its VERDICT comment before proceeding.
+
+#### A4: Approve or Reject
+
+**Approve:**
+
+```
+chorus_admin_approve_proposal({
+  proposalUuid: "<proposal-uuid>",
+  reviewNote: "Approved. Good breakdown of tasks."
+})
+```
+
+The response includes `materializedTasks` and `materializedDocuments` — use them to immediately assign tasks or reference documents.
+
+When approved:
+- Document drafts become real Documents
+- Task drafts become real Tasks (status: `open`)
+
+**Reject:**
+
+```
+chorus_pm_reject_proposal({
+  proposalUuid: "<proposal-uuid>",
+  reviewNote: "PRD missing error handling requirements. Task 3 needs clearer AC."
+})
+
+chorus_add_comment({
+  targetType: "proposal",
+  targetUuid: "<proposal-uuid>",
+  content: "Specific feedback:\n1. Add error scenarios to PRD\n2. Task 3 AC should include performance benchmarks"
+})
+```
+
+### Workflow A2: Revoking Approved Proposals
+
+If an approved Proposal's direction turns out to be wrong, use `chorus_pm_revoke_proposal` to undo the approval. Unlike `reject` (which acts on pending proposals), `revoke` acts on already-approved proposals and rolls back all materialized resources.
+
+```
+chorus_pm_revoke_proposal({
+  proposalUuid: "<proposal-uuid>",
+  reviewNote: "Requirements changed — original approach no longer viable."
+})
+```
+
+Cascade effects: all materialized Tasks are closed, all materialized Documents are deleted, and related AcceptanceCriteria/TaskDependencies/SessionCheckins are cleaned up. The Proposal returns to `draft` status so the PM can revise and resubmit.
+
+### Workflow B: Task Verification
+
+#### B1: Review the Submitted Task
+
+```
+chorus_get_task({ taskUuid: "<task-uuid>" })
+```
+
+Check: developer's work summary, acceptance criteria, self-check results.
+
+#### B2: Read Comments and Work Reports
+
+```
+chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+```
+
+#### B2.5: Independent Review
+
+Spawn `chorus-task-reviewer` per the [Review Strategy](#review-strategy) above via `spawn_agent` + `wait_agent`. After it completes, read its VERDICT:
+
+- **VERDICT: PASS** or **PASS WITH NOTES** → proceed to B3 (mark AC) and B4 (verify).
+- **VERDICT: FAIL** → skip to B4 and **reopen** the task. Do NOT mark AC as passed.
+
+#### B3: Mark Acceptance Criteria
+
+Review and mark each criterion:
+
+```
+chorus_mark_acceptance_criteria({
+  taskUuid: "<task-uuid>",
+  criteria: [
+    { uuid: "<criterion-uuid>", status: "passed" },
+    { uuid: "<criterion-uuid>", status: "passed" },
+    { uuid: "<criterion-uuid>", status: "failed", evidence: "Missing edge case handling" }
+  ]
+})
+```
+
+#### B4: Verify or Reopen
+
+**Verify (all required AC passed):**
+
+```
+chorus_admin_verify_task({ taskUuid: "<task-uuid>" })
+```
+
+This moves the task to `done`. **Important:** verifying may unblock downstream tasks. Check:
+
+```
+chorus_get_unblocked_tasks({ projectUuid: "<project-uuid>" })
+```
+
+If new tasks are unblocked, assign them or notify developers.
+
+**Reopen (needs fixes):**
+
+```
+chorus_admin_reopen_task({ taskUuid: "<task-uuid>" })
+
+chorus_add_comment({
+  targetType: "task",
+  targetUuid: "<task-uuid>",
+  content: "Reopened: Missing error handling for user-not-found edge case."
+})
+```
+
+The task returns to `in_progress`. All acceptance criteria are reset.
+
+#### B5: Close / Delete Tasks
+
+```
+# Close (preserves history)
+chorus_admin_close_task({ taskUuid: "<task-uuid>" })
+
+# Delete (permanent, use sparingly)
+chorus_admin_delete_task({ taskUuid: "<task-uuid>" })
+```
+
+### Workflow C: Project & Idea Management
+
+#### Create Project
+
+```
+chorus_get_project_groups()  # List available groups first
+chorus_admin_create_project({
+  name: "My Project",
+  description: "Project goals...",
+  groupUuid: "<optional-group-uuid>"
+})
+```
+
+#### Manage Project Groups
+
+```
+chorus_admin_create_project_group({ name: "Mobile Apps", description: "All mobile projects" })
+chorus_admin_move_project_to_group({ projectUuid: "<uuid>", groupUuid: "<uuid>" })
+chorus_admin_move_project_to_group({ projectUuid: "<uuid>", groupUuid: null })  # Ungroup
+chorus_admin_delete_project_group({ groupUuid: "<uuid>" })  # Projects become ungrouped
+```
+
+#### Close / Delete Ideas
+
+```
+chorus_admin_close_idea({ ideaUuid: "<idea-uuid>" })
+chorus_admin_delete_idea({ ideaUuid: "<idea-uuid>" })
+```
+
+> **Note:** Creating ideas is a PM tool (`chorus_pm_create_idea`). See `/idea`.
+
+#### Document Management
+
+```
+chorus_admin_delete_document({ documentUuid: "<doc-uuid>" })
+chorus_pm_update_document({ documentUuid: "<doc-uuid>", content: "Updated..." })
+```
+
+---
+
+## Daily Admin Routine
+
+1. **Check in** — `chorus_checkin()`
+2. **Review activity** — `chorus_get_activity()` for recent events
+3. **Process proposals** — Review and approve/reject pending proposals
+4. **Verify tasks** — Review and verify/reopen tasks in `to_verify`
+5. **Create new ideas** — If the human has new requirements
+6. **Check project health** — Stale tasks? Blocked items? Orphaned ideas?
+
+---
+
+## Tips
+
+- **Review thoroughly** — Don't rubber-stamp proposals; check quality
+- **Give actionable feedback** — When rejecting, explain specifically what to fix
+- **Verify against criteria** — Check acceptance criteria, not just the summary
+- **Manage scope** — Close ideas and tasks that are no longer relevant
+- **Unblock the team** — Prioritize proposal reviews to keep PM and Developer work flowing
+- **Use delete sparingly** — Prefer closing over deleting; closing preserves history
+- **Document decisions** — Use comments to explain approval/rejection reasoning
+- **Verify between waves** — When running workers in parallel via `spawn_agent`, verify tasks to `done` between waves to unblock downstream dependencies
+
+---
+
+## Governance Principles
+
+1. **Quality over speed** — A rejected proposal now saves rework later
+2. **Actionable feedback** — Every rejection should include specific fixes
+3. **Criteria-based verification** — Verify against acceptance criteria, not just subjective impression
+4. **Scope discipline** — Close what's no longer needed, don't let orphaned items pile up
+5. **Unblock others** — Your reviews are the bottleneck; prioritize them
+6. **Preserve history** — Close > Delete; comments > silent actions
+7. **Document reasoning** — Future agents will read your comments to understand decisions
+
+---
+
+## Next
+
+- For platform overview and shared tools, see `/chorus`
+- For Idea elaboration (before proposals), see `/idea`
+- For Proposal creation (what you're reviewing), see `/proposal`
+- For Developer workflow (what you're verifying), see `/develop`

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -1,0 +1,514 @@
+---
+name: yolo
+description: Full-auto AI-DLC pipeline — from prompt to done. Automates the entire Idea -> Proposal -> Execute -> Verify lifecycle.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.7.5"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Yolo Skill
+
+Full-auto AI-DLC pipeline. User provides a prompt; agent drives the entire lifecycle: Idea -> Elaboration -> Proposal -> Review -> Execute -> Verify -> Done.
+
+---
+
+## Overview
+
+`/yolo` automates the complete AI-DLC workflow. You provide a natural language description of what you want built, and the agent handles everything:
+
+1. **Planning** -- create project, idea, self-elaboration, proposal with docs & tasks
+2. **Proposal Review** -- proposal-reviewer adversarial loop
+3. **Execution** -- wave-based parallel task dispatch via `spawn_agent`
+4. **Verification** -- task-reviewer adversarial loop + admin verify
+5. **Report** -- completion summary
+
+```
+/yolo <prompt>
+       |
+       v
+  Project + Idea + Elaboration + Proposal
+       |
+       v
+  Proposal Reviewer (auto, up to maxProposalReviewRounds)
+       |
+       v
+  Admin Approve --> Tasks materialize
+       |
+       v
+  Wave-based spawn_agent parallel execution
+       |  (dev agent + task-reviewer per task)
+       v
+  Admin Verify each wave --> unblock next
+       |
+       v
+  Done. Report summary.
+```
+
+**Escape hatch:** Ctrl+C at any time. All created entities (project, idea, proposal, tasks) persist in Chorus. Resume manually via `/develop` or `/review`.
+
+---
+
+## Prerequisites
+
+**All 3 agent roles are required on the API key:**
+
+| Role | Why |
+|------|-----|
+| `pm_agent` | Idea creation, elaboration, proposal management (`chorus_pm_*` tools) |
+| `admin_agent` | Proposal approval, task verification (`chorus_admin_*` tools) |
+| `developer_agent` | Sub-agents claim and execute tasks (`chorus_claim_task`, `chorus_update_task`) |
+
+Sub-agents share the same API key as the main agent. The plugin injects session info into sub-agents, but **roles come from the API key itself**, not from hook injection.
+
+**Check at startup:**
+
+```
+result = chorus_checkin()
+roles = result.agent.roles
+
+required = ["pm_agent", "admin_agent", "developer_agent"]
+missing = [r for r in required if r not in roles]
+
+if missing:
+  ABORT: "Cannot run /yolo. Missing required roles: {missing}. 
+          Your API key must have all 3 roles: pm_agent, admin_agent, developer_agent."
+```
+
+---
+
+## Input
+
+```
+/yolo <natural language prompt>
+/yolo <prompt> --project <project-uuid>
+```
+
+- `<prompt>` -- what you want built (becomes the Idea content)
+- `--project <uuid>` -- optional; use an existing project instead of creating a new one
+
+---
+
+## Workflow
+
+### Phase 1: Planning
+
+#### Step 1.1: Resolve Project
+
+Parse the arguments for `--project <uuid>`.
+
+**If `--project` is provided:**
+```
+chorus_get_project({ projectUuid: "<uuid>" })
+```
+Verify it exists and proceed.
+
+**If not provided**, search for a suitable existing project first:
+```
+# 1. Search for projects matching the prompt topic
+chorus_search({ query: "<key terms from prompt>", entityTypes: ["project"] })
+
+# 2. Or list recent projects to find a match
+chorus_list_projects()
+```
+
+Review the results. If a project clearly matches the user's intent (same topic, active, relevant scope), use it. If no suitable project exists, create a new one:
+```
+chorus_admin_create_project({
+  name: "<short title derived from prompt>",
+  description: "<1-2 sentence summary of the prompt>"
+})
+```
+
+#### Step 1.2: Create Idea
+
+```
+chorus_pm_create_idea({
+  projectUuid: "<project-uuid>",
+  title: "<concise title derived from prompt>",
+  content: "<full user prompt as-is>"
+})
+```
+
+Then claim it:
+```
+chorus_claim_idea({ ideaUuid: "<idea-uuid>" })
+```
+
+#### Step 1.3: Self-Elaboration
+
+In /yolo mode, the agent generates elaboration questions and answers them itself -- no `AskUserQuestion` calls. This preserves an audit trail without interrupting the user.
+
+1. **Generate and submit questions:**
+   ```
+   chorus_pm_start_elaboration({
+     ideaUuid: "<idea-uuid>",
+     depth: "standard",
+     questions: [
+       {
+         id: "q1",
+         text: "<question about scope, architecture, etc.>",
+         category: "functional",
+         options: [
+           { id: "a", label: "<option A>" },
+           { id: "b", label: "<option B>" }
+         ]
+       }
+       // ... 5-8 questions covering functional, technical, scope aspects
+     ]
+   })
+   ```
+
+2. **Answer immediately** (agent selects best options based on the prompt):
+   ```
+   chorus_answer_elaboration({
+     ideaUuid: "<idea-uuid>",
+     roundUuid: "<round-uuid>",
+     answers: [
+       { questionId: "q1", selectedOptionId: "a", customText: "Rationale: ..." },
+       // ...
+     ]
+   })
+   ```
+
+3. **Validate** (no issues in self-mode):
+   ```
+   chorus_pm_validate_elaboration({
+     ideaUuid: "<idea-uuid>",
+     roundUuid: "<round-uuid>",
+     issues: []
+   })
+   ```
+
+#### Step 1.4: Create Proposal
+
+1. **Create empty container:**
+   ```
+   chorus_pm_create_proposal({
+     projectUuid: "<project-uuid>",
+     title: "<feature name>",
+     description: "<summary of what the proposal covers>",
+     inputType: "idea",
+     inputUuids: ["<idea-uuid>"]
+   })
+   ```
+
+2. **Add tech design document draft:**
+   ```
+   chorus_pm_add_document_draft({
+     proposalUuid: "<proposal-uuid>",
+     type: "tech_design",
+     title: "Tech Design: <feature>",
+     content: "<markdown tech design covering architecture, data model, API, module contracts>"
+   })
+   ```
+
+3. **Add task drafts incrementally** (use returned `draftUuid` for dependency chaining):
+   ```
+   # First task
+   result1 = chorus_pm_add_task_draft({
+     proposalUuid: "<proposal-uuid>",
+     title: "<module name>",
+     description: "<what to build, referencing tech design>",
+     priority: "high",
+     storyPoints: 3,
+     acceptanceCriteriaItems: [
+       { description: "<testable criterion>", required: true },
+       // ...
+     ]
+   })
+
+   # Second task, depends on first
+   chorus_pm_add_task_draft({
+     proposalUuid: "<proposal-uuid>",
+     title: "<dependent module>",
+     description: "...",
+     priority: "medium",
+     storyPoints: 2,
+     acceptanceCriteriaItems: [...],
+     dependsOnDraftUuids: ["<result1.draftUuid>"]
+   })
+   ```
+
+4. **Validate:**
+   ```
+   chorus_pm_validate_proposal({ proposalUuid: "<proposal-uuid>" })
+   ```
+   Fix any errors, then proceed.
+
+5. **Submit:**
+   ```
+   chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
+   ```
+   After this call, the PostToolUse hook injects context instructing you to spawn the `chorus-proposal-reviewer` sub-agent. You MUST spawn it yourself via `spawn_agent` and wait for its return with `wait_agent` — it is NOT auto-launched.
+
+---
+
+### Phase 2: Proposal Review Loop
+
+After `chorus_pm_submit_proposal`, the PostToolUse hook injects context instructing you to spawn the `chorus-proposal-reviewer` sub-agent. The reviewer is a SKILL, not a built-in agent_type — spawn it by mounting the skill into a default agent:
+
+```
+spawn_agent(
+  agent_type="default",
+  items=[
+    { type: "skill", name: "Chorus Proposal Reviewer", path: "chorus:chorus-proposal-reviewer" },
+    { type: "text",  text: "Review proposal <proposal-uuid>. Max review rounds: 3. Post VERDICT comment." }
+  ]
+)
+wait_agent([reviewer_id])
+```
+
+Then:
+
+1. **Read the reviewer's VERDICT:**
+   ```
+   chorus_get_comments({ targetType: "proposal", targetUuid: "<proposal-uuid>" })
+   ```
+   Look for the most recent comment containing `VERDICT:`.
+
+   **IMPORTANT — release thread slot**: after `wait_agent` returns, immediately call `close_agent(reviewer_id)`. Codex caps concurrent agent threads at 6; `completed` status does NOT free a slot — only `close_agent` does. On long `$yolo` runs you WILL hit the limit if you don't close each reviewer after use.
+
+2. **Act on the VERDICT:**
+
+   - **PASS** or **PASS WITH NOTES** --
+     ```
+     chorus_admin_approve_proposal({
+       proposalUuid: "<proposal-uuid>",
+       reviewNote: "PASS from reviewer. <brief summary of notes if any>"
+     })
+     ```
+     Tasks and documents materialize automatically. Proceed to Phase 3.
+
+   - **FAIL** --
+     Read the BLOCKERs from the reviewer comment. Then:
+     ```
+     chorus_pm_reject_proposal({
+       proposalUuid: "<proposal-uuid>",
+       reviewNote: "FAIL from reviewer. Fixing BLOCKERs: <list>"
+     })
+     ```
+     Revise the drafts (`chorus_pm_update_document_draft`, `chorus_pm_update_task_draft`) to address each BLOCKER, then resubmit:
+     ```
+     chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
+     ```
+     After resubmission, the hook injects context again — spawn the reviewer yourself for Round 2.
+
+3. **Max rounds:** Loop up to `maxProposalReviewRounds` (from plugin config, default 3). If exhausted:
+   ```
+   STOP: "Proposal review failed after {maxRounds} rounds. 
+          Remaining BLOCKERs: <list>. Human review needed.
+          Proposal UUID: <uuid>"
+   ```
+
+4. **No new VERDICT comment after reviewer returns?** The reviewer exhausted its `maxTurns` budget. Respawn it ONCE with a concise-budget hint: *"Stay within turn budget. Skip deep source verification. Fetch proposal + comments + idea only, skim for obvious BLOCKERs, and post your VERDICT within the first 10 turns."* If the second attempt still produces no VERDICT, treat the proposal as PASS WITH NOTES and proceed — the pipeline cannot loop forever on a silent reviewer.
+
+---
+
+### Phase 3: Task Execution (Wave-Based)
+
+After proposal approval, tasks exist in `open` status. Execute them in dependency-ordered waves using Codex `spawn_agent`. If parallel spawn is not desired or too many workers in flight, fall back to sequential main-agent execution.
+
+#### Primary: Parallel `spawn_agent` workers
+
+```
+wave = 1
+
+loop:
+  # 1. Find ready tasks
+  unblocked = chorus_get_unblocked_tasks({ projectUuid: "<project-uuid>" })
+
+  if no unblocked tasks and all tasks done:
+    break  # All complete
+
+  if no unblocked tasks and some tasks not done:
+    # Stuck -- tasks failed review and can't proceed
+    break with escalation report
+
+  # 2. For each unblocked task, spawn a worker
+  for each task in unblocked:
+    # Optional: create a Chorus session for observability
+    session = chorus_create_session({ name: f"worker-{task.title[:20]}" })
+
+    spawn_agent(
+      agent_type="worker",
+      message=f"""You are a Chorus developer worker. Follow the $develop skill.
+
+      Your sessionUuid: {session.uuid}   # omit this line if no session
+      Your task UUID: {task.uuid}
+      Project UUID: {project_uuid}
+
+      Implement per task description + acceptance criteria. Read task, proposal, and project documents for context. After chorus_submit_for_verify, exit and let the main agent spawn the task-reviewer."""
+    )
+
+  # 3. Wait for workers to return (use wait_agent)
+  #    Each worker follows $develop skill:
+  #    claim -> in_progress -> develop -> report -> self-check AC -> submit_for_verify
+
+  # 4. Close worker sessions (main agent responsibility — no SubagentStop hook)
+  for each session:
+    chorus_close_session({ sessionUuid: session.uuid })
+
+  # 5. Proceed to Phase 4 (verification) for this wave
+  wave += 1
+```
+
+**What the worker prompt needs:**
+- `taskUuid` (required)
+- `sessionUuid` (optional — only if main agent created one for observability)
+- `projectUuid` (required for context lookups)
+- Explicit instruction to follow `$develop` skill — the skill itself has all the workflow detail
+
+#### Fallback: Main Agent (sequential)
+
+If parallel spawn is not practical (rate limits, token budget, or simpler debugging wanted), fall back to executing tasks sequentially as the main agent:
+
+```
+for each task in unblocked:
+  # Follow the /develop workflow directly as main agent
+  chorus_claim_task({ taskUuid: "<task-uuid>" })
+  chorus_update_task({ taskUuid: "<task-uuid>", status: "in_progress" })
+
+  # ... implement the task: read context, write code, run tests ...
+
+  chorus_report_work({ taskUuid: "<task-uuid>", report: "..." })
+  chorus_report_criteria_self_check({ taskUuid: "<task-uuid>", criteria: [...] })
+  chorus_submit_for_verify({ taskUuid: "<task-uuid>", summary: "..." })
+
+  # PostToolUse hook injects context — you must spawn task-reviewer yourself
+  # Proceed to Phase 4 verification for this task before moving to next
+```
+
+The fallback is slower (sequential, not parallel) but still completes the pipeline. The PostToolUse hook injects reviewer instructions the same way in both modes — you must always spawn the reviewer manually.
+
+---
+
+### Phase 4: Verification
+
+After each wave's sub-agents complete, verify their tasks:
+
+```
+for each task in wave_tasks:
+  # 1. Check task status
+  task = chorus_get_task({ taskUuid: "<task-uuid>" })
+
+  if task.status != "to_verify":
+    # Sub-agent may have failed; skip or handle
+    continue
+
+  # 2. Spawn task-reviewer in FOREGROUND and wait for it (use wait_agent)
+  #    Mount the chorus-task-reviewer SKILL into a default sub-agent
+  #    (Codex only has default/explorer/worker built-in types).
+  spawn_agent(
+    agent_type="default",
+    items=[
+      { type: "skill", name: "Chorus Task Reviewer", path: "chorus:chorus-task-reviewer" },
+      { type: "text",  text: "Review Chorus task <task-uuid>. Post VERDICT as a comment before exit." }
+    ]
+  )
+  wait_agent([reviewer_id])
+  close_agent(reviewer_id)   # IMPORTANT: release the thread slot (max 6 concurrent, completed != closed)
+
+  # 3. Read task-reviewer VERDICT
+  comments = chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+  # Find the most recent comment containing "VERDICT:"
+
+  # 4. Act on VERDICT — three possible outcomes:
+  if VERDICT is "PASS":
+    # All AC verified, no issues. Mark AC and verify.
+    chorus_mark_acceptance_criteria({
+      taskUuid: "<task-uuid>",
+      criteria: [
+        { uuid: "<ac-uuid>", status: "passed", evidence: "<from reviewer>" },
+        // ...
+      ]
+    })
+    chorus_admin_verify_task({ taskUuid: "<task-uuid>" })
+    # Task is now "done" -- unblocks dependents
+
+  if VERDICT is "PASS WITH NOTES":
+    # All AC verified, minor non-blocking notes. Still mark AC and verify.
+    chorus_mark_acceptance_criteria({ ... })
+    chorus_admin_verify_task({ taskUuid: "<task-uuid>" })
+
+  if VERDICT is "FAIL":
+    # BLOCKERs found. Do NOT verify. Reopen for rework.
+    chorus_admin_reopen_task({ taskUuid: "<task-uuid>" })
+    # Task returns to "open", will be picked up in next wave
+```
+
+After verifying all tasks in the wave, return to Phase 3 to check for newly unblocked tasks.
+
+**Max rounds per task:** Tracked by `maxTaskReviewRounds` from plugin config (default 3). If a task has been reopened `maxRounds` times, skip it and flag for human escalation:
+
+```
+ESCALATE: "Task '{title}' failed review after {maxRounds} rounds. 
+           Last BLOCKERs: <list>. Manual intervention needed.
+           Task UUID: <uuid>"
+```
+
+Continue with remaining tasks -- do not halt the entire pipeline for one stuck task.
+
+**No new VERDICT comment after the task-reviewer returns?** It exhausted its `maxTurns` budget. Respawn it ONCE with a concise-budget hint: *"Stay within turn budget. Skip deep verification. Fetch task/proposal/comments, run only the core tests, and post your VERDICT within the first 12 turns."* If the second attempt also produces no VERDICT, treat as PASS WITH NOTES and proceed — do not loop indefinitely.
+
+---
+
+### Phase 5: Report
+
+After all waves complete, output a markdown summary:
+
+```markdown
+## /yolo Complete
+
+**Project:** <project-name> (<project-uuid>)
+**Proposal:** <proposal-title> (<proposal-uuid>)
+**Idea:** <idea-title> (<idea-uuid>)
+
+### Tasks
+| Task | Status | Review Rounds |
+|------|--------|---------------|
+| <title> | done | 1 |
+| <title> | done | 2 |
+| <title> | ESCALATED | 3 (max) |
+
+### Summary
+- Total tasks: N
+- Completed: X / N
+- Escalated: Y (need human review)
+- Waves executed: W
+```
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Missing roles at startup | Abort with message listing all 3 required roles and which are missing |
+| Project creation fails | Report error, suggest user create project manually and retry with `--project` |
+| Proposal reviewer FAIL after maxRounds | Stop pipeline, report persisting BLOCKERs, suggest manual review |
+| Task reviewer FAIL after maxRounds | Flag task as escalation-needed, continue with other tasks |
+| Sub-agent crash / no submit | Log error, skip task, pick it up in next wave if possible |
+| Ctrl+C | All entities persist in Chorus. User can resume via `/develop` or `/review` |
+
+---
+
+## Tips
+
+- Keep the initial prompt detailed -- the more context you provide, the better the auto-generated proposal quality
+- The proposal-reviewer is your quality gate -- if it keeps FAILing, the prompt may be too vague
+- Watch the wave count -- if tasks keep getting reopened, consider Ctrl+C and manually reviewing the feedback
+- All audit trail is preserved: elaboration Q&A, reviewer VERDICTs, work reports. Check Chorus UI for full history
+- For small/simple tasks, consider `/quick-dev` instead -- it skips the Idea->Proposal overhead
+- Sub-agents share your API key; ensure it has all 3 roles before starting
+
+---
+
+## Next
+
+- To manually review proposals: `/review`
+- To manually develop tasks: `/develop`
+- To create quick standalone tasks: `/quick-dev`
+- For platform overview: `/chorus`

--- a/public/install-codex.sh
+++ b/public/install-codex.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Chorus + Codex CLI one-shot installer
+#
+# Usage:
+#   curl -sSL https://chorus.ai/install-codex.sh | bash
+#   # or non-interactive:
+#   CHORUS_URL=https://... CHORUS_API_KEY=cho_... \
+#     bash <(curl -sSL https://chorus.ai/install-codex.sh)
+#
+# What this does (idempotent, safe to re-run):
+#   1. Verifies `codex` CLI is installed.
+#   2. Registers the Chorus plugin marketplace.
+#   3. Writes [mcp_servers.chorus] (url + Authorization header) into ~/.codex/config.toml.
+#   4. Tells you to finish with `/plugins` → Install Chorus inside the TUI.
+
+set -euo pipefail
+
+# ---------- cosmetics ----------
+BOLD=$'\033[1m'; DIM=$'\033[2m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'; RESET=$'\033[0m'
+ok()   { printf "${GREEN}✓${RESET} %s\n" "$*"; }
+warn() { printf "${YELLOW}!${RESET} %s\n" "$*" >&2; }
+die()  { printf "${RED}✗${RESET} %s\n" "$*" >&2; exit 1; }
+hdr()  { printf "\n${BOLD}%s${RESET}\n" "$*"; }
+
+# ---------- config ----------
+MARKETPLACE_NAME="chorus-plugins"
+MARKETPLACE_SOURCE_DEFAULT="${CHORUS_MARKETPLACE_SOURCE:-https://github.com/Chorus-AIDLC/Chorus}"
+CHORUS_URL_DEFAULT="${CHORUS_URL_DEFAULT:-http://localhost:8637/api/mcp}"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+CONFIG_TOML="$CODEX_HOME/config.toml"
+
+is_tty() { [ -t 0 ] && [ -t 1 ]; }
+
+# If piped through `curl | bash`, stdin is the script body. Re-open from /dev/tty
+# so interactive prompts still work — but only if a real TTY is available AND we
+# actually need to prompt for input. Both CHORUS_URL and CHORUS_API_KEY being set
+# lets us run fully non-interactively (useful in CI or unified-exec sandboxes).
+if [ -z "${CHORUS_API_KEY:-}" ] && ! is_tty; then
+  if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    exec < /dev/tty
+  fi
+fi
+
+# ---------- step 1: check codex ----------
+hdr "1/5  Checking Codex CLI"
+command -v codex >/dev/null 2>&1 || die "codex not found in PATH. Install it first: npm i -g @openai/codex"
+ok "Found $(codex --version 2>/dev/null | head -1)"
+
+# ---------- step 2: register marketplace ----------
+hdr "2/5  Registering the Chorus plugin marketplace"
+if grep -q "^\[marketplaces\.${MARKETPLACE_NAME}\]" "$CONFIG_TOML" 2>/dev/null; then
+  ok "Marketplace '${MARKETPLACE_NAME}' already registered"
+else
+  codex plugin marketplace add "$MARKETPLACE_SOURCE_DEFAULT" >/dev/null
+  ok "Added marketplace: $MARKETPLACE_SOURCE_DEFAULT"
+fi
+
+# ---------- step 3: collect Chorus URL + API key ----------
+hdr "3/5  Configuring the Chorus MCP server"
+
+# URL
+if [ -n "${CHORUS_URL:-}" ]; then
+  url="$CHORUS_URL"
+  ok "Using CHORUS_URL from env: $url"
+elif [ -t 0 ]; then
+  printf "  Chorus MCP URL ${DIM}[default: $CHORUS_URL_DEFAULT]${RESET}: "
+  read -r url
+  url="${url:-$CHORUS_URL_DEFAULT}"
+else
+  url="$CHORUS_URL_DEFAULT"
+  warn "No TTY and CHORUS_URL unset — using default: $url"
+fi
+
+# API key
+if [ -n "${CHORUS_API_KEY:-}" ]; then
+  apikey="$CHORUS_API_KEY"
+  ok "Using CHORUS_API_KEY from env"
+elif [ -t 0 ]; then
+  printf "  Chorus API key (starts with cho_): "
+  stty -echo 2>/dev/null || true
+  read -r apikey
+  stty echo 2>/dev/null || true
+  printf "\n"
+  [ -n "$apikey" ] || die "API key is required"
+else
+  die "No TTY and CHORUS_API_KEY unset — cannot continue"
+fi
+
+# Sanity check: a root URL without a path is almost always wrong — the Chorus
+# MCP endpoint is served under a path (e.g. /api/mcp). Warn loudly; don't abort
+# so advanced users with a path-less reverse proxy can still proceed.
+case "$url" in
+  http://*/*|https://*/*)
+    # Has a path component — check it's not just a trailing slash.
+    path="${url#http*://}"
+    path="${path#*/}"
+    if [ -z "$path" ]; then
+      warn "URL has no path (just a host). MCP endpoints usually live under /api/mcp or similar."
+      warn "If /mcp in the TUI shows 'chorus' failing to connect, re-run with the full URL."
+    fi
+    ;;
+  http://*|https://*)
+    warn "URL has no path (just a host). MCP endpoints usually live under /api/mcp or similar."
+    warn "If /mcp in the TUI shows 'chorus' failing to connect, re-run with the full URL."
+    ;;
+  *)
+    die "URL must start with http:// or https:// — got: $url"
+    ;;
+esac
+
+# ---------- step 4: write config.toml ----------
+hdr "4/5  Writing ~/.codex/config.toml"
+mkdir -p "$CODEX_HOME"
+[ -f "$CONFIG_TOML" ] || touch "$CONFIG_TOML"
+
+# Back up once
+if [ ! -f "$CONFIG_TOML.chorus-bak" ]; then
+  cp "$CONFIG_TOML" "$CONFIG_TOML.chorus-bak"
+  ok "Backed up original config to ${CONFIG_TOML}.chorus-bak"
+fi
+
+# Remove any existing [mcp_servers.chorus] and [mcp_servers.chorus.*] sub-tables
+# (idempotent — old rotated keys / headers are wiped, then fresh section appended).
+# Pure awk so we do not require Python on the user's machine.
+tmp="$(mktemp "${TMPDIR:-/tmp}/chorus-config.XXXXXX")"
+awk '
+  # A TOML table header line. Match [mcp_servers.chorus] and any
+  # [mcp_servers.chorus.<subtable>], set a flag that suppresses lines
+  # until the next [section] header appears.
+  /^\[mcp_servers\.chorus(\..*)?\][[:space:]]*$/ { skip = 1; next }
+  /^\[/                                             { skip = 0 }
+  skip != 1                                          { print }
+' "$CONFIG_TOML" > "$tmp"
+mv "$tmp" "$CONFIG_TOML"
+
+# Ensure user-owned file mode 600 (contains secret).
+chmod 600 "$CONFIG_TOML"
+
+# Append [mcp_servers.chorus] with literal URL + Authorization header.
+# (Codex does NOT expand ${VAR}; the token is a literal string in the header.)
+cat >> "$CONFIG_TOML" <<TOML
+
+[mcp_servers.chorus]
+url = "${url}"
+
+[mcp_servers.chorus.http_headers]
+Authorization = "Bearer ${apikey}"
+TOML
+
+ok "Wrote [mcp_servers.chorus] → ${CONFIG_TOML}"
+
+# ---------- step 5: install hooks ----------
+hdr "5/5  Installing Chorus hooks"
+
+# Locate the installed plugin version on disk (glob picks the first / newest version).
+# If the plugin has not been installed from /plugins yet, we skip this step with a hint.
+PLUGIN_CACHE_GLOB="$CODEX_HOME/plugins/cache/chorus-plugins/chorus"
+if [ ! -d "$PLUGIN_CACHE_GLOB" ]; then
+  warn "Plugin not yet installed — skipping hooks. Run Codex TUI \`/plugins → Install\` first, then re-run this installer."
+else
+  # Newest installed version directory (lexicographic max; version dirs are semver).
+  PLUGIN_VER_DIR="$(ls -1 "$PLUGIN_CACHE_GLOB" 2>/dev/null | sort -V | tail -1)"
+  if [ -z "$PLUGIN_VER_DIR" ]; then
+    warn "Plugin cache dir is empty — skipping hooks. Finish installing via \`/plugins\` first."
+  else
+    HOOKS_DIR="$PLUGIN_CACHE_GLOB/$PLUGIN_VER_DIR/hooks"
+    if [ ! -d "$HOOKS_DIR" ]; then
+      warn "Hooks directory not found at $HOOKS_DIR — skipping."
+    else
+      HOOKS_JSON="$CODEX_HOME/hooks.json"
+      # Only write/overwrite if the file is absent, or is clearly a previous Chorus-owned file.
+      if [ -f "$HOOKS_JSON" ] && ! grep -q "chorus-plugins/chorus" "$HOOKS_JSON" 2>/dev/null; then
+        warn "Found a non-Chorus $HOOKS_JSON — not overwriting."
+        warn "  Add the Chorus hook entries manually (see $HOOKS_DIR/*.sh), or move your existing hooks.json aside and re-run."
+      else
+        # Write a fresh Chorus hooks.json with absolute paths into the installed plugin cache.
+        cat > "$HOOKS_JSON" <<HJSON
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          { "type": "command", "command": "$HOOKS_DIR/on-session-start.sh", "timeout": 20, "statusMessage": "Chorus: checkin" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*chorus_pm_submit_proposal",
+        "hooks": [
+          { "type": "command", "command": "$HOOKS_DIR/on-post-submit-proposal.sh", "timeout": 10 }
+        ]
+      },
+      {
+        "matcher": ".*chorus_submit_for_verify",
+        "hooks": [
+          { "type": "command", "command": "$HOOKS_DIR/on-post-submit-for-verify.sh", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+HJSON
+        ok "Wrote $HOOKS_JSON (pointing at $HOOKS_DIR/*.sh)"
+      fi
+
+      # Enable the codex_hooks feature flag in config.toml (idempotent).
+      if grep -qE "^\[features\]" "$CONFIG_TOML"; then
+        # [features] section already exists; ensure codex_hooks = true is present.
+        if ! grep -qE "^codex_hooks\s*=\s*true" "$CONFIG_TOML"; then
+          # Insert codex_hooks = true right after the [features] header.
+          tmp="$(mktemp "${TMPDIR:-/tmp}/chorus-features.XXXXXX")"
+          awk '
+            /^\[features\][[:space:]]*$/ { print; print "codex_hooks = true"; inserted=1; next }
+            { print }
+          ' "$CONFIG_TOML" > "$tmp" && mv "$tmp" "$CONFIG_TOML"
+          ok "Added codex_hooks = true under existing [features]"
+        else
+          ok "codex_hooks feature flag already enabled"
+        fi
+      else
+        cat >> "$CONFIG_TOML" <<'TFEAT'
+
+[features]
+codex_hooks = true
+TFEAT
+        ok "Appended [features] codex_hooks = true"
+      fi
+    fi
+  fi
+fi
+
+# ---------- epilogue ----------
+hdr "Done."
+cat <<NEXT
+
+Last step (install the plugin inside the Codex TUI):
+
+  ${BOLD}codex${RESET}
+  > /plugins
+  → select "chorus-plugins" → "chorus" → Install
+
+Verify anytime:
+  ${BOLD}codex mcp list${RESET}         # 'chorus' row, Auth = 'Bearer token'
+
+Then in Codex type ${BOLD}\$chorus${RESET} (or \$develop, \$review, \$proposal, …) to
+activate a skill. To change your API key later, just re-run this installer.
+
+NEXT

--- a/public/install-codex.sh
+++ b/public/install-codex.sh
@@ -2,16 +2,17 @@
 # Chorus + Codex CLI one-shot installer
 #
 # Usage:
-#   curl -sSL https://chorus.ai/install-codex.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh | bash
 #   # or non-interactive:
 #   CHORUS_URL=https://... CHORUS_API_KEY=cho_... \
-#     bash <(curl -sSL https://chorus.ai/install-codex.sh)
+#     bash <(curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh)
 #
 # What this does (idempotent, safe to re-run):
 #   1. Verifies `codex` CLI is installed.
 #   2. Registers the Chorus plugin marketplace.
 #   3. Writes [mcp_servers.chorus] (url + Authorization header) into ~/.codex/config.toml.
-#   4. Tells you to finish with `/plugins` → Install Chorus inside the TUI.
+#   4. Registers plugin as INSTALLED_BY_DEFAULT — Codex picks it up on first launch
+#      (falls back to one-click `/plugins → Install` if auto-install does not fire).
 
 set -euo pipefail
 
@@ -152,36 +153,59 @@ ok "Wrote [mcp_servers.chorus] → ${CONFIG_TOML}"
 # ---------- step 5: install hooks ----------
 hdr "5/5  Installing Chorus hooks"
 
-# Locate the installed plugin version on disk (glob picks the first / newest version).
-# If the plugin has not been installed from /plugins yet, we skip this step with a hint.
-PLUGIN_CACHE_GLOB="$CODEX_HOME/plugins/cache/chorus-plugins/chorus"
-if [ ! -d "$PLUGIN_CACHE_GLOB" ]; then
-  warn "Plugin not yet installed — skipping hooks. Run Codex TUI \`/plugins → Install\` first, then re-run this installer."
-else
-  # Newest installed version directory (lexicographic max; version dirs are semver).
-  PLUGIN_VER_DIR="$(ls -1 "$PLUGIN_CACHE_GLOB" 2>/dev/null | sort -V | tail -1)"
-  if [ -z "$PLUGIN_VER_DIR" ]; then
-    warn "Plugin cache dir is empty — skipping hooks. Finish installing via \`/plugins\` first."
+# Install a tiny wrapper that lazily resolves the newest plugin cache at
+# hook-run time. This lets us write hooks.json BEFORE `/plugins → Install`
+# has materialized the plugin cache — first-run UX becomes truly one-shot.
+WRAPPER_DIR="$CODEX_HOME/hooks/chorus"
+WRAPPER="$WRAPPER_DIR/run-hook.sh"
+mkdir -p "$WRAPPER_DIR"
+cat > "$WRAPPER" <<'WRAP'
+#!/usr/bin/env bash
+# Chorus hook wrapper (installed by public/install-codex.sh).
+# Resolves the newest installed Chorus plugin version at runtime and execs
+# the named hook script from its hooks/ directory. Exits 0 (no-op) if the
+# plugin has not been installed yet, so Codex sessions still start cleanly.
+set -eu
+HOOK_NAME="${1:-}"
+if [ -z "$HOOK_NAME" ]; then
+  echo '{}' ; exit 0
+fi
+shift
+CODEX_HOME_RESOLVED="${CODEX_HOME:-$HOME/.codex}"
+PLUGIN_ROOT="$CODEX_HOME_RESOLVED/plugins/cache/chorus-plugins/chorus"
+if [ ! -d "$PLUGIN_ROOT" ]; then
+  echo '{}' ; exit 0
+fi
+VER="$(ls -1 "$PLUGIN_ROOT" 2>/dev/null | sort -V | tail -1)"
+if [ -z "$VER" ]; then
+  echo '{}' ; exit 0
+fi
+SCRIPT="$PLUGIN_ROOT/$VER/hooks/$HOOK_NAME"
+if [ ! -x "$SCRIPT" ]; then
+  if [ -f "$SCRIPT" ]; then
+    chmod +x "$SCRIPT" 2>/dev/null || true
   else
-    HOOKS_DIR="$PLUGIN_CACHE_GLOB/$PLUGIN_VER_DIR/hooks"
-    if [ ! -d "$HOOKS_DIR" ]; then
-      warn "Hooks directory not found at $HOOKS_DIR — skipping."
-    else
-      HOOKS_JSON="$CODEX_HOME/hooks.json"
-      # Only write/overwrite if the file is absent, or is clearly a previous Chorus-owned file.
-      if [ -f "$HOOKS_JSON" ] && ! grep -q "chorus-plugins/chorus" "$HOOKS_JSON" 2>/dev/null; then
-        warn "Found a non-Chorus $HOOKS_JSON — not overwriting."
-        warn "  Add the Chorus hook entries manually (see $HOOKS_DIR/*.sh), or move your existing hooks.json aside and re-run."
-      else
-        # Write a fresh Chorus hooks.json with absolute paths into the installed plugin cache.
-        cat > "$HOOKS_JSON" <<HJSON
+    echo '{}' ; exit 0
+  fi
+fi
+exec "$SCRIPT" "$@"
+WRAP
+chmod +x "$WRAPPER"
+ok "Installed hook wrapper → $WRAPPER"
+
+HOOKS_JSON="$CODEX_HOME/hooks.json"
+if [ -f "$HOOKS_JSON" ] && ! grep -q "hooks/chorus/run-hook.sh\|chorus-plugins/chorus" "$HOOKS_JSON" 2>/dev/null; then
+  warn "Found a non-Chorus $HOOKS_JSON — not overwriting."
+  warn "  Add Chorus hook entries manually (command = $WRAPPER on-session-start.sh | on-post-submit-proposal.sh | on-post-submit-for-verify.sh)."
+else
+  cat > "$HOOKS_JSON" <<HJSON
 {
   "hooks": {
     "SessionStart": [
       {
         "matcher": "startup|resume|clear",
         "hooks": [
-          { "type": "command", "command": "$HOOKS_DIR/on-session-start.sh", "timeout": 20, "statusMessage": "Chorus: checkin" }
+          { "type": "command", "command": "$WRAPPER on-session-start.sh", "timeout": 20, "statusMessage": "Chorus: checkin" }
         ]
       }
     ],
@@ -189,60 +213,59 @@ else
       {
         "matcher": ".*chorus_pm_submit_proposal",
         "hooks": [
-          { "type": "command", "command": "$HOOKS_DIR/on-post-submit-proposal.sh", "timeout": 10 }
+          { "type": "command", "command": "$WRAPPER on-post-submit-proposal.sh", "timeout": 10 }
         ]
       },
       {
         "matcher": ".*chorus_submit_for_verify",
         "hooks": [
-          { "type": "command", "command": "$HOOKS_DIR/on-post-submit-for-verify.sh", "timeout": 10 }
+          { "type": "command", "command": "$WRAPPER on-post-submit-for-verify.sh", "timeout": 10 }
         ]
       }
     ]
   }
 }
 HJSON
-        ok "Wrote $HOOKS_JSON (pointing at $HOOKS_DIR/*.sh)"
-      fi
+  ok "Wrote $HOOKS_JSON (routing through $WRAPPER)"
+fi
 
-      # Enable the codex_hooks feature flag in config.toml (idempotent).
-      if grep -qE "^\[features\]" "$CONFIG_TOML"; then
-        # [features] section already exists; ensure codex_hooks = true is present.
-        if ! grep -qE "^codex_hooks\s*=\s*true" "$CONFIG_TOML"; then
-          # Insert codex_hooks = true right after the [features] header.
-          tmp="$(mktemp "${TMPDIR:-/tmp}/chorus-features.XXXXXX")"
-          awk '
-            /^\[features\][[:space:]]*$/ { print; print "codex_hooks = true"; inserted=1; next }
-            { print }
-          ' "$CONFIG_TOML" > "$tmp" && mv "$tmp" "$CONFIG_TOML"
-          ok "Added codex_hooks = true under existing [features]"
-        else
-          ok "codex_hooks feature flag already enabled"
-        fi
-      else
-        cat >> "$CONFIG_TOML" <<'TFEAT'
+# Enable the codex_hooks feature flag in config.toml (idempotent).
+if grep -qE "^\[features\]" "$CONFIG_TOML"; then
+  if ! grep -qE "^codex_hooks\s*=\s*true" "$CONFIG_TOML"; then
+    tmp="$(mktemp "${TMPDIR:-/tmp}/chorus-features.XXXXXX")"
+    awk '
+      /^\[features\][[:space:]]*$/ { print; print "codex_hooks = true"; inserted=1; next }
+      { print }
+    ' "$CONFIG_TOML" > "$tmp" && mv "$tmp" "$CONFIG_TOML"
+    ok "Added codex_hooks = true under existing [features]"
+  else
+    ok "codex_hooks feature flag already enabled"
+  fi
+else
+  cat >> "$CONFIG_TOML" <<'TFEAT'
 
 [features]
 codex_hooks = true
 TFEAT
-        ok "Appended [features] codex_hooks = true"
-      fi
-    fi
-  fi
+  ok "Appended [features] codex_hooks = true"
 fi
 
 # ---------- epilogue ----------
 hdr "Done."
 cat <<NEXT
 
-Last step (install the plugin inside the Codex TUI):
+Start Codex — the plugin is registered as INSTALLED_BY_DEFAULT so it
+should activate on first launch:
 
   ${BOLD}codex${RESET}
-  > /plugins
-  → select "chorus-plugins" → "chorus" → Install
+
+If /plugins does not show "chorus" as installed on first launch, open it
+and click Install once (Codex has no \`plugin install\` CLI command yet,
+so one manual click is the fallback path).
 
 Verify anytime:
   ${BOLD}codex mcp list${RESET}         # 'chorus' row, Auth = 'Bearer token'
+  ${BOLD}codex features list${RESET}    # codex_hooks + plugins both true
 
 Then in Codex type ${BOLD}\$chorus${RESET} (or \$develop, \$review, \$proposal, …) to
 activate a skill. To change your API key later, just re-run this installer.

--- a/public/test-install-codex.sh
+++ b/public/test-install-codex.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Test public/install-codex.sh for macOS bash 3.2 compatibility.
+#
+# Usage:
+#   bash public/test-install-codex.sh
+#   BASH32=/path/to/bash-3.2 bash public/test-install-codex.sh
+#
+# Picks a bash: $BASH32 → /tmp/bash32-build/bash-3.2/bash (hand-built)
+#              → /bin/bash (macOS system bash is 3.2.57)
+#              → `bash` on PATH.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/public/install-codex.sh"
+
+if [ -n "${BASH32:-}" ] && [ -x "$BASH32" ]; then
+  TEST_BASH="$BASH32"
+elif [ -x "/tmp/bash32-build/bash-3.2/bash" ]; then
+  TEST_BASH="/tmp/bash32-build/bash-3.2/bash"
+elif [ -x "/bin/bash" ]; then
+  TEST_BASH="/bin/bash"
+else
+  TEST_BASH="$(command -v bash)"
+fi
+
+BOLD=$'\033[1m'; GREEN=$'\033[32m'; RED=$'\033[31m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+
+PASS=0; FAIL=0; FAIL_NOTES=""
+
+pass() { printf "  ${GREEN}PASS${RESET}  %s\n" "$*"; PASS=$((PASS + 1)); }
+fail() { printf "  ${RED}FAIL${RESET}  %s\n" "$*"; FAIL=$((FAIL + 1)); FAIL_NOTES="$FAIL_NOTES
+  - $*"; }
+
+echo "${BOLD}Testing:${RESET} $SCRIPT"
+echo "${BOLD}Using:${RESET}   $TEST_BASH ($("$TEST_BASH" --version | head -1))"
+echo ""
+
+# [1/4] Static scan — reject bash 4+ constructs
+echo "${BOLD}[1/4]${RESET} Static scan for bash 4+ constructs"
+scan() {
+  local label="$1"; local pattern="$2"
+  if grep -nE "$pattern" "$SCRIPT" >/tmp/install-codex-scan.$$ 2>/dev/null; then
+    fail "$label"
+    sed 's/^/         /' /tmp/install-codex-scan.$$
+  else
+    pass "$label"
+  fi
+  rm -f /tmp/install-codex-scan.$$
+}
+scan 'no ${VAR,,} / ${VAR^^} case conversion' '\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]+\])?[,^]{1,2}\}'
+scan 'no "declare -A" / "typeset -A"'         '^[[:space:]]*(declare|typeset|local)[[:space:]]+-[A-Za-z]*A'
+scan 'no mapfile / readarray'                 '^\s*(mapfile|readarray)\b'
+scan 'no "&>" redirection'                    '[^|]&>[^>]'
+scan 'no "|&" redirection'                    '\|&'
+scan 'no ";;&" case fallthrough'              ';;&'
+
+# [2/4] Parse
+echo ""
+echo "${BOLD}[2/4]${RESET} Parse with $TEST_BASH -n"
+if "$TEST_BASH" -n "$SCRIPT" 2>/tmp/install-codex-parse.$$; then
+  pass "parses without syntax errors"
+else
+  fail "parse error"
+  sed 's/^/         /' /tmp/install-codex-parse.$$
+fi
+rm -f /tmp/install-codex-parse.$$
+
+# [3/4] End-to-end dry run with an isolated CODEX_HOME
+echo ""
+echo "${BOLD}[3/4]${RESET} End-to-end dry run (isolated CODEX_HOME)"
+
+TMP_HOME="$(mktemp -d -t chorus-install-test.XXXXXX)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+FAKE_BIN="$TMP_HOME/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/codex" <<'FAKE'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "codex 0.125.0-test" ;;
+  plugin)
+    if [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "list" ]; then
+      echo ""
+      exit 0
+    fi
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+FAKE
+chmod +x "$FAKE_BIN/codex"
+
+run_out="$TMP_HOME/run.log"
+set +e
+env \
+  PATH="$FAKE_BIN:$PATH" \
+  HOME="$TMP_HOME" \
+  CODEX_HOME="$TMP_HOME/.codex" \
+  CHORUS_URL="https://chorus.test/api/mcp" \
+  CHORUS_API_KEY="cho_test_key_abc123" \
+  CHORUS_MARKETPLACE_SOURCE="https://github.com/Chorus-AIDLC/Chorus" \
+  "$TEST_BASH" "$SCRIPT" >"$run_out" 2>&1
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+  fail "installer exited non-zero ($rc)"
+  sed 's/^/         /' "$run_out"
+else
+  pass "installer exited 0"
+fi
+
+cfg="$TMP_HOME/.codex/config.toml"
+if [ ! -f "$cfg" ]; then
+  fail "config.toml not created at $cfg"
+else
+  pass "config.toml created"
+  grep -q '^\[mcp_servers\.chorus\]' "$cfg" && pass "[mcp_servers.chorus] block present" || fail "[mcp_servers.chorus] missing"
+  grep -q 'url = "https://chorus.test/api/mcp"' "$cfg" && pass "url written literally" || fail "url not literal"
+  grep -q 'Authorization = "Bearer cho_test_key_abc123"' "$cfg" && pass "Authorization header literal" || fail "Authorization not literal"
+  if command -v stat >/dev/null 2>&1; then
+    mode="$(stat -c '%a' "$cfg" 2>/dev/null || stat -f '%OLp' "$cfg" 2>/dev/null || echo "")"
+    if [ "$mode" = "600" ]; then
+      pass "config.toml mode=600"
+    elif [ -n "$mode" ]; then
+      fail "config.toml mode=$mode (expected 600)"
+    fi
+  fi
+fi
+
+# [4/4] Idempotent re-run with a rotated key
+echo ""
+echo "${BOLD}[4/4]${RESET} Idempotent re-run with a rotated key"
+set +e
+env \
+  PATH="$FAKE_BIN:$PATH" \
+  HOME="$TMP_HOME" \
+  CODEX_HOME="$TMP_HOME/.codex" \
+  CHORUS_URL="https://chorus.test/api/mcp" \
+  CHORUS_API_KEY="cho_rotated_key_xyz789" \
+  "$TEST_BASH" "$SCRIPT" >"$run_out" 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 0 ] && pass "rerun exited 0" || { fail "rerun exited non-zero ($rc)"; sed 's/^/         /' "$run_out"; }
+
+blocks="$(grep -c '^\[mcp_servers\.chorus\]' "$cfg" 2>/dev/null || echo 0)"
+[ "$blocks" = "1" ] && pass "exactly one [mcp_servers.chorus] block" || fail "found $blocks [mcp_servers.chorus] blocks"
+
+hdr_blocks="$(grep -c '^\[mcp_servers\.chorus\.http_headers\]' "$cfg" 2>/dev/null || echo 0)"
+[ "$hdr_blocks" = "1" ] && pass "exactly one [mcp_servers.chorus.http_headers] block" || fail "found $hdr_blocks http_headers blocks"
+
+if grep -q 'Authorization = "Bearer cho_rotated_key_xyz789"' "$cfg" && ! grep -q 'cho_test_key_abc123' "$cfg"; then
+  pass "rotated key replaced the previous key"
+else
+  fail "rotated key not applied cleanly"
+fi
+
+echo ""
+echo "${BOLD}Summary:${RESET} $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  printf "${RED}%s${RESET}\n" "$FAIL_NOTES"
+  exit 1
+fi
+echo "${GREEN}All checks passed.${RESET}"


### PR DESCRIPTION
Closes #160

## Summary
Ports the full Chorus plugin to **OpenAI Codex CLI** in response to the community request in #160. The Claude Code version (`public/chorus-plugin/`) is untouched; the Codex version lives independently under `plugins/chorus/`.

**One-shot install:**
```bash
curl -sSL https://raw.githubusercontent.com/Chorus-AIDLC/Chorus/main/public/install-codex.sh | bash
```
Then launch `codex` — marketplace policy is set to `INSTALLED_BY_DEFAULT`, so the plugin auto-installs on first TUI launch. If the automation does not fire (older Codex versions), a one-click `/plugins → Install` is the fallback.

## What's included (24 new files, ~5k lines)

| Area | Contents |
|---|---|
| **Marketplace manifest** | `.agents/plugins/marketplace.json` — registers `chorus-plugins` with policy `INSTALLED_BY_DEFAULT` |
| **Plugin body** | `plugins/chorus/` — `plugin.json` metadata, `hooks.json` declaration, 5 bash 3.2-compatible hook scripts, 9 SKILL.md files (7 workflow skills + 2 reviewer skills) |
| **Hook scripts** | `chorus-mcp-call.sh` (pure curl+jq MCP-over-HTTP helper), `on-session-start.sh` (calls `chorus_checkin`, injects `additionalContext`), `on-post-submit-proposal.sh` / `on-post-submit-for-verify.sh` (prompt the main agent to spawn a reviewer) |
| **Skills** | `$chorus`, `$idea`, `$proposal`, `$develop`, `$review`, `$quick-dev`, `$yolo`, plus two read-only reviewers (proposal-reviewer, task-reviewer) |
| **Installer** | `public/install-codex.sh` — idempotent; writes `[mcp_servers.chorus]` + `[mcp_servers.chorus.http_headers]` to `~/.codex/config.toml`, installs a hook wrapper at `~/.codex/hooks/chorus/run-hook.sh`, writes `~/.codex/hooks.json`, enables `codex_hooks = true`; bash 3.2-compatible |
| **Installer regression test** | `public/test-install-codex.sh` — 17 assertions (bash 4+ syntax scan, `bash -n` parse, isolated `CODEX_HOME` E2E dry run, idempotent key rotation) |
| **Design docs** | `docs/codex-plugin-plan.md` (final design + decision log) and `docs/_archive/codex-plugin-plan.history.md` (15-chapter research log) |

## Key design decisions

1. **MCP config lives outside the plugin.** Codex 0.125 does not expand `${VAR}` in `config.toml` and cannot read bearer tokens from env. The installer writes a literal URL plus `Authorization: Bearer cho_…` header into `~/.codex/config.toml` and `chmod 600`s the file.
2. **Stateless port.** No `.chorus/` directory. Codex lacks `SubagentStart`/`Stop`/`TeammateIdle`/`SessionEnd` events, so session lifecycle cannot be automated. Sessions are optional per-worker observability for Team-Lead orchestration — not required for single-agent use.
3. **Reviewers are skills mounted into a default agent, not custom agent_types.** `spawn_agent` only accepts `default` / `explorer` / `worker`. Invocation uses `spawn_agent(agent_type="default", items=[{type:"skill", path:"chorus:chorus-proposal-reviewer"}, ...])`.
4. **VERDICT is a literal, grep-enforced value.** Exactly one of `PASS` / `PASS WITH NOTES` / `FAIL`, documented in both the SKILL.md and the hook reminder to prevent the LLM from inventing synonyms like "APPROVE".
5. **Dropped the `UserPromptSubmit` hook.** Codex TUI echoes `additionalContext` on every turn, which becomes noisy; the marginal value didn't justify the noise.
6. **Lazy hook wrapper.** The installer drops `run-hook.sh` that resolves the newest installed plugin cache **at run time**. This breaks the chicken-and-egg where `hooks.json` previously had to be written *after* `/plugins → Install` materialized the cache. Now the installer finishes everything in one pass; the wrapper no-ops cleanly if the plugin cache doesn't exist yet.
7. **`plugins/chorus/` holds real code, not a symlink.** Aligns with the `./plugins/chorus` path in `marketplace.json` and avoids a layer of indirection.
8. **Installer uses only bash + awk.** No dependency on python/node — must work on macOS's stock bash 3.2.

Full rationale and incident log in `docs/codex-plugin-plan.md`.

## Test plan
- [x] `bash public/test-install-codex.sh` — 17/17 assertions pass (bash 3.2 compatibility, parse, E2E dry run, idempotent key rotation)
- [ ] Manual: run `bash public/install-codex.sh` on macOS → launch `codex` → verify marketplace auto-installs → `/mcp` shows connected → `$chorus` / `$develop` skills activate
- [ ] Verify PostToolUse hooks fire correctly after `chorus_pm_submit_proposal` and `chorus_submit_for_verify` and prompt reviewer spawns

Generated with [Claude Code](https://claude.com/claude-code)