### PR TITLE
docs: add Codex onboarding tab + per-client connect guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,48 +288,19 @@ The interactive installer provisions VPC, Aurora Serverless v2, ElastiCache Serv
 
 ### Connect AI Agents
 
-Create API Keys in the Web UI (Settings > Agents > Create API Key).
+The fastest path is the in-app setup wizard: open the Web UI, go to **Settings → Setup Guide → Open setup guide**, and follow the step-by-step instructions for your client (Claude Code, Codex, OpenClaw, or other agents). The wizard creates the API key for you, shows the exact commands, and walks through verifying the connection.
+
+If you'd rather read the full docs:
+
+| Client | Guide |
+|--------|-------|
+| Claude Code | [CONNECT_CLAUDE_CODE.md](docs/CONNECT_CLAUDE_CODE.md) |
+| Codex CLI | [CONNECT_CODEX.md](docs/CONNECT_CODEX.md) |
+| Other MCP agents (Cursor, Continue, custom, …) | [CONNECT_OTHER_AGENTS.md](docs/CONNECT_OTHER_AGENTS.md) |
+
+Create API Keys in the Web UI under **Settings → Agents → Create API Key**. Keys start with `cho_` and are shown only once.
 
 ![Create API Key](docs/images/create-key.png)
-
-#### Option 1: Chorus Plugin (Recommended)
-
-```bash
-export CHORUS_URL="http://localhost:8637"
-export CHORUS_API_KEY="cho_your_api_key"
-```
-
-Install from Plugin Marketplace:
-
-```bash
-claude
-/plugin marketplace add Chorus-AIDLC/chorus
-/plugin install chorus@chorus-plugins
-```
-
-Or load locally:
-
-```bash
-claude --plugin-dir public/chorus-plugin
-```
-
-#### Option 2: Manual MCP Configuration
-
-Create `.mcp.json` in the project root:
-
-```json
-{
-  "mcpServers": {
-    "chorus": {
-      "type": "http",
-      "url": "http://localhost:8637/api/mcp",
-      "headers": {
-        "Authorization": "Bearer cho_your_api_key"
-      }
-    }
-  }
-}
-```
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -279,48 +279,19 @@ PGlite 在端口 5433 运行嵌入式 PostgreSQL。数据存储在 `.pglite/`，
 
 ### 连接 AI Agent
 
-在 Web UI 创建 API Key（Settings > Agents > Create API Key）。
+最快的方式是用应用内的 setup 向导：打开 Web UI，进入 **Settings → Setup Guide → 打开设置向导**，按照向导给出的分步指引接入自己的客户端（Claude Code、Codex、OpenClaw 或其他 agent）。向导会帮你创建 API Key、展示完整命令，并引导你验证连接。
+
+如果偏好文档：
+
+| 客户端 | 接入文档 |
+|--------|---------|
+| Claude Code | [CONNECT_CLAUDE_CODE.zh.md](docs/CONNECT_CLAUDE_CODE.zh.md) |
+| Codex CLI | [CONNECT_CODEX.zh.md](docs/CONNECT_CODEX.zh.md) |
+| 其他 MCP agent（Cursor / Continue / 自研等） | [CONNECT_OTHER_AGENTS.zh.md](docs/CONNECT_OTHER_AGENTS.zh.md) |
+
+在 Web UI 的 **Settings → Agents → Create API Key** 创建 API Key。Key 以 `cho_` 开头，仅在创建时显示一次。
 
 ![Create API Key](docs/images/create-key.png)
-
-#### 方式一：Chorus Plugin（推荐）
-
-```bash
-export CHORUS_URL="http://localhost:8637"
-export CHORUS_API_KEY="cho_your_api_key"
-```
-
-从 Plugin Marketplace 安装：
-
-```bash
-claude
-/plugin marketplace add Chorus-AIDLC/chorus
-/plugin install chorus@chorus-plugins
-```
-
-或本地加载：
-
-```bash
-claude --plugin-dir public/chorus-plugin
-```
-
-#### 方式二：手动配置 MCP
-
-在项目根目录创建 `.mcp.json`：
-
-```json
-{
-  "mcpServers": {
-    "chorus": {
-      "type": "http",
-      "url": "http://localhost:8637/api/mcp",
-      "headers": {
-        "Authorization": "Bearer cho_your_api_key"
-      }
-    }
-  }
-}
-```
 
 ---
 

--- a/docs/CONNECT_CLAUDE_CODE.md
+++ b/docs/CONNECT_CLAUDE_CODE.md
@@ -1,0 +1,63 @@
+# Connect Claude Code to Chorus
+
+This guide walks through connecting [Claude Code](https://claude.com/claude-code) to a running Chorus instance so Claude can call Chorus MCP tools (ideas, proposals, tasks, verify workflow, etc.).
+
+> **Tip:** The in-app setup wizard at **Settings → Setup Guide → Open setup guide** walks you through the same steps interactively, including API-key creation. Use this doc if you prefer a reference you can read end-to-end or automate.
+
+## Prerequisites
+
+- Chorus instance running and reachable (e.g. `http://localhost:8637` or a deployed URL)
+- `claude` CLI installed ([install instructions](https://docs.claude.com/en/docs/claude-code/setup))
+- A Chorus **API Key** (create one in the Web UI under **Settings → Agents → Create API Key**). Keys start with `cho_`.
+
+## Step 1: Export environment variables
+
+```bash
+export CHORUS_URL="http://localhost:8637"
+export CHORUS_API_KEY="cho_your_api_key"
+```
+
+> Add these to `~/.bashrc` or `~/.zshrc` if you want them to persist across shells.
+
+## Step 2: Install the Chorus plugin
+
+The recommended path is the official Chorus plugin — it bundles hooks, skills, and auto-managed sessions on top of the raw MCP connection.
+
+**From the plugin marketplace** (recommended):
+
+```bash
+claude
+/plugin marketplace add Chorus-AIDLC/chorus
+/plugin install chorus@chorus-plugins
+```
+
+**From a local clone** (for development):
+
+```bash
+claude --plugin-dir public/chorus-plugin
+```
+
+That's it. On next launch, Claude will see Chorus MCP tools (`chorus_checkin`, `chorus_pm_*`, `chorus_claim_task`, …) and the workflow slash commands (`/chorus`, `/chorus:develop`, `/chorus:proposal`, `/chorus:yolo`, etc.).
+
+## Step 3: Verify the connection
+
+Inside Claude Code, type:
+
+```
+check in to chorus
+```
+
+Claude will call `chorus_checkin()` and report back with your agent identity, roles, and recent activity.
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — API key wrong or revoked. Recreate under Settings → Agents.
+- **`404` or `connection refused`** — `CHORUS_URL` points to an unreachable host. Curl it: `curl "$CHORUS_URL/api/mcp"` should return a JSON error, not a network error.
+- **Tools don't appear** — Restart Claude Code after installing the plugin. Check `/plugin list`.
+
+## Next
+
+- Skill docs (tools reference): `public/chorus-plugin/skills/chorus/SKILL.md` (served as `/skill/chorus/SKILL.md` on your Chorus instance)
+- Workflow overview: run `/chorus` inside Claude Code
+- To connect Codex instead, see [CONNECT_CODEX.md](CONNECT_CODEX.md)
+- For any other MCP-capable agent (Cursor, Continue, custom, etc.), see [CONNECT_OTHER_AGENTS.md](CONNECT_OTHER_AGENTS.md)

--- a/docs/CONNECT_CLAUDE_CODE.zh.md
+++ b/docs/CONNECT_CLAUDE_CODE.zh.md
@@ -1,0 +1,63 @@
+# Claude Code 接入 Chorus
+
+本文档介绍如何把 [Claude Code](https://claude.com/claude-code) 接入 Chorus 实例，让 Claude 能调用 Chorus 的 MCP 工具（idea、proposal、task、verify 等）。
+
+> **提示：**应用内 setup 向导（**Settings → Setup Guide → 打开设置向导**）会用交互式方式引导你完成这些步骤，包括 API Key 的创建。如果你想要一份可以从头读到尾或脚本化的参考，就看本文档。
+
+## 前置条件
+
+- 运行中且可访问的 Chorus 实例（例如 `http://localhost:8637`，或部署后的 URL）
+- 已安装 `claude` CLI（[安装指引](https://docs.claude.com/en/docs/claude-code/setup)）
+- 一个 Chorus **API Key**（在 Web UI 的 **Settings → Agents → Create API Key** 创建）。Key 以 `cho_` 开头。
+
+## 第 1 步：导出环境变量
+
+```bash
+export CHORUS_URL="http://localhost:8637"
+export CHORUS_API_KEY="cho_your_api_key"
+```
+
+> 如果希望跨 shell 持久化，可以加入 `~/.bashrc` 或 `~/.zshrc`。
+
+## 第 2 步：安装 Chorus Plugin
+
+推荐用官方 Chorus plugin —— 除了底层 MCP 连接，它还打包了 hooks、skills、session 自动管理。
+
+**从 plugin marketplace 安装**（推荐）：
+
+```bash
+claude
+/plugin marketplace add Chorus-AIDLC/chorus
+/plugin install chorus@chorus-plugins
+```
+
+**从本地目录加载**（开发用）：
+
+```bash
+claude --plugin-dir public/chorus-plugin
+```
+
+装完即可。下次启动 Claude Code 时，你就能看到 Chorus 的 MCP 工具（`chorus_checkin`、`chorus_pm_*`、`chorus_claim_task` 等）和 workflow slash 命令（`/chorus`、`/chorus:develop`、`/chorus:proposal`、`/chorus:yolo` 等）。
+
+## 第 3 步：验证连接
+
+在 Claude Code 中输入：
+
+```
+check in to chorus
+```
+
+Claude 会调用 `chorus_checkin()`，返回你的 agent 身份、角色和最近的活动记录。
+
+## 故障排查
+
+- **`401 Unauthorized`** —— API Key 错误或已失效。到 Settings → Agents 重新创建。
+- **`404` 或 `connection refused`** —— `CHORUS_URL` 指向不可达的主机。用 `curl "$CHORUS_URL/api/mcp"` 测一下，应当返回 JSON 错误而不是网络错误。
+- **工具没出现** —— 装完 plugin 后重启 Claude Code，用 `/plugin list` 检查状态。
+
+## 下一步
+
+- Skill 文档（工具参考）：`public/chorus-plugin/skills/chorus/SKILL.md`（也会在 Chorus 实例上以 `/skill/chorus/SKILL.md` 提供）
+- 工作流概览：在 Claude Code 里输入 `/chorus`
+- 要接入 Codex，见 [CONNECT_CODEX.zh.md](CONNECT_CODEX.zh.md)
+- 其他 MCP 兼容的 agent（Cursor、Continue、自研等）见 [CONNECT_OTHER_AGENTS.zh.md](CONNECT_OTHER_AGENTS.zh.md)

--- a/docs/CONNECT_CODEX.md
+++ b/docs/CONNECT_CODEX.md
@@ -64,7 +64,7 @@ CHORUS_API_KEY=cho_xxx \
 
 ## Next
 
-- Skill docs (tools reference): `public/chorus-plugin/skills/chorus/SKILL.md` (served as `/skill/chorus/SKILL.md` on your Chorus instance)
+- Skill docs (tools reference): `plugins/chorus/skills/chorus/SKILL.md` (the standalone version served as `/skill/chorus/SKILL.md` on your Chorus instance comes from `public/skill/chorus/SKILL.md`)
 - Workflow overview: run `$chorus` inside Codex
 - To connect Claude Code instead, see [CONNECT_CLAUDE_CODE.md](CONNECT_CLAUDE_CODE.md)
 - For any other MCP-capable agent (Cursor, Continue, custom, etc.), see [CONNECT_OTHER_AGENTS.md](CONNECT_OTHER_AGENTS.md)

--- a/docs/CONNECT_CODEX.md
+++ b/docs/CONNECT_CODEX.md
@@ -1,0 +1,70 @@
+# Connect Codex to Chorus
+
+This guide walks through connecting the [Codex CLI](https://github.com/openai/codex) to a running Chorus instance. Codex has its own standalone Chorus plugin (under `plugins/chorus`, published via `.agents/plugins/marketplace.json`) — a separate package from the Claude Code plugin, with its own set of skills and supported features. A one-shot installer takes care of wiring it into Codex's `~/.codex/config.toml`.
+
+> **Tip:** The in-app setup wizard at **Settings → Setup Guide → Open setup guide** walks you through the same steps interactively, including API-key creation. Use this doc if you prefer a reference you can read end-to-end or automate.
+
+## Prerequisites
+
+- Chorus instance running and reachable (e.g. `http://localhost:8637` or a deployed URL)
+- `codex` CLI installed (`npm i -g @openai/codex`)
+- A Chorus **API Key** (create one in the Web UI under **Settings → Agents → Create API Key**). Keys start with `cho_`.
+
+## Step 1: Export environment variables
+
+```bash
+export CHORUS_URL="http://localhost:8637"
+export CHORUS_API_KEY="cho_your_api_key"
+```
+
+> Add these to `~/.bashrc` or `~/.zshrc` if you want them to persist across shells.
+
+## Step 2: Run the installer
+
+```bash
+curl -fsSL "$CHORUS_URL/install-codex.sh" | bash
+```
+
+The script is idempotent and safe to re-run. It will:
+
+1. Verify `codex` is installed.
+2. Register the `chorus-plugins` marketplace (or upgrade it if already registered).
+3. Write `[mcp_servers.chorus]` and `[plugins."chorus@chorus-plugins"]` into `~/.codex/config.toml` (mode `600`, backing up your original once to `config.toml.chorus-bak`).
+4. Install a lazy hook wrapper under `~/.codex/hooks/chorus/run-hook.sh` so Chorus hooks fire on first Codex launch, even before the plugin cache is materialized.
+
+If `CHORUS_URL` / `CHORUS_API_KEY` aren't set, the installer will prompt for them interactively (provided you have a TTY).
+
+## Step 3: Verify the connection
+
+Open Codex and type:
+
+```
+check in to chorus
+```
+
+Codex will call `chorus_checkin()` via the MCP server and report back with your agent identity, roles, and recent activity. The Chorus workflow skills (`$chorus`, `$develop`, `$proposal`, `$yolo`, etc.) are also available.
+
+## Non-interactive install (CI / sandboxed environments)
+
+The installer runs fine without a TTY as long as both vars are in the environment:
+
+```bash
+CHORUS_URL=https://chorus.example.com \
+CHORUS_API_KEY=cho_xxx \
+  bash <(curl -fsSL https://chorus.example.com/install-codex.sh)
+```
+
+## Troubleshooting
+
+- **`codex not found in PATH`** — Install it: `npm i -g @openai/codex`.
+- **`401 Unauthorized`** on `check in` — API key wrong or revoked. Recreate under Settings → Agents, then re-run the installer (or edit the `Authorization` line in `config.toml`).
+- **`URL must start with http:// or https://`** — `CHORUS_URL` missing the scheme. Use `http://` or `https://`.
+- **Marketplace source conflict** — You previously registered `chorus-plugins` from a different URL. The installer detects this and auto-re-registers; check the `!` warnings it prints.
+- **Hook didn't fire on first launch** — Open `/plugins` inside Codex and click `Install` manually for `chorus@chorus-plugins`. The plugin cache will materialize and hooks will start firing on the next tool call.
+
+## Next
+
+- Skill docs (tools reference): `public/chorus-plugin/skills/chorus/SKILL.md` (served as `/skill/chorus/SKILL.md` on your Chorus instance)
+- Workflow overview: run `$chorus` inside Codex
+- To connect Claude Code instead, see [CONNECT_CLAUDE_CODE.md](CONNECT_CLAUDE_CODE.md)
+- For any other MCP-capable agent (Cursor, Continue, custom, etc.), see [CONNECT_OTHER_AGENTS.md](CONNECT_OTHER_AGENTS.md)

--- a/docs/CONNECT_CODEX.zh.md
+++ b/docs/CONNECT_CODEX.zh.md
@@ -64,7 +64,7 @@ CHORUS_API_KEY=cho_xxx \
 
 ## 下一步
 
-- Skill 文档（工具参考）：`public/chorus-plugin/skills/chorus/SKILL.md`（也会在 Chorus 实例上以 `/skill/chorus/SKILL.md` 提供）
+- Skill 文档（工具参考）：`plugins/chorus/skills/chorus/SKILL.md`（Chorus 实例上 `/skill/chorus/SKILL.md` 提供的是独立版本，来自 `public/skill/chorus/SKILL.md`）
 - 工作流概览：在 Codex 里输入 `$chorus`
 - 要接入 Claude Code，见 [CONNECT_CLAUDE_CODE.zh.md](CONNECT_CLAUDE_CODE.zh.md)
 - 其他 MCP 兼容的 agent（Cursor、Continue、自研等）见 [CONNECT_OTHER_AGENTS.zh.md](CONNECT_OTHER_AGENTS.zh.md)

--- a/docs/CONNECT_CODEX.zh.md
+++ b/docs/CONNECT_CODEX.zh.md
@@ -1,0 +1,70 @@
+# Codex 接入 Chorus
+
+本文档介绍如何把 [Codex CLI](https://github.com/openai/codex) 接入 Chorus 实例。Codex 有自己独立的 Chorus plugin（位于 `plugins/chorus`，通过 `.agents/plugins/marketplace.json` 发布），是和 Claude Code plugin 完全不同的一个包，支持的 skills 和功能也有差异。一键脚本会负责把它写进 Codex 的 `~/.codex/config.toml`。
+
+> **提示：**应用内 setup 向导（**Settings → Setup Guide → 打开设置向导**）会用交互式方式引导你完成这些步骤，包括 API Key 的创建。如果你想要一份可以从头读到尾或脚本化的参考，就看本文档。
+
+## 前置条件
+
+- 运行中且可访问的 Chorus 实例（例如 `http://localhost:8637`，或部署后的 URL）
+- 已安装 `codex` CLI（`npm i -g @openai/codex`）
+- 一个 Chorus **API Key**（在 Web UI 的 **Settings → Agents → Create API Key** 创建）。Key 以 `cho_` 开头。
+
+## 第 1 步：导出环境变量
+
+```bash
+export CHORUS_URL="http://localhost:8637"
+export CHORUS_API_KEY="cho_your_api_key"
+```
+
+> 如果希望跨 shell 持久化，可以加入 `~/.bashrc` 或 `~/.zshrc`。
+
+## 第 2 步：运行安装脚本
+
+```bash
+curl -fsSL "$CHORUS_URL/install-codex.sh" | bash
+```
+
+脚本是幂等的，重复运行是安全的。它会：
+
+1. 检查 `codex` 是否已安装。
+2. 注册 `chorus-plugins` marketplace（如果已注册则升级）。
+3. 把 `[mcp_servers.chorus]` 和 `[plugins."chorus@chorus-plugins"]` 写入 `~/.codex/config.toml`（权限 `600`，原文件首次备份到 `config.toml.chorus-bak`）。
+4. 在 `~/.codex/hooks/chorus/run-hook.sh` 安装一个 lazy hook wrapper，保证 Codex 首次启动时 Chorus hooks 就能生效 —— 哪怕 plugin cache 还没生成。
+
+如果没有设置 `CHORUS_URL` / `CHORUS_API_KEY`，脚本会在有 TTY 的情况下交互式地询问你。
+
+## 第 3 步：验证连接
+
+打开 Codex，输入：
+
+```
+check in to chorus
+```
+
+Codex 会通过 MCP 调用 `chorus_checkin()`，返回你的 agent 身份、角色和最近的活动记录。Chorus workflow skills（`$chorus`、`$develop`、`$proposal`、`$yolo` 等）也都可以直接使用。
+
+## 非交互安装（CI / sandbox 环境）
+
+只要两个环境变量都有值，脚本不依赖 TTY 也能正常跑完：
+
+```bash
+CHORUS_URL=https://chorus.example.com \
+CHORUS_API_KEY=cho_xxx \
+  bash <(curl -fsSL https://chorus.example.com/install-codex.sh)
+```
+
+## 故障排查
+
+- **`codex not found in PATH`** —— 先装 Codex：`npm i -g @openai/codex`。
+- **`check in` 返回 `401 Unauthorized`** —— API Key 错误或已失效。到 Settings → Agents 重新创建，然后重新跑安装脚本（或手改 `config.toml` 里的 `Authorization` 行）。
+- **`URL must start with http:// or https://`** —— `CHORUS_URL` 缺了协议头，补上 `http://` 或 `https://`。
+- **Marketplace source conflict** —— 你之前用不同 URL 注册过 `chorus-plugins`。脚本会检测到并自动重新注册，留意它打印的 `!` 警告。
+- **Hook 在首次启动时没触发** —— 在 Codex 里打开 `/plugins`，对 `chorus@chorus-plugins` 手动点 `Install`。plugin cache 生成后，下一次工具调用 hook 就会生效了。
+
+## 下一步
+
+- Skill 文档（工具参考）：`public/chorus-plugin/skills/chorus/SKILL.md`（也会在 Chorus 实例上以 `/skill/chorus/SKILL.md` 提供）
+- 工作流概览：在 Codex 里输入 `$chorus`
+- 要接入 Claude Code，见 [CONNECT_CLAUDE_CODE.zh.md](CONNECT_CLAUDE_CODE.zh.md)
+- 其他 MCP 兼容的 agent（Cursor、Continue、自研等）见 [CONNECT_OTHER_AGENTS.zh.md](CONNECT_OTHER_AGENTS.zh.md)

--- a/docs/CONNECT_OTHER_AGENTS.md
+++ b/docs/CONNECT_OTHER_AGENTS.md
@@ -1,0 +1,71 @@
+# Connect Other AI Agents to Chorus
+
+For agents **other than Claude Code and Codex** — any MCP-capable client such as Cursor, Continue, a custom agent, or a hand-rolled integration — the fastest path is to let the agent itself install and configure Chorus using a natural-language prompt. You hand it the Chorus URL + API Key and point it at the skill doc; it handles the rest.
+
+> For Claude Code, see [CONNECT_CLAUDE_CODE.md](CONNECT_CLAUDE_CODE.md). For Codex, see [CONNECT_CODEX.md](CONNECT_CODEX.md). Both have official plugins that give you more than the raw MCP tools (hooks, skills, slash commands).
+
+## Prerequisites
+
+- Chorus instance running and reachable (e.g. `http://localhost:8637` or a deployed URL)
+- An AI agent that supports MCP servers (HTTP streamable transport or equivalent)
+- A Chorus **API Key** (create one in the Web UI under **Settings → Agents → Create API Key**). Keys start with `cho_`.
+
+## The install prompt
+
+Copy the prompt below and send it to your agent. Replace `CHORUS_URL` and `API_KEY` with your real values first.
+
+```text
+Please install and configure the Chorus AI-DLC collaboration platform.
+
+Chorus URL: http://localhost:8637
+API Key: cho_your_api_key
+
+Read the setup instructions from:
+http://localhost:8637/skill/chorus/SKILL.md
+
+Follow the "Setup" section to configure the MCP server,
+then call chorus_checkin() to verify the connection.
+```
+
+The Web UI's setup wizard (**Settings → Setup Guide → Open setup guide → Other Agents** tab) renders this same prompt with your actual `CHORUS_URL` and API key already filled in — so you can copy-paste directly instead of editing values by hand.
+
+## What the agent will do
+
+The skill doc at `/skill/chorus/SKILL.md` describes how to register Chorus as an MCP server in the agent's config. The exact mechanism depends on the client:
+
+- **Cursor / Continue / Zed**: add an entry under their `mcpServers` config (JSON or settings UI).
+- **Custom agent using `@modelcontextprotocol/sdk`**: open an HTTP streamable transport to `CHORUS_URL/api/mcp` with `Authorization: Bearer <API_KEY>`.
+- **OpenAI Agents SDK / LangChain / etc.**: wire Chorus as an MCP tool source and pass the same URL + header.
+
+All of them converge on the same two pieces of config:
+
+| Field | Value |
+|-------|-------|
+| MCP server URL | `{CHORUS_URL}/api/mcp` |
+| Auth header | `Authorization: Bearer {API_KEY}` |
+
+The agent should then call `chorus_checkin` — if that returns your agent's identity and roles, you're connected.
+
+## Verification
+
+Ask the agent:
+
+```text
+check in to chorus
+```
+
+You should see a JSON response describing the agent, its roles, and recent Chorus activity. If the agent can also list the available MCP tools (e.g. `chorus_pm_create_idea`, `chorus_claim_task`), the connection is fully working.
+
+## Troubleshooting
+
+- **Agent says "no MCP server named chorus"** — It didn't persist the config. Ask it to show you the MCP config file it wrote to, then verify the entry is there.
+- **`401 Unauthorized`** — API key wrong or revoked. Recreate under Settings → Agents and resend the prompt with the new key.
+- **`404` from `/api/mcp`** — URL likely missing `/api/mcp` or pointing at the wrong host. Test with `curl -H "Authorization: Bearer $CHORUS_API_KEY" "$CHORUS_URL/api/mcp"` — you should get a JSON error response (not a network error).
+- **Agent calls tools but doesn't follow the AI-DLC workflow** — Point it at the full skill doc at `/skill/chorus/SKILL.md`; the `Setup` section is just the minimum. The workflow sections (`Idea`, `Proposal`, `Develop`, `Review`) describe how to actually use the tools together.
+
+## Next
+
+- Skill reference: `http://localhost:8637/skill/chorus/SKILL.md` (served from your Chorus instance)
+- Full MCP tool reference: [MCP_TOOLS.md](MCP_TOOLS.md)
+- To connect Claude Code instead, see [CONNECT_CLAUDE_CODE.md](CONNECT_CLAUDE_CODE.md)
+- To connect Codex instead, see [CONNECT_CODEX.md](CONNECT_CODEX.md)

--- a/docs/CONNECT_OTHER_AGENTS.zh.md
+++ b/docs/CONNECT_OTHER_AGENTS.zh.md
@@ -1,0 +1,71 @@
+# 其他 AI Agent 接入 Chorus
+
+对于 **Claude Code 和 Codex 之外** 的 agent —— 任意 MCP 兼容客户端，例如 Cursor、Continue、自研 agent 或手写集成 —— 最快的路径是把 Chorus 的 URL 和 API Key 喂给 agent 本身，用自然语言 prompt 让它自己完成安装和配置。你把指引文档地址告诉它，剩下的它搞定。
+
+> Claude Code 见 [CONNECT_CLAUDE_CODE.zh.md](CONNECT_CLAUDE_CODE.zh.md)；Codex 见 [CONNECT_CODEX.zh.md](CONNECT_CODEX.zh.md)。这两个客户端都有官方 plugin，除了 MCP 工具本身，还能用上 hooks、skills、slash 命令等。
+
+## 前置条件
+
+- 运行中且可访问的 Chorus 实例（例如 `http://localhost:8637`，或部署后的 URL）
+- 一个支持 MCP server 的 AI agent（HTTP streamable transport 或同等方式）
+- 一个 Chorus **API Key**（在 Web UI 的 **Settings → Agents → Create API Key** 创建）。Key 以 `cho_` 开头。
+
+## 安装 prompt
+
+复制下面这段 prompt 发给你的 agent。记得先把 `CHORUS_URL` 和 `API_KEY` 换成你的真实值。
+
+```text
+Please install and configure the Chorus AI-DLC collaboration platform.
+
+Chorus URL: http://localhost:8637
+API Key: cho_your_api_key
+
+Read the setup instructions from:
+http://localhost:8637/skill/chorus/SKILL.md
+
+Follow the "Setup" section to configure the MCP server,
+then call chorus_checkin() to verify the connection.
+```
+
+Web UI 的 setup 向导（**Settings → Setup Guide → 打开设置向导 → 其他智能体** tab）会把这段 prompt 用你当前的 `CHORUS_URL` 和 API Key 预填好渲染出来 —— 直接复制即可，不用手改。
+
+## Agent 会做什么
+
+`/skill/chorus/SKILL.md` 这份 skill 文档描述了怎么把 Chorus 注册为 MCP server，具体机制因客户端而异：
+
+- **Cursor / Continue / Zed**：在它们的 `mcpServers` 配置（JSON 或 settings UI）里加一条。
+- **基于 `@modelcontextprotocol/sdk` 的自研 agent**：对 `CHORUS_URL/api/mcp` 打开 HTTP streamable transport，带上 `Authorization: Bearer <API_KEY>` header。
+- **OpenAI Agents SDK / LangChain 等**：把 Chorus 作为 MCP 工具源接入，传同样的 URL + header。
+
+所有方式最终都归到同样的两项配置：
+
+| 字段 | 值 |
+|------|----|
+| MCP server URL | `{CHORUS_URL}/api/mcp` |
+| Auth header | `Authorization: Bearer {API_KEY}` |
+
+配好之后让 agent 调用 `chorus_checkin` —— 如果能返回你的 agent 身份和角色，就说明连上了。
+
+## 验证
+
+对 agent 说：
+
+```text
+check in to chorus
+```
+
+你应该能看到一份描述 agent、角色、最近 Chorus 活动的 JSON 响应。如果 agent 还能列出可用的 MCP 工具（例如 `chorus_pm_create_idea`、`chorus_claim_task`），那就是完全 OK 了。
+
+## 故障排查
+
+- **Agent 提示 "no MCP server named chorus"** —— 它没把配置写进去。让它告诉你它写到了哪个 MCP 配置文件，然后去确认一下那条记录确实在。
+- **`401 Unauthorized`** —— API Key 错误或已失效。到 Settings → Agents 重新创建，再把新 Key 发给 agent。
+- **`/api/mcp` 返回 `404`** —— URL 可能漏了 `/api/mcp`，或者指向了错误的 host。用 `curl -H "Authorization: Bearer $CHORUS_API_KEY" "$CHORUS_URL/api/mcp"` 测一下，应当返回 JSON 错误而不是网络错误。
+- **Agent 调工具了，但没按 AI-DLC 工作流走** —— 把完整 skill 文档 `/skill/chorus/SKILL.md` 发给它；`Setup` 章节只是最小必要配置，`Idea`、`Proposal`、`Develop`、`Review` 这些章节描述了这些工具该怎么组合使用。
+
+## 下一步
+
+- Skill 参考：`http://localhost:8637/skill/chorus/SKILL.md`（由 Chorus 实例本身提供）
+- 完整 MCP 工具参考：[MCP_TOOLS.md](MCP_TOOLS.md)
+- 要接入 Claude Code，见 [CONNECT_CLAUDE_CODE.zh.md](CONNECT_CLAUDE_CODE.zh.md)
+- 要接入 Codex，见 [CONNECT_CODEX.zh.md](CONNECT_CODEX.zh.md)

--- a/messages/en.json
+++ b/messages/en.json
@@ -1009,6 +1009,7 @@
       "description": "Choose your AI agent client and follow the setup instructions below.",
       "tabs": {
         "claudeCode": "Claude Code",
+        "codex": "Codex",
         "openClaw": "OpenClaw",
         "other": "Other Agents"
       },
@@ -1016,6 +1017,14 @@
         "step1Title": "Step 1: Set environment variables",
         "step1Tip": "Tip: Add these to ~/.bashrc or ~/.zshrc for persistence.",
         "step2Title": "Step 2: Open Claude Code and run"
+      },
+      "codex": {
+        "step1Title": "Step 1: Set environment variables",
+        "step1Tip": "Tip: Add these to ~/.bashrc or ~/.zshrc for persistence.",
+        "step2Title": "Step 2: Run the Codex installer",
+        "step2Tip": "The script registers the plugin marketplace and writes the MCP server entry into ~/.codex/config.toml.",
+        "step3Title": "Step 3: Verify connection",
+        "step3Desc": "Open Codex and ask it to check in to Chorus — e.g. type \"check in to chorus\"."
       },
       "openClaw": {
         "step1Title": "Step 1: Install plugin",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1010,6 +1010,7 @@
       "description": "选择您的 AI 智能体客户端，然后按照以下说明进行设置。",
       "tabs": {
         "claudeCode": "Claude Code",
+        "codex": "Codex",
         "openClaw": "OpenClaw",
         "other": "其他智能体"
       },
@@ -1017,6 +1018,14 @@
         "step1Title": "第 1 步：设置环境变量",
         "step1Tip": "提示：将这些添加到 ~/.bashrc 或 ~/.zshrc 以实现持久化。",
         "step2Title": "第 2 步：打开 Claude Code 并运行"
+      },
+      "codex": {
+        "step1Title": "第 1 步：设置环境变量",
+        "step1Tip": "提示：将这些添加到 ~/.bashrc 或 ~/.zshrc 以实现持久化。",
+        "step2Title": "第 2 步：运行 Codex 安装脚本",
+        "step2Tip": "脚本会自动注册 plugin marketplace 并写入 ~/.codex/config.toml 的 MCP 服务器配置。",
+        "step3Title": "第 3 步：验证连接",
+        "step3Desc": "打开 Codex，让它 check in 到 Chorus，例如输入 \"check in to chorus\"。"
       },
       "openClaw": {
         "step1Title": "第 1 步：安装插件",

--- a/public/install-codex.sh
+++ b/public/install-codex.sh
@@ -9,10 +9,13 @@
 #
 # What this does (idempotent, safe to re-run):
 #   1. Verifies `codex` CLI is installed.
-#   2. Registers the Chorus plugin marketplace.
-#   3. Writes [mcp_servers.chorus] (url + Authorization header) into ~/.codex/config.toml.
-#   4. Registers plugin as INSTALLED_BY_DEFAULT — Codex picks it up on first launch
-#      (falls back to one-click `/plugins → Install` if auto-install does not fire).
+#   2. Registers (or upgrades) the Chorus plugin marketplace.
+#   3. Writes [mcp_servers.chorus] (url + Authorization header) and
+#      [plugins."chorus@chorus-plugins"] enabled = true into ~/.codex/config.toml,
+#      so Codex auto-enables the plugin on first launch (falls back to one-click
+#      `/plugins → Install` if auto-install does not fire).
+#   4. Installs a lazy hook wrapper under ~/.codex/hooks/chorus/ so Chorus hooks
+#      work even before the plugin cache is materialized.
 
 set -euo pipefail
 
@@ -54,7 +57,7 @@ hdr "2/5  Registering the Chorus plugin marketplace"
 existing_source=""
 if [ -f "$CONFIG_TOML" ]; then
   existing_source="$(awk -v name="$MARKETPLACE_NAME" '
-    $0 == "[marketplaces." name "]" { in_block=1; next }
+    $0 ~ "^\\[marketplaces\\." name "\\][[:space:]]*$" { in_block=1; next }
     in_block && /^\[/              { in_block=0 }
     in_block && /^source[[:space:]]*=/ {
       sub(/^source[[:space:]]*=[[:space:]]*/, "")

--- a/public/install-codex.sh
+++ b/public/install-codex.sh
@@ -49,11 +49,40 @@ ok "Found $(codex --version 2>/dev/null | head -1)"
 
 # ---------- step 2: register marketplace ----------
 hdr "2/5  Registering the Chorus plugin marketplace"
-if grep -q "^\[marketplaces\.${MARKETPLACE_NAME}\]" "$CONFIG_TOML" 2>/dev/null; then
-  ok "Marketplace '${MARKETPLACE_NAME}' already registered"
-else
+# Extract the currently registered source (if any) for chorus-plugins.
+# awk scoped between the matching [marketplaces.<name>] header and the next [section].
+existing_source=""
+if [ -f "$CONFIG_TOML" ]; then
+  existing_source="$(awk -v name="$MARKETPLACE_NAME" '
+    $0 == "[marketplaces." name "]" { in_block=1; next }
+    in_block && /^\[/              { in_block=0 }
+    in_block && /^source[[:space:]]*=/ {
+      sub(/^source[[:space:]]*=[[:space:]]*/, "")
+      gsub(/^"|"$/, "")
+      print
+      exit
+    }
+  ' "$CONFIG_TOML" 2>/dev/null || true)"
+fi
+
+if [ -z "$existing_source" ]; then
   codex plugin marketplace add "$MARKETPLACE_SOURCE_DEFAULT" >/dev/null
   ok "Added marketplace: $MARKETPLACE_SOURCE_DEFAULT"
+elif [ "$existing_source" = "$MARKETPLACE_SOURCE_DEFAULT" ]; then
+  # Same source — pull the latest plugin manifest/version.
+  if codex plugin marketplace upgrade "$MARKETPLACE_NAME" >/dev/null 2>&1; then
+    ok "Upgraded marketplace '${MARKETPLACE_NAME}' to latest"
+  else
+    warn "Marketplace '${MARKETPLACE_NAME}' already registered; upgrade skipped"
+  fi
+else
+  # Source changed — remove the stale registration and re-add.
+  warn "Marketplace '${MARKETPLACE_NAME}' points at a different source; re-registering"
+  warn "  old: $existing_source"
+  warn "  new: $MARKETPLACE_SOURCE_DEFAULT"
+  codex plugin marketplace remove "$MARKETPLACE_NAME" >/dev/null 2>&1 || true
+  codex plugin marketplace add "$MARKETPLACE_SOURCE_DEFAULT" >/dev/null
+  ok "Re-added marketplace: $MARKETPLACE_SOURCE_DEFAULT"
 fi
 
 # ---------- step 3: collect Chorus URL + API key ----------
@@ -87,27 +116,22 @@ else
   die "No TTY and CHORUS_API_KEY unset — cannot continue"
 fi
 
-# Sanity check: a root URL without a path is almost always wrong — the Chorus
-# MCP endpoint is served under a path (e.g. /api/mcp). Warn loudly; don't abort
-# so advanced users with a path-less reverse proxy can still proceed.
+# Must be http(s).
 case "$url" in
-  http://*/*|https://*/*)
-    # Has a path component — check it's not just a trailing slash.
-    path="${url#http*://}"
-    path="${path#*/}"
-    if [ -z "$path" ]; then
-      warn "URL has no path (just a host). MCP endpoints usually live under /api/mcp or similar."
-      warn "If /mcp in the TUI shows 'chorus' failing to connect, re-run with the full URL."
-    fi
-    ;;
-  http://*|https://*)
-    warn "URL has no path (just a host). MCP endpoints usually live under /api/mcp or similar."
-    warn "If /mcp in the TUI shows 'chorus' failing to connect, re-run with the full URL."
-    ;;
-  *)
-    die "URL must start with http:// or https:// — got: $url"
-    ;;
+  http://*|https://*) ;;
+  *) die "URL must start with http:// or https:// — got: $url" ;;
 esac
+
+# Normalize: the Chorus MCP endpoint lives under /api/mcp. If the user gave us
+# just a host (or a host with trailing slash, or any path that doesn't already
+# end in /api/mcp), append it so the MCP handshake hits the right route.
+case "$url" in
+  */api/mcp) ;;
+  */api/mcp/) url="${url%/}" ;;
+  */) url="${url}api/mcp" ;;
+  *)  url="${url}/api/mcp" ;;
+esac
+ok "MCP endpoint: $url"
 
 # ---------- step 4: write config.toml ----------
 hdr "4/5  Writing ~/.codex/config.toml"
@@ -126,11 +150,12 @@ fi
 tmp="$(mktemp "${TMPDIR:-/tmp}/chorus-config.XXXXXX")"
 awk '
   # A TOML table header line. Match [mcp_servers.chorus] and any
-  # [mcp_servers.chorus.<subtable>], set a flag that suppresses lines
-  # until the next [section] header appears.
-  /^\[mcp_servers\.chorus(\..*)?\][[:space:]]*$/ { skip = 1; next }
-  /^\[/                                             { skip = 0 }
-  skip != 1                                          { print }
+  # [mcp_servers.chorus.<subtable>], plus [plugins."chorus@chorus-plugins"],
+  # and suppress lines until the next [section] header appears.
+  /^\[mcp_servers\.chorus(\..*)?\][[:space:]]*$/           { skip = 1; next }
+  /^\[plugins\."chorus@chorus-plugins"\][[:space:]]*$/      { skip = 1; next }
+  /^\[/                                                      { skip = 0 }
+  skip != 1                                                   { print }
 ' "$CONFIG_TOML" > "$tmp"
 mv "$tmp" "$CONFIG_TOML"
 
@@ -146,9 +171,12 @@ url = "${url}"
 
 [mcp_servers.chorus.http_headers]
 Authorization = "Bearer ${apikey}"
+
+[plugins."chorus@chorus-plugins"]
+enabled = true
 TOML
 
-ok "Wrote [mcp_servers.chorus] → ${CONFIG_TOML}"
+ok "Wrote [mcp_servers.chorus] and [plugins.\"chorus@chorus-plugins\"] → ${CONFIG_TOML}"
 
 # ---------- step 5: install hooks ----------
 hdr "5/5  Installing Chorus hooks"

--- a/src/app/onboarding/components/InstallGuideStep.tsx
+++ b/src/app/onboarding/components/InstallGuideStep.tsx
@@ -49,6 +49,9 @@ export function InstallGuideStep({ apiKey, onNext, onBack }: InstallGuideStepPro
               <TabsTrigger value="claude-code" className="flex-1">
                 {t("install.tabs.claudeCode")}
               </TabsTrigger>
+              <TabsTrigger value="codex" className="flex-1">
+                {t("install.tabs.codex")}
+              </TabsTrigger>
               <TabsTrigger value="openclaw" className="flex-1">
                 {t("install.tabs.openClaw")}
               </TabsTrigger>
@@ -80,6 +83,44 @@ export function InstallGuideStep({ apiKey, onNext, onBack }: InstallGuideStepPro
                   language="bash"
                   code={`/plugin marketplace add Chorus-AIDLC/chorus\n/plugin install chorus@chorus-plugins`}
                 />
+              </div>
+            </TabsContent>
+
+            {/* Codex Tab */}
+            <TabsContent value="codex" className="mt-4 space-y-4">
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-foreground">
+                  {t("install.codex.step1Title")}
+                </h3>
+                <CodeBlock
+                  language="bash"
+                  code={`export CHORUS_URL="${origin}"\nexport CHORUS_API_KEY="${displayKey}"`}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {t("install.codex.step1Tip")}
+                </p>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-foreground">
+                  {t("install.codex.step2Title")}
+                </h3>
+                <CodeBlock
+                  language="bash"
+                  code={`curl -fsSL ${origin}/install-codex.sh | bash`}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {t("install.codex.step2Tip")}
+                </p>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-foreground">
+                  {t("install.codex.step3Title")}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  {t("install.codex.step3Desc")}
+                </p>
               </div>
             </TabsContent>
 


### PR DESCRIPTION
Promoting #224 from `develop` to `main`.

## Summary

- Onboarding **Install Guide** now shows a **Codex** tab between Claude Code and OpenClaw, with a 3-step one-shot installer flow (env vars → \`curl install-codex.sh | bash\` → natural-language verify)
- New \`docs/CONNECT_CLAUDE_CODE\`, \`CONNECT_CODEX\`, \`CONNECT_OTHER_AGENTS\` (en + zh) — per-client connect guides mirroring the in-app setup wizard
- \`README.md\` / \`README.zh.md\`: replaced the inline Claude-Code-only snippet with a pointer at Settings → Setup Guide plus a 3-row table linking to the per-client guides
- \`install-codex.sh\`: upgrade existing \`chorus-plugins\` marketplace registration instead of skipping; re-register if source differs; header-match regex is whitespace-tolerant; docstring updated to reflect the current mechanism

## Test plan

- [x] Onboarding step 4 renders \`Claude Code → Codex → OpenClaw → Other Agents\` in both \`en\` and \`zh\` locales (Playwright against dev server)
- [x] Codex tab in both locales shows 3 steps with \`\${origin}\` / \`\${displayKey}\` interpolated; OpenClaw Troubleshooting collapsible unchanged
- [x] \`npx tsc --noEmit\` clean; \`pnpm lint\` introduces zero new errors
- [x] \`messages/{en,zh}.json\` are valid JSON
- [x] CI green on #224 against develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)