### PR TITLE
docs: v0.7.0 release blog and README entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ## What's New
 
+**[v0.7.0](https://chorus-ai.dev/blog/chorus-v0.7.0-release/)** — Fine-grained agent permissions: 5 resources × 3 actions grid replaces the PM/Developer/Admin three-way choice, with presets + a Custom option for free combination.
+
 **[v0.6.7](https://chorus-ai.dev/blog/chorus-v0.6.7-release/)** — Chorus plugin for Codex CLI (one-command installer), workspace picker when one email belongs to multiple Companies, per-client connect guides.
 
 **[v0.6.6](https://chorus-ai.dev/blog/chorus-v0.6.6-release/)** — npm one-click install (`npx @chorus-aidlc/chorus`), document export (MD/PDF/Word), proposal revoke, faster agent checkin with work status at a glance.

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,6 +26,8 @@ creates   analyzes       drafts PRD            codes &      reviews   closes
 
 ## 最近更新
 
+**[v0.7.0](https://chorus-ai.dev/zh/blog/chorus-v0.7.0-release/)** — 细粒度 Agent 权限：5 类资源 × 3 个动作组成的网格，取代 PM / Developer / Admin 三选一。保留原有预设，新增 Custom 选项自由组合。
+
 **[v0.6.7](https://chorus-ai.dev/zh/blog/chorus-v0.6.7-release/)** — Codex CLI 版 Chorus 插件（一条命令装完）、同一邮箱属于多个 Company 时的工作区选择器、每种客户端的接入文档。
 
 **[v0.6.6](https://chorus-ai.dev/zh/blog/chorus-v0.6.6-release/)** — npm 一键安装（`npx @chorus-aidlc/chorus`）、文档导出（MD/PDF/Word）、Proposal 撤回、优化 Agent Checkin 快速获取工作状态。

--- a/packages/landing/src/content/blog/chorus-v0.7.0-release.md
+++ b/packages/landing/src/content/blog/chorus-v0.7.0-release.md
@@ -1,0 +1,73 @@
+---
+title: "Chorus v0.7.0: Build Your Own Agent Permissions"
+description: "Creating an agent used to be a three-way choice: PM, Developer, or Admin. Now you pick by resource and action."
+date: 2026-05-02
+lang: en
+postSlug: chorus-v0.7.0-release
+---
+
+# Chorus v0.7.0: Build Your Own Agent Permissions
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.7.0 is out. One thing in this release: agent permissions are no longer a three-way choice. You mix and match them yourself.
+
+---
+
+## Three presets, making do
+
+Before this release, creating an agent gave you three checkboxes: PM, Developer, Admin. Want an agent that can work on tasks but can't touch ideas? Not possible. Want a read-only review agent? Also not possible — the Developer preset comes with claim and close baked in. You picked the preset that was closest, and lived with whatever else it dragged along.
+
+Fine for simple cases. But the moment you want something that doesn't map cleanly onto one of the three boxes, you either settle for the nearest preset or hand the agent Admin and call it a day.
+
+v0.7.0 takes the permissions out of the roles.
+
+---
+
+## 5 resources × 3 actions
+
+An agent's permissions are now a grid: five resources (idea, proposal, document, task, project) and three actions on each (read, write, admin). Fifteen toggles in total.
+
+The three old roles are still there, rebranded as **presets**. Pick Developer and it flips on one set of bits; pick PM and it flips on another. What's new is the **Custom** option — the grid opens up and every cell is clickable.
+
+So now you can do things like:
+
+- Read-only agent: check all five `:read` bits, leave everything else off.
+- Task-only worker: only the task column is on — ideas and proposals are off-limits.
+- PM who can also close their own tasks: PM preset plus an extra `task:admin`.
+
+Under the hood, the MCP tools and REST API stopped asking "are you a developer role?" and started asking "do you have task:write?". The checkin response now returns permissions pre-aggregated, so plugin hooks and skills don't have to parse roles themselves — they just read what they're allowed to do.
+
+---
+
+## A heads-up for upgraders
+
+Existing agents keep working as-is.
+
+The plugin moved to 0.8.0 too (both Claude Code and Codex). Skill docs that used to say "requires the developer role" now say "requires task:write" — matching the new check underneath.
+
+---
+
+## Upgrade
+
+```bash
+npx @chorus-aidlc/chorus@latest
+```
+
+Claude Code plugin:
+
+```bash
+/plugin marketplace update chorus-plugins
+```
+
+Codex CLI plugin:
+
+```bash
+bash <(curl -fsSL $CHORUS_URL/install-codex.sh)
+```
+
+v0.7.0 is on [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.7.0) and [npm](https://www.npmjs.com/package/@chorus-aidlc/chorus).
+
+Questions or feedback? [GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) or [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions).
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.7.0](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.7.0)

--- a/packages/landing/src/content/blog/zh-chorus-v0.7.0-release.md
+++ b/packages/landing/src/content/blog/zh-chorus-v0.7.0-release.md
@@ -1,0 +1,73 @@
+---
+title: "Chorus v0.7.0: Agent 权限，自己拼"
+description: "之前创建 agent 只能三选一：PM、Developer、Admin。现在可以按资源和动作自己搭。"
+date: 2026-05-02
+lang: zh
+postSlug: chorus-v0.7.0-release
+---
+
+# Chorus v0.7.0: Agent 权限，自己拼
+
+[Chorus](https://github.com/Chorus-AIDLC/Chorus) v0.7.0 发布了。这版只做了一件事：把 agent 的权限从三选一，拆成了可以自己组合的开关。
+
+---
+
+## 三个预设，凑合着用
+
+之前创建 agent 的时候，页面上就三个选项：PM、Developer、Admin。想要一个能接 task 但碰不到 idea 的 agent？没办法。想要一个只能看、不能改的 review agent？也没办法，Developer 预设自带 claim 和 close。只能勾哪个算哪个。
+
+简单场景够用，但只要稍微想搭一个不那么标准的 agent，就得把就近的预设将就着用，或者干脆开 Admin 让它全都能干。
+
+v0.7.0 把这件事往下拆了一层：权限不再跟着角色走。
+
+---
+
+## 5 类资源 × 3 个动作
+
+现在每个 agent 的权限是一张表：idea、proposal、document、task、project 五类资源，每类各有 read、write、admin 三个动作，一共 15 个开关。
+
+三个老角色留着，改叫 **预设**。选 Developer，就是替你勾上一组位；选 PM，勾另一组。新多出来的是 **Custom**，表格里的每一格都能自己点。
+
+所以现在可以做这些事：
+
+- 只读 agent：五个 `:read` 全勾，别的不给。
+- 专职执行：只勾 task 那一列，idea 和 proposal 碰不到。
+- PM + 能关自己的 task：PM 预设打底，再加一个 `task:admin`。
+
+MCP 工具和 REST API 底层也跟着换了。之前是"你是不是 developer 角色"，现在是"你有没有 task:write"。Checkin 返回的也是聚合后的权限对象，plugin 的 hook 和 skill 不用自己解析，一看就知道能做什么、不能做什么。
+
+---
+
+## 升级的时候注意一下
+
+旧的 agent 不用管，照常工作。
+
+插件跟着走到了 0.8.0（Claude Code 和 Codex 两边都升了）。skill 里原先写的"需要 developer 角色"之类的话，都换成了"需要 task:write 权限"，对得上新的判断逻辑。
+
+---
+
+## 升级
+
+```bash
+npx @chorus-aidlc/chorus@latest
+```
+
+Claude Code 插件：
+
+```bash
+/plugin marketplace update chorus-plugins
+```
+
+Codex CLI 插件：
+
+```bash
+bash <(curl -fsSL $CHORUS_URL/install-codex.sh)
+```
+
+v0.7.0 已发布到 [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.7.0) 和 [npm](https://www.npmjs.com/package/@chorus-aidlc/chorus)。
+
+有问题或反馈？[GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) 或 [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions)。
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.7.0](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.7.0)


### PR DESCRIPTION
## Summary
- Add bilingual (zh + en) release blog posts for v0.7.0 — narrative framed around "agent permissions you assemble yourself," replacing the old three-way PM/Developer/Admin choice.
- Add v0.7.0 entry to the "What's New" section in both README.md and README.zh.md.

## Changed files
| File | Change |
|------|--------|
| `packages/landing/src/content/blog/chorus-v0.7.0-release.md` | New — English release blog |
| `packages/landing/src/content/blog/zh-chorus-v0.7.0-release.md` | New — Chinese release blog |
| `README.md` | v0.7.0 "What's New" entry |
| `README.zh.md` | v0.7.0 "最近更新" entry |

## Test plan
- [x] Links to release/blog slugs match v0.6.7 pattern
- [x] `postSlug` matches between zh and en
- [x] No em dashes in the Chinese post

Generated with [Claude Code](https://claude.com/claude-code)