### PR TITLE
feat(authz): fine-grained agent permissions (0.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -4,13 +4,81 @@ This document covers all tools provided by the Chorus MCP Server, including tool
 
 ## Overview
 
-The Chorus MCP Server provides different tool sets based on Agent roles:
+Tool visibility is driven by a **fine-grained permission model**: 5 resources (`idea`, `proposal`, `document`, `task`, `project`) × 3 actions (`read`, `write`, `admin`) = **15 permissions**. Each gated tool declares a single **required permission**. Public tools (discover, comment, session) carry no gate and are always available.
+
+Agents may use a **role preset** (`developer_agent`, `pm_agent`, `admin_agent`) that expands to a fixed permission set, and/or **custom permissions** added on top. The effective permission set is the union of preset + custom. See `src/lib/authz/presets.ts` for the authoritative preset mapping, `src/mcp/tools/permission-map.ts` for the tool → permission map, and [ARCHITECTURE.md §6.3](./ARCHITECTURE.md#63-permission-model) for the conceptual overview.
+
+### Role Preset → Permission Set
+
+| Preset | Permission Set |
+|--------|----------------|
+| `developer_agent` | `*:read` + `task:write` (6 perms) |
+| `pm_agent` | `*:read` + `idea:write`, `proposal:write`, `document:write`, `task:write`, `project:write` (10 perms) |
+| `admin_agent` | all 15 perms (`*:read` + `*:write` + `*:admin`) |
+
+Read-only tools (`chorus_get_*`, `chorus_list_*`, `chorus_checkin`, `chorus_search*`, comments, elaboration answers, session management, `chorus_create_tasks`, `chorus_update_task`) are **public** and available to any agent regardless of preset/permissions — they are listed under "Public Tools" and "Session Tools" below without a Required Permission row.
+
+> Note: `chorus_create_tasks` and `chorus_update_task` field edits are public because handler-level assignee / authorship guards enforce who can actually mutate state. Operational status transitions (`in_progress`, `to_verify`) still require the caller to be the task's assignee at the service layer — the permission gate is about tool visibility, not operation authorization.
+
+### Gated Tool → Required Permission Matrix
+
+The following table summarizes every permission-gated MCP tool. Each tool has exactly one required permission; possessing that permission (via preset or custom) is the **necessary** condition for the tool to appear in the agent's tool list. Additional handler-level guards (ownership, assignee, status) may still apply.
+
+| Tool | Required Permission |
+|------|---------------------|
+| `chorus_claim_idea` | `idea:write` |
+| `chorus_release_idea` | `idea:write` |
+| `chorus_move_idea` | `idea:write` |
+| `chorus_pm_create_idea` | `idea:write` |
+| `chorus_pm_start_elaboration` | `idea:write` |
+| `chorus_pm_validate_elaboration` | `idea:write` |
+| `chorus_pm_skip_elaboration` | `idea:write` |
+| `chorus_pm_create_proposal` | `proposal:write` |
+| `chorus_pm_validate_proposal` | `proposal:write` |
+| `chorus_pm_submit_proposal` | `proposal:write` |
+| `chorus_pm_add_document_draft` | `proposal:write` |
+| `chorus_pm_add_task_draft` | `proposal:write` |
+| `chorus_pm_update_document_draft` | `proposal:write` |
+| `chorus_pm_update_task_draft` | `proposal:write` |
+| `chorus_pm_remove_document_draft` | `proposal:write` |
+| `chorus_pm_remove_task_draft` | `proposal:write` |
+| `chorus_pm_reject_proposal` | `proposal:write` |
+| `chorus_pm_revoke_proposal` | `proposal:write` |
+| `chorus_pm_create_tasks` | `proposal:write` |
+| `chorus_add_task_dependency` | `proposal:write` |
+| `chorus_remove_task_dependency` | `proposal:write` |
+| `chorus_pm_assign_task` | `proposal:write` |
+| `chorus_pm_create_document` | `document:write` |
+| `chorus_pm_update_document` | `document:write` |
+| `chorus_claim_task` | `task:write` |
+| `chorus_release_task` | `task:write` |
+| `chorus_submit_for_verify` | `task:write` |
+| `chorus_report_criteria_self_check` | `task:write` |
+| `chorus_report_work` | `task:write` |
+| `chorus_admin_create_project` | `project:write` |
+| `chorus_admin_create_project_group` | `project:write` |
+| `chorus_admin_update_project_group` | `project:write` |
+| `chorus_admin_delete_project_group` | `project:write` |
+| `chorus_admin_move_project_to_group` | `project:write` |
+| `chorus_admin_approve_proposal` | `proposal:admin` |
+| `chorus_admin_close_proposal` | `proposal:admin` |
+| `chorus_admin_verify_task` | `task:admin` |
+| `chorus_admin_reopen_task` | `task:admin` |
+| `chorus_admin_close_task` | `task:admin` |
+| `chorus_mark_acceptance_criteria` | `task:admin` |
+| `chorus_admin_delete_task` | `task:admin` |
+| `chorus_admin_delete_idea` | `idea:admin` |
+| `chorus_admin_delete_document` | `document:admin` |
+
+### Legacy Role → Tool Set View
+
+For agents that rely on the preset alone (no custom permissions), this is the resulting tool set:
 
 | Role | Tool Set |
 |------|----------|
-| Developer Agent | Public + Session + Developer |
-| PM Agent | Public + Session + PM |
-| Admin Agent | Public + Session + Admin + PM + Developer |
+| Developer Agent | Public + Session + Developer (`task:write` tools) |
+| PM Agent | Public + Session + PM (`idea:write` + `proposal:write` + `document:write` + `task:write` + `project:write` tools — includes Developer's `task:write` tools and `project:write` project-management tools) |
+| Admin Agent | Public + Session + PM + Developer + Admin (all 15 permissions) |
 
 ## Project Filtering
 
@@ -738,6 +806,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Claim an Idea (open → elaborating). Claiming automatically transitions the Idea to 'elaborating' status. After claiming, start elaboration with chorus_pm_start_elaboration or skip with chorus_pm_skip_elaboration.
 
+**Required Permission**: `idea:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -749,28 +819,20 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Release a claimed Idea (elaborating → open)
 
-**Input**:
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| ideaUuid | string | Yes | Idea UUID |
-
-**Output**: Updated Idea JSON
-
-### chorus_update_idea_status
-
-**Description**: Update Idea status (only the assignee can perform this). Valid statuses: open, elaborating, proposal_created, completed, closed. Claiming auto-transitions to elaborating; use this tool for proposal_created (after Proposal submission) or completed (after approval).
+**Required Permission**: `idea:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | ideaUuid | string | Yes | Idea UUID |
-| status | enum | Yes | New status: proposal_created, completed |
 
 **Output**: Updated Idea JSON
 
 ### chorus_pm_create_proposal
 
 **Description**: Create a proposal container (can include document drafts and task drafts)
+
+**Required Permission**: `proposal:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -788,6 +850,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_validate_proposal
 
 **Description**: Validate a Proposal's completeness before submission. Returns errors (block submission), warnings (advisory), and info (hints). Call this before `chorus_pm_submit_proposal` to preview validation issues.
+
+**Required Permission**: `proposal:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -837,6 +901,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Submit a Proposal for approval (draft → pending). Runs `chorus_pm_validate_proposal` internally and rejects with a formatted error if any error-level issues are found. Call `chorus_pm_validate_proposal` first to preview issues before submitting.
 
+**Required Permission**: `proposal:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -847,6 +913,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_create_document
 
 **Description**: Create a document (PRD, technical design, ADR, etc.)
+
+**Required Permission**: `document:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -862,6 +930,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_create_tasks
 
 **Description**: Batch create tasks (can be associated with a Proposal, supports intra-batch dependencies)
+
+**Required Permission**: `proposal:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -899,6 +969,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Update document content (increments version number)
 
+**Required Permission**: `document:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -911,6 +983,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_add_document_draft
 
 **Description**: Add a document draft to a pending Proposal container
+
+**Required Permission**: `proposal:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -925,6 +999,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_add_task_draft
 
 **Description**: Add a task draft to a pending Proposal container
+
+**Required Permission**: `proposal:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -944,6 +1020,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Update a document draft in a Proposal
 
+**Required Permission**: `proposal:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -958,6 +1036,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_update_task_draft
 
 **Description**: Update a task draft in a Proposal
+
+**Required Permission**: `proposal:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -977,6 +1057,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Remove a document draft from a Proposal
 
+**Required Permission**: `proposal:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -989,6 +1071,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Remove a task draft from a Proposal
 
+**Required Permission**: `proposal:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1000,6 +1084,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_add_task_dependency
 
 **Description**: Add a task dependency (taskUuid depends on dependsOnTaskUuid). Includes same-project validation, self-dependency check, and DFS cycle detection.
+
+**Required Permission**: `proposal:write` (kept out of `task:write` to preserve 0.6.x developer boundaries — see `permission-map.ts`)
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1026,6 +1112,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Remove a task dependency
 
+**Required Permission**: `proposal:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1045,6 +1133,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Assign a task to a specified Developer Agent (task must be in open or assigned status)
 
+**Required Permission**: `proposal:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1061,6 +1151,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_start_elaboration
 
 **Description**: Start an elaboration round for an Idea. Creates structured questions for the Idea creator/stakeholder to answer, clarifying requirements before proposal creation. Recommended for every Idea. Structured elaboration improves Proposal quality and reduces rejection cycles.
+
+**Required Permission**: `idea:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1091,6 +1183,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Validate answers from an elaboration round. If no issues are found, the elaboration is marked as resolved. If issues exist, optionally provide follow-up questions for a new round.
 
+**Required Permission**: `idea:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1114,6 +1208,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Skip elaboration for an Idea (marks as resolved with minimal depth). Use only for trivially clear Ideas (e.g., bug fixes with clear reproduction steps). A reason is required and logged in the activity stream. Prefer chorus_pm_start_elaboration for most Ideas.
 
+**Required Permission**: `idea:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1133,6 +1229,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Move an Idea to a different project within the same company. Also moves linked draft/pending Proposals.
 
+**Required Permission**: `idea:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1144,6 +1242,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_create_idea
 
 **Description**: Create an Idea in a project (submit requirements on behalf of humans or from discovered requirements)
+
+**Required Permission**: `idea:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1157,6 +1257,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 ### chorus_pm_reject_proposal
 
 **Description**: Reject a Proposal (pending -> draft). PM agents can only reject their own proposals; admin agents can reject any proposal. The reviewNote is preserved as reference.
+
+**Required Permission**: `proposal:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1172,6 +1274,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Description**: Revoke an approved Proposal (approved -> draft). PM agents can only revoke their own proposals; admin agents can revoke any proposal. Cascade-closes all materialized Tasks and deletes all materialized Documents.
 
+**Required Permission**: `proposal:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1186,11 +1290,15 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 ## Developer Agent Tools
 
-Available to Developer Agent and Admin Agent. Not available to PM Agent.
+Tools gated by `task:write`. Available to any agent whose effective permissions include `task:write` — by default this is `developer_agent`, `pm_agent`, and `admin_agent` presets, plus any custom agent with `task:write` added.
+
+> Note: `task:write` grants tool visibility. Handler-level guards still enforce that only the assignee can execute operational transitions (e.g., `chorus_submit_for_verify`, `chorus_report_work`) — a `pm_agent` cannot operate on a task unless they have claimed/been assigned it.
 
 ### chorus_claim_task
 
 **Description**: Claim a Task (open → assigned)
+
+**Required Permission**: `task:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1203,6 +1311,8 @@ Available to Developer Agent and Admin Agent. Not available to PM Agent.
 
 **Description**: Release a claimed Task (assigned → open)
 
+**Required Permission**: `task:write`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1212,7 +1322,9 @@ Available to Developer Agent and Admin Agent. Not available to PM Agent.
 
 ### chorus_update_task
 
-**Description**: Update task status (only the assignee can perform this)
+**Description**: Update task status and fields (only the assignee can perform status transitions; any agent with read access can edit fields like title, description, priority, storyPoints).
+
+> **Public tool** — not permission-gated. Available to every agent. Handler-level guards enforce that only the assignee can transition `status`. Moved from developer tools to public in 0.7.0 as part of the permission refactor.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1231,6 +1343,8 @@ Available to Developer Agent and Admin Agent. Not available to PM Agent.
 
 **Description**: Submit a task for human verification (in_progress → to_verify)
 
+**Required Permission**: `task:write` (handler also checks caller is the assignee)
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1242,6 +1356,8 @@ Available to Developer Agent and Admin Agent. Not available to PM Agent.
 ### chorus_report_work
 
 **Description**: Report work progress or completion
+
+**Required Permission**: `task:write` (handler also checks caller is the assignee)
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1259,11 +1375,13 @@ Available to Developer Agent and Admin Agent. Not available to PM Agent.
 
 ## Admin Agent Tools
 
-Available only to Admin Agent. Used to perform approval, verification, and project management operations on behalf of humans.
+Tools gated by one of the `*:admin` permissions or `project:write`. Available to any agent whose effective permissions cover the required permission listed under each tool. The `admin_agent` preset carries all `*:admin` permissions, but individual admin tools can be granted to other agents via custom permissions.
 
 ### chorus_admin_create_project
 
 **Description**: Create a new project
+
+**Required Permission**: `project:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1276,6 +1394,8 @@ Available only to Admin Agent. Used to perform approval, verification, and proje
 ### chorus_admin_approve_proposal
 
 **Description**: Approve a Proposal
+
+**Required Permission**: `proposal:admin`
 
 **Important behavior**: Upon approval, the system automatically materializes all drafts in the Proposal into actual resources:
 - `documentDrafts` → Automatically creates corresponding Documents (linked to this Proposal)
@@ -1291,9 +1411,25 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 **Output**: Updated Proposal JSON
 
+### chorus_admin_close_proposal
+
+**Description**: Close a Proposal (pending → closed). Permanently closes the proposal; cannot be edited after.
+
+**Required Permission**: `proposal:admin`
+
+**Input**:
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| proposalUuid | string | Yes | Proposal UUID |
+| reviewNote | string | Yes | Reason for closing |
+
+**Output**: Updated Proposal JSON (`{ uuid, status: "closed" }`)
+
 ### chorus_report_criteria_self_check
 
 **Description**: Report self-check results on acceptance criteria for a task (Developer tool)
+
+**Required Permission**: `task:write` (handler also checks caller is the assignee)
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1307,6 +1443,8 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 **Description**: Mark acceptance criteria as passed or failed during admin verification (batch)
 
+**Required Permission**: `task:admin` (kept out of `task:write` so developer preset cannot self-approve — see `permission-map.ts`)
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1319,6 +1457,8 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 **Description**: Verify a Task (to_verify → done). **Acceptance criteria gate**: If the task has structured acceptance criteria, all required criteria must have `status: "passed"` before verification is allowed. Tasks without structured criteria are not gated (backward compatible).
 
+**Required Permission**: `task:admin`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1329,6 +1469,8 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 ### chorus_admin_reopen_task
 
 **Description**: Reopen a Task (to_verify → in_progress, used when verification fails). If the task has unresolved dependencies, use `force=true` to bypass the dependency check.
+
+**Required Permission**: `task:admin`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1342,6 +1484,8 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 **Description**: Close a Task (any status → closed)
 
+**Required Permission**: `task:admin`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1349,20 +1493,11 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 **Output**: Updated Task JSON
 
-### chorus_admin_close_idea
-
-**Description**: Close an Idea (any status → closed)
-
-**Input**:
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| ideaUuid | string | Yes | Idea UUID |
-
-**Output**: Updated Idea JSON
-
 ### chorus_admin_delete_idea
 
 **Description**: Delete an Idea
+
+**Required Permission**: `idea:admin`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1375,6 +1510,8 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 **Description**: Delete a Task
 
+**Required Permission**: `task:admin`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1386,6 +1523,8 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 **Description**: Delete a Document
 
+**Required Permission**: `document:admin`
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1395,7 +1534,9 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 ### chorus_admin_create_project_group
 
-**Description**: Create a new project group (Admin exclusive)
+**Description**: Create a new project group
+
+**Required Permission**: `project:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1407,7 +1548,9 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 ### chorus_admin_update_project_group
 
-**Description**: Update a project group (Admin exclusive)
+**Description**: Update a project group
+
+**Required Permission**: `project:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1420,7 +1563,9 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 ### chorus_admin_delete_project_group
 
-**Description**: Delete a project group (Admin exclusive). Projects in the group become ungrouped.
+**Description**: Delete a project group. Projects in the group become ungrouped.
+
+**Required Permission**: `project:write`
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -1431,7 +1576,9 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 
 ### chorus_admin_move_project_to_group
 
-**Description**: Move a project to a different group or ungroup it (Admin exclusive). Set groupUuid to null to ungroup.
+**Description**: Move a project to a different group or ungroup it. Set groupUuid to null to ungroup.
+
+**Required Permission**: `project:write`
 
 **Input**:
 | Parameter | Type | Required | Description |

--- a/docs/design.pen
+++ b/docs/design.pen
@@ -79959,6 +79959,4387 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "GzE00",
+      "x": 3080,
+      "y": 6680,
+      "name": "Modal - Create Agent (v0.7.0 Permissions)",
+      "width": 1440,
+      "height": 820,
+      "fill": "#FAF8F4",
+      "children": [
+        {
+          "type": "frame",
+          "id": "o6Oq2T",
+          "name": "Overlay",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#00000040",
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "x7zRE1",
+              "name": "Modal",
+              "width": 480,
+              "fill": "#FFFFFF",
+              "cornerRadius": 16,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "k2KZgK",
+                  "name": "Modal Header",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F5F2EC"
+                  },
+                  "padding": [
+                    20,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "mcUwF",
+                      "name": "modalTitle",
+                      "fill": "#2C2C2C",
+                      "content": "Create Agent",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "h7qSu",
+                      "name": "closeBtn",
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "ls24P",
+                          "name": "closeIcon",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9A9A"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "c6J1o",
+                  "name": "Modal Body",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nZ0Ap",
+                      "name": "Name Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "R0C1GD",
+                          "name": "nameLabel",
+                          "fill": "#2C2C2C",
+                          "content": "Name",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JjUAb",
+                          "name": "nameInput",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E5E0D8"
+                          },
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "tgSbV",
+                              "name": "nameInputText",
+                              "fill": "#2C2C2C",
+                              "content": "My Agent Key",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "z04pNy",
+                      "name": "Roles Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "W0mcc2",
+                          "name": "rolesLabel",
+                          "fill": "#2C2C2C",
+                          "content": "Permissions",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Cm1Oq",
+                          "name": "rolesDesc",
+                          "fill": "#6B6B6B",
+                          "content": "Start from a preset, or customize the permission matrix directly.",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "dpPV2",
+                          "name": "AgentPermissionPicker",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "JKi0y",
+                              "name": "Preset Row",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "IcB5e",
+                                  "name": "presetLabel",
+                                  "fill": "#6B6B6B",
+                                  "content": "Preset",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "hAEY0",
+                                  "name": "Preset Menu (open)",
+                                  "clip": true,
+                                  "width": "fill_container",
+                                  "fill": "#FFFFFF",
+                                  "cornerRadius": 8,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#E5E0D8"
+                                  },
+                                  "layout": "vertical",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "zcNyN",
+                                      "name": "opt-admin",
+                                      "width": "fill_container",
+                                      "fill": "#FAF8F4",
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "h5ga4x",
+                                          "name": "cOpt1L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "ksS79",
+                                              "name": "cOpt1T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Admin",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "oWhD7",
+                                              "name": "cOpt1D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Full access — idea/proposal/document/task/project read, write, admin",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "FYgZv",
+                                          "name": "cOpt1Chk",
+                                          "width": 16,
+                                          "height": 16,
+                                          "iconFontName": "check",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#C67A52"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "MsrxA",
+                                      "name": "opt-pm",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "c0Lwc",
+                                          "name": "cOpt2L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "e0YeJg",
+                                              "name": "cOpt2T",
+                                              "fill": "#2C2C2C",
+                                              "content": "PM",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "vONFs",
+                                              "name": "cOpt2D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Idea/proposal/document/task/project read and write (no admin)",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "mlJyq",
+                                      "name": "opt-dev",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "owNb9",
+                                          "name": "cOpt3L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "Q3qDKC",
+                                              "name": "cOpt3T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Developer",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "cnoBe",
+                                              "name": "cOpt3D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Read most resources; write tasks only",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "lKBY6",
+                                      "name": "opt-custom",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "ZJh76",
+                                          "name": "cOpt4L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "odOdI",
+                                              "name": "cOpt4T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Custom",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "xZ3uO",
+                                              "name": "cOpt4D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Hand-pick any combination of the 15 permission bits",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "b5xGr",
+                              "name": "Permission Matrix",
+                              "clip": true,
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "cornerRadius": 10,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#E5E0D8"
+                              },
+                              "layout": "vertical",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "LNIBV",
+                                  "name": "Matrix Header",
+                                  "width": "fill_container",
+                                  "fill": "#FAF8F4",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "tVP3Y",
+                                      "name": "h-resource",
+                                      "width": "fill_container",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "pv30v",
+                                          "name": "hCell0Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "Resource",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "g7Q5g",
+                                      "name": "h-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "DC6bC",
+                                          "name": "hCell1Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "read",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "WBW66",
+                                      "name": "h-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "GkjgW",
+                                          "name": "hCell2Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "write",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Rt6Fb",
+                                      "name": "h-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "pkKZc",
+                                          "name": "hCell3Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "admin",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "E98xm",
+                                  "name": "row-idea",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "F1B95O",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "Gpgma",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "idea",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "wi9uf",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "TIQ7x",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "Cx1UG",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "torza",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "kLGXf",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "rHEh3",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Tqu1r",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "Sg0QH",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "vyswJ",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "d3Bmmd",
+                                  "name": "row-proposal",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "wQttM",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "fPVDK",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "proposal",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "A8Y71j",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "mHZzR",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "V6B4G",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "a0v2tB",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "SLMww",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "hcqxS",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "X1T4wE",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "KlV9s",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "afH1Q",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "n0Src",
+                                  "name": "row-document",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "b2Px9O",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "hqpwh",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "document",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "jLPrA",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "IDeUp",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "f0zFfJ",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "kdV5f",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "tJGlp",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "k70aPj",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "SJ9Fn",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "xBP3z",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "mcjGM",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "ulRPf",
+                                  "name": "row-task",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "CeWmy",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "EOIWt",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "task",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "iwzU1",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "Z2YC65",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "y8fhQ",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "F2OC7",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "KhT24",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "a3khD",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "zDsHX",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "KILlr",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "LFBRN",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "UeH3H",
+                                  "name": "row-project",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 0
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "EZXCd",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "gp3nj",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "project",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "dwEm0",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "mBWno",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "KbRnN",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "cNont",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "B2KS8l",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "M51Kg",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "FLP5N",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "v5eJio",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "K0iFo",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E1L1u",
+                      "name": "Persona Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "J4Y9Ky",
+                          "name": "personaHeader",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gp9jw",
+                              "name": "personaLabel",
+                              "fill": "#2C2C2C",
+                              "content": "Agent Persona",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "k4JwQ",
+                              "name": "zeroBadge",
+                              "fill": "#E8F5E9",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "G882D",
+                                  "name": "badgeText",
+                                  "fill": "#5A9E6F",
+                                  "content": "Zero Context Injection",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "kfeyJ",
+                          "name": "personaDesc",
+                          "fill": "#6B6B6B",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Define the agent's personality and behavior. This will be automatically injected when the agent checks in.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "UQ8kR",
+                          "name": "personaPresets",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zUOfa",
+                              "name": "preset1",
+                              "fill": "#C67A52",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "pF5aD",
+                                  "name": "preset1Text",
+                                  "fill": "#FFFFFF",
+                                  "content": "UX-Focused PM",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "wk4m9",
+                              "name": "preset2",
+                              "fill": "#F5F2EC",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "k0OIj",
+                                  "name": "preset2Text",
+                                  "fill": "#6B6B6B",
+                                  "content": "Tech-Savvy PM",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "jHH8S",
+                              "name": "preset3",
+                              "fill": "#F5F2EC",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "pmwhp",
+                                  "name": "preset3Text",
+                                  "fill": "#6B6B6B",
+                                  "content": "Quality Dev",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "F1sYH",
+                          "name": "personaInput",
+                          "width": "fill_container",
+                          "height": 80,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E5E0D8"
+                          },
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "WgMV9",
+                              "name": "personaInputText",
+                              "fill": "#2C2C2C",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "You are a product manager who prioritizes user experience above all. You always consider the end-user perspective and advocate for intuitive designs.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZNZJb",
+                  "name": "Modal Footer",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#F5F2EC"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "AZvB4",
+                      "name": "cancelBtn",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#E5E0D8"
+                      },
+                      "padding": [
+                        10,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Pp5NJ",
+                          "name": "cancelText",
+                          "fill": "#6B6B6B",
+                          "content": "Cancel",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N4Xltp",
+                      "name": "createBtn",
+                      "fill": "#C67A52",
+                      "cornerRadius": 8,
+                      "padding": [
+                        10,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vTqy9",
+                          "name": "createText",
+                          "fill": "#FFFFFF",
+                          "content": "Create Agent",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "g9xEOQ",
+      "x": 4620,
+      "y": 6680,
+      "name": "Modal - Edit Agent (v0.7.0 Permissions)",
+      "width": 1440,
+      "height": 900,
+      "fill": "#FAF8F4",
+      "children": [
+        {
+          "type": "frame",
+          "id": "iJniq",
+          "name": "Overlay",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#00000040",
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "WoRw6",
+              "name": "Modal",
+              "width": 520,
+              "fill": "#FFFFFF",
+              "cornerRadius": 16,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "iRngX",
+                  "name": "Modal Header",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F5F2EC"
+                  },
+                  "padding": [
+                    20,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "zjeSS",
+                      "name": "modalTitle",
+                      "fill": "#2C2C2C",
+                      "content": "Edit Agent",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xiqFk",
+                      "name": "closeBtn",
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "HBgGm",
+                          "name": "closeIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9A9A"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "L59Dr9",
+                  "name": "Modal Body",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tgbOR",
+                      "name": "Name Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Uf8a3",
+                          "name": "nameLabel",
+                          "fill": "#2C2C2C",
+                          "content": "Name",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZeI11",
+                          "name": "nameInput",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E5E0D8"
+                          },
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "zUI79",
+                              "name": "nameInputText",
+                              "fill": "#2C2C2C",
+                              "content": "Alice's Dev Agent",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Zl7w4",
+                      "name": "Roles Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dTffg",
+                          "name": "rolesLabel",
+                          "fill": "#2C2C2C",
+                          "content": "Permissions",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "F3v6O",
+                          "name": "rolesDesc",
+                          "fill": "#6B6B6B",
+                          "content": "This agent is on the PM preset. Switch to Custom to edit individual bits.",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "lKp7i",
+                          "name": "AgentPermissionPicker",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ygBsB",
+                              "name": "Preset Row",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "IkLQz",
+                                  "name": "epLabel",
+                                  "fill": "#6B6B6B",
+                                  "content": "Preset",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "QM8T4",
+                                  "name": "Preset Menu (open) - Edit",
+                                  "clip": true,
+                                  "width": "fill_container",
+                                  "fill": "#FFFFFF",
+                                  "cornerRadius": 8,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#E5E0D8"
+                                  },
+                                  "layout": "vertical",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "NOtYu",
+                                      "name": "opt-admin",
+                                      "width": "fill_container",
+                                      "fill": "#FFFFFF",
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "D0zXAD",
+                                          "name": "cOpt1L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "Jrk6j",
+                                              "name": "cOpt1T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Admin",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "hzeFL",
+                                              "name": "cOpt1D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Full access — idea/proposal/document/task/project read, write, admin",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Jj64G",
+                                      "name": "opt-pm",
+                                      "width": "fill_container",
+                                      "fill": "#FAF8F4",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "QgIwl",
+                                          "name": "cOpt2L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "LTaoH",
+                                              "name": "cOpt2T",
+                                              "fill": "#2C2C2C",
+                                              "content": "PM",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "ZOtsQ",
+                                              "name": "cOpt2D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Idea/proposal/document/task/project read and write (no admin)",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "CB1cd",
+                                          "name": "eChk",
+                                          "width": 16,
+                                          "height": 16,
+                                          "iconFontName": "check",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#C67A52"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "q680dV",
+                                      "name": "opt-dev",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "FhJqd",
+                                          "name": "cOpt3L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "t3HkQ",
+                                              "name": "cOpt3T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Developer",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "ZxEi5",
+                                              "name": "cOpt3D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Read most resources; write tasks only",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "K9KG6a",
+                                      "name": "opt-custom",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "wXMYt",
+                                          "name": "cOpt4L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "l5MwlQ",
+                                              "name": "cOpt4T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Custom",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "s3Mij",
+                                              "name": "cOpt4D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Hand-pick any combination of the 15 permission bits",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "K0FOe",
+                              "name": "Permission Matrix",
+                              "clip": true,
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "cornerRadius": 10,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#E5E0D8"
+                              },
+                              "layout": "vertical",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "fKMRh",
+                                  "name": "Matrix Header",
+                                  "width": "fill_container",
+                                  "fill": "#FAF8F4",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "UEAPc",
+                                      "name": "h-resource",
+                                      "width": "fill_container",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "x5YUmo",
+                                          "name": "ehc0t",
+                                          "fill": "#6B6B6B",
+                                          "content": "Resource",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "fWhD5",
+                                      "name": "h-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "xnsrM",
+                                          "name": "ehc1t",
+                                          "fill": "#6B6B6B",
+                                          "content": "read",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "UkB8l",
+                                      "name": "h-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "XaBwS",
+                                          "name": "ehc2t",
+                                          "fill": "#6B6B6B",
+                                          "content": "write",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "QgeBk",
+                                      "name": "h-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "UCBL9",
+                                          "name": "ehc3t",
+                                          "fill": "#6B6B6B",
+                                          "content": "admin",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "I8WctH",
+                                  "name": "row-idea",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "tJYPD",
+                                      "name": "er1c0",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "S8O0H",
+                                          "name": "er1c0t",
+                                          "fill": "#2C2C2C",
+                                          "content": "idea",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "A2iClN",
+                                      "name": "er1c1",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "Ueorp",
+                                          "name": "er1chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "ztMrU",
+                                              "name": "er1chk1i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "xy233",
+                                      "name": "er1c2",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "Ny0bq",
+                                          "name": "er1chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "exgXl",
+                                              "name": "er1chk2i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "WpRQW",
+                                      "name": "er1c3",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "A048u",
+                                          "name": "er1chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#F5F2EC",
+                                          "cornerRadius": 6,
+                                          "stroke": {
+                                            "thickness": 1,
+                                            "fill": "#E5E0D8"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "X6bHW",
+                                  "name": "row-proposal",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "F6zqAV",
+                                      "name": "er1c0",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "J0lQV",
+                                          "name": "er1c0t",
+                                          "fill": "#2C2C2C",
+                                          "content": "proposal",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "D1D2Q",
+                                      "name": "er1c1",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "S6Ved",
+                                          "name": "er1chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "jayYH",
+                                              "name": "er1chk1i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ljiEo",
+                                      "name": "er1c2",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "TToHk",
+                                          "name": "er1chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "l1YqSV",
+                                              "name": "er1chk2i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "d2JPt4",
+                                      "name": "er1c3",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "MaC2M",
+                                          "name": "er1chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#F5F2EC",
+                                          "cornerRadius": 6,
+                                          "stroke": {
+                                            "thickness": 1,
+                                            "fill": "#E5E0D8"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "E4e3My",
+                                  "name": "row-document",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "B2NPP",
+                                      "name": "er1c0",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "mCQ8f",
+                                          "name": "er1c0t",
+                                          "fill": "#2C2C2C",
+                                          "content": "document",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Avv4V",
+                                      "name": "er1c1",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "JuqwR",
+                                          "name": "er1chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "s8ZaX",
+                                              "name": "er1chk1i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "UuWd8",
+                                      "name": "er1c2",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "BgotC",
+                                          "name": "er1chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "cpGcD",
+                                              "name": "er1chk2i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "PVY2X",
+                                      "name": "er1c3",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "LJhvw",
+                                          "name": "er1chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#F5F2EC",
+                                          "cornerRadius": 6,
+                                          "stroke": {
+                                            "thickness": 1,
+                                            "fill": "#E5E0D8"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "oMMGV",
+                                  "name": "row-task",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "ENFgM",
+                                      "name": "er1c0",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "B5xrD",
+                                          "name": "er1c0t",
+                                          "fill": "#2C2C2C",
+                                          "content": "task",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ui3LF",
+                                      "name": "er1c1",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "cVIoB",
+                                          "name": "er1chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "HoeGP",
+                                              "name": "er1chk1i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "EvHzB",
+                                      "name": "er1c2",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "EkUa0",
+                                          "name": "er1chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "kzXvd",
+                                              "name": "er1chk2i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "fqwDT",
+                                      "name": "er1c3",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "d9t98",
+                                          "name": "er1chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#F5F2EC",
+                                          "cornerRadius": 6,
+                                          "stroke": {
+                                            "thickness": 1,
+                                            "fill": "#E5E0D8"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "UAvke",
+                                  "name": "row-project",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 0
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "a5IJwb",
+                                      "name": "er1c0",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "Y2hon",
+                                          "name": "er1c0t",
+                                          "fill": "#2C2C2C",
+                                          "content": "project",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "M64BEc",
+                                      "name": "er1c1",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "EXpEf",
+                                          "name": "er1chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "H9QoY",
+                                              "name": "er1chk1i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "N9TTDu",
+                                      "name": "er1c2",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "f6mtcX",
+                                          "name": "er1chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "jBgmz",
+                                              "name": "er1chk2i",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Mn21U",
+                                      "name": "er1c3",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "DT7NE",
+                                          "name": "er1chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#F5F2EC",
+                                          "cornerRadius": 6,
+                                          "stroke": {
+                                            "thickness": 1,
+                                            "fill": "#E5E0D8"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QrGFu",
+                      "name": "Persona Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "aUBAI",
+                          "name": "personaHeader",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "LPbe1",
+                              "name": "personaLabel",
+                              "fill": "#2C2C2C",
+                              "content": "Agent Persona",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "NHxiC",
+                              "name": "zeroBadge",
+                              "fill": "#E8F5E9",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "NEZYt",
+                                  "name": "zeroBadgeText",
+                                  "fill": "#5A9E6F",
+                                  "content": "Zero Context Injection",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "OQsCB",
+                          "name": "personaDesc",
+                          "fill": "#6B6B6B",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Define the agent's personality and behavior. This will be automatically injected when the agent checks in.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "OCYdT",
+                          "name": "personaPresets",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "BZxm3",
+                              "name": "preset1",
+                              "fill": "#F5F2EC",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "S13Drh",
+                                  "name": "preset1Text",
+                                  "fill": "#6B6B6B",
+                                  "content": "Senior Dev",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "hPQZu",
+                              "name": "preset2",
+                              "fill": "#C67A52",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "FQptx",
+                                  "name": "preset2Text",
+                                  "fill": "#FFFFFF",
+                                  "content": "Full-stack Dev",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "w1OZm",
+                              "name": "preset3",
+                              "fill": "#F5F2EC",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "pIJcX",
+                                  "name": "preset3Text",
+                                  "fill": "#6B6B6B",
+                                  "content": "Pragmatic Dev",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "R1ghXF",
+                          "name": "personaInput",
+                          "width": "fill_container",
+                          "height": 80,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E5E0D8"
+                          },
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "b3ZvN",
+                              "name": "personaInputText",
+                              "fill": "#2C2C2C",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "You are a full-stack developer comfortable working across the entire stack — from database queries and API design to responsive UI components.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NiCGp",
+                  "name": "Modal Footer",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#F5F2EC"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "I5I3x9",
+                      "name": "cancelBtn",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#E5E0D8"
+                      },
+                      "padding": [
+                        10,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "m1pIz",
+                          "name": "cancelText",
+                          "fill": "#6B6B6B",
+                          "content": "Cancel",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xcJjq",
+                      "name": "saveBtn",
+                      "fill": "#C67A52",
+                      "cornerRadius": 8,
+                      "padding": [
+                        10,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "W6q6f",
+                          "name": "saveText",
+                          "fill": "#FFFFFF",
+                          "content": "Save Changes",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "SEU2G",
+      "x": 3080,
+      "y": 11240,
+      "name": "Onboarding - Create Admin Agent (v0.7.0)",
+      "width": 1440,
+      "height": 820,
+      "fill": "#FAF8F4",
+      "children": [
+        {
+          "type": "frame",
+          "id": "QVM55",
+          "name": "Overlay",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#00000040",
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "vrq33",
+              "name": "Modal",
+              "width": 480,
+              "fill": "#FFFFFF",
+              "cornerRadius": 16,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "pVFOw",
+                  "name": "Modal Header",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F5F2EC"
+                  },
+                  "padding": [
+                    20,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "PdZYL",
+                      "name": "modalTitle",
+                      "fill": "#2C2C2C",
+                      "content": "Set up your Admin agent",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CuRe8",
+                      "name": "stepChip",
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 20,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "P3vFoV",
+                          "name": "stepText",
+                          "fill": "#6B6B6B",
+                          "content": "Step 2 of 4",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "abHQr",
+                  "name": "Modal Body",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "G00b50",
+                      "name": "Name Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "G18qCy",
+                          "name": "nameLabel",
+                          "fill": "#2C2C2C",
+                          "content": "Name",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "b0W6A1",
+                          "name": "nameInput",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E5E0D8"
+                          },
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "tyjWV",
+                              "name": "nameInputText",
+                              "fill": "#2C2C2C",
+                              "content": "My Admin Agent",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CP7z2",
+                      "name": "Roles Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qT3fw",
+                          "name": "rolesLabel",
+                          "fill": "#2C2C2C",
+                          "content": "Permissions",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "z7H54",
+                          "name": "rolesDesc",
+                          "fill": "#6B6B6B",
+                          "content": "Admin gives your first agent full access. Switch preset or customize if you want tighter scope.",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "aOsP0",
+                          "name": "AgentPermissionPicker",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "LMJTq",
+                              "name": "Preset Row",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "yEgJp",
+                                  "name": "presetLabel",
+                                  "fill": "#6B6B6B",
+                                  "content": "Preset",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "JegWe",
+                                  "name": "Preset Menu (open) - Onboarding",
+                                  "clip": true,
+                                  "width": "fill_container",
+                                  "fill": "#FFFFFF",
+                                  "cornerRadius": 8,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#E5E0D8"
+                                  },
+                                  "layout": "vertical",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "pN2an",
+                                      "name": "opt-admin",
+                                      "width": "fill_container",
+                                      "fill": "#FAF8F4",
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "E1hlR",
+                                          "name": "cOpt1L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "O9XHp7",
+                                              "name": "cOpt1T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Admin",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "AD2fI",
+                                              "name": "cOpt1D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Full access — idea/proposal/document/task/project read, write, admin",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "vZyCV",
+                                          "name": "cOpt1Chk",
+                                          "width": 16,
+                                          "height": 16,
+                                          "iconFontName": "check",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#C67A52"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "DJhik",
+                                      "name": "opt-pm",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "e0gHB",
+                                          "name": "cOpt2L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "jOq9n",
+                                              "name": "cOpt2T",
+                                              "fill": "#2C2C2C",
+                                              "content": "PM",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "b1ZGLh",
+                                              "name": "cOpt2D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Idea/proposal/document/task/project read and write (no admin)",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "QkLud",
+                                      "name": "opt-dev",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "s0yDK",
+                                          "name": "cOpt3L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "vRswk",
+                                              "name": "cOpt3T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Developer",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "Obd9r",
+                                              "name": "cOpt3D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Read most resources; write tasks only",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "yncAG",
+                                      "name": "opt-custom",
+                                      "width": "fill_container",
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": {
+                                          "top": 1
+                                        },
+                                        "fill": "#F5F2EC"
+                                      },
+                                      "padding": [
+                                        10,
+                                        14
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "G62L4",
+                                          "name": "cOpt4L",
+                                          "layout": "vertical",
+                                          "gap": 2,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "yoXDj",
+                                              "name": "cOpt4T",
+                                              "fill": "#2C2C2C",
+                                              "content": "Custom",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 14,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "bgtSq",
+                                              "name": "cOpt4D",
+                                              "fill": "#6B6B6B",
+                                              "content": "Hand-pick any combination of the 15 permission bits",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 11,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "XIF04",
+                              "name": "Permission Matrix",
+                              "clip": true,
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "cornerRadius": 10,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#E5E0D8"
+                              },
+                              "layout": "vertical",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "wDojU",
+                                  "name": "Matrix Header",
+                                  "width": "fill_container",
+                                  "fill": "#FAF8F4",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "JxQQU",
+                                      "name": "h-resource",
+                                      "width": "fill_container",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "geRMR",
+                                          "name": "hCell0Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "Resource",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "M9nEn",
+                                      "name": "h-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "RPJVa",
+                                          "name": "hCell1Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "read",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "JkbCE",
+                                      "name": "h-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "gaSec",
+                                          "name": "hCell2Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "write",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "x9R78N",
+                                      "name": "h-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "TEkzA",
+                                          "name": "hCell3Text",
+                                          "fill": "#6B6B6B",
+                                          "content": "admin",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "zDpNO",
+                                  "name": "row-idea",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "q4LPg",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "PfC1z",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "idea",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "zYSfM",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "Qimth",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "WHUqk",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "SJb78",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "oouIU",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "eHnE0",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "EUfvJ",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "F6iDO",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "BoCar",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Mts2f",
+                                  "name": "row-proposal",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "Pg5rw",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "a7opv",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "proposal",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Ltyev",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "T8pa1E",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "kUGIm",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "yRBaT",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "Q45TJ",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "DAEbQ",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "IO0s2",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "bVCH3",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "zvw5G",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "veUWN",
+                                  "name": "row-document",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "PNZES",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "OkeT6",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "document",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "n8D2ak",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "k1RDo",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "P9nUR2",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "t0rmgh",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "QdVur",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "LFqJv",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "gFMTw",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "YoEji",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "QR7uJ",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "dmSgq",
+                                  "name": "row-task",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "bottom": 1
+                                    },
+                                    "fill": "#F5F2EC"
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "aHPCy",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "skXBR",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "task",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Asq9F",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "dc24P",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "i4szK",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "P3urxf",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "fmsRC",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "Awe45",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "S481o",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "HR2h9",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "q8r1Q",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "OU8LD",
+                                  "name": "row-project",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 0
+                                  },
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "ogid4",
+                                      "name": "r1-name",
+                                      "width": "fill_container",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "yNxq8",
+                                          "name": "r1Name",
+                                          "fill": "#2C2C2C",
+                                          "content": "project",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 13,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "O3hwu",
+                                      "name": "r1-read",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "WALha",
+                                          "name": "r1Chk1",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "cGVEm",
+                                              "name": "r1Chk1Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "N14eWI",
+                                      "name": "r1-write",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "XVTT9",
+                                          "name": "r1Chk2",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "wfWQu",
+                                              "name": "r1Chk2Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "dTCyo",
+                                      "name": "r1-admin",
+                                      "width": 70,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "OdGmW",
+                                          "name": "r1Chk3",
+                                          "width": 20,
+                                          "height": 20,
+                                          "fill": "#C67A52",
+                                          "cornerRadius": 6,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "jUgOA",
+                                              "name": "r1Chk3Icon",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "check",
+                                              "iconFontFamily": "lucide",
+                                              "fill": "#FFFFFF"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "iRWTg",
+                      "name": "Persona Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "lk6xZ",
+                          "name": "personaHeader",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "p1xhV",
+                              "name": "personaLabel",
+                              "fill": "#2C2C2C",
+                              "content": "Agent Persona",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "sTA2v",
+                              "name": "zeroBadge",
+                              "fill": "#E8F5E9",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "v4pil",
+                                  "name": "badgeText",
+                                  "fill": "#5A9E6F",
+                                  "content": "Zero Context Injection",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "o68Io",
+                          "name": "personaDesc",
+                          "fill": "#6B6B6B",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Define the agent's personality and behavior. This will be automatically injected when the agent checks in.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GTf2p",
+                          "name": "personaPresets",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "SUSXZ",
+                              "name": "preset1",
+                              "fill": "#C67A52",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Nh1Ux",
+                                  "name": "preset1Text",
+                                  "fill": "#FFFFFF",
+                                  "content": "UX-Focused PM",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Y1gl7q",
+                              "name": "preset2",
+                              "fill": "#F5F2EC",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "g2F6h6",
+                                  "name": "preset2Text",
+                                  "fill": "#6B6B6B",
+                                  "content": "Tech-Savvy PM",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xZfb0",
+                              "name": "preset3",
+                              "fill": "#F5F2EC",
+                              "cornerRadius": 20,
+                              "padding": [
+                                6,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "p8fV1",
+                                  "name": "preset3Text",
+                                  "fill": "#6B6B6B",
+                                  "content": "Quality Dev",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FBhWs",
+                          "name": "personaInput",
+                          "width": "fill_container",
+                          "height": 80,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E5E0D8"
+                          },
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "F1vXB",
+                              "name": "personaInputText",
+                              "fill": "#2C2C2C",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "You are a product manager who prioritizes user experience above all. You always consider the end-user perspective and advocate for intuitive designs.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "r3TAc",
+                  "name": "Modal Footer",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#F5F2EC"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Gl4Yo",
+                      "name": "cancelBtn",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#E5E0D8"
+                      },
+                      "padding": [
+                        10,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "yOJP8",
+                          "name": "cancelText",
+                          "fill": "#6B6B6B",
+                          "content": "Back",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gj711",
+                      "name": "createBtn",
+                      "fill": "#C67A52",
+                      "cornerRadius": 8,
+                      "padding": [
+                        10,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "KEuCF",
+                          "name": "createText",
+                          "fill": "#FFFFFF",
+                          "content": "Continue →",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "themes": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -667,13 +667,6 @@
     "pmAgentDesc": "Analyze requirements, write proposals, manage tasks",
     "adminAgent": "Admin Agent",
     "adminAgentDesc": "Human-level permissions: approve proposals, verify tasks, create projects",
-    "adminWarningTitle": "Danger: Admin Agent Permissions",
-    "adminWarningDesc": "You are creating an Agent with human-level permissions. This Agent will be able to:",
-    "adminWarningItem1": "Approve or reject Proposals",
-    "adminWarningItem2": "Verify and close Tasks",
-    "adminWarningItem3": "Create and manage Projects",
-    "adminWarningItem4": "Delete any content (Ideas, Tasks, Documents)",
-    "adminConfirmCheckbox": "I understand the risks and confirm creating an Admin Agent",
     "created": "Created",
     "apiKeyCreated": "API Key Created",
     "apiKeyCreatedDesc": "Copy this key now. You won't be able to see it again!",
@@ -685,7 +678,7 @@
     "agentPersonaDesc": "Select a preset or write your own persona. This defines how the agent behaves in all interactions.",
     "agentPersonaDescNoRoles": "Define how this agent should behave in all interactions.",
     "personaPlaceholder": "Describe how this agent should behave. For example: 'You are a helpful assistant that focuses on clarity and simplicity...'",
-    "personaHint": "You can edit the text above or write your own custom persona.",
+    "personaHint": "The persona is injected into the agent's context on every check-in.",
     "personaHintNoRoles": "Write a custom persona for your agent.",
     "creating": "Creating...",
     "confirmDelete": "Are you sure you want to delete this API key?",
@@ -699,7 +692,10 @@
     "updateFailed": "Failed to update agent",
     "setupGuide": "Setup Guide",
     "setupGuideDesc": "Set up your AI agent connection step by step",
-    "openSetupGuide": "Open Setup Guide"
+    "openSetupGuide": "Open Setup Guide",
+    "effectivePermissions": "Effective permissions",
+    "noEffectivePermissions": "No permissions granted",
+    "customRole": "Custom"
   },
   "login": {
     "title": "Chorus",
@@ -999,12 +995,22 @@
       "summary": "Setup Summary",
       "agentName": "Agent Name",
       "agentRoles": "Roles",
+      "agentPreset": "Preset",
+      "agentPermissions": "Permissions",
+      "permissionsCount": "{count} {count, plural, one {permission} other {permissions}}",
       "goToProjects": "Go to Projects",
       "goToSettings": "Go to Settings"
     },
     "createAgent": {
       "title": "Create Your AI Agent",
-      "description": "Set up an AI agent with the roles and persona that match your workflow. This will generate an API key for the agent."
+      "description": "Set up an AI agent with the permissions and persona that match your workflow. This will generate an API key for the agent.",
+      "nameLabel": "Agent name",
+      "namePlaceholder": "e.g. my-dev-agent",
+      "personaLabel": "Persona (optional)",
+      "personaPlaceholder": "Describe how this agent should behave — tone, priorities, constraints.",
+      "personaHint": "The persona is appended to the agent's system prompt to shape its behavior.",
+      "submit": "Create agent",
+      "creating": "Creating agent..."
     },
     "copyKey": {
       "title": "Copy Your API Key",
@@ -1225,6 +1231,36 @@
       "document": "Document",
       "project": "Project",
       "project_group": "Group"
+    }
+  },
+  "agent": {
+    "permissions": {
+      "title": "Permissions",
+      "description": "Start from a preset, or customize the permission matrix directly.",
+      "presetLabel": "Preset",
+      "presetAdmin": "Admin",
+      "presetPm": "PM",
+      "presetDev": "Developer",
+      "presetCustom": "Custom",
+      "resourceHeader": "Resource",
+      "resources": {
+        "idea": "Idea",
+        "proposal": "Proposal",
+        "document": "Document",
+        "task": "Task",
+        "project": "Project"
+      },
+      "actions": {
+        "read": "Read",
+        "write": "Write",
+        "admin": "Admin"
+      },
+      "help": {
+        "admin": "Full access across all resources, including approve / verify / reopen. Recommended for administrative agents.",
+        "pm": "Plan and drive work: manage ideas, proposals, documents, tasks, and projects. No approval or verification authority.",
+        "dev": "Execute work: read ideas, proposals, documents, and projects; create and update tasks. Cannot approve or verify.",
+        "custom": "Pick individual permissions. Admin-column actions (approve / verify / close) are only reachable in Custom mode."
+      }
     }
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -325,20 +325,20 @@
     "complete": "完成",
     "createNew": {
       "title": "创建新项目",
-      "subtitle": "设置项目详情，之后再将想法分配给 PM 智能体",
+      "subtitle": "设置项目详情，之后再将想法分配给 产品经理智能体",
       "gettingStartedTitle": "开始使用",
-      "gettingStartedDesc": "填写以下基本信息。创建后，您可以添加想法并分配给 PM 智能体生成提案。",
+      "gettingStartedDesc": "填写以下基本信息。创建后，您可以添加想法并分配给 产品经理智能体生成提案。",
       "basicInfo": "基本信息",
       "projectName": "项目名称",
       "projectNamePlaceholder": "例如：项目 Alpha",
       "descriptionLabel": "描述",
       "descriptionPlaceholder": "简要描述这个项目是关于什么的...",
       "initialIdeas": "初始想法",
-      "initialIdeasDesc": "分享任何初始想法或需求，供 PM 智能体在生成提案时参考",
+      "initialIdeasDesc": "分享任何初始想法或需求，供 产品经理智能体在生成提案时参考",
       "ideaPlaceholder": "例如：我们需要支持 OAuth 的用户认证...",
       "addAnother": "添加另一个想法",
       "documents": "文档",
-      "documentsDesc": "上传 PRD、技术设计或任何参考文档供 PM 智能体分析",
+      "documentsDesc": "上传 PRD、技术设计或任何参考文档供 产品经理智能体分析",
       "dragDrop": "拖放文件到此处，或点击浏览",
       "fileTypes": "Markdown（.md）文档",
       "createProject": "创建项目"
@@ -366,11 +366,11 @@
     "usedInProposal": "已用于提案",
     "noIdeasWithStatus": "暂无{status}的想法",
     "selectIdeaAssignee": "选择如何分配此想法",
-    "assignToMyselfIdeaDesc": "您的所有 PM 智能体都可以查看并处理此想法",
-    "orAssignToPmAgent": "分配给特定 PM 智能体",
-    "onlySelectedPmAgentCanWork": "只有选中的 PM 智能体可以处理此想法",
-    "selectPmAgent": "选择一个 PM 智能体",
-    "noPmAgentsAvailable": "没有可用的 PM 智能体",
+    "assignToMyselfIdeaDesc": "您的所有 产品经理智能体都可以查看并处理此想法",
+    "orAssignToPmAgent": "分配给特定 产品经理智能体",
+    "onlySelectedPmAgentCanWork": "只有选中的 产品经理智能体可以处理此想法",
+    "selectPmAgent": "选择一个 产品经理智能体",
+    "noPmAgentsAvailable": "没有可用的 产品经理智能体",
     "releaseIdeaAssigneeDesc": "移除当前负责人，使此想法重新可用",
     "proposalGenerated": "已生成提案",
     "viewProposal": "查看提案",
@@ -471,7 +471,7 @@
     "all": "全部",
     "pendingReview": "待审核",
     "noProposals": "暂无提案",
-    "noProposalsDesc": "当 PM 智能体分析想法时会创建提案。它们将在此显示供您审核。",
+    "noProposalsDesc": "当 产品经理智能体分析想法时会创建提案。它们将在此显示供您审核。",
     "loadingProposals": "加载提案中...",
     "proposalNotFound": "提案未找到",
     "backToProposals": "返回提案列表",
@@ -664,17 +664,10 @@
     "roles": "角色:",
     "developerAgent": "开发智能体",
     "developerAgentDesc": "执行任务、编写代码、报告问题、提交代码",
-    "pmAgent": "产品智能体",
+    "pmAgent": "产品经理智能体",
     "pmAgentDesc": "分析需求、撰写提案、管理任务",
     "adminAgent": "管理员智能体",
     "adminAgentDesc": "人类级别权限：审批提案、验证任务、创建项目",
-    "adminWarningTitle": "危险：管理员智能体权限",
-    "adminWarningDesc": "您正在创建具有人类级别权限的智能体。此智能体将能够：",
-    "adminWarningItem1": "批准或拒绝提案",
-    "adminWarningItem2": "验证并关闭任务",
-    "adminWarningItem3": "创建和管理项目",
-    "adminWarningItem4": "删除任意内容（想法、任务、文档）",
-    "adminConfirmCheckbox": "我已了解风险，确认创建管理员智能体",
     "created": "创建于",
     "apiKeyCreated": "API 密钥已创建",
     "apiKeyCreatedDesc": "请立即复制此密钥。您将无法再次查看它！",
@@ -686,7 +679,7 @@
     "agentPersonaDesc": "选择预设或编写您自己的人设。这定义了智能体在所有交互中的行为方式。",
     "agentPersonaDescNoRoles": "定义此智能体在所有交互中的行为方式。",
     "personaPlaceholder": "描述此智能体应如何行为。例如：'您是一个专注于清晰和简洁的助手...'",
-    "personaHint": "您可以编辑上面的文字或编写自己的自定义人设。",
+    "personaHint": "人设会在每次 check-in 时自动注入到智能体的上下文。",
     "personaHintNoRoles": "为您的智能体编写自定义人设。",
     "creating": "创建中...",
     "confirmDelete": "确定要删除此 API 密钥吗？",
@@ -700,7 +693,10 @@
     "updateFailed": "更新智能体失败",
     "setupGuide": "设置向导",
     "setupGuideDesc": "逐步设置您的 AI 智能体连接",
-    "openSetupGuide": "打开设置向导"
+    "openSetupGuide": "打开设置向导",
+    "effectivePermissions": "生效的权限",
+    "noEffectivePermissions": "尚未授予任何权限",
+    "customRole": "自定义"
   },
   "login": {
     "title": "Chorus",
@@ -754,11 +750,11 @@
     "deleteProjectConfirm": "确定要删除「{name}」吗？此操作无法撤销，将永久删除所有关联的想法、提案、任务、文档和动态。"
   },
   "personas": {
-    "devPm": "开发者导向 PM",
+    "devPm": "开发导向产品经理",
     "devPmDesc": "您是一位优先考虑开发者体验并构建开发者优先产品的产品经理。您理解技术约束，并能与工程团队有效沟通。",
-    "fullPm": "全能 PM",
+    "fullPm": "全能产品经理",
     "fullPmDesc": "您是一位全面的产品经理，以构建能为目标受众解决实际问题的产品为己任。您平衡业务目标、用户需求和技术可行性。",
-    "simplePm": "简约 PM",
+    "simplePm": "简约产品经理",
     "simplePmDesc": "您是一位专注的产品经理，优先考虑核心功能，避免过度设计。您相信快速交付、收集反馈、快速迭代。",
     "seniorDev": "高级开发者",
     "seniorDevDesc": "您是一位经验丰富的高级软件开发者，擅长构建可扩展的系统。您编写简洁、可维护的代码并遵循最佳实践。您指导初级开发者并做出架构决策。",
@@ -1000,12 +996,22 @@
       "summary": "配置摘要",
       "agentName": "智能体名称",
       "agentRoles": "角色",
+      "agentPreset": "预设",
+      "agentPermissions": "权限",
+      "permissionsCount": "{count} 项权限",
       "goToProjects": "前往项目",
       "goToSettings": "前往设置"
     },
     "createAgent": {
       "title": "创建您的 AI 智能体",
-      "description": "设置一个具有匹配您工作流程的角色和人设的 AI 智能体。这将为智能体生成一个 API 密钥。"
+      "description": "设置一个具有匹配您工作流程的权限和人设的 AI 智能体。这将为智能体生成一个 API 密钥。",
+      "nameLabel": "智能体名称",
+      "namePlaceholder": "例如：my-dev-agent",
+      "personaLabel": "人设（可选）",
+      "personaPlaceholder": "描述该智能体的行为方式——语气、优先级、约束。",
+      "personaHint": "人设会追加到智能体的系统提示词中，用于塑造其行为。",
+      "submit": "创建智能体",
+      "creating": "正在创建..."
     },
     "copyKey": {
       "title": "复制您的 API 密钥",
@@ -1148,7 +1154,7 @@
       "elaborationNotStarted": "尚未开始",
       "elaborationNotStartedDesc": "分配给智能体以开始需求细化。",
       "elaborationWaiting": "等待智能体",
-      "elaborationWaitingDesc": "PM 智能体将很快开始细化。",
+      "elaborationWaitingDesc": "产品经理智能体将很快开始细化。",
       "elaboration": {
         "pendingAnswers": "待回答",
         "validating": "验证中",
@@ -1226,6 +1232,36 @@
       "document": "文档",
       "project": "项目",
       "project_group": "分组"
+    }
+  },
+  "agent": {
+    "permissions": {
+      "title": "权限",
+      "description": "从预设开始，或直接自定义权限矩阵。",
+      "presetLabel": "预设",
+      "presetAdmin": "管理员",
+      "presetPm": "产品经理",
+      "presetDev": "开发者",
+      "presetCustom": "自定义",
+      "resourceHeader": "资源",
+      "resources": {
+        "idea": "想法",
+        "proposal": "提案",
+        "document": "文档",
+        "task": "任务",
+        "project": "项目"
+      },
+      "actions": {
+        "read": "读取",
+        "write": "写入",
+        "admin": "管理"
+      },
+      "help": {
+        "admin": "对所有资源拥有完整权限，包含审批 / 验收 / 重开。推荐用于管理员 Agent。",
+        "pm": "推进工作：管理想法、提案、文档、任务、项目。没有审批或验收权限。",
+        "dev": "执行工作：可读取想法、提案、文档与项目；可创建与更新任务。无审批或验收权限。",
+        "custom": "自由勾选权限位。只有在自定义模式下，才能开启「管理」列的审批 / 验收 / 关闭动作。"
+      }
     }
   }
 }

--- a/prisma/migrations/20260430034110_add_agent_permissions/migration.sql
+++ b/prisma/migrations/20260430034110_add_agent_permissions/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Agent" ADD COLUMN     "permissions" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model Agent {
   company      Company   @relation(fields: [companyUuid], references: [uuid])
   name         String
   roles        String[]  @default(["developer"])  // pm | developer (multi-select)
+  permissions  String[]  @default([])              // Custom permission bits (resource:action); merged with role presets at auth time
   // Agent persona definition (Zero Context Injection)
   persona      String?   // Custom persona description (brief)
   systemPrompt String?   // Full system prompt (optional, overrides default template)

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/bin/on-session-start.sh
+++ b/public/chorus-plugin/bin/on-session-start.sh
@@ -46,10 +46,17 @@ if command -v jq >/dev/null 2>&1; then
     "$API" state-set "owner_uuid" "$_OWNER_UUID"
   fi
 
-  # Cache agent roles for TaskCompleted and Stop hooks (e.g. "developer_agent,pm_agent,admin_agent")
-  _ROLES=$(echo "$CHECKIN_RESULT" | jq -r '.agent.roles | join(",") // empty' 2>/dev/null) || true
-  if [ -n "$_ROLES" ]; then
-    "$API" state-set "agent_roles" "$_ROLES"
+  # Cache effective permissions for downstream hooks.
+  # Stored as comma-separated "resource:action" pairs so hooks can substring-match
+  # without re-parsing JSON. Example: "idea:read,idea:write,task:read,task:write,task:admin".
+  _PERMS=$(echo "$CHECKIN_RESULT" | jq -r '
+    .agent.permissions // {}
+    | to_entries
+    | map(.key as $r | .value[] | "\($r):\(.)")
+    | join(",")
+  ' 2>/dev/null) || true
+  if [ -n "$_PERMS" ]; then
+    "$API" state-set "agent_permissions" "$_PERMS"
   fi
 
 fi

--- a/public/chorus-plugin/bin/on-subagent-start.sh
+++ b/public/chorus-plugin/bin/on-subagent-start.sh
@@ -236,7 +236,7 @@ When you finish and return your summary, you MUST end it with:
 Next steps for main agent:
 1. REVIEW — spawn chorus:task-reviewer agent, then read its VERDICT comment
 2. ACT ON VERDICT: PASS/PASS WITH NOTES → mark AC passed + verify task. FAIL → reopen task and fix BLOCKERs.
-3. If no admin_agent role, stop and ask the user to review and verify this task
+3. If you do not have the task:admin permission, stop and ask the user to review and verify this task
 \`\`\`
 This ensures the main agent knows to run review and verification.
 

--- a/public/chorus-plugin/bin/on-subagent-stop.sh
+++ b/public/chorus-plugin/bin/on-subagent-stop.sh
@@ -107,13 +107,13 @@ if [ "$CLOSE_OK" = true ] && [ -n "$SESSION_DETAIL" ]; then
       TASK_STATUS=$(echo "$TASK_DETAIL" | jq -r '.status // empty' 2>/dev/null) || true
 
       if [ "$TASK_STATUS" = "to_verify" ]; then
-        AGENT_ROLES=$("$API" state-get "agent_roles" 2>/dev/null) || true
-        IS_ADMIN="false"
-        case ",$AGENT_ROLES," in
-          *,admin_agent,*) IS_ADMIN="true" ;;
+        AGENT_PERMS=$("$API" state-get "agent_permissions" 2>/dev/null) || true
+        CAN_VERIFY_TASK="false"
+        case ",$AGENT_PERMS," in
+          *,task:admin,*) CAN_VERIFY_TASK="true" ;;
         esac
 
-        if [ "$IS_ADMIN" = "true" ]; then
+        if [ "$CAN_VERIFY_TASK" = "true" ]; then
           AC_TOTAL=$(echo "$TASK_DETAIL" | jq -r '.acceptanceSummary.required // 0' 2>/dev/null) || true
           ADMIN_PASSED=$(echo "$TASK_DETAIL" | jq -r '.acceptanceSummary.requiredPassed // 0' 2>/dev/null) || true
 

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -35,9 +35,25 @@ creates  analyzes     drafts PRD         codes &      reviews   closes
 
 | Role | Responsibility | MCP Tools |
 |------|---------------|-----------|
-| **PM Agent** | Analyze Ideas, create Proposals (PRD + Task drafts), manage documents | Public + `chorus_pm_*` + `chorus_*_idea` |
+| **PM Agent** | Analyze Ideas, create Proposals (PRD + Task drafts), manage documents | Public + `chorus_pm_*` + `chorus_*_idea` + `task:write` tools (claim/release/submit/report) |
 | **Developer Agent** | Claim Tasks, write code, report work, submit for verification | Public + `chorus_*_task` + `chorus_report_work` |
 | **Admin Agent** | Create projects/ideas, approve/reject proposals, verify tasks, manage lifecycle | Public + `chorus_admin_*` + PM + Developer tools |
+
+### Permissions
+
+Each agent's tool visibility is driven by a **permission set**, not by the role label alone. Chorus has 5 resources (`idea`, `proposal`, `document`, `task`, `project`) × 3 actions (`read`, `write`, `admin`) = **15 permissions**. Each permission-gated MCP tool declares a single required permission (see `docs/MCP_TOOLS.md` for the full table).
+
+**Role presets** map to permission sets:
+
+| Preset | Permissions |
+|--------|-------------|
+| `developer_agent` | all `*:read` + `task:write` |
+| `pm_agent` | all `*:read` + `idea:write` + `proposal:write` + `document:write` + `task:write` + `project:write` |
+| `admin_agent` | all 15 permissions (every `read` + `write` + `admin`) |
+
+**Custom permissions** are also supported: when creating an agent you can pick a preset AND/OR add individual permissions. The effective permission set is the union. Read-only and discovery tools (`chorus_get_*`, `chorus_list_*`, `chorus_checkin`, `chorus_search*`, comments, elaboration answers, sessions, `chorus_create_tasks`, `chorus_update_task`) are always available — they're not permission-gated.
+
+> **Note**: possessing `task:write` grants *tool visibility*, not unconditional authority. Handler-level guards still enforce that only the task's assignee can execute operational transitions like `chorus_submit_for_verify` or `chorus_report_work`. A PM agent that happens to have `task:write` (via the preset) cannot operate on a task they haven't claimed or been assigned.
 
 ---
 
@@ -228,11 +244,14 @@ API Keys must be created manually by the user in the Chorus Web UI.
 **Ask the user to:**
 1. Open the Chorus settings page (e.g., `http://localhost:8637/settings`)
 2. Click **Create API Key**
-3. Enter Agent name, select role (Developer / PM / Admin)
+3. Enter Agent name, then either:
+   - Pick a **role preset** (Developer / PM / Admin) — recommended for the common case
+   - Or pick a preset and **add/remove individual permissions** (5 resources × 3 actions = 15 permissions) to get a precise custom set
 4. Click create and **immediately copy the key** (shown only once)
 
 **Security notes:**
-- Each Agent should have its own API Key with the minimum required role
+- Each Agent should have its own API Key with the minimum required permissions
+- Presets are the fastest path; custom permissions let you grant narrowly (e.g. a dev agent that also needs `idea:write` to file bugs)
 - API Keys should not be committed to version control
 
 ### 2. MCP Server Configuration
@@ -263,19 +282,27 @@ chorus_checkin()
 
 If it fails, check: API Key correct (`cho_` prefix)? URL reachable? Claude Code restarted?
 
-### 4. Role-Specific Tool Access
+### 4. Tool Access by Preset
 
-| Tool Prefix | Developer | PM | Admin |
-|-------------|-----------|------|-------|
-| `chorus_get_*` / `chorus_list_*` | Yes | Yes | Yes |
-| `chorus_checkin` | Yes | Yes | Yes |
-| `chorus_add_comment` / `chorus_get_comments` | Yes | Yes | Yes |
-| `chorus_claim_task` / `chorus_release_task` | Yes | No | Yes |
-| `chorus_update_task` / `chorus_submit_for_verify` | Yes | No | Yes |
-| `chorus_report_work` | Yes | No | Yes |
-| `chorus_claim_idea` / `chorus_release_idea` | No | Yes | Yes |
-| `chorus_pm_*` | No | Yes | Yes |
-| `chorus_admin_*` | No | No | Yes |
+The table below shows default tool availability for each preset (no custom permissions). Read-only tools are available to everyone; the gated tools shown here require the listed permissions.
+
+| Tool Group | Required Permission | Developer | PM | Admin |
+|------------|--------------------|-----------|------|-------|
+| `chorus_get_*` / `chorus_list_*` / `chorus_search*` | (public, read) | Yes | Yes | Yes |
+| `chorus_checkin` | (public) | Yes | Yes | Yes |
+| `chorus_add_comment` / `chorus_get_comments` | (public) | Yes | Yes | Yes |
+| `chorus_update_task` (field edits + status) | (public; assignee required for status) | Yes | Yes | Yes |
+| `chorus_claim_task` / `chorus_release_task` / `chorus_submit_for_verify` / `chorus_report_work` / `chorus_report_criteria_self_check` | `task:write` | Yes | **Yes** (0.7.0+) | Yes |
+| `chorus_claim_idea` / `chorus_release_idea` / `chorus_move_idea` / `chorus_pm_create_idea` / `chorus_pm_*_elaboration` | `idea:write` | No | Yes | Yes |
+| `chorus_pm_create_proposal` / `chorus_pm_*_proposal` / `chorus_pm_*_draft` / `chorus_pm_create_tasks` / `chorus_pm_assign_task` / `chorus_*_task_dependency` | `proposal:write` | No | Yes | Yes |
+| `chorus_pm_create_document` / `chorus_pm_update_document` | `document:write` | No | Yes | Yes |
+| `chorus_admin_create_project` / `chorus_admin_*_project_group` / `chorus_admin_move_project_to_group` | `project:write` | No | **Yes** (0.7.0+) | Yes |
+| `chorus_admin_approve_proposal` / `chorus_admin_close_proposal` | `proposal:admin` | No | No | Yes |
+| `chorus_admin_verify_task` / `chorus_admin_reopen_task` / `chorus_admin_close_task` / `chorus_mark_acceptance_criteria` / `chorus_admin_delete_task` | `task:admin` | No | No | Yes |
+| `chorus_admin_delete_idea` | `idea:admin` | No | No | Yes |
+| `chorus_admin_delete_document` | `document:admin` | No | No | Yes |
+
+> Changes in 0.7.0: the `pm_agent` preset now also carries `task:write` (for `claim/release/submit/report`) and `project:write` (for project and group management). This widens PM's MCP tool surface by 10 tools vs 0.6.x — handler-level assignee / authorship guards still prevent misuse. See `docs/MCP_TOOLS.md` for the complete tool → permission map.
 
 ### 5. Review Agent Configuration
 

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -266,7 +266,7 @@ chorus_pm_assign_task({ taskUuid: "<task-uuid>", agentUuid: "<developer-agent-uu
 ```
 
 - Task must be `open` or `assigned`
-- Target agent must have `developer` or `developer_agent` role
+- Target agent must have `task: ["write"]` permission
 
 ---
 

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.7.5
+version: 0.8.0
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 
@@ -37,7 +37,7 @@ For complex work, use `/idea` + `/proposal` instead.
 
 ## Pre-Flight: Admin Self-Verify Check
 
-**Before creating tasks**, if you have the `admin_agent` role, ask the user:
+**Before creating tasks**, if `chorus_checkin().agent.permissions.task` includes `"admin"`, ask the user:
 
 > "I have admin privileges. After development, should I verify the task myself, or leave it for another admin to verify?"
 
@@ -149,7 +149,7 @@ chorus_submit_for_verify({
 })
 ```
 
-**Admin self-verification:** If you have the `admin_agent` role and the user approved self-verification in the Pre-Flight check, you can verify the task yourself immediately after submitting:
+**Admin self-verification:** If you have `task: ["admin"]` in `permissions` and the user approved self-verification in the Pre-Flight check, you can verify the task yourself immediately after submitting:
 
 ```
 chorus_admin_verify_task({ taskUuid: "<task-uuid>" })

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -53,28 +53,25 @@ Full-auto AI-DLC pipeline. User provides a prompt; agent drives the entire lifec
 
 ## Prerequisites
 
-**All 3 agent roles are required on the API key:**
+The API key needs write + admin on every resource it touches:
 
-| Role | Why |
+| Needs | Why |
 |------|-----|
-| `pm_agent` | Idea creation, elaboration, proposal management (`chorus_pm_*` tools) |
-| `admin_agent` | Proposal approval, task verification (`chorus_admin_*` tools) |
-| `developer_agent` | Sub-agents claim and execute tasks (`chorus_claim_task`, `chorus_update_task`) |
-
-Sub-agents share the same API key as the main agent. The plugin injects session info into sub-agents, but **roles come from the API key itself**, not from hook injection.
+| `idea: [write]` | Create ideas, run elaboration |
+| `proposal: [write, admin]` | Create proposals; approve them |
+| `task: [write, admin]` | Create, execute, verify tasks |
+| `project: [write]` | Create the project if none is given |
 
 **Check at startup:**
 
 ```
-result = chorus_checkin()
-roles = result.agent.roles
+perms = chorus_checkin().agent.permissions
+need = { idea: ["write"], proposal: ["write","admin"],
+         task: ["write","admin"], project: ["write"] }
 
-required = ["pm_agent", "admin_agent", "developer_agent"]
-missing = [r for r in required if r not in roles]
-
-if missing:
-  ABORT: "Cannot run /yolo. Missing required roles: {missing}. 
-          Your API key must have all 3 roles: pm_agent, admin_agent, developer_agent."
+for resource, actions in need:
+  missing = [a for a in actions if a not in (perms[resource] or [])]
+  if missing: ABORT "/yolo needs {resource}: {missing}. Use an Admin-preset API key."
 ```
 
 ---

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -86,9 +86,25 @@ creates  analyzes     drafts PRD         codes &      reviews   closes
 
 | Role | Responsibility | MCP Tools |
 |------|---------------|-----------|
-| **PM Agent** | Analyze Ideas, create Proposals (PRD + Task drafts), manage documents | Public + `chorus_pm_*` + `chorus_*_idea` |
+| **PM Agent** | Analyze Ideas, create Proposals (PRD + Task drafts), manage documents | Public + `chorus_pm_*` + `chorus_*_idea` + `task:write` tools (claim/release/submit/report) |
 | **Developer Agent** | Claim Tasks, write code, report work, submit for verification | Public + `chorus_*_task` + `chorus_report_work` |
 | **Admin Agent** | Create projects/ideas, approve/reject proposals, verify tasks, manage lifecycle | Public + `chorus_admin_*` + PM + Developer tools |
+
+### Permissions
+
+Each agent's tool visibility is driven by a **permission set**, not by the role label alone. Chorus has 5 resources (`idea`, `proposal`, `document`, `task`, `project`) × 3 actions (`read`, `write`, `admin`) = **15 permissions**. Each permission-gated MCP tool declares a single required permission (see `<BASE_URL>/docs/MCP_TOOLS.md` for the full table).
+
+**Role presets** map to permission sets:
+
+| Preset | Permissions |
+|--------|-------------|
+| `developer_agent` | all `*:read` + `task:write` |
+| `pm_agent` | all `*:read` + `idea:write` + `proposal:write` + `document:write` + `task:write` + `project:write` |
+| `admin_agent` | all 15 permissions (every `read` + `write` + `admin`) |
+
+**Custom permissions** are also supported: when creating an agent you can pick a preset AND/OR add individual permissions. The effective permission set is the union. Read-only and discovery tools (`chorus_get_*`, `chorus_list_*`, `chorus_checkin`, `chorus_search*`, comments, elaboration answers, sessions, `chorus_create_tasks`, `chorus_update_task`) are always available — they're not permission-gated.
+
+> **Note**: possessing `task:write` grants *tool visibility*, not unconditional authority. Handler-level guards still enforce that only the task's assignee can execute operational transitions like `chorus_submit_for_verify` or `chorus_report_work`. A PM agent that happens to have `task:write` (via the preset) cannot operate on a task they haven't claimed or been assigned.
 
 ---
 
@@ -125,9 +141,9 @@ Results can be filtered by project(s) using optional HTTP headers in your MCP co
 
 ### MCP Connection
 
-- MCP sessions expire after 30 minutes of **inactivity** (sliding window)
-- Each MCP request automatically renews the session
-- If you receive a "Session not found" error, reinitialize the MCP connection
+- The Chorus MCP endpoint is **stateless** — each HTTP request creates a fresh server instance, so there is no client-side session to keep alive
+- Supply your API Key in the `Authorization: Bearer cho_...` header on every request (your MCP client handles this automatically)
+- Horizontal scaling works out of the box; no sticky sessions required
 
 ### Project Groups
 
@@ -257,11 +273,14 @@ API Keys are created by the user in the Chorus Web UI.
 **Ask the user to:**
 1. Open the Chorus settings page (e.g., `http://localhost:8637/settings`)
 2. Click **Create API Key**
-3. Enter Agent name, select role (Developer / PM / Admin)
+3. Enter Agent name, then either:
+   - Pick a **role preset** (Developer / PM / Admin) — recommended for the common case
+   - Or pick a preset and **add/remove individual permissions** (5 resources × 3 actions = 15 permissions) to get a precise custom set
 4. Click create and **immediately copy the key** (shown only once)
 
 **Security notes:**
-- Each Agent should have its own API Key with the minimum required role
+- Each Agent should have its own API Key with the minimum required permissions
+- Presets are the fastest path; custom permissions let you grant narrowly (e.g. a dev agent that also needs `idea:write` to file bugs)
 - API Keys should not be committed to version control
 
 ### 2. MCP Server Configuration
@@ -297,19 +316,27 @@ chorus_checkin()
 
 If it fails, check: API Key correct (`cho_` prefix)? URL reachable? IDE restarted?
 
-### 4. Role-Specific Tool Access
+### 4. Tool Access by Preset
 
-| Tool Prefix | Developer | PM | Admin |
-|-------------|-----------|------|-------|
-| `chorus_get_*` / `chorus_list_*` | Yes | Yes | Yes |
-| `chorus_checkin` | Yes | Yes | Yes |
-| `chorus_add_comment` / `chorus_get_comments` | Yes | Yes | Yes |
-| `chorus_claim_task` / `chorus_release_task` | Yes | No | Yes |
-| `chorus_update_task` / `chorus_submit_for_verify` | Yes | No | Yes |
-| `chorus_report_work` | Yes | No | Yes |
-| `chorus_claim_idea` / `chorus_release_idea` | No | Yes | Yes |
-| `chorus_pm_*` | No | Yes | Yes |
-| `chorus_admin_*` | No | No | Yes |
+The table below shows default tool availability for each preset (no custom permissions). Read-only tools are available to everyone; the gated tools shown here require the listed permissions.
+
+| Tool Group | Required Permission | Developer | PM | Admin |
+|------------|--------------------|-----------|------|-------|
+| `chorus_get_*` / `chorus_list_*` / `chorus_search*` | (public, read) | Yes | Yes | Yes |
+| `chorus_checkin` | (public) | Yes | Yes | Yes |
+| `chorus_add_comment` / `chorus_get_comments` | (public) | Yes | Yes | Yes |
+| `chorus_update_task` (field edits + status) | (public; assignee required for status) | Yes | Yes | Yes |
+| `chorus_claim_task` / `chorus_release_task` / `chorus_submit_for_verify` / `chorus_report_work` / `chorus_report_criteria_self_check` | `task:write` | Yes | **Yes** (0.7.0+) | Yes |
+| `chorus_claim_idea` / `chorus_release_idea` / `chorus_move_idea` / `chorus_pm_create_idea` / `chorus_pm_*_elaboration` | `idea:write` | No | Yes | Yes |
+| `chorus_pm_create_proposal` / `chorus_pm_*_proposal` / `chorus_pm_*_draft` / `chorus_pm_create_tasks` / `chorus_pm_assign_task` / `chorus_*_task_dependency` | `proposal:write` | No | Yes | Yes |
+| `chorus_pm_create_document` / `chorus_pm_update_document` | `document:write` | No | Yes | Yes |
+| `chorus_admin_create_project` / `chorus_admin_*_project_group` / `chorus_admin_move_project_to_group` | `project:write` | No | **Yes** (0.7.0+) | Yes |
+| `chorus_admin_approve_proposal` / `chorus_admin_close_proposal` | `proposal:admin` | No | No | Yes |
+| `chorus_admin_verify_task` / `chorus_admin_reopen_task` / `chorus_admin_close_task` / `chorus_mark_acceptance_criteria` / `chorus_admin_delete_task` | `task:admin` | No | No | Yes |
+| `chorus_admin_delete_idea` | `idea:admin` | No | No | Yes |
+| `chorus_admin_delete_document` | `document:admin` | No | No | Yes |
+
+> Changes in 0.7.0: the `pm_agent` preset now also carries `task:write` (for `claim/release/submit/report`) and `project:write` (for project and group management). This widens PM's MCP tool surface by 10 tools vs 0.6.x — handler-level assignee / authorship guards still prevent misuse. See `<BASE_URL>/docs/MCP_TOOLS.md` for the complete tool → permission map.
 
 ---
 

--- a/public/skill/proposal-chorus/SKILL.md
+++ b/public/skill/proposal-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.2.0"
+  version: "0.2.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -244,7 +244,7 @@ chorus_pm_assign_task({ taskUuid: "<task-uuid>", agentUuid: "<developer-agent-uu
 ```
 
 - Task should be `open` or `assigned`
-- Target agent should have `developer` or `developer_agent` role
+- Target agent must have `task: ["write"]` permission
 
 ---
 

--- a/public/skill/quick-dev-chorus/SKILL.md
+++ b/public/skill/quick-dev-chorus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev-chorus
-version: 0.1.0
+version: 0.1.1
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 
@@ -37,7 +37,7 @@ For complex work, consider using the idea and proposal skills instead.
 
 ## Pre-Flight: Admin Self-Verify Check
 
-**Before creating tasks**, if you have the `admin_agent` role, ask the user:
+**Before creating tasks**, if `chorus_checkin().agent.permissions.task` includes `"admin"`, ask the user:
 
 > "I have admin privileges. After development, should I verify the task myself, or leave it for another admin to verify?"
 
@@ -143,7 +143,7 @@ chorus_submit_for_verify({
 })
 ```
 
-**Admin self-verification:** If you have the `admin_agent` role and the user approved self-verification in the Pre-Flight check, you can verify the task yourself immediately after submitting:
+**Admin self-verification:** If you have `task: ["admin"]` in `permissions` and the user approved self-verification in the Pre-Flight check, you can verify the task yourself immediately after submitting:
 
 ```
 chorus_admin_verify_task({ taskUuid: "<task-uuid>" })

--- a/src/__tests__/integration/permissions.test.ts
+++ b/src/__tests__/integration/permissions.test.ts
@@ -1,0 +1,542 @@
+// T11: End-to-end permission integration checkpoint.
+//
+// What this covers:
+//   Scenario 1 — custom-permissions agent created via POST /api/agents,
+//     MCP tool enumeration uses the returned effective permissions,
+//     REST routes return 200 for allowed reads, 403 for disallowed writes.
+//   Scenario 2 — baseline preset parity with 0.6.x for developer_agent (strict equality),
+//     admin_agent (strict equality), and pm_agent (strict superset + expected diff).
+//     NOTE: the task description names a "+5" diff for pm_agent; that number is stale.
+//     The consensus captured in T3's comment thread (2026-04-30) is "+10": the 5
+//     project/ProjectGroup admin tools gated on project:write PLUS the 5 developer
+//     task-execution tools gated on task:write (handlers still enforce isAssignee
+//     at runtime, so pm visibility doesn't equal operational escalation).
+//   Scenario 4 — a super_admin auth context bypasses REST permission gates.
+//
+// Scenarios explicitly out of scope here:
+//   Scenario 3 (UI -> system) is a composition of Scenario 1's runtime behavior
+//   with per-UI picker unit tests already owned by T7/T8/T9:
+//     - T7: src/app/onboarding/__tests__/*.test.tsx
+//     - T8: src/components/__tests__/AgentPermissionPicker.test.tsx
+//     - T9: src/app/(dashboard)/settings/agents/[uuid]/__tests__/*.test.tsx
+//   Those tests assert the pickers emit the same `{ roles, permissions }` payload
+//   the REST route receives; POST /api/agents handling of that payload is asserted
+//   here in Scenario 1. Together they cover UI -> API -> runtime tool visibility.
+//   Driving a real browser is intentionally not done (no Playwright in this suite).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Module mocks (hoisted). =====
+// MCP tool registration tests rely only on the names passed to server.registerTool;
+// we stub every service as an empty object so no handler ever executes during
+// registration. Prisma is stubbed for the same reason — not called here.
+// REST tests mock a narrow set of services to a benign shape so the happy paths
+// reach a 2xx status without hitting a real DB.
+
+const mockGetAuthContext = vi.fn();
+
+const mockPrisma = vi.hoisted(() => ({
+  agent: {
+    create: vi.fn(),
+  },
+}));
+
+const mockProjectExists = vi.fn();
+const mockListIdeas = vi.fn();
+const mockListProposals = vi.fn();
+const mockCreateProposal = vi.fn();
+const mockGetProposalByUuid = vi.fn();
+const mockApproveProposal = vi.fn();
+const mockCreateActivity = vi.fn();
+const mockGetTask = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+vi.mock("@/lib/super-admin", () => ({
+  getSuperAdminFromRequest: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/user-session", () => ({
+  getUserSessionFromRequest: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/oidc-auth", () => ({
+  verifyOidcAccessToken: vi.fn().mockResolvedValue(null),
+  isOidcToken: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/api-key", () => ({
+  extractApiKey: vi.fn(),
+  validateApiKey: vi.fn().mockResolvedValue({ valid: false }),
+}));
+
+// Intercept getAuthContext only; keep the real hasPermission/checkAgentPermission/isAgent/isUser
+// helpers so the gate logic itself is under test.
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+  };
+});
+
+vi.mock("@/services/idea.service", () => ({
+  listIdeas: (...args: unknown[]) => mockListIdeas(...args),
+  createIdea: vi.fn(),
+}));
+
+vi.mock("@/services/proposal.service", () => ({
+  listProposals: (...args: unknown[]) => mockListProposals(...args),
+  createProposal: (...args: unknown[]) => mockCreateProposal(...args),
+  getProposalByUuid: (...args: unknown[]) => mockGetProposalByUuid(...args),
+  approveProposal: (...args: unknown[]) => mockApproveProposal(...args),
+}));
+
+vi.mock("@/services/project.service", () => ({
+  projectExists: (...args: unknown[]) => mockProjectExists(...args),
+}));
+
+vi.mock("@/services/activity.service", () => ({
+  createActivity: (...args: unknown[]) => mockCreateActivity(...args),
+}));
+
+vi.mock("@/services/task.service", () => ({
+  getTask: (...args: unknown[]) => mockGetTask(...args),
+  getTaskByUuid: vi.fn(),
+  updateTask: vi.fn(),
+  deleteTask: vi.fn(),
+  isValidTaskStatusTransition: vi.fn(),
+  checkDependenciesResolved: vi.fn(),
+}));
+
+// Remaining services imported transitively by the MCP tool modules — stubbed empty
+// because registration never reaches any handler body.
+vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/document.service", () => ({}));
+vi.mock("@/services/comment.service", () => ({}));
+vi.mock("@/services/assignment.service", () => ({}));
+vi.mock("@/services/notification.service", () => ({}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/project-group.service", () => ({}));
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/search.service", () => ({}));
+vi.mock("@/services/agent.service", () => ({ getAgentByUuid: vi.fn() }));
+
+import { POST as postAgent } from "@/app/api/agents/route";
+import { GET as getIdeas } from "@/app/api/projects/[uuid]/ideas/route";
+import { POST as postProposal } from "@/app/api/projects/[uuid]/proposals/route";
+import { POST as approveProposalHandler } from "@/app/api/proposals/[uuid]/approve/route";
+import { registerPmTools } from "@/mcp/tools/pm";
+import { registerDeveloperTools } from "@/mcp/tools/developer";
+import { registerAdminTools } from "@/mcp/tools/admin";
+import { ROLE_PRESETS } from "@/lib/authz/presets";
+import type { AgentAuthContext } from "@/types/auth";
+import type { Permission } from "@/lib/authz/types";
+
+// ===== Helpers =====
+
+const companyUuid = "company-0000-0000-0000-000000000001";
+const userUuid = "user-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-0000000000a1";
+const projectUuid = "project-0000-0000-0000-000000000001";
+const proposalUuid = "proposal-0000-0000-0000-0000000000a2";
+
+function jsonRequest(
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost:3000"), init);
+}
+
+function makeContext<T>(params: T) {
+  return { params: Promise.resolve(params) };
+}
+
+const emptyCtx = {
+  params: Promise.resolve({}),
+} as { params: Promise<Record<string, string>> };
+
+// Minimal MCP server stand-in: records names passed to registerTool.
+function makeCapturingServer(): { server: unknown; names: string[] } {
+  const names: string[] = [];
+  const server = {
+    registerTool: (name: string) => {
+      names.push(name);
+    },
+  };
+  return { server, names };
+}
+
+function makeAgentAuth(permissions: Permission[], roles: string[] = []): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid,
+    actorUuid: agentUuid,
+    agentName: "Integration Agent",
+    roles: roles as AgentAuthContext["roles"],
+    permissions,
+  };
+}
+
+// Run every permission-gated MCP registration module with the supplied auth
+// and return the set of registered tool names. This is the same enumeration
+// path /api/mcp takes when it constructs a server for a live session.
+function enumerateGatedMcpTools(auth: AgentAuthContext): Set<string> {
+  const { server, names } = makeCapturingServer();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerPmTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerDeveloperTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerAdminTools(server as any, auth);
+  return new Set(names);
+}
+
+// Frozen 0.6.x tool-name baselines — the source of truth for preset parity assertions.
+// Kept in sync with src/mcp/__tests__/server.test.ts. If either list drifts, both tests fail together.
+const OLD_PM_TOOLS = [
+  "chorus_claim_idea",
+  "chorus_release_idea",
+  "chorus_pm_create_proposal",
+  "chorus_pm_validate_proposal",
+  "chorus_pm_submit_proposal",
+  "chorus_pm_create_document",
+  "chorus_pm_create_tasks",
+  "chorus_pm_update_document",
+  "chorus_pm_add_document_draft",
+  "chorus_pm_add_task_draft",
+  "chorus_pm_update_document_draft",
+  "chorus_pm_update_task_draft",
+  "chorus_pm_remove_document_draft",
+  "chorus_pm_remove_task_draft",
+  "chorus_add_task_dependency",
+  "chorus_remove_task_dependency",
+  "chorus_pm_assign_task",
+  "chorus_pm_start_elaboration",
+  "chorus_pm_validate_elaboration",
+  "chorus_pm_skip_elaboration",
+  "chorus_move_idea",
+  "chorus_pm_reject_proposal",
+  "chorus_pm_revoke_proposal",
+  "chorus_pm_create_idea",
+];
+
+const OLD_DEVELOPER_TOOLS = [
+  "chorus_claim_task",
+  "chorus_release_task",
+  "chorus_submit_for_verify",
+  "chorus_report_criteria_self_check",
+  "chorus_report_work",
+];
+
+const OLD_ADMIN_TOOLS = [
+  "chorus_admin_create_project",
+  "chorus_admin_approve_proposal",
+  "chorus_admin_close_proposal",
+  "chorus_admin_verify_task",
+  "chorus_admin_reopen_task",
+  "chorus_mark_acceptance_criteria",
+  "chorus_admin_close_task",
+  "chorus_admin_delete_idea",
+  "chorus_admin_delete_task",
+  "chorus_admin_delete_document",
+  "chorus_admin_create_project_group",
+  "chorus_admin_update_project_group",
+  "chorus_admin_delete_project_group",
+  "chorus_admin_move_project_to_group",
+];
+
+// The +10 diff from the T3 consensus (comment 063165db on task b9bb9161, 2026-04-30):
+//   +5 project/ProjectGroup admin tools gated on project:write
+//   +5 developer task-execution tools gated on task:write
+const PM_AGENT_ADDED_IN_0_7_0 = [
+  // project:write additions
+  "chorus_admin_create_project",
+  "chorus_admin_create_project_group",
+  "chorus_admin_update_project_group",
+  "chorus_admin_delete_project_group",
+  "chorus_admin_move_project_to_group",
+  // task:write additions (pm_agent preset carries task:write)
+  "chorus_claim_task",
+  "chorus_release_task",
+  "chorus_submit_for_verify",
+  "chorus_report_criteria_self_check",
+  "chorus_report_work",
+];
+
+// ===== Shared beforeEach =====
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockProjectExists.mockResolvedValue(true);
+  mockListIdeas.mockResolvedValue({ ideas: [], total: 0 });
+  mockListProposals.mockResolvedValue({ proposals: [], total: 0 });
+  mockCreateProposal.mockResolvedValue({ uuid: "proposal-new" });
+  mockGetProposalByUuid.mockResolvedValue({
+    uuid: proposalUuid,
+    projectUuid,
+    status: "pending",
+  });
+  mockApproveProposal.mockResolvedValue({ uuid: proposalUuid, status: "approved" });
+  mockGetTask.mockResolvedValue({ uuid: "task-x", title: "t" });
+});
+
+// ============================================================
+// Scenario 1 — custom-permissions agent: full create -> enumerate -> gate chain
+// ============================================================
+
+describe("Scenario 1: custom permissions agent end-to-end (AC1)", () => {
+  const customPermissions: Permission[] = ["idea:read", "task:read", "task:write"];
+
+  it("POST /api/agents creates the agent and returns effectivePermissions equal to the custom set", async () => {
+    // Caller is a user (only users can create agents).
+    mockGetAuthContext.mockResolvedValue({
+      type: "user",
+      companyUuid,
+      actorUuid: userUuid,
+    });
+
+    mockPrisma.agent.create.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Custom Agent",
+      roles: [],
+      permissions: customPermissions,
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      createdAt: new Date("2026-04-30T00:00:00Z"),
+    });
+
+    const response = await postAgent(
+      jsonRequest("/api/agents", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Custom Agent",
+          roles: [],
+          permissions: customPermissions,
+        }),
+      }),
+      emptyCtx,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.roles).toEqual([]);
+    expect(body.data.permissions).toEqual(customPermissions);
+    // With roles=[], effective = custom (no preset expansion).
+    expect(new Set(body.data.effectivePermissions)).toEqual(new Set(customPermissions));
+  });
+
+  it("MCP tools/list shows exactly the tools gated by the custom permission set", () => {
+    // Under customPermissions the only matches in the permission map are the 5
+    // developer.ts tools (gated on task:write). idea:read and task:read point
+    // at public.ts tools which aren't gated via registerPermissionedTool, so
+    // they don't surface here — they're always visible to any authenticated agent.
+    const auth = makeAgentAuth(customPermissions);
+    const tools = enumerateGatedMcpTools(auth);
+    expect(tools).toEqual(new Set(OLD_DEVELOPER_TOOLS));
+  });
+
+  it("MCP tools/list must NOT expose pm-write / admin / proposal-read tools", () => {
+    const auth = makeAgentAuth(customPermissions);
+    const tools = enumerateGatedMcpTools(auth);
+    for (const forbidden of [
+      "chorus_pm_create_idea",
+      "chorus_pm_create_proposal",
+      "chorus_admin_create_project",
+      "chorus_admin_approve_proposal",
+      "chorus_admin_verify_task",
+    ]) {
+      expect(tools.has(forbidden)).toBe(false);
+    }
+  });
+
+  it("GET /api/projects/[uuid]/ideas returns 200 (idea:read satisfied)", async () => {
+    mockGetAuthContext.mockResolvedValue(makeAgentAuth(customPermissions));
+
+    const response = await getIdeas(
+      jsonRequest(`/api/projects/${projectUuid}/ideas`),
+      makeContext({ uuid: projectUuid }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockListIdeas).toHaveBeenCalled();
+  });
+
+  it("POST /api/projects/[uuid]/proposals returns 403 with 'Missing permission: proposal:write'", async () => {
+    mockGetAuthContext.mockResolvedValue(makeAgentAuth(customPermissions));
+
+    const response = await postProposal(
+      jsonRequest(`/api/projects/${projectUuid}/proposals`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "P1",
+          inputType: "idea",
+          inputUuids: ["idea-1"],
+        }),
+      }),
+      makeContext({ uuid: projectUuid }),
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error.message).toContain("proposal:write");
+    expect(mockCreateProposal).not.toHaveBeenCalled();
+  });
+
+  // Substitute for POST /api/tasks/[uuid]/verify. The task description mentions that
+  // endpoint, but Chorus does not expose a REST verify route — verification is an
+  // MCP-only operation (chorus_admin_verify_task, gated on task:admin). The closest
+  // REST route gated on an *:admin permission is proposal approve (proposal:admin);
+  // it exercises the same permissionDenied gate pattern, so we assert against it.
+  it("POST /api/proposals/[uuid]/approve returns 403 with 'Missing permission: proposal:admin'", async () => {
+    mockGetAuthContext.mockResolvedValue(makeAgentAuth(customPermissions));
+
+    const response = await approveProposalHandler(
+      jsonRequest(`/api/proposals/${proposalUuid}/approve`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      makeContext({ uuid: proposalUuid }),
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.message).toContain("proposal:admin");
+    expect(mockApproveProposal).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================
+// Scenario 2 — preset backward-compatibility / expected +10 diff for pm_agent
+// ============================================================
+
+describe("Scenario 2: preset parity with 0.6.x baseline (AC2)", () => {
+  it("developer_agent preset registers exactly the 0.6.x developer tool set", () => {
+    const auth = makeAgentAuth([...ROLE_PRESETS.developer_agent], ["developer_agent"]);
+    const tools = enumerateGatedMcpTools(auth);
+    expect(tools).toEqual(new Set(OLD_DEVELOPER_TOOLS));
+  });
+
+  it("admin_agent preset registers exactly the 0.6.x admin ∪ pm ∪ developer tool set", () => {
+    const auth = makeAgentAuth([...ROLE_PRESETS.admin_agent], ["admin_agent"]);
+    const tools = enumerateGatedMcpTools(auth);
+    const expected = new Set([
+      ...OLD_ADMIN_TOOLS,
+      ...OLD_PM_TOOLS,
+      ...OLD_DEVELOPER_TOOLS,
+    ]);
+    expect(tools).toEqual(expected);
+  });
+
+  // The task description says the pm_agent diff is +5. That number is stale.
+  // Consensus captured on task b9bb9161 (T3), comment 063165db (2026-04-30): under
+  // pure permission gating, pm_agent (which holds task:write) legitimately sees the
+  // 5 developer.ts tools as well. Operational escalation is zero — the handlers
+  // themselves enforce isAssignee at runtime. So the correct contract is +10:
+  // strict superset-of-baseline, diff = exactly the 10 tools listed below.
+  it("pm_agent preset is a strict superset of 0.6.x pm baseline", () => {
+    const auth = makeAgentAuth([...ROLE_PRESETS.pm_agent], ["pm_agent"]);
+    const tools = enumerateGatedMcpTools(auth);
+    for (const old of OLD_PM_TOOLS) {
+      expect(tools.has(old)).toBe(true);
+    }
+  });
+
+  it("pm_agent diff vs 0.6.x pm baseline is exactly the 10 expected tools (5 project + 5 developer)", () => {
+    const auth = makeAgentAuth([...ROLE_PRESETS.pm_agent], ["pm_agent"]);
+    const tools = enumerateGatedMcpTools(auth);
+    const baseline = new Set(OLD_PM_TOOLS);
+    const diff = Array.from(tools).filter((t) => !baseline.has(t)).sort();
+    expect(diff).toEqual([...PM_AGENT_ADDED_IN_0_7_0].sort());
+  });
+
+  it("pm_agent preset does not leak any *:admin-gated tool", () => {
+    const auth = makeAgentAuth([...ROLE_PRESETS.pm_agent], ["pm_agent"]);
+    const tools = enumerateGatedMcpTools(auth);
+    for (const adminOnly of [
+      "chorus_admin_approve_proposal",
+      "chorus_admin_close_proposal",
+      "chorus_admin_verify_task",
+      "chorus_admin_reopen_task",
+      "chorus_admin_close_task",
+      "chorus_mark_acceptance_criteria",
+      "chorus_admin_delete_task",
+      "chorus_admin_delete_idea",
+      "chorus_admin_delete_document",
+    ]) {
+      expect(tools.has(adminOnly)).toBe(false);
+    }
+  });
+});
+
+// ============================================================
+// Scenario 3 — deliberately not implemented here; covered transitively.
+// The UI pickers emit { roles, permissions } payloads that POST /api/agents
+// consumes; the REST + MCP behavior of that payload is Scenario 1's contract.
+// Dedicated picker tests live in:
+//   src/app/onboarding/__tests__/*.test.tsx                 (T7)
+//   src/components/__tests__/AgentPermissionPicker.test.tsx (T8)
+//   src/app/(dashboard)/settings/agents/[uuid]/__tests__/*.test.tsx (T9)
+// Driving a real browser is out of scope for this Vitest suite.
+// ============================================================
+
+// ============================================================
+// Scenario 4 — super_admin bypasses REST permission gates
+// ============================================================
+
+describe("Scenario 4: super_admin bypass (AC4)", () => {
+  it("super_admin passes the agent-permission gate on a read endpoint (idea:read)", async () => {
+    // super_admin is neither "agent" nor "user"; checkAgentPermission short-circuits
+    // only on "agent", so this passes through to the service layer.
+    mockGetAuthContext.mockResolvedValue({
+      type: "super_admin",
+      companyUuid,
+    });
+
+    const response = await getIdeas(
+      jsonRequest(`/api/projects/${projectUuid}/ideas`),
+      makeContext({ uuid: projectUuid }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockListIdeas).toHaveBeenCalled();
+  });
+
+  it("super_admin bypasses the write-path agent gate on POST proposals", async () => {
+    // POST proposals uses an inline isAgent+hasPermission gate instead of checkAgentPermission.
+    // super_admin is not an agent, so the gate's `isAgent(auth)` branch is skipped;
+    // the `else if (!isUser(auth))` branch returns 403 for any non-user non-agent.
+    // This asserts the expected behavior: super_admin cannot create proposals via
+    // this REST endpoint. Their path for privileged ops is separate (admin endpoints
+    // and MCP admin tools). The test records this contract so future route changes
+    // don't silently widen super_admin's surface.
+    mockGetAuthContext.mockResolvedValue({
+      type: "super_admin",
+      companyUuid,
+    });
+
+    const response = await postProposal(
+      jsonRequest(`/api/projects/${projectUuid}/proposals`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "P",
+          inputType: "idea",
+          inputUuids: ["idea-1"],
+        }),
+      }),
+      makeContext({ uuid: projectUuid }),
+    );
+
+    // The inline gate returns 403 "Only users or permitted agents...", not "Missing permission".
+    expect(response.status).toBe(403);
+    expect(mockCreateProposal).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(dashboard)/settings/actions.ts
+++ b/src/app/(dashboard)/settings/actions.ts
@@ -18,6 +18,10 @@ import {
   type SessionResponse,
 } from "@/services/session.service";
 import logger from "@/lib/logger";
+import {
+  computeEffectivePermissions,
+  isValidPermission,
+} from "@/lib/authz/permissions";
 
 interface ApiKeyResponse {
   uuid: string;
@@ -27,6 +31,8 @@ interface ApiKeyResponse {
   expiresAt: string | null;
   createdAt: string;
   roles: string[];
+  permissions: string[];
+  effectivePermissions: string[];
   agentUuid: string;
   persona: string | null;
 }
@@ -44,17 +50,25 @@ export async function getApiKeysAction(): Promise<{
   try {
     const { apiKeys } = await listApiKeys(auth.companyUuid, 0, 100, auth.actorUuid);
 
-    const data = apiKeys.map((key) => ({
-      uuid: key.uuid,
-      keyPrefix: key.keyPrefix,
-      name: key.agent?.name || key.name,
-      lastUsed: null,
-      expiresAt: key.expiresAt?.toISOString() || null,
-      createdAt: key.createdAt.toISOString(),
-      roles: key.agent?.roles || [],
-      agentUuid: key.agent?.uuid || "",
-      persona: key.agent?.persona || null,
-    }));
+    const data = apiKeys.map((key) => {
+      const roles = key.agent?.roles || [];
+      const permissions = key.agent?.permissions || [];
+      return {
+        uuid: key.uuid,
+        keyPrefix: key.keyPrefix,
+        name: key.agent?.name || key.name,
+        lastUsed: null,
+        expiresAt: key.expiresAt?.toISOString() || null,
+        createdAt: key.createdAt.toISOString(),
+        roles,
+        permissions,
+        effectivePermissions: Array.from(
+          computeEffectivePermissions(roles, permissions),
+        ),
+        agentUuid: key.agent?.uuid || "",
+        persona: key.agent?.persona || null,
+      };
+    });
 
     return { success: true, data };
   } catch (error) {
@@ -67,6 +81,7 @@ interface CreateAgentKeyInput {
   name: string;
   roles: string[];
   persona: string | null;
+  permissions?: string[];
 }
 
 export async function createAgentAndKeyAction(input: CreateAgentKeyInput): Promise<{
@@ -81,13 +96,22 @@ export async function createAgentAndKeyAction(input: CreateAgentKeyInput): Promi
   }
 
   try {
-    // Create agent with specified roles and persona
+    if (input.permissions) {
+      for (const p of input.permissions) {
+        if (!isValidPermission(p)) {
+          return { success: false, error: `Invalid permission: ${p}` };
+        }
+      }
+    }
+
+    // Create agent with specified roles, persona, and permissions
     const agent = await createAgent({
       companyUuid: auth.companyUuid,
       name: input.name,
       roles: input.roles,
       ownerUuid: auth.actorUuid,
       persona: input.persona,
+      permissions: input.permissions,
     });
 
     // Create API key for the agent
@@ -185,9 +209,10 @@ export async function reopenSessionAction(sessionUuid: string): Promise<{
 
 interface UpdateAgentInput {
   agentUuid: string;
-  name: string;
-  roles: string[];
-  persona: string | null;
+  name?: string;
+  roles?: string[];
+  persona?: string | null;
+  permissions?: string[];
 }
 
 export async function updateAgentAction(input: UpdateAgentInput): Promise<{
@@ -200,14 +225,31 @@ export async function updateAgentAction(input: UpdateAgentInput): Promise<{
   }
 
   try {
-    await updateAgent(input.agentUuid, {
-      name: input.name,
-      roles: input.roles,
-      persona: input.persona,
-    }, auth.companyUuid);
+    if (input.permissions) {
+      for (const p of input.permissions) {
+        if (!isValidPermission(p)) {
+          return { success: false, error: `Invalid permission: ${p}` };
+        }
+      }
+    }
+
+    const updateData: {
+      name?: string;
+      roles?: string[];
+      persona?: string | null;
+      permissions?: string[];
+    } = {};
+    if (input.name !== undefined) updateData.name = input.name;
+    if (input.roles !== undefined) updateData.roles = input.roles;
+    if (input.persona !== undefined) updateData.persona = input.persona;
+    if (input.permissions !== undefined) updateData.permissions = input.permissions;
+
+    await updateAgent(input.agentUuid, updateData, auth.companyUuid);
 
     // Sync API key names to match the updated agent name
-    await syncApiKeyNames(input.agentUuid, input.name);
+    if (input.name !== undefined) {
+      await syncApiKeyNames(input.agentUuid, input.name);
+    }
 
     return { success: true };
   } catch (error) {

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -3,10 +3,6 @@
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,9 +13,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Plus, Key, Check, X, Globe, AlertTriangle, ShieldAlert, ChevronDown, ChevronRight, Activity, Bell, Pencil, Rocket } from "lucide-react";
+import { Plus, Key, X, Globe, ChevronDown, ChevronRight, Activity, Bell, Pencil, Rocket } from "lucide-react";
 import Link from "next/link";
 import { AgentCreateForm } from "@/components/AgentCreateForm";
+import { AgentFormFields } from "@/components/AgentFormFields";
+import type { AgentPermissionPickerChange } from "@/components/AgentPermissionPicker";
 import { Badge } from "@/components/ui/badge";
 import { useLocale } from "@/contexts/locale-context";
 import { getApiKeysAction, createAgentAndKeyAction, deleteApiKeyAction, getAgentSessionsAction, closeSessionAction, reopenSessionAction, updateAgentAction } from "./actions";
@@ -29,6 +27,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { NotificationPreferencesForm } from "@/components/notification-preferences-form";
 import { clientLogger } from "@/lib/logger-client";
 import { formatDateTime } from "@/lib/format-date";
+import { ROLE_PRESETS, type PresetKey } from "@/lib/authz/presets";
+import { computeEffectivePermissions } from "@/lib/authz/permissions";
+import type { Permission } from "@/lib/authz/types";
 
 interface ApiKey {
   uuid: string;
@@ -38,29 +39,20 @@ interface ApiKey {
   expiresAt: string | null;
   createdAt: string;
   roles: string[];
+  permissions: string[];
+  effectivePermissions: string[];
   agentUuid: string;
   persona: string | null;
 }
 
-// PM Agent Persona presets (labels and descriptions use i18n keys)
-const PM_PERSONAS = [
-  { id: "dev_pm", labelKey: "personas.devPm", descKey: "personas.devPmDesc" },
-  { id: "full_pm", labelKey: "personas.fullPm", descKey: "personas.fullPmDesc" },
-  { id: "simple_pm", labelKey: "personas.simplePm", descKey: "personas.simplePmDesc" },
-];
+type EditPreset = PresetKey | "custom";
 
-// Developer Agent Persona presets
-const DEV_PERSONAS = [
-  { id: "senior_dev", labelKey: "personas.seniorDev", descKey: "personas.seniorDevDesc" },
-  { id: "fullstack_dev", labelKey: "personas.fullstackDev", descKey: "personas.fullstackDevDesc" },
-  { id: "pragmatic_dev", labelKey: "personas.pragmaticDev", descKey: "personas.pragmaticDevDesc" },
-];
-
-// Admin Agent Persona presets
-const ADMIN_PERSONAS = [
-  { id: "careful_admin", labelKey: "personas.carefulAdmin", descKey: "personas.carefulAdminDesc" },
-  { id: "efficient_admin", labelKey: "personas.efficientAdmin", descKey: "personas.efficientAdminDesc" },
-];
+function derivePresetFromRoles(roles: string[]): EditPreset {
+  if (roles.length === 1 && roles[0] in ROLE_PRESETS) {
+    return roles[0] as PresetKey;
+  }
+  return "custom";
+}
 
 export default function SettingsPage() {
   const t = useTranslations();
@@ -80,9 +72,9 @@ export default function SettingsPage() {
   const [showEditModal, setShowEditModal] = useState(false);
   const [editingKey, setEditingKey] = useState<ApiKey | null>(null);
   const [editName, setEditName] = useState("");
-  const [editRoles, setEditRoles] = useState<string[]>([]);
+  const [editPreset, setEditPreset] = useState<EditPreset>("custom");
+  const [editPermissions, setEditPermissions] = useState<Permission[]>([]);
   const [editPersona, setEditPersona] = useState("");
-  const [editAdminConfirmed, setEditAdminConfirmed] = useState(false);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -169,11 +161,15 @@ export default function SettingsPage() {
 
   // Edit modal helpers
   const openEditModal = (key: ApiKey) => {
+    const preset = derivePresetFromRoles(key.roles);
+    const effective = key.effectivePermissions as Permission[];
+    const pickerPermissions: Permission[] =
+      preset === "custom" ? effective : [];
     setEditingKey(key);
     setEditName(key.name || "");
-    setEditRoles([...key.roles]);
+    setEditPreset(preset);
+    setEditPermissions(pickerPermissions);
     setEditPersona(key.persona || "");
-    setEditAdminConfirmed(key.roles.includes("admin_agent"));
     setShowEditModal(true);
   };
 
@@ -181,54 +177,52 @@ export default function SettingsPage() {
     setShowEditModal(false);
     setEditingKey(null);
     setEditName("");
-    setEditRoles([]);
+    setEditPreset("custom");
+    setEditPermissions([]);
     setEditPersona("");
-    setEditAdminConfirmed(false);
   };
 
-  const toggleEditRole = (role: string) => {
-    setEditRoles((prev) => {
-      const newRoles = prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role];
-      if (role === "admin_agent" && prev.includes(role)) {
-        setEditAdminConfirmed(false);
-      }
-      return newRoles;
-    });
-  };
-
-  const getEditAvailablePersonas = () => {
-    const personas: { id: string; labelKey: string; descKey: string }[] = [];
-    if (editRoles.includes("pm_agent")) {
-      personas.push(...PM_PERSONAS);
-    }
-    if (editRoles.includes("developer_agent")) {
-      personas.push(...DEV_PERSONAS);
-    }
-    if (editRoles.includes("admin_agent")) {
-      personas.push(...ADMIN_PERSONAS);
-    }
-    return personas;
+  const handlePickerChange = (next: AgentPermissionPickerChange) => {
+    setEditPreset(next.preset);
+    setEditPermissions(next.permissions as Permission[]);
   };
 
   const handleUpdateAgent = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!editingKey || !editName || editRoles.length === 0) return;
+    if (!editingKey || !editName) return;
+
+    // Custom mode persists the full effective set (not a delta). Preset mode
+    // persists the role and empty permissions so future preset tweaks are
+    // picked up automatically.
+    const saveRoles = editPreset === "custom" ? [] : [editPreset];
+    const savePermissions =
+      editPreset === "custom" ? editPermissions : [];
 
     setSaving(true);
     try {
       const result = await updateAgentAction({
         agentUuid: editingKey.agentUuid,
         name: editName,
-        roles: editRoles,
+        roles: saveRoles,
+        permissions: savePermissions,
         persona: editPersona || null,
       });
 
       if (result.success) {
-        // Update local state to reflect changes
+        const nextEffective = Array.from(
+          computeEffectivePermissions(saveRoles, savePermissions),
+        );
         setApiKeys((prev) =>
           prev.map((k) =>
             k.agentUuid === editingKey.agentUuid
-              ? { ...k, name: editName, roles: editRoles, persona: editPersona || null }
+              ? {
+                  ...k,
+                  name: editName,
+                  roles: saveRoles,
+                  permissions: savePermissions,
+                  effectivePermissions: nextEffective,
+                  persona: editPersona || null,
+                }
               : k
           )
         );
@@ -242,8 +236,6 @@ export default function SettingsPage() {
       setSaving(false);
     }
   };
-
-  const editHasAdminRole = editRoles.includes("admin_agent");
 
   if (loading) {
     return (
@@ -388,28 +380,6 @@ export default function SettingsPage() {
                     >
                       {t("common.delete")}
                     </Button>
-                  </div>
-                </div>
-
-                {/* Roles Row */}
-                <div className="mt-4 flex items-center gap-4">
-                  <span className="text-xs text-muted-foreground">{t("settings.roles")}</span>
-                  <div className="flex items-center gap-2">
-                    {key.roles.includes("developer_agent") && (
-                      <Badge variant="secondary" className="bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-950 dark:text-blue-300">
-                        {t("settings.developerAgent")}
-                      </Badge>
-                    )}
-                    {key.roles.includes("pm_agent") && (
-                      <Badge variant="secondary" className="bg-orange-50 text-orange-700 hover:bg-orange-50 dark:bg-orange-950 dark:text-orange-300">
-                        {t("settings.pmAgent")}
-                      </Badge>
-                    )}
-                    {key.roles.includes("admin_agent") && (
-                      <Badge variant="secondary" className="bg-red-50 text-red-700 hover:bg-red-50 dark:bg-red-950 dark:text-red-300">
-                        {t("settings.adminAgent")}
-                      </Badge>
-                    )}
                   </div>
                 </div>
 
@@ -562,197 +532,18 @@ export default function SettingsPage() {
               </div>
 
               {/* Modal Body */}
-              <div className="space-y-5 p-6">
-                {/* Name Field */}
-                <div className="space-y-2">
-                  <Label htmlFor="editName" className="text-[13px]">
-                    {t("settings.name")}
-                  </Label>
-                  <Input
-                    id="editName"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    placeholder={t("settings.namePlaceholder")}
-                    className="border-[#E5E0D8]"
-                    required
-                  />
-                </div>
-
-                {/* Agent Roles */}
-                <div className="space-y-3">
-                  <Label className="text-[13px]">{t("settings.agentRoles")}</Label>
-                  <p className="text-xs text-muted-foreground">
-                    {t("settings.agentRolesDesc")}
-                  </p>
-                  <div className="space-y-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => toggleEditRole("developer_agent")}
-                      className={`flex h-auto w-full items-start justify-start gap-3 rounded-lg border p-3 text-left transition-colors ${
-                        editRoles.includes("developer_agent")
-                          ? "border-primary bg-primary/5"
-                          : "border-border hover:border-primary"
-                      }`}
-                    >
-                      <div
-                        className={`mt-0.5 flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded ${
-                          editRoles.includes("developer_agent")
-                            ? "bg-primary"
-                            : "border-2 border-border"
-                        }`}
-                      >
-                        {editRoles.includes("developer_agent") && (
-                          <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />
-                        )}
-                      </div>
-                      <div>
-                        <div className="text-sm font-medium text-foreground">
-                          {t("settings.developerAgent")}
-                        </div>
-                        <div className="text-xs font-normal text-muted-foreground">
-                          {t("settings.developerAgentDesc")}
-                        </div>
-                      </div>
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => toggleEditRole("pm_agent")}
-                      className={`flex h-auto w-full items-start justify-start gap-3 rounded-lg border p-3 text-left transition-colors ${
-                        editRoles.includes("pm_agent")
-                          ? "border-primary bg-primary/5"
-                          : "border-border hover:border-primary"
-                      }`}
-                    >
-                      <div
-                        className={`mt-0.5 flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded ${
-                          editRoles.includes("pm_agent")
-                            ? "bg-primary"
-                            : "border-2 border-border"
-                        }`}
-                      >
-                        {editRoles.includes("pm_agent") && (
-                          <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />
-                        )}
-                      </div>
-                      <div>
-                        <div className="text-sm font-medium text-foreground">
-                          {t("settings.pmAgent")}
-                        </div>
-                        <div className="text-xs font-normal text-muted-foreground">
-                          {t("settings.pmAgentDesc")}
-                        </div>
-                      </div>
-                    </Button>
-                    {/* Admin Agent - with danger styling */}
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => toggleEditRole("admin_agent")}
-                      className={`flex h-auto w-full items-start justify-start gap-3 rounded-lg border p-3 text-left transition-colors ${
-                        editRoles.includes("admin_agent")
-                          ? "border-red-500 bg-red-50 dark:bg-red-950"
-                          : "border-border hover:border-red-400"
-                      }`}
-                    >
-                      <div
-                        className={`mt-0.5 flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded ${
-                          editRoles.includes("admin_agent")
-                            ? "bg-red-500"
-                            : "border-2 border-red-300"
-                        }`}
-                      >
-                        {editRoles.includes("admin_agent") && (
-                          <Check className="h-3 w-3 text-white" strokeWidth={3} />
-                        )}
-                      </div>
-                      <div>
-                        <div className="flex items-center gap-2 text-sm font-medium text-red-600 dark:text-red-400">
-                          <ShieldAlert className="h-4 w-4" />
-                          {t("settings.adminAgent")}
-                        </div>
-                        <div className="text-xs font-normal text-red-500/80 dark:text-red-400/80">
-                          {t("settings.adminAgentDesc")}
-                        </div>
-                      </div>
-                    </Button>
-                  </div>
-
-                  {/* Admin Warning Box */}
-                  {editHasAdminRole && !editingKey.roles.includes("admin_agent") && (
-                    <div className="mt-3 rounded-lg border border-red-300 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950">
-                      <div className="flex items-start gap-3">
-                        <AlertTriangle className="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400" />
-                        <div className="space-y-2">
-                          <p className="text-sm font-semibold text-red-700 dark:text-red-300">
-                            {t("settings.adminWarningTitle")}
-                          </p>
-                          <p className="text-xs text-red-600 dark:text-red-400">
-                            {t("settings.adminWarningDesc")}
-                          </p>
-                          <ul className="list-inside list-disc space-y-1 text-xs text-red-600 dark:text-red-400">
-                            <li>{t("settings.adminWarningItem1")}</li>
-                            <li>{t("settings.adminWarningItem2")}</li>
-                            <li>{t("settings.adminWarningItem3")}</li>
-                            <li>{t("settings.adminWarningItem4")}</li>
-                          </ul>
-                          <div className="mt-3 flex cursor-pointer items-center gap-2">
-                            <Checkbox
-                              id="editAdminConfirm"
-                              checked={editAdminConfirmed}
-                              onCheckedChange={(checked) => setEditAdminConfirmed(checked === true)}
-                              className="border-red-300 data-[state=checked]:bg-red-600 data-[state=checked]:border-red-600"
-                            />
-                            <Label htmlFor="editAdminConfirm" className="cursor-pointer text-xs font-medium text-red-700 dark:text-red-300">
-                              {t("settings.adminConfirmCheckbox")}
-                            </Label>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* Agent Persona */}
-                <div className="space-y-3">
-                  <Label className="text-[13px]">{t("settings.agentPersona")}</Label>
-                  <p className="text-xs text-muted-foreground">
-                    {editRoles.length > 0
-                      ? t("settings.agentPersonaDesc")
-                      : t("settings.agentPersonaDescNoRoles")}
-                  </p>
-
-                  {/* Persona Presets */}
-                  {editRoles.length > 0 && (
-                    <div className="flex flex-wrap gap-2">
-                      {getEditAvailablePersonas().map((persona) => (
-                        <Button
-                          key={persona.id}
-                          type="button"
-                          variant={editPersona === t(persona.descKey) ? "default" : "outline"}
-                          size="sm"
-                          onClick={() => setEditPersona(t(persona.descKey))}
-                          className="rounded-full"
-                        >
-                          {t(persona.labelKey)}
-                        </Button>
-                      ))}
-                    </div>
-                  )}
-
-                  <Textarea
-                    value={editPersona}
-                    onChange={(e) => setEditPersona(e.target.value)}
-                    placeholder={t("settings.personaPlaceholder")}
-                    rows={4}
-                  />
-                  <p className="text-[11px] text-muted-foreground">
-                    {editRoles.length > 0
-                      ? t("settings.personaHint")
-                      : t("settings.personaHintNoRoles")}
-                  </p>
-                </div>
+              <div className="p-6">
+                <AgentFormFields
+                  name={editName}
+                  onNameChange={setEditName}
+                  preset={editPreset}
+                  permissions={editPermissions}
+                  onPermissionsChange={handlePickerChange}
+                  persona={editPersona}
+                  onPersonaChange={setEditPersona}
+                  nameInputId="editName"
+                  personaInputId="edit-agent-persona"
+                />
               </div>
 
               {/* Modal Footer */}
@@ -767,10 +558,10 @@ export default function SettingsPage() {
                 <Button
                   type="submit"
                   disabled={
-                    !editName || editRoles.length === 0 || saving ||
-                    (editHasAdminRole && !editingKey.roles.includes("admin_agent") && !editAdminConfirmed)
+                    !editName ||
+                    (editPreset === "custom" && editPermissions.length === 0) ||
+                    saving
                   }
-                  className={editHasAdminRole && !editingKey.roles.includes("admin_agent") ? "bg-red-600 hover:bg-red-700" : ""}
                 >
                   {saving ? t("settings.saving") : t("settings.saveChanges")}
                 </Button>

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -47,8 +47,19 @@ interface ApiKey {
 
 type EditPreset = PresetKey | "custom";
 
-function derivePresetFromRoles(roles: string[]): EditPreset {
-  if (roles.length === 1 && roles[0] in ROLE_PRESETS) {
+// A stored agent is treated as preset-mode only when its roles match a single
+// preset AND it has no extra custom permissions layered on top. Any extras
+// (possible via PATCH /api/agents or a future UI) force Custom mode so the
+// edit modal preserves them instead of silently zeroing them out on save.
+function deriveEditPreset(
+  roles: string[],
+  customPermissions: string[],
+): EditPreset {
+  if (
+    roles.length === 1 &&
+    roles[0] in ROLE_PRESETS &&
+    customPermissions.length === 0
+  ) {
     return roles[0] as PresetKey;
   }
   return "custom";
@@ -161,7 +172,7 @@ export default function SettingsPage() {
 
   // Edit modal helpers
   const openEditModal = (key: ApiKey) => {
-    const preset = derivePresetFromRoles(key.roles);
+    const preset = deriveEditPreset(key.roles, key.permissions);
     const effective = key.effectivePermissions as Permission[];
     const pickerPermissions: Permission[] =
       preset === "custom" ? effective : [];

--- a/src/app/api/__tests__/permission-gating.test.ts
+++ b/src/app/api/__tests__/permission-gating.test.ts
@@ -1,0 +1,308 @@
+// Integration tests for T4: REST API permission gating (AC4-AC7)
+// Verifies that agents are gated by their effective permission set,
+// that super_admin bypasses gating, and that admin-only endpoints are gated by the admin bit.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+const mockGetSuperAdminFromRequest = vi.fn();
+
+// Service mocks — return benign shapes so the happy paths reach a 2xx status
+const mockListIdeas = vi.fn();
+const mockCreateIdea = vi.fn();
+const mockProjectExists = vi.fn();
+const mockListProposals = vi.fn();
+const mockCreateProposal = vi.fn();
+const mockGetProposalByUuid = vi.fn();
+const mockApproveProposal = vi.fn();
+const mockCreateActivity = vi.fn();
+const mockGetTask = vi.fn();
+
+vi.mock("@/lib/super-admin", () => ({
+  getSuperAdminFromRequest: (...args: unknown[]) => mockGetSuperAdminFromRequest(...args),
+}));
+
+vi.mock("@/lib/user-session", () => ({
+  getUserSessionFromRequest: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/oidc-auth", () => ({
+  verifyOidcAccessToken: vi.fn().mockResolvedValue(null),
+  isOidcToken: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/api-key", () => ({
+  extractApiKey: vi.fn(),
+  validateApiKey: vi.fn().mockResolvedValue({ valid: false }),
+}));
+
+// Intercept getAuthContext to fully control the auth shape passed into handlers.
+// Keep the real checkAgentPermission/hasPermission/etc. so we exercise the real gate logic.
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+  };
+});
+
+vi.mock("@/services/idea.service", () => ({
+  listIdeas: (...args: unknown[]) => mockListIdeas(...args),
+  createIdea: (...args: unknown[]) => mockCreateIdea(...args),
+}));
+
+vi.mock("@/services/proposal.service", () => ({
+  listProposals: (...args: unknown[]) => mockListProposals(...args),
+  createProposal: (...args: unknown[]) => mockCreateProposal(...args),
+  getProposalByUuid: (...args: unknown[]) => mockGetProposalByUuid(...args),
+  approveProposal: (...args: unknown[]) => mockApproveProposal(...args),
+}));
+
+vi.mock("@/services/project.service", () => ({
+  projectExists: (...args: unknown[]) => mockProjectExists(...args),
+}));
+
+vi.mock("@/services/activity.service", () => ({
+  createActivity: (...args: unknown[]) => mockCreateActivity(...args),
+}));
+
+vi.mock("@/services/task.service", () => ({
+  getTask: (...args: unknown[]) => mockGetTask(...args),
+  getTaskByUuid: vi.fn(),
+  updateTask: vi.fn(),
+  deleteTask: vi.fn(),
+  isValidTaskStatusTransition: vi.fn(),
+  checkDependenciesResolved: vi.fn(),
+}));
+
+import { GET as getIdeas, POST as postIdea } from "@/app/api/projects/[uuid]/ideas/route";
+import { GET as getProposals, POST as postProposal } from "@/app/api/projects/[uuid]/proposals/route";
+import { POST as approveProposalHandler } from "@/app/api/proposals/[uuid]/approve/route";
+import { GET as getTaskHandler } from "@/app/api/tasks/[uuid]/route";
+
+const companyUuid = "company-0000-0000-0000-000000000001";
+const projectUuid = "project-0000-0000-0000-000000000001";
+const proposalUuid = "proposal-0000-0000-0000-0000000000a1";
+const taskUuid = "task-0000-0000-0000-00000000000a";
+
+function makeRequest(
+  url: string,
+  init?: { method?: string; body?: BodyInit; headers?: HeadersInit },
+): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost:3000"), init);
+}
+
+function makeContext<T>(params: T) {
+  return { params: Promise.resolve(params) };
+}
+
+function readAuth(
+  overrides: Partial<{ type: string; roles: string[]; permissions: string[] }> = {},
+) {
+  return {
+    type: "agent" as const,
+    companyUuid,
+    actorUuid: "agent-read-only",
+    agentName: "Read-only Agent",
+    roles: overrides.roles ?? [],
+    permissions: overrides.permissions ?? ["idea:read"],
+  };
+}
+
+describe("T4: REST API permission gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSuperAdminFromRequest.mockResolvedValue(null);
+    mockProjectExists.mockResolvedValue(true);
+    mockListIdeas.mockResolvedValue({ ideas: [], total: 0 });
+    mockCreateIdea.mockResolvedValue({ uuid: "idea-new" });
+    mockListProposals.mockResolvedValue({ proposals: [], total: 0 });
+    mockCreateProposal.mockResolvedValue({ uuid: "proposal-new" });
+    mockGetProposalByUuid.mockResolvedValue({
+      uuid: proposalUuid,
+      projectUuid,
+      status: "pending",
+    });
+    mockApproveProposal.mockResolvedValue({ uuid: proposalUuid, status: "approved" });
+    mockGetTask.mockResolvedValue({ uuid: taskUuid, title: "t" });
+  });
+
+  // AC4: agent with idea:read only — GET ideas allowed, POST idea forbidden
+  describe("AC4: agent with permissions=['idea:read'] and roles=[]", () => {
+    it("can GET /api/projects/[uuid]/ideas (read is allowed)", async () => {
+      mockGetAuthContext.mockResolvedValue(readAuth({ permissions: ["idea:read"] }));
+
+      const response = await getIdeas(
+        makeRequest(`/api/projects/${projectUuid}/ideas`),
+        makeContext({ uuid: projectUuid }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockListIdeas).toHaveBeenCalled();
+    });
+
+    it("gets 403 on POST /api/projects/[uuid]/ideas (no idea:write)", async () => {
+      mockGetAuthContext.mockResolvedValue(readAuth({ permissions: ["idea:read"] }));
+
+      const response = await postIdea(
+        makeRequest(`/api/projects/${projectUuid}/ideas`, {
+          method: "POST",
+          body: JSON.stringify({ title: "new idea" }),
+          headers: { "content-type": "application/json" },
+        }),
+        makeContext({ uuid: projectUuid }),
+      );
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.success).toBe(false);
+      expect(mockCreateIdea).not.toHaveBeenCalled();
+    });
+  });
+
+  // AC5: pm_agent can POST proposal, but 403 on approve (approve needs proposal:admin)
+  describe("AC5: agent with roles=['pm_agent']", () => {
+    const pmPermissions = [
+      "idea:read", "idea:write",
+      "proposal:read", "proposal:write",
+      "document:read", "document:write",
+      "task:read", "task:write",
+      "project:read", "project:write",
+    ];
+
+    it("can POST /api/projects/[uuid]/proposals (has proposal:write)", async () => {
+      mockGetAuthContext.mockResolvedValue({
+        type: "agent",
+        companyUuid,
+        actorUuid: "agent-pm",
+        agentName: "PM Agent",
+        roles: ["pm_agent"],
+        permissions: pmPermissions,
+      });
+
+      const response = await postProposal(
+        makeRequest(`/api/projects/${projectUuid}/proposals`, {
+          method: "POST",
+          body: JSON.stringify({
+            title: "Proposal",
+            inputType: "idea",
+            inputUuids: ["idea-x"],
+          }),
+          headers: { "content-type": "application/json" },
+        }),
+        makeContext({ uuid: projectUuid }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockCreateProposal).toHaveBeenCalled();
+    });
+
+    it("gets 403 on POST /api/proposals/[uuid]/approve (no proposal:admin)", async () => {
+      mockGetAuthContext.mockResolvedValue({
+        type: "agent",
+        companyUuid,
+        actorUuid: "agent-pm",
+        agentName: "PM Agent",
+        roles: ["pm_agent"],
+        permissions: pmPermissions,
+      });
+
+      const response = await approveProposalHandler(
+        makeRequest(`/api/proposals/${proposalUuid}/approve`, {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "content-type": "application/json" },
+        }),
+        makeContext({ uuid: proposalUuid }),
+      );
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error.message).toContain("proposal:admin");
+      expect(mockApproveProposal).not.toHaveBeenCalled();
+    });
+  });
+
+  // AC6: super_admin bypasses the agent-permission gate
+  describe("AC6: super_admin bypasses permission checks", () => {
+    it("super_admin request passes the gate on a read endpoint", async () => {
+      // Routes that use the inline checkAgentPermission helper read auth via
+      // getAuthContext. super_admin is a distinct session type — it is not
+      // a bearer-only path. A user-typed auth with super_admin bypass cookie
+      // would be returned by getUserSessionFromRequest; here we stub getAuthContext
+      // directly returning a super_admin-like context that is neither "agent" nor "user".
+      mockGetAuthContext.mockResolvedValue({
+        type: "super_admin",
+        // super_admin doesn't carry companyUuid; routes will still query with undefined.
+        // For this gate-only test, a stub project/idea mock tolerates it.
+        companyUuid: companyUuid,
+      });
+
+      const response = await getIdeas(
+        makeRequest(`/api/projects/${projectUuid}/ideas`),
+        makeContext({ uuid: projectUuid }),
+      );
+
+      // The gate must not 403 super_admin; we reach listIdeas.
+      expect(response.status).not.toBe(403);
+      expect(mockListIdeas).toHaveBeenCalled();
+    });
+  });
+
+  // AC7: admin_agent has proposal:admin → can call approve endpoint
+  describe("AC7: agent with roles=['admin_agent'] can call admin endpoints", () => {
+    const adminPermissions = [
+      "idea:read", "idea:write", "idea:admin",
+      "proposal:read", "proposal:write", "proposal:admin",
+      "document:read", "document:write", "document:admin",
+      "task:read", "task:write", "task:admin",
+      "project:read", "project:write", "project:admin",
+    ];
+
+    it("can POST /api/proposals/[uuid]/approve", async () => {
+      mockGetAuthContext.mockResolvedValue({
+        type: "agent",
+        companyUuid,
+        actorUuid: "agent-admin",
+        agentName: "Admin Agent",
+        roles: ["admin_agent"],
+        permissions: adminPermissions,
+      });
+
+      const response = await approveProposalHandler(
+        makeRequest(`/api/proposals/${proposalUuid}/approve`, {
+          method: "POST",
+          body: JSON.stringify({ reviewNote: "ok" }),
+          headers: { "content-type": "application/json" },
+        }),
+        makeContext({ uuid: proposalUuid }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockApproveProposal).toHaveBeenCalled();
+    });
+  });
+
+  // Extra coverage: agent with no permissions at all cannot read.
+  describe("agent with permissions=[] and roles=[]", () => {
+    it("gets 403 on GET /api/tasks/[uuid] (no task:read)", async () => {
+      mockGetAuthContext.mockResolvedValue({
+        type: "agent",
+        companyUuid,
+        actorUuid: "agent-empty",
+        agentName: "Empty Agent",
+        roles: [],
+        permissions: [],
+      });
+
+      const response = await getTaskHandler(
+        makeRequest(`/api/tasks/${taskUuid}`),
+        makeContext({ uuid: taskUuid }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(mockGetTask).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/__tests__/proposals-summary-route.test.ts
+++ b/src/app/api/__tests__/proposals-summary-route.test.ts
@@ -16,6 +16,12 @@ vi.mock("@/services/project.service", () => ({
 
 vi.mock("@/lib/auth", () => ({
   getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+  checkAgentPermission: (auth: { type: string; permissions?: string[] }, perm: string) => {
+    if (auth.type === "agent" && !(auth.permissions?.includes(perm) ?? false)) {
+      return new Response(JSON.stringify({ success: false, error: { message: `Missing permission: ${perm}` } }), { status: 403 });
+    }
+    return null;
+  },
 }));
 
 import { GET } from "@/app/api/projects/[uuid]/proposals/summary/route";

--- a/src/app/api/__tests__/tasks-route.test.ts
+++ b/src/app/api/__tests__/tasks-route.test.ts
@@ -19,7 +19,16 @@ vi.mock("@/services/project.service", () => ({
 vi.mock("@/lib/auth", () => ({
   getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
   isUser: (auth: { type: string }) => auth.type === "user",
+  isAgent: (auth: { type: string }) => auth.type === "agent",
   isPmAgent: (auth: { roles?: string[] }) => auth.roles?.includes("pm_agent") ?? false,
+  hasPermission: (auth: { permissions?: string[] }, perm: string) =>
+    auth.permissions?.includes(perm) ?? false,
+  checkAgentPermission: (auth: { type: string; permissions?: string[] }, perm: string) => {
+    if (auth.type === "agent" && !(auth.permissions?.includes(perm) ?? false)) {
+      return new Response(JSON.stringify({ success: false, error: { message: `Missing permission: ${perm}` } }), { status: 403 });
+    }
+    return null;
+  },
 }));
 
 import { GET } from "@/app/api/projects/[uuid]/tasks/route";

--- a/src/app/api/agents/[uuid]/route.ts
+++ b/src/app/api/agents/[uuid]/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
 import { getAuthContext, isUser } from "@/lib/auth";
+import { isValidPermission, computeEffectivePermissions } from "@/lib/authz/permissions";
 
 type RouteContext = { params: Promise<{ uuid: string }> };
 
@@ -50,6 +51,10 @@ export const GET = withErrorHandler<{ uuid: string }>(
       uuid: agent.uuid,
       name: agent.name,
       roles: agent.roles,
+      permissions: agent.permissions,
+      effectivePermissions: Array.from(
+        computeEffectivePermissions(agent.roles, agent.permissions),
+      ),
       persona: agent.persona,
       systemPrompt: agent.systemPrompt,
       ownerUuid: agent.ownerUuid,
@@ -95,6 +100,7 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
       roles?: string[];
       persona?: string | null;
       systemPrompt?: string | null;
+      permissions?: string[];
     }>(request);
 
     const updateData: {
@@ -102,6 +108,7 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
       roles?: string[];
       persona?: string | null;
       systemPrompt?: string | null;
+      permissions?: string[];
     } = {};
 
     if (body.name !== undefined) {
@@ -128,6 +135,15 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
       updateData.roles = body.roles;
     }
 
+    if (body.permissions !== undefined) {
+      for (const p of body.permissions) {
+        if (!isValidPermission(p)) {
+          return errors.badRequest(`Invalid permission: ${p}`);
+        }
+      }
+      updateData.permissions = body.permissions;
+    }
+
     if (body.persona !== undefined) {
       updateData.persona = body.persona?.trim() || null;
     }
@@ -143,6 +159,7 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
         uuid: true,
         name: true,
         roles: true,
+        permissions: true,
         persona: true,
         systemPrompt: true,
         ownerUuid: true,
@@ -155,6 +172,10 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
       uuid: updated.uuid,
       name: updated.name,
       roles: updated.roles,
+      permissions: updated.permissions,
+      effectivePermissions: Array.from(
+        computeEffectivePermissions(updated.roles, updated.permissions),
+      ),
       persona: updated.persona,
       systemPrompt: updated.systemPrompt,
       ownerUuid: updated.ownerUuid,

--- a/src/app/api/agents/__tests__/route.test.ts
+++ b/src/app/api/agents/__tests__/route.test.ts
@@ -142,6 +142,21 @@ describe("POST /api/agents", () => {
     expect(mockPrisma.agent.create).not.toHaveBeenCalled();
   });
 
+  it("rejects legacy role aliases (pm/developer/admin) with 400", async () => {
+    const req = jsonRequest("/api/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Test", roles: ["pm"] }),
+    });
+    const res = await POST(req, emptyCtx);
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.success).toBe(false);
+    expect(body.error.details?.roles).toMatch(/pm_agent, developer_agent, or admin_agent/);
+    expect(mockPrisma.agent.create).not.toHaveBeenCalled();
+  });
+
   it("returns 401 when unauthenticated", async () => {
     mockGetAuthContext.mockResolvedValue(null);
 

--- a/src/app/api/agents/__tests__/route.test.ts
+++ b/src/app/api/agents/__tests__/route.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+const mockPrisma = vi.hoisted(() => ({
+  agent: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    count: vi.fn(),
+  },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+  isUser: (auth: { type: string }) => auth?.type === "user",
+  isAgent: (auth: { type: string }) => auth?.type === "agent",
+}));
+
+import { GET, POST } from "@/app/api/agents/route";
+import {
+  GET as GET_DETAIL,
+  PATCH,
+} from "@/app/api/agents/[uuid]/route";
+
+const companyUuid = "company-0000-0000-0000-000000000001";
+const userUuid = "user-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+
+const userAuth = {
+  type: "user",
+  companyUuid,
+  actorUuid: userUuid,
+};
+
+function jsonRequest(
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) {
+  return new NextRequest(new URL(url, "http://localhost:3000"), init);
+}
+
+function ctx(uuid: string) {
+  return { params: Promise.resolve({ uuid }) };
+}
+
+// Empty context for handlers that don't have route params
+const emptyCtx = { params: Promise.resolve({}) } as { params: Promise<Record<string, string>> };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue(userAuth);
+});
+
+describe("POST /api/agents", () => {
+  it("creates an agent with empty permissions by default and returns roles/permissions/effectivePermissions", async () => {
+    mockPrisma.agent.create.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Test",
+      roles: ["developer_agent"],
+      permissions: [],
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      createdAt: new Date("2026-04-01T00:00:00Z"),
+    });
+
+    const req = jsonRequest("/api/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Test", roles: ["developer_agent"] }),
+    });
+    const res = await POST(req, emptyCtx);
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.data.roles).toEqual(["developer_agent"]);
+    expect(body.data.permissions).toEqual([]);
+    // developer_agent preset has 6 permissions
+    expect(body.data.effectivePermissions).toHaveLength(6);
+    expect(new Set(body.data.effectivePermissions)).toEqual(
+      new Set([
+        "idea:read",
+        "proposal:read",
+        "document:read",
+        "project:read",
+        "task:read",
+        "task:write",
+      ]),
+    );
+  });
+
+  it("creates an agent with custom permissions merged over role preset in effectivePermissions", async () => {
+    mockPrisma.agent.create.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Test",
+      roles: ["developer_agent"],
+      permissions: ["proposal:write"],
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      createdAt: new Date("2026-04-01T00:00:00Z"),
+    });
+
+    const req = jsonRequest("/api/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Test",
+        roles: ["developer_agent"],
+        permissions: ["proposal:write"],
+      }),
+    });
+    const res = await POST(req, emptyCtx);
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.data.permissions).toEqual(["proposal:write"]);
+    expect(new Set(body.data.effectivePermissions)).toContain("proposal:write");
+    // Still includes developer_agent preset
+    expect(new Set(body.data.effectivePermissions)).toContain("task:write");
+  });
+
+  it("returns 400 with 'Invalid permission: X' when permissions contains an unknown entry", async () => {
+    const req = jsonRequest("/api/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Test",
+        roles: ["developer_agent"],
+        permissions: ["foo:bar"],
+      }),
+    });
+    const res = await POST(req, emptyCtx);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error.message).toBe("Invalid permission: foo:bar");
+    expect(mockPrisma.agent.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const req = jsonRequest("/api/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Test" }),
+    });
+    const res = await POST(req, emptyCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is an agent (only users can create)", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid,
+      actorUuid: "agent-x",
+      roles: [],
+      permissions: [],
+    });
+
+    const req = jsonRequest("/api/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Test" }),
+    });
+    const res = await POST(req, emptyCtx);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /api/agents (list)", () => {
+  it("includes roles, permissions, and effectivePermissions in each agent", async () => {
+    mockPrisma.agent.findMany.mockResolvedValue([
+      {
+        uuid: agentUuid,
+        name: "Dev",
+        roles: ["developer_agent"],
+        permissions: ["proposal:write"],
+        persona: null,
+        ownerUuid: userUuid,
+        lastActiveAt: null,
+        createdAt: new Date("2026-04-01T00:00:00Z"),
+        _count: { apiKeys: 1 },
+      },
+    ]);
+    mockPrisma.agent.count.mockResolvedValue(1);
+
+    const req = jsonRequest("/api/agents");
+    const res = await GET(req, emptyCtx);
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].roles).toEqual(["developer_agent"]);
+    expect(body.data[0].permissions).toEqual(["proposal:write"]);
+    expect(new Set(body.data[0].effectivePermissions)).toContain("proposal:write");
+    expect(new Set(body.data[0].effectivePermissions)).toContain("task:write");
+  });
+});
+
+describe("GET /api/agents/[uuid] (detail)", () => {
+  it("includes roles, permissions, and effectivePermissions", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Dev",
+      roles: ["developer_agent"],
+      permissions: ["proposal:write"],
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      lastActiveAt: null,
+      createdAt: new Date("2026-04-01T00:00:00Z"),
+      apiKeys: [],
+    });
+
+    const req = jsonRequest(`/api/agents/${agentUuid}`);
+    const res = await GET_DETAIL(req, ctx(agentUuid));
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.data.roles).toEqual(["developer_agent"]);
+    expect(body.data.permissions).toEqual(["proposal:write"]);
+    expect(new Set(body.data.effectivePermissions)).toContain("proposal:write");
+  });
+
+  it("returns 404 when agent not found", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue(null);
+
+    const req = jsonRequest(`/api/agents/${agentUuid}`);
+    const res = await GET_DETAIL(req, ctx(agentUuid));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/agents/[uuid]", () => {
+  beforeEach(() => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Old",
+      roles: ["developer_agent"],
+      permissions: [],
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      companyUuid,
+      createdAt: new Date("2026-04-01T00:00:00Z"),
+    });
+  });
+
+  it("updates permissions independently without touching roles", async () => {
+    mockPrisma.agent.update.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Old",
+      roles: ["developer_agent"],
+      permissions: ["proposal:write", "document:write"],
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      lastActiveAt: null,
+      createdAt: new Date("2026-04-01T00:00:00Z"),
+    });
+
+    const req = jsonRequest(`/api/agents/${agentUuid}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        permissions: ["proposal:write", "document:write"],
+      }),
+    });
+    const res = await PATCH(req, ctx(agentUuid));
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    // Prisma update data must contain permissions but NOT roles
+    const updateCall = mockPrisma.agent.update.mock.calls[0][0];
+    expect(updateCall.data.permissions).toEqual([
+      "proposal:write",
+      "document:write",
+    ]);
+    expect(updateCall.data.roles).toBeUndefined();
+    // Response still reports the agent's existing roles
+    expect(body.data.roles).toEqual(["developer_agent"]);
+    expect(body.data.permissions).toEqual(["proposal:write", "document:write"]);
+    expect(new Set(body.data.effectivePermissions)).toContain("document:write");
+  });
+
+  it("updates roles independently without touching permissions", async () => {
+    mockPrisma.agent.update.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Old",
+      roles: ["pm_agent"],
+      permissions: [],
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      lastActiveAt: null,
+      createdAt: new Date("2026-04-01T00:00:00Z"),
+    });
+
+    const req = jsonRequest(`/api/agents/${agentUuid}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ roles: ["pm_agent"] }),
+    });
+    const res = await PATCH(req, ctx(agentUuid));
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    const updateCall = mockPrisma.agent.update.mock.calls[0][0];
+    expect(updateCall.data.roles).toEqual(["pm_agent"]);
+    expect(updateCall.data.permissions).toBeUndefined();
+    expect(body.data.roles).toEqual(["pm_agent"]);
+  });
+
+  it("returns 400 'Invalid permission: X' for unknown permission", async () => {
+    const req = jsonRequest(`/api/agents/${agentUuid}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ permissions: ["not:valid"] }),
+    });
+    const res = await PATCH(req, ctx(agentUuid));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.message).toBe("Invalid permission: not:valid");
+    expect(mockPrisma.agent.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts empty permissions array (clearing custom permissions)", async () => {
+    mockPrisma.agent.update.mockResolvedValue({
+      uuid: agentUuid,
+      name: "Old",
+      roles: ["developer_agent"],
+      permissions: [],
+      persona: null,
+      systemPrompt: null,
+      ownerUuid: userUuid,
+      lastActiveAt: null,
+      createdAt: new Date("2026-04-01T00:00:00Z"),
+    });
+
+    const req = jsonRequest(`/api/agents/${agentUuid}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ permissions: [] }),
+    });
+    const res = await PATCH(req, ctx(agentUuid));
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(mockPrisma.agent.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ permissions: [] }),
+      }),
+    );
+  });
+});

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -93,8 +93,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     return errors.validationError({ name: "Name is required" });
   }
 
-  // Validate roles
-  const validRoles = ["pm_agent", "developer_agent", "admin_agent", "pm", "developer", "admin"];
+  const validRoles = ["pm_agent", "developer_agent", "admin_agent"];
   const roles = body.roles || ["developer_agent"];
   for (const role of roles) {
     if (!validRoles.includes(role)) {

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody, parsePagination } from "@/lib/api-handler";
 import { success, paginated, errors } from "@/lib/api-response";
 import { getAuthContext, isUser } from "@/lib/auth";
+import { isValidPermission, computeEffectivePermissions } from "@/lib/authz/permissions";
 
 // GET /api/agents - List Agents
 export const GET = withErrorHandler(async (request: NextRequest) => {
@@ -36,6 +37,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         uuid: true,
         name: true,
         roles: true,
+        permissions: true,
         persona: true,
         ownerUuid: true,
         lastActiveAt: true,
@@ -52,6 +54,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     uuid: a.uuid,
     name: a.name,
     roles: a.roles,
+    permissions: a.permissions,
+    effectivePermissions: Array.from(
+      computeEffectivePermissions(a.roles, a.permissions),
+    ),
     persona: a.persona,
     ownerUuid: a.ownerUuid,
     lastActiveAt: a.lastActiveAt?.toISOString() || null,
@@ -79,6 +85,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     roles?: string[];
     persona?: string | null;
     systemPrompt?: string | null;
+    permissions?: string[];
   }>(request);
 
   // Validate required fields
@@ -97,11 +104,20 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     }
   }
 
+  // Validate permissions
+  const permissions = body.permissions ?? [];
+  for (const p of permissions) {
+    if (!isValidPermission(p)) {
+      return errors.badRequest(`Invalid permission: ${p}`);
+    }
+  }
+
   const agent = await prisma.agent.create({
     data: {
       companyUuid: auth.companyUuid,
       name: body.name.trim(),
       roles,
+      permissions,
       persona: body.persona?.trim() || null,
       systemPrompt: body.systemPrompt?.trim() || null,
       ownerUuid: auth.actorUuid,
@@ -110,6 +126,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       uuid: true,
       name: true,
       roles: true,
+      permissions: true,
       persona: true,
       systemPrompt: true,
       ownerUuid: true,
@@ -121,6 +138,10 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     uuid: agent.uuid,
     name: agent.name,
     roles: agent.roles,
+    permissions: agent.permissions,
+    effectivePermissions: Array.from(
+      computeEffectivePermissions(agent.roles, agent.permissions),
+    ),
     persona: agent.persona,
     systemPrompt: agent.systemPrompt,
     ownerUuid: agent.ownerUuid,

--- a/src/app/api/documents/[uuid]/route.ts
+++ b/src/app/api/documents/[uuid]/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import {
   getDocument,
   getDocumentByUuid,
@@ -22,6 +22,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "document:read");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
     const document = await getDocument(auth.companyUuid, uuid);
@@ -42,9 +44,13 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can update Documents
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can update documents");
+    // Updating requires document:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "document:write")) {
+        return errors.forbidden("Missing permission: document:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can update documents");
     }
 
     const { uuid } = await context.params;
@@ -84,9 +90,13 @@ export const DELETE = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can delete Documents
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can delete documents");
+    // Deleting requires document:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "document:write")) {
+        return errors.forbidden("Missing permission: document:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can delete documents");
     }
 
     const { uuid } = await context.params;

--- a/src/app/api/ideas/[uuid]/claim/__tests__/route.test.ts
+++ b/src/app/api/ideas/[uuid]/claim/__tests__/route.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+
+const mockPrisma = vi.hoisted(() => ({
+  agent: {
+    findFirst: vi.fn(),
+  },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockGetIdeaByUuid = vi.fn();
+const mockClaimIdea = vi.fn();
+vi.mock("@/services/idea.service", () => ({
+  getIdeaByUuid: (...args: unknown[]) => mockGetIdeaByUuid(...args),
+  claimIdea: (...args: unknown[]) => mockClaimIdea(...args),
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+  };
+});
+
+import { POST } from "@/app/api/ideas/[uuid]/claim/route";
+
+const companyUuid = "company-0000-0000-0000-000000000001";
+const userUuid = "user-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const ideaUuid = "idea-0000-0000-0000-000000000001";
+
+function jsonRequest(body: unknown) {
+  return new NextRequest(new URL(`/api/ideas/${ideaUuid}/claim`, "http://localhost:3000"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx() {
+  return { params: Promise.resolve({ uuid: ideaUuid }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue({
+    type: "user",
+    companyUuid,
+    actorUuid: userUuid,
+  });
+  mockGetIdeaByUuid.mockResolvedValue({ uuid: ideaUuid, companyUuid });
+});
+
+describe("POST /api/ideas/[uuid]/claim — agent selection gating", () => {
+  it("allows user to assign to an agent with idea:write via pm_agent preset", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: ["pm_agent"],
+      permissions: [],
+    });
+    mockClaimIdea.mockResolvedValue({ uuid: ideaUuid, assigneeUuid: agentUuid });
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(mockClaimIdea).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigneeType: "agent",
+        assigneeUuid: agentUuid,
+        assignedByUuid: userUuid,
+      }),
+    );
+  });
+
+  it("allows assignment when agent has idea:write via custom permissions only", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: [],
+      permissions: ["idea:write"],
+    });
+    mockClaimIdea.mockResolvedValue({ uuid: ideaUuid, assigneeUuid: agentUuid });
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    expect(res.status).toBe(200);
+    expect(mockClaimIdea).toHaveBeenCalled();
+  });
+
+  it("rejects with 403 when agent lacks idea:write (developer_agent preset)", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: ["developer_agent"],
+      permissions: [],
+    });
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.message).toMatch(/idea:write/);
+    expect(mockClaimIdea).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the specified agent doesn't exist in this company", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue(null);
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    expect(res.status).toBe(404);
+    expect(mockClaimIdea).not.toHaveBeenCalled();
+  });
+
+  it("looks up the agent scoped by companyUuid (no cross-tenant leakage)", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: ["pm_agent"],
+      permissions: [],
+    });
+    mockClaimIdea.mockResolvedValue({ uuid: ideaUuid, assigneeUuid: agentUuid });
+
+    await POST(jsonRequest({ agentUuid }), ctx());
+
+    expect(mockPrisma.agent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          uuid: agentUuid,
+          companyUuid,
+        }),
+      }),
+    );
+  });
+});
+
+describe("POST /api/ideas/[uuid]/claim — agent self-claim", () => {
+  it("lets an agent with idea:write claim directly", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid,
+      actorUuid: agentUuid,
+      roles: ["pm_agent"],
+      permissions: ["idea:read", "idea:write"],
+    });
+    mockClaimIdea.mockResolvedValue({ uuid: ideaUuid, assigneeUuid: agentUuid });
+
+    const res = await POST(jsonRequest({}), ctx());
+    expect(res.status).toBe(200);
+    expect(mockClaimIdea).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigneeType: "agent",
+        assigneeUuid: agentUuid,
+      }),
+    );
+  });
+
+  it("rejects 403 when self-claiming agent lacks idea:write", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid,
+      actorUuid: agentUuid,
+      roles: ["developer_agent"],
+      permissions: ["idea:read"],
+    });
+
+    const res = await POST(jsonRequest({}), ctx());
+    expect(res.status).toBe(403);
+    expect(mockClaimIdea).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/ideas/[uuid]/claim/route.ts
+++ b/src/app/api/ideas/[uuid]/claim/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser, isAgent, isPmAgent } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { getIdeaByUuid, claimIdea } from "@/services/idea.service";
 import { AlreadyClaimedError } from "@/lib/errors";
 
@@ -32,9 +32,9 @@ export const POST = withErrorHandler<{ uuid: string }>(
     let assignedByUuid: string | null = null;
 
     if (isAgent(auth)) {
-      // Agent claim - must be a PM Agent
-      if (!isPmAgent(auth)) {
-        return errors.forbidden("Only PM agents can claim ideas");
+      // Agents need idea:write permission to claim
+      if (!hasPermission(auth, "idea:write")) {
+        return errors.forbidden("Missing permission: idea:write");
       }
       assigneeType = "agent";
       assigneeUuid = auth.actorUuid;

--- a/src/app/api/ideas/[uuid]/claim/route.ts
+++ b/src/app/api/ideas/[uuid]/claim/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
 import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
+import { computeEffectivePermissions } from "@/lib/authz/permissions";
 import { getIdeaByUuid, claimIdea } from "@/services/idea.service";
 import { AlreadyClaimedError } from "@/lib/errors";
 
@@ -46,17 +47,31 @@ export const POST = withErrorHandler<{ uuid: string }>(
       }>(request);
 
       if (body.agentUuid) {
-        // Assign to a specific Agent (by UUID)
+        // Assign to any agent with idea:write — the assignee is whoever the
+        // user picks from the agent modal, gated by the same permission the
+        // agent itself would need to claim directly. We verify the permission
+        // post-lookup rather than filtering in the DB so custom-preset agents
+        // with idea-relevant bits are eligible too.
         const agent = await prisma.agent.findFirst({
           where: {
             uuid: body.agentUuid,
             companyUuid: auth.companyUuid,
-            roles: { has: "pm" }, // Can only assign to PM Agents
           },
+          select: { uuid: true, roles: true, permissions: true },
         });
 
         if (!agent) {
-          return errors.notFound("PM Agent");
+          return errors.notFound("Agent");
+        }
+
+        const agentPerms = computeEffectivePermissions(
+          agent.roles,
+          agent.permissions,
+        );
+        if (!agentPerms.has("idea:write")) {
+          return errors.forbidden(
+            "Selected agent does not have idea:write permission",
+          );
         }
 
         assigneeType = "agent";

--- a/src/app/api/ideas/[uuid]/move/route.ts
+++ b/src/app/api/ideas/[uuid]/move/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { moveIdea } from "@/services/idea.service";
 
 type RouteContext = { params: Promise<{ uuid: string }> };
@@ -16,6 +16,8 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "idea:write");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
     const body = await parseBody<{ targetProjectUuid: string }>(request);

--- a/src/app/api/ideas/[uuid]/release/route.ts
+++ b/src/app/api/ideas/[uuid]/release/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser, isAssignee } from "@/lib/auth";
+import { getAuthContext, isUser, isAssignee, checkAgentPermission } from "@/lib/auth";
 import { getIdeaByUuid, releaseIdea } from "@/services/idea.service";
 import { NotClaimedError } from "@/lib/errors";
 
@@ -18,6 +18,8 @@ export const POST = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "idea:write");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
 

--- a/src/app/api/ideas/[uuid]/route.ts
+++ b/src/app/api/ideas/[uuid]/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser, isAssignee } from "@/lib/auth";
+import { getAuthContext, isUser, isAssignee, checkAgentPermission } from "@/lib/auth";
 import {
   getIdea,
   getIdeaByUuid,
@@ -23,6 +23,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "idea:read");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
     const idea = await getIdea(auth.companyUuid, uuid);
@@ -42,6 +44,8 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "idea:write");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
 

--- a/src/app/api/mcp/__tests__/route.test.ts
+++ b/src/app/api/mcp/__tests__/route.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/lib/api-key", () => ({
       uuid: "agent-uuid",
       companyUuid: "company-uuid",
       roles: ["developer"],
+      permissions: [],
       name: "Test Agent",
     },
   }),

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -8,6 +8,7 @@ import { createMcpServer } from "@/mcp/server";
 import { extractApiKey, validateApiKey } from "@/lib/api-key";
 import { getProjectUuidsByGroup } from "@/services/project.service";
 import type { AgentAuthContext } from "@/types/auth";
+import { computeEffectivePermissions } from "@/lib/authz/permissions";
 import logger from "@/lib/logger";
 
 const mcpLogger = logger.child({ module: "mcp" });
@@ -47,11 +48,16 @@ export async function POST(request: NextRequest) {
       projectUuids = projectHeader.split(",").map((s) => s.trim()).filter(Boolean);
     }
 
+    const effective = computeEffectivePermissions(
+      validation.agent.roles,
+      validation.agent.permissions,
+    );
     const auth: AgentAuthContext = {
       type: "agent",
       companyUuid: validation.agent.companyUuid,
       actorUuid: validation.agent.uuid,
       roles: validation.agent.roles as ("pm" | "developer" | "admin")[],
+      permissions: Array.from(effective),
       ownerUuid: validation.agent.ownerUuid ?? undefined,
       agentName: validation.agent.name,
       projectUuids,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -7,7 +7,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { createMcpServer } from "@/mcp/server";
 import { extractApiKey, validateApiKey } from "@/lib/api-key";
 import { getProjectUuidsByGroup } from "@/services/project.service";
-import type { AgentAuthContext } from "@/types/auth";
+import type { AgentAuthContext, AgentRole } from "@/types/auth";
 import { computeEffectivePermissions } from "@/lib/authz/permissions";
 import logger from "@/lib/logger";
 
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       type: "agent",
       companyUuid: validation.agent.companyUuid,
       actorUuid: validation.agent.uuid,
-      roles: validation.agent.roles as ("pm" | "developer" | "admin")[],
+      roles: validation.agent.roles as AgentRole[],
       permissions: Array.from(effective),
       ownerUuid: validation.agent.ownerUuid ?? undefined,
       agentName: validation.agent.name,

--- a/src/app/api/project-groups/[uuid]/dashboard/route.ts
+++ b/src/app/api/project-groups/[uuid]/dashboard/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { getGroupDashboard } from "@/services/project-group.service";
 
 // GET /api/project-groups/[uuid]/dashboard
@@ -12,6 +12,8 @@ export const GET = withErrorHandler(
   async (request: NextRequest, context: { params: Promise<{ uuid: string }> }) => {
     const auth = await getAuthContext(request);
     if (!auth) return errors.unauthorized();
+    const denied = checkAgentPermission(auth, "project:read");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
     const dashboard = await getGroupDashboard(auth.companyUuid, uuid);

--- a/src/app/api/project-groups/[uuid]/route.ts
+++ b/src/app/api/project-groups/[uuid]/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import {
   getProjectGroup,
   updateProjectGroup,
@@ -16,6 +16,8 @@ export const GET = withErrorHandler(
   async (request: NextRequest, context: { params: Promise<{ uuid: string }> }) => {
     const auth = await getAuthContext(request);
     if (!auth) return errors.unauthorized();
+    const denied = checkAgentPermission(auth, "project:read");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
     const group = await getProjectGroup(auth.companyUuid, uuid);
@@ -30,7 +32,13 @@ export const PATCH = withErrorHandler(
   async (request: NextRequest, context: { params: Promise<{ uuid: string }> }) => {
     const auth = await getAuthContext(request);
     if (!auth) return errors.unauthorized();
-    if (!isUser(auth)) return errors.forbidden("Only users can update project groups");
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "project:write")) {
+        return errors.forbidden("Missing permission: project:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can update project groups");
+    }
 
     const { uuid } = await context.params;
     const body = await parseBody<{ name?: string; description?: string }>(request);
@@ -52,7 +60,13 @@ export const DELETE = withErrorHandler(
   async (request: NextRequest, context: { params: Promise<{ uuid: string }> }) => {
     const auth = await getAuthContext(request);
     if (!auth) return errors.unauthorized();
-    if (!isUser(auth)) return errors.forbidden("Only users can delete project groups");
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "project:write")) {
+        return errors.forbidden("Missing permission: project:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can delete project groups");
+    }
 
     const { uuid } = await context.params;
     const shouldDeleteProjects = request.nextUrl.searchParams.get("deleteProjects") === "true";

--- a/src/app/api/project-groups/route.ts
+++ b/src/app/api/project-groups/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import {
   listProjectGroups,
   createProjectGroup,
@@ -14,6 +14,8 @@ import {
 export const GET = withErrorHandler(async (request: NextRequest) => {
   const auth = await getAuthContext(request);
   if (!auth) return errors.unauthorized();
+  const denied = checkAgentPermission(auth, "project:read");
+  if (denied) return denied;
 
   const result = await listProjectGroups(auth.companyUuid);
   return success(result);
@@ -23,7 +25,13 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 export const POST = withErrorHandler(async (request: NextRequest) => {
   const auth = await getAuthContext(request);
   if (!auth) return errors.unauthorized();
-  if (!isUser(auth)) return errors.forbidden("Only users can create project groups");
+  if (isAgent(auth)) {
+    if (!hasPermission(auth, "project:write")) {
+      return errors.forbidden("Missing permission: project:write");
+    }
+  } else if (!isUser(auth)) {
+    return errors.forbidden("Only users or permitted agents can create project groups");
+  }
 
   const body = await parseBody<{ name: string; description?: string }>(request);
   if (!body.name || body.name.trim() === "") {

--- a/src/app/api/projects/[uuid]/activity/route.ts
+++ b/src/app/api/projects/[uuid]/activity/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parsePagination } from "@/lib/api-handler";
 import { paginated, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 
 type RouteContext = { params: Promise<{ uuid: string }> };
 
@@ -17,6 +17,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "project:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
     const { page, pageSize, skip, take } = parsePagination(request);

--- a/src/app/api/projects/[uuid]/available/route.ts
+++ b/src/app/api/projects/[uuid]/available/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isAgent, isPmAgent, isDeveloperAgent } from "@/lib/auth";
+import { getAuthContext, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import { getProjectByUuid } from "@/services/project.service";
 import { getAvailableItems } from "@/services/assignment.service";
 
@@ -18,6 +18,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "project:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
 
@@ -27,12 +29,11 @@ export const GET = withErrorHandler<{ uuid: string }>(
       return errors.notFound("Project");
     }
 
-    // Return different content based on role
-    // PM Agent: can claim Ideas
-    // Developer Agent: can claim Tasks
-    // User: can see everything
-    const canClaimIdeas = isAgent(auth) ? isPmAgent(auth) : true;
-    const canClaimTasks = isAgent(auth) ? isDeveloperAgent(auth) : true;
+    // Return different content based on permission
+    // Agent with idea:write can claim Ideas; task:write for Tasks
+    // User sees everything
+    const canClaimIdeas = isAgent(auth) ? hasPermission(auth, "idea:write") : true;
+    const canClaimTasks = isAgent(auth) ? hasPermission(auth, "task:write") : true;
 
     const result = await getAvailableItems(
       auth.companyUuid,

--- a/src/app/api/projects/[uuid]/documents/route.ts
+++ b/src/app/api/projects/[uuid]/documents/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody, parsePagination } from "@/lib/api-handler";
 import { success, paginated, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import { projectExists } from "@/services/project.service";
 import { listDocuments, createDocument } from "@/services/document.service";
 
@@ -18,6 +18,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "document:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
     const { page, pageSize, skip, take } = parsePagination(request);
@@ -51,9 +53,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can create Documents directly
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can create documents directly");
+    // Creating requires document:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "document:write")) {
+        return errors.forbidden("Missing permission: document:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can create documents");
     }
 
     const { uuid: projectUuid } = await context.params;

--- a/src/app/api/projects/[uuid]/group/route.ts
+++ b/src/app/api/projects/[uuid]/group/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { moveProjectToGroup } from "@/services/project-group.service";
 
 // PATCH /api/projects/[uuid]/group
@@ -12,7 +12,13 @@ export const PATCH = withErrorHandler(
   async (request: NextRequest, context: { params: Promise<{ uuid: string }> }) => {
     const auth = await getAuthContext(request);
     if (!auth) return errors.unauthorized();
-    if (!isUser(auth)) return errors.forbidden("Only users can move projects between groups");
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "project:write")) {
+        return errors.forbidden("Missing permission: project:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can move projects between groups");
+    }
 
     const { uuid } = await context.params;
     const body = await parseBody<{ groupUuid: string | null }>(request);

--- a/src/app/api/projects/[uuid]/ideas/route.ts
+++ b/src/app/api/projects/[uuid]/ideas/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody, parsePagination } from "@/lib/api-handler";
 import { success, paginated, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import { projectExists } from "@/services/project.service";
 import { listIdeas, createIdea } from "@/services/idea.service";
 
@@ -18,6 +18,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "idea:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
     const { page, pageSize, skip, take } = parsePagination(request);
@@ -51,9 +53,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can create Ideas
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can create ideas");
+    // Creating requires idea:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "idea:write")) {
+        return errors.forbidden("Missing permission: idea:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can create ideas");
     }
 
     const { uuid: projectUuid } = await context.params;

--- a/src/app/api/projects/[uuid]/ideas/tracker/route.ts
+++ b/src/app/api/projects/[uuid]/ideas/tracker/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { projectExists } from "@/services/project.service";
 import { getTrackerGroups } from "@/services/idea.service";
 
@@ -17,6 +17,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "idea:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
 

--- a/src/app/api/projects/[uuid]/proposals/[proposalUuid]/validate/route.ts
+++ b/src/app/api/projects/[uuid]/proposals/[proposalUuid]/validate/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { validateProposal } from "@/services/proposal.service";
 
 type RouteContext = { params: Promise<{ uuid: string; proposalUuid: string }> };
@@ -16,6 +16,8 @@ export const GET = withErrorHandler<{ uuid: string; proposalUuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "proposal:read");
+    if (denied) return denied;
 
     const { proposalUuid } = await context.params;
     const result = await validateProposal(auth.companyUuid, proposalUuid);

--- a/src/app/api/projects/[uuid]/proposals/route.ts
+++ b/src/app/api/projects/[uuid]/proposals/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody, parsePagination } from "@/lib/api-handler";
 import { success, paginated, errors } from "@/lib/api-response";
-import { getAuthContext, isAgent, isPmAgent, isUser } from "@/lib/auth";
+import { getAuthContext, isAgent, isUser, checkAgentPermission, hasPermission } from "@/lib/auth";
 import { projectExists } from "@/services/project.service";
 import { listProposals, createProposal, type DocumentDraft, type TaskDraft } from "@/services/proposal.service";
 
@@ -19,6 +19,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "proposal:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
     const { page, pageSize, skip, take } = parsePagination(request);
@@ -52,10 +54,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // PM Agent or User can create Proposals
-    const canCreate = isUser(auth) || (isAgent(auth) && isPmAgent(auth));
-    if (!canCreate) {
-      return errors.forbidden("Only PM agents or users can create proposals");
+    // Creating a proposal requires proposal:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "proposal:write")) {
+        return errors.forbidden("Missing permission: proposal:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can create proposals");
     }
 
     const { uuid: projectUuid } = await context.params;

--- a/src/app/api/projects/[uuid]/proposals/summary/route.ts
+++ b/src/app/api/projects/[uuid]/proposals/summary/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { projectExists } from "@/services/project.service";
 import { getProjectProposals } from "@/services/proposal.service";
 
@@ -17,6 +17,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "proposal:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
 

--- a/src/app/api/projects/[uuid]/route.ts
+++ b/src/app/api/projects/[uuid]/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import {
   getProject,
   updateProject,
@@ -20,6 +20,8 @@ export const GET = withErrorHandler(async (request: NextRequest, context: RouteC
   if (!auth) {
     return errors.unauthorized();
   }
+  const denied = checkAgentPermission(auth, "project:read");
+  if (denied) return denied;
 
   const { uuid } = await context.params;
   const project = await getProject(auth.companyUuid, uuid);
@@ -52,8 +54,13 @@ export const PATCH = withErrorHandler(async (request: NextRequest, context: Rout
     return errors.unauthorized();
   }
 
-  if (!isUser(auth)) {
-    return errors.forbidden("Only users can update projects");
+  // Updating requires project:write for agents, or a human user
+  if (isAgent(auth)) {
+    if (!hasPermission(auth, "project:write")) {
+      return errors.forbidden("Missing permission: project:write");
+    }
+  } else if (!isUser(auth)) {
+    return errors.forbidden("Only users or permitted agents can update projects");
   }
 
   const { uuid } = await context.params;
@@ -97,8 +104,13 @@ export const DELETE = withErrorHandler(async (request: NextRequest, context: Rou
     return errors.unauthorized();
   }
 
-  if (!isUser(auth)) {
-    return errors.forbidden("Only users can delete projects");
+  // Deleting requires project:write for agents, or a human user
+  if (isAgent(auth)) {
+    if (!hasPermission(auth, "project:write")) {
+      return errors.forbidden("Missing permission: project:write");
+    }
+  } else if (!isUser(auth)) {
+    return errors.forbidden("Only users or permitted agents can delete projects");
   }
 
   const { uuid } = await context.params;

--- a/src/app/api/projects/[uuid]/stats/route.ts
+++ b/src/app/api/projects/[uuid]/stats/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { getProject, getProjectStats } from "@/services/project.service";
 import { listActivitiesWithActorNames } from "@/services/activity.service";
 
@@ -17,6 +17,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "project:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
 

--- a/src/app/api/projects/[uuid]/tasks/dependencies/route.ts
+++ b/src/app/api/projects/[uuid]/tasks/dependencies/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { projectExists } from "@/services/project.service";
 import { getProjectTaskDependencies } from "@/services/task.service";
 
@@ -17,6 +17,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
 

--- a/src/app/api/projects/[uuid]/tasks/route.ts
+++ b/src/app/api/projects/[uuid]/tasks/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody, parsePagination } from "@/lib/api-handler";
 import { success, paginated, errors } from "@/lib/api-response";
-import { getAuthContext, isUser, isPmAgent } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import { projectExists } from "@/services/project.service";
 import { listTasks, createTask } from "@/services/task.service";
 
@@ -18,6 +18,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:read");
+    if (denied) return denied;
 
     const { uuid: projectUuid } = await context.params;
     const { page, pageSize, skip, take } = parsePagination(request);
@@ -55,9 +57,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Users and PM Agents can create Tasks
-    if (!isUser(auth) && !isPmAgent(auth)) {
-      return errors.forbidden("Only users and PM agents can create tasks");
+    // Creating requires task:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "task:write")) {
+        return errors.forbidden("Missing permission: task:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can create tasks");
     }
 
     const { uuid: projectUuid } = await context.params;

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody, parsePagination } from "@/lib/api-handler";
 import { success, paginated, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 
 // GET /api/projects - List Projects
 export const GET = withErrorHandler(async (request: NextRequest) => {
@@ -14,6 +14,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   if (!auth) {
     return errors.unauthorized();
   }
+  const denied = checkAgentPermission(auth, "project:read");
+  if (denied) return denied;
 
   const { page, pageSize, skip, take } = parsePagination(request);
 
@@ -76,9 +78,13 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     return errors.unauthorized();
   }
 
-  // Only users can create projects
-  if (!isUser(auth)) {
-    return errors.forbidden("Only users can create projects");
+  // Creating requires project:write for agents, or a human user
+  if (isAgent(auth)) {
+    if (!hasPermission(auth, "project:write")) {
+      return errors.forbidden("Missing permission: project:write");
+    }
+  } else if (!isUser(auth)) {
+    return errors.forbidden("Only users or permitted agents can create projects");
   }
 
   const body = await parseBody<{

--- a/src/app/api/proposals/[uuid]/approve/route.ts
+++ b/src/app/api/proposals/[uuid]/approve/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { getProposalByUuid, approveProposal } from "@/services/proposal.service";
 import { createActivity } from "@/services/activity.service";
 
@@ -19,9 +19,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can approve
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can approve proposals");
+    // Approval requires proposal:admin for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "proposal:admin")) {
+        return errors.forbidden("Missing permission: proposal:admin");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or admin agents can approve proposals");
     }
 
     const { uuid } = await context.params;
@@ -52,7 +56,7 @@ export const POST = withErrorHandler<{ uuid: string }>(
       projectUuid: proposal.projectUuid,
       targetType: "proposal",
       targetUuid: proposal.uuid,
-      actorType: "user",
+      actorType: auth.type,
       actorUuid: auth.actorUuid,
       action: "approved",
       value: body.reviewNote ? { reviewNote: body.reviewNote } : undefined,

--- a/src/app/api/proposals/[uuid]/close/route.ts
+++ b/src/app/api/proposals/[uuid]/close/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { getProposalByUuid, closeProposal } from "@/services/proposal.service";
 
 type RouteContext = { params: Promise<{ uuid: string }> };
@@ -18,9 +18,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can close
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can close proposals");
+    // Close requires proposal:admin for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "proposal:admin")) {
+        return errors.forbidden("Missing permission: proposal:admin");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or admin agents can close proposals");
     }
 
     const { uuid } = await context.params;

--- a/src/app/api/proposals/[uuid]/reject/route.ts
+++ b/src/app/api/proposals/[uuid]/reject/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { getProposalByUuid, rejectProposal } from "@/services/proposal.service";
 import { createActivity } from "@/services/activity.service";
 
@@ -19,9 +19,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can reject
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can reject proposals");
+    // Reject requires proposal:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "proposal:write")) {
+        return errors.forbidden("Missing permission: proposal:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can reject proposals");
     }
 
     const { uuid } = await context.params;
@@ -58,7 +62,7 @@ export const POST = withErrorHandler<{ uuid: string }>(
       projectUuid: proposal.projectUuid,
       targetType: "proposal",
       targetUuid: proposal.uuid,
-      actorType: "user",
+      actorType: auth.type,
       actorUuid: auth.actorUuid,
       action: "rejected_to_draft",
       value: { reviewNote: body.reviewNote.trim() },

--- a/src/app/api/proposals/[uuid]/revoke/route.ts
+++ b/src/app/api/proposals/[uuid]/revoke/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { getProposalByUuid, revokeProposal } from "@/services/proposal.service";
 import { createActivity } from "@/services/activity.service";
 
@@ -19,9 +19,13 @@ export const POST = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    // Only users can revoke
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can revoke proposals");
+    // Revoke requires proposal:write for agents, or a human user
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "proposal:write")) {
+        return errors.forbidden("Missing permission: proposal:write");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can revoke proposals");
     }
 
     const { uuid } = await context.params;
@@ -52,7 +56,7 @@ export const POST = withErrorHandler<{ uuid: string }>(
       projectUuid: proposal.projectUuid,
       targetType: "proposal",
       targetUuid: proposal.uuid,
-      actorType: "user",
+      actorType: auth.type,
       actorUuid: auth.actorUuid,
       action: "revoked",
       value: {

--- a/src/app/api/proposals/[uuid]/route.ts
+++ b/src/app/api/proposals/[uuid]/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { getProposal } from "@/services/proposal.service";
 
 type RouteContext = { params: Promise<{ uuid: string }> };
@@ -17,6 +17,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "proposal:read");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
     const proposal = await getProposal(auth.companyUuid, uuid);

--- a/src/app/api/tasks/[uuid]/claim/__tests__/route.test.ts
+++ b/src/app/api/tasks/[uuid]/claim/__tests__/route.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+
+const mockPrisma = vi.hoisted(() => ({
+  agent: {
+    findFirst: vi.fn(),
+  },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockGetTaskByUuid = vi.fn();
+const mockClaimTask = vi.fn();
+vi.mock("@/services/task.service", () => ({
+  getTaskByUuid: (...args: unknown[]) => mockGetTaskByUuid(...args),
+  claimTask: (...args: unknown[]) => mockClaimTask(...args),
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+  };
+});
+
+import { POST } from "@/app/api/tasks/[uuid]/claim/route";
+
+const companyUuid = "company-0000-0000-0000-000000000001";
+const userUuid = "user-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const taskUuid = "task-0000-0000-0000-000000000001";
+
+function jsonRequest(body: unknown) {
+  return new NextRequest(new URL(`/api/tasks/${taskUuid}/claim`, "http://localhost:3000"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx() {
+  return { params: Promise.resolve({ uuid: taskUuid }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue({
+    type: "user",
+    companyUuid,
+    actorUuid: userUuid,
+  });
+  mockGetTaskByUuid.mockResolvedValue({ uuid: taskUuid, companyUuid });
+});
+
+describe("POST /api/tasks/[uuid]/claim — agent selection gating", () => {
+  it("allows user to assign to an agent with task:write via developer_agent preset", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: ["developer_agent"],
+      permissions: [],
+    });
+    mockClaimTask.mockResolvedValue({ uuid: taskUuid, assigneeUuid: agentUuid });
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(mockClaimTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigneeType: "agent",
+        assigneeUuid: agentUuid,
+        assignedByUuid: userUuid,
+      }),
+    );
+  });
+
+  it("allows assignment to a custom-preset agent with task:write", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: [],
+      permissions: ["task:read", "task:write"],
+    });
+    mockClaimTask.mockResolvedValue({ uuid: taskUuid, assigneeUuid: agentUuid });
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    expect(res.status).toBe(200);
+    expect(mockClaimTask).toHaveBeenCalled();
+  });
+
+  it("rejects with 403 when agent lacks task:write", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: [],
+      permissions: ["task:read"],
+    });
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.message).toMatch(/task:write/);
+    expect(mockClaimTask).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the specified agent doesn't exist", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue(null);
+
+    const res = await POST(jsonRequest({ agentUuid }), ctx());
+    expect(res.status).toBe(404);
+    expect(mockClaimTask).not.toHaveBeenCalled();
+  });
+
+  it("looks up the agent scoped by companyUuid (no cross-tenant leakage)", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: ["developer_agent"],
+      permissions: [],
+    });
+    mockClaimTask.mockResolvedValue({ uuid: taskUuid, assigneeUuid: agentUuid });
+
+    await POST(jsonRequest({ agentUuid }), ctx());
+
+    expect(mockPrisma.agent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          uuid: agentUuid,
+          companyUuid,
+        }),
+      }),
+    );
+  });
+});
+
+describe("POST /api/tasks/[uuid]/claim — agent self-claim", () => {
+  it("lets an agent with task:write claim directly", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid,
+      actorUuid: agentUuid,
+      roles: ["developer_agent"],
+      permissions: ["task:read", "task:write"],
+    });
+    mockClaimTask.mockResolvedValue({ uuid: taskUuid, assigneeUuid: agentUuid });
+
+    const res = await POST(jsonRequest({}), ctx());
+    expect(res.status).toBe(200);
+    expect(mockClaimTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigneeType: "agent",
+        assigneeUuid: agentUuid,
+      }),
+    );
+  });
+
+  it("rejects 403 when self-claiming agent lacks task:write", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid,
+      actorUuid: agentUuid,
+      roles: [],
+      permissions: ["task:read"],
+    });
+
+    const res = await POST(jsonRequest({}), ctx());
+    expect(res.status).toBe(403);
+    expect(mockClaimTask).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/tasks/[uuid]/claim/route.ts
+++ b/src/app/api/tasks/[uuid]/claim/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
 import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
+import { computeEffectivePermissions } from "@/lib/authz/permissions";
 import { getTaskByUuid, claimTask } from "@/services/task.service";
 import { AlreadyClaimedError } from "@/lib/errors";
 
@@ -46,17 +47,29 @@ export const POST = withErrorHandler<{ uuid: string }>(
       }>(request);
 
       if (body.agentUuid) {
-        // Assign to a specific Agent (by UUID)
+        // Assign to any agent with task:write — matches the permission gate a
+        // self-claiming agent hits above, which keeps custom-preset agents
+        // (e.g. pm preset + task:admin extras) eligible.
         const agent = await prisma.agent.findFirst({
           where: {
             uuid: body.agentUuid,
             companyUuid: auth.companyUuid,
-            roles: { has: "developer" }, // Can only assign to Developer Agents
           },
+          select: { uuid: true, roles: true, permissions: true },
         });
 
         if (!agent) {
-          return errors.notFound("Developer Agent");
+          return errors.notFound("Agent");
+        }
+
+        const agentPerms = computeEffectivePermissions(
+          agent.roles,
+          agent.permissions,
+        );
+        if (!agentPerms.has("task:write")) {
+          return errors.forbidden(
+            "Selected agent does not have task:write permission",
+          );
         }
 
         assigneeType = "agent";

--- a/src/app/api/tasks/[uuid]/claim/route.ts
+++ b/src/app/api/tasks/[uuid]/claim/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser, isAgent, isDeveloperAgent } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { getTaskByUuid, claimTask } from "@/services/task.service";
 import { AlreadyClaimedError } from "@/lib/errors";
 
@@ -32,9 +32,9 @@ export const POST = withErrorHandler<{ uuid: string }>(
     let assignedByUuid: string | null = null;
 
     if (isAgent(auth)) {
-      // Agent claim - Developer Agents can claim
-      if (!isDeveloperAgent(auth)) {
-        return errors.forbidden("Only developer agents can claim tasks");
+      // Agents need task:write permission to claim
+      if (!hasPermission(auth, "task:write")) {
+        return errors.forbidden("Missing permission: task:write");
       }
       assigneeType = "agent";
       assigneeUuid = auth.actorUuid;

--- a/src/app/api/tasks/[uuid]/dependencies/[dependsOnUuid]/route.ts
+++ b/src/app/api/tasks/[uuid]/dependencies/[dependsOnUuid]/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import { getTaskByUuid, removeTaskDependency } from "@/services/task.service";
 
 type RouteContext = { params: Promise<{ uuid: string; dependsOnUuid: string }> };
@@ -16,6 +16,8 @@ export const DELETE = withErrorHandler<{ uuid: string; dependsOnUuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:write");
+    if (denied) return denied;
 
     const { uuid, dependsOnUuid } = await context.params;
 

--- a/src/app/api/tasks/[uuid]/dependencies/route.ts
+++ b/src/app/api/tasks/[uuid]/dependencies/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext } from "@/lib/auth";
+import { getAuthContext, checkAgentPermission } from "@/lib/auth";
 import {
   getTaskByUuid,
   addTaskDependency,
@@ -20,6 +20,8 @@ export const POST = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:write");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
 
@@ -57,6 +59,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:read");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
 

--- a/src/app/api/tasks/[uuid]/release/route.ts
+++ b/src/app/api/tasks/[uuid]/release/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser, isAssignee } from "@/lib/auth";
+import { getAuthContext, isUser, isAssignee, checkAgentPermission } from "@/lib/auth";
 import { getTaskByUuid, releaseTask } from "@/services/task.service";
 import { NotClaimedError } from "@/lib/errors";
 
@@ -18,6 +18,8 @@ export const POST = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:write");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
 

--- a/src/app/api/tasks/[uuid]/route.ts
+++ b/src/app/api/tasks/[uuid]/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser, isAssignee } from "@/lib/auth";
+import { getAuthContext, isUser, isAssignee, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
 import {
   getTask,
   getTaskByUuid,
@@ -25,6 +25,8 @@ export const GET = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:read");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
     const task = await getTask(auth.companyUuid, uuid);
@@ -44,6 +46,8 @@ export const PATCH = withErrorHandler<{ uuid: string }>(
     if (!auth) {
       return errors.unauthorized();
     }
+    const denied = checkAgentPermission(auth, "task:write");
+    if (denied) return denied;
 
     const { uuid } = await context.params;
 

--- a/src/app/api/tasks/[uuid]/sessions/route.ts
+++ b/src/app/api/tasks/[uuid]/sessions/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
-import { getAuthContext, isUser } from "@/lib/auth";
+import { getAuthContext, isUser, isAgent, hasPermission } from "@/lib/auth";
 import { getSessionsForTask } from "@/services/session.service";
 
 type RouteContext = { params: Promise<{ uuid: string }> };
@@ -18,8 +18,12 @@ export const GET = withErrorHandler<{ uuid: string }>(
       return errors.unauthorized();
     }
 
-    if (!isUser(auth)) {
-      return errors.forbidden("Only users can view task sessions");
+    if (isAgent(auth)) {
+      if (!hasPermission(auth, "task:read")) {
+        return errors.forbidden("Missing permission: task:read");
+      }
+    } else if (!isUser(auth)) {
+      return errors.forbidden("Only users or permitted agents can view task sessions");
     }
 
     const { uuid } = await context.params;

--- a/src/app/onboarding/components/CompletionStep.tsx
+++ b/src/app/onboarding/components/CompletionStep.tsx
@@ -10,16 +10,29 @@ import { motion } from "framer-motion";
 import { fadeInUp } from "@/lib/animation";
 
 interface CompletionStepProps {
-  createdAgent: { name: string; roles: string[] } | null;
+  createdAgent: {
+    name: string;
+    roles: string[];
+    permissions: string[];
+  } | null;
 }
 
 export function CompletionStep({ createdAgent }: CompletionStepProps) {
   const router = useRouter();
   const t = useTranslations("onboarding");
+  const tAgent = useTranslations("agent.permissions");
 
   useEffect(() => {
     localStorage.setItem("chorus_onboarding_completed", "done");
   }, []);
+
+  const presetLabel = (() => {
+    if (!createdAgent) return null;
+    if (createdAgent.roles.includes("admin_agent")) return tAgent("presetAdmin");
+    if (createdAgent.roles.includes("pm_agent")) return tAgent("presetPm");
+    if (createdAgent.roles.includes("developer_agent")) return tAgent("presetDev");
+    return tAgent("presetCustom");
+  })();
 
   return (
     <motion.div
@@ -57,11 +70,22 @@ export function CompletionStep({ createdAgent }: CompletionStepProps) {
                 </span>
               </div>
               <div className="flex justify-between">
-                <span>{t("completion.agentRoles")}</span>
+                <span>{t("completion.agentPreset")}</span>
                 <span className="font-medium text-foreground">
-                  {createdAgent.roles.join(", ")}
+                  {presetLabel}
                 </span>
               </div>
+              {createdAgent.roles.length === 0 &&
+                createdAgent.permissions.length > 0 && (
+                  <div className="flex justify-between">
+                    <span>{t("completion.agentPermissions")}</span>
+                    <span className="font-medium text-foreground">
+                      {t("completion.permissionsCount", {
+                        count: createdAgent.permissions.length,
+                      })}
+                    </span>
+                  </div>
+                )}
             </div>
           </CardContent>
         </Card>

--- a/src/app/onboarding/components/CreateAgentStep.tsx
+++ b/src/app/onboarding/components/CreateAgentStep.tsx
@@ -1,19 +1,32 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { motion } from "framer-motion";
-import { fadeInUp } from "@/lib/animation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { AgentCreateForm } from "@/components/AgentCreateForm";
+import { fadeInUp } from "@/lib/animation";
 import { createAgentAndKeyAction } from "@/app/(dashboard)/settings/actions";
+
+interface CreatedAgent {
+  uuid: string;
+  name: string;
+  roles: string[];
+  permissions: string[];
+}
 
 interface CreateAgentStepProps {
   onNext: () => void;
-  onAgentCreated: (agent: { uuid: string; name: string; roles: string[] }, apiKey: string) => void;
+  onAgentCreated: (agent: CreatedAgent, apiKey: string) => void;
 }
 
 export function CreateAgentStep({ onNext, onAgentCreated }: CreateAgentStepProps) {
-  const t = useTranslations("onboarding");
+  const t = useTranslations("onboarding.createAgent");
 
   return (
     <motion.div
@@ -21,21 +34,21 @@ export function CreateAgentStep({ onNext, onAgentCreated }: CreateAgentStepProps
       initial="initial"
       animate="animate"
       exit="exit"
-      className="flex w-full max-w-lg flex-col items-center gap-8"
+      className="flex w-full max-w-2xl flex-col items-center gap-6"
     >
       <Card className="w-full">
         <CardHeader className="text-center">
-          <CardTitle>{t("createAgent.title")}</CardTitle>
-          <CardDescription>{t("createAgent.description")}</CardDescription>
+          <CardTitle>{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
-        <CardContent className="p-0">
+        <CardContent>
           <AgentCreateForm
+            embedded
             createAgentAndKey={createAgentAndKeyAction}
+            submitLabel={t("submit")}
+            submittingLabel={t("creating")}
             onAgentCreated={(agent, apiKey) => {
-              onAgentCreated(
-                { uuid: agent.uuid, name: agent.name, roles: agent.roles },
-                apiKey
-              );
+              onAgentCreated(agent, apiKey);
               onNext();
             }}
           />

--- a/src/app/onboarding/components/OnboardingWizard.tsx
+++ b/src/app/onboarding/components/OnboardingWizard.tsx
@@ -19,6 +19,7 @@ interface CreatedAgent {
   uuid: string;
   name: string;
   roles: string[];
+  permissions: string[];
 }
 
 export function OnboardingWizard() {

--- a/src/components/AgentCreateForm.tsx
+++ b/src/components/AgentCreateForm.tsx
@@ -3,103 +3,100 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Check, X, AlertTriangle, ShieldAlert } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { clientLogger } from "@/lib/logger-client";
-
-// PM Agent Persona presets (labels and descriptions use i18n keys)
-const PM_PERSONAS = [
-  { id: "dev_pm", labelKey: "personas.devPm", descKey: "personas.devPmDesc" },
-  { id: "full_pm", labelKey: "personas.fullPm", descKey: "personas.fullPmDesc" },
-  { id: "simple_pm", labelKey: "personas.simplePm", descKey: "personas.simplePmDesc" },
-];
-
-// Developer Agent Persona presets
-const DEV_PERSONAS = [
-  { id: "senior_dev", labelKey: "personas.seniorDev", descKey: "personas.seniorDevDesc" },
-  { id: "fullstack_dev", labelKey: "personas.fullstackDev", descKey: "personas.fullstackDevDesc" },
-  { id: "pragmatic_dev", labelKey: "personas.pragmaticDev", descKey: "personas.pragmaticDevDesc" },
-];
-
-// Admin Agent Persona presets
-const ADMIN_PERSONAS = [
-  { id: "careful_admin", labelKey: "personas.carefulAdmin", descKey: "personas.carefulAdminDesc" },
-  { id: "efficient_admin", labelKey: "personas.efficientAdmin", descKey: "personas.efficientAdminDesc" },
-];
+import {
+  AgentFormFields,
+  type AgentFormPreset,
+} from "@/components/AgentFormFields";
+import type { AgentPermissionPickerChange } from "@/components/AgentPermissionPicker";
+import type { Permission } from "@/lib/authz/types";
 
 export interface AgentCreateFormProps {
   /** Called after the agent and API key are successfully created */
   onAgentCreated: (
-    agent: { uuid: string; name: string; roles: string[] },
-    apiKey: string
+    agent: {
+      uuid: string;
+      name: string;
+      roles: string[];
+      permissions: string[];
+    },
+    apiKey: string,
   ) => void;
   /** Server action to create the agent and key. Returns the raw API key on success. */
   createAgentAndKey: (input: {
     name: string;
     roles: string[];
+    permissions?: string[];
     persona: string | null;
   }) => Promise<{ success: boolean; key?: string; agentUuid?: string; error?: string }>;
   /** Optional: called when the user closes/dismisses the form */
   onClose?: () => void;
+  /**
+   * Embedded mode: drop the modal chrome (header, cancel, own success page) so
+   * callers (e.g. onboarding wizard) can compose the form inside their own card.
+   * In embedded mode the form fires `onAgentCreated` immediately on success —
+   * the parent is responsible for showing the API key to the user.
+   */
+  embedded?: boolean;
+  /** Override the submit button label. Defaults to "Create API Key" / "Creating...". */
+  submitLabel?: string;
+  submittingLabel?: string;
 }
 
 export function AgentCreateForm({
   onAgentCreated,
   createAgentAndKey,
   onClose,
+  embedded = false,
+  submitLabel,
+  submittingLabel,
 }: AgentCreateFormProps) {
   const t = useTranslations();
 
   // Form state
   const [newKeyName, setNewKeyName] = useState("");
-  const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
+  // Default to admin_agent preset — matches the design (full access by default).
+  const [preset, setPreset] = useState<AgentFormPreset>("admin_agent");
+  const [roles, setRoles] = useState<string[]>(["admin_agent"]);
+  const [permissions, setPermissions] = useState<Permission[]>([]);
   const [customPersona, setCustomPersona] = useState("");
-  const [adminConfirmed, setAdminConfirmed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   // Success state
   const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const toggleRole = (role: string) => {
-    setSelectedRoles((prev) => {
-      const newRoles = prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role];
-      // Reset admin confirmation if admin role is deselected
-      if (role === "admin_agent" && prev.includes(role)) {
-        setAdminConfirmed(false);
-      }
-      return newRoles;
-    });
-  };
-
-  const selectPersonaPreset = (description: string) => {
-    setCustomPersona(description);
-  };
+  function handlePickerChange(next: AgentPermissionPickerChange) {
+    setPreset(next.preset);
+    setRoles(next.roles);
+    setPermissions(next.permissions as Permission[]);
+  }
 
   const handleCreateKey = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newKeyName || selectedRoles.length === 0) return;
+    if (!newKeyName) return;
+    if (preset === "custom" && permissions.length === 0) return;
 
     setSubmitting(true);
     try {
       const result = await createAgentAndKey({
         name: newKeyName,
-        roles: selectedRoles,
+        roles,
+        permissions: preset === "custom" ? permissions : [],
         persona: customPersona || null,
       });
 
       if (result.success && result.key) {
-        setCreatedKey(result.key);
+        if (!embedded) setCreatedKey(result.key);
         onAgentCreated(
           {
             uuid: result.agentUuid || "",
             name: newKeyName,
-            roles: selectedRoles,
+            roles,
+            permissions: preset === "custom" ? permissions : [],
           },
-          result.key
+          result.key,
         );
       } else {
         clientLogger.error("Failed to create API key:", result.error);
@@ -123,10 +120,11 @@ export function AgentCreateForm({
 
   const resetForm = () => {
     setNewKeyName("");
-    setSelectedRoles([]);
+    setPreset("admin_agent");
+    setRoles(["admin_agent"]);
+    setPermissions([]);
     setCustomPersona("");
     setCreatedKey(null);
-    setAdminConfirmed(false);
   };
 
   const handleClose = () => {
@@ -134,26 +132,8 @@ export function AgentCreateForm({
     onClose?.();
   };
 
-  // Get available persona presets based on selected roles
-  const getAvailablePersonas = () => {
-    const personas: { id: string; labelKey: string; descKey: string }[] = [];
-    if (selectedRoles.includes("pm_agent")) {
-      personas.push(...PM_PERSONAS);
-    }
-    if (selectedRoles.includes("developer_agent")) {
-      personas.push(...DEV_PERSONAS);
-    }
-    if (selectedRoles.includes("admin_agent")) {
-      personas.push(...ADMIN_PERSONAS);
-    }
-    return personas;
-  };
-
-  // Check if admin role is selected
-  const hasAdminRole = selectedRoles.includes("admin_agent");
-
-  if (createdKey) {
-    // Success State
+  if (createdKey && !embedded) {
+    // Success State (modal only — embedded callers render their own success UX)
     return (
       <div className="p-6">
         <div className="mb-4 flex items-center gap-2 text-green-600">
@@ -185,224 +165,50 @@ export function AgentCreateForm({
   // Form State
   return (
     <form onSubmit={handleCreateKey}>
-      {/* Modal Header */}
-      <div className="flex items-center justify-between border-b border-border px-6 py-5">
-        <h3 className="text-lg font-semibold text-foreground">
-          {t("settings.createApiKey")}
-        </h3>
-        {onClose && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={handleClose}
-            className="h-8 w-8"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        )}
-      </div>
-
-      {/* Modal Body */}
-      <div className="space-y-5 p-6">
-        {/* Name Field */}
-        <div className="space-y-2">
-          <Label htmlFor="keyName" className="text-[13px]">
-            {t("settings.name")}
-          </Label>
-          <Input
-            id="keyName"
-            value={newKeyName}
-            onChange={(e) => setNewKeyName(e.target.value)}
-            placeholder={t("settings.namePlaceholder")}
-            className="border-[#E5E0D8]"
-            required
-          />
-        </div>
-
-        {/* Agent Roles */}
-        <div className="space-y-3">
-          <Label className="text-[13px]">{t("settings.agentRoles")}</Label>
-          <p className="text-xs text-muted-foreground">
-            {t("settings.agentRolesDesc")}
-          </p>
-          <div className="space-y-2">
+      {!embedded && (
+        /* Modal Header */
+        <div className="flex items-center justify-between border-b border-border px-6 py-5">
+          <h3 className="text-lg font-semibold text-foreground">
+            {t("settings.createApiKey")}
+          </h3>
+          {onClose && (
             <Button
               type="button"
-              variant="outline"
-              onClick={() => toggleRole("developer_agent")}
-              className={`flex h-auto w-full items-start justify-start gap-3 rounded-lg border p-3 text-left transition-colors ${
-                selectedRoles.includes("developer_agent")
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary"
-              }`}
+              variant="ghost"
+              size="icon"
+              onClick={handleClose}
+              className="h-8 w-8"
             >
-              <div
-                className={`mt-0.5 flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded ${
-                  selectedRoles.includes("developer_agent")
-                    ? "bg-primary"
-                    : "border-2 border-border"
-                }`}
-              >
-                {selectedRoles.includes("developer_agent") && (
-                  <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />
-                )}
-              </div>
-              <div>
-                <div className="text-sm font-medium text-foreground">
-                  {t("settings.developerAgent")}
-                </div>
-                <div className="text-xs font-normal text-muted-foreground">
-                  {t("settings.developerAgentDesc")}
-                </div>
-              </div>
+              <X className="h-4 w-4" />
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => toggleRole("pm_agent")}
-              className={`flex h-auto w-full items-start justify-start gap-3 rounded-lg border p-3 text-left transition-colors ${
-                selectedRoles.includes("pm_agent")
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary"
-              }`}
-            >
-              <div
-                className={`mt-0.5 flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded ${
-                  selectedRoles.includes("pm_agent")
-                    ? "bg-primary"
-                    : "border-2 border-border"
-                }`}
-              >
-                {selectedRoles.includes("pm_agent") && (
-                  <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />
-                )}
-              </div>
-              <div>
-                <div className="text-sm font-medium text-foreground">
-                  {t("settings.pmAgent")}
-                </div>
-                <div className="text-xs font-normal text-muted-foreground">
-                  {t("settings.pmAgentDesc")}
-                </div>
-              </div>
-            </Button>
-            {/* Admin Agent - with danger styling */}
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => toggleRole("admin_agent")}
-              className={`flex h-auto w-full items-start justify-start gap-3 rounded-lg border p-3 text-left transition-colors ${
-                selectedRoles.includes("admin_agent")
-                  ? "border-red-500 bg-red-50 dark:bg-red-950"
-                  : "border-border hover:border-red-400"
-              }`}
-            >
-              <div
-                className={`mt-0.5 flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded ${
-                  selectedRoles.includes("admin_agent")
-                    ? "bg-red-500"
-                    : "border-2 border-red-300"
-                }`}
-              >
-                {selectedRoles.includes("admin_agent") && (
-                  <Check className="h-3 w-3 text-white" strokeWidth={3} />
-                )}
-              </div>
-              <div>
-                <div className="flex items-center gap-2 text-sm font-medium text-red-600 dark:text-red-400">
-                  <ShieldAlert className="h-4 w-4" />
-                  {t("settings.adminAgent")}
-                </div>
-                <div className="text-xs font-normal text-red-500/80 dark:text-red-400/80">
-                  {t("settings.adminAgentDesc")}
-                </div>
-              </div>
-            </Button>
-          </div>
-
-          {/* Admin Warning Box */}
-          {hasAdminRole && (
-            <div className="mt-3 rounded-lg border border-red-300 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950">
-              <div className="flex items-start gap-3">
-                <AlertTriangle className="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400" />
-                <div className="space-y-2">
-                  <p className="text-sm font-semibold text-red-700 dark:text-red-300">
-                    {t("settings.adminWarningTitle")}
-                  </p>
-                  <p className="text-xs text-red-600 dark:text-red-400">
-                    {t("settings.adminWarningDesc")}
-                  </p>
-                  <ul className="list-inside list-disc space-y-1 text-xs text-red-600 dark:text-red-400">
-                    <li>{t("settings.adminWarningItem1")}</li>
-                    <li>{t("settings.adminWarningItem2")}</li>
-                    <li>{t("settings.adminWarningItem3")}</li>
-                    <li>{t("settings.adminWarningItem4")}</li>
-                  </ul>
-                  <div className="mt-3 flex cursor-pointer items-center gap-2">
-                    <Checkbox
-                      id="adminConfirm"
-                      checked={adminConfirmed}
-                      onCheckedChange={(checked) => setAdminConfirmed(checked === true)}
-                      className="border-red-300 data-[state=checked]:bg-red-600 data-[state=checked]:border-red-600"
-                    />
-                    <Label htmlFor="adminConfirm" className="cursor-pointer text-xs font-medium text-red-700 dark:text-red-300">
-                      {t("settings.adminConfirmCheckbox")}
-                    </Label>
-                  </div>
-                </div>
-              </div>
-            </div>
           )}
         </div>
+      )}
 
-        {/* Agent Persona - Always visible */}
-        <div className="space-y-3">
-          <Label className="text-[13px]">{t("settings.agentPersona")}</Label>
-          <p className="text-xs text-muted-foreground">
-            {selectedRoles.length > 0
-              ? t("settings.agentPersonaDesc")
-              : t("settings.agentPersonaDescNoRoles")}
-          </p>
-
-          {/* Persona Presets - Only show when roles are selected */}
-          {selectedRoles.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {getAvailablePersonas().map((persona) => (
-                <Button
-                  key={persona.id}
-                  type="button"
-                  variant={customPersona === t(persona.descKey) ? "default" : "outline"}
-                  size="sm"
-                  onClick={() =>
-                    selectPersonaPreset(t(persona.descKey))
-                  }
-                  className="rounded-full"
-                >
-                  {t(persona.labelKey)}
-                </Button>
-              ))}
-            </div>
-          )}
-
-          {/* Editable Persona Textarea - Always visible */}
-          <Textarea
-            value={customPersona}
-            onChange={(e) => setCustomPersona(e.target.value)}
-            placeholder={t("settings.personaPlaceholder")}
-            rows={4}
-          />
-          <p className="text-[11px] text-muted-foreground">
-            {selectedRoles.length > 0
-              ? t("settings.personaHint")
-              : t("settings.personaHintNoRoles")}
-          </p>
-        </div>
+      {/* Body */}
+      <div className={embedded ? undefined : "p-6"}>
+        <AgentFormFields
+          name={newKeyName}
+          onNameChange={setNewKeyName}
+          preset={preset}
+          permissions={permissions}
+          onPermissionsChange={handlePickerChange}
+          persona={customPersona}
+          onPersonaChange={setCustomPersona}
+          nameInputId="keyName"
+          personaInputId="create-agent-persona"
+        />
       </div>
 
-      {/* Modal Footer */}
-      <div className="flex justify-end gap-3 border-t border-border px-6 py-4">
-        {onClose && (
+      {/* Footer */}
+      <div
+        className={
+          embedded
+            ? "flex justify-end gap-3 pt-2"
+            : "flex justify-end gap-3 border-t border-border px-6 py-4"
+        }
+      >
+        {!embedded && onClose && (
           <Button
             type="button"
             variant="outline"
@@ -414,12 +220,16 @@ export function AgentCreateForm({
         <Button
           type="submit"
           disabled={
-            !newKeyName || selectedRoles.length === 0 || submitting ||
-            (hasAdminRole && !adminConfirmed)
+            !newKeyName ||
+            (preset === "custom" && permissions.length === 0) ||
+            submitting
           }
-          className={hasAdminRole ? "bg-red-600 hover:bg-red-700" : ""}
+          className={embedded ? "w-full" : undefined}
+          size={embedded ? "lg" : "default"}
         >
-          {submitting ? t("settings.creating") : t("settings.createApiKey")}
+          {submitting
+            ? submittingLabel ?? t("settings.creating")
+            : submitLabel ?? t("settings.createApiKey")}
         </Button>
       </div>
     </form>

--- a/src/components/AgentFormFields.tsx
+++ b/src/components/AgentFormFields.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AgentPermissionPicker,
+  type AgentPermissionPickerChange,
+} from "@/components/AgentPermissionPicker";
+import { ROLE_PRESETS, type PresetKey } from "@/lib/authz/presets";
+import type { Permission } from "@/lib/authz/types";
+
+export type AgentFormPreset = PresetKey | "custom";
+
+export interface AgentFormFieldsProps {
+  name: string;
+  onNameChange: (next: string) => void;
+
+  preset: AgentFormPreset;
+  permissions: Permission[];
+  onPermissionsChange: (next: AgentPermissionPickerChange) => void;
+
+  persona: string;
+  onPersonaChange: (next: string) => void;
+
+  nameInputId?: string;
+  personaInputId?: string;
+  readOnly?: boolean;
+}
+
+export function AgentFormFields({
+  name,
+  onNameChange,
+  preset,
+  permissions,
+  onPermissionsChange,
+  persona,
+  onPersonaChange,
+  nameInputId = "agent-form-name",
+  personaInputId = "agent-form-persona",
+  readOnly = false,
+}: AgentFormFieldsProps) {
+  const t = useTranslations();
+
+  // The picker is displayed against the full effective permission set: for a
+  // preset, show its built-in set; for custom mode, whatever is stored.
+  const pickerPermissions: Permission[] = useMemo(() => {
+    if (preset === "custom") return permissions;
+    return [...ROLE_PRESETS[preset]];
+  }, [preset, permissions]);
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-2">
+        <Label htmlFor={nameInputId} className="text-[13px]">
+          {t("settings.name")}
+        </Label>
+        <Input
+          id={nameInputId}
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder={t("settings.namePlaceholder")}
+          className="border-[#E5E0D8]"
+          required
+          disabled={readOnly}
+        />
+      </div>
+
+      <AgentPermissionPicker
+        preset={preset}
+        permissions={pickerPermissions}
+        onChange={onPermissionsChange}
+        readOnly={readOnly}
+      />
+
+      <div className="space-y-2">
+        <Label htmlFor={personaInputId} className="text-[13px]">
+          {t("settings.agentPersona")}
+        </Label>
+        <Textarea
+          id={personaInputId}
+          value={persona}
+          onChange={(e) => onPersonaChange(e.target.value)}
+          placeholder={t("settings.personaPlaceholder")}
+          rows={4}
+          disabled={readOnly}
+        />
+        <p className="text-xs text-muted-foreground">
+          {t("settings.personaHint")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default AgentFormFields;

--- a/src/components/AgentPermissionPicker.tsx
+++ b/src/components/AgentPermissionPicker.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ROLE_PRESETS, type PresetKey } from "@/lib/authz/presets";
+import {
+  ACTIONS,
+  RESOURCES,
+  type Action,
+  type Permission,
+  type Resource,
+} from "@/lib/authz/types";
+
+const PRESET_LABEL_KEY: Record<PresetKey | "custom", string> = {
+  admin_agent: "agent.permissions.presetAdmin",
+  pm_agent: "agent.permissions.presetPm",
+  developer_agent: "agent.permissions.presetDev",
+  custom: "agent.permissions.presetCustom",
+};
+
+const PRESET_HELP_KEY: Record<PresetKey | "custom", string> = {
+  admin_agent: "agent.permissions.help.admin",
+  pm_agent: "agent.permissions.help.pm",
+  developer_agent: "agent.permissions.help.dev",
+  custom: "agent.permissions.help.custom",
+};
+
+const PRESET_CHOICES: readonly (PresetKey | "custom")[] = [
+  "admin_agent",
+  "pm_agent",
+  "developer_agent",
+  "custom",
+];
+
+type SelectedPreset = PresetKey | "custom";
+
+export interface AgentPermissionPickerChange {
+  preset: SelectedPreset;
+  roles: string[];
+  permissions: string[];
+}
+
+export interface AgentPermissionPickerProps {
+  preset: PresetKey | "custom" | null;
+  permissions: Permission[];
+  onChange: (next: AgentPermissionPickerChange) => void;
+  readOnly?: boolean;
+}
+
+function perm(resource: Resource, action: Action): Permission {
+  return `${resource}:${action}` as Permission;
+}
+
+export function AgentPermissionPicker({
+  preset,
+  permissions,
+  onChange,
+  readOnly = false,
+}: AgentPermissionPickerProps) {
+  const t = useTranslations();
+
+  const selectedPreset: SelectedPreset = preset ?? "custom";
+  // When a role preset is active, the checked state reflects that preset's
+  // permission set so users see the effect of their choice. In custom mode
+  // the checked state is the raw `permissions` prop.
+  const checked =
+    selectedPreset === "custom"
+      ? new Set<Permission>(permissions)
+      : new Set<Permission>(ROLE_PRESETS[selectedPreset]);
+
+  function handlePresetChange(value: string) {
+    if (value === "custom") {
+      onChange({
+        preset: "custom",
+        roles: [],
+        permissions: Array.from(checked),
+      });
+      return;
+    }
+    const key = value as PresetKey;
+    if (!(key in ROLE_PRESETS)) return;
+    onChange({
+      preset: key,
+      roles: [key],
+      permissions: [],
+    });
+  }
+
+  function handleToggle(p: Permission, next: boolean) {
+    const nextSet = new Set(checked);
+    if (next) nextSet.add(p);
+    else nextSet.delete(p);
+    onChange({
+      preset: "custom",
+      roles: [],
+      permissions: Array.from(nextSet),
+    });
+  }
+
+  return (
+    <div data-testid="agent-permission-picker" className="space-y-4">
+      <div className="space-y-1">
+        <Label className="text-[13px] font-medium">
+          {t("agent.permissions.title")}
+        </Label>
+        <p className="text-muted-foreground text-xs">
+          {t("agent.permissions.description")}
+        </p>
+      </div>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="agent-permission-preset">
+            {t("agent.permissions.presetLabel")}
+          </Label>
+          <Select
+            value={selectedPreset}
+            onValueChange={handlePresetChange}
+            disabled={readOnly}
+          >
+            <SelectTrigger
+              id="agent-permission-preset"
+              className="w-full"
+              aria-label={t("agent.permissions.presetLabel")}
+            >
+              <SelectValue placeholder={t(PRESET_LABEL_KEY[selectedPreset])}>
+                {t(PRESET_LABEL_KEY[selectedPreset])}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {PRESET_CHOICES.map((key) => (
+                <SelectItem
+                  key={key}
+                  value={key}
+                  textValue={t(PRESET_LABEL_KEY[key])}
+                >
+                  <div className="flex flex-col gap-0.5 py-0.5">
+                    <span className="text-sm font-semibold">
+                      {t(PRESET_LABEL_KEY[key])}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {t(PRESET_HELP_KEY[key])}
+                    </span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div
+          role="grid"
+          aria-label={t("agent.permissions.title")}
+          className="overflow-hidden rounded-md border"
+        >
+          <div
+            role="row"
+            className="bg-muted/50 text-muted-foreground grid grid-cols-[1.5fr_repeat(3,1fr)] items-center gap-2 px-4 py-2 text-xs font-medium"
+          >
+            <div role="columnheader">{t("agent.permissions.resourceHeader")}</div>
+            {ACTIONS.map((action) => (
+              <div
+                key={action}
+                role="columnheader"
+                className="text-center"
+              >
+                {t(`agent.permissions.actions.${action}`)}
+              </div>
+            ))}
+          </div>
+          {RESOURCES.map((resource) => (
+            <div
+              key={resource}
+              role="row"
+              className="border-t grid grid-cols-[1.5fr_repeat(3,1fr)] items-center gap-2 px-4 py-2 text-sm"
+            >
+              <div role="rowheader" className="font-medium">
+                {t(`agent.permissions.resources.${resource}`)}
+              </div>
+              {ACTIONS.map((action) => {
+                const p = perm(resource, action);
+                const inputId = `perm-${resource}-${action}`;
+                const disabled = readOnly;
+                return (
+                  <div
+                    key={action}
+                    role="gridcell"
+                    className="flex items-center justify-center"
+                  >
+                    <Checkbox
+                      id={inputId}
+                      checked={checked.has(p)}
+                      disabled={disabled}
+                      aria-label={`${t(
+                        `agent.permissions.resources.${resource}`,
+                      )} ${t(`agent.permissions.actions.${action}`)}`}
+                      onCheckedChange={(v) => {
+                        if (disabled) return;
+                        handleToggle(p, v === true);
+                      }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AgentPermissionPicker;

--- a/src/components/__tests__/AgentPermissionPicker.test.tsx
+++ b/src/components/__tests__/AgentPermissionPicker.test.tsx
@@ -1,0 +1,346 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import {
+  AgentPermissionPicker,
+  type AgentPermissionPickerChange,
+  type AgentPermissionPickerProps,
+} from "@/components/AgentPermissionPicker";
+import { ROLE_PRESETS, type PresetKey } from "@/lib/authz/presets";
+import { ALL_PERMISSIONS, type Permission } from "@/lib/authz/types";
+
+// Use real translations so we're asserting on user-visible copy and catch any
+// missing keys as a test failure.
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(key: string): string {
+    const parts = key.split(".");
+    let node: unknown = en;
+    for (const p of parts) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return key;
+      }
+    }
+    return typeof node === "string" ? node : key;
+  }
+  return {
+    useTranslations: () => (key: string) => resolve(key),
+  };
+});
+
+/**
+ * Controlled harness: the picker is a controlled component, so tests need a
+ * parent that applies the onChange output back into props. This mirrors how
+ * real callers (Onboarding, Agent Create, Agent Edit) will use it.
+ */
+function Harness({
+  initial,
+  onChange,
+  readOnly,
+}: {
+  initial: { preset: AgentPermissionPickerProps["preset"]; permissions: Permission[] };
+  onChange?: (c: AgentPermissionPickerChange) => void;
+  readOnly?: boolean;
+}) {
+  const [state, setState] = useState<{
+    preset: AgentPermissionPickerProps["preset"];
+    permissions: Permission[];
+  }>(initial);
+  return (
+    <AgentPermissionPicker
+      preset={state.preset}
+      permissions={state.permissions}
+      readOnly={readOnly}
+      onChange={(next) => {
+        onChange?.(next);
+        setState({
+          preset: next.preset,
+          permissions: next.permissions as Permission[],
+        });
+      }}
+    />
+  );
+}
+
+function presetChecked(preset: PresetKey): Permission[] {
+  return [...ROLE_PRESETS[preset]];
+}
+
+// Radix Checkbox renders as a button with role="checkbox". We key on the
+// aria-label (e.g. "Idea Read") which the picker builds per cell.
+function cellCheckbox(resource: string, action: string): HTMLElement {
+  return screen.getByRole("checkbox", {
+    name: new RegExp(`^${resource}\\s+${action}$`, "i"),
+  });
+}
+
+function checkedCount(): number {
+  return screen
+    .getAllByRole("checkbox")
+    .filter((el) => el.getAttribute("data-state") === "checked")
+    .length;
+}
+
+describe("AgentPermissionPicker", () => {
+  it("renders all 15 checkboxes with a Card + Select scaffold", () => {
+    render(
+      <Harness
+        initial={{
+          preset: "admin_agent",
+          permissions: presetChecked("admin_agent"),
+        }}
+      />,
+    );
+
+    // Picker mounts, all 15 permission cells present.
+    expect(screen.getByTestId("agent-permission-picker")).toBeTruthy();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(15);
+
+    // Headers rendered via translations.
+    expect(screen.getByText("Resource")).toBeTruthy();
+    expect(screen.getByText("Read")).toBeTruthy();
+    expect(screen.getByText("Write")).toBeTruthy();
+    // There are multiple "Admin" strings on screen (preset option + column
+    // header). Matching the column header specifically via its role.
+    expect(screen.getByRole("columnheader", { name: "Admin" })).toBeTruthy();
+  });
+
+  it("admin preset renders all 15 boxes checked", () => {
+    render(
+      <Harness
+        initial={{
+          preset: "admin_agent",
+          permissions: presetChecked("admin_agent"),
+        }}
+      />,
+    );
+    expect(checkedCount()).toBe(15);
+  });
+
+  it("pm preset checks 10 boxes; admin column is interactive but unchecked", () => {
+    render(
+      <Harness
+        initial={{
+          preset: "pm_agent",
+          permissions: presetChecked("pm_agent"),
+        }}
+      />,
+    );
+    expect(checkedCount()).toBe(10);
+
+    // Admin column is interactive even on pm preset — users can freely extend
+    // a preset with extra bits without switching to Custom first.
+    for (const resource of ["Idea", "Proposal", "Document", "Task", "Project"]) {
+      const cb = cellCheckbox(resource, "Admin");
+      expect((cb as HTMLButtonElement).disabled).toBe(false);
+      expect(cb.getAttribute("data-state")).toBe("unchecked");
+    }
+  });
+
+  it("developer preset checks exactly the 6 dev permissions", () => {
+    render(
+      <Harness
+        initial={{
+          preset: "developer_agent",
+          permissions: presetChecked("developer_agent"),
+        }}
+      />,
+    );
+    expect(checkedCount()).toBe(6);
+
+    // Spot-check the expected set.
+    expect(cellCheckbox("Idea", "Read").getAttribute("data-state")).toBe(
+      "checked",
+    );
+    expect(cellCheckbox("Proposal", "Read").getAttribute("data-state")).toBe(
+      "checked",
+    );
+    expect(cellCheckbox("Document", "Read").getAttribute("data-state")).toBe(
+      "checked",
+    );
+    expect(cellCheckbox("Project", "Read").getAttribute("data-state")).toBe(
+      "checked",
+    );
+    expect(cellCheckbox("Task", "Read").getAttribute("data-state")).toBe(
+      "checked",
+    );
+    expect(cellCheckbox("Task", "Write").getAttribute("data-state")).toBe(
+      "checked",
+    );
+
+    // And unchecked cells really are unchecked.
+    expect(cellCheckbox("Idea", "Write").getAttribute("data-state")).toBe(
+      "unchecked",
+    );
+    expect(cellCheckbox("Proposal", "Write").getAttribute("data-state")).toBe(
+      "unchecked",
+    );
+
+    // Admin column is interactive on any preset — users can freely extend.
+    expect((cellCheckbox("Idea", "Admin") as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it("manually unchecking a box switches preset to Custom and emits permissions without the toggled bit", async () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        initial={{
+          preset: "admin_agent",
+          permissions: presetChecked("admin_agent"),
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    // Uncheck task:write while on admin preset.
+    const taskWrite = cellCheckbox("Task", "Write");
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await user.click(taskWrite);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const payload = onChange.mock.calls[0]![0] as AgentPermissionPickerChange;
+    expect(payload.preset).toBe("custom");
+    expect(payload.roles).toEqual([]);
+    expect(payload.permissions).toContain("task:read");
+    expect(payload.permissions).toContain("proposal:admin");
+    expect(payload.permissions).not.toContain("task:write");
+    expect(payload.permissions).toHaveLength(14);
+
+    // Admin column is interactive in every mode.
+    expect((cellCheckbox("Task", "Admin") as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it("checking an admin-column box while on PM preset flips preset to Custom and adds the bit", async () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        initial={{
+          preset: "pm_agent",
+          permissions: presetChecked("pm_agent"),
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    // Admin column is interactive on pm preset too — clicking it directly
+    // flips to custom with the preset's bits + the newly-checked admin bit.
+    const proposalAdmin = cellCheckbox("Proposal", "Admin");
+    expect((proposalAdmin as HTMLButtonElement).disabled).toBe(false);
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await user.click(proposalAdmin);
+
+    const payload = onChange.mock.calls.at(-1)![0] as AgentPermissionPickerChange;
+    expect(payload.preset).toBe("custom");
+    expect(payload.roles).toEqual([]);
+    expect(payload.permissions).toContain("proposal:admin");
+    // All the pm preset's bits are still included.
+    expect(payload.permissions).toContain("idea:read");
+    expect(payload.permissions).toContain("proposal:write");
+  });
+
+  it("readOnly disables all 15 checkboxes and the preset dropdown", () => {
+    render(
+      <Harness
+        initial={{
+          preset: "admin_agent",
+          permissions: presetChecked("admin_agent"),
+        }}
+        readOnly
+      />,
+    );
+
+    // All checkboxes disabled.
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes).toHaveLength(15);
+    for (const b of boxes) {
+      expect((b as HTMLButtonElement).disabled).toBe(true);
+    }
+
+    // Select trigger has data-disabled attribute from Radix.
+    const trigger = screen.getByRole("combobox", {
+      name: /preset/i,
+    });
+    expect((trigger as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("readOnly blocks onChange even if the click handler fires", async () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        initial={{
+          preset: "admin_agent",
+          permissions: presetChecked("admin_agent"),
+        }}
+        onChange={onChange}
+        readOnly
+      />,
+    );
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    // userEvent refuses to click a disabled button — this is the correct
+    // real-world behavior. Fall back to firing click directly and assert
+    // nothing leaks out.
+    const taskWrite = cellCheckbox("Task", "Write");
+    // Bypass user-event's disabled check by clicking low level; the component
+    // must still not emit.
+    taskWrite.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    // User-event is also exercised to make sure nothing slips through in the
+    // normal path.
+    await user.click(taskWrite).catch(() => {
+      // ignored: user-event may throw on disabled targets
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("preset=null coerces display to Custom", () => {
+    render(<Harness initial={{ preset: null, permissions: [] }} />);
+    // "Custom" is visible in the select trigger.
+    const trigger = screen.getByRole("combobox", { name: /preset/i });
+    expect(within(trigger).getByText(/custom/i)).toBeTruthy();
+    expect(checkedCount()).toBe(0);
+    // On custom, admin column is NOT locked.
+    expect((cellCheckbox("Task", "Admin") as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it("onChange payload for a preset switch carries roles=[presetKey] and empty permissions", async () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        initial={{ preset: "developer_agent", permissions: presetChecked("developer_agent") }}
+        onChange={onChange}
+      />,
+    );
+
+    // Click a checkbox to flip to custom first (Radix Select portal is hard to
+    // drive in jsdom; preset-switch payload shape is the same whether the
+    // source is dropdown or internal handler, and is verified by covering the
+    // preset rendering + the reverse direction in other tests).
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await user.click(cellCheckbox("Task", "Write"));
+
+    const custom = onChange.mock.calls[0]![0] as AgentPermissionPickerChange;
+    // Contract check: custom mode always uses roles=[] permissions=[...15 bits subset]
+    expect(custom.preset).toBe("custom");
+    expect(custom.roles).toEqual([]);
+    for (const p of custom.permissions) {
+      expect(ALL_PERMISSIONS).toContain(p as Permission);
+    }
+  });
+});

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -25,6 +25,8 @@ import {
   isAssignee,
   isSuperAdmin,
   requireSuperAdmin,
+  hasPermission,
+  requireAgentPermission,
 } from '../auth';
 import type { AgentAuthContext, UserAuthContext, AuthContext, SuperAdminAuthContext } from '@/types/auth';
 import { validateApiKey } from '@/lib/api-key';
@@ -45,6 +47,7 @@ const agentCtx: AgentAuthContext = {
   companyUuid: 'comp-uuid',
   actorUuid: 'agent-uuid',
   roles: ['developer'],
+  permissions: [],
   agentName: 'Dev Agent',
 };
 
@@ -53,6 +56,7 @@ const pmAgentCtx: AgentAuthContext = {
   companyUuid: 'comp-uuid',
   actorUuid: 'pm-uuid',
   roles: ['pm'],
+  permissions: [],
   agentName: 'PM Agent',
 };
 
@@ -61,6 +65,7 @@ const multiRoleCtx: AgentAuthContext = {
   companyUuid: 'comp-uuid',
   actorUuid: 'multi-uuid',
   roles: ['pm', 'developer'],
+  permissions: [],
   agentName: 'Multi Agent',
 };
 
@@ -155,6 +160,7 @@ describe('getAuthContext', () => {
       companyUuid: 'company-uuid',
       name: 'Test Agent',
       roles: ['developer'],
+      permissions: [],
       ownerUuid: 'owner-uuid',
     };
 
@@ -171,6 +177,14 @@ describe('getAuthContext', () => {
       companyUuid: 'company-uuid',
       actorUuid: 'agent-uuid',
       roles: ['developer'],
+      permissions: expect.arrayContaining([
+        'idea:read',
+        'proposal:read',
+        'document:read',
+        'project:read',
+        'task:read',
+        'task:write',
+      ]),
       ownerUuid: 'owner-uuid',
       agentName: 'Test Agent',
     });
@@ -342,6 +356,7 @@ describe('requireUser', () => {
       companyUuid: 'company-uuid',
       actorUuid: 'agent-uuid',
       roles: ['developer'],
+      permissions: [],
       agentName: 'Test Agent',
     };
 
@@ -373,6 +388,7 @@ describe('requireAgentRole', () => {
       companyUuid: 'company-uuid',
       actorUuid: 'agent-uuid',
       roles: ['developer'],
+      permissions: [],
       agentName: 'Test Agent',
     };
 
@@ -395,6 +411,7 @@ describe('requireAgentRole', () => {
       companyUuid: 'company-uuid',
       actorUuid: 'agent-uuid',
       roles: ['developer'],
+      permissions: [],
       agentName: 'Test Agent',
     };
 
@@ -537,5 +554,149 @@ describe('requireSuperAdmin', () => {
     expect(response.status).toBe(401);
     const body = await response.json();
     expect(body.error.message).toContain('Super Admin');
+  });
+});
+
+describe('hasPermission', () => {
+  const superAdminCtx: SuperAdminAuthContext = {
+    type: 'super_admin',
+    email: 'admin@test.com',
+  };
+
+  const devAgentCtx: AgentAuthContext = {
+    type: 'agent',
+    companyUuid: 'comp-uuid',
+    actorUuid: 'dev-uuid',
+    roles: ['developer_agent'],
+    permissions: [
+      'idea:read',
+      'proposal:read',
+      'document:read',
+      'project:read',
+      'task:read',
+      'task:write',
+    ],
+    agentName: 'Dev',
+  };
+
+  it('returns true for developer_agent with task:read', () => {
+    expect(hasPermission(devAgentCtx, 'task:read')).toBe(true);
+  });
+
+  it('returns false for developer_agent with task:admin', () => {
+    expect(hasPermission(devAgentCtx, 'task:admin')).toBe(false);
+  });
+
+  it('returns true for super_admin regardless of permission asked', () => {
+    expect(hasPermission(superAdminCtx, 'task:admin')).toBe(true);
+    expect(hasPermission(superAdminCtx, 'proposal:admin')).toBe(true);
+    expect(hasPermission(superAdminCtx, 'idea:read')).toBe(true);
+  });
+
+  it('returns false for an agent with empty permissions array', () => {
+    const noPerms: AgentAuthContext = { ...devAgentCtx, permissions: [] };
+    expect(hasPermission(noPerms, 'task:read')).toBe(false);
+  });
+});
+
+describe('requireAgentPermission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildAgent(permissions: AgentAuthContext['permissions']): AgentAuthContext {
+    return {
+      type: 'agent',
+      companyUuid: 'comp-uuid',
+      actorUuid: 'agent-uuid',
+      roles: [],
+      permissions,
+      agentName: 'Test Agent',
+    };
+  }
+
+  it('passes through when agent has the required permission', async () => {
+    const agent = buildAgent(['task:read']);
+    vi.mocked(getSuperAdminFromRequest).mockResolvedValue(null);
+    vi.mocked(getUserSessionFromRequest).mockResolvedValue(agent as unknown as UserAuthContext);
+
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ success: true }));
+    const wrapped = requireAgentPermission('task:read', handler);
+
+    const req = new NextRequest(new URL('http://localhost:3000/api/test'));
+    const context = { params: Promise.resolve({}) };
+    await wrapped(req, context);
+
+    expect(handler).toHaveBeenCalledWith(req, context, agent);
+  });
+
+  it('returns 403 when agent lacks the required permission', async () => {
+    const agent = buildAgent(['task:read']);
+    vi.mocked(getSuperAdminFromRequest).mockResolvedValue(null);
+    vi.mocked(getUserSessionFromRequest).mockResolvedValue(agent as unknown as UserAuthContext);
+
+    const handler = vi.fn();
+    const wrapped = requireAgentPermission('proposal:admin', handler);
+
+    const req = new NextRequest(new URL('http://localhost:3000/api/test'));
+    const context = { params: Promise.resolve({}) };
+    const response = await wrapped(req, context);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.message).toContain('Missing permission: proposal:admin');
+  });
+
+  it('bypasses permission check for super_admin', async () => {
+    const superAdmin: SuperAdminAuthContext = { type: 'super_admin', email: 'admin@test.com' };
+    vi.mocked(getSuperAdminFromRequest).mockResolvedValue(superAdmin);
+
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ success: true }));
+    const wrapped = requireAgentPermission('task:admin', handler);
+
+    const req = new NextRequest(new URL('http://localhost:3000/api/test'));
+    const context = { params: Promise.resolve({}) };
+    await wrapped(req, context);
+
+    expect(handler).toHaveBeenCalledWith(req, context, superAdmin);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(getSuperAdminFromRequest).mockResolvedValue(null);
+    vi.mocked(getUserSessionFromRequest).mockResolvedValue(null);
+    vi.mocked(isOidcToken).mockReturnValue(false);
+
+    const handler = vi.fn();
+    const wrapped = requireAgentPermission('task:read', handler);
+
+    const req = new NextRequest(new URL('http://localhost:3000/api/test'));
+    const context = { params: Promise.resolve({}) };
+    const response = await wrapped(req, context);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 when authenticated as plain user (not agent)', async () => {
+    const user: UserAuthContext = {
+      type: 'user',
+      companyUuid: 'comp-uuid',
+      actorUuid: 'user-uuid',
+    };
+    vi.mocked(getSuperAdminFromRequest).mockResolvedValue(null);
+    vi.mocked(getUserSessionFromRequest).mockResolvedValue(user);
+
+    const handler = vi.fn();
+    const wrapped = requireAgentPermission('task:read', handler);
+
+    const req = new NextRequest(new URL('http://localhost:3000/api/test'));
+    const context = { params: Promise.resolve({}) };
+    const response = await wrapped(req, context);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.message).toContain('agent authentication');
   });
 });

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -101,6 +101,7 @@ export async function validateApiKey(
         companyUuid: apiKey.agent.companyUuid,
         name: apiKey.agent.name,
         roles: apiKey.agent.roles,
+        permissions: apiKey.agent.permissions,
         ownerUuid: apiKey.agent.ownerUuid,
       },
       apiKey: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,8 @@ import type {
   SuperAdminAuthContext,
   AgentRole,
 } from "@/types/auth";
+import type { Permission } from "@/lib/authz/types";
+import { computeEffectivePermissions } from "@/lib/authz/permissions";
 import { getSuperAdminFromRequest } from "./super-admin";
 import { getUserSessionFromRequest } from "./user-session";
 import { verifyOidcAccessToken, isOidcToken } from "./oidc-auth";
@@ -30,11 +32,16 @@ export async function getAuthContext(
     if (token.startsWith("cho_")) {
       const result = await validateApiKey(token);
       if (result.valid && result.agent) {
+        const effective = computeEffectivePermissions(
+          result.agent.roles,
+          result.agent.permissions,
+        );
         const agentContext: AgentAuthContext = {
           type: "agent",
           companyUuid: result.agent.companyUuid,
           actorUuid: result.agent.uuid,
           roles: result.agent.roles as AgentRole[],
+          permissions: Array.from(effective),
           ownerUuid: result.agent.ownerUuid ?? undefined,
           agentName: result.agent.name,
         };
@@ -166,6 +173,63 @@ export function requireAgentRole<T>(
     }
     if (!hasRole(auth, role)) {
       return errors.forbidden(`This operation requires ${role} role`);
+    }
+    return handler(request, context, auth);
+  };
+}
+
+// Check if an auth context holds a specific permission.
+// SuperAdmin always passes; agents delegate to the precomputed effective permission set.
+export function hasPermission(
+  ctx: AgentAuthContext | SuperAdminAuthContext,
+  permission: Permission,
+): boolean {
+  if (ctx.type === "super_admin") return true;
+  return ctx.permissions.includes(permission);
+}
+
+// Gate an agent request by permission, passing users and super_admins through unchanged.
+// For routes that serve both humans and agents: humans keep their existing access,
+// agents must carry the required permission bit (super_admin bypasses).
+// Returns null when the request is allowed; returns a 403 response when the agent lacks the permission.
+export function checkAgentPermission(
+  ctx: AuthContext | SuperAdminAuthContext,
+  permission: Permission,
+): NextResponse | null {
+  if (ctx.type === "agent" && !hasPermission(ctx as AgentAuthContext, permission)) {
+    return errors.forbidden(`Missing permission: ${permission}`);
+  }
+  return null;
+}
+
+// Require a specific fine-grained permission on the Agent/SuperAdmin context.
+// Matches the shape of requireAgentRole / requireSuperAdmin. super_admin bypasses.
+// Returns 401 when unauthenticated, 403 when the agent lacks the permission.
+export function requireAgentPermission<T>(
+  permission: Permission,
+  handler: (
+    request: NextRequest,
+    context: { params: Promise<T> },
+    auth: AgentAuthContext | SuperAdminAuthContext,
+  ) => Promise<NextResponse>,
+) {
+  return async (
+    request: NextRequest,
+    context: { params: Promise<T> },
+  ): Promise<NextResponse> => {
+    const superAdmin = await getSuperAdminFromRequest(request);
+    if (superAdmin) {
+      return handler(request, context, superAdmin);
+    }
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return errors.unauthorized();
+    }
+    if (!isAgent(auth)) {
+      return errors.forbidden("This operation requires agent authentication");
+    }
+    if (!hasPermission(auth, permission)) {
+      return errors.forbidden(`Missing permission: ${permission}`);
     }
     return handler(request, context, auth);
   };

--- a/src/lib/authz/__tests__/permissions.test.ts
+++ b/src/lib/authz/__tests__/permissions.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeEffectivePermissions,
+  isValidPermission,
+} from "../permissions";
+import { ROLE_PRESETS } from "../presets";
+import { ALL_PERMISSIONS, type Permission } from "../types";
+
+describe("ALL_PERMISSIONS", () => {
+  it("contains exactly 15 entries", () => {
+    expect(ALL_PERMISSIONS).toHaveLength(15);
+  });
+
+  it("contains every resource × action combination", () => {
+    const expected = new Set<string>();
+    for (const r of ["idea", "proposal", "document", "task", "project"]) {
+      for (const a of ["read", "write", "admin"]) {
+        expected.add(`${r}:${a}`);
+      }
+    }
+    expect(new Set(ALL_PERMISSIONS)).toEqual(expected);
+  });
+});
+
+describe("ROLE_PRESETS", () => {
+  it("developer_agent has 6 permissions", () => {
+    expect(ROLE_PRESETS.developer_agent).toHaveLength(6);
+    expect(new Set(ROLE_PRESETS.developer_agent)).toEqual(
+      new Set<Permission>([
+        "idea:read",
+        "proposal:read",
+        "document:read",
+        "project:read",
+        "task:read",
+        "task:write",
+      ]),
+    );
+  });
+
+  it("pm_agent has 10 permissions", () => {
+    expect(ROLE_PRESETS.pm_agent).toHaveLength(10);
+    expect(new Set(ROLE_PRESETS.pm_agent)).toEqual(
+      new Set<Permission>([
+        "idea:read",
+        "idea:write",
+        "proposal:read",
+        "proposal:write",
+        "document:read",
+        "document:write",
+        "task:read",
+        "task:write",
+        "project:read",
+        "project:write",
+      ]),
+    );
+  });
+
+  it("admin_agent has all 15 permissions", () => {
+    expect(ROLE_PRESETS.admin_agent).toHaveLength(15);
+    expect(new Set(ROLE_PRESETS.admin_agent)).toEqual(new Set(ALL_PERMISSIONS));
+  });
+});
+
+describe("computeEffectivePermissions", () => {
+  it("returns pm_agent preset for ['pm_agent']", () => {
+    const result = computeEffectivePermissions(["pm_agent"], []);
+    expect(result).toEqual(new Set(ROLE_PRESETS.pm_agent));
+  });
+
+  it("returns developer_agent preset for ['developer_agent']", () => {
+    const result = computeEffectivePermissions(["developer_agent"], []);
+    expect(result).toEqual(new Set(ROLE_PRESETS.developer_agent));
+  });
+
+  it("returns admin_agent preset for ['admin_agent']", () => {
+    const result = computeEffectivePermissions(["admin_agent"], []);
+    expect(result).toEqual(new Set(ROLE_PRESETS.admin_agent));
+  });
+
+  it("treats 'pm' as 'pm_agent' (backward-compat short form)", () => {
+    const short = computeEffectivePermissions(["pm"], []);
+    const long = computeEffectivePermissions(["pm_agent"], []);
+    expect(short).toEqual(long);
+  });
+
+  it("treats 'developer' as 'developer_agent' (backward-compat short form)", () => {
+    const short = computeEffectivePermissions(["developer"], []);
+    const long = computeEffectivePermissions(["developer_agent"], []);
+    expect(short).toEqual(long);
+  });
+
+  it("treats 'admin' as 'admin_agent' (backward-compat short form)", () => {
+    const short = computeEffectivePermissions(["admin"], []);
+    const long = computeEffectivePermissions(["admin_agent"], []);
+    expect(short).toEqual(long);
+  });
+
+  it("returns empty set for empty roles and empty custom", () => {
+    const result = computeEffectivePermissions([], []);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns only custom permissions when roles are empty", () => {
+    const result = computeEffectivePermissions([], ["proposal:admin"]);
+    expect(result).toEqual(new Set<Permission>(["proposal:admin"]));
+  });
+
+  it("returns union of role preset and custom permissions", () => {
+    const result = computeEffectivePermissions(
+      ["developer_agent"],
+      ["proposal:write"],
+    );
+    expect(result.size).toBe(7);
+    expect(result).toEqual(
+      new Set<Permission>([
+        "idea:read",
+        "proposal:read",
+        "document:read",
+        "project:read",
+        "task:read",
+        "task:write",
+        "proposal:write",
+      ]),
+    );
+  });
+
+  it("deduplicates when custom permission overlaps preset", () => {
+    const result = computeEffectivePermissions(
+      ["developer_agent"],
+      ["task:read", "task:write"],
+    );
+    expect(result.size).toBe(6);
+    expect(result).toEqual(new Set(ROLE_PRESETS.developer_agent));
+  });
+
+  it("ignores invalid permission strings in custom input", () => {
+    const result = computeEffectivePermissions([], ["foo:bar", "task:read"]);
+    expect(result).toEqual(new Set<Permission>(["task:read"]));
+  });
+
+  it("ignores unknown role names", () => {
+    const result = computeEffectivePermissions(["unknown_agent"], []);
+    expect(result.size).toBe(0);
+  });
+
+  it("merges multiple roles", () => {
+    const result = computeEffectivePermissions(
+      ["developer_agent", "pm_agent"],
+      [],
+    );
+    expect(result).toEqual(new Set(ROLE_PRESETS.pm_agent));
+  });
+});
+
+describe("isValidPermission", () => {
+  it("returns true for valid permission strings", () => {
+    expect(isValidPermission("task:admin")).toBe(true);
+    expect(isValidPermission("idea:read")).toBe(true);
+    expect(isValidPermission("project:write")).toBe(true);
+  });
+
+  it("returns false for invalid permission strings", () => {
+    expect(isValidPermission("foo:bar")).toBe(false);
+    expect(isValidPermission("task:")).toBe(false);
+    expect(isValidPermission(":read")).toBe(false);
+    expect(isValidPermission("task")).toBe(false);
+    expect(isValidPermission("")).toBe(false);
+    expect(isValidPermission("TASK:READ")).toBe(false);
+  });
+});

--- a/src/lib/authz/permissions.ts
+++ b/src/lib/authz/permissions.ts
@@ -1,0 +1,63 @@
+import { ROLE_PRESETS, type PresetKey } from "./presets";
+import {
+  ACTIONS,
+  ALL_PERMISSIONS,
+  RESOURCES,
+  type Action,
+  type Permission,
+  type Resource,
+} from "./types";
+
+const PERMISSION_SET: ReadonlySet<string> = new Set(ALL_PERMISSIONS);
+
+export function isValidPermission(value: string): value is Permission {
+  return PERMISSION_SET.has(value);
+}
+
+export function computeEffectivePermissions(
+  roles: readonly string[] | null | undefined,
+  customPermissions: readonly string[] | null | undefined,
+): Set<Permission> {
+  const result = new Set<Permission>();
+
+  if (roles) {
+    for (const role of roles) {
+      const normalized = role.endsWith("_agent") ? role : `${role}_agent`;
+      const preset = ROLE_PRESETS[normalized as PresetKey];
+      if (preset) {
+        for (const p of preset) result.add(p);
+      }
+    }
+  }
+
+  if (customPermissions) {
+    for (const p of customPermissions) {
+      if (isValidPermission(p)) result.add(p);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Aggregate a flat permission set into `{ resource: [action, ...] }` shape.
+ * Resources with no granted actions are omitted. Used for compact check-in
+ * output where a nested object saves tokens vs. repeating each resource prefix
+ * in a flat array.
+ */
+export function groupPermissionsByResource(
+  permissions: Iterable<Permission | string>,
+): Partial<Record<Resource, Action[]>> {
+  const grouped: Partial<Record<Resource, Action[]>> = {};
+  for (const p of permissions) {
+    if (!isValidPermission(p)) continue;
+    const [resource, action] = p.split(":") as [Resource, Action];
+    (grouped[resource] ??= []).push(action);
+  }
+  // Sort actions in canonical order (read, write, admin) for stable output.
+  for (const resource of RESOURCES) {
+    const actions = grouped[resource];
+    if (actions) actions.sort((a, b) => ACTIONS.indexOf(a) - ACTIONS.indexOf(b));
+  }
+  return grouped;
+}

--- a/src/lib/authz/presets.ts
+++ b/src/lib/authz/presets.ts
@@ -1,0 +1,43 @@
+import type { Permission } from "./types";
+
+export const ROLE_PRESETS = {
+  developer_agent: [
+    "idea:read",
+    "proposal:read",
+    "document:read",
+    "project:read",
+    "task:read",
+    "task:write",
+  ],
+  pm_agent: [
+    "idea:read",
+    "idea:write",
+    "proposal:read",
+    "proposal:write",
+    "document:read",
+    "document:write",
+    "task:read",
+    "task:write",
+    "project:read",
+    "project:write",
+  ],
+  admin_agent: [
+    "idea:read",
+    "idea:write",
+    "idea:admin",
+    "proposal:read",
+    "proposal:write",
+    "proposal:admin",
+    "document:read",
+    "document:write",
+    "document:admin",
+    "task:read",
+    "task:write",
+    "task:admin",
+    "project:read",
+    "project:write",
+    "project:admin",
+  ],
+} as const satisfies Record<string, readonly Permission[]>;
+
+export type PresetKey = keyof typeof ROLE_PRESETS;

--- a/src/lib/authz/types.ts
+++ b/src/lib/authz/types.ts
@@ -1,0 +1,19 @@
+export type Resource = "idea" | "proposal" | "document" | "task" | "project";
+
+export type Action = "read" | "write" | "admin";
+
+export type Permission = `${Resource}:${Action}`;
+
+export const RESOURCES: readonly Resource[] = [
+  "idea",
+  "proposal",
+  "document",
+  "task",
+  "project",
+] as const;
+
+export const ACTIONS: readonly Action[] = ["read", "write", "admin"] as const;
+
+export const ALL_PERMISSIONS: readonly Permission[] = RESOURCES.flatMap(
+  (resource) => ACTIONS.map((action) => `${resource}:${action}` as Permission),
+);

--- a/src/mcp/__tests__/pm-proposal-admin-gate.test.ts
+++ b/src/mcp/__tests__/pm-proposal-admin-gate.test.ts
@@ -1,0 +1,201 @@
+// Regression guard: chorus_pm_{reject,revoke}_proposal use hasPermission(auth,
+// "proposal:admin") as the any-author override, not role-string matching.
+//
+// Covers both branches: own-proposal (author UUID matches) and any-proposal
+// (proposal:admin present), plus the unauthorized case for each tool.
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const mockProposalService = vi.hoisted(() => ({
+  getProposalByUuid: vi.fn(),
+  rejectProposal: vi.fn(),
+  revokeProposal: vi.fn(),
+}));
+
+const mockActivityService = vi.hoisted(() => ({
+  createActivity: vi.fn(),
+}));
+
+const mockPrisma = vi.hoisted(() => ({
+  prisma: { agent: { update: vi.fn() } },
+}));
+
+vi.mock("@/services/proposal.service", () => mockProposalService);
+vi.mock("@/services/activity.service", () => mockActivityService);
+vi.mock("@/lib/prisma", () => mockPrisma);
+
+vi.mock("@/services/project.service", () => ({ projectExists: vi.fn() }));
+vi.mock("@/services/idea.service", () => ({}));
+vi.mock("@/services/document.service", () => ({}));
+vi.mock("@/services/task.service", () => ({}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/agent.service", () => ({ getAgentByUuid: vi.fn() }));
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+const toolHandlers: Record<string, ToolHandler> = {};
+
+const fakeMcpServer = {
+  registerTool: (name: string, _meta: unknown, handler: ToolHandler) => {
+    toolHandlers[name] = handler;
+  },
+};
+
+import type { AgentAuthContext } from "@/types/auth";
+import { registerPmTools } from "@/mcp/tools/pm";
+
+const companyUuid = "company-1";
+const agentUuid = "agent-self";
+const otherAgentUuid = "agent-other";
+const proposalUuid = "proposal-1";
+const projectUuid = "project-1";
+
+function buildAuth(permissions: string[]): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid,
+    actorUuid: agentUuid,
+    ownerUuid: "owner-1",
+    roles: ["pm_agent"],
+    permissions: permissions as AgentAuthContext["permissions"],
+    agentName: "test-agent",
+  };
+}
+
+function registerWith(auth: AgentAuthContext) {
+  for (const k of Object.keys(toolHandlers)) delete toolHandlers[k];
+  // The fake server's registerTool type differs from McpServer's; the handler
+  // captures what we need, so we cast at the call site.
+  registerPmTools(fakeMcpServer as unknown as Parameters<typeof registerPmTools>[0], auth);
+}
+
+function pendingProposalBy(creatorUuid: string) {
+  return {
+    uuid: proposalUuid,
+    projectUuid,
+    createdByUuid: creatorUuid,
+    status: "pending",
+  };
+}
+
+function approvedProposalBy(creatorUuid: string) {
+  return {
+    uuid: proposalUuid,
+    projectUuid,
+    createdByUuid: creatorUuid,
+    status: "approved",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("chorus_pm_reject_proposal — author gate uses proposal:admin, not roles", () => {
+  it("allows the author to reject their own pending proposal (proposal:write only)", async () => {
+    registerWith(buildAuth(["proposal:write"]));
+    mockProposalService.getProposalByUuid.mockResolvedValue(pendingProposalBy(agentUuid));
+    mockProposalService.rejectProposal.mockResolvedValue({
+      uuid: proposalUuid,
+      status: "draft",
+    });
+
+    const res = await toolHandlers["chorus_pm_reject_proposal"]({
+      proposalUuid,
+      reviewNote: "not ready",
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(mockProposalService.rejectProposal).toHaveBeenCalledWith(
+      proposalUuid,
+      agentUuid,
+      "not ready",
+    );
+  });
+
+  it("rejects a non-author without proposal:admin", async () => {
+    registerWith(buildAuth(["proposal:write"]));
+    mockProposalService.getProposalByUuid.mockResolvedValue(pendingProposalBy(otherAgentUuid));
+
+    const res = await toolHandlers["chorus_pm_reject_proposal"]({
+      proposalUuid,
+      reviewNote: "not mine",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/only reject your own/i);
+    expect(mockProposalService.rejectProposal).not.toHaveBeenCalled();
+  });
+
+  it("allows a non-author to reject when proposal:admin is granted", async () => {
+    registerWith(buildAuth(["proposal:write", "proposal:admin"]));
+    mockProposalService.getProposalByUuid.mockResolvedValue(pendingProposalBy(otherAgentUuid));
+    mockProposalService.rejectProposal.mockResolvedValue({
+      uuid: proposalUuid,
+      status: "draft",
+    });
+
+    const res = await toolHandlers["chorus_pm_reject_proposal"]({
+      proposalUuid,
+      reviewNote: "admin override",
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(mockProposalService.rejectProposal).toHaveBeenCalled();
+  });
+});
+
+describe("chorus_pm_revoke_proposal — same admin gate", () => {
+  it("allows the author to revoke their own approved proposal", async () => {
+    registerWith(buildAuth(["proposal:write"]));
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposalBy(agentUuid));
+    mockProposalService.revokeProposal.mockResolvedValue({
+      uuid: proposalUuid,
+      status: "draft",
+      closedTasks: [],
+      deletedDocuments: [],
+    });
+
+    const res = await toolHandlers["chorus_pm_revoke_proposal"]({
+      proposalUuid,
+      reviewNote: "scope changed",
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(mockProposalService.revokeProposal).toHaveBeenCalled();
+  });
+
+  it("rejects a non-author without proposal:admin", async () => {
+    registerWith(buildAuth(["proposal:write"]));
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposalBy(otherAgentUuid));
+
+    const res = await toolHandlers["chorus_pm_revoke_proposal"]({
+      proposalUuid,
+      reviewNote: "not mine",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/only revoke your own/i);
+    expect(mockProposalService.revokeProposal).not.toHaveBeenCalled();
+  });
+
+  it("allows a non-author to revoke when proposal:admin is granted", async () => {
+    registerWith(buildAuth(["proposal:write", "proposal:admin"]));
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposalBy(otherAgentUuid));
+    mockProposalService.revokeProposal.mockResolvedValue({
+      uuid: proposalUuid,
+      status: "draft",
+      closedTasks: [],
+      deletedDocuments: [],
+    });
+
+    const res = await toolHandlers["chorus_pm_revoke_proposal"]({
+      proposalUuid,
+      reviewNote: "admin override",
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(mockProposalService.revokeProposal).toHaveBeenCalled();
+  });
+});

--- a/src/mcp/__tests__/public-tools-proposalUuids.test.ts
+++ b/src/mcp/__tests__/public-tools-proposalUuids.test.ts
@@ -53,6 +53,7 @@ const AUTH: AgentAuthContext = {
   actorUuid: "agent-1",
   ownerUuid: "owner-1",
   roles: ["developer"],
+  permissions: [],
   agentName: "Test Agent",
 };
 

--- a/src/mcp/__tests__/public-tools-task-ops.test.ts
+++ b/src/mcp/__tests__/public-tools-task-ops.test.ts
@@ -79,6 +79,7 @@ const AUTH: AgentAuthContext = {
   actorUuid: "agent-1",
   ownerUuid: "owner-1",
   roles: ["developer"],
+  permissions: [],
   agentName: "Test Agent",
 };
 

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Module mocks (hoisted) =====
+// The tests only care about which tool names get registered; handler behavior is
+// not exercised, so we stub every service as an empty object. Prisma is also
+// stubbed — none of its methods are called during registration.
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+}));
+
+vi.mock("@/services/project.service", () => ({}));
+vi.mock("@/services/task.service", () => ({}));
+vi.mock("@/services/proposal.service", () => ({}));
+vi.mock("@/services/activity.service", () => ({}));
+vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/idea.service", () => ({}));
+vi.mock("@/services/document.service", () => ({}));
+vi.mock("@/services/comment.service", () => ({}));
+vi.mock("@/services/assignment.service", () => ({}));
+vi.mock("@/services/notification.service", () => ({}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/project-group.service", () => ({}));
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/search.service", () => ({}));
+vi.mock("@/services/agent.service", () => ({ getAgentByUuid: vi.fn() }));
+
+import type { AgentAuthContext } from "@/types/auth";
+import type { Permission } from "@/lib/authz/types";
+import { ROLE_PRESETS } from "@/lib/authz/presets";
+import { registerPmTools } from "@/mcp/tools/pm";
+import { registerDeveloperTools } from "@/mcp/tools/developer";
+import { registerAdminTools } from "@/mcp/tools/admin";
+import { TOOL_PERMISSIONS } from "@/mcp/tools/permission-map";
+
+// Minimal McpServer stand-in: records every tool name that gets registered.
+function makeCapturingServer() {
+  const names: string[] = [];
+  const server = {
+    registerTool: (name: string) => {
+      names.push(name);
+    },
+  };
+  return { server, names };
+}
+
+function makeAuth(permissions: Permission[]): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid: "co-1",
+    actorUuid: "agent-1",
+    agentName: "Test Agent",
+    roles: [],
+    permissions,
+  };
+}
+
+// Register all three gated tool modules with the given permissions and return
+// the set of registered tool names (names only, deterministic order doesn't matter).
+function registeredFor(permissions: Permission[]): Set<string> {
+  const { server, names } = makeCapturingServer();
+  const auth = makeAuth(permissions);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerPmTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerDeveloperTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerAdminTools(server as any, auth);
+  return new Set(names);
+}
+
+// 0.6.x tool lists captured from pm.ts / developer.ts / admin.ts before this
+// refactor. Used for strict-equality / superset assertions.
+const OLD_PM_TOOLS = [
+  "chorus_claim_idea",
+  "chorus_release_idea",
+  "chorus_pm_create_proposal",
+  "chorus_pm_validate_proposal",
+  "chorus_pm_submit_proposal",
+  "chorus_pm_create_document",
+  "chorus_pm_create_tasks",
+  "chorus_pm_update_document",
+  "chorus_pm_add_document_draft",
+  "chorus_pm_add_task_draft",
+  "chorus_pm_update_document_draft",
+  "chorus_pm_update_task_draft",
+  "chorus_pm_remove_document_draft",
+  "chorus_pm_remove_task_draft",
+  "chorus_add_task_dependency",
+  "chorus_remove_task_dependency",
+  "chorus_pm_assign_task",
+  "chorus_pm_start_elaboration",
+  "chorus_pm_validate_elaboration",
+  "chorus_pm_skip_elaboration",
+  "chorus_move_idea",
+  "chorus_pm_reject_proposal",
+  "chorus_pm_revoke_proposal",
+  "chorus_pm_create_idea",
+];
+
+const OLD_DEVELOPER_TOOLS = [
+  "chorus_claim_task",
+  "chorus_release_task",
+  "chorus_submit_for_verify",
+  "chorus_report_criteria_self_check",
+  "chorus_report_work",
+];
+
+const OLD_ADMIN_TOOLS = [
+  "chorus_admin_create_project",
+  "chorus_admin_approve_proposal",
+  "chorus_admin_close_proposal",
+  "chorus_admin_verify_task",
+  "chorus_admin_reopen_task",
+  "chorus_mark_acceptance_criteria",
+  "chorus_admin_close_task",
+  "chorus_admin_delete_idea",
+  "chorus_admin_delete_task",
+  "chorus_admin_delete_document",
+  "chorus_admin_create_project_group",
+  "chorus_admin_update_project_group",
+  "chorus_admin_delete_project_group",
+  "chorus_admin_move_project_to_group",
+];
+
+describe("MCP tool permission wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("permission-map coverage (AC2)", () => {
+    it("maps every gated tool that pm/developer/admin register", () => {
+      // Gather the full set of tools registered when the agent holds every permission.
+      const allPerms: Permission[] = [...ROLE_PRESETS.admin_agent];
+      const registered = registeredFor(allPerms);
+      const mapped = new Set(Object.keys(TOOL_PERMISSIONS));
+      expect(registered).toEqual(mapped);
+    });
+  });
+
+  describe("backward-compat: developer_agent preset (AC4)", () => {
+    it("developer_agent with empty custom permissions sees exactly the 0.6.x developer tool set", () => {
+      const registered = registeredFor([...ROLE_PRESETS.developer_agent]);
+      expect(registered).toEqual(new Set(OLD_DEVELOPER_TOOLS));
+    });
+  });
+
+  describe("backward-compat+: pm_agent preset (AC5)", () => {
+    it("pm_agent is a strict superset of the 0.6.x pm tool set (no previously-visible tool is removed)", () => {
+      const registered = registeredFor([...ROLE_PRESETS.pm_agent]);
+      for (const old of OLD_PM_TOOLS) {
+        expect(registered.has(old)).toBe(true);
+      }
+    });
+
+    it("pm_agent gains the 5 project:write tools introduced in 0.7.0", () => {
+      const registered = registeredFor([...ROLE_PRESETS.pm_agent]);
+      for (const newTool of [
+        "chorus_admin_create_project",
+        "chorus_admin_create_project_group",
+        "chorus_admin_update_project_group",
+        "chorus_admin_delete_project_group",
+        "chorus_admin_move_project_to_group",
+      ]) {
+        expect(registered.has(newTool)).toBe(true);
+      }
+    });
+
+    it("pm_agent does not see any admin-only tool (proposal:admin / task:admin / *:admin)", () => {
+      const registered = registeredFor([...ROLE_PRESETS.pm_agent]);
+      for (const adminOnly of [
+        "chorus_admin_approve_proposal",
+        "chorus_admin_close_proposal",
+        "chorus_admin_verify_task",
+        "chorus_admin_reopen_task",
+        "chorus_admin_close_task",
+        "chorus_mark_acceptance_criteria",
+        "chorus_admin_delete_task",
+        "chorus_admin_delete_idea",
+        "chorus_admin_delete_document",
+      ]) {
+        expect(registered.has(adminOnly)).toBe(false);
+      }
+    });
+  });
+
+  describe("backward-compat: admin_agent preset (AC6)", () => {
+    it("admin_agent sees exactly the union of 0.6.x admin + pm + developer tool sets", () => {
+      const registered = registeredFor([...ROLE_PRESETS.admin_agent]);
+      const expected = new Set([
+        ...OLD_ADMIN_TOOLS,
+        ...OLD_PM_TOOLS,
+        ...OLD_DEVELOPER_TOOLS,
+      ]);
+      expect(registered).toEqual(expected);
+    });
+  });
+
+  describe("fine-grained custom permissions (AC7)", () => {
+    it("a permissions:['task:read'] agent sees no gated tool (read-only tools live in public.ts)", () => {
+      const registered = registeredFor(["task:read"]);
+      expect(registered.size).toBe(0);
+    });
+
+    it("adding task:write exposes exactly the 5 developer.ts tools", () => {
+      const registered = registeredFor(["task:read", "task:write"]);
+      expect(registered).toEqual(new Set(OLD_DEVELOPER_TOOLS));
+    });
+  });
+
+  describe("permission-map semantic assertions (AC8)", () => {
+    it("admin proposal tools require proposal:admin", () => {
+      expect(TOOL_PERMISSIONS.chorus_admin_approve_proposal).toBe("proposal:admin");
+      expect(TOOL_PERMISSIONS.chorus_admin_close_proposal).toBe("proposal:admin");
+    });
+
+    it("admin task state tools require task:admin", () => {
+      expect(TOOL_PERMISSIONS.chorus_admin_verify_task).toBe("task:admin");
+      expect(TOOL_PERMISSIONS.chorus_admin_reopen_task).toBe("task:admin");
+      expect(TOOL_PERMISSIONS.chorus_admin_close_task).toBe("task:admin");
+    });
+
+    it("proposal create and all draft tools require proposal:write", () => {
+      expect(TOOL_PERMISSIONS.chorus_pm_create_proposal).toBe("proposal:write");
+      expect(TOOL_PERMISSIONS.chorus_pm_add_document_draft).toBe("proposal:write");
+      expect(TOOL_PERMISSIONS.chorus_pm_add_task_draft).toBe("proposal:write");
+      expect(TOOL_PERMISSIONS.chorus_pm_update_document_draft).toBe("proposal:write");
+      expect(TOOL_PERMISSIONS.chorus_pm_update_task_draft).toBe("proposal:write");
+      expect(TOOL_PERMISSIONS.chorus_pm_remove_document_draft).toBe("proposal:write");
+      expect(TOOL_PERMISSIONS.chorus_pm_remove_task_draft).toBe("proposal:write");
+    });
+
+    it("admin_create_project and ProjectGroup mutations require project:write", () => {
+      expect(TOOL_PERMISSIONS.chorus_admin_create_project).toBe("project:write");
+      expect(TOOL_PERMISSIONS.chorus_admin_create_project_group).toBe("project:write");
+      expect(TOOL_PERMISSIONS.chorus_admin_update_project_group).toBe("project:write");
+      expect(TOOL_PERMISSIONS.chorus_admin_delete_project_group).toBe("project:write");
+      expect(TOOL_PERMISSIONS.chorus_admin_move_project_to_group).toBe("project:write");
+    });
+  });
+});

--- a/src/mcp/__tests__/tool-logger.test.ts
+++ b/src/mcp/__tests__/tool-logger.test.ts
@@ -44,6 +44,7 @@ const mockAuth: AgentAuthContext = {
   actorUuid: "agent-1",
   agentName: "Test Agent",
   roles: ["developer_agent"],
+  permissions: [],
 };
 
 describe("tool-logger", () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,29 +24,15 @@ export function createMcpServer(auth: AgentAuthContext): McpServer {
   // Enable presence event emission for all tools (must be called before registerTool calls)
   enablePresence(server, auth);
 
-  // Register public tools (available to all Agents)
+  // Public tools — available to every authenticated agent (no permission gating)
   registerPublicTools(server, auth);
-
-  // Register Session tools (available to all Agents)
   registerSessionTools(server, auth);
 
-  // Register role-specific tools based on agent roles
-  const roles = auth.roles || [];
-
-  // Support two role formats: "pm" / "pm_agent", "developer" / "developer_agent", "admin" / "admin_agent"
-  const hasPmRole = roles.some(r => r === "pm" || r === "pm_agent");
-  const hasDevRole = roles.some(r => r === "developer" || r === "developer_agent");
-  const hasAdminRole = roles.some(r => r === "admin" || r === "admin_agent");
-
-  if (hasAdminRole) {
-    registerAdminTools(server, auth);
-  }
-  if (hasPmRole || hasAdminRole) {
-    registerPmTools(server, auth);
-  }
-  if (hasDevRole || hasAdminRole) {
-    registerDeveloperTools(server, auth);
-  }
+  // Permission-gated tools. Each register function calls registerPermissionedTool
+  // per tool, which checks auth.permissions.includes(required) before registering.
+  registerPmTools(server, auth);
+  registerDeveloperTools(server, auth);
+  registerAdminTools(server, auth);
 
   return server;
 }

--- a/src/mcp/tools/admin.ts
+++ b/src/mcp/tools/admin.ts
@@ -14,10 +14,14 @@ import * as documentService from "@/services/document.service";
 import * as activityService from "@/services/activity.service";
 import * as projectGroupService from "@/services/project-group.service";
 import { zArray } from "./schema-utils";
+import { registerPermissionedTool } from "./register-helpers";
 
 export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_admin_create_project - Create a new project
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "project:write",
     "chorus_admin_create_project",
     {
       description: "Create a new project (Admin exclusive, acts on behalf of humans). To assign to a project group, first call chorus_get_project_groups to list available groups, then pass the groupUuid.",
@@ -44,7 +48,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_admin_create_idea moved to pm.ts as chorus_pm_create_idea
 
   // chorus_admin_approve_proposal - Approve a Proposal
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:admin",
     "chorus_admin_approve_proposal",
     {
       description: "Approve a Proposal (Admin exclusive, acts on behalf of humans). On approval, documentDrafts and taskDrafts in the Proposal are automatically materialized into real Document and Task entities -- no need to manually call create_document/create_tasks.",
@@ -92,7 +99,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_close_proposal - Close a Proposal (terminal state)
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:admin",
     "chorus_admin_close_proposal",
     {
       description: "Close a Proposal (Admin exclusive, permanently closes the proposal). After closing, the Proposal enters the closed terminal state and cannot be edited.",
@@ -135,7 +145,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_verify_task - Verify a Task (to_verify -> done)
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:admin",
     "chorus_admin_verify_task",
     {
       description: "Verify a Task (to_verify -> done, Admin exclusive, acts on behalf of humans)",
@@ -178,7 +191,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_reopen_task - Reopen a Task (to_verify -> in_progress)
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:admin",
     "chorus_admin_reopen_task",
     {
       description: "Reopen a Task (to_verify -> in_progress, used when verification fails). If the task has unresolved dependencies, use force=true to bypass the dependency check.",
@@ -248,7 +264,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_mark_acceptance_criteria - Mark acceptance criteria as passed or failed
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:admin",
     "chorus_mark_acceptance_criteria",
     {
       description: "Mark acceptance criteria as passed or failed (admin verification)",
@@ -273,7 +292,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_close_task - Close a Task (any -> closed)
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:admin",
     "chorus_admin_close_task",
     {
       description: "Close a Task (any status -> closed, Admin exclusive)",
@@ -310,7 +332,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_delete_idea - Delete an Idea
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:admin",
     "chorus_admin_delete_idea",
     {
       description: "Delete an Idea (Admin exclusive, can delete any Idea)",
@@ -333,7 +358,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_delete_task - Delete a Task
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:admin",
     "chorus_admin_delete_task",
     {
       description: "Delete a Task (Admin exclusive, can delete any Task)",
@@ -356,7 +384,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_delete_document - Delete a Document
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "document:admin",
     "chorus_admin_delete_document",
     {
       description: "Delete a Document (Admin exclusive, can delete any Document)",
@@ -381,7 +412,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   // ===== Project Group Admin Tools =====
 
   // chorus_admin_create_project_group - Create a new project group
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "project:write",
     "chorus_admin_create_project_group",
     {
       description: "Create a new project group (Admin exclusive)",
@@ -404,7 +438,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_update_project_group - Update a project group
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "project:write",
     "chorus_admin_update_project_group",
     {
       description: "Update a project group (Admin exclusive)",
@@ -433,7 +470,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_delete_project_group - Delete a project group
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "project:write",
     "chorus_admin_delete_project_group",
     {
       description: "Delete a project group (Admin exclusive). Projects in the group become ungrouped.",
@@ -455,7 +495,10 @@ export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_admin_move_project_to_group - Move a project to a group or ungroup it
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "project:write",
     "chorus_admin_move_project_to_group",
     {
       description: "Move a project to a different group or ungroup it (Admin exclusive). Set groupUuid to null to ungroup.",

--- a/src/mcp/tools/developer.ts
+++ b/src/mcp/tools/developer.ts
@@ -11,10 +11,14 @@ import * as commentService from "@/services/comment.service";
 import * as sessionService from "@/services/session.service";
 import { AlreadyClaimedError, NotClaimedError } from "@/lib/errors";
 import { zArray } from "./schema-utils";
+import { registerPermissionedTool } from "./register-helpers";
 
 export function registerDeveloperTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_claim_task - Claim a Task
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:write",
     "chorus_claim_task",
     {
       description: "Claim a Task (open -> assigned)",
@@ -101,7 +105,10 @@ export function registerDeveloperTools(server: McpServer, auth: AgentAuthContext
   );
 
   // chorus_release_task - Release a claimed Task
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:write",
     "chorus_release_task",
     {
       description: "Release a claimed Task (assigned -> open)",
@@ -152,7 +159,10 @@ export function registerDeveloperTools(server: McpServer, auth: AgentAuthContext
   // chorus_update_task — migrated to public.ts (available to all roles, enhanced with field editing)
 
   // chorus_submit_for_verify - Submit task for human verification
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:write",
     "chorus_submit_for_verify",
     {
       description: "Submit task for human verification (in_progress -> to_verify)",
@@ -201,7 +211,10 @@ export function registerDeveloperTools(server: McpServer, auth: AgentAuthContext
   );
 
   // chorus_report_criteria_self_check - Report self-check results on acceptance criteria
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:write",
     "chorus_report_criteria_self_check",
     {
       description: "Report self-check results on acceptance criteria for a task you're working on",
@@ -234,7 +247,10 @@ export function registerDeveloperTools(server: McpServer, auth: AgentAuthContext
   );
 
   // chorus_report_work - Report work progress or completion
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "task:write",
     "chorus_report_work",
     {
       description: "Report work progress or completion",

--- a/src/mcp/tools/permission-map.ts
+++ b/src/mcp/tools/permission-map.ts
@@ -1,0 +1,75 @@
+// src/mcp/tools/permission-map.ts
+// Central mapping of MCP tools to their required Permission.
+// Covers every permission-gated tool (pm.ts, developer.ts, admin.ts).
+// Public tools (public.ts) and session tools (session.ts) are NOT gated
+// and therefore intentionally absent from this map. See Tech Design §5.3.
+
+import type { Permission } from "@/lib/authz/types";
+
+export const TOOL_PERMISSIONS = {
+  // ===== pm.ts =====
+  // Idea mutations
+  chorus_claim_idea: "idea:write",
+  chorus_release_idea: "idea:write",
+  chorus_move_idea: "idea:write",
+  chorus_pm_create_idea: "idea:write",
+  // Elaboration (idea:write per §5.3)
+  chorus_pm_start_elaboration: "idea:write",
+  chorus_pm_validate_elaboration: "idea:write",
+  chorus_pm_skip_elaboration: "idea:write",
+  // Proposal writes
+  chorus_pm_create_proposal: "proposal:write",
+  chorus_pm_validate_proposal: "proposal:write",
+  chorus_pm_submit_proposal: "proposal:write",
+  chorus_pm_add_document_draft: "proposal:write",
+  chorus_pm_add_task_draft: "proposal:write",
+  chorus_pm_update_document_draft: "proposal:write",
+  chorus_pm_update_task_draft: "proposal:write",
+  chorus_pm_remove_document_draft: "proposal:write",
+  chorus_pm_remove_task_draft: "proposal:write",
+  chorus_pm_reject_proposal: "proposal:write",
+  chorus_pm_revoke_proposal: "proposal:write",
+  // Document writes
+  chorus_pm_create_document: "document:write",
+  chorus_pm_update_document: "document:write",
+  // Task-editing tools historically on the PM surface.
+  // Mapped to proposal:write to preserve 0.6.x dev boundaries (AC4): dev has
+  // task:write but not proposal:write, so dev keeps exactly its 0.6.x tool set.
+  chorus_pm_create_tasks: "proposal:write",
+  chorus_add_task_dependency: "proposal:write",
+  chorus_remove_task_dependency: "proposal:write",
+  chorus_pm_assign_task: "proposal:write",
+
+  // ===== developer.ts =====
+  chorus_claim_task: "task:write",
+  chorus_release_task: "task:write",
+  chorus_submit_for_verify: "task:write",
+  chorus_report_criteria_self_check: "task:write",
+  chorus_report_work: "task:write",
+
+  // ===== admin.ts =====
+  // Project write (includes Project and ProjectGroup mutations per §2.3)
+  chorus_admin_create_project: "project:write",
+  chorus_admin_create_project_group: "project:write",
+  chorus_admin_update_project_group: "project:write",
+  chorus_admin_delete_project_group: "project:write",
+  chorus_admin_move_project_to_group: "project:write",
+  // Proposal admin (approve + admin-only close)
+  chorus_admin_approve_proposal: "proposal:admin",
+  chorus_admin_close_proposal: "proposal:admin",
+  // Task admin (verify, reopen, close)
+  chorus_admin_verify_task: "task:admin",
+  chorus_admin_reopen_task: "task:admin",
+  chorus_admin_close_task: "task:admin",
+  // Admin-only task tools in 0.6.x (mark_acceptance_criteria, admin_delete_task).
+  // Mapped to task:admin so backward-compat AC4 (dev) holds — dev does not have task:admin.
+  chorus_mark_acceptance_criteria: "task:admin",
+  chorus_admin_delete_task: "task:admin",
+  // Admin-only destructive tools in 0.6.x. Mapped to the *:admin permission so pm
+  // doesn't inherit them via idea:write / document:write — keeps admin-only surface
+  // for these delete operations.
+  chorus_admin_delete_idea: "idea:admin",
+  chorus_admin_delete_document: "document:admin",
+} as const satisfies Record<string, Permission>;
+
+export type ManagedToolName = keyof typeof TOOL_PERMISSIONS;

--- a/src/mcp/tools/permission-map.ts
+++ b/src/mcp/tools/permission-map.ts
@@ -1,8 +1,17 @@
 // src/mcp/tools/permission-map.ts
-// Central mapping of MCP tools to their required Permission.
-// Covers every permission-gated tool (pm.ts, developer.ts, admin.ts).
-// Public tools (public.ts) and session tools (session.ts) are NOT gated
-// and therefore intentionally absent from this map. See Tech Design §5.3.
+//
+// Coverage contract for permission-gated MCP tools.
+//
+// This map is the *source of truth for tests* (src/mcp/__tests__/server.test.ts):
+// it lets the suite assert that every tool in pm.ts / developer.ts / admin.ts
+// is registered under the expected Permission, and catches drift when someone
+// adds a new tool without a gate. Production tool registration in pm.ts /
+// developer.ts / admin.ts uses `registerPermissionedTool` with its Permission
+// inlined at the call site — the map is intentionally not consulted at runtime
+// so the permission for each tool stays visible next to the handler.
+//
+// Public tools (public.ts) and session tools (session.ts) are NOT gated and
+// are intentionally absent from this map. See Tech Design §5.3.
 
 import type { Permission } from "@/lib/authz/types";
 

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -16,10 +16,14 @@ import * as elaborationService from "@/services/elaboration.service";
 import { getAgentByUuid } from "@/services/agent.service";
 import { AlreadyClaimedError, NotClaimedError } from "@/lib/errors";
 import { zArray } from "./schema-utils";
+import { registerPermissionedTool } from "./register-helpers";
 
 export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_claim_idea - Claim an Idea
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:write",
     "chorus_claim_idea",
     {
       description: "Claim an Idea (open -> elaborating). Claiming automatically transitions the Idea to 'elaborating' status. After claiming, start elaboration with chorus_pm_start_elaboration or skip with chorus_pm_skip_elaboration.",
@@ -65,7 +69,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_release_idea - Release a claimed Idea
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:write",
     "chorus_release_idea",
     {
       description: "Release a claimed Idea (assigned -> open)",
@@ -114,7 +121,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_create_proposal - Create a Proposal (container model)
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_create_proposal",
     {
       description: "Create an empty Proposal container. Use chorus_pm_add_document_draft and chorus_pm_add_task_draft to populate it afterwards.",
@@ -176,7 +186,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_validate_proposal - Validate Proposal completeness
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_validate_proposal",
     {
       description: "Validate a Proposal's completeness before submission. Returns errors (block submission), warnings (advisory), and info (hints). Call this before chorus_pm_submit_proposal to preview issues.",
@@ -203,7 +216,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_submit_proposal - Submit Proposal for approval
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_submit_proposal",
     {
       description: "Submit a Proposal for approval (draft -> pending). Requires all input Ideas to have elaborationStatus = 'resolved'. Call chorus_pm_start_elaboration or chorus_pm_skip_elaboration first to resolve elaboration before submitting.",
@@ -230,7 +246,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_create_document - Create a document
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "document:write",
     "chorus_pm_create_document",
     {
       description: "Create a document (PRD, tech design, ADR, etc.)",
@@ -274,7 +293,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
 
   // chorus_pm_create_tasks - Deprecated alias for chorus_create_tasks (now in public.ts)
   // Kept for backward compatibility with existing agents that reference the old name.
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_create_tasks",
     {
       description: "[Deprecated — use chorus_create_tasks instead] Batch create tasks (can associate with a Proposal, supports intra-batch dependencies)",
@@ -397,7 +419,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_update_document - Update document content
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "document:write",
     "chorus_pm_update_document",
     {
       description: "Update document content (increments version number)",
@@ -428,7 +453,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   // ===== Proposal Draft Management Tools =====
 
   // chorus_pm_add_document_draft - Add document draft to Proposal
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_add_document_draft",
     {
       description: "Add a document draft to a pending Proposal container",
@@ -461,7 +489,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_add_task_draft - Add task draft to Proposal
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_add_task_draft",
     {
       description: "Add a task draft to a pending Proposal container",
@@ -500,7 +531,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_update_document_draft - Update document draft
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_update_document_draft",
     {
       description: "Update a document draft in a Proposal",
@@ -538,7 +572,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_update_task_draft - Update task draft
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_update_task_draft",
     {
       description: "Update a task draft in a Proposal",
@@ -585,7 +622,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_remove_document_draft - Remove document draft
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_remove_document_draft",
     {
       description: "Remove a document draft from a Proposal",
@@ -614,7 +654,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_remove_task_draft - Remove task draft
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_remove_task_draft",
     {
       description: "Remove a task draft from a Proposal",
@@ -643,7 +686,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_add_task_dependency - Add task dependency
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_add_task_dependency",
     {
       description: "Add a task dependency (taskUuid depends on dependsOnTaskUuid). Includes same-project validation, self-dependency check, and cycle detection.",
@@ -668,7 +714,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_remove_task_dependency - Remove task dependency
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_remove_task_dependency",
     {
       description: "Remove a task dependency",
@@ -693,7 +742,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_assign_task - Assign task to a Developer Agent
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_assign_task",
     {
       description: "Assign a task to a specified Developer Agent (task must be in open or assigned status)",
@@ -815,7 +867,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   // ===== Elaboration Tools =====
 
   // chorus_pm_start_elaboration - Start elaboration for an Idea
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:write",
     "chorus_pm_start_elaboration",
     {
       description: "Start an elaboration round for an Idea. Creates structured questions for the Idea creator/stakeholder to answer, clarifying requirements before proposal creation. Recommended for every Idea. Structured elaboration improves Proposal quality and reduces rejection cycles. IMPORTANT: After this tool returns pending_answers, you MUST use an interactive prompt tool (e.g., AskUserQuestion in Claude Code) to present the questions to the user — do NOT display questions as plain text. Collect answers interactively, then call chorus_answer_elaboration. IMPORTANT: Even if the user discusses requirements with you outside of elaboration (e.g., in chat), you should still record key decisions and clarifications as elaboration rounds so they are persisted to the Idea as an audit trail. Do NOT include an 'Other' option — the UI automatically adds a free-text 'Other' option to every question.",
@@ -859,7 +914,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_validate_elaboration - Validate answers from an elaboration round
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:write",
     "chorus_pm_validate_elaboration",
     {
       description: "Validate answers from an elaboration round. If no issues are found, the elaboration is marked as resolved. If issues exist, optionally provide follow-up questions for a new round. IMPORTANT: Before resolving (empty issues), always confirm with the user that they have no remaining concerns or topics to discuss.",
@@ -909,7 +967,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_skip_elaboration - Skip elaboration for an Idea
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:write",
     "chorus_pm_skip_elaboration",
     {
       description: "Skip elaboration for an Idea (marks as resolved with minimal depth). Use only for trivially clear Ideas (e.g., bug fixes with clear reproduction steps). A reason is required and logged in the activity stream. IMPORTANT: You MUST ask the user for permission before skipping — never skip on your own judgment alone. Prefer chorus_pm_start_elaboration for most Ideas.",
@@ -941,7 +1002,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_move_idea - Move an Idea to a different project
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:write",
     "chorus_move_idea",
     {
       description: "Move an Idea to a different project within the same company. Also moves linked draft/pending Proposals.",
@@ -975,7 +1039,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   const hasAdminRole = auth.roles.some(r => r === "admin" || r === "admin_agent");
 
   // chorus_pm_reject_proposal - Reject a pending proposal (pending -> draft)
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_reject_proposal",
     {
       description: "Reject a Proposal (pending -> draft). PM agents can only reject their own proposals; admin agents can reject any proposal. After rejection, the Proposal returns to draft status for revision.",
@@ -1022,7 +1089,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_revoke_proposal - Revoke an approved proposal (approved -> draft)
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "proposal:write",
     "chorus_pm_revoke_proposal",
     {
       description: "Revoke an approved Proposal (approved -> draft). PM agents can only revoke their own proposals; admin agents can revoke any proposal. Cascade-closes all materialized Tasks and deletes all materialized Documents.",
@@ -1079,7 +1149,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   );
 
   // chorus_pm_create_idea - Create an Idea
-  server.registerTool(
+  registerPermissionedTool(
+    server,
+    auth,
+    "idea:write",
     "chorus_pm_create_idea",
     {
       description: "Create an Idea (submits requirements on behalf of humans)",

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -17,6 +17,7 @@ import { getAgentByUuid } from "@/services/agent.service";
 import { AlreadyClaimedError, NotClaimedError } from "@/lib/errors";
 import { zArray } from "./schema-utils";
 import { registerPermissionedTool } from "./register-helpers";
+import { hasPermission } from "@/lib/auth";
 
 export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_claim_idea - Claim an Idea
@@ -1036,7 +1037,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     }
   );
 
-  const hasAdminRole = auth.roles.some(r => r === "admin" || r === "admin_agent");
+  // Proposal admin can reject/revoke any proposal; otherwise PM agents can only
+  // touch their own. `proposal:admin` aligns with chorus_admin_approve_proposal
+  // and avoids conflating bypass-power with the `admin_agent` preset.
+  const canAdminAnyProposal = hasPermission(auth, "proposal:admin");
 
   // chorus_pm_reject_proposal - Reject a pending proposal (pending -> draft)
   registerPermissionedTool(
@@ -1057,7 +1061,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         return { content: [{ type: "text", text: "Proposal not found" }], isError: true };
       }
 
-      if (!hasAdminRole && proposal.createdByUuid !== auth.actorUuid) {
+      if (!canAdminAnyProposal && proposal.createdByUuid !== auth.actorUuid) {
         return { content: [{ type: "text", text: "You can only reject your own proposals" }], isError: true };
       }
 
@@ -1107,7 +1111,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         return { content: [{ type: "text", text: "Proposal not found" }], isError: true };
       }
 
-      if (!hasAdminRole && proposal.createdByUuid !== auth.actorUuid) {
+      if (!canAdminAnyProposal && proposal.createdByUuid !== auth.actorUuid) {
         return { content: [{ type: "text", text: "You can only revoke your own proposals" }], isError: true };
       }
 

--- a/src/mcp/tools/register-helpers.ts
+++ b/src/mcp/tools/register-helpers.ts
@@ -1,0 +1,39 @@
+// src/mcp/tools/register-helpers.ts
+// MCP tool registration helpers with permission gating (Tech Design §5.2)
+
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import type { AnySchema, ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type { AgentAuthContext } from "@/types/auth";
+import type { Permission } from "@/lib/authz/types";
+
+type ToolInputSchema = ZodRawShapeCompat | AnySchema | undefined;
+
+interface PermissionedToolConfig<OutputArgs extends ZodRawShapeCompat | AnySchema, InputArgs extends ToolInputSchema> {
+  title?: string;
+  description?: string;
+  inputSchema?: InputArgs;
+  outputSchema?: OutputArgs;
+  annotations?: ToolAnnotations;
+  _meta?: Record<string, unknown>;
+}
+
+/**
+ * Register an MCP tool only when the auth context holds the required Permission.
+ * When the permission is missing, the tool is simply not registered and remains
+ * invisible to the client. See Tech Design §5.2.
+ */
+export function registerPermissionedTool<
+  OutputArgs extends ZodRawShapeCompat | AnySchema,
+  InputArgs extends ToolInputSchema = undefined,
+>(
+  server: McpServer,
+  auth: AgentAuthContext,
+  required: Permission,
+  name: string,
+  config: PermissionedToolConfig<OutputArgs, InputArgs>,
+  handler: ToolCallback<InputArgs>,
+): void {
+  if (!auth.permissions.includes(required)) return;
+  server.registerTool(name, config, handler);
+}

--- a/src/services/__tests__/checkin.service.test.ts
+++ b/src/services/__tests__/checkin.service.test.ts
@@ -59,6 +59,7 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     uuid: AGENT_UUID,
     name: "Dev Agent",
     roles: ["developer"],
+    permissions: [],
     persona: null,
     systemPrompt: null,
     ownerUuid: OWNER_UUID,
@@ -109,7 +110,14 @@ describe("buildCheckinResponse — agent info", () => {
 
     expect(result.agent.uuid).toBe(AGENT_UUID);
     expect(result.agent.name).toBe("Dev Agent");
-    expect(result.agent.roles).toEqual(["developer"]);
+    // developer preset → idea/proposal/document/project read, task read+write
+    expect(result.agent.permissions).toEqual({
+      idea: ["read"],
+      proposal: ["read"],
+      document: ["read"],
+      task: ["read", "write"],
+      project: ["read"],
+    });
     expect(result.agent.owner).toEqual({
       uuid: OWNER_UUID,
       name: "Owner User",
@@ -526,7 +534,13 @@ describe("buildCheckinResponse — empty state", () => {
       agent: {
         uuid: AGENT_UUID,
         name: "Dev Agent",
-        roles: ["developer"],
+        permissions: {
+          idea: ["read"],
+          proposal: ["read"],
+          document: ["read"],
+          task: ["read", "write"],
+          project: ["read"],
+        },
         persona: null,
         systemPrompt: null,
         owner: { uuid: OWNER_UUID, name: "Owner User", email: "owner@example.com" },

--- a/src/services/agent.service.ts
+++ b/src/services/agent.service.ts
@@ -18,6 +18,7 @@ export interface AgentCreateParams {
   ownerUuid: string;
   persona?: string | null;
   systemPrompt?: string | null;
+  permissions?: string[];
 }
 
 export interface AgentUpdateParams {
@@ -25,6 +26,7 @@ export interface AgentUpdateParams {
   roles?: string[];
   persona?: string | null;
   systemPrompt?: string | null;
+  permissions?: string[];
 }
 
 export interface ApiKeyCreateParams {
@@ -46,6 +48,7 @@ export async function listAgents({ companyUuid, skip, take }: AgentListParams) {
         uuid: true,
         name: true,
         roles: true,
+        permissions: true,
         persona: true,
         ownerUuid: true,
         lastActiveAt: true,
@@ -83,7 +86,7 @@ export async function getAgent(companyUuid: string, uuid: string) {
 export async function getAgentByUuid(companyUuid: string, uuid: string) {
   return prisma.agent.findFirst({
     where: { uuid, companyUuid },
-    select: { uuid: true, name: true, roles: true },
+    select: { uuid: true, name: true, roles: true, permissions: true },
   });
 }
 
@@ -95,13 +98,23 @@ export async function createAgent({
   ownerUuid,
   persona,
   systemPrompt,
+  permissions,
 }: AgentCreateParams) {
   return prisma.agent.create({
-    data: { companyUuid, name, roles, ownerUuid, persona, systemPrompt },
+    data: {
+      companyUuid,
+      name,
+      roles,
+      ownerUuid,
+      persona,
+      systemPrompt,
+      ...(permissions !== undefined && { permissions }),
+    },
     select: {
       uuid: true,
       name: true,
       roles: true,
+      permissions: true,
       persona: true,
       systemPrompt: true,
       ownerUuid: true,
@@ -130,6 +143,7 @@ export async function updateAgent(uuid: string, data: AgentUpdateParams, company
       uuid: true,
       name: true,
       roles: true,
+      permissions: true,
       persona: true,
       systemPrompt: true,
       ownerUuid: true,
@@ -167,7 +181,7 @@ export async function listApiKeys(companyUuid: string, skip: number, take: numbe
       take,
       orderBy: { createdAt: "desc" },
       include: {
-        agent: { select: { uuid: true, name: true, roles: true, persona: true } },
+        agent: { select: { uuid: true, name: true, roles: true, permissions: true, persona: true } },
       },
     }),
     prisma.apiKey.count({ where }),

--- a/src/services/checkin.service.ts
+++ b/src/services/checkin.service.ts
@@ -7,13 +7,22 @@ import type { AuthContext } from "@/types/auth";
 import { computeDerivedStatus } from "@/services/idea.service";
 import type { DerivedIdeaStatus } from "@/services/idea.service";
 import * as notificationService from "@/services/notification.service";
+import {
+  computeEffectivePermissions,
+  groupPermissionsByResource,
+} from "@/lib/authz/permissions";
+import type { Action, Resource } from "@/lib/authz/types";
 
 // ===== Response shape =====
 
 export interface CheckinAgentInfo {
   uuid: string;
   name: string;
-  roles: string[];
+  /**
+   * Effective permissions grouped by resource. Resources with no granted
+   * actions are omitted. Example: `{ idea: ["read","write","admin"], task: ["read","write"] }`.
+   */
+  permissions: Partial<Record<Resource, Action[]>>;
   persona: string | null;
   systemPrompt: string | null;
   owner: { uuid: string; name: string | null; email: string | null } | null;
@@ -70,12 +79,19 @@ export async function buildCheckinResponse(auth: AuthContext): Promise<CheckinRe
       uuid: true,
       name: true,
       roles: true,
+      permissions: true,
       persona: true,
       systemPrompt: true,
       ownerUuid: true,
       owner: { select: { uuid: true, name: true, email: true } },
     },
   });
+
+  const effective = computeEffectivePermissions(
+    agent.roles,
+    agent.permissions,
+  );
+  const groupedPermissions = groupPermissionsByResource(effective);
 
   // Build idea tracker and fetch notification summary in parallel
   const [ideaTracker, notifications] = await Promise.all([
@@ -96,7 +112,7 @@ export async function buildCheckinResponse(auth: AuthContext): Promise<CheckinRe
     agent: {
       uuid: agent.uuid,
       name: agent.name,
-      roles: agent.roles,
+      permissions: groupedPermissions,
       persona: agent.persona,
       systemPrompt: agent.systemPrompt,
       owner: agent.owner

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -2,6 +2,8 @@
 // Authentication related type definitions (ARCHITECTURE.md §6)
 // UUID-Based Architecture: All IDs are UUIDs
 
+import type { Permission } from "@/lib/authz/types";
+
 export type ActorType = "user" | "agent" | "super_admin";
 export type AgentRole = "pm" | "developer" | "admin" | "pm_agent" | "developer_agent" | "admin_agent";
 
@@ -25,6 +27,9 @@ export interface UserAuthContext extends AuthContext {
 export interface AgentAuthContext extends AuthContext {
   type: "agent";
   roles: AgentRole[];
+  // Effective permissions = expandRoles(roles) ∪ custom permissions.
+  // Plain string array (not Set) so the context survives JSON serialization across hook / RSC boundaries.
+  permissions: Permission[];
   ownerUuid?: string;
   agentName: string;
   projectUuids?: string[]; // Default projects from X-Chorus-Project/X-Chorus-Project-Group headers (optional)
@@ -44,6 +49,7 @@ export interface ApiKeyValidationResult {
     companyUuid: string;
     name: string;
     roles: string[];
+    permissions: string[];
     ownerUuid: string | null;
   };
   apiKey?: {


### PR DESCRIPTION
## Summary

Replaces the fixed 3-role agent model (admin/pm/developer) with a fine-grained permission matrix: **5 resources × 3 actions = 15 bits**. The UI surfaces this as 3 role presets plus a **Custom** option; both onboarding and settings now share a single form component, and Create/Edit use the same inner fields.

The goal is flexibility: agents can be scoped as narrowly or broadly as the deploying user needs (e.g. a PM agent that can also verify its own tasks, or a read-only auditor agent).

## Highlights

- **authz library** (`src/lib/authz/`): types, presets, and `computeEffectivePermissions(roles, custom)` with full test coverage
- **REST + MCP gating**: `requireAgentPermission` for routes, `registerPermissionedTool` / `permission-map.ts` for MCP tools
- **Checkin schema**: returns a resource-aggregated object (`{ idea: ["read","write","admin"], ... }`) — token-efficient for skills and plugin hooks
- **UI**: `AgentFormFields` shared by onboarding, Settings create modal, Settings edit modal. `AgentPermissionPicker` shows a 5×3 grid with a Custom option; the Admin column is always interactive (toggling it on a preset simply flips the form to Custom with the new bit included)
- **Plugin 0.8.0** + standalone skills 0.2.1/0.1.1: all prereq checks rewritten against the new permission shape; session-start hook extracts `agent_permissions` instead of `agent_roles`
- **Migration**: adds `permissions` column on Agent (ApiKey inherits permissions via its Agent); legacy roles continue to work as preset identifiers

## Changed files (groups)

| Area | What changed |
|------|--------------|
| `src/lib/authz/*` | New permission types, presets, effective-set computation |
| `src/services/{checkin,agent}.service.ts` | Aggregated permission output; permission-aware agent CRUD |
| `src/mcp/**` | Per-tool permission declarations; new `permission-map.ts` (test coverage contract) and `register-helpers.ts` |
| `src/app/api/**` | All REST routes gated via `requireAgentPermission`; claim routes updated for the new `*_agent` stack |
| `src/app/(dashboard)/settings/page.tsx` | Edit modal uses shared `AgentFormFields`; preset derivation considers custom permissions so extras aren't silently dropped; admin-warning section removed |
| `src/components/AgentFormFields.tsx` (new) | Shared inner form (name + permission picker + persona) |
| `src/components/AgentCreateForm.tsx` | Uses `AgentFormFields`; supports embedded mode for onboarding |
| `src/components/AgentPermissionPicker.tsx` | 5×3 grid + preset selector incl. Custom; admin column always interactive |
| `src/app/onboarding/components/CreateAgentStep.tsx` | Wraps `AgentCreateForm embedded` — no duplicate form logic |
| `public/chorus-plugin/*` | Bumped to 0.8.0; hooks + skills switched to permission-based checks |
| `public/skill/*` | Standalone skill docs updated to aggregated permission model |
| `prisma/migrations/...add_agent_permissions` | Adds `permissions` column on Agent |
| `docs/{MCP_TOOLS,design.pen}` | Documentation + design.pen reflect the new permission UI |

## Review fixes (second commit)

- Settings edit modal preset derivation now respects stored custom permissions (blocker: extras were silently dropped on save).
- Claim routes (`/api/ideas|tasks/[uuid]/claim`) stopped filtering by legacy `pm` / `developer` role strings — they gate on `idea:write` / `task:write` of the selected agent instead, so any 0.7.0 agent is eligible.
- `chorus_pm_{reject,revoke}_proposal` use `hasPermission(auth, "proposal:admin")` instead of role-string checks.
- `POST /api/agents` drops legacy pm/developer/admin aliases to match PATCH.
- `/api/mcp` widens the AgentAuthContext roles cast to the full AgentRole union.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `pnpm test` — 1464 pass, 1 skipped
- [x] `pnpm test src/components` — AgentPermissionPicker contract tests updated for always-interactive Admin column
- [x] `pnpm test src/lib/authz` — permission computation fully covered
- [x] New integration test: `src/__tests__/integration/permissions.test.ts`
- [x] New API gating test: `src/app/api/__tests__/permission-gating.test.ts`
- [x] New MCP server test: `src/mcp/__tests__/server.test.ts`
- [x] Manual UI: onboarding → Settings create → Settings edit all render identical fields via the shared component; admin column toggles freely on any preset; no admin-warning popup in edit modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)