### PR TITLE
feat(onboarding): add OpenCode client install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ The interactive installer provisions VPC, Aurora Serverless v2, ElastiCache Serv
 
 ### Connect AI Agents
 
-The fastest path is the in-app setup wizard: open the Web UI, go to **Settings → Setup Guide → Open setup guide**, and follow the step-by-step instructions for your client (Claude Code, Codex, OpenClaw, or other agents). The wizard creates the API key for you, shows the exact commands, and walks through verifying the connection.
+The fastest path is the in-app setup wizard: open the Web UI, go to **Settings → Setup Guide → Open setup guide**, and follow the step-by-step instructions for your client (Claude Code, Codex, OpenCode, OpenClaw, or other agents). The wizard creates the API key for you, shows the exact commands, and walks through verifying the connection.
 
 If you'd rather read the full docs:
 
@@ -302,7 +302,10 @@ If you'd rather read the full docs:
 |--------|-------|
 | Claude Code | [CONNECT_CLAUDE_CODE.md](docs/CONNECT_CLAUDE_CODE.md) |
 | Codex CLI | [CONNECT_CODEX.md](docs/CONNECT_CODEX.md) |
+| OpenCode † | [CONNECT_OPENCODE.md](docs/CONNECT_OPENCODE.md) |
 | Other MCP agents (Cursor, Continue, custom, …) | [CONNECT_OTHER_AGENTS.md](docs/CONNECT_OTHER_AGENTS.md) |
+
+† OpenCode support is provided by the community-maintained [`opencode-chorus`](https://github.com/etnperlong/opencode-chorus) plugin (npm: [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus)), authored by [@etnperlong](https://github.com/etnperlong). Thanks!
 
 Create API Keys in the Web UI under **Settings → Agents → Create API Key**. Keys start with `cho_` and are shown only once.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -285,7 +285,7 @@ PGlite 在端口 5433 运行嵌入式 PostgreSQL。数据存储在 `.pglite/`，
 
 ### 连接 AI Agent
 
-最快的方式是用应用内的 setup 向导：打开 Web UI，进入 **Settings → Setup Guide → 打开设置向导**，按照向导给出的分步指引接入自己的客户端（Claude Code、Codex、OpenClaw 或其他 agent）。向导会帮你创建 API Key、展示完整命令，并引导你验证连接。
+最快的方式是用应用内的 setup 向导：打开 Web UI，进入 **Settings → Setup Guide → 打开设置向导**，按照向导给出的分步指引接入自己的客户端（Claude Code、Codex、OpenCode、OpenClaw 或其他 agent）。向导会帮你创建 API Key、展示完整命令，并引导你验证连接。
 
 如果偏好文档：
 
@@ -293,7 +293,10 @@ PGlite 在端口 5433 运行嵌入式 PostgreSQL。数据存储在 `.pglite/`，
 |--------|---------|
 | Claude Code | [CONNECT_CLAUDE_CODE.zh.md](docs/CONNECT_CLAUDE_CODE.zh.md) |
 | Codex CLI | [CONNECT_CODEX.zh.md](docs/CONNECT_CODEX.zh.md) |
+| OpenCode † | [CONNECT_OPENCODE.zh.md](docs/CONNECT_OPENCODE.zh.md) |
 | 其他 MCP agent（Cursor / Continue / 自研等） | [CONNECT_OTHER_AGENTS.zh.md](docs/CONNECT_OTHER_AGENTS.zh.md) |
+
+† OpenCode 的接入由社区维护的 [`opencode-chorus`](https://github.com/etnperlong/opencode-chorus) 插件提供（npm: [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus)），作者 [@etnperlong](https://github.com/etnperlong)，特此感谢！
 
 在 Web UI 的 **Settings → Agents → Create API Key** 创建 API Key。Key 以 `cho_` 开头，仅在创建时显示一次。
 

--- a/docs/CONNECT_OPENCODE.md
+++ b/docs/CONNECT_OPENCODE.md
@@ -1,0 +1,110 @@
+# Connect OpenCode to Chorus
+
+This guide walks through connecting the [OpenCode CLI](https://opencode.ai) to a running Chorus instance via the community-maintained [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus) plugin. The plugin ships Chorus MCP tools, reviewer hooks, and the Chorus skill library into OpenCode through OpenCode's native plugin mechanism.
+
+> **Tip:** The in-app setup wizard at **Settings → Setup Guide → Open setup guide** walks you through the same steps interactively, including API-key creation. Use this doc if you prefer a reference you can read end-to-end or automate.
+
+## Prerequisites
+
+- Chorus instance running and reachable (e.g. `http://localhost:8637` or a deployed URL)
+- `opencode` CLI installed (see [opencode.ai/docs](https://opencode.ai/docs/))
+- A Chorus **API Key** (create one in the Web UI under **Settings → Agents → Create API Key**). Keys start with `cho_`.
+
+## Step 1: Export environment variables
+
+```bash
+export CHORUS_URL="http://localhost:8637"
+export CHORUS_API_KEY="cho_your_api_key"
+```
+
+> Add these to `~/.bashrc` or `~/.zshrc` so OpenCode can read them on startup. The `opencode-chorus` plugin reads `process.env.CHORUS_URL` (or `CHORUS_BASE_URL`) and `process.env.CHORUS_API_KEY` during plugin initialization.
+>
+> **Note on URL format:** `CHORUS_URL` should be the **root URL** of your Chorus instance (e.g. `https://chorus.example.com`), without the `/api/mcp` suffix. The plugin appends the MCP path internally.
+
+## Step 2: Enable the Chorus plugin
+
+Run the one-shot installer:
+
+```bash
+curl -fsSL "$CHORUS_URL/install-opencode.sh" | bash
+```
+
+The script is idempotent and safe to re-run. It will:
+
+1. Verify `opencode` is installed (warns if not, but still writes the config).
+2. Idempotently add `"opencode-chorus"` to the `plugin` array in `~/.config/opencode/opencode.json`. Existing plugin entries are preserved.
+3. Back up the original config to `opencode.json.chorus-bak` (only on first modification) and set file mode to `600`.
+
+**What the script does NOT do:**
+
+- It does **not** write to `~/.bashrc` / `~/.zshrc`. You are responsible for exporting `CHORUS_URL` and `CHORUS_API_KEY` yourself before launching `opencode`.
+- It does **not** install the plugin package. OpenCode fetches `opencode-chorus` from npm via Bun the first time you launch it after editing `opencode.json` (cache lives at `~/.cache/opencode/packages/opencode-chorus@latest/`).
+
+### Manual alternative
+
+If you prefer to edit the config by hand, add this to `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-chorus"]
+}
+```
+
+Merge `"opencode-chorus"` into any existing `plugin` array instead of replacing it.
+
+## Step 3: Verify the connection
+
+Launch OpenCode:
+
+```bash
+opencode
+```
+
+On first launch Bun will fetch `opencode-chorus` from npm (this adds a few seconds the first time). Then ask the agent:
+
+```
+check in to chorus
+```
+
+The plugin will call `chorus_checkin()` via its MCP client and the agent will report back with your identity, permissions, and recent activity. The Chorus workflow skills (`chorus`, `chorus-develop`, `chorus-proposal`, `chorus-review`, `chorus-yolo`, etc.) are automatically registered under OpenCode.
+
+## Troubleshooting
+
+- **Plugin not loaded.** Clear the package cache and restart OpenCode:
+  ```bash
+  rm -rf ~/.cache/opencode/packages/opencode-chorus@latest
+  ```
+  OpenCode will re-fetch the latest version from npm on next launch.
+
+- **Environment variables not taking effect.** Confirm you launched OpenCode from a shell where `CHORUS_URL` and `CHORUS_API_KEY` are exported. Run `env | grep CHORUS_` in the shell to verify. Re-source your shell rc file if needed (`source ~/.zshrc`).
+
+- **`check in` not responding.** Double-check `CHORUS_API_KEY` for typos or trailing whitespace. If the plugin still fails to load on startup, try upgrading OpenCode (`opencode upgrade`). The `opencode-chorus` plugin depends on a recent `@opencode-ai/plugin` SDK version.
+
+- **`401 Unauthorized`.** API key wrong or revoked. Recreate under Settings → Agents, then update `CHORUS_API_KEY` in your shell rc and restart OpenCode.
+
+- **Need to roll back?** The installer saved your original config to `~/.config/opencode/opencode.json.chorus-bak`. Restore with:
+  ```bash
+  mv ~/.config/opencode/opencode.json.chorus-bak ~/.config/opencode/opencode.json
+  ```
+
+## Advanced: use a config file instead of env
+
+If you prefer not to touch your shell rc, `opencode-chorus` also reads from `~/.config/opencode/chorus.json`:
+
+```json
+{
+  "chorusUrl": "https://chorus.example.com",
+  "apiKey": "cho_your_api_key"
+}
+```
+
+Environment variables take precedence over file values when both are set. The file approach is useful for shared dev containers or when you want to keep secrets out of `~/.zshrc`. Make sure to `chmod 600 ~/.config/opencode/chorus.json` since it contains your API key.
+
+## Next
+
+- Workflow overview: tell the OpenCode agent `load the chorus skill`
+- Project-level install: write the same `plugin` array into `./opencode.json` at the project root. OpenCode loads per-project configs on top of the global one.
+- To connect Claude Code instead, see [CONNECT_CLAUDE_CODE.md](CONNECT_CLAUDE_CODE.md)
+- To connect Codex, see [CONNECT_CODEX.md](CONNECT_CODEX.md)
+- For any other MCP-capable agent (Cursor, Continue, custom, etc.), see [CONNECT_OTHER_AGENTS.md](CONNECT_OTHER_AGENTS.md)

--- a/docs/CONNECT_OPENCODE.zh.md
+++ b/docs/CONNECT_OPENCODE.zh.md
@@ -1,0 +1,110 @@
+# 连接 OpenCode 到 Chorus
+
+本指南介绍如何通过社区维护的 [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus) 插件把 [OpenCode CLI](https://opencode.ai) 接入正在运行的 Chorus 实例。该插件通过 OpenCode 原生的插件机制注入 Chorus MCP 工具、reviewer hook，以及整套 Chorus skill 文档。
+
+> **提示：** 应用内的 Setup Wizard（**设置 → Setup Guide → 打开 setup guide**）会以交互方式引导你完成同样的步骤，包含 API Key 创建。如果你更喜欢一篇可通读的参考文档或需要自动化，请使用本文。
+
+## 前置条件
+
+- Chorus 实例正在运行且可访问（例如 `http://localhost:8637` 或一个部署好的 URL）
+- 已安装 `opencode` CLI（参考 [opencode.ai/docs](https://opencode.ai/docs/)）
+- 一把 Chorus **API Key**（在 Web UI 的 **设置 → Agents → 创建 API Key** 里生成）。Key 以 `cho_` 开头。
+
+## 第 1 步：设置环境变量
+
+```bash
+export CHORUS_URL="http://localhost:8637"
+export CHORUS_API_KEY="cho_your_api_key"
+```
+
+> 建议把这两行加到 `~/.bashrc` 或 `~/.zshrc`，以便 OpenCode 启动时能读到。`opencode-chorus` 插件在初始化时会读取 `process.env.CHORUS_URL`（或 `CHORUS_BASE_URL`）和 `process.env.CHORUS_API_KEY`。
+>
+> **URL 格式说明：** `CHORUS_URL` 填 Chorus 实例的**根 URL**（例如 `https://chorus.example.com`），**不要带 `/api/mcp` 后缀**。插件内部会自动拼接 MCP 路径。
+
+## 第 2 步：启用 Chorus 插件
+
+运行一键安装脚本：
+
+```bash
+curl -fsSL "$CHORUS_URL/install-opencode.sh" | bash
+```
+
+脚本幂等，可安全重复执行。它会：
+
+1. 检查 `opencode` 是否已安装（未安装则警告但仍会写配置）。
+2. 幂等地把 `"opencode-chorus"` 加入 `~/.config/opencode/opencode.json` 的 `plugin` 数组，已有的 plugin 条目会保留。
+3. 首次修改前备份原配置到 `opencode.json.chorus-bak`，并将文件权限设为 `600`。
+
+**脚本不做的事：**
+
+- **不会**写 `~/.bashrc` / `~/.zshrc`。你需要自己在启动 `opencode` 前 export 好 `CHORUS_URL` 和 `CHORUS_API_KEY`。
+- **不会**下载 `opencode-chorus` 包。OpenCode 在你修改 `opencode.json` 后首次启动时，通过 Bun 从 npm 拉取该包（缓存路径是 `~/.cache/opencode/packages/opencode-chorus@latest/`）。
+
+### 手动替代方案
+
+如果你更愿意手工编辑配置，把下面内容加进 `~/.config/opencode/opencode.json`：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-chorus"]
+}
+```
+
+注意：如果已经有 `plugin` 数组，把 `"opencode-chorus"` merge 进去，而不是替换整个数组。
+
+## 第 3 步：验证连接
+
+启动 OpenCode：
+
+```bash
+opencode
+```
+
+首次启动时 Bun 会从 npm 拉取 `opencode-chorus`（首次会多几秒钟）。然后告诉 agent：
+
+```
+check in to chorus
+```
+
+插件会通过 MCP client 调用 `chorus_checkin()`，agent 会报告你的身份、权限和最近的活动。Chorus 工作流 skills（`chorus`、`chorus-develop`、`chorus-proposal`、`chorus-review`、`chorus-yolo` 等）会自动注册到 OpenCode。
+
+## 故障排除
+
+- **插件未加载。** 清空包缓存后重启 OpenCode：
+  ```bash
+  rm -rf ~/.cache/opencode/packages/opencode-chorus@latest
+  ```
+  OpenCode 会在下次启动时从 npm 重新拉取最新版本。
+
+- **环境变量未生效。** 确认启动 OpenCode 的 shell 里已经 export `CHORUS_URL` 和 `CHORUS_API_KEY`。在 shell 中 `env | grep CHORUS_` 验证一下。如有需要，先 `source ~/.zshrc` 再启动。
+
+- **`check in` 无响应。** 核对 `CHORUS_API_KEY` 是否有错字或末尾多余的空格。如果插件仍加载失败，尝试升级 OpenCode（`opencode upgrade`）。`opencode-chorus` 依赖较新版本的 `@opencode-ai/plugin` SDK。
+
+- **`401 Unauthorized`。** API Key 错误或已撤销。去 设置 → Agents 重新生成，更新 shell rc 里的 `CHORUS_API_KEY`，然后重启 OpenCode。
+
+- **想回滚？** 安装脚本把你的原配置保存到了 `~/.config/opencode/opencode.json.chorus-bak`。恢复命令：
+  ```bash
+  mv ~/.config/opencode/opencode.json.chorus-bak ~/.config/opencode/opencode.json
+  ```
+
+## 高级：用配置文件代替 env
+
+如果你不想动 shell rc，`opencode-chorus` 也支持从 `~/.config/opencode/chorus.json` 读配置：
+
+```json
+{
+  "chorusUrl": "https://chorus.example.com",
+  "apiKey": "cho_your_api_key"
+}
+```
+
+两者同时存在时，env 优先。配置文件方式适合共享开发容器，或想把密钥从 `~/.zshrc` 里挪走的场景。记得 `chmod 600 ~/.config/opencode/chorus.json`，因为里面有你的 API Key。
+
+## 下一步
+
+- 工作流概览：在 OpenCode 中告诉 agent `load the chorus skill`
+- 项目级安装：把同样的 `plugin` 数组写进项目根目录的 `./opencode.json`，OpenCode 会在全局配置之上叠加项目配置。
+- 接入 Claude Code，请看 [CONNECT_CLAUDE_CODE.zh.md](CONNECT_CLAUDE_CODE.zh.md)
+- 接入 Codex，请看 [CONNECT_CODEX.zh.md](CONNECT_CODEX.zh.md)
+- 任何其他支持 MCP 的 agent（Cursor、Continue、自定义 agent 等），请看 [CONNECT_OTHER_AGENTS.zh.md](CONNECT_OTHER_AGENTS.zh.md)

--- a/docs/design.pen
+++ b/docs/design.pen
@@ -84340,6 +84340,414 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "gKGZ6",
+      "x": 4620,
+      "y": 11240,
+      "name": "Onboarding - Install Guide (OpenCode tab) (v0.7.0)",
+      "width": 1440,
+      "height": 820,
+      "fill": "#FAF8F4",
+      "layout": "vertical",
+      "gap": 24,
+      "padding": 48,
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Ggucb",
+          "name": "header",
+          "layout": "vertical",
+          "gap": 8,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "OjsdP",
+              "name": "title",
+              "fill": "#2C2C2C",
+              "content": "Install the Chorus plugin",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 22,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "hwcW4",
+              "name": "subtitle",
+              "fill": "#6B6B6B",
+              "content": "Choose your AI agent client and follow the setup instructions below.",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "HVci9",
+          "name": "card",
+          "width": 680,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "stroke": {
+            "thickness": 1,
+            "fill": "#E5E0D8"
+          },
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "r8BWdq",
+              "name": "tabs",
+              "width": "fill_container",
+              "fill": "#F5F2EC",
+              "cornerRadius": 8,
+              "gap": 4,
+              "padding": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "mAYma",
+                  "name": "tab1",
+                  "width": "fill_container",
+                  "cornerRadius": 6,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "b8rld",
+                      "name": "tab1t",
+                      "fill": "#6B6B6B",
+                      "content": "Claude Code",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MnDfc",
+                  "name": "tab2",
+                  "width": "fill_container",
+                  "cornerRadius": 6,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "HrF5V",
+                      "name": "tab2t",
+                      "fill": "#6B6B6B",
+                      "content": "Codex",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "baMaJ",
+                  "name": "tab3",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#C67A52"
+                  },
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "HUNOT",
+                      "name": "tab3t",
+                      "fill": "#C67A52",
+                      "content": "OpenCode",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "THUx6",
+                  "name": "tab4",
+                  "width": "fill_container",
+                  "cornerRadius": 6,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "d26NxE",
+                      "name": "tab4t",
+                      "fill": "#6B6B6B",
+                      "content": "OpenClaw",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rQRNe",
+                  "name": "tab5",
+                  "width": "fill_container",
+                  "cornerRadius": 6,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VGFVN",
+                      "name": "tab5t",
+                      "fill": "#6B6B6B",
+                      "content": "Other Agents",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ZAlK7",
+              "name": "body",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 20,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "D1HPqP",
+                  "name": "step1",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qf8pd",
+                      "name": "step1Title",
+                      "fill": "#2C2C2C",
+                      "content": "Step 1: Set environment variables",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lemDW",
+                      "name": "step1Code",
+                      "width": "fill_container",
+                      "fill": "#1F1F1F",
+                      "cornerRadius": 8,
+                      "layout": "vertical",
+                      "gap": 4,
+                      "padding": 16,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "A7Nbu",
+                          "name": "step1Line1",
+                          "fill": "#E5E5E5",
+                          "content": "export CHORUS_URL=\"https://chorus.example.com\"",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "n1FYe",
+                          "name": "step1Line2",
+                          "fill": "#E5E5E5",
+                          "content": "export CHORUS_API_KEY=\"cho_...\"",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "j5k0y",
+                      "name": "step1Tip",
+                      "fill": "#9A9A9A",
+                      "content": "Tip: Add these to ~/.bashrc or ~/.zshrc so the plugin can read them on OpenCode startup.",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IhWrr",
+                  "name": "step2",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fB5SA",
+                      "name": "step2Title",
+                      "fill": "#2C2C2C",
+                      "content": "Step 2: Enable the Chorus plugin",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZGk2C",
+                      "name": "step2Code",
+                      "width": "fill_container",
+                      "fill": "#1F1F1F",
+                      "cornerRadius": 8,
+                      "padding": 16,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "J6ZK0z",
+                          "name": "step2Line",
+                          "fill": "#E5E5E5",
+                          "content": "curl -fsSL https://chorus.example.com/install-opencode.sh | bash",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "ibfKF",
+                      "name": "step2Tip",
+                      "fill": "#9A9A9A",
+                      "content": "The installer idempotently adds \"opencode-chorus\" to the \"plugin\" array in ~/.config/opencode/opencode.json. It does not touch your shell rc.",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "EJdCA",
+                  "name": "step3",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "aIsrV",
+                      "name": "step3Title",
+                      "fill": "#2C2C2C",
+                      "content": "Step 3: Verify connection",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VDf7s",
+                      "name": "step3Desc",
+                      "fill": "#6B6B6B",
+                      "content": "Open OpenCode and ask the agent to \"check in to chorus\". This step auto-advances when the connection succeeds.",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QcdmD",
+                  "name": "ts",
+                  "width": "fill_container",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E5E0D8"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "v3tun",
+                      "name": "tsTitle",
+                      "width": "fill_container",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jMtJc",
+                          "name": "tsChevron",
+                          "fill": "#9A9A9A",
+                          "content": "▸",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "S5E2ZK",
+                          "name": "tsLabel",
+                          "fill": "#6B6B6B",
+                          "content": "Troubleshooting",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "themes": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1024,6 +1024,7 @@
       "tabs": {
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "opencode": "OpenCode",
         "openClaw": "OpenClaw",
         "other": "Other Agents"
       },
@@ -1039,6 +1040,27 @@
         "step2Tip": "The script registers the plugin marketplace and writes the MCP server entry into ~/.codex/config.toml.",
         "step3Title": "Step 3: Verify connection",
         "step3Desc": "Open Codex and ask it to check in to Chorus — e.g. type \"check in to chorus\"."
+      },
+      "opencode": {
+        "step1Title": "Step 1: Set environment variables",
+        "step1Tip": "Tip: Add these to ~/.bashrc or ~/.zshrc so the plugin can read them on OpenCode startup.",
+        "step2Title": "Step 2: Enable the Chorus plugin",
+        "step2Tip": "The installer idempotently adds \"opencode-chorus\" to the \"plugin\" array in ~/.config/opencode/opencode.json. It does not touch your shell rc. OpenCode installs the plugin via Bun on first launch.",
+        "step3Title": "Step 3: Verify connection",
+        "step3Desc": "Open OpenCode and ask the agent to \"check in to chorus\". This step auto-advances when the connection succeeds.",
+        "troubleshootingTitle": "Troubleshooting",
+        "issueCache": {
+          "title": "Plugin not loaded",
+          "fix": "Clear the plugin cache with `rm -rf ~/.cache/opencode/packages/opencode-chorus@latest` and restart OpenCode."
+        },
+        "issueEnv": {
+          "title": "Environment variables not taking effect",
+          "fix": "Confirm you launched OpenCode from a shell where CHORUS_URL and CHORUS_API_KEY are exported. Re-source your shell rc file if needed."
+        },
+        "issueCheckin": {
+          "title": "check-in not responding",
+          "fix": "Double-check CHORUS_API_KEY for typos or trailing whitespace. If the plugin still fails to load, try upgrading OpenCode."
+        }
       },
       "openClaw": {
         "step1Title": "Step 1: Install plugin",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1025,6 +1025,7 @@
       "tabs": {
         "claudeCode": "Claude Code",
         "codex": "Codex",
+        "opencode": "OpenCode",
         "openClaw": "OpenClaw",
         "other": "其他智能体"
       },
@@ -1040,6 +1041,27 @@
         "step2Tip": "脚本会自动注册 plugin marketplace 并写入 ~/.codex/config.toml 的 MCP 服务器配置。",
         "step3Title": "第 3 步：验证连接",
         "step3Desc": "打开 Codex，让它 check in 到 Chorus，例如输入 \"check in to chorus\"。"
+      },
+      "opencode": {
+        "step1Title": "第 1 步：设置环境变量",
+        "step1Tip": "提示：将这些添加到 ~/.bashrc 或 ~/.zshrc，插件会在 OpenCode 启动时读取这两个变量。",
+        "step2Title": "第 2 步：启用 Chorus 插件",
+        "step2Tip": "安装脚本会幂等地把 \"opencode-chorus\" 加入 ~/.config/opencode/opencode.json 的 \"plugin\" 数组，不会修改你的 shell rc。OpenCode 首次启动时 Bun 会自动安装该插件。",
+        "step3Title": "第 3 步：验证连接",
+        "step3Desc": "打开 OpenCode，告诉 agent \"check in to chorus\"。连接成功后本步骤会自动跳转。",
+        "troubleshootingTitle": "故障排除",
+        "issueCache": {
+          "title": "插件未加载",
+          "fix": "清空插件缓存：`rm -rf ~/.cache/opencode/packages/opencode-chorus@latest`，然后重启 OpenCode。"
+        },
+        "issueEnv": {
+          "title": "环境变量未生效",
+          "fix": "确认启动 OpenCode 的 shell 已 export CHORUS_URL 和 CHORUS_API_KEY。如有需要，先 re-source 一下 shell rc。"
+        },
+        "issueCheckin": {
+          "title": "check-in 无响应",
+          "fix": "核对 CHORUS_API_KEY 是否有错字或多余空格。如果插件仍然加载失败，尝试升级 OpenCode。"
+        }
       },
       "openClaw": {
         "step1Title": "第 1 步：安装插件",

--- a/public/install-opencode.sh
+++ b/public/install-opencode.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Chorus + OpenCode one-shot plugin installer
+#
+# Usage:
+#   curl -fsSL https://<your-chorus>/install-opencode.sh | bash
+#
+# What this does (idempotent, safe to re-run):
+#   1. Verifies `opencode` CLI is installed.
+#   2. Adds "opencode-chorus" to the `plugin` array in
+#      ~/.config/opencode/opencode.json. Creates the file if missing.
+#      Preserves any existing plugins.
+#   3. Sets file permissions to 600.
+#
+# What this does NOT do:
+#   - Write to ~/.bashrc / ~/.zshrc. You must export CHORUS_URL and
+#     CHORUS_API_KEY yourself before launching opencode (the plugin reads
+#     process.env on startup).
+#   - Invoke jq / node / python. Pure POSIX awk/sed/grep only.
+
+set -euo pipefail
+
+# ---------- cosmetics ----------
+BOLD=$'\033[1m'; DIM=$'\033[2m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'; RESET=$'\033[0m'
+ok()   { printf "${GREEN}\xe2\x9c\x93${RESET} %s\n" "$*"; }
+warn() { printf "${YELLOW}!${RESET} %s\n" "$*" >&2; }
+die()  { printf "${RED}\xe2\x9c\x97${RESET} %s\n" "$*" >&2; exit 1; }
+hdr()  { printf "\n${BOLD}%s${RESET}\n" "$*"; }
+
+# ---------- config ----------
+PLUGIN_NAME="opencode-chorus"
+CONFIG_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CONFIG_FILE="$CONFIG_DIR/opencode.json"
+BACKUP_FILE="$CONFIG_FILE.chorus-bak"
+
+# ---------- step 1: check opencode ----------
+hdr "1/3  Checking OpenCode CLI"
+if command -v opencode >/dev/null 2>&1; then
+  ok "Found $(opencode --version 2>/dev/null | head -1)"
+else
+  warn "opencode not found in PATH — install it first: https://opencode.ai/docs/"
+  warn "Proceeding to write the config anyway. OpenCode will pick it up on install."
+fi
+
+# ---------- step 2: ensure config dir ----------
+hdr "2/3  Updating $CONFIG_FILE"
+mkdir -p "$CONFIG_DIR"
+
+# Helper: print the manual instructions and exit 0 (non-fatal).
+print_manual_hint() {
+  warn "Could not automatically update $CONFIG_FILE."
+  warn "Please add \"$PLUGIN_NAME\" to the \"plugin\" array manually:"
+  cat >&2 <<HINT
+
+  {
+    "\$schema": "https://opencode.ai/config.json",
+    "plugin": ["$PLUGIN_NAME"${EXISTING_PLUGIN_HINT:-}]
+    ...
+  }
+
+HINT
+  exit 0
+}
+
+# ---------- Case A: file does not exist ----------
+if [ ! -f "$CONFIG_FILE" ]; then
+  cat > "$CONFIG_FILE" <<JSON
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "plugin": ["$PLUGIN_NAME"]
+}
+JSON
+  chmod 600 "$CONFIG_FILE"
+  ok "Created $CONFIG_FILE with $PLUGIN_NAME"
+else
+  # File exists — back it up once.
+  if [ ! -f "$BACKUP_FILE" ]; then
+    cp "$CONFIG_FILE" "$BACKUP_FILE"
+    chmod 600 "$BACKUP_FILE"
+    ok "Backed up original config to $BACKUP_FILE"
+  fi
+
+  # Reject JSONC (comments). Presence of // or /* strongly suggests the file
+  # is hand-edited JSONC; our line-based awk would mangle it. Bail cleanly.
+  if grep -qE '^[[:space:]]*//|/\*' "$CONFIG_FILE"; then
+    warn "Detected // or /* in $CONFIG_FILE — looks like JSONC with comments."
+    print_manual_hint
+  fi
+
+  # Case C1: plugin array already contains opencode-chorus → no-op.
+  # grep matches both "opencode-chorus" in a plugin entry and other strings;
+  # to be specific we look for the quoted token.
+  if grep -q "\"$PLUGIN_NAME\"" "$CONFIG_FILE"; then
+    ok "$PLUGIN_NAME already present in $CONFIG_FILE — nothing to do"
+  else
+    # Decide: Case B (no plugin key) vs Case C2 (plugin key exists without this plugin).
+    if grep -qE '"plugin"[[:space:]]*:' "$CONFIG_FILE"; then
+      # Case C2: insert into existing plugin array.
+      # Strategy: find the first "plugin" key, locate its array bracket pair,
+      # insert "opencode-chorus" before the closing ].
+      #
+      # Only handle the common cases where the array is on a single line or
+      # a multi-line array that has one entry per line. Otherwise bail to hint.
+      tmp="$(mktemp "${TMPDIR:-/tmp}/chorus-opencode.XXXXXX")"
+      if awk -v plugin="$PLUGIN_NAME" '
+        BEGIN { done = 0 }
+        # Single-line empty array: "plugin": []
+        !done && /"plugin"[[:space:]]*:[[:space:]]*\[[[:space:]]*\]/ {
+          sub(/\[[[:space:]]*\]/, "[\"" plugin "\"]")
+          done = 1
+          print
+          next
+        }
+        # Single-line non-empty array: "plugin": [ "foo", "bar" ]
+        !done && match($0, /"plugin"[[:space:]]*:[[:space:]]*\[[^\]]*\]/) {
+          line = $0
+          pre  = substr(line, 1, RSTART - 1)
+          match_text = substr(line, RSTART, RLENGTH)
+          post = substr(line, RSTART + RLENGTH)
+          # Insert before the closing ]
+          sub(/\][[:space:]]*$/, ", \"" plugin "\"]", match_text)
+          # If the match still ends in ] (no trailing whitespace stripped), fall through
+          print pre match_text post
+          done = 1
+          next
+        }
+        # Multi-line array opener: "plugin": [ (and not on same line closer)
+        !done && /"plugin"[[:space:]]*:[[:space:]]*\[[[:space:]]*$/ {
+          print
+          getline nextline
+          # Empty multi-line array: next line is just ]
+          if (nextline ~ /^[[:space:]]*\][[:space:]]*,?[[:space:]]*$/) {
+            print "    \"" plugin "\""
+            print nextline
+            done = 1
+            next
+          }
+          # Non-empty multi-line: emit entries verbatim until we hit the ]
+          buffer[++bn] = nextline
+          while ((getline nextline) > 0) {
+            if (nextline ~ /^[[:space:]]*\][[:space:]]*,?[[:space:]]*$/) {
+              # Last existing entry may not have trailing comma; add one.
+              last = buffer[bn]
+              if (last !~ /,[[:space:]]*$/) {
+                sub(/[[:space:]]*$/, ",", buffer[bn])
+              }
+              for (i = 1; i <= bn; i++) print buffer[i]
+              # Insert new entry before the closing ]
+              # Determine indentation from first buffered entry.
+              match(buffer[1], /^[[:space:]]*/)
+              indent = substr(buffer[1], 1, RLENGTH)
+              print indent "\"" plugin "\""
+              print nextline
+              done = 1
+              bn = 0
+              break
+            }
+            buffer[++bn] = nextline
+          }
+          next
+        }
+        { print }
+        END {
+          if (!done) exit 2
+        }
+      ' "$CONFIG_FILE" > "$tmp"; then
+        mv "$tmp" "$CONFIG_FILE"
+        chmod 600 "$CONFIG_FILE"
+        ok "Added $PLUGIN_NAME to existing \"plugin\" array"
+      else
+        rm -f "$tmp"
+        warn "The \"plugin\" key exists but I could not safely determine where to insert the new entry."
+        EXISTING_PLUGIN_HINT=", ...your existing entries..."
+        print_manual_hint
+      fi
+    else
+      # Case B: no plugin key in file → inject it.
+      # We look for the first top-level "{" then insert `"plugin": [...]` on the next line.
+      # Safer: look for the first line containing just "{" optionally with whitespace.
+      tmp="$(mktemp "${TMPDIR:-/tmp}/chorus-opencode.XXXXXX")"
+      if awk -v plugin="$PLUGIN_NAME" '
+        BEGIN { inserted = 0 }
+        !inserted && /^[[:space:]]*\{[[:space:]]*$/ {
+          print
+          print "  \"plugin\": [\"" plugin "\"],"
+          inserted = 1
+          next
+        }
+        { print }
+        END { if (!inserted) exit 2 }
+      ' "$CONFIG_FILE" > "$tmp"; then
+        mv "$tmp" "$CONFIG_FILE"
+        chmod 600 "$CONFIG_FILE"
+        ok "Added \"plugin\" field with $PLUGIN_NAME to $CONFIG_FILE"
+      else
+        rm -f "$tmp"
+        warn "Could not find a line with just \"{\" to inject the plugin array."
+        print_manual_hint
+      fi
+    fi
+  fi
+fi
+
+# ---------- step 3: reminders ----------
+hdr "3/3  Final reminders"
+
+# Environment check — read-only warning, don't export.
+missing_env=""
+if [ -z "${CHORUS_URL:-}" ]; then
+  missing_env="$missing_env CHORUS_URL"
+fi
+if [ -z "${CHORUS_API_KEY:-}" ]; then
+  missing_env="$missing_env CHORUS_API_KEY"
+fi
+
+if [ -n "$missing_env" ]; then
+  warn "The following environment variables are not set in this shell:$missing_env"
+  warn "The plugin reads them on OpenCode startup. Please export them in your shell rc:"
+  cat >&2 <<'HINT'
+
+  export CHORUS_URL="https://<your-chorus-instance>"
+  export CHORUS_API_KEY="cho_..."
+
+HINT
+  warn "Then re-source your shell rc, or launch opencode from a shell where they are exported."
+else
+  ok "CHORUS_URL and CHORUS_API_KEY are set in this shell"
+fi
+
+hdr "Done."
+cat <<'NEXT'
+Start OpenCode — Bun will fetch opencode-chorus on first launch:
+
+  opencode
+
+Then in OpenCode, ask the agent:
+
+  check in to chorus
+
+If the plugin fails to load, clear the package cache and retry:
+
+  rm -rf ~/.cache/opencode/packages/opencode-chorus@latest
+
+To roll back this change:
+NEXT
+printf "  mv %s %s\n\n" "$BACKUP_FILE" "$CONFIG_FILE"

--- a/public/install-opencode.sh
+++ b/public/install-opencode.sh
@@ -87,9 +87,48 @@ else
   fi
 
   # Case C1: plugin array already contains opencode-chorus → no-op.
-  # grep matches both "opencode-chorus" in a plugin entry and other strings;
-  # to be specific we look for the quoted token.
-  if grep -q "\"$PLUGIN_NAME\"" "$CONFIG_FILE"; then
+  # Scope the check to the "plugin" array itself: a top-level occurrence of
+  # "opencode-chorus" outside that array (e.g. in a "lastInstalled" field)
+  # must not trigger the no-op shortcut.
+  plugin_contains_self() {
+    awk -v plugin="$PLUGIN_NAME" '
+      # Track whether we are currently inside the first "plugin" array.
+      # State machine:
+      #   0 = before the plugin key
+      #   1 = inside the plugin array (between its [ and matching ])
+      BEGIN { state = 0 }
+      state == 0 {
+        # Is the "plugin" key on this line?
+        if (match($0, /"plugin"[[:space:]]*:[[:space:]]*\[/)) {
+          # Consume the rest of the line starting at the [
+          rest = substr($0, RSTART + RLENGTH - 1)
+          state = 1
+          # Fall through to state == 1 handling for this rest.
+          $0 = rest
+        } else {
+          next
+        }
+      }
+      state == 1 {
+        # Look for the closing ] on this line (naive — good enough for
+        # standard JSON because plugin entries are plain strings).
+        close_pos = index($0, "]")
+        if (close_pos > 0) {
+          chunk = substr($0, 1, close_pos - 1)
+        } else {
+          chunk = $0
+        }
+        # Check for the quoted token inside the array chunk only.
+        if (index(chunk, "\"" plugin "\"") > 0) {
+          print "yes"
+          exit 0
+        }
+        if (close_pos > 0) exit 0
+      }
+    ' "$CONFIG_FILE"
+  }
+
+  if [ "$(plugin_contains_self)" = "yes" ]; then
     ok "$PLUGIN_NAME already present in $CONFIG_FILE — nothing to do"
   else
     # Decide: Case B (no plugin key) vs Case C2 (plugin key exists without this plugin).

--- a/src/app/onboarding/components/InstallGuideStep.tsx
+++ b/src/app/onboarding/components/InstallGuideStep.tsx
@@ -52,6 +52,9 @@ export function InstallGuideStep({ apiKey, onNext, onBack }: InstallGuideStepPro
               <TabsTrigger value="codex" className="flex-1">
                 {t("install.tabs.codex")}
               </TabsTrigger>
+              <TabsTrigger value="opencode" className="flex-1">
+                {t("install.tabs.opencode")}
+              </TabsTrigger>
               <TabsTrigger value="openclaw" className="flex-1">
                 {t("install.tabs.openClaw")}
               </TabsTrigger>
@@ -122,6 +125,80 @@ export function InstallGuideStep({ apiKey, onNext, onBack }: InstallGuideStepPro
                   {t("install.codex.step3Desc")}
                 </p>
               </div>
+            </TabsContent>
+
+            {/* OpenCode Tab */}
+            <TabsContent value="opencode" className="mt-4 space-y-4">
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-foreground">
+                  {t("install.opencode.step1Title")}
+                </h3>
+                <CodeBlock
+                  language="bash"
+                  code={`export CHORUS_URL="${origin}"\nexport CHORUS_API_KEY="${displayKey}"`}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {t("install.opencode.step1Tip")}
+                </p>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-foreground">
+                  {t("install.opencode.step2Title")}
+                </h3>
+                <CodeBlock
+                  language="bash"
+                  code={`curl -fsSL ${origin}/install-opencode.sh | bash`}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {t("install.opencode.step2Tip")}
+                </p>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-foreground">
+                  {t("install.opencode.step3Title")}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  {t("install.opencode.step3Desc")}
+                </p>
+              </div>
+
+              {/* Troubleshooting collapsible */}
+              <Collapsible>
+                <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
+                  <ChevronDown className="size-4 transition-transform duration-200 [[data-state=open]>&]:rotate-180" />
+                  {t("install.opencode.troubleshootingTitle")}
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="mt-2 space-y-2">
+                    <div className="rounded-md border border-amber-500/20 bg-amber-500/5 p-3">
+                      <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                        {t("install.opencode.issueCache.title")}
+                      </p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {t("install.opencode.issueCache.fix")}
+                      </p>
+                    </div>
+                    <div className="rounded-md border border-amber-500/20 bg-amber-500/5 p-3">
+                      <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                        {t("install.opencode.issueEnv.title")}
+                      </p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {t("install.opencode.issueEnv.fix")}
+                      </p>
+                    </div>
+                    <div className="rounded-md border border-amber-500/20 bg-amber-500/5 p-3">
+                      <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                        {t("install.opencode.issueCheckin.title")}
+                      </p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {t("install.opencode.issueCheckin.fix")}
+                      </p>
+                    </div>
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
             </TabsContent>
 
             {/* OpenClaw Tab */}


### PR DESCRIPTION
Closes #226

## Summary

- Adds a fifth **OpenCode** tab to the onboarding Install Guide between Codex and OpenClaw, giving users a one-shot path from API key → `check in to chorus` without reading external docs.
- Uses the community-maintained [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus) npm plugin (declared in `opencode.json`, fetched via Bun on first launch). Huge thanks to @etnperlong for building and maintaining this integration — this PR just wires his plugin into our onboarding flow.
- Ships a pure-POSIX installer (`install-opencode.sh`) that idempotently merges `"opencode-chorus"` into `~/.config/opencode/opencode.json` without touching the user's shell rc.

Chorus AI-DLC trace:
- Idea: [75650da5](http://localhost:8637/projects/51a8e042-75e1-4987-ba28-e6b12f25576e/ideas/75650da5-6455-48fd-b8fa-b1e6456711ad)
- Proposal: [6d78c350](http://localhost:8637/projects/51a8e042-75e1-4987-ba28-e6b12f25576e/proposals/6d78c350-7589-44c2-9ae4-d794a0b064c4) (5 tasks, all verified done)

## Changes

| File | Kind | Notes |
|------|------|-------|
| `public/install-opencode.sh` | new | Bash 3.2-compatible, no jq/node/python. 4 file-state cases + JSONC fallback. Backs up to `opencode.json.chorus-bak`. |
| `src/app/onboarding/components/InstallGuideStep.tsx` | modified | New `TabsTrigger` + `TabsContent` for `opencode`. Reuses `CodeBlock`, `Collapsible`, and lucide `ChevronDown`. |
| `messages/{en,zh}.json` | modified | +13 keys each under `onboarding.install.opencode.*` (step1-3, troubleshootingTitle, issueCache/issueEnv/issueCheckin.{title,fix}) plus `tabs.opencode`. |
| `docs/CONNECT_OPENCODE.{md,zh.md}` | new | Bilingual reference (intro, prereq, 3-step setup, troubleshooting, advanced `chorus.json` alternative). |
| `docs/design.pen` | modified | New frame **"Onboarding - Install Guide (OpenCode tab) (v0.7.0)"** at (4620, 11240). |

## Testing

- `npx tsc --noEmit` passes.
- `npx eslint src/app/onboarding/components/InstallGuideStep.tsx` passes (exit 0, no warnings).
- `pnpm test` — **75 test files, 1485 tests pass, 1 skipped** (unchanged from baseline).
- `install-opencode.sh` manually tested across 6 scenarios:
  1. No config file → creates minimal `opencode.json`
  2. Config with no `plugin` key → injects array after `{`
  3. Config with `plugin` key already containing `"opencode-chorus"` → no-op
  4. Config with `plugin: []` → replaces with `["opencode-chorus"]`
  5. Config with `plugin: ["foo-plugin"]` → appends
  6. Multi-line plugin array with 2 entries → buffers, patches trailing comma, inserts with matching indentation
  7. JSONC (file contains `//` comments) → prints manual hint, exits 0 without modifying
- JSON locale symmetry verified: 13 keys in each `opencode` namespace, `missing=[] extra=[]`.

## Key decisions

1. **`CHORUS_URL` is the root URL**, not the `/api/mcp` endpoint. Verified in `opencode-chorus@0.3.0` source (`config-loader.js:61-62`, `mcp-config.js:4-5`) — the plugin appends `/api/mcp` internally.
2. **No minimum OpenCode version claim.** Troubleshooting suggests upgrading if the plugin fails to load.
3. **Installer only merges `opencode.json`**; it does NOT write to shell rc. Users remain responsible for `export CHORUS_URL` and `export CHORUS_API_KEY`. This avoids collisions with existing `CHORUS_*` exports and keeps the script focused.
4. **No Chorus-owned OpenCode plugin.** Reuses the community `opencode-chorus` package; no `public/opencode-plugin/` bundled assets.

## Out of scope

- Modifying the Settings "Setup Guide" card (only the Onboarding entry point is updated).
- Documenting `~/.config/opencode/chorus.json` as the primary config path (mentioned in docs' Advanced section only).