### PR TITLE
docs: sync v0.6.7 release blog to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ## What's New
 
+**[v0.6.7](https://chorus-ai.dev/blog/chorus-v0.6.7-release/)** — Chorus plugin for Codex CLI (one-command installer), workspace picker when one email belongs to multiple Companies, per-client connect guides.
+
 **[v0.6.6](https://chorus-ai.dev/blog/chorus-v0.6.6-release/)** — npm one-click install (`npx @chorus-aidlc/chorus`), document export (MD/PDF/Word), proposal revoke, faster agent checkin with work status at a glance.
 
 **[v0.6.2](https://chorus-ai.dev/blog/chorus-v0.6.2-release/)** — Embedded PGlite mode (zero-dependency deployment), structured logging with Pino, stateless MCP for horizontal scaling, default port changed to 8637.

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,6 +26,8 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ## 最近更新
 
+**[v0.6.7](https://chorus-ai.dev/zh/blog/chorus-v0.6.7-release/)** — Codex CLI 版 Chorus 插件（一条命令装完）、同一邮箱属于多个 Company 时的工作区选择器、每种客户端的接入文档。
+
 **[v0.6.6](https://chorus-ai.dev/zh/blog/chorus-v0.6.6-release/)** — npm 一键安装（`npx @chorus-aidlc/chorus`）、文档导出（MD/PDF/Word）、Proposal 撤回、优化 Agent Checkin 快速获取工作状态。
 
 **[v0.6.2](https://chorus-ai.dev/zh/blog/chorus-v0.6.2-release/)** — 嵌入式 PGlite 模式（零依赖部署）、Pino 结构化日志、无状态 MCP 支持水平扩展、默认端口改为 8637。

--- a/packages/landing/src/content/blog/chorus-v0.6.7-release.md
+++ b/packages/landing/src/content/blog/chorus-v0.6.7-release.md
@@ -1,0 +1,71 @@
+---
+title: "Chorus v0.6.7: Codex Users, We Got You"
+description: "The Chorus plugin was Claude-Code-only. Now Codex CLI gets it too, one command away."
+date: 2026-04-28
+lang: en
+postSlug: chorus-v0.6.7-release
+---
+
+# Chorus v0.6.7: Codex Users, We Got You
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.6.7 is out. One headline change: the Chorus plugin now works on Codex CLI too.
+
+---
+
+## "I'm on Codex — can I still use it?"
+
+From v0.6.0 through v0.6.6, the Chorus plugin was Claude-Code-only. Codex CLI users kept asking, and the answer was always the same: "MCP works, the plugin doesn't."
+
+But MCP just exposes the tools. The thing that actually makes Chorus pleasant is the plugin: it checks in at the right moments, nudges sub-agents to review, follows task state as you move through the flow. When the plugin quietly handles all that in the background, everything feels smooth. Without it, you're stitching the workflow together by hand. Codex users were getting half a product.
+
+v0.6.7 closes that gap.
+
+---
+
+## One command on Codex
+
+```bash
+bash <(curl -fsSL $CHORUS_URL/install-codex.sh)
+```
+
+The installer edits your `~/.codex/config.toml`, wires up MCP and hooks, and drops in 7 workflow skills (chorus/idea/proposal/develop/review/quick-dev/yolo) plus 2 reviewer skills. Run it once. Run it again if you want — it's idempotent. Restart Codex and you're in.
+
+One thing to watch: Codex invokes skills differently than Claude Code. Where you'd type `/chorus:develop` in Claude Code, you type `$develop` in Codex. Same content, different prefix.
+
+If you'd rather click than type commands, the Chorus Install Guide now has a Codex tab sitting between Claude Code and OpenClaw. Copy key, run installer, test connection — three steps.
+
+---
+
+## Also in this release
+
+- **Workspace picker**: When one email belongs to multiple Companies, the login flow lets you pick which workspace to enter. No more juggling accounts.
+- **Logout no longer signs you out of the IdP**: Clearing the local session is enough. The IdP SSO session stays, so the next login can go silent.
+- **Better connect docs**: New `CONNECT_CLAUDE_CODE` / `CONNECT_CODEX` / `CONNECT_OTHER_AGENTS` guides (en + zh) walk through each client path end to end.
+
+---
+
+## Upgrade
+
+```bash
+npx @chorus-aidlc/chorus@latest
+```
+
+Claude Code plugin:
+
+```bash
+/plugin marketplace update chorus-plugins
+```
+
+Codex CLI plugin:
+
+```bash
+bash <(curl -fsSL $CHORUS_URL/install-codex.sh)
+```
+
+v0.6.7 is on [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.7) and [npm](https://www.npmjs.com/package/@chorus-aidlc/chorus).
+
+Questions or feedback? [GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) or [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions).
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.6.7](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.7)

--- a/packages/landing/src/content/blog/zh-chorus-v0.6.7-release.md
+++ b/packages/landing/src/content/blog/zh-chorus-v0.6.7-release.md
@@ -1,0 +1,71 @@
+---
+title: "Chorus v0.6.7: Codex 用户，我们来了"
+description: "之前 Chorus 的插件只给 Claude Code 用。现在 Codex CLI 也能一行命令接入。"
+date: 2026-04-28
+lang: zh
+postSlug: chorus-v0.6.7-release
+---
+
+# Chorus v0.6.7: Codex 用户，我们来了
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.6.7 发布。这个版本主要做了一件事：Codex CLI 也能用上 Chorus 插件了。
+
+---
+
+## "我用的是 Codex，能接吗？"
+
+从 v0.6.0 到 v0.6.6，Chorus 的插件一直只对 Claude Code 开放。Codex CLI 用户每次问起来，答案都是"可以接 MCP，但插件用不了"。
+
+但 MCP 只是把工具暴露出来。真正让 Chorus 好用的是插件：它会在合适的时机自动 checkin、提醒 sub-agent 去 review、跟着任务状态走。插件在后台默默做完这些，用起来就很顺；没有这些，整个流程就得手动一步步敲命令串起来。Codex 用户之前拿到的，是半成品。
+
+v0.6.7 把这个缺口补上。
+
+---
+
+## 一行命令接入 Codex
+
+```bash
+bash <(curl -fsSL $CHORUS_URL/install-codex.sh)
+```
+
+脚本会帮你改好 `~/.codex/config.toml`，把 MCP 和 hooks 接上，再装好 7 个工作流 skill（chorus/idea/proposal/develop/review/quick-dev/yolo）和 2 个 reviewer skill。跑一次就行，重复跑也没问题。重启 Codex 就能用。
+
+有一点要注意：Codex 的 skill 调用跟 Claude Code 不一样。Claude Code 里输 `/chorus:develop`，Codex 里输 `$develop`。内容一样，前缀不同。
+
+不想记命令也行，Chorus 里的 Install Guide 现在有 Codex 这一栏，夹在 Claude Code 和 OpenClaw 中间，复制 key、跑 installer、测连接，三步点完就行。
+
+---
+
+## 其他
+
+- **工作区选择器**：同一个邮箱属于多个 Company 时，登录页会让你挑进哪个 workspace，不用再换号。
+- **Logout 不再 signout IdP**：登出只清本地 session，IdP 那边的 SSO session 留着，下次静默续上。
+- **更完整的连接文档**：新增 `CONNECT_CLAUDE_CODE` / `CONNECT_CODEX` / `CONNECT_OTHER_AGENTS` 三份中英文档，每种客户端的接入路径都讲清楚。
+
+---
+
+## 升级
+
+```bash
+npx @chorus-aidlc/chorus@latest
+```
+
+Claude Code 插件：
+
+```bash
+/plugin marketplace update chorus-plugins
+```
+
+Codex CLI 插件：
+
+```bash
+bash <(curl -fsSL $CHORUS_URL/install-codex.sh)
+```
+
+v0.6.7 已发布到 [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.7) 和 [npm](https://www.npmjs.com/package/@chorus-aidlc/chorus)。
+
+有问题或反馈？[GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) 或 [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions)。
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.6.7](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.6.7)


### PR DESCRIPTION
## Summary
- Sync v0.6.7 release blog + README "What's New" entries from develop to main

## Commits
- `a3c060d` docs: add v0.6.7 release blog and README entries (#229)

## Test plan
- [ ] CI passes
- [ ] Merged with a merge commit (not squashed) to preserve per-PR history on main

Generated with [Claude Code](https://claude.com/claude-code)