### PR TITLE
fix(blog): correct zh blog link to shared postSlug route

### DIFF
--- a/packages/landing/src/content/blog/zh-claude-code-vs-codex-plugin-systems.md
+++ b/packages/landing/src/content/blog/zh-claude-code-vs-codex-plugin-systems.md
@@ -14,7 +14,7 @@ postSlug: claude-code-vs-codex-plugin-systems
 
 > 基准版本: Claude Code `2.1.126`，Codex CLI `0.128.0`。两边都在快速迭代，后面版本应该会修掉其中一些问题。
 
-Claude Code 那版我之前写过实现细节: [为 Claude Code Agent Teams 构建插件](/blog/zh-building-claude-code-plugin-for-agent-teams)。这篇重点在 Codex 踩过的坑，以及这些坑给插件开发者意味着什么。
+Claude Code 那版我之前写过实现细节: [为 Claude Code Agent Teams 构建插件](/blog/building-claude-code-plugin-for-agent-teams)。这篇重点在 Codex 踩过的坑，以及这些坑给插件开发者意味着什么。
 
 ---
 


### PR DESCRIPTION
## Summary

The landing site routes blog posts by `postSlug`, which is shared between the zh and en versions of the same post. The new blog's zh version referenced `/blog/zh-building-claude-code-plugin-for-agent-teams`, which 404s — the correct route is `/blog/building-claude-code-plugin-for-agent-teams`.

## Changed files

| File | Change |
|------|--------|
| `packages/landing/src/content/blog/zh-claude-code-vs-codex-plugin-systems.md` | Drop `zh-` prefix from the internal link |

## Test plan
- [x] Confirmed via `postSlug: building-claude-code-plugin-for-agent-teams` on both zh and en versions of the linked post
- [ ] Visual check in the landing preview

Generated with [Claude Code](https://claude.com/claude-code)