### PR TITLE
docs(plugin): port 0.7.0 permission updates to Codex plugin

### DIFF
--- a/.claude/skills/plugin-maintenance/SKILL.md
+++ b/.claude/skills/plugin-maintenance/SKILL.md
@@ -1,76 +1,128 @@
 ---
 name: plugin-maintenance
-description: Guide for modifying the Chorus plugin, updating skill documentation, and releasing new plugin versions.
+description: Guide for modifying the Chorus plugin (Claude Code + Codex ports), updating skill documentation, and releasing new plugin versions.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.1.0"
+  version: "0.2.0"
   category: development
 ---
 
 # Chorus Plugin & Skill Maintenance
 
-How to modify the Chorus plugin, update skill documentation, and release new versions.
+How to modify the Chorus plugin, update skill documentation, and release new versions. **Two plugin packages** are maintained in parallel — Claude Code and Codex — plus the standalone skill surface.
 
 ## File Structure
 
 ```
 .claude-plugin/
-  marketplace.json              ← Marketplace registry (version here)
+  marketplace.json              ← Claude Code marketplace registry (version here)
 
-public/chorus-plugin/           ← The plugin package
+public/chorus-plugin/           ← Claude Code plugin package
   .claude-plugin/
     plugin.json                 ← Plugin metadata (version here)
   hooks.json                    ← Hook definitions (SubagentStart, etc.)
-  bin/                          ← Hook scripts (bash)
-  skills/chorus/
-    SKILL.md                    ← Main skill file (execution rules, lifecycle)
-    references/
-      00-common-tools.md        ← Public MCP tools shared by all roles
-      01-setup.md               ← MCP configuration guide
-      02-pm-workflow.md          ← PM Agent complete workflow
-      03-developer-workflow.md   ← Developer Agent complete workflow
-      04-admin-workflow.md       ← Admin Agent complete workflow
-      05-session-sub-agent.md    ← Session & observability guide
-      06-claude-code-agent-teams.md ← Agent Teams integration
+  bin/                          ← Hook scripts (bash) — stateful via API state-get/set
+  skills/
+    chorus/SKILL.md             ← Core skill
+    develop/ idea/ proposal/ quick-dev/ review/ yolo/SKILL.md
+  agents/                       ← Reviewer agents as .md (Claude Code style)
+    proposal-reviewer.md
+    task-reviewer.md
 
-public/skill/                   ← Standalone skill (non-CC agents)
-  SKILL.md                      ← Same structure, softer language
-  references/                   ← Same files, IDE-agnostic wording
+plugins/chorus/                 ← Codex plugin package (separate from Claude Code)
+  .codex-plugin/
+    plugin.json                 ← Plugin metadata (version here)
+  hooks.json
+  hooks/                        ← Hook scripts (bash) — intentionally stateless
+    on-session-start.sh
+    on-post-submit-proposal.sh
+    on-post-submit-for-verify.sh
+    chorus-mcp-call.sh          ← MCP helper (has hardcoded clientInfo version)
+    hook-output.sh
+  skills/
+    chorus/SKILL.md             ← Codex port — mentions $skill syntax, ~/.codex/config.toml
+    develop/ idea/ proposal/ quick-dev/ review/ yolo/SKILL.md
+    chorus-proposal-reviewer/SKILL.md  ← Reviewers as skills in Codex (no agents/)
+    chorus-task-reviewer/SKILL.md
+
+public/skill/                   ← Standalone skill (any MCP-compatible agent)
+  chorus/SKILL.md               ← Same structure, softer language, IDE-agnostic
+  proposal-chorus/SKILL.md
+  quick-dev-chorus/SKILL.md
 ```
+
+### Claude Code vs Codex plugin: key differences
+
+| Aspect | `public/chorus-plugin/` (Claude Code) | `plugins/chorus/` (Codex) |
+|--------|---------------------------------------|---------------------------|
+| Skill invocation | `/chorus:develop` etc. | `$develop`, `$yolo` (no namespace) |
+| MCP config | `.mcp.json` | `~/.codex/config.toml` with `[mcp_servers.chorus.http_headers]` |
+| Session lifecycle | Auto-managed via SubagentStart/Stop hooks | **Stateless** — main agent manages sessions manually |
+| Reviewers | `agents/*.md` + spawned via Task tool | Skills mounted into `agent_type="default"` via `spawn_agent` + `items` |
+| Hook scripts | `bin/` — use `"$API" state-set` to persist data between hooks | `hooks/` — no persistence, each hook is self-contained |
+| Role/permission state | `on-session-start.sh` caches `agent_permissions`, read by `on-subagent-stop.sh` | Not cached — Codex has no subagent events so there's nowhere to read it from |
+
+When porting a Claude-Code change to Codex (or vice versa), preserve these intentional differences. Don't add state files to the Codex plugin and don't use `$`-prefix in Claude Code docs.
 
 ## When to Update What
 
 | Change | Files to update |
 |--------|----------------|
-| New MCP tool added | `src/mcp/tools/*.ts` (implementation) + `docs/MCP_TOOLS.md` + plugin `00-common-tools.md` or `02-pm-workflow.md` + standalone equivalents |
+| New MCP tool added | `src/mcp/tools/*.ts` (implementation) + `docs/MCP_TOOLS.md` + both plugin `chorus/SKILL.md` files + standalone `public/skill/chorus/SKILL.md` |
 | MCP tool description changed | `src/mcp/tools/*.ts` only (skill docs reference tool names, not descriptions) |
-| New workflow step | Plugin `02-pm-workflow.md` (or 03/04) + standalone equivalent |
-| New Idea/Task status | Plugin `SKILL.md` lifecycle diagram + standalone `SKILL.md` + `messages/en.json` + `messages/zh.json` |
-| New execution rule | Plugin `SKILL.md` execution rules + standalone `SKILL.md` (softer wording) |
-| Hook script change | `public/chorus-plugin/bin/*.sh` + `hooks.json` if new hook |
-| Any plugin change | Bump version in BOTH files (see below) |
+| New workflow step | Both plugin stage-specific `SKILL.md` (e.g. `develop/`, `proposal/`) + standalone equivalent |
+| New Idea/Task status | Both plugin `chorus/SKILL.md` lifecycle diagrams + standalone `SKILL.md` + `messages/en.json` + `messages/zh.json` |
+| New execution rule | Both plugin `chorus/SKILL.md` execution rules + standalone `SKILL.md` (softer wording) |
+| Permission model change | Both plugin `chorus/SKILL.md` permission tables + `yolo/SKILL.md` prereq check + `quick-dev/SKILL.md` admin-verify check + all role-based checks in hook scripts (only Claude Code hooks need edits — Codex hooks are stateless) |
+| Hook script change (Claude Code) | `public/chorus-plugin/bin/*.sh` + `hooks.json` if new hook. **Never copy hook changes blindly into `plugins/chorus/hooks/`** — Codex hooks are intentionally stateless and lack subagent events. |
+| Hook script change (Codex) | `plugins/chorus/hooks/*.sh` — rarely needed; session-start, post-submit-proposal, post-submit-for-verify are the only three. If bumping plugin version, also update the hardcoded `clientInfo.version` in `chorus-mcp-call.sh`. |
+| Any plugin change | Bump version in every file below |
 
 ## Version Bump Checklist
 
-Every time the plugin content changes, bump the version in **all** of these locations:
+Every time **either** plugin package changes, bump the version in **all** of that package's locations. The Claude Code plugin and the Codex plugin share a version sequence (both bump together when they ship the same feature), but they're independent files — you must edit each one.
 
-1. `public/chorus-plugin/.claude-plugin/plugin.json` — `"version": "X.Y.Z"`
-2. `.claude-plugin/marketplace.json` — `"version": "X.Y.Z"`
-3. Every plugin skill's YAML frontmatter `metadata.version` field — `public/chorus-plugin/skills/*/SKILL.md`
-4. Every standalone skill's YAML frontmatter `metadata.version` field — `public/skill/*/SKILL.md` (only if the standalone skill was modified)
+### Claude Code plugin — bump together
+1. `.claude-plugin/marketplace.json` — `"version": "X.Y.Z"`
+2. `public/chorus-plugin/.claude-plugin/plugin.json` — `"version": "X.Y.Z"`
+3. Every skill under `public/chorus-plugin/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (or `version: X.Y.Z` for `quick-dev/` which uses a flat frontmatter)
 
-Items 1-3 must always match the same plugin version. Item 4 is independent — bump only the standalone skills that changed, using their own version sequence.
+### Codex plugin — bump together
+4. `plugins/chorus/.codex-plugin/plugin.json` — `"version": "X.Y.Z"`
+5. Every skill under `plugins/chorus/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (or flat `version:` for `quick-dev/`). **Don't forget the two reviewer skills**: `chorus-proposal-reviewer/SKILL.md` and `chorus-task-reviewer/SKILL.md`.
+6. `plugins/chorus/hooks/chorus-mcp-call.sh` — hardcoded `clientInfo.version` string in the JSON-RPC `initialize` payload
+
+### Standalone skills — independent versioning
+7. `public/skill/*/SKILL.md` — bump only the standalone skills that changed, using their own version sequence (do NOT sync to the plugin version)
 
 Quick way to check all versions:
 ```bash
-grep -r 'version' public/chorus-plugin/.claude-plugin/plugin.json public/chorus-plugin/skills/*/SKILL.md public/skill/*/SKILL.md | grep -v '^--'
+grep -rn '"version"\|^  version:\|^version:' \
+  .claude-plugin/marketplace.json \
+  public/chorus-plugin/.claude-plugin/plugin.json \
+  public/chorus-plugin/skills/*/SKILL.md \
+  plugins/chorus/.codex-plugin/plugin.json \
+  plugins/chorus/skills/*/SKILL.md \
+  plugins/chorus/hooks/chorus-mcp-call.sh \
+  public/skill/*/SKILL.md
 ```
 
 Users update via:
 ```bash
-/plugin update chorus@chorus-plugins
+/plugin update chorus@chorus-plugins           # Claude Code
+codex plugin update chorus@chorus-plugins      # Codex
 ```
+
+## Porting Changes Between Plugins
+
+Whenever you change content in one plugin, mirror it into the other unless the difference is intentional (see the table above). Typical workflow:
+
+1. Make the change in `public/chorus-plugin/skills/<skill>/SKILL.md`
+2. Diff-check the counterpart: `diff public/chorus-plugin/skills/<skill>/SKILL.md plugins/chorus/skills/<skill>/SKILL.md`
+3. Apply the same content change to `plugins/chorus/skills/<skill>/SKILL.md`, but **preserve** Codex-specific phrasing: `.mcp.json` → `~/.codex/config.toml`, `Task tool` → `spawn_agent`, `/chorus:X` → `$X`, "sessions auto-managed" → "sessions are optional / stateless port"
+4. Bump both plugins' versions (all files above)
+5. For the Codex plugin, also verify `chorus-mcp-call.sh` `clientInfo.version` matches
 
 ## Plugin vs Standalone Skill: Tone Differences
 
@@ -89,22 +141,36 @@ The plugin skill targets Claude Code specifically. The standalone skill targets 
 
 1. Implement in `src/mcp/tools/*.ts` (pm.ts, public.ts, etc.)
 2. Add to `docs/MCP_TOOLS.md`
-3. If public tool: add to plugin `00-common-tools.md` + standalone `00-common-tools.md` + both `SKILL.md` shared tools tables
-4. If PM tool: add to plugin `02-pm-workflow.md` tool list + standalone equivalent
-5. If it changes the workflow: update the relevant workflow steps
-6. Bump plugin version
-7. Run `npx tsc --noEmit` to verify
+3. Update permission tables and tool lists in:
+   - `public/chorus-plugin/skills/chorus/SKILL.md`
+   - `plugins/chorus/skills/chorus/SKILL.md`
+   - `public/skill/chorus/SKILL.md`
+4. If it changes a stage workflow, update the matching stage skill in all three locations (`develop/`, `idea/`, `proposal/`, `quick-dev/`, `review/`, `yolo/`)
+5. Bump both plugins' versions (see Version Bump Checklist)
+6. Run `npx tsc --noEmit` to verify
 
 ## Modifying Hook Scripts
 
-Hook scripts are in `public/chorus-plugin/bin/`:
-- `on-session-start.sh` — SessionStart hook
+### Claude Code plugin hooks (`public/chorus-plugin/bin/`)
+- `on-session-start.sh` — SessionStart hook (caches `agent_permissions` via `"$API" state-set`)
 - `on-user-prompt.sh` — UserPromptSubmit hook
 - `on-subagent-start.sh` — SubagentStart hook
-- `on-subagent-stop.sh` — SubagentStop hook
+- `on-subagent-stop.sh` — SubagentStop hook (reads `agent_permissions` via `state-get`)
 - `on-teammate-idle.sh` — TeammateIdle hook
+- `on-pre-enter-plan.sh`, `on-pre-exit-plan.sh` — Plan mode hooks
+- `on-task-completed.sh` — TaskCompleted hook
+- `on-post-submit-proposal.sh`, `on-post-submit-for-verify.sh` — PostToolUse reviewer reminders
 
-**CRITICAL: All hook scripts MUST be compatible with Bash 3.2.** macOS ships with `/bin/bash` 3.2 (due to GPL licensing) and Claude Code uses it to execute hooks. Do NOT use Bash 4+ features:
+### Codex plugin hooks (`plugins/chorus/hooks/`)
+- `on-session-start.sh` — SessionStart hook (stateless; no caching)
+- `on-post-submit-proposal.sh` — PostToolUse for `chorus_pm_submit_proposal`
+- `on-post-submit-for-verify.sh` — PostToolUse for `chorus_submit_for_verify`
+- `chorus-mcp-call.sh` — shared MCP-over-HTTP helper (bump `clientInfo.version` on release)
+- `hook-output.sh` — stdout-formatting helper
+
+**Codex has no SubagentStart/Stop events** — do not try to port lifecycle hooks from the Claude Code plugin. Instead, session management is documented as a main-agent responsibility in `plugins/chorus/skills/develop/SKILL.md` and `$yolo`.
+
+**CRITICAL: All hook scripts MUST be compatible with Bash 3.2.** macOS ships with `/bin/bash` 3.2 (due to GPL licensing) and Claude Code + Codex both use it to execute hooks. Do NOT use Bash 4+ features:
 
 | Bash 4+ (FORBIDDEN) | Bash 3.2 alternative |
 |---------------------|---------------------|
@@ -117,9 +183,9 @@ Hook scripts are in `public/chorus-plugin/bin/`:
 
 After modifying:
 1. Run `/bin/bash public/chorus-plugin/bin/test-syntax.sh` on macOS to verify Bash 3.2 compatibility
-2. Test locally: `claude --plugin-dir public/chorus-plugin`
-3. Bump plugin version
-4. Users must restart CC and run `/plugin update` to get changes
+2. Test locally: `claude --plugin-dir public/chorus-plugin` (Claude Code) or install the plugin via `codex plugin install` and reload (Codex)
+3. Bump plugin version for whichever packages changed (both packages if the change applies to both)
+4. Users must restart Claude Code / Codex and run the plugin update command
 
 ## Testing Plugin Changes
 

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -54,7 +54,7 @@ ACCEPT="Accept: application/json, text/event-stream"
 CT="Content-Type: application/json"
 
 INIT=$(cat <<JSON
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.7.5"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.8.0"}}}
 JSON
 )
 

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, au
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus proposal reviewer

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus task reviewer

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -35,9 +35,25 @@ creates  analyzes     drafts PRD         codes &      reviews   closes
 
 | Role | Responsibility | MCP Tools |
 |------|---------------|-----------|
-| **PM Agent** | Analyze Ideas, create Proposals (PRD + Task drafts), manage documents | Public + `chorus_pm_*` + `chorus_*_idea` |
+| **PM Agent** | Analyze Ideas, create Proposals (PRD + Task drafts), manage documents | Public + `chorus_pm_*` + `chorus_*_idea` + `task:write` tools (claim/release/submit/report) |
 | **Developer Agent** | Claim Tasks, write code, report work, submit for verification | Public + `chorus_*_task` + `chorus_report_work` |
 | **Admin Agent** | Create projects/ideas, approve/reject proposals, verify tasks, manage lifecycle | Public + `chorus_admin_*` + PM + Developer tools |
+
+### Permissions
+
+Each agent's tool visibility is driven by a **permission set**, not by the role label alone. Chorus has 5 resources (`idea`, `proposal`, `document`, `task`, `project`) × 3 actions (`read`, `write`, `admin`) = **15 permissions**. Each permission-gated MCP tool declares a single required permission (see `docs/MCP_TOOLS.md` for the full table).
+
+**Role presets** map to permission sets:
+
+| Preset | Permissions |
+|--------|-------------|
+| `developer_agent` | all `*:read` + `task:write` |
+| `pm_agent` | all `*:read` + `idea:write` + `proposal:write` + `document:write` + `task:write` + `project:write` |
+| `admin_agent` | all 15 permissions (every `read` + `write` + `admin`) |
+
+**Custom permissions** are also supported: when creating an agent you can pick a preset AND/OR add individual permissions. The effective permission set is the union. Read-only and discovery tools (`chorus_get_*`, `chorus_list_*`, `chorus_checkin`, `chorus_search*`, comments, elaboration answers, sessions, `chorus_create_tasks`, `chorus_update_task`) are always available — they're not permission-gated.
+
+> **Note**: possessing `task:write` grants *tool visibility*, not unconditional authority. Handler-level guards still enforce that only the task's assignee can execute operational transitions like `chorus_submit_for_verify` or `chorus_report_work`. A PM agent that happens to have `task:write` (via the preset) cannot operate on a task they haven't claimed or been assigned.
 
 ---
 
@@ -221,11 +237,14 @@ API Keys must be created manually by the user in the Chorus Web UI.
 **Ask the user to:**
 1. Open the Chorus settings page (e.g., `http://localhost:8637/settings`)
 2. Click **Create API Key**
-3. Enter Agent name, select role (Developer / PM / Admin)
+3. Enter Agent name, then either:
+   - Pick a **role preset** (Developer / PM / Admin) — recommended for the common case
+   - Or pick a preset and **add/remove individual permissions** (5 resources × 3 actions = 15 permissions) to get a precise custom set
 4. Click create and **immediately copy the key** (shown only once)
 
 **Security notes:**
-- Each Agent should have its own API Key with the minimum required role
+- Each Agent should have its own API Key with the minimum required permissions
+- Presets are the fastest path; custom permissions let you grant narrowly (e.g. a dev agent that also needs `idea:write` to file bugs)
 - API Keys should not be committed to version control
 
 ### 2. MCP Server Configuration
@@ -253,19 +272,25 @@ chorus_checkin()
 
 If it fails, check: API Key correct (`cho_` prefix)? URL reachable? Codex CLI restarted?
 
-### 4. Role-Specific Tool Access
+### 4. Tool Access by Preset
 
-| Tool Prefix | Developer | PM | Admin |
-|-------------|-----------|------|-------|
-| `chorus_get_*` / `chorus_list_*` | Yes | Yes | Yes |
-| `chorus_checkin` | Yes | Yes | Yes |
-| `chorus_add_comment` / `chorus_get_comments` | Yes | Yes | Yes |
-| `chorus_claim_task` / `chorus_release_task` | Yes | No | Yes |
-| `chorus_update_task` / `chorus_submit_for_verify` | Yes | No | Yes |
-| `chorus_report_work` | Yes | No | Yes |
-| `chorus_claim_idea` / `chorus_release_idea` | No | Yes | Yes |
-| `chorus_pm_*` | No | Yes | Yes |
-| `chorus_admin_*` | No | No | Yes |
+The table below shows default tool availability for each preset (no custom permissions). Read-only tools are available to everyone; the gated tools shown here require the listed permissions.
+
+| Tool Group | Required Permission | Developer | PM | Admin |
+|------------|--------------------|-----------|------|-------|
+| `chorus_get_*` / `chorus_list_*` / `chorus_search*` | (public, read) | Yes | Yes | Yes |
+| `chorus_checkin` | (public) | Yes | Yes | Yes |
+| `chorus_add_comment` / `chorus_get_comments` | (public) | Yes | Yes | Yes |
+| `chorus_update_task` (field edits + status) | (public; assignee required for status) | Yes | Yes | Yes |
+| `chorus_claim_task` / `chorus_release_task` / `chorus_submit_for_verify` / `chorus_report_work` / `chorus_report_criteria_self_check` | `task:write` | Yes | **Yes** (0.7.0+) | Yes |
+| `chorus_claim_idea` / `chorus_release_idea` / `chorus_move_idea` / `chorus_pm_create_idea` / `chorus_pm_*_elaboration` | `idea:write` | No | Yes | Yes |
+| `chorus_pm_create_proposal` / `chorus_pm_*_proposal` / `chorus_pm_*_draft` / `chorus_pm_create_tasks` / `chorus_pm_assign_task` / `chorus_*_task_dependency` | `proposal:write` | No | Yes | Yes |
+| `chorus_pm_create_document` / `chorus_pm_update_document` | `document:write` | No | Yes | Yes |
+| `chorus_admin_create_project` / `chorus_admin_*_project_group` / `chorus_admin_move_project_to_group` | `project:write` | No | **Yes** (0.7.0+) | Yes |
+| `chorus_admin_approve_proposal` / `chorus_admin_close_proposal` | `proposal:admin` | No | No | Yes |
+| `chorus_admin_verify_task` / `chorus_admin_reopen_task` / `chorus_admin_close_task` / `chorus_mark_acceptance_criteria` / `chorus_admin_delete_task` | `task:admin` | No | No | Yes |
+| `chorus_admin_delete_idea` | `idea:admin` | No | No | Yes |
+| `chorus_admin_delete_document` | `document:admin` | No | No | Yes |
 
 ### 5. Review Agent Configuration
 

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -368,7 +368,7 @@ This is the core overview skill. For stage-specific workflows, use:
 
 1. Call `chorus_checkin()` to learn your role and assignments
 2. Based on your role, use the appropriate skill:
-   - **Full Auto** → `/yolo` — give a prompt, agent handles everything (requires all 3 roles: admin + pm + developer)
+   - **Full Auto** → `$yolo` — give a prompt, agent handles everything (requires Admin-preset permissions: write on every resource + approve/verify admin bits)
    - PM Agent → `/idea` then `/proposal`
    - Developer Agent → `/develop`
    - Admin Agent → `/review` (also has access to all PM and Developer tools)

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, and spawn
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -354,7 +354,7 @@ Sub-agents spawned via `spawn_agent` inherit the parent's MCP configuration. Ens
 
 | Problem | Solution |
 |---------|----------|
-| Worker can't access Chorus MCP tools | Verify MCP is configured and `CHORUS_API_KEY` has `developer_agent` role |
+| Worker can't access Chorus MCP tools | Verify MCP is configured and `CHORUS_API_KEY` has `task: ["write"]` permission |
 | UI doesn't show active worker | Worker forgot `chorus_session_checkin_task`, or main agent didn't create a session. Sessions are optional — it's fine to not have one |
 | Session shows "inactive" (yellow) | No heartbeat — backend session TTL will clean it up, or call `chorus_close_session` explicitly |
 | Task stuck in wrong status | Use `chorus_update_task` to reset status manually |

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -289,8 +289,8 @@ chorus_list_tasks({ projectUuid: "<project-uuid>" })
 chorus_get_unblocked_tasks({ projectUuid: "<project-uuid>" })
 
 # 2. For each worker you intend to spawn, create a Chorus session
-session_a = chorus_create_session({ name: "frontend-worker", roles: ["developer_agent"] })
-session_b = chorus_create_session({ name: "backend-worker", roles: ["developer_agent"] })
+session_a = chorus_create_session({ name: "frontend-worker" })
+session_b = chorus_create_session({ name: "backend-worker" })
 
 # 3. Spawn workers, pass sessionUuid + taskUuid(s) in the message
 spawn_agent(

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -266,7 +266,7 @@ chorus_pm_assign_task({ taskUuid: "<task-uuid>", agentUuid: "<developer-agent-uu
 ```
 
 - Task must be `open` or `assigned`
-- Target agent must have `developer` or `developer_agent` role
+- Target agent must have `task: ["write"]` permission
 
 ---
 

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.7.5
+version: 0.8.0
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 
@@ -37,7 +37,7 @@ For complex work, use `/idea` + `/proposal` instead.
 
 ## Pre-Flight: Admin Self-Verify Check
 
-**Before creating tasks**, if you have the `admin_agent` role, ask the user:
+**Before creating tasks**, if `chorus_checkin().agent.permissions.task` includes `"admin"`, ask the user:
 
 > "I have admin privileges. After development, should I verify the task myself, or leave it for another admin to verify?"
 
@@ -149,7 +149,7 @@ chorus_submit_for_verify({
 })
 ```
 
-**Admin self-verification:** If you have the `admin_agent` role and the user approved self-verification in the Pre-Flight check, you can verify the task yourself immediately after submitting:
+**Admin self-verification:** If you have `task: ["admin"]` in `permissions` and the user approved self-verification in the Pre-Flight check, you can verify the task yourself immediately after submitting:
 
 ```
 chorus_admin_verify_task({ taskUuid: "<task-uuid>" })

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.7.5"
+  version: "0.8.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -53,28 +53,25 @@ Full-auto AI-DLC pipeline. User provides a prompt; agent drives the entire lifec
 
 ## Prerequisites
 
-**All 3 agent roles are required on the API key:**
+The API key needs write + admin on every resource it touches:
 
-| Role | Why |
+| Needs | Why |
 |------|-----|
-| `pm_agent` | Idea creation, elaboration, proposal management (`chorus_pm_*` tools) |
-| `admin_agent` | Proposal approval, task verification (`chorus_admin_*` tools) |
-| `developer_agent` | Sub-agents claim and execute tasks (`chorus_claim_task`, `chorus_update_task`) |
-
-Sub-agents share the same API key as the main agent. The plugin injects session info into sub-agents, but **roles come from the API key itself**, not from hook injection.
+| `idea: [write]` | Create ideas, run elaboration |
+| `proposal: [write, admin]` | Create proposals; approve them |
+| `task: [write, admin]` | Create, execute, verify tasks |
+| `project: [write]` | Create the project if none is given |
 
 **Check at startup:**
 
 ```
-result = chorus_checkin()
-roles = result.agent.roles
+perms = chorus_checkin().agent.permissions
+need = { idea: ["write"], proposal: ["write","admin"],
+         task: ["write","admin"], project: ["write"] }
 
-required = ["pm_agent", "admin_agent", "developer_agent"]
-missing = [r for r in required if r not in roles]
-
-if missing:
-  ABORT: "Cannot run /yolo. Missing required roles: {missing}. 
-          Your API key must have all 3 roles: pm_agent, admin_agent, developer_agent."
+for resource, actions in need:
+  missing = [a for a in actions if a not in (perms[resource] or [])]
+  if missing: ABORT "/yolo needs {resource}: {missing}. Use an Admin-preset API key."
 ```
 
 ---

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -483,7 +483,7 @@ After all waves complete, output a markdown summary:
 
 | Scenario | Action |
 |----------|--------|
-| Missing roles at startup | Abort with message listing all 3 required roles and which are missing |
+| Missing permissions at startup | Abort with message listing the missing resource/action pairs (see Prerequisites). Recommend an Admin-preset API key. |
 | Project creation fails | Report error, suggest user create project manually and retry with `--project` |
 | Proposal reviewer FAIL after maxRounds | Stop pipeline, report persisting BLOCKERs, suggest manual review |
 | Task reviewer FAIL after maxRounds | Flag task as escalation-needed, continue with other tasks |
@@ -499,7 +499,7 @@ After all waves complete, output a markdown summary:
 - Watch the wave count -- if tasks keep getting reopened, consider Ctrl+C and manually reviewing the feedback
 - All audit trail is preserved: elaboration Q&A, reviewer VERDICTs, work reports. Check Chorus UI for full history
 - For small/simple tasks, consider `/quick-dev` instead -- it skips the Idea->Proposal overhead
-- Sub-agents share your API key; ensure it has all 3 roles before starting
+- Sub-agents share your API key; ensure it has the permissions listed in Prerequisites before starting
 
 ---
 

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -302,8 +302,6 @@ The table below shows default tool availability for each preset (no custom permi
 | `chorus_admin_delete_idea` | `idea:admin` | No | No | Yes |
 | `chorus_admin_delete_document` | `document:admin` | No | No | Yes |
 
-> Changes in 0.7.0: the `pm_agent` preset now also carries `task:write` (for `claim/release/submit/report`) and `project:write` (for project and group management). This widens PM's MCP tool surface by 10 tools vs 0.6.x — handler-level assignee / authorship guards still prevent misuse. See `docs/MCP_TOOLS.md` for the complete tool → permission map.
-
 ### 5. Review Agent Configuration
 
 The plugin includes two independent review agents. After proposal submission or task verification, a PostToolUse hook injects context instructing the main agent to spawn the reviewer. The main agent must spawn it manually — it is NOT auto-launched. Both are **enabled by default**.

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -392,7 +392,7 @@ This is the core overview skill. For stage-specific workflows, use:
 
 1. Call `chorus_checkin()` to learn your role and assignments
 2. Based on your role, use the appropriate skill:
-   - **Full Auto** → `/yolo` — give a prompt, agent handles everything (requires all 3 roles: admin + pm + developer)
+   - **Full Auto** → `/yolo` — give a prompt, agent handles everything (requires Admin-preset permissions: write on every resource + approve/verify admin bits)
    - PM Agent → `/idea` then `/proposal`
    - Developer Agent → `/develop`
    - Admin Agent → `/review` (also has access to all PM and Developer tools)

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -449,7 +449,7 @@ After all waves complete, output a markdown summary:
 
 | Scenario | Action |
 |----------|--------|
-| Missing roles at startup | Abort with message listing all 3 required roles and which are missing |
+| Missing permissions at startup | Abort with message listing the missing resource/action pairs (see Prerequisites). Recommend an Admin-preset API key. |
 | Project creation fails | Report error, suggest user create project manually and retry with `--project` |
 | Proposal reviewer FAIL after maxRounds | Stop pipeline, report persisting BLOCKERs, suggest manual review |
 | Task reviewer FAIL after maxRounds | Flag task as escalation-needed, continue with other tasks |
@@ -465,7 +465,7 @@ After all waves complete, output a markdown summary:
 - Watch the wave count -- if tasks keep getting reopened, consider Ctrl+C and manually reviewing the feedback
 - All audit trail is preserved: elaboration Q&A, reviewer VERDICTs, work reports. Check Chorus UI for full history
 - For small/simple tasks, consider `/quick-dev` instead -- it skips the Idea->Proposal overhead
-- Sub-agents share your API key; ensure it has all 3 roles before starting
+- Sub-agents share your API key; ensure it has the permissions listed in Prerequisites before starting
 
 ---
 

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -336,8 +336,6 @@ The table below shows default tool availability for each preset (no custom permi
 | `chorus_admin_delete_idea` | `idea:admin` | No | No | Yes |
 | `chorus_admin_delete_document` | `document:admin` | No | No | Yes |
 
-> Changes in 0.7.0: the `pm_agent` preset now also carries `task:write` (for `claim/release/submit/report`) and `project:write` (for project and group management). This widens PM's MCP tool surface by 10 tools vs 0.6.x — handler-level assignee / authorship guards still prevent misuse. See `<BASE_URL>/docs/MCP_TOOLS.md` for the complete tool → permission map.
-
 ---
 
 ## Execution Rules


### PR DESCRIPTION
## Summary
- Port the 0.7.0 permission-model skill changes (originally merged in #232) to the Codex plugin at \`plugins/chorus/\`, which was missed in that PR.
- Bump Codex plugin manifest + every skill (+ two reviewer skills) + the hardcoded \`clientInfo.version\` in \`chorus-mcp-call.sh\` from 0.7.5 → 0.8.0.
- Rewrite \`chorus/SKILL.md\` (Codex) with the Permissions section and Tool-Access-by-Preset table; replace remaining \`admin_agent\`/\`developer_agent\` role-label checks in \`quick-dev\`, \`yolo\`, \`proposal\`, and \`develop\` with \`permissions.*\` / \`task:write\` language.
- Drop a filler \"Changes in 0.7.0\" blockquote from all three \`chorus/SKILL.md\` copies (Claude plugin, Codex plugin, standalone) — the info is already in the table directly above it.
- Update \`.claude/skills/plugin-maintenance/SKILL.md\` (0.1.0 → 0.2.0) so future plugin work covers **both** packages: expanded file-structure diagram, a Claude-Code-vs-Codex difference table, a three-part version-bump checklist (now including \`.codex-plugin/plugin.json\`, reviewer skills, and the \`clientInfo\` string), and a \"Porting Changes Between Plugins\" section that flags the intentional stateless-hooks / \`\$\`-prefix / TOML-config differences.

## Changed files
| File | Change |
|------|--------|
| \`plugins/chorus/.codex-plugin/plugin.json\` | Version 0.7.5 → 0.8.0 |
| \`plugins/chorus/hooks/chorus-mcp-call.sh\` | Hardcoded \`clientInfo.version\` bumped |
| \`plugins/chorus/skills/chorus/SKILL.md\` | Permissions section + Tool Access by Preset table + API-key preset/custom guidance |
| \`plugins/chorus/skills/yolo/SKILL.md\` | Prereq check: 3 roles required → per-resource permission requirements |
| \`plugins/chorus/skills/quick-dev/SKILL.md\` | Admin-verify checks \`permissions.task\` instead of \`admin_agent\` role |
| \`plugins/chorus/skills/proposal/SKILL.md\` | Assignment prereq: developer role → \`task: [write]\` |
| \`plugins/chorus/skills/develop/SKILL.md\` | Troubleshooting row: developer role → \`task: [write]\` permission |
| \`plugins/chorus/skills/{idea,review,chorus-proposal-reviewer,chorus-task-reviewer}/SKILL.md\` | Version bump only |
| \`public/chorus-plugin/skills/chorus/SKILL.md\` + \`public/skill/chorus/SKILL.md\` | Drop redundant \"Changes in 0.7.0\" blockquote |
| \`.claude/skills/plugin-maintenance/SKILL.md\` | Cover both plugin packages; new porting workflow |

## Test plan
- [x] Docs-only change; no code paths touched
- [x] \`grep\` sweep confirms no lingering role-label references in \`plugins/chorus/\`
- [x] All plugin files share version 0.8.0 (manifest, 9 skills, \`clientInfo\`)
- [ ] Load the Codex plugin locally and spot-check the updated skills

Generated with [Claude Code](https://claude.com/claude-code)