### PR TITLE
refactor(my_assignments): align with checkin.ideaTracker via shared helper

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1142,7 +1142,7 @@ Time 1:00  - Cleanup runs, session deleted
 | `chorus_get_proposals` / `chorus_get_proposal` | List/get Proposals (including drafts) |
 | `chorus_list_tasks` / `chorus_get_task` | List/get Tasks |
 | `chorus_get_activity` | Project activity stream |
-| `chorus_get_my_assignments` | My claimed Ideas + Tasks |
+| `chorus_get_my_assignments` | Idea/task tracker grouped by project (same shape as `checkin.ideaTracker`) |
 | `chorus_get_available_ideas` | Claimable Ideas |
 | `chorus_get_available_tasks` | Claimable Tasks |
 | `chorus_get_unblocked_tasks` | Tasks with all dependencies completed (for scheduling) |

--- a/docs/ARCHITECTURE.zh.md
+++ b/docs/ARCHITECTURE.zh.md
@@ -1078,7 +1078,7 @@ Header: Authorization: Bearer {api_key}
 | `chorus_get_proposals` / `chorus_get_proposal` | 列出/获取 Proposals（含草稿） |
 | `chorus_list_tasks` / `chorus_get_task` | 列出/获取 Tasks |
 | `chorus_get_activity` | 项目活动流 |
-| `chorus_get_my_assignments` | 我认领的 Ideas + Tasks |
+| `chorus_get_my_assignments` | 按 project 分组的 idea/task tracker（与 `checkin.ideaTracker` 同构） |
 | `chorus_get_available_ideas` | 可认领的 Ideas |
 | `chorus_get_available_tasks` | 可认领的 Tasks |
 | `chorus_get_unblocked_tasks` | 依赖已全部完成的 Tasks（调度用） |

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -102,7 +102,7 @@ Agents can filter results by project(s) using HTTP headers during MCP connection
 
 The following tools respect project filtering:
 - `chorus_checkin` - Returns filtered assignments
-- `chorus_get_my_assignments` - Returns filtered ideas and tasks
+- `chorus_get_my_assignments` - Returns filtered idea/task tracker (grouped by project)
 
 ### Usage Example
 
@@ -388,22 +388,55 @@ Tools available to all Agents.
 
 ### chorus_get_my_assignments
 
-**Description**: Get all Ideas and Tasks assigned to the current Agent
+**Description**: Get the agent's idea/task tracker, grouped by project. Output is structurally identical to `chorus_checkin.ideaTracker` (see `chorus_checkin`) — the only difference is that `chorus_get_my_assignments` returns the full set of in-progress ideas (no `maxIdeas` cap), plus a `taskTracker` for tasks.
 
 **Project Filtering**: Results can be filtered by project using HTTP headers during MCP connection:
 - `X-Chorus-Project`: Single or multiple project UUIDs (comma-separated)
 - `X-Chorus-Project-Group`: Project group UUID (includes all projects in the group)
 - No header: Returns all projects (default behavior)
 
+**Filtering**: Excludes ideas with `status=closed` and ideas whose derived status is `done` (rolled-up completion based on linked proposals + tasks). Excludes tasks with `status` in `[done, closed]`.
+
 **Input**: None
 
 **Output**:
 ```json
 {
-  "ideas": [...],
-  "tasks": [...]
+  "ideaTracker": {
+    "<projectUuid>": {
+      "name": "Project Name",
+      "ideas": [
+        {
+          "uuid": "...",
+          "title": "...",
+          "status": "in_progress",
+          "proposals": 1,
+          "tasks": 3
+        }
+      ]
+    }
+  },
+  "taskTracker": {
+    "<projectUuid>": {
+      "name": "Project Name",
+      "tasks": [
+        {
+          "uuid": "...",
+          "title": "...",
+          "status": "in_progress",
+          "priority": "high",
+          "assignedAt": "2026-05-08T01:25:58.833Z",
+          "ac": { "passed": 2, "total": 5 }
+        }
+      ]
+    }
+  }
 }
 ```
+
+Each idea entry's `status` is the derived status (`todo` / `in_progress` / `human_conduct_required`); each task entry's `ac` reports admin-verified acceptance-criteria progress.
+
+> **BREAKING (0.7.2)**: prior to 0.7.2 this tool returned a flat `{ ideas: [], tasks: [] }`. The new shape aligns 1:1 with `chorus_checkin.ideaTracker`.
 
 ### chorus_get_available_ideas
 
@@ -1618,7 +1651,7 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 | 7 | chorus_get_available_ideas | Get claimable Ideas | ✅ Pass | |
 | 8 | chorus_claim_idea | Claim Idea | ✅ Pass | open → elaborating |
 | 9 | chorus_update_idea_status | Update Idea status | ✅ Pass | (status transitions) |
-| 10 | chorus_get_my_assignments | Get my assignments | ✅ Pass | ideas and tasks lists |
+| 10 | chorus_get_my_assignments | Get my assignments | ✅ Pass | ideaTracker + taskTracker grouped by project (0.7.2) |
 | 11 | chorus_add_comment (idea) | Comment on Idea | ✅ Pass | |
 | 12 | chorus_get_comments | Get comments list | ✅ Pass | |
 | 13 | chorus_pm_create_proposal | Create Proposal | ✅ Pass | Contains documentDrafts + taskDrafts, status=draft |

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -348,14 +348,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_my_assignments",
     {
-      description: "Get all Ideas and Tasks claimed by the current Agent",
+      description:
+        "Get the agent's idea/task tracker, grouped by project — same shape as checkin.ideaTracker. Returns { ideaTracker, taskTracker } where ideaTracker carries derivedStatus + proposal/task counts and taskTracker carries acceptance criteria progress.",
       inputSchema: z.object({}),
     },
     async () => {
-      const { ideas, tasks } = await assignmentService.getMyAssignments(auth, auth.projectUuids);
+      const result = await assignmentService.getMyAssignments(auth, auth.projectUuids);
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ ideas, tasks }, null, 2) }],
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       };
     }
   );

--- a/src/services/__tests__/assignment.service.test.ts
+++ b/src/services/__tests__/assignment.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// ===== Prisma mock =====
+// ===== Prisma mock (used by getAvailableItems only) =====
 const mockPrisma = vi.hoisted(() => ({
   idea: {
     findMany: vi.fn(),
@@ -11,11 +11,17 @@ const mockPrisma = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
-const mockFormatAssignee = vi.fn();
 const mockFormatCreatedBy = vi.fn();
 vi.mock("@/lib/uuid-resolver", () => ({
-  formatAssignee: (...args: unknown[]) => mockFormatAssignee(...args),
   formatCreatedBy: (...args: unknown[]) => mockFormatCreatedBy(...args),
+}));
+
+// ===== idea-tracker.service mock (used by getMyAssignments) =====
+const mockBuildIdeaTracker = vi.hoisted(() => vi.fn());
+const mockBuildTaskTracker = vi.hoisted(() => vi.fn());
+vi.mock("@/services/idea-tracker.service", () => ({
+  buildIdeaTracker: mockBuildIdeaTracker,
+  buildTaskTracker: mockBuildTaskTracker,
 }));
 
 import { getMyAssignments, getAvailableItems } from "@/services/assignment.service";
@@ -34,14 +40,9 @@ function makeIdea(overrides: Record<string, unknown> = {}) {
     uuid: "idea-0000-0000-0000-000000000001",
     title: "Test Idea",
     content: "Idea content",
-    status: "claimed",
-    assigneeType: "user",
-    assigneeUuid: userUuid,
-    assignedAt: now,
-    project: { uuid: projectUuid, name: "Test Project" },
-    createdAt: now,
-    updatedAt: now,
+    status: "open",
     createdByUuid: userUuid,
+    createdAt: now,
     ...overrides,
   };
 }
@@ -51,90 +52,67 @@ function makeTask(overrides: Record<string, unknown> = {}) {
     uuid: "task-0000-0000-0000-000000000001",
     title: "Test Task",
     description: "Task description",
-    status: "assigned",
+    status: "open",
     priority: "high",
-    assigneeType: "user",
-    assigneeUuid: userUuid,
-    assignedAt: now,
-    project: { uuid: projectUuid, name: "Test Project" },
-    createdAt: now,
-    updatedAt: now,
     createdByUuid: userUuid,
+    createdAt: now,
     ...overrides,
   };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockFormatAssignee.mockResolvedValue({
-    type: "user",
-    uuid: userUuid,
-    name: "Test User",
-  });
   mockFormatCreatedBy.mockResolvedValue({
     type: "user",
     uuid: userUuid,
     name: "Test User",
   });
+  mockBuildIdeaTracker.mockResolvedValue({});
+  mockBuildTaskTracker.mockResolvedValue({});
 });
 
 // ===== getMyAssignments =====
 describe("getMyAssignments", () => {
-  it("should return user's claimed ideas and tasks", async () => {
+  it("returns { ideaTracker, taskTracker } shaped result", async () => {
     const userAuth: AuthContext = {
       type: "user",
       companyUuid,
       actorUuid: userUuid,
     };
 
-    const idea = makeIdea();
-    const task = makeTask();
+    const ideaTracker = {
+      [projectUuid]: {
+        name: "Test Project",
+        ideas: [
+          { uuid: "i1", title: "I1", status: "in_progress" as const, proposals: 1, tasks: 2 },
+        ],
+      },
+    };
+    const taskTracker = {
+      [projectUuid]: {
+        name: "Test Project",
+        tasks: [
+          {
+            uuid: "t1",
+            title: "T1",
+            status: "assigned",
+            priority: "high",
+            assignedAt: now.toISOString(),
+            ac: { passed: 1, total: 3 },
+          },
+        ],
+      },
+    };
 
-    mockPrisma.idea.findMany.mockResolvedValue([idea]);
-    mockPrisma.task.findMany.mockResolvedValue([task]);
+    mockBuildIdeaTracker.mockResolvedValue(ideaTracker);
+    mockBuildTaskTracker.mockResolvedValue(taskTracker);
 
     const result = await getMyAssignments(userAuth);
 
-    expect(result.ideas).toHaveLength(1);
-    expect(result.tasks).toHaveLength(1);
-    expect(result.ideas[0].uuid).toBe(idea.uuid);
-    expect(result.tasks[0].uuid).toBe(task.uuid);
+    expect(result).toEqual({ ideaTracker, taskTracker });
   });
 
-  it("should query with user assignment condition", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-          status: { notIn: ["completed", "closed"] },
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-          status: { notIn: ["done", "closed"] },
-        }),
-      })
-    );
-  });
-
-  it("should query with agent assignment conditions (agent + owner)", async () => {
+  it("delegates to buildIdeaTracker / buildTaskTracker with auth", async () => {
     const agentAuth: AuthContext = {
       type: "agent",
       companyUuid,
@@ -143,229 +121,13 @@ describe("getMyAssignments", () => {
       ownerUuid,
     };
 
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
     await getMyAssignments(agentAuth);
 
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [
-            { assigneeType: "agent", assigneeUuid: agentUuid },
-            { assigneeType: "user", assigneeUuid: ownerUuid },
-          ],
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [
-            { assigneeType: "agent", assigneeUuid: agentUuid },
-            { assigneeType: "user", assigneeUuid: ownerUuid },
-          ],
-        }),
-      })
-    );
+    expect(mockBuildIdeaTracker).toHaveBeenCalledWith(agentAuth, { projectUuids: undefined });
+    expect(mockBuildTaskTracker).toHaveBeenCalledWith(agentAuth, { projectUuids: undefined });
   });
 
-  it("should exclude completed ideas and done tasks", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          status: { notIn: ["completed", "closed"] },
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          status: { notIn: ["done", "closed"] },
-        }),
-      })
-    );
-  });
-
-  it("should format ideas with assignee info", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    const idea = makeIdea();
-    mockPrisma.idea.findMany.mockResolvedValue([idea]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    mockFormatAssignee.mockResolvedValue({
-      type: "user",
-      uuid: userUuid,
-      name: "John Doe",
-    });
-
-    const result = await getMyAssignments(userAuth);
-
-    expect(result.ideas[0].assignee).toEqual({
-      type: "user",
-      uuid: userUuid,
-      name: "John Doe",
-    });
-    expect(mockFormatAssignee).toHaveBeenCalledWith("user", userUuid);
-  });
-
-  it("should format tasks with assignee info", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    const task = makeTask();
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([task]);
-
-    mockFormatAssignee.mockResolvedValue({
-      type: "agent",
-      uuid: agentUuid,
-      name: "Bot Agent",
-    });
-
-    const result = await getMyAssignments(userAuth);
-
-    expect(result.tasks[0].assignee).toEqual({
-      type: "agent",
-      uuid: agentUuid,
-      name: "Bot Agent",
-    });
-  });
-
-  it("should return ISO date strings for timestamps", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    const idea = makeIdea();
-    const task = makeTask();
-    mockPrisma.idea.findMany.mockResolvedValue([idea]);
-    mockPrisma.task.findMany.mockResolvedValue([task]);
-
-    const result = await getMyAssignments(userAuth);
-
-    expect(result.ideas[0].createdAt).toBe(now.toISOString());
-    expect(result.ideas[0].assignedAt).toBe(now.toISOString());
-    expect(result.tasks[0].createdAt).toBe(now.toISOString());
-    expect(result.tasks[0].assignedAt).toBe(now.toISOString());
-  });
-
-  it("should order ideas by assignedAt desc", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orderBy: { assignedAt: "desc" },
-      })
-    );
-  });
-
-  it("should order tasks by priority desc, then assignedAt desc", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
-      })
-    );
-  });
-
-  it("should filter by projectUuids when provided", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth, [projectUuid]);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
-  });
-
-  it("should not filter by projectUuids when not provided", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    const ideaWhere = mockPrisma.idea.findMany.mock.calls[0][0].where;
-    const taskWhere = mockPrisma.task.findMany.mock.calls[0][0].where;
-
-    expect(ideaWhere).not.toHaveProperty("projectUuid");
-    expect(taskWhere).not.toHaveProperty("projectUuid");
-  });
-
-  it("should filter by multiple projectUuids", async () => {
+  it("forwards projectUuids when provided", async () => {
     const userAuth: AuthContext = {
       type: "user",
       companyUuid,
@@ -374,38 +136,65 @@ describe("getMyAssignments", () => {
 
     const projectUuid2 = "project-0000-0000-0000-000000000002";
 
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
     await getMyAssignments(userAuth, [projectUuid, projectUuid2]);
 
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid, projectUuid2] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
+    expect(mockBuildIdeaTracker).toHaveBeenCalledWith(userAuth, {
+      projectUuids: [projectUuid, projectUuid2],
+    });
+    expect(mockBuildTaskTracker).toHaveBeenCalledWith(userAuth, {
+      projectUuids: [projectUuid, projectUuid2],
+    });
+  });
 
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid, projectUuid2] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
+  it("invokes both helpers in parallel (Promise.all)", async () => {
+    const userAuth: AuthContext = {
+      type: "user",
+      companyUuid,
+      actorUuid: userUuid,
+    };
+
+    // Configure each mock to resolve after a microtask delay so we can detect
+    // that the result waits for both — i.e. neither call is sequential.
+    let ideaResolved = false;
+    let taskResolved = false;
+    mockBuildIdeaTracker.mockImplementation(async () => {
+      ideaResolved = true;
+      return {};
+    });
+    mockBuildTaskTracker.mockImplementation(async () => {
+      taskResolved = true;
+      return {};
+    });
+
+    const result = await getMyAssignments(userAuth);
+
+    expect(ideaResolved).toBe(true);
+    expect(taskResolved).toBe(true);
+    expect(result).toEqual({ ideaTracker: {}, taskTracker: {} });
+  });
+
+  it("returns empty trackers when helpers return empty objects", async () => {
+    const userAuth: AuthContext = {
+      type: "user",
+      companyUuid,
+      actorUuid: userUuid,
+    };
+
+    mockBuildIdeaTracker.mockResolvedValue({});
+    mockBuildTaskTracker.mockResolvedValue({});
+
+    const result = await getMyAssignments(userAuth);
+
+    expect(result.ideaTracker).toEqual({});
+    expect(result.taskTracker).toEqual({});
   });
 });
 
-// ===== getAvailableItems =====
+// ===== getAvailableItems (unchanged in 0.7.2) =====
 describe("getAvailableItems", () => {
   it("should return available ideas and tasks when both allowed", async () => {
-    const idea = makeIdea({ status: "open", assigneeType: null, assigneeUuid: null });
-    const task = makeTask({ status: "open", assigneeType: null, assigneeUuid: null });
+    const idea = makeIdea();
+    const task = makeTask();
 
     mockPrisma.idea.findMany.mockResolvedValue([idea]);
     mockPrisma.task.findMany.mockResolvedValue([task]);

--- a/src/services/__tests__/idea-tracker.service.test.ts
+++ b/src/services/__tests__/idea-tracker.service.test.ts
@@ -1,0 +1,607 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Prisma mock (hoisted) =====
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    idea: { findMany: vi.fn() },
+    proposal: { findMany: vi.fn() },
+    task: { findMany: vi.fn() },
+    project: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+import { buildIdeaTracker, buildTaskTracker } from "@/services/idea-tracker.service";
+import type { AuthContext } from "@/types/auth";
+
+// ===== Fixtures =====
+const COMPANY_UUID = "company-1111-1111-1111-111111111111";
+const AGENT_UUID = "agent-2222-2222-2222-222222222222";
+const OWNER_UUID = "owner-3333-3333-3333-333333333333";
+const OTHER_USER_UUID = "user-9999-9999-9999-999999999999";
+const PROJECT_A = "project-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PROJECT_B = "project-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const now = new Date("2026-05-01T10:00:00Z");
+
+const agentAuth: AuthContext = {
+  type: "agent",
+  companyUuid: COMPANY_UUID,
+  actorUuid: AGENT_UUID,
+  ownerUuid: OWNER_UUID,
+  roles: ["developer_agent"],
+};
+
+const userAuth: AuthContext = {
+  type: "user",
+  companyUuid: COMPANY_UUID,
+  actorUuid: OTHER_USER_UUID,
+};
+
+function makeIdea(
+  uuid: string,
+  projectUuid: string,
+  status: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    uuid,
+    title: `Idea ${uuid}`,
+    status,
+    elaborationStatus: null,
+    projectUuid,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeProposal(
+  uuid: string,
+  projectUuid: string,
+  status: string,
+  inputUuids: string[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    uuid,
+    projectUuid,
+    status,
+    inputType: "idea",
+    inputUuids,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.idea.findMany.mockResolvedValue([]);
+  mockPrisma.proposal.findMany.mockResolvedValue([]);
+  mockPrisma.task.findMany.mockResolvedValue([]);
+  mockPrisma.project.findMany.mockResolvedValue([]);
+});
+
+// ============================================================
+// buildIdeaTracker
+// ============================================================
+
+describe("buildIdeaTracker — assignee conditions", () => {
+  it("agent without owner: only matches agent.actorUuid", async () => {
+    const noOwnerAuth: AuthContext = {
+      type: "agent",
+      companyUuid: COMPANY_UUID,
+      actorUuid: AGENT_UUID,
+      roles: ["developer_agent"],
+    };
+
+    await buildIdeaTracker(noOwnerAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ assigneeType: "agent", assigneeUuid: AGENT_UUID }],
+        }),
+      }),
+    );
+  });
+
+  it("agent with owner: matches both agent and owner-as-user", async () => {
+    await buildIdeaTracker(agentAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { assigneeType: "agent", assigneeUuid: AGENT_UUID },
+            { assigneeType: "user", assigneeUuid: OWNER_UUID },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("user auth: only matches user.actorUuid", async () => {
+    await buildIdeaTracker(userAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ assigneeType: "user", assigneeUuid: OTHER_USER_UUID }],
+        }),
+      }),
+    );
+  });
+});
+
+describe("buildIdeaTracker — filters", () => {
+  it("excludes status=closed at the DB layer", async () => {
+    await buildIdeaTracker(agentAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { not: "closed" },
+        }),
+      }),
+    );
+  });
+
+  it("filters out ideas whose derivedStatus === done (all tasks done)", async () => {
+    const proposalUuid = "proposal-done";
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal(proposalUuid, PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid, status: "done" },
+      { proposalUuid, status: "closed" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker).toEqual({});
+  });
+
+  it("returns empty object when there are no ideas at all", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([]);
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker).toEqual({});
+    expect(mockPrisma.proposal.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildIdeaTracker — derivedStatus mapping", () => {
+  it("status=open maps to derivedStatus=todo", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("todo");
+  });
+
+  it("status=elaborating + pending_answers maps to human_conduct_required", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborating", { elaborationStatus: "pending_answers" }),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("human_conduct_required");
+  });
+
+  it("status=elaborated + pending proposal maps to human_conduct_required", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "pending", ["i1"]),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("human_conduct_required");
+  });
+
+  it("status=elaborated + approved proposal + tasks in progress maps to in_progress", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p1", status: "in_progress" },
+      { proposalUuid: "p1", status: "open" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("in_progress");
+  });
+
+  it("status=elaborated + approved proposal + a task in to_verify -> human_conduct_required", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p1", status: "to_verify" },
+      { proposalUuid: "p1", status: "done" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("human_conduct_required");
+  });
+});
+
+describe("buildIdeaTracker — proposal/task counts", () => {
+  it("proposals counts both pending and approved attached to the idea", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "pending", ["i1"]),
+      makeProposal("p2", PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p2", status: "in_progress" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].proposals).toBe(2);
+    expect(tracker[PROJECT_A].ideas[0].tasks).toBe(1);
+  });
+
+  it("tasks count is based on the most-recently-approved proposal only", async () => {
+    const old = new Date("2026-04-01T00:00:00Z");
+    const recent = new Date("2026-04-15T00:00:00Z");
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p_old", PROJECT_A, "approved", ["i1"], { createdAt: old }),
+      makeProposal("p_recent", PROJECT_A, "approved", ["i1"], { createdAt: recent }),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      // p_old has 5 tasks (irrelevant)
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      // p_recent has 2 tasks (counted)
+      { proposalUuid: "p_recent", status: "in_progress" },
+      { proposalUuid: "p_recent", status: "open" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    // task query is filtered by approvedProposalUuids — implementation will fetch
+    // tasks for both p_old and p_recent, but only p_recent's count is reported.
+    expect(tracker[PROJECT_A].ideas[0].tasks).toBe(2);
+  });
+
+  it("ignores proposals with non-array inputUuids gracefully", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      // malformed inputUuids — should be skipped
+      { ...makeProposal("p1", PROJECT_A, "approved", []), inputUuids: null },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].proposals).toBe(0);
+    expect(tracker[PROJECT_A].ideas[0].tasks).toBe(0);
+  });
+
+  it("ignores proposal entries that don't reference any of the agent's ideas", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "approved", ["unrelated-idea-uuid"]),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].proposals).toBe(0);
+  });
+});
+
+describe("buildIdeaTracker — grouping & ordering & options", () => {
+  it("groups ideas by project and uses project.name", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "open"),
+      makeIdea("i2", PROJECT_B, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([
+      { uuid: PROJECT_A, name: "A" },
+      { uuid: PROJECT_B, name: "B" },
+    ]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("A");
+    expect(tracker[PROJECT_A].ideas).toHaveLength(1);
+    expect(tracker[PROJECT_B].name).toBe("B");
+    expect(tracker[PROJECT_B].ideas).toHaveLength(1);
+  });
+
+  it("falls back to empty string when project name is missing", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([]); // no project rows
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("");
+  });
+
+  it("orderBy updatedAt desc is requested at the prisma layer", async () => {
+    await buildIdeaTracker(agentAuth);
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { updatedAt: "desc" } }),
+    );
+  });
+
+  it("respects options.maxIdeas cap (keeps the first N visited, which are most recent)", async () => {
+    const ideas = Array.from({ length: 5 }, (_, i) =>
+      makeIdea(`i${i}`, PROJECT_A, "open"),
+    );
+    mockPrisma.idea.findMany.mockResolvedValue(ideas);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth, { maxIdeas: 3 });
+    expect(tracker[PROJECT_A].ideas.map((i) => i.uuid)).toEqual(["i0", "i1", "i2"]);
+  });
+
+  it("default maxIdeas=Infinity returns the full set", async () => {
+    const ideas = Array.from({ length: 25 }, (_, i) =>
+      makeIdea(`i${i}`, PROJECT_A, "open"),
+    );
+    mockPrisma.idea.findMany.mockResolvedValue(ideas);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas).toHaveLength(25);
+  });
+
+  it("forwards options.projectUuids as a prisma 'in' filter", async () => {
+    await buildIdeaTracker(agentAuth, { projectUuids: [PROJECT_A] });
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ projectUuid: { in: [PROJECT_A] } }),
+      }),
+    );
+  });
+
+  it("does NOT add projectUuid filter when projectUuids is empty array", async () => {
+    await buildIdeaTracker(agentAuth, { projectUuids: [] });
+    const callArg = mockPrisma.idea.findMany.mock.calls[0][0];
+    expect(callArg.where).not.toHaveProperty("projectUuid");
+  });
+});
+
+// ============================================================
+// buildTaskTracker
+// ============================================================
+
+describe("buildTaskTracker — assignee conditions", () => {
+  it("agent with owner: matches both", async () => {
+    await buildTaskTracker(agentAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { assigneeType: "agent", assigneeUuid: AGENT_UUID },
+            { assigneeType: "user", assigneeUuid: OWNER_UUID },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("user auth: matches user only", async () => {
+    await buildTaskTracker(userAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ assigneeType: "user", assigneeUuid: OTHER_USER_UUID }],
+        }),
+      }),
+    );
+  });
+});
+
+describe("buildTaskTracker — filters & ordering", () => {
+  it("excludes status in [done, closed]", async () => {
+    await buildTaskTracker(agentAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { notIn: ["done", "closed"] },
+        }),
+      }),
+    );
+  });
+
+  it("orders by [priority desc, assignedAt desc]", async () => {
+    await buildTaskTracker(agentAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
+      }),
+    );
+  });
+
+  it("returns empty object when there are no tasks", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([]);
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker).toEqual({});
+  });
+
+  it("forwards options.projectUuids as a prisma 'in' filter", async () => {
+    await buildTaskTracker(agentAuth, { projectUuids: [PROJECT_A, PROJECT_B] });
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          projectUuid: { in: [PROJECT_A, PROJECT_B] },
+        }),
+      }),
+    );
+  });
+});
+
+describe("buildTaskTracker — ac progress", () => {
+  function makeTask(uuid: string, projectUuid: string, items: Array<{ status: string }>) {
+    return {
+      uuid,
+      title: `Task ${uuid}`,
+      status: "in_progress",
+      priority: "high",
+      assignedAt: now,
+      projectUuid,
+      project: { uuid: projectUuid, name: projectUuid === PROJECT_A ? "A" : "B" },
+      acceptanceCriteriaItems: items,
+    };
+  }
+
+  it("counts admin-verified passes only", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, [
+        { status: "passed" },
+        { status: "passed" },
+        { status: "failed" },
+        { status: "pending" },
+      ]),
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].ac).toEqual({ passed: 2, total: 4 });
+  });
+
+  it("returns ac:{0,0} when items array is empty", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, []),
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].ac).toEqual({ passed: 0, total: 0 });
+  });
+
+  it("returns ac:{0,0} when acceptanceCriteriaItems is missing entirely (null/undefined defensiveness)", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      {
+        ...makeTask("t1", PROJECT_A, []),
+        acceptanceCriteriaItems: null,
+      },
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].ac).toEqual({ passed: 0, total: 0 });
+  });
+
+  it("groups tasks by project and uses task.project.name", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, [{ status: "passed" }]),
+      makeTask("t2", PROJECT_B, [{ status: "pending" }]),
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("A");
+    expect(tracker[PROJECT_A].tasks).toHaveLength(1);
+    expect(tracker[PROJECT_B].name).toBe("B");
+    expect(tracker[PROJECT_B].tasks).toHaveLength(1);
+  });
+
+  it("includes assignedAt as ISO string and falls back to null", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, []),
+      { ...makeTask("t2", PROJECT_A, []), assignedAt: null },
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].assignedAt).toBe(now.toISOString());
+    expect(tracker[PROJECT_A].tasks[1].assignedAt).toBeNull();
+  });
+
+  it("falls back to empty string when task.project is missing", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      { ...makeTask("t1", PROJECT_A, []), project: null },
+    ]);
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("");
+  });
+});
+
+// ============================================================
+// Consistency: checkin vs my_assignments
+// ============================================================
+//
+// Both call buildIdeaTracker on the same auth + same prisma mock.
+// my_assignments calls with no maxIdeas (Infinity), checkin with maxIdeas:10.
+// The expected invariant: the my_assignments idea set is the same as the
+// checkin idea set when total <=10, and a strict superset when >10.
+
+describe("consistency: checkin.ideaTracker ⊆ my_assignments.ideaTracker", () => {
+  it("with 4 ideas (1 done, 1 closed): both surfaces return the same 2 ideas", async () => {
+    mockPrisma.idea.findMany.mockImplementation(async (args: { where: { status?: unknown } }) => {
+      // The DB layer filters status:{not:"closed"} — so "closed" never returns.
+      // We honor that filter in the mock by returning only the 3 non-closed ideas.
+      void args;
+      return [
+        makeIdea("i_in_progress", PROJECT_A, "elaborating", { elaborationStatus: "validated" }),
+        makeIdea("i_open", PROJECT_A, "open"),
+        // i_done has approved proposal where all tasks are done — should be filtered
+        makeIdea("i_done", PROJECT_A, "elaborated"),
+      ];
+    });
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p_done", PROJECT_A, "approved", ["i_done"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p_done", status: "done" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const myAssignments = await buildIdeaTracker(agentAuth);
+    const checkin = await buildIdeaTracker(agentAuth, { maxIdeas: 10 });
+
+    // Same uuid set
+    const myIds = (myAssignments[PROJECT_A]?.ideas ?? []).map((i) => i.uuid).sort();
+    const ckIds = (checkin[PROJECT_A]?.ideas ?? []).map((i) => i.uuid).sort();
+    expect(myIds).toEqual(["i_in_progress", "i_open"]);
+    expect(ckIds).toEqual(myIds);
+
+    // Same status / counts per idea
+    expect(myAssignments[PROJECT_A].ideas).toEqual(checkin[PROJECT_A].ideas);
+  });
+
+  it("with 12 active ideas: my_assignments returns all 12, checkin caps to 10", async () => {
+    const ideas = Array.from({ length: 12 }, (_, i) =>
+      makeIdea(`i${i}`, PROJECT_A, "open"),
+    );
+    mockPrisma.idea.findMany.mockResolvedValue(ideas);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const myAssignments = await buildIdeaTracker(agentAuth);
+    const checkin = await buildIdeaTracker(agentAuth, { maxIdeas: 10 });
+
+    expect(myAssignments[PROJECT_A].ideas).toHaveLength(12);
+    expect(checkin[PROJECT_A].ideas).toHaveLength(10);
+
+    // checkin set is a strict prefix (most-recent 10) of my_assignments
+    const myFirst10 = myAssignments[PROJECT_A].ideas.slice(0, 10).map((i) => i.uuid);
+    const ckIds = checkin[PROJECT_A].ideas.map((i) => i.uuid);
+    expect(ckIds).toEqual(myFirst10);
+  });
+});

--- a/src/services/assignment.service.ts
+++ b/src/services/assignment.service.ts
@@ -4,37 +4,15 @@
 
 import { prisma } from "@/lib/prisma";
 import type { AuthContext } from "@/types/auth";
-import { isAgent } from "@/lib/auth";
-import { formatAssignee, formatCreatedBy } from "@/lib/uuid-resolver";
+import { formatCreatedBy } from "@/lib/uuid-resolver";
+import {
+  buildIdeaTracker,
+  buildTaskTracker,
+  type IdeaTrackerProject,
+  type TaskTrackerProject,
+} from "@/services/idea-tracker.service";
 
 // ===== Type Definitions =====
-
-// Claimed Idea response format
-export interface AssignedIdeaResponse {
-  uuid: string;
-  title: string;
-  content: string | null;
-  status: string;
-  assignee: { type: string; uuid: string; name: string } | null;
-  assignedAt: string | null;
-  project: { uuid: string; name: string };
-  createdAt: string;
-  updatedAt: string;
-}
-
-// Claimed Task response format
-export interface AssignedTaskResponse {
-  uuid: string;
-  title: string;
-  description: string | null;
-  status: string;
-  priority: string;
-  assignee: { type: string; uuid: string; name: string } | null;
-  assignedAt: string | null;
-  project: { uuid: string; name: string };
-  createdAt: string;
-  updatedAt: string;
-}
 
 // Available Idea response format
 export interface AvailableIdeaResponse {
@@ -57,10 +35,12 @@ export interface AvailableTaskResponse {
   createdAt: string;
 }
 
-// My assignments response
+// My assignments response — 0.7.2: aligned with chorus_checkin.ideaTracker.
+// Idea data is grouped by project with derivedStatus + proposal/task counts.
+// Task data is similarly grouped, with admin-verified acceptance progress.
 export interface MyAssignmentsResponse {
-  ideas: AssignedIdeaResponse[];
-  tasks: AssignedTaskResponse[];
+  ideaTracker: Record<string, IdeaTrackerProject>;
+  taskTracker: Record<string, TaskTrackerProject>;
 }
 
 // Available items response
@@ -70,83 +50,6 @@ export interface AvailableItemsResponse {
 }
 
 // ===== Internal Helper Functions =====
-
-// Get assignment conditions for the current user/Agent
-function getAssignmentConditions(auth: AuthContext) {
-  const conditions: Array<{ assigneeType: string; assigneeUuid: string }> = [];
-
-  if (isAgent(auth)) {
-    // Directly claimed by Agent
-    conditions.push({ assigneeType: "agent", assigneeUuid: auth.actorUuid });
-    // Claimed by Agent's Owner ("Assign to myself")
-    if (auth.ownerUuid) {
-      conditions.push({ assigneeType: "user", assigneeUuid: auth.ownerUuid });
-    }
-  } else {
-    // Directly claimed by user
-    conditions.push({ assigneeType: "user", assigneeUuid: auth.actorUuid });
-  }
-
-  return conditions;
-}
-
-// Format claimed Idea
-async function formatAssignedIdea(idea: {
-  uuid: string;
-  title: string;
-  content: string | null;
-  status: string;
-  assigneeType: string | null;
-  assigneeUuid: string | null;
-  assignedAt: Date | null;
-  project: { uuid: string; name: string };
-  createdAt: Date;
-  updatedAt: Date;
-}): Promise<AssignedIdeaResponse> {
-  const assignee = await formatAssignee(idea.assigneeType, idea.assigneeUuid);
-
-  return {
-    uuid: idea.uuid,
-    title: idea.title,
-    content: idea.content,
-    status: idea.status,
-    assignee,
-    assignedAt: idea.assignedAt?.toISOString() ?? null,
-    project: idea.project,
-    createdAt: idea.createdAt.toISOString(),
-    updatedAt: idea.updatedAt.toISOString(),
-  };
-}
-
-// Format claimed Task
-async function formatAssignedTask(task: {
-  uuid: string;
-  title: string;
-  description: string | null;
-  status: string;
-  priority: string;
-  assigneeType: string | null;
-  assigneeUuid: string | null;
-  assignedAt: Date | null;
-  project: { uuid: string; name: string };
-  createdAt: Date;
-  updatedAt: Date;
-}): Promise<AssignedTaskResponse> {
-  const assignee = await formatAssignee(task.assigneeType, task.assigneeUuid);
-
-  return {
-    uuid: task.uuid,
-    title: task.title,
-    description: task.description,
-    status: task.status,
-    priority: task.priority,
-    assignee,
-    assignedAt: task.assignedAt?.toISOString() ?? null,
-    project: task.project,
-    createdAt: task.createdAt.toISOString(),
-    updatedAt: task.updatedAt.toISOString(),
-  };
-}
 
 // Format available Idea
 async function formatAvailableIdea(idea: {
@@ -194,67 +97,24 @@ async function formatAvailableTask(task: {
 
 // ===== Service Methods =====
 
-// Get my claimed Ideas + Tasks
+/**
+ * Get the agent's idea + task trackers, grouped by project. Aligned 1:1 with
+ * chorus_checkin.ideaTracker (no maxIdeas cap here — checkin returns at most
+ * 10 for compactness; my_assignments returns the full set).
+ *
+ * BREAKING (Chorus 0.7.2): the previous flat `{ ideas: [], tasks: [] }` shape
+ * is replaced by `{ ideaTracker, taskTracker }`.
+ */
 export async function getMyAssignments(
   auth: AuthContext,
   projectUuids?: string[],
 ): Promise<MyAssignmentsResponse> {
-  const conditions = getAssignmentConditions(auth);
-
-  const [rawIdeas, rawTasks] = await Promise.all([
-    // Get claimed Ideas
-    prisma.idea.findMany({
-      where: {
-        companyUuid: auth.companyUuid,
-        ...(projectUuids && projectUuids.length > 0 && { projectUuid: { in: projectUuids } }),
-        OR: conditions,
-        status: { notIn: ["completed", "closed"] },
-      },
-      select: {
-        uuid: true,
-        title: true,
-        content: true,
-        status: true,
-        assigneeType: true,
-        assigneeUuid: true,
-        assignedAt: true,
-        project: { select: { uuid: true, name: true } },
-        createdAt: true,
-        updatedAt: true,
-      },
-      orderBy: { assignedAt: "desc" },
-    }),
-    // Get claimed Tasks
-    prisma.task.findMany({
-      where: {
-        companyUuid: auth.companyUuid,
-        ...(projectUuids && projectUuids.length > 0 && { projectUuid: { in: projectUuids } }),
-        OR: conditions,
-        status: { notIn: ["done", "closed"] },
-      },
-      select: {
-        uuid: true,
-        title: true,
-        description: true,
-        status: true,
-        priority: true,
-        assigneeType: true,
-        assigneeUuid: true,
-        assignedAt: true,
-        project: { select: { uuid: true, name: true } },
-        createdAt: true,
-        updatedAt: true,
-      },
-      orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
-    }),
+  const [ideaTracker, taskTracker] = await Promise.all([
+    buildIdeaTracker(auth, { projectUuids }),
+    buildTaskTracker(auth, { projectUuids }),
   ]);
 
-  const [ideas, tasks] = await Promise.all([
-    Promise.all(rawIdeas.map(formatAssignedIdea)),
-    Promise.all(rawTasks.map(formatAssignedTask)),
-  ]);
-
-  return { ideas, tasks };
+  return { ideaTracker, taskTracker };
 }
 
 // Get available Ideas + Tasks in a project

--- a/src/services/checkin.service.ts
+++ b/src/services/checkin.service.ts
@@ -1,11 +1,12 @@
 // src/services/checkin.service.ts
 // Checkin service — builds the agent checkin response with ideaTracker + notifications.
-// Uses an agent-centric batch (3 queries + project-name lookup) to avoid per-project N+1.
+// The idea-tracker logic lives in idea-tracker.service so that chorus_get_my_assignments
+// stays in lockstep with checkin (see Chorus 0.7.2).
 
 import { prisma } from "@/lib/prisma";
 import type { AuthContext } from "@/types/auth";
-import { computeDerivedStatus } from "@/services/idea.service";
 import type { DerivedIdeaStatus } from "@/services/idea.service";
+import { buildIdeaTracker as buildIdeaTrackerService } from "@/services/idea-tracker.service";
 import * as notificationService from "@/services/notification.service";
 import {
   computeEffectivePermissions,
@@ -124,158 +125,10 @@ export async function buildCheckinResponse(auth: AuthContext): Promise<CheckinRe
   };
 }
 
-// ===== Idea tracker (agent-centric 3-query batch) =====
+// ===== Idea tracker (delegates to idea-tracker.service) =====
 
 async function buildIdeaTracker(auth: AuthContext): Promise<Record<string, CheckinProject>> {
-  // Q1: Ideas assigned to the agent OR to the agent's owner.
-  // Exclude legacy "closed" status (terminal) — elaborated/completed/etc. still flow to
-  // ideaTracker so the agent sees downstream proposal/task work.
-  const assigneeConditions: Array<{ assigneeType: string; assigneeUuid: string }> = [
-    { assigneeType: "agent", assigneeUuid: auth.actorUuid },
-  ];
-  if (auth.ownerUuid) {
-    assigneeConditions.push({ assigneeType: "user", assigneeUuid: auth.ownerUuid });
-  }
-
-  const rawIdeas = await prisma.idea.findMany({
-    where: {
-      companyUuid: auth.companyUuid,
-      OR: assigneeConditions,
-      status: { not: "closed" },
-    },
-    select: {
-      uuid: true,
-      title: true,
-      status: true,
-      elaborationStatus: true,
-      projectUuid: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-    orderBy: { updatedAt: "desc" },
-  });
-
-  if (rawIdeas.length === 0) return {};
-
-  const ideaUuidSet = new Set(rawIdeas.map((i) => i.uuid));
-  const projectUuidSet = new Set(rawIdeas.map((i) => i.projectUuid));
-  const projectUuids = [...projectUuidSet];
-
-  // Q2: Pending + approved proposals in those projects, filtered in-memory by inputUuids overlap.
-  // Scoping by projectUuid keeps the fetch small; JSON overlap filtering in Prisma is awkward.
-  const rawProposals = await prisma.proposal.findMany({
-    where: {
-      companyUuid: auth.companyUuid,
-      projectUuid: { in: projectUuids },
-      status: { in: ["pending", "approved"] },
-      inputType: "idea",
-    },
-    select: {
-      uuid: true,
-      status: true,
-      inputUuids: true,
-      createdAt: true,
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
-  // Map ideaUuid → { proposalCount, latestApproved, hasPending }
-  const ideaProposalCount = new Map<string, number>();
-  const ideaHasPending = new Set<string>();
-  const ideaLatestApproved = new Map<string, { uuid: string; createdAt: Date }>();
-
-  for (const proposal of rawProposals) {
-    const inputUuids = proposal.inputUuids as unknown;
-    if (!Array.isArray(inputUuids)) continue;
-    for (const ideaUuid of inputUuids) {
-      if (typeof ideaUuid !== "string" || !ideaUuidSet.has(ideaUuid)) continue;
-      ideaProposalCount.set(ideaUuid, (ideaProposalCount.get(ideaUuid) ?? 0) + 1);
-      if (proposal.status === "pending") {
-        ideaHasPending.add(ideaUuid);
-      } else if (proposal.status === "approved") {
-        const existing = ideaLatestApproved.get(ideaUuid);
-        if (!existing || proposal.createdAt > existing.createdAt) {
-          ideaLatestApproved.set(ideaUuid, { uuid: proposal.uuid, createdAt: proposal.createdAt });
-        }
-      }
-    }
-  }
-
-  const approvedProposalUuids = [
-    ...new Set([...ideaLatestApproved.values()].map((p) => p.uuid)),
-  ];
-
-  // Q3: Tasks on the approved proposals
-  const proposalToTaskStatuses = new Map<string, string[]>();
-  if (approvedProposalUuids.length > 0) {
-    const tasks = await prisma.task.findMany({
-      where: {
-        companyUuid: auth.companyUuid,
-        proposalUuid: { in: approvedProposalUuids },
-      },
-      select: { proposalUuid: true, status: true },
-    });
-
-    for (const task of tasks) {
-      if (!task.proposalUuid) continue;
-      const statuses = proposalToTaskStatuses.get(task.proposalUuid) ?? [];
-      statuses.push(task.status);
-      proposalToTaskStatuses.set(task.proposalUuid, statuses);
-    }
-  }
-
-  // Q4: Project names (only for projects that have surviving ideas)
-  const projects = await prisma.project.findMany({
-    where: {
-      companyUuid: auth.companyUuid,
-      uuid: { in: projectUuids },
-    },
-    select: { uuid: true, name: true },
-  });
-  const projectNames = new Map(projects.map((p) => [p.uuid, p.name]));
-
-  // Compute derivedStatus + group by project, filter out "done", cap at 10 ideas
-  const MAX_IDEAS = 10;
-  const tracker: Record<string, CheckinProject> = {};
-  let count = 0;
-
-  for (const idea of rawIdeas) {
-    if (count >= MAX_IDEAS) break;
-
-    const latestApproved = ideaLatestApproved.get(idea.uuid);
-    const taskStatuses = latestApproved
-      ? proposalToTaskStatuses.get(latestApproved.uuid) ?? []
-      : [];
-
-    const { derivedStatus } = computeDerivedStatus({
-      ideaStatus: idea.status,
-      elaborationStatus: idea.elaborationStatus,
-      hasPendingProposal: ideaHasPending.has(idea.uuid),
-      hasApprovedProposal: !!latestApproved,
-      taskStatuses,
-    });
-
-    if (derivedStatus === "done") continue;
-
-    const projectUuid = idea.projectUuid;
-    if (!tracker[projectUuid]) {
-      tracker[projectUuid] = {
-        name: projectNames.get(projectUuid) ?? "",
-        ideas: [],
-      };
-    }
-
-    tracker[projectUuid].ideas.push({
-      uuid: idea.uuid,
-      title: idea.title,
-      status: derivedStatus,
-      proposals: ideaProposalCount.get(idea.uuid) ?? 0,
-      tasks: taskStatuses.length,
-    });
-    count++;
-  }
-
-  return tracker;
+  return buildIdeaTrackerService(auth, { maxIdeas: 10 });
 }
 
 // ===== Notification summary (fetch 5 unread, mark read) =====

--- a/src/services/idea-tracker.service.ts
+++ b/src/services/idea-tracker.service.ts
@@ -1,0 +1,316 @@
+// src/services/idea-tracker.service.ts
+// Single source of truth for "what work is on this agent's plate" — used by
+// both chorus_checkin (capped) and chorus_get_my_assignments (full).
+//
+// Idea-tracker logic was originally inlined in checkin.service.ts; the assignment
+// service had a parallel, divergent implementation. Both now go through here so
+// the two surfaces cannot drift again (see Chorus 0.7.2 idea-tracker proposal).
+
+import { prisma } from "@/lib/prisma";
+import type { AuthContext } from "@/types/auth";
+import { computeDerivedStatus, type DerivedIdeaStatus } from "@/services/idea.service";
+
+// ===== Idea tracker types =====
+
+export interface IdeaTrackerEntry {
+  uuid: string;
+  title: string;
+  status: DerivedIdeaStatus;
+  proposals: number;
+  tasks: number;
+}
+
+export interface IdeaTrackerProject {
+  name: string;
+  ideas: IdeaTrackerEntry[];
+}
+
+export interface BuildIdeaTrackerOptions {
+  /** Restrict to specific project UUIDs. Empty/undefined = all projects. */
+  projectUuids?: string[];
+  /** Cap total ideas returned across projects. Default: Number.POSITIVE_INFINITY. */
+  maxIdeas?: number;
+}
+
+// ===== Task tracker types =====
+
+export interface TaskAcceptanceProgress {
+  passed: number;
+  total: number;
+}
+
+export interface TaskTrackerEntry {
+  uuid: string;
+  title: string;
+  status: string;
+  priority: string;
+  assignedAt: string | null;
+  ac: TaskAcceptanceProgress;
+}
+
+export interface TaskTrackerProject {
+  name: string;
+  tasks: TaskTrackerEntry[];
+}
+
+export interface BuildTaskTrackerOptions {
+  projectUuids?: string[];
+}
+
+// ===== Internal helpers =====
+
+// Assignee conditions for the current agent/user. For agents, also match the
+// owner-as-assignee path so "owner claims for themselves" shows up under the
+// agent's tracker too.
+function getAssigneeConditions(
+  auth: AuthContext,
+): Array<{ assigneeType: string; assigneeUuid: string }> {
+  const conditions: Array<{ assigneeType: string; assigneeUuid: string }> = [];
+  if (auth.type === "agent") {
+    conditions.push({ assigneeType: "agent", assigneeUuid: auth.actorUuid });
+    if (auth.ownerUuid) {
+      conditions.push({ assigneeType: "user", assigneeUuid: auth.ownerUuid });
+    }
+  } else {
+    conditions.push({ assigneeType: "user", assigneeUuid: auth.actorUuid });
+  }
+  return conditions;
+}
+
+// ===== Idea tracker =====
+
+/**
+ * Build the agent's idea tracker — assigned-to-me ideas grouped by project,
+ * each carrying derivedStatus + proposal/task counts.
+ *
+ * Filters: excludes status="closed" (terminal) and derivedStatus="done"
+ * (rolled-up completion of the proposal/task chain).
+ *
+ * Ordering: ideas are visited in `updatedAt desc` so the cap, when applied,
+ * keeps the most-recently-touched work.
+ *
+ * Query budget: 4 prisma calls (ideas → proposals → tasks → projects).
+ */
+export async function buildIdeaTracker(
+  auth: AuthContext,
+  options: BuildIdeaTrackerOptions = {},
+): Promise<Record<string, IdeaTrackerProject>> {
+  const maxIdeas = options.maxIdeas ?? Number.POSITIVE_INFINITY;
+  const projectFilter =
+    options.projectUuids && options.projectUuids.length > 0
+      ? { projectUuid: { in: options.projectUuids } }
+      : {};
+
+  // Q1: Ideas assigned to the agent OR to the agent's owner.
+  // Exclude legacy "closed" (terminal) — elaborated/completed/etc. still flow
+  // through so the agent sees downstream proposal/task work.
+  const rawIdeas = await prisma.idea.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      OR: getAssigneeConditions(auth),
+      status: { not: "closed" },
+      ...projectFilter,
+    },
+    select: {
+      uuid: true,
+      title: true,
+      status: true,
+      elaborationStatus: true,
+      projectUuid: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  if (rawIdeas.length === 0) return {};
+
+  const ideaUuidSet = new Set(rawIdeas.map((i) => i.uuid));
+  const projectUuids = [...new Set(rawIdeas.map((i) => i.projectUuid))];
+
+  // Q2: Pending + approved proposals in those projects, filtered in-memory by
+  // inputUuids overlap. Scoping by projectUuid keeps the fetch small; JSON
+  // overlap filtering in Prisma is awkward.
+  const rawProposals = await prisma.proposal.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      projectUuid: { in: projectUuids },
+      status: { in: ["pending", "approved"] },
+      inputType: "idea",
+    },
+    select: {
+      uuid: true,
+      status: true,
+      inputUuids: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const ideaProposalCount = new Map<string, number>();
+  const ideaHasPending = new Set<string>();
+  const ideaLatestApproved = new Map<string, { uuid: string; createdAt: Date }>();
+
+  for (const proposal of rawProposals) {
+    const inputUuids = proposal.inputUuids as unknown;
+    if (!Array.isArray(inputUuids)) continue;
+    for (const ideaUuid of inputUuids) {
+      if (typeof ideaUuid !== "string" || !ideaUuidSet.has(ideaUuid)) continue;
+      ideaProposalCount.set(ideaUuid, (ideaProposalCount.get(ideaUuid) ?? 0) + 1);
+      if (proposal.status === "pending") {
+        ideaHasPending.add(ideaUuid);
+      } else if (proposal.status === "approved") {
+        const existing = ideaLatestApproved.get(ideaUuid);
+        if (!existing || proposal.createdAt > existing.createdAt) {
+          ideaLatestApproved.set(ideaUuid, { uuid: proposal.uuid, createdAt: proposal.createdAt });
+        }
+      }
+    }
+  }
+
+  const approvedProposalUuids = [
+    ...new Set([...ideaLatestApproved.values()].map((p) => p.uuid)),
+  ];
+
+  // Q3: Tasks on the latest-approved proposals
+  const proposalToTaskStatuses = new Map<string, string[]>();
+  if (approvedProposalUuids.length > 0) {
+    const tasks = await prisma.task.findMany({
+      where: {
+        companyUuid: auth.companyUuid,
+        proposalUuid: { in: approvedProposalUuids },
+      },
+      select: { proposalUuid: true, status: true },
+    });
+    for (const task of tasks) {
+      if (!task.proposalUuid) continue;
+      const statuses = proposalToTaskStatuses.get(task.proposalUuid) ?? [];
+      statuses.push(task.status);
+      proposalToTaskStatuses.set(task.proposalUuid, statuses);
+    }
+  }
+
+  // Q4: Project names (only for projects that have surviving ideas)
+  const projects = await prisma.project.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      uuid: { in: projectUuids },
+    },
+    select: { uuid: true, name: true },
+  });
+  const projectNames = new Map(projects.map((p) => [p.uuid, p.name]));
+
+  const tracker: Record<string, IdeaTrackerProject> = {};
+  let count = 0;
+
+  for (const idea of rawIdeas) {
+    if (count >= maxIdeas) break;
+
+    const latestApproved = ideaLatestApproved.get(idea.uuid);
+    const taskStatuses = latestApproved
+      ? proposalToTaskStatuses.get(latestApproved.uuid) ?? []
+      : [];
+
+    const { derivedStatus } = computeDerivedStatus({
+      ideaStatus: idea.status,
+      elaborationStatus: idea.elaborationStatus,
+      hasPendingProposal: ideaHasPending.has(idea.uuid),
+      hasApprovedProposal: !!latestApproved,
+      taskStatuses,
+    });
+
+    if (derivedStatus === "done") continue;
+
+    const projectUuid = idea.projectUuid;
+    if (!tracker[projectUuid]) {
+      tracker[projectUuid] = {
+        name: projectNames.get(projectUuid) ?? "",
+        ideas: [],
+      };
+    }
+
+    tracker[projectUuid].ideas.push({
+      uuid: idea.uuid,
+      title: idea.title,
+      status: derivedStatus,
+      proposals: ideaProposalCount.get(idea.uuid) ?? 0,
+      tasks: taskStatuses.length,
+    });
+    count++;
+  }
+
+  return tracker;
+}
+
+// ===== Task tracker =====
+
+/**
+ * Build the agent's task tracker — assigned-to-me tasks grouped by project,
+ * each carrying admin-verified acceptance-criteria progress.
+ *
+ * Filters: excludes status in ["done","closed"].
+ *
+ * Ordering: [priority desc, assignedAt desc] — preserves the original
+ * getMyAssignments ordering so the BREAKING schema change does not also
+ * reshuffle the user's mental order.
+ *
+ * `ac.passed` counts admin-verified passes (`AcceptanceCriterion.status`),
+ * not dev self-checks. Tasks without acceptance items return {0,0}.
+ */
+export async function buildTaskTracker(
+  auth: AuthContext,
+  options: BuildTaskTrackerOptions = {},
+): Promise<Record<string, TaskTrackerProject>> {
+  const projectFilter =
+    options.projectUuids && options.projectUuids.length > 0
+      ? { projectUuid: { in: options.projectUuids } }
+      : {};
+
+  const rawTasks = await prisma.task.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      OR: getAssigneeConditions(auth),
+      status: { notIn: ["done", "closed"] },
+      ...projectFilter,
+    },
+    select: {
+      uuid: true,
+      title: true,
+      status: true,
+      priority: true,
+      assignedAt: true,
+      projectUuid: true,
+      project: { select: { uuid: true, name: true } },
+      acceptanceCriteriaItems: { select: { status: true } },
+    },
+    orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
+  });
+
+  if (rawTasks.length === 0) return {};
+
+  const tracker: Record<string, TaskTrackerProject> = {};
+
+  for (const task of rawTasks) {
+    const items = task.acceptanceCriteriaItems ?? [];
+    const passed = items.filter((i) => i.status === "passed").length;
+
+    const projectUuid = task.projectUuid;
+    if (!tracker[projectUuid]) {
+      tracker[projectUuid] = {
+        name: task.project?.name ?? "",
+        tasks: [],
+      };
+    }
+
+    tracker[projectUuid].tasks.push({
+      uuid: task.uuid,
+      title: task.title,
+      status: task.status,
+      priority: task.priority,
+      assignedAt: task.assignedAt?.toISOString() ?? null,
+      ac: { passed, total: items.length },
+    });
+  }
+
+  return tracker;
+}


### PR DESCRIPTION
## Summary

`chorus_get_my_assignments` and `chorus_checkin` both answer *"what's on this agent's plate"* but historically returned different shapes, used different idea status fields, and applied different completion filters — so the two surfaces drifted constantly.

Both now go through a single `idea-tracker.service` helper:

- **MCP `chorus_get_my_assignments`** and **`GET /api/me/assignments`** return `{ ideaTracker, taskTracker }` grouped by `projectUuid` — same shape as `chorus_checkin.ideaTracker`. **BREAKING:** old flat `{ ideas: [], tasks: [] }` is removed.
- **`chorus_checkin`** keeps its `maxIdeas:10` cap unchanged.
- **`chorus_get_my_assignments`** returns the full set, plus a `taskTracker` with admin-verified acceptance-criteria progress (`ac: { passed, total }`).

## Changed files

| File | Change |
|------|--------|
| `src/services/idea-tracker.service.ts` | **new** — `buildIdeaTracker` (migrated from checkin) + `buildTaskTracker` |
| `src/services/__tests__/idea-tracker.service.test.ts` | **new** — 36 tests, lines 99% / branches 94% on the SUT, includes consistency block (checkin ⊆ my_assignments) |
| `src/services/checkin.service.ts` | Inline ~150-line idea-tracker now a 1-line delegation; output JSON unchanged |
| `src/services/assignment.service.ts` | `getMyAssignments` rewritten; old `AssignedIdeaResponse` / formatters removed |
| `src/services/__tests__/assignment.service.test.ts` | Rewritten — mock point moved from prisma to `idea-tracker.service` |
| `src/mcp/tools/public.ts` | `chorus_get_my_assignments` description + return shape updated |
| `docs/MCP_TOOLS.md` | `chorus_get_my_assignments` section rewritten with new schema example + BREAKING note |
| `docs/ARCHITECTURE.md` / `ARCHITECTURE.zh.md` | Tool table descriptions updated |

`/api/me/assignments` route handler is unchanged — it just passes through `getMyAssignments`'s new return value.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 76 files / 1514 passed / 1 skipped / 0 failed
- [x] `pnpm test:coverage` — `idea-tracker.service.ts`: lines 99% / branches 94% / functions 100% / statements 100%
- [x] Live verification on local Chorus: `chorus_checkin.ideaTracker` and `chorus_get_my_assignments.ideaTracker` return the same first-9 projects in the same order; my_assignments is a strict superset (27 ideas vs checkin's 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)