### PR TITLE
release: merge develop into main (0.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/README.md
+++ b/README.md
@@ -320,6 +320,20 @@ Create API Keys in the Web UI under **Settings → Agents → Create API Key**. 
 | **Plugin-embedded** | `public/chorus-plugin/skills/chorus/` | Claude Code + Plugin, automated Sessions |
 | **Standalone** | `public/skill/` (served at `/skill/`) | Any Agent, manual Session management |
 
+### OpenSpec mode (opt-in, 0.8.0+)
+
+PM agents that have the [OpenSpec](https://github.com/Fission-AI/OpenSpec)
+CLI installed can author proposals in a structured `proposal.md` +
+`design.md` + `specs/<capability>/spec.md` layout. Local files are the
+working copy and Chorus `documentDrafts` are the mirror; reviewers see a
+predictable shape (`## ADDED Requirements`, `### Requirement:`,
+`#### Scenario:`) instead of free-form Markdown. The mode is opt-in: when
+`openspec` is not installed, behavior is unchanged. To turn it off
+explicitly, set `CHORUS_OPENSPEC_MODE=off`. No new MCP tools or schema
+changes ship in 0.8.0; the canonical skill reuses the existing
+`chorus_pm_*` draft and document tools. See
+[OPENSPEC_MODE.md](docs/OPENSPEC_MODE.md) for the full guide.
+
 ---
 
 ## Documentation
@@ -330,6 +344,7 @@ Create API Keys in the Web UI under **Settings → Agents → Create API Key**. 
 | [Architecture](docs/ARCHITECTURE.md) | Technical Architecture Document |
 | [MCP Tools](docs/MCP_TOOLS.md) | MCP Tools Reference |
 | [Chorus Plugin](docs/chorus-plugin.md) | Plugin Design & Hook Documentation |
+| [OpenSpec Mode](docs/OPENSPEC_MODE.md) | Opt-in OpenSpec authoring mode for PM agents (0.8.0+) |
 | [Search](docs/SEARCH.md) | Global Search Technical Design |
 | [AI-DLC Gap Analysis](docs/AIDLC_GAP_ANALYSIS.md) | AI-DLC Methodology Gap Analysis |
 | [AIG Implementation Plan](docs/CHORUS_AIG_PLAN.md) | Agent transparency roadmap |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1142,7 +1142,7 @@ Time 1:00  - Cleanup runs, session deleted
 | `chorus_get_proposals` / `chorus_get_proposal` | List/get Proposals (including drafts) |
 | `chorus_list_tasks` / `chorus_get_task` | List/get Tasks |
 | `chorus_get_activity` | Project activity stream |
-| `chorus_get_my_assignments` | My claimed Ideas + Tasks |
+| `chorus_get_my_assignments` | Idea/task tracker grouped by project (same shape as `checkin.ideaTracker`) |
 | `chorus_get_available_ideas` | Claimable Ideas |
 | `chorus_get_available_tasks` | Claimable Tasks |
 | `chorus_get_unblocked_tasks` | Tasks with all dependencies completed (for scheduling) |

--- a/docs/ARCHITECTURE.zh.md
+++ b/docs/ARCHITECTURE.zh.md
@@ -1078,7 +1078,7 @@ Header: Authorization: Bearer {api_key}
 | `chorus_get_proposals` / `chorus_get_proposal` | 列出/获取 Proposals（含草稿） |
 | `chorus_list_tasks` / `chorus_get_task` | 列出/获取 Tasks |
 | `chorus_get_activity` | 项目活动流 |
-| `chorus_get_my_assignments` | 我认领的 Ideas + Tasks |
+| `chorus_get_my_assignments` | 按 project 分组的 idea/task tracker（与 `checkin.ideaTracker` 同构） |
 | `chorus_get_available_ideas` | 可认领的 Ideas |
 | `chorus_get_available_tasks` | 可认领的 Tasks |
 | `chorus_get_unblocked_tasks` | 依赖已全部完成的 Tasks（调度用） |

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -102,7 +102,7 @@ Agents can filter results by project(s) using HTTP headers during MCP connection
 
 The following tools respect project filtering:
 - `chorus_checkin` - Returns filtered assignments
-- `chorus_get_my_assignments` - Returns filtered ideas and tasks
+- `chorus_get_my_assignments` - Returns filtered idea/task tracker (grouped by project)
 
 ### Usage Example
 
@@ -388,22 +388,55 @@ Tools available to all Agents.
 
 ### chorus_get_my_assignments
 
-**Description**: Get all Ideas and Tasks assigned to the current Agent
+**Description**: Get the agent's idea/task tracker, grouped by project. Output is structurally identical to `chorus_checkin.ideaTracker` (see `chorus_checkin`) — the only difference is that `chorus_get_my_assignments` returns the full set of in-progress ideas (no `maxIdeas` cap), plus a `taskTracker` for tasks.
 
 **Project Filtering**: Results can be filtered by project using HTTP headers during MCP connection:
 - `X-Chorus-Project`: Single or multiple project UUIDs (comma-separated)
 - `X-Chorus-Project-Group`: Project group UUID (includes all projects in the group)
 - No header: Returns all projects (default behavior)
 
+**Filtering**: Excludes ideas with `status=closed` and ideas whose derived status is `done` (rolled-up completion based on linked proposals + tasks). Excludes tasks with `status` in `[done, closed]`.
+
 **Input**: None
 
 **Output**:
 ```json
 {
-  "ideas": [...],
-  "tasks": [...]
+  "ideaTracker": {
+    "<projectUuid>": {
+      "name": "Project Name",
+      "ideas": [
+        {
+          "uuid": "...",
+          "title": "...",
+          "status": "in_progress",
+          "proposals": 1,
+          "tasks": 3
+        }
+      ]
+    }
+  },
+  "taskTracker": {
+    "<projectUuid>": {
+      "name": "Project Name",
+      "tasks": [
+        {
+          "uuid": "...",
+          "title": "...",
+          "status": "in_progress",
+          "priority": "high",
+          "assignedAt": "2026-05-08T01:25:58.833Z",
+          "ac": { "passed": 2, "total": 5 }
+        }
+      ]
+    }
+  }
 }
 ```
+
+Each idea entry's `status` is the derived status (`todo` / `in_progress` / `human_conduct_required`); each task entry's `ac` reports admin-verified acceptance-criteria progress.
+
+> **BREAKING (0.7.2)**: prior to 0.7.2 this tool returned a flat `{ ideas: [], tasks: [] }`. The new shape aligns 1:1 with `chorus_checkin.ideaTracker`.
 
 ### chorus_get_available_ideas
 
@@ -1618,7 +1651,7 @@ Therefore, after approval there is **no need** to manually call `chorus_pm_creat
 | 7 | chorus_get_available_ideas | Get claimable Ideas | ✅ Pass | |
 | 8 | chorus_claim_idea | Claim Idea | ✅ Pass | open → elaborating |
 | 9 | chorus_update_idea_status | Update Idea status | ✅ Pass | (status transitions) |
-| 10 | chorus_get_my_assignments | Get my assignments | ✅ Pass | ideas and tasks lists |
+| 10 | chorus_get_my_assignments | Get my assignments | ✅ Pass | ideaTracker + taskTracker grouped by project (0.7.2) |
 | 11 | chorus_add_comment (idea) | Comment on Idea | ✅ Pass | |
 | 12 | chorus_get_comments | Get comments list | ✅ Pass | |
 | 13 | chorus_pm_create_proposal | Create Proposal | ✅ Pass | Contains documentDrafts + taskDrafts, status=draft |

--- a/docs/OPENSPEC_MODE.md
+++ b/docs/OPENSPEC_MODE.md
@@ -1,0 +1,186 @@
+# OpenSpec Mode
+
+OpenSpec mode is an opt-in authoring style for Chorus PM agents. When the agent has the [`openspec`](https://github.com/Fission-AI/OpenSpec) CLI installed locally, the proposal-authoring flow switches from free-form Markdown to a structured `proposal.md` + `design.md` + `specs/<capability>/spec.md` layout that lives on disk and is mirrored into Chorus `documentDrafts` via the plugin's MCP wrapper script. The local files are the working copy; the Chorus drafts are a mirror that reviewers can read on the proposal page.
+
+This document is a user-facing summary. The authoritative behavior lives in two hand-maintained skill files:
+
+- **Claude Code plugin:** [`public/chorus-plugin/skills/openspec-aware/SKILL.md`](../public/chorus-plugin/skills/openspec-aware/SKILL.md) — uses `chorus-api.sh mcp-tool` as the wrapper.
+- **Codex plugin:** [`plugins/chorus/skills/openspec-aware/SKILL.md`](../plugins/chorus/skills/openspec-aware/SKILL.md) — uses `chorus-mcp-call.sh` (different invocation shape; no `mcp-tool` subcommand).
+
+The two skills carry the same core logic, but each is hand-edited to match its plugin's wrapper path, conventions, and host runtime. **There is no shared canonical file and no sync script.** When this guide diverges from a SKILL.md, the SKILL.md wins.
+
+OpenSpec mode is **not** available for the standalone `public/skill/` distribution — that channel ships no plugin wrappers, so the wrapper-driven mirror flow has no implementation there.
+
+---
+
+## What it does
+
+OpenSpec mode gives every spec draft on a Proposal a predictable shape: top-level delta blocks (`## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`, `## RENAMED Requirements`) containing `### Requirement:` entries with `SHALL` / `MUST` wording, and `#### Scenario:` blocks written in `**WHEN** ... **THEN** ...` form. Reviewers (human and agent) can lean on that structure instead of reading every PRD as a free-form essay. When OpenSpec is **not** installed, behavior is unchanged: drafts are free-form Markdown.
+
+The mode is purely client-side. **Chorus 0.8.0 ships no new MCP tools, no schema changes, and no server-side OpenSpec awareness.** The skill authors local files with `openspec`, then calls the same `chorus_pm_create_proposal` / `chorus_pm_add_document_draft` / `chorus_pm_update_document_draft` / `chorus_pm_update_document` tools that already existed — but for document mirror calls, it goes through the plugin's wrapper script (`chorus-api.sh` for Claude Code, `chorus-mcp-call.sh` for Codex) so file content streams through `jq -Rs '.'` byte-for-byte instead of being re-emitted by the LLM.
+
+---
+
+## When it activates (detection contract)
+
+Detection runs **once per session**, in the plugin's SessionStart hook (`bin/on-session-start.sh` for Claude Code, `hooks/on-session-start.sh` for Codex). The hook computes a single value `CHORUS_OPENSPEC_ACTIVE` and writes a `## OpenSpec Mode` section into the developer-message / additional-context block. Stage skills (proposal, develop, yolo) read that value when they need to branch — they do not re-detect.
+
+`CHORUS_OPENSPEC_ACTIVE=1` requires **all three** of:
+
+1. `CHORUS_OPENSPEC_MODE` is **not** set to `off` (explicit opt-out wins).
+2. The project root contains an `openspec/` directory — i.e. someone has run `openspec init` here. This is the "this repo intends to use OpenSpec" signal.
+3. The `openspec` CLI is on `PATH`. The OpenSpec authoring path needs the CLI to scaffold (`openspec new change`), validate, and archive — the folder alone is not enough.
+
+If any check fails, the hook still writes `## OpenSpec Mode` into context with `CHORUS_OPENSPEC_ACTIVE=0` and a one-line reason ("CHORUS_OPENSPEC_MODE=off (explicit opt-out)" / "no openspec/ directory at …" / "openspec/ directory present but `openspec` CLI not on PATH"). When the folder is present but the CLI is missing, the user-visible toast also surfaces an install hint:
+
+```
+Chorus connected at <URL> (OpenSpec repo detected — install with: npm i -g @fission-ai/openspec)
+```
+
+The agent should pass that hint through to the user instead of silently choosing the free-form path.
+
+When all three signals hold, the user-visible toast looks like:
+
+```
+Chorus connected at <URL> (OpenSpec Enabled)
+```
+
+### Why folder + CLI both, not just one
+
+Either signal alone leaves the workflow unrunnable:
+
+- Folder without CLI: `openspec new change "$SLUG"` errors immediately — there's nothing to scaffold with. Activating OpenSpec mode in this state would point the agent at a dead end.
+- CLI without folder: `openspec new change` complains it's not in a project ("Run `openspec init` first"). The repo isn't OpenSpec-init'd, so this likely isn't where OpenSpec is wanted.
+
+Requiring both makes the activation predicate match what's actually needed at runtime.
+
+### Sub-agents and sub-shells
+
+Detection runs in the plugin's session-start hook, which fires once per top-level session. Sub-agents that get the parent's context forwarded inherit `CHORUS_OPENSPEC_ACTIVE` for free. If you spawn a sub-agent without forwarding context, the `openspec-aware` skill §1 has a manual fallback block that performs the same three checks locally — use only when SessionStart context is genuinely unavailable.
+
+---
+
+## Install + initialize
+
+OpenSpec is a Node CLI from Fission AI. Install it globally:
+
+```bash
+npm install -g @fission-ai/openspec
+openspec --version    # Chorus 0.8.0 was tested against 1.3.1
+```
+
+Then, inside the repository where the agent will author proposals:
+
+```bash
+openspec init
+```
+
+`openspec init` creates the `openspec/` working directory (`changes/`, `specs/`, `config.yaml`, instruction files). Without it, the `openspec new change <slug>` step in the skill's §3.2 will fail.
+
+---
+
+## Opt-out
+
+Two switches, in precedence order:
+
+**1. `enableOpenSpec` userConfig toggle** (Claude Code plugin only, default `true`). Configurable from the plugin install UI like the reviewer toggles. When set to `false`, SessionStart detection short-circuits with reason `enableOpenSpec userConfig=false (plugin-level opt-out)`, and the post-verify archive hook also exits 0 immediately. Equivalent to "OpenSpec is uninstalled" from the agent's perspective.
+
+**2. `CHORUS_OPENSPEC_MODE=off` env var** (both plugins). Per-shell / CI-friendly opt-out:
+
+```bash
+export CHORUS_OPENSPEC_MODE=off
+```
+
+This forces fallback mode even when both the `openspec/` directory and the `openspec` CLI are present. The SessionStart hook checks the userConfig toggle first, then this env var, before the folder/CLI signals. The reason recorded in the `## OpenSpec Mode` context block when env-off wins is exactly:
+
+```
+CHORUS_OPENSPEC_ACTIVE=0 (CHORUS_OPENSPEC_MODE=off (explicit opt-out))
+```
+
+After detection, no `openspec/` folder is created or referenced (existing folders on disk are untouched), and the proposal description gets no `OpenSpec change slug:` line. Behavior is identical to a host that doesn't have OpenSpec installed.
+
+The Codex plugin has no userConfig surface, so only the env var applies there.
+
+---
+
+## What gets mirrored to Chorus
+
+| OpenSpec local file | Chorus `Document.type` | Mirrored? |
+|---|---|---|
+| `openspec/changes/<slug>/proposal.md` | `prd` | yes |
+| `openspec/changes/<slug>/design.md` | `tech_design` | yes |
+| `openspec/changes/<slug>/specs/<capability>/spec.md` | `spec` | yes (one draft per capability) |
+| `openspec/changes/<slug>/tasks.md` | _(not mapped)_ | **no** |
+
+All three mapped types (`prd`, `tech_design`, `spec`) are pre-existing valid `Document.type` values — no schema change required.
+
+The proposal description must contain a single line in the exact format `OpenSpec change slug: <slug>` so the post-verify-task hook (and future runs of the skill) can recover the slug from a fresh shell.
+
+---
+
+## How mirror calls are made (Rule 1)
+
+This is the rule most likely to bite you, so it gets its own section.
+
+When `CHORUS_OPENSPEC_ACTIVE=1`, **every** call to `chorus_pm_add_document_draft`, `chorus_pm_update_document_draft`, or `chorus_pm_update_document` MUST go through the plugin's wrapper script with `content` produced by `json_encode_file` (defined in the skill's §3.4):
+
+- Claude Code: `"$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/chorus-api.sh" mcp-tool <tool_name> "$PAYLOAD"`
+- Codex: `"$CHORUS_PLUGIN_DIR/hooks/chorus-mcp-call.sh" <tool_name> "$PAYLOAD"`
+
+Calling these tools directly from the agent's MCP harness with a hand-typed `content` field is a **protocol violation** in OpenSpec mode and will fail review. Three reasons (full version in skill §2 Rule 1):
+
+1. **Token cost.** Re-typing thousands of lines of markdown body through the LLM burns 20k+ content tokens per proposal. The wrapper streams bytes through `jq -Rs '.'`; content never enters LLM context.
+2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder. LLM re-emission of long markdown drifts (table alignment, fence escapes, long-URL wraps). The byte-equality guarantee (modulo trailing `\n`) holds **only** on the wrapper path.
+3. **Single source of truth.** With the wrapper, the local `openspec/changes/<slug>/*.md` is authoritative; Chorus is a mirror. With agent re-typing, authority splits and a future diff cannot tell which side is correct.
+
+Free-form mode (`CHORUS_OPENSPEC_ACTIVE=0`) is unaffected — there's no local file to mirror, so direct MCP calls with inline `content` are still the right pattern.
+
+---
+
+## FAQ
+
+### What happens if I edit the local file but not Chorus?
+
+The local file under `openspec/changes/<slug>/` is the working copy. The Chorus draft is a mirror written by the wrapper-driven `chorus_pm_add_document_draft` / `chorus_pm_update_document_draft` calls. If you edit the local file out-of-band, the mirror drifts.
+
+To resync, re-run the relevant mirror snippet from `openspec-aware` §3.7. Same wrapper, same `json_encode_file`, same `chorus_check_response` halt-on-error.
+
+The Chorus backend appends a single trailing `\n` on write, so a round-trip is byte-equal **modulo a trailing newline**. Don't read that 1-byte diff as content drift.
+
+After approval the draft becomes a Document with a fresh `documentUuid`. Use `chorus_pm_update_document` (skill §3.8) instead of `chorus_pm_update_document_draft`.
+
+### What about `openspec archive`?
+
+After the **last** task of an OpenSpec-mode idea is verified via `chorus_admin_verify_task`, both the Claude Code and Codex plugins' PostToolUse hook automatically inject a reminder telling the main agent to run `openspec archive <slug>` and mirror the resulting `openspec/specs/<capability>/spec.md` files back to the corresponding Chorus Documents via `chorus_pm_update_document` (still through the wrapper).
+
+The hook fires only when:
+
+- the proposal description carries an `OpenSpec change slug: <slug>` line, AND
+- the `openspec` CLI is on `PATH`, AND
+- every task under the proposal is `done`.
+
+Otherwise it exits 0 silently. See `openspec-aware` §3.9 for the full agent action sequence (run with `-y` / `--yes`, halt on error, byte-equal round-trip check).
+
+### Why isn't `tasks.md` mirrored?
+
+OpenSpec's `tasks.md` is the OpenSpec-side task list. Chorus already has its own task model — task drafts on the Proposal, materialized into Tasks with acceptance criteria, dependencies, assignees, and status — and that is the source of truth for task tracking. Mirroring `tasks.md` would duplicate state and create a second place to keep in sync. The skill explicitly skips it.
+
+If you want Chorus tasks to reflect a `tasks.md`, write the Chorus task drafts directly via `chorus_pm_add_task_draft` (no wrapper required — task drafts are not document content).
+
+---
+
+## Known limitations (0.8.0)
+
+- **`chorus-api.sh mcp-tool` is silent on HTTP 4xx.** Known wrapper bug in `public/chorus-plugin/bin/chorus-api.sh`: on HTTP 4xx (e.g. `401 Unauthorized` from a bad `CHORUS_API_KEY`), the wrapper's final `jq -r '.result.content[]?'` filter produces empty stdout, and the wrapper itself exits **0**. A bare `RC=$?` check would not halt on the most common runtime failure mode. The skill works around this with a `chorus_check_response` helper that checks **three** signals (wrapper exit code, `"error":` field in body, empty body) and halts on any of them. Every mirror call in the skill uses this helper. See `openspec-aware` §6 for the helper and rationale. The wrapper bug itself is tracked separately and out of scope for 0.8.0.
+
+- **Materialized-Document path requires re-deriving UUIDs.** After approval, the draft's `draftUuid` no longer applies; the Document has a fresh `documentUuid`. From a fresh shell you re-derive it via `chorus_get_documents` for the proposal's project, matching by `title` and `type`, and re-derive `$SLUG` by grepping the proposal description for `^OpenSpec change slug: `. See skill §3.8.
+
+- **Standalone `public/skill/` distribution does not support OpenSpec mode.** The standalone skill ships without a plugin wrapper. Since wrapper-driven mirror is mandatory in OpenSpec mode, the standalone channel skips it entirely. Users on that channel always run free-form.
+
+---
+
+## See also
+
+- [`public/chorus-plugin/skills/openspec-aware/SKILL.md`](../public/chorus-plugin/skills/openspec-aware/SKILL.md) — Claude Code plugin skill (authoritative for that runtime).
+- [`plugins/chorus/skills/openspec-aware/SKILL.md`](../plugins/chorus/skills/openspec-aware/SKILL.md) — Codex plugin skill (authoritative for that runtime).
+- OpenSpec upstream: <https://github.com/Fission-AI/OpenSpec>.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/archive-trigger/spec.md
+++ b/openspec/specs/archive-trigger/spec.md
@@ -1,0 +1,87 @@
+# archive-trigger Specification
+
+## Purpose
+TBD - created by archiving change add-openspec-archive-trigger-hook. Update Purpose after archive.
+## Requirements
+### Requirement: A PostToolUse hook on chorus_admin_verify_task SHALL emit an archive reminder when an OpenSpec-mode idea's last task is verified
+
+When `chorus_admin_verify_task` succeeds and the verified task is the final task of an OpenSpec-mode idea (as defined by §3.4 slug provenance), the plugin's PostToolUse hook MUST inject `additionalContext` instructing the main agent to run `openspec archive <slug>` and mirror the resulting `specs/<capability>/spec.md` back to the corresponding Chorus Document.
+
+#### Scenario: Last task of an OpenSpec-mode idea is verified
+
+- **GIVEN** a Chorus idea has 3 tasks, all approved by an admin via `chorus_admin_verify_task`
+- **AND** the idea's proposal description contains a line `OpenSpec change slug: my-feature`
+- **AND** `openspec --version` exits 0 in the developer's shell
+- **WHEN** `chorus_admin_verify_task` is called for the third (last) task
+- **THEN** the PostToolUse hook injects an `additionalContext` block whose body contains the literal substring `openspec archive my-feature`
+- **AND** the injected block also instructs the agent to mirror updated `openspec/specs/<capability>/spec.md` files back to Chorus Documents via `chorus_pm_update_document`
+- **AND** the hook exits 0
+
+#### Scenario: Verified task is NOT the last task of the idea
+
+- **GIVEN** a Chorus idea has 3 tasks, only 2 of which are in `done` status
+- **AND** the idea's proposal description contains a line `OpenSpec change slug: my-feature`
+- **WHEN** `chorus_admin_verify_task` is called for the second task (third still `to_verify` or `open`)
+- **THEN** the hook MUST exit 0 silently with no `additionalContext` emitted
+- **AND** no archive reminder is injected
+
+#### Scenario: Idea has no OpenSpec slug (free-form proposal)
+
+- **GIVEN** a Chorus idea whose proposal description does NOT contain a line matching `^OpenSpec change slug: ` (free-form authoring per canonical §4)
+- **WHEN** the last task of that idea is verified via `chorus_admin_verify_task`
+- **THEN** the hook MUST exit 0 silently with no `additionalContext` emitted
+- **AND** no archive reminder is injected
+- **AND** the agent's existing free-form behavior is preserved unchanged
+
+#### Scenario: openspec CLI is not installed locally
+
+- **GIVEN** the developer's machine returns non-zero exit from `openspec --version`
+- **WHEN** any task is verified via `chorus_admin_verify_task`
+- **THEN** the hook MUST exit 0 silently regardless of slug presence
+- **AND** no archive reminder is injected
+
+### Requirement: The hook SHALL be installed in BOTH the Claude Code plugin and the Codex plugin with identical detection semantics
+
+The PostToolUse hook MUST be present and registered in both `public/chorus-plugin/hooks/hooks.json` and `plugins/chorus/hooks.json`, and both copies MUST honor the same triple-signal detection contract (slug present + all-tasks-done + openspec installed).
+
+#### Scenario: Both plugin packages register the new matcher
+
+- **GIVEN** a fresh checkout of the repo
+- **WHEN** a reviewer inspects `public/chorus-plugin/hooks/hooks.json` and `plugins/chorus/hooks.json`
+- **THEN** both files MUST declare a PostToolUse hooks entry with matcher `.*chorus_admin_verify_task`
+- **AND** each entry MUST point at a per-package `on-post-verify-task.sh` script
+
+#### Scenario: Detection logic is consistent across plugins
+
+- **GIVEN** the same synthetic PostToolUse event JSON (verified task + slug + all-tasks-done)
+- **WHEN** the event is piped to the Claude Code hook AND to the Codex hook
+- **THEN** both hooks MUST emit `additionalContext` containing the same `openspec archive <slug>` substring
+- **AND** both MUST exit 0
+
+### Requirement: The hook SHALL be Bash 3.2 compatible
+
+The new hook script MUST run on macOS's default `/bin/bash` (Bash 3.2). It MUST NOT use Bash 4+ syntax (`${VAR,,}`, `${VAR^^}`, `declare -A`, `mapfile`, `readarray`, `|&`, `&>>`).
+
+#### Scenario: Hook passes the project's syntax check
+
+- **GIVEN** the new `on-post-verify-task.sh` exists in both plugin packages
+- **WHEN** `/bin/bash public/chorus-plugin/bin/test-syntax.sh` runs (per CLAUDE.md pitfall #10)
+- **THEN** the script MUST report success for both copies
+- **AND** the test MUST fail loudly if any Bash 4-only feature is introduced
+
+### Requirement: The skill canonical SHALL document the archive trigger contract in §3.9
+
+`scripts/openspec-skill/canonical/openspec-aware.md` MUST gain a new §3.9 "Archive after the last task is verified" section that explains the trigger semantics, the agent's archive + mirror-back responsibility, and the halt-on-error rule.
+
+#### Scenario: Canonical §3.9 explains the agent's archive responsibility
+
+- **WHEN** a reader inspects the canonical openspec-aware.md
+- **THEN** §3.9 MUST exist and contain at minimum: (a) trigger description (PostToolUse hook on `chorus_admin_verify_task`), (b) the four-step agent action sequence (run archive → read each spec.md → call `chorus_pm_update_document` → halt on error), (c) reference to canonical §3.8 for mirror-back specifics, (d) reference to §6 for the no-silent-errors rule
+
+#### Scenario: Canonical sync produces 3 consistent copies
+
+- **GIVEN** §3.9 is added to the canonical
+- **WHEN** `scripts/sync-openspec-skill.sh` runs
+- **THEN** §3.9 MUST appear (with package-appropriate `${CHORUS_API_SH}` substitution) in `public/chorus-plugin/skills/chorus/openspec-aware.md`, `plugins/chorus/skills/chorus/openspec-aware.md`, and `public/skill/openspec-aware.md`
+- **AND** all three synced copies MUST be byte-equal modulo the wrapper-path substitution
+

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/plugins/chorus/hooks.json
+++ b/plugins/chorus/hooks.json
@@ -33,6 +33,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": ".*chorus_admin_verify_task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/on-post-verify-task.sh",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -54,7 +54,7 @@ ACCEPT="Accept: application/json, text/event-stream"
 CT="Content-Type: application/json"
 
 INIT=$(cat <<JSON
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.8.0"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.8.1"}}}
 JSON
 )
 

--- a/plugins/chorus/hooks/on-post-verify-task.sh
+++ b/plugins/chorus/hooks/on-post-verify-task.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# on-post-verify-task.sh — Codex PostToolUse hook for chorus_admin_verify_task.
+#
+# Mirrors the Claude Code variant at
+# public/chorus-plugin/bin/on-post-verify-task.sh: detects "last task
+# verified for an OpenSpec-mode idea" and reminds the main agent to
+# `openspec archive <slug>` + mirror updated specs back to Chorus
+# Documents.
+#
+# Detection contract (all signals must hold to fire):
+#   1. CHORUS_OPENSPEC_MODE != "off" — explicit opt-out wins.
+#   2. The project root contains an `openspec/` directory — this repo is
+#      OpenSpec-init'd. Probed via $PWD/openspec.
+#   3. `openspec` CLI is on PATH — needed for the agent's later
+#      `openspec archive` step. Both (2) and (3) are required because
+#      either alone leaves the archive workflow unrunnable.
+#   4. The verified task's proposal description contains a line matching
+#      ^OpenSpec change slug: <slug>$ (slug provenance from §3.5).
+#   5. Every task under the same proposal has status === "done".
+#
+# If any signal fails, the hook exits 0 silently (strict opt-in).
+#
+# Bash 3.2 compatible (per CLAUDE.md pitfall #10).
+#
+# All shell variable parsing of captured JSON uses
+# `printf '%s' "$VAR" | jq ...` rather than `echo "$VAR" | jq ...` —
+# echo corrupts multi-line content on `\n` (canonical §6 warning).
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./hook-output.sh
+source "${DIR}/hook-output.sh"
+
+MCP="${DIR}/chorus-mcp-call.sh"
+
+# Read event JSON from stdin (PostToolUse hook input)
+EVENT=""
+if [ ! -t 0 ]; then
+  EVENT=$(cat)
+fi
+
+if [ -z "$EVENT" ]; then
+  exit 0
+fi
+
+# Step 2: Extract taskUuid — Codex's tool_response is a content[0].text
+# JSON blob; fall back to tool_input.taskUuid (mirrors the existing
+# on-post-submit-for-verify.sh pattern).
+TASK_UUID=""
+if command -v jq >/dev/null 2>&1; then
+  TASK_UUID=$(printf '%s' "$EVENT" | jq -r '
+    (.tool_response.content[0].text // "") as $t
+    | ($t | fromjson? // {}) as $tj
+    | ($tj.taskUuid // $tj.uuid // .tool_input.taskUuid // empty)
+  ' 2>/dev/null) || true
+fi
+
+# Step 3: If taskUuid is empty -> exit 0 silently
+if [ -z "$TASK_UUID" ]; then
+  exit 0
+fi
+
+# Step 4: OpenSpec gate — explicit opt-out, then folder + CLI both required.
+# Both folder-presence and CLI-presence are necessary: the agent will run
+# `openspec archive <slug>` on receipt of the injected reminder, and that
+# command needs the openspec/ working directory AND the CLI on PATH. If
+# either is missing, the reminder would point the agent at a dead end, so
+# we silently skip injection and let the verify pass through unannotated.
+if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+  exit 0
+fi
+PROJECT_ROOT="$PWD"
+if [ ! -d "${PROJECT_ROOT}/openspec" ]; then
+  exit 0
+fi
+if ! command -v openspec >/dev/null 2>&1; then
+  exit 0
+fi
+if ! openspec --version >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Step 5: chorus_get_task -> proposalUuid + project.uuid
+TASK_JSON=$("$MCP" chorus_get_task "$(printf '{"taskUuid":"%s"}' "$TASK_UUID")" 2>/dev/null) || exit 0
+if [ -z "$TASK_JSON" ]; then
+  exit 0
+fi
+
+PROPOSAL_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.proposalUuid // empty' 2>/dev/null) || true
+PROJECT_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.project.uuid // empty' 2>/dev/null) || true
+
+# Step 6: If proposalUuid empty -> exit 0 silently (Quick Tasks have no proposal)
+if [ -z "$PROPOSAL_UUID" ]; then
+  exit 0
+fi
+
+# Step 7: chorus_get_proposal -> description (for slug grep)
+PROPOSAL_JSON=$("$MCP" chorus_get_proposal "$(printf '{"proposalUuid":"%s"}' "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
+if [ -z "$PROPOSAL_JSON" ]; then
+  exit 0
+fi
+
+PROPOSAL_DESC=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.description // empty' 2>/dev/null) || true
+
+# Step 9: grep description for ^OpenSpec change slug: (.+)$ — first match wins
+SLUG=""
+if [ -n "$PROPOSAL_DESC" ]; then
+  SLUG_LINE=$(printf '%s\n' "$PROPOSAL_DESC" | grep -E '^OpenSpec change slug: .+' | head -1 || true)
+  if [ -n "$SLUG_LINE" ]; then
+    SLUG=$(printf '%s' "$SLUG_LINE" | sed -e 's/^OpenSpec change slug:[[:space:]]*//' -e 's/[[:space:]]*$//')
+  fi
+fi
+
+# Step 10: If $SLUG is empty -> exit 0 silently (free-form proposal)
+if [ -z "$SLUG" ]; then
+  exit 0
+fi
+
+# Step 8: chorus_list_tasks (filtered by proposalUuid) -> verify every task
+# is "done". Pagination guard: if total > returned, exit silently.
+TASKS_JSON=$("$MCP" chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
+if [ -z "$TASKS_JSON" ]; then
+  exit 0
+fi
+
+TOTAL_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.total // 0' 2>/dev/null) || true
+RETURNED_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.tasks | length' 2>/dev/null) || true
+
+if [ -n "$TOTAL_TASKS" ] && [ -n "$RETURNED_TASKS" ] && [ "$TOTAL_TASKS" -gt "$RETURNED_TASKS" ]; then
+  exit 0
+fi
+
+# Defensive: zero-task proposal would otherwise fall through with
+# NOT_DONE_COUNT=0. Proposal-submit validation prevents this in practice;
+# this guard makes the gate complete.
+if [ -z "$RETURNED_TASKS" ] || [ "$RETURNED_TASKS" -eq 0 ]; then
+  exit 0
+fi
+
+NOT_DONE_COUNT=$(printf '%s' "$TASKS_JSON" | jq -r '[.tasks[] | select(.status != "done")] | length' 2>/dev/null) || true
+
+if [ -z "$NOT_DONE_COUNT" ] || [ "$NOT_DONE_COUNT" != "0" ]; then
+  exit 0
+fi
+
+# Step 11: Build CONTEXT — instruct the agent to run `openspec archive
+# <SLUG>` and mirror the resulting specs back to the matching Chorus
+# Documents. (chorus_get_documents only supports projectUuid + type as
+# server-side filters — title matching is client-side, canonical §3.8.)
+
+CTX="[Chorus — OpenSpec Archive Trigger]
+The last task of OpenSpec-mode proposal ${PROPOSAL_UUID} (slug \`${SLUG}\`) has been admin-verified.
+
+ACTION REQUIRED: archive the OpenSpec change locally and mirror updated specs back to the Chorus Documents. Run the steps below in order; HALT immediately on any error (canonical §6 — no silent errors).
+
+1. Run \`openspec archive ${SLUG}\` in the repo root. This moves \`openspec/changes/${SLUG}/\` under \`openspec/changes/archive/<date>-${SLUG}/\` and emits/updates one \`openspec/specs/<capability>/spec.md\` per capability. If the CLI prompts interactively and a \`--yes\`/\`--no-confirm\` flag is available, use it (verify with \`openspec archive --help\`).
+
+2. For EACH newly-emitted \`openspec/specs/<capability>/spec.md\`:
+   - List all spec-type Documents in this project: \`chorus_get_documents({projectUuid: \"${PROJECT_UUID}\", type: \"spec\"})\`. The \`type\` filter is the only server-side filter — do client-side title matching against the documents you get back.
+   - Find the Document whose title matches the capability (canonical §3.8 mirror-back contract; typical title shape \`Spec: <capability>\`).
+   - Call \`chorus_pm_update_document\` with the new content from the on-disk spec.md.
+
+3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: \"proposal\", targetUuid: \"${PROPOSAL_UUID}\", content: \"...\"})\`), and HALT. No retry, no silent skip.
+
+4. Confirm success by listing \`openspec/specs/<capability>/spec.md\` files and verifying they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+
+References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors)."
+
+# Step 12: Inject CTX as additionalContext (Codex hook_output emits the
+# JSON envelope expected by Codex hook host).
+hook_output "" "$CTX" "PostToolUse"
+
+# Step 13: exit 0
+exit 0

--- a/plugins/chorus/hooks/on-session-start.sh
+++ b/plugins/chorus/hooks/on-session-start.sh
@@ -29,6 +29,31 @@ CHECKIN=$("${DIR}/chorus-mcp-call.sh" chorus_checkin '{}' 2>/dev/null) || {
   exit 0
 }
 
+# Detect OpenSpec mode for this repo, once per session.
+# Both conditions are required for OpenSpec mode to be usable:
+#   (a) an openspec/ directory at the project root (this repo was inited via `openspec init`), AND
+#   (b) the `openspec` CLI on PATH (so we can `openspec new change`, `validate`, `archive`).
+# Override: CHORUS_OPENSPEC_MODE=off (explicit opt-out wins even if both
+# signals are present — same precedence as the original detection contract).
+# Codex doesn't expose a project-dir env var, so we use $PWD (Codex hooks
+# run from the project root).
+PROJECT_ROOT="$PWD"
+OPENSPEC_HINT=""
+if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_REASON="CHORUS_OPENSPEC_MODE=off (explicit opt-out)"
+elif [ ! -d "${PROJECT_ROOT}/openspec" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_REASON="no openspec/ directory at ${PROJECT_ROOT}/openspec"
+elif ! command -v openspec >/dev/null 2>&1; then
+  CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_REASON="openspec/ directory present but \`openspec\` CLI not on PATH"
+  OPENSPEC_HINT="install with: npm i -g @fission-ai/openspec"
+else
+  CHORUS_OPENSPEC_ACTIVE=1
+  OPENSPEC_REASON="openspec/ directory + openspec CLI both present"
+fi
+
 CTX="# Chorus Plugin — Active (Codex port)
 
 Chorus is connected at ${CHORUS_URL}. MCP tools are available under the \`chorus\` server.
@@ -37,6 +62,29 @@ Chorus is connected at ${CHORUS_URL}. MCP tools are available under the \`chorus
 
 ${CHECKIN}
 
+## OpenSpec Mode
+
+CHORUS_OPENSPEC_ACTIVE=${CHORUS_OPENSPEC_ACTIVE} (${OPENSPEC_REASON})"
+
+if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
+  CTX="${CTX}
+
+OpenSpec mode is **active** for this session. When the proposal / develop / yolo skills reach an OpenSpec-aware step, load the openspec-aware skill at \`~/.codex/skills/openspec-aware/SKILL.md\` and follow §3 (OpenSpec authoring) — do NOT re-run the §1 detection block, the answer is already known.
+
+Critical rule (openspec-aware §2 Rule 1): document mirror calls (\`chorus_pm_add_document_draft\` / \`chorus_pm_update_document_draft\` / \`chorus_pm_update_document\`) MUST go through \`chorus-mcp-call.sh\` with \`content\` produced by \`json_encode_file\`. Do NOT invoke these MCP tools directly with hand-typed \`content\` in OpenSpec mode."
+else
+  CTX="${CTX}
+
+OpenSpec mode is **inactive** for this session. The proposal / develop / yolo skills follow their free-form path; do NOT scaffold \`openspec/changes/\`, do NOT add an \`OpenSpec change slug:\` line to proposal descriptions, and do NOT route document mirror calls through \`chorus-mcp-call.sh\`."
+  if [ -n "$OPENSPEC_HINT" ]; then
+    CTX="${CTX}
+
+Note: this repo has an \`openspec/\` directory, so the user likely intends to use OpenSpec mode but the \`openspec\` CLI is not installed. Surface this to the user (e.g. \"This repo is OpenSpec-init'd but the \\\`openspec\\\` CLI isn't installed locally — ${OPENSPEC_HINT}\") before authoring documents so they can install it and re-launch the session if they want spec-driven mode."
+  fi
+fi
+
+CTX="${CTX}
+
 ## Quick Reference
 
 - **Sessions are optional**: the Codex port does NOT auto-create Chorus sessions for sub-agents. If you spawn workers via \`spawn_agent\` and want per-worker observability, create a session manually with \`chorus_create_session\` before spawning and \`chorus_close_session\` after the worker returns. Otherwise skip session tools entirely.
@@ -44,4 +92,11 @@ ${CHECKIN}
 - **Skills**: use \`\$chorus\`, \`\$idea\`, \`\$proposal\`, \`\$develop\`, \`\$review\`, \`\$quick-dev\`, or \`\$yolo\` to load the stage-specific workflow.
 - **Reviewer sub-agents**: mount the reviewer skill into a default sub-agent — \`spawn_agent(agent_type=\"default\", items=[{type:\"skill\", path:\"chorus:chorus-proposal-reviewer\"}, {type:\"text\", text:\"Review proposal <uuid>.\"}])\` after \`chorus_pm_submit_proposal\`; same pattern with \`chorus:chorus-task-reviewer\` after \`chorus_submit_for_verify\`. Codex 0.125 only ships three built-in roles (default / explorer / worker) — custom agent_types like \`chorus-proposal-reviewer\` will be rejected. Remember \`close_agent\` after \`wait_agent\`; completed ≠ closed, 6 concurrent max."
 
-hook_output "Chorus connected at ${CHORUS_URL}" "$CTX" "SessionStart"
+USER_MSG="Chorus connected at ${CHORUS_URL}"
+if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec Enabled)"
+elif [ -n "$OPENSPEC_HINT" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec repo detected — ${OPENSPEC_HINT})"
+fi
+
+hook_output "$USER_MSG" "$CTX" "SessionStart"

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, au
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus proposal reviewer

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus task reviewer

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -363,6 +363,7 @@ This is the core overview skill. For stage-specific workflows, use:
 | **Planning** | `/proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
 | **Development** | `/develop` | Claim Tasks, report work, (optional) session management, sub-agent spawn patterns |
 | **Review** | `/review` | Approve/reject Proposals, verify Tasks, project governance |
+| **OpenSpec mode** | `openspec-aware` | Opt-in **shared sub-procedure** invoked by `proposal`, `develop`, and `yolo` whenever the user has the `openspec` CLI installed. Scaffolds `openspec/changes/<slug>/` on disk and mirrors files into Chorus document drafts via the `chorus-mcp-call.sh` wrapper. Skips silently in fallback mode. See `~/.codex/skills/openspec-aware/SKILL.md`. |
 
 ### Getting Started
 

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, and spawn
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -134,6 +134,14 @@ Each task and proposal includes a `commentCount` field — use it to decide whic
    ```
    chorus_get_documents({ projectUuid: "<project-uuid>" })
    ```
+
+> **Document update flow (OpenSpec mode):** if the originating proposal `description` contains a line `OpenSpec change slug: <slug>`, the project's PRD / tech_design / spec Documents are **mirrors** of files under `openspec/changes/<slug>/`. To update such a Document (e.g. clarify an AC, fix a spec scenario before resubmitting), load the `openspec-aware` skill at `~/.codex/skills/openspec-aware/SKILL.md` and follow §3.8: edit the local `.md` file first, then mirror through the `chorus-mcp-call.sh` wrapper with `json_encode_file` and `chorus_check_response`.
+>
+> **⛔ Do not** call `chorus_pm_update_document` directly from Codex's MCP harness with a hand-typed `content` field in OpenSpec mode. The local file is the source of truth; agent-typed content drifts and burns tokens (`openspec-aware` §2 Rule 1).
+>
+> When the LAST task of an OpenSpec idea is verified, the plugin's PostToolUse hook injects an archive reminder (`openspec-aware` §3.9) — run `openspec archive <slug> --yes`, then mirror each emitted `openspec/specs/<capability>/spec.md` back via §3.8.
+>
+> In the no-OpenSpec fallback (no slug line, or no `openspec` CLI), edit the Document content directly via the existing MCP tool with no wrapper, no local file step.
 
 ### Step 5: Start Working
 

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/openspec-aware/SKILL.md
+++ b/plugins/chorus/skills/openspec-aware/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: openspec-aware
+description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Codex. Detects the local `openspec` CLI, scaffolds `openspec/changes/<slug>/` on disk, and mirrors Markdown files into Chorus document drafts via the `chorus-mcp-call.sh` wrapper. Required reading for the proposal, develop, and yolo skills whenever the user has the `openspec` CLI installed.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.8.1"
+  category: project-management
+  mcp_server: chorus
+---
+
+# OpenSpec-aware Authoring (Codex plugin)
+
+This skill is a **shared sub-procedure** invoked by the Chorus stage skills (proposal, develop, yolo) whenever the user wants spec-driven authoring through the [OpenSpec CLI](https://github.com/Fission-AI/OpenSpec). It is opt-in:
+
+- Activates when **all three** signals hold (see §1): `CHORUS_OPENSPEC_MODE` is not `off`, an `openspec/` directory exists at the project root, and the `openspec` CLI is on `PATH`.
+- Otherwise the calling skill falls back to its existing free-form behavior.
+
+When you reach a point in proposal / develop / yolo where this skill is referenced, **read the value of `CHORUS_OPENSPEC_ACTIVE` from the SessionStart context** (see §1) and branch on it. Do not re-run the detection block — the SessionStart hook has already done it once for this session.
+
+> **Codex specifics:** Codex's stateless MCP wrapper is `chorus-mcp-call.sh`, located at `$CHORUS_PLUGIN_DIR/hooks/chorus-mcp-call.sh`. It is invoked as `chorus-mcp-call.sh <TOOL_NAME> '<JSON_ARGUMENTS>'` — no `mcp-tool` subcommand (unlike the Claude Code variant). The Codex port has no on-disk session state; every call is self-contained.
+
+---
+
+## §1. Detection — already done at SessionStart
+
+The Chorus plugin's SessionStart hook (`hooks/on-session-start.sh`) computes `CHORUS_OPENSPEC_ACTIVE` once when the session opens and writes a `## OpenSpec Mode` section into the developer-message context. The value of `CHORUS_OPENSPEC_ACTIVE` is `1` only when **all three** of these hold:
+
+1. `CHORUS_OPENSPEC_MODE` is **not** set to `off` (explicit opt-out wins).
+2. The project root contains an `openspec/` directory (i.e. someone ran `openspec init` here).
+3. The `openspec` CLI is on `PATH`.
+
+Both signals (2) and (3) are required because the OpenSpec authoring path needs the working directory **and** the CLI — having one without the other leaves the workflow unrunnable. If signal (2) holds but (3) does not, the SessionStart hook surfaces a "OpenSpec repo detected — install with: `npm i -g @fission-ai/openspec`" hint to the user; the agent should pass this through if asked rather than silently choosing free-form.
+
+### How to read the value
+
+You should already see something like this in your context (look for the `## OpenSpec Mode` section near the top of the developer message):
+
+```
+## OpenSpec Mode
+
+CHORUS_OPENSPEC_ACTIVE=1 (openspec/ directory + openspec CLI both present)
+```
+
+or:
+
+```
+## OpenSpec Mode
+
+CHORUS_OPENSPEC_ACTIVE=0 (no openspec/ directory at /path/to/repo/openspec)
+```
+
+Branch:
+
+- `CHORUS_OPENSPEC_ACTIVE=1` → follow §3 (OpenSpec authoring).
+- `CHORUS_OPENSPEC_ACTIVE=0` → return to the calling skill's free-form path. **Do not** scaffold `openspec/changes/`. **Do not** add the slug line to the proposal description.
+
+### Manual fallback
+
+If you're in a sub-agent that did not see the SessionStart context (e.g. spawned mid-session with the parent's context not forwarded), reconstruct the value yourself with the same three checks — Codex hooks run from `$PWD`, so use that as the project root probe:
+
+```bash
+if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+elif [ ! -d "$PWD/openspec" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+elif ! openspec --version >/dev/null 2>&1; then
+  CHORUS_OPENSPEC_ACTIVE=0
+else
+  CHORUS_OPENSPEC_ACTIVE=1
+fi
+```
+
+Use this only when SessionStart context is genuinely unavailable — duplicating the detection is wasteful when the hook already computed it.
+
+---
+
+## §2. ⛔ Two non-negotiable rules
+
+Both are enforced at review time. Both have caused incidents in past releases.
+
+### Rule 1 — Mirror via the wrapper, never re-type document content from agent output
+
+Document/draft mirror calls (`chorus_pm_add_document_draft`, `chorus_pm_update_document_draft`, `chorus_pm_update_document`) **MUST** go through:
+
+```
+"$CHORUS_PLUGIN_DIR/hooks/chorus-mcp-call.sh" <TOOL_NAME> "$PAYLOAD"
+```
+
+with `$PAYLOAD` built using `json_encode_file` (defined in §3.4). Calling these tools directly from Codex's MCP harness with a hand-typed `content` field is a **protocol violation** for OpenSpec mode and will fail review. Reasons:
+
+1. **Token cost.** Re-typing a multi-thousand-line markdown body through the model burns input + output tokens for every draft. The wrapper streams bytes through `jq -Rs '.'` — content never enters model context. A typical 3-doc proposal mirror via the script costs roughly zero content-tokens; via direct MCP it routinely costs 20k+.
+2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. Model re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The byte-equality guarantee (modulo trailing `\n`) holds **only** on the wrapper path.
+3. **Single source of truth.** With the wrapper, the local `openspec/changes/<slug>/*.md` is authoritative and Chorus is a mirror. With agent re-typing, authority splits between local file and whatever the model happened to output — a future diff cannot tell which one is correct.
+
+### Rule 2 — Halt on error via `chorus_check_response`
+
+Every wrapper call must check three signals: wrapper exit code, `"error":` in body, empty body. Bare `RC=$?` is **insufficient** for the same wrapper-bug reason described in §6 — keep using the helper even though Codex's `chorus-mcp-call.sh` differs slightly in implementation from Claude Code's `chorus-api.sh`.
+
+---
+
+## §3. OpenSpec mode authoring
+
+### 3.1 Pick a slug
+
+`openspec/changes/<slug>/` is the local change folder. The slug must be:
+
+- kebab-case (`add-export-csv`, not `addExportCsv` or `add_export_csv`),
+- derived from the source Idea title,
+- unique within `openspec/changes/`.
+
+Record it for later steps:
+
+```bash
+SLUG="add-export-csv"
+```
+
+### 3.2 Scaffold the change folder
+
+```bash
+openspec new change "$SLUG" --description "<one-line idea summary>"
+```
+
+This creates `openspec/changes/$SLUG/` with `README.md` and `.openspec.yaml`. Then author by hand:
+
+| Local file | Purpose | Mirror as `Document.type` |
+|---|---|---|
+| `proposal.md` | Why + What Changes + Capabilities + Impact | `prd` |
+| `design.md` | Architecture, contracts, risks | `tech_design` |
+| `specs/<capability>/spec.md` | Delta spec (`## ADDED Requirements` + Scenarios) | `spec` (one draft per capability) |
+| `tasks.md` | OpenSpec tasks list | _(not mirrored — Chorus task drafts are source of truth)_ |
+
+Use `openspec instructions <artifact> --change "$SLUG"` (artifacts: `proposal`, `specs`, `design`, `tasks`) for templates.
+
+### 3.3 Spec file shape (verified against `openspec instructions specs`)
+
+A delta spec lists one or more block headers — `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`, `## RENAMED Requirements` — and within each, `### Requirement:` entries. Mix freely in the same file; only include the blocks you actually need.
+
+#### `## ADDED Requirements`
+
+Append a brand-new Requirement to the long-term spec.
+
+```
+## ADDED Requirements
+
+### Requirement: <name>
+<requirement text — use SHALL / MUST for normative behavior>
+
+#### Scenario: <name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+```
+
+#### `## MODIFIED Requirements`
+
+**Whole-block replacement, not merge.** Whatever you write here completely replaces the existing same-named Requirement in the long-term spec — title, description, and *all* scenarios. Half-writing it deletes the rest.
+
+```
+## MODIFIED Requirements
+
+### Requirement: <existing name>
+<full updated requirement text>
+
+#### Scenario: <name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+
+#### Scenario: <other name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+```
+
+Always include every scenario you want the post-archive spec to have, even ones that were already present and unchanged.
+
+#### `## REMOVED Requirements`
+
+Delete a Requirement from the long-term spec. The block under the heading is just the requirement name(s) you're removing — no scenarios needed.
+
+```
+## REMOVED Requirements
+
+### Requirement: <existing name>
+```
+
+#### `## RENAMED Requirements`
+
+Rename a Requirement's title. Body and scenarios are preserved as-is in the long-term spec; use `MODIFIED` instead if you need to change anything besides the title.
+
+```
+## RENAMED Requirements
+
+### Requirement: <old name> -> <new name>
+```
+
+**Critical formatting rules (verified):**
+
+- Scenarios MUST use **exactly 4 hashtags** (`#### Scenario:`). 3 hashtags or a bullet list silently fail validation.
+- Every `### Requirement:` under `ADDED` or `MODIFIED` MUST have at least one `#### Scenario:`.
+- `MODIFIED` blocks MUST include the **full updated content** — they overwrite, not patch.
+- Use `SHALL` / `MUST` for normative requirements; avoid `should` / `may`.
+- The merge into `openspec/specs/<capability>/spec.md` happens at `openspec archive` time (§3.9), not at proposal time. While the proposal is in flight, Chorus only sees the delta file as one `spec` Document — there is no half-merged state for the skill to reason about.
+
+Optional:
+
+```bash
+openspec validate "$SLUG"
+```
+
+### 3.4 Helper: `json_encode_file`
+
+Define once at the top of the authoring session. With `jq` available it streams the file into a JSON string; the fallback matches the Codex wrapper's escaping when `jq` is missing.
+
+```bash
+json_encode_file() {
+  local _path="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rs '.' < "$_path"
+  else
+    local _content
+    _content=$(cat "$_path")
+    _content=${_content//\\/\\\\}
+    _content=${_content//\"/\\\"}
+    _content=${_content//$'\n'/\\n}
+    printf '"%s"' "$_content"
+  fi
+}
+```
+
+Round-trip: the Chorus backend appends a single `\n` to draft content on write, so server `content` is **byte-equal modulo a trailing newline**. Reviewers diffing local file vs server should ignore that one byte.
+
+### 3.5 Create the proposal container with the slug provenance line
+
+Use the regular `chorus_pm_create_proposal` MCP tool (no wrapper required for this single call — the description is short, the model-emitted version is fine). The description **must** carry exactly one line:
+
+```
+OpenSpec change slug: <slug>
+```
+
+- on its own line (no other text on that line),
+- literal prefix `OpenSpec change slug: ` (capital O, capital S, single space after colon),
+- no trailing punctuation,
+- value matches the slug passed to `openspec new change`.
+
+This line is machine-grep-able by future runs of this skill and by the §3.9 archive trigger.
+
+### 3.6 Mirror each document draft via the wrapper
+
+> **Rule 1 reminder:** these calls go through `chorus-mcp-call.sh`, not direct MCP. The agent must not retype the document body.
+
+Define the halt-on-error helper from §6 once at the top, then run one call per file. Note the **two-arg** Codex wrapper signature: `<TOOL_NAME> <JSON_ARGUMENTS>` — there is no `mcp-tool` subcommand.
+
+```bash
+API="$CHORUS_PLUGIN_DIR/hooks/chorus-mcp-call.sh"
+
+# PRD draft
+CONTENT=$(json_encode_file "openspec/changes/$SLUG/proposal.md")
+PAYLOAD=$(cat <<JSON
+{
+  "proposalUuid": "$PROPOSAL_UUID",
+  "type": "prd",
+  "title": "PRD: $HUMAN_TITLE",
+  "content": $CONTENT
+}
+JSON
+)
+RESULT=$("$API" chorus_pm_add_document_draft "$PAYLOAD")
+RC=$?
+chorus_check_response "chorus_pm_add_document_draft (prd)" "$RC" "$RESULT"
+PRD_DRAFT_UUID=$(printf '%s' "$RESULT" | grep -o '"draftUuid"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+```
+
+Repeat with `type: "tech_design"` for `design.md`, and one call per capability with `type: "spec"` for each `specs/<capability>/spec.md`. Do **not** mirror `tasks.md` — Chorus task drafts (created via the `chorus_pm_add_task_draft` MCP tool, no wrapper needed) are the source of truth for tasks.
+
+> Why parsing uses `printf '%s' "$RESULT" | grep` not `echo "$RESULT" | jq`: `echo` interprets backslash sequences inside the captured JSON, turning embedded `\n` into a real newline. `jq` then aborts with `Invalid string: control characters from U+0000 through U+001F must be escaped`. `printf '%s'` emits the captured bytes verbatim. Same pattern applies to all wrapper-result parsing in this skill.
+
+### 3.7 Editing a draft after the first mirror
+
+Local file changes propagate via `chorus_pm_update_document_draft` — same wrapper, same `json_encode_file`, same halt check.
+
+```bash
+CONTENT=$(json_encode_file "openspec/changes/$SLUG/proposal.md")
+PAYLOAD=$(cat <<JSON
+{
+  "proposalUuid": "$PROPOSAL_UUID",
+  "draftUuid": "$PRD_DRAFT_UUID",
+  "content": $CONTENT
+}
+JSON
+)
+RESULT=$("$API" chorus_pm_update_document_draft "$PAYLOAD")
+RC=$?
+chorus_check_response "chorus_pm_update_document_draft" "$RC" "$RESULT"
+```
+
+### 3.8 Editing a Document after proposal approval
+
+Once the proposal is approved, drafts materialize into Documents with their own UUIDs. To keep `openspec/changes/$SLUG/` and the Chorus Document in sync, mirror file edits via `chorus_pm_update_document`:
+
+```bash
+CONTENT=$(json_encode_file "openspec/changes/$SLUG/specs/<capability>/spec.md")
+PAYLOAD=$(cat <<JSON
+{
+  "documentUuid": "$SPEC_DOCUMENT_UUID",
+  "content": $CONTENT
+}
+JSON
+)
+RESULT=$("$API" chorus_pm_update_document "$PAYLOAD")
+RC=$?
+chorus_check_response "chorus_pm_update_document" "$RC" "$RESULT"
+```
+
+To re-derive `$SPEC_DOCUMENT_UUID` from a fresh shell, look it up via `chorus_get_documents` for the proposal's project and match by `title` + `type`. Re-derive `$SLUG` by grepping the proposal's `description` for `^OpenSpec change slug: `.
+
+### 3.9 Archive after the last task is verified
+
+When the **LAST** task of an OpenSpec-mode idea is admin-verified via `chorus_admin_verify_task`, the plugin's PostToolUse hook (`hooks/on-post-verify-task.sh`) injects an `additionalContext` reminder containing the literal substring `openspec archive <slug>` so you can act without re-reading the slug.
+
+The hook is read-only; you (the agent) perform the archive:
+
+1. **Run archive locally.** Use `--yes` for non-interactive mode. Do NOT pass `--skip-specs` (defeats the mirror-back) or `--no-validate` (lets malformed deltas corrupt cumulative specs).
+
+   ```bash
+   openspec archive "$SLUG" --yes
+   ```
+
+   This moves `openspec/changes/$SLUG/` under `openspec/changes/archive/<date>-<slug>/` and emits/updates `openspec/specs/<capability>/spec.md` for each capability. (Run `openspec archive --help` against your installed version to confirm the current flag set — flags can drift between releases.)
+
+2. **Mirror each updated `openspec/specs/<capability>/spec.md` back** to the matching post-approval Chorus Document (§3.8 contract). `chorus_get_documents` only supports `projectUuid` + `type` server-side filters; filter by title client-side. One `chorus_pm_update_document` call per capability.
+
+3. **Halt on any error** from `openspec archive` or `chorus_pm_update_document`. Print stderr verbatim, post a comment on the proposal recording the failure (`chorus_add_comment` with `targetType: "proposal"`, `targetUuid: <proposalUuid>`), then stop. No retry. Matches §6 "no silent errors." (Comment on the proposal, not the idea: the failure is in archiving proposal-derived specs, and proposals can be `inputType: "document"` with no idea attached.)
+
+4. **Confirm success.** List `openspec/specs/<capability>/spec.md` files and verify they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+
+**Strict opt-in:** if the verified task is not the last of its idea, OR the proposal description carries no `OpenSpec change slug: <slug>` line, OR the local shell has no `openspec` CLI, the hook exits 0 silently and no archive reminder is injected. Existing free-form behavior is preserved.
+
+---
+
+## §4. Fallback authoring (no openspec)
+
+When detection puts the agent in fallback mode (`CHORUS_OPENSPEC_ACTIVE=0`), this skill is a **no-op**. Return to the calling skill's free-form path:
+
+- No `openspec/changes/` folder is created or referenced.
+- No `OpenSpec change slug: …` line is added to the proposal description.
+- Document drafts are authored via direct MCP `chorus_pm_add_document_draft` calls with inline `content` — same as before this skill existed.
+- Rule 1 (wrapper-only mirror) does not apply — there is no local file source of truth.
+- The §3.9 archive hook does nothing (no slug → silent exit).
+
+---
+
+## §5. Document type mapping (reference table)
+
+| Local file | Chorus `Document.type` | Mirrored? |
+|---|---|---|
+| `openspec/changes/<slug>/proposal.md` | `prd` | yes |
+| `openspec/changes/<slug>/design.md` | `tech_design` | yes |
+| `openspec/changes/<slug>/specs/<capability>/spec.md` | `spec` | yes (one draft per capability) |
+| `openspec/changes/<slug>/tasks.md` | _(not mapped)_ | **no** — Chorus task drafts are source of truth |
+
+`prd`, `tech_design`, `spec` are pre-existing valid `Document.type` values — no schema change required.
+
+---
+
+## §6. Failure visibility — the `chorus_check_response` helper
+
+There is a known wrapper edge case shared with the Claude Code variant: when the server returns HTTP 4xx (e.g. 401 from a bad `CHORUS_API_KEY`), the wrapper's internal jq filter can produce empty stdout and exit 0. A bare `RC=$?` check would not halt on this — the most common runtime failure mode would be invisible.
+
+Define this helper **once** at the top of the authoring session and use it after every wrapper call:
+
+```bash
+chorus_check_response() {
+  local _tool="$1"
+  local _rc="$2"
+  local _body="$3"
+  local _has_error=0
+  local _is_empty=0
+
+  local _trimmed
+  _trimmed=$(printf '%s' "$_body" | tr -d ' \t\n\r')
+  [ -z "$_trimmed" ] && _is_empty=1
+
+  if [ "$_is_empty" -eq 0 ]; then
+    if command -v jq >/dev/null 2>&1; then
+      if printf '%s' "$_body" | jq -e 'try ([.. | objects | has("error")] | any) catch false' >/dev/null 2>&1; then
+        _has_error=1
+      fi
+    else
+      printf '%s' "$_body" | grep -qE '"error"[[:space:]]*:' && _has_error=1
+    fi
+  fi
+
+  if [ "$_rc" -ne 0 ] || [ "$_has_error" -eq 1 ] || [ "$_is_empty" -eq 1 ]; then
+    echo "ERROR: $_tool failed (exit=$_rc, error_in_body=$_has_error, empty_body=$_is_empty)" >&2
+    echo "Output: $_body" >&2
+    [ "$_rc" -ne 0 ] && exit "$_rc" || exit 1
+  fi
+}
+```
+
+**Anti-patterns** — do **not**:
+
+- Collapse to `|| true`.
+- Redirect stderr to `/dev/null`.
+- Bury the wrapper call inside a pipeline (masks `$?`).
+- Skip capturing `$RESULT` into a variable; the helper needs the body.
+- Use only `if [ "$RC" -ne 0 ]; then ...` — that misses the HTTP-error path.
+
+**Minimal call site shape (Codex):**
+
+```bash
+RESULT=$("$API" <tool_name> "$PAYLOAD")
+RC=$?
+chorus_check_response "<tool_name>" "$RC" "$RESULT"
+# ...if we reach here, the call succeeded; parse RESULT and continue.
+```
+
+This is project-wide policy: no silent errors.
+
+---
+
+## §7. Quick reference checklist
+
+When invoked from a stage skill (proposal / develop / yolo):
+
+1. Read `CHORUS_OPENSPEC_ACTIVE` from the `## OpenSpec Mode` section in the SessionStart developer-message context (§1). If it isn't there, fall back to the manual probe in §1.
+2. If `CHORUS_OPENSPEC_ACTIVE=0` → return to caller's free-form path (§4).
+3. Otherwise:
+   a. Pick `$SLUG` (§3.1).
+   b. `openspec new change "$SLUG"` (§3.2).
+   c. Author `proposal.md`, `design.md`, `specs/<capability>/spec.md` (§3.2–§3.3). Mix `ADDED` / `MODIFIED` / `REMOVED` / `RENAMED` blocks as needed; remember `MODIFIED` overwrites the whole Requirement.
+   d. Optional: `openspec validate "$SLUG"`.
+   e. `chorus_pm_create_proposal` (direct MCP) with the `OpenSpec change slug: $SLUG` line in description (§3.5).
+   f. Define `$API`, `json_encode_file`, `chorus_check_response` helpers.
+   g. For each row in §5 with "yes" — mirror via `"$API" chorus_pm_add_document_draft` (§3.6). Record each `$DRAFT_UUID`.
+   h. On any failed `chorus_check_response` — halt, surface the error, do NOT proceed.
+4. Edits before approval → §3.7. Edits after approval → §3.8.
+5. Last task verified → hook fires → run §3.9 archive flow.

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -83,6 +83,16 @@ chorus_pm_create_proposal({
 ```
 
 **Multiple Ideas:** You can combine multiple ideas into one proposal by passing multiple UUIDs in `inputUuids`.
+
+### Step 1.5: Detect OpenSpec mode
+
+Before authoring document drafts, **load the `openspec-aware` skill at `~/.codex/skills/openspec-aware/SKILL.md`** and run its §1 detection contract. Branch on the result:
+
+- **`CHORUS_OPENSPEC_ACTIVE=1`** → follow `openspec-aware` §3. Pick `$SLUG`, scaffold `openspec/changes/<slug>/`, author `proposal.md` / `design.md` / `specs/<capability>/spec.md` locally, then create the proposal container (Step 1 above) with the literal line `OpenSpec change slug: <slug>` in `description`, and mirror each local file into a document draft.
+
+  > **⛔ Mandatory in OpenSpec mode:** mirror calls go through the `chorus-mcp-call.sh` wrapper with `content` produced by `json_encode_file` — see `openspec-aware` §3.6. Do **not** call `chorus_pm_add_document_draft` directly from Codex's MCP harness with a hand-typed `content` field. Re-typing thousands of lines through the model burns 20k+ content tokens per proposal and breaks byte-equality with the local source of truth (`openspec-aware` §2 Rule 1 explains the full reasoning). Skip Step 2 below when in OpenSpec mode — the wrapper-based flow in `openspec-aware` §3.6 replaces it for documents.
+
+- **`CHORUS_OPENSPEC_ACTIVE=0`** (CLI absent or `CHORUS_OPENSPEC_MODE=off`) → proceed with Step 2 unchanged. Author drafts inline as free-form Markdown via direct MCP `chorus_pm_add_document_draft`.
 
 ### Step 2: Add Document Drafts
 

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.8.0
+version: 0.8.1
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -181,18 +181,40 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
 
 #### Step 1.4: Create Proposal
 
-1. **Create empty container:**
+1. **Detect OpenSpec mode.** Load the `openspec-aware` skill at `~/.codex/skills/openspec-aware/SKILL.md` and run its §1 detection contract. The result determines how the rest of this step authors documents:
+
+   - `CHORUS_OPENSPEC_ACTIVE=1` → spec-driven branch (sub-step 2a below).
+   - `CHORUS_OPENSPEC_ACTIVE=0` → free-form branch (sub-step 2b below).
+
+   This is mandatory — yolo runs unattended, so silently picking the wrong mode is exactly the failure scenario the detection contract exists to prevent.
+
+2. **Create the empty proposal container.** In OpenSpec mode, the `description` MUST contain the literal line `OpenSpec change slug: <slug>` (use the `$SLUG` you'll pick in 2a); in free-form mode, omit that line.
+
    ```
    chorus_pm_create_proposal({
      projectUuid: "<project-uuid>",
      title: "<feature name>",
-     description: "<summary of what the proposal covers>",
+     description: "<summary>\n\nOpenSpec change slug: <slug>",   // OpenSpec mode
+     // description: "<summary>",                                 // free-form mode
      inputType: "idea",
      inputUuids: ["<idea-uuid>"]
    })
    ```
 
-2. **Add tech design document draft:**
+   Then branch:
+
+   **2a. OpenSpec mode (`CHORUS_OPENSPEC_ACTIVE=1`).** Follow `openspec-aware` §3 end-to-end:
+   - Pick `$SLUG`, run `openspec new change "$SLUG"` (§3.1–§3.2).
+   - Author `proposal.md`, `design.md`, and one `specs/<capability>/spec.md` per capability locally on disk (§3.3). ADDED Requirements only; per-spec fallback to free-form Markdown if MODIFIED/REMOVED is needed.
+   - Define `$API`, `json_encode_file`, `chorus_check_response` helpers (§3.4, §6).
+   - Mirror each local file via `"$API" chorus_pm_add_document_draft "$PAYLOAD"` (§3.6) — one call per file, with the document type from `openspec-aware` §5. (Codex's `chorus-mcp-call.sh` takes `<TOOL_NAME> <JSON>` directly; no `mcp-tool` subcommand.)
+
+   > **⛔ Do not** invoke `chorus_pm_add_document_draft` / `chorus_pm_update_document_draft` / `chorus_pm_update_document` from Codex's MCP harness with a hand-typed `content` field in this branch. Re-typing the markdown body wastes 20k+ tokens per proposal and breaks byte-equality with the local files. See `openspec-aware` §2 Rule 1.
+
+   Then continue to step 3 (task drafts).
+
+   **2b. Free-form mode (`CHORUS_OPENSPEC_ACTIVE=0`).** Add a tech design document draft directly via MCP, content authored inline:
+
    ```
    chorus_pm_add_document_draft({
      proposalUuid: "<proposal-uuid>",

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Chorus-AIDLC"
   },
@@ -32,6 +32,12 @@
       "title": "Max Task Review Rounds",
       "description": "Maximum review rounds before escalating to human. Set to 0 for unlimited.",
       "default": 3
+    },
+    "enableOpenSpec": {
+      "type": "boolean",
+      "title": "Enable OpenSpec Mode",
+      "description": "Opt-in spec-driven authoring path. When enabled and the repo is OpenSpec-init'd (openspec/ folder + openspec CLI both present), proposal/develop/yolo skills author proposal.md / design.md / specs/<capability>/spec.md on disk and mirror them into Chorus drafts via the wrapper script (saves ~20k tokens per proposal vs. retyping through MCP). Also enables the post-verify archive hook that reminds the agent to run `openspec archive <slug>` after the last task is verified. Silent no-op when the repo is not OpenSpec-init'd.",
+      "default": true
     }
   },
   "keywords": [

--- a/public/chorus-plugin/bin/on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/on-post-verify-task.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# on-post-verify-task.sh — PostToolUse hook for chorus_admin_verify_task
+#
+# Detects the "last task verified for an OpenSpec-mode idea" condition and
+# injects an additionalContext reminder telling the main agent to run
+# `openspec archive <slug>` and mirror the resulting
+# openspec/specs/<capability>/spec.md files back to the matching Chorus
+# Documents.
+#
+# Detection contract (all signals must hold to fire):
+#   1. CHORUS_OPENSPEC_MODE != "off" — explicit opt-out wins.
+#   2. The project root contains an `openspec/` directory — this repo is
+#      OpenSpec-init'd. Probed via $CLAUDE_PROJECT_DIR/openspec.
+#   3. `openspec` CLI is on PATH — needed for the agent's later
+#      `openspec archive` step. Both (2) and (3) are required because
+#      either alone leaves the archive workflow unrunnable.
+#   4. The verified task's proposal description contains a line matching
+#      ^OpenSpec change slug: <slug>$ (slug provenance from §3.5).
+#   5. Every task under the same proposal has status === "done".
+#
+# If any signal fails, the hook exits 0 silently (strict opt-in).
+#
+# Bash 3.2 compatible (per CLAUDE.md pitfall #10): no ${VAR,,}, no
+# ${VAR^^}, no `declare -A`, no `mapfile`, no `readarray`, no `|&`,
+# no `&>>`.
+#
+# All shell variable parsing of captured JSON uses
+# `printf '%s' "$VAR" | jq ...` rather than `echo "$VAR" | jq ...` —
+# echo corrupts multi-line content on `\n` (canonical §6 warning).
+
+set -euo pipefail
+
+# Check userConfig toggle — default enabled. The same `enableOpenSpec`
+# switch gates SessionStart detection; if it's off, we skip the archive
+# reminder too. (Env-level CHORUS_OPENSPEC_MODE=off is checked separately
+# at step 4 for symmetry with the SessionStart gate.)
+if [ "${CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC:-true}" != "true" ]; then
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API="${SCRIPT_DIR}/chorus-api.sh"
+
+# Read event JSON from stdin (PostToolUse hook input)
+EVENT=""
+if [ ! -t 0 ]; then
+  EVENT=$(cat)
+fi
+
+if [ -z "$EVENT" ]; then
+  exit 0
+fi
+
+# Step 2: Extract taskUuid from .tool_input
+TASK_UUID=$(printf '%s' "$EVENT" | jq -r '.tool_input.taskUuid // empty' 2>/dev/null) || true
+
+# Step 3: If taskUuid is empty -> exit 0 silently
+if [ -z "$TASK_UUID" ]; then
+  exit 0
+fi
+
+# Step 4: OpenSpec gate — explicit opt-out, then folder + CLI both required.
+# Both folder-presence and CLI-presence are necessary: the agent will run
+# `openspec archive <slug>` on receipt of the injected reminder, and that
+# command needs the openspec/ working directory AND the CLI on PATH. If
+# either is missing, the reminder would point the agent at a dead end, so
+# we silently skip injection and let the verify pass through unannotated.
+if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+  exit 0
+fi
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+if [ ! -d "${PROJECT_ROOT}/openspec" ]; then
+  exit 0
+fi
+if ! command -v openspec >/dev/null 2>&1; then
+  exit 0
+fi
+if ! openspec --version >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Step 5: chorus_get_task -> proposalUuid
+TASK_JSON=$("$API" mcp-tool chorus_get_task "$(printf '{"taskUuid":"%s"}' "$TASK_UUID")" 2>/dev/null) || exit 0
+if [ -z "$TASK_JSON" ]; then
+  exit 0
+fi
+
+PROPOSAL_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.proposalUuid // empty' 2>/dev/null) || true
+PROJECT_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.project.uuid // empty' 2>/dev/null) || true
+
+# Step 6: If proposalUuid empty -> exit 0 silently (Quick Tasks have no proposal)
+if [ -z "$PROPOSAL_UUID" ]; then
+  exit 0
+fi
+
+# Step 7: chorus_get_proposal -> description (for slug grep)
+PROPOSAL_JSON=$("$API" mcp-tool chorus_get_proposal "$(printf '{"proposalUuid":"%s"}' "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
+if [ -z "$PROPOSAL_JSON" ]; then
+  exit 0
+fi
+
+PROPOSAL_DESC=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.description // empty' 2>/dev/null) || true
+
+# Step 9: grep description for ^OpenSpec change slug: (.+)$ — first match wins
+SLUG=""
+if [ -n "$PROPOSAL_DESC" ]; then
+  # POSIX-portable: print description with embedded newlines via printf %s
+  # then grep line-anchored for the slug marker.
+  SLUG_LINE=$(printf '%s\n' "$PROPOSAL_DESC" | grep -E '^OpenSpec change slug: .+' | head -1 || true)
+  if [ -n "$SLUG_LINE" ]; then
+    # Strip the prefix; trim trailing whitespace.
+    SLUG=$(printf '%s' "$SLUG_LINE" | sed -e 's/^OpenSpec change slug:[[:space:]]*//' -e 's/[[:space:]]*$//')
+  fi
+fi
+
+# Step 10: If $SLUG is empty -> exit 0 silently (free-form proposal)
+if [ -z "$SLUG" ]; then
+  exit 0
+fi
+
+# Step 8: chorus_list_tasks (filtered by proposalUuid) -> verify every task is "done".
+# (The proposal-design assumed chorus_get_idea returned tasks[], but the
+# actual MCP tool only returns IdeaResponse; chorus_list_tasks with the
+# proposalUuids filter is the closest equivalent and is the documented
+# contract.)
+#
+# We page through up to 200 tasks (pageSize=200) — far above the design
+# expectation of ~10-20 tasks per proposal. If a proposal exceeds 200
+# tasks the hook conservatively exits 0 silently, matching the
+# Tech Design "Risk: chorus_get_idea is paginated" mitigation.
+TASKS_JSON=$("$API" mcp-tool chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
+if [ -z "$TASKS_JSON" ]; then
+  exit 0
+fi
+
+TOTAL_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.total // 0' 2>/dev/null) || true
+RETURNED_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.tasks | length' 2>/dev/null) || true
+
+# Pagination guard: if total exceeds what we fetched, exit silently (better
+# safe than fire prematurely).
+if [ -n "$TOTAL_TASKS" ] && [ -n "$RETURNED_TASKS" ] && [ "$TOTAL_TASKS" -gt "$RETURNED_TASKS" ]; then
+  exit 0
+fi
+
+# Defensive: zero-task proposal would otherwise fall through with
+# NOT_DONE_COUNT=0. Proposal-submit validation prevents this in practice;
+# this guard makes the gate complete.
+if [ -z "$RETURNED_TASKS" ] || [ "$RETURNED_TASKS" -eq 0 ]; then
+  exit 0
+fi
+
+NOT_DONE_COUNT=$(printf '%s' "$TASKS_JSON" | jq -r '[.tasks[] | select(.status != "done")] | length' 2>/dev/null) || true
+
+if [ -z "$NOT_DONE_COUNT" ] || [ "$NOT_DONE_COUNT" != "0" ]; then
+  exit 0
+fi
+
+# Step 11: Build CONTEXT — instruct the agent to run `openspec archive <SLUG>`
+# and mirror the resulting specs/<capability>/spec.md files back to the
+# matching Chorus Documents.
+#
+# Note on chorus_get_documents: the canonical §3.8 mirror-back step uses
+# `chorus_get_documents(projectUuid)` (the only filter the tool supports
+# server-side is `type` — there is NO server-side title-prefix filter).
+# The agent must list all `type:"spec"` documents and filter client-side
+# by title prefix `Spec:` to find the matching capability.
+
+CONTEXT="[Chorus Plugin — OpenSpec Archive Trigger]
+The last task of OpenSpec-mode proposal ${PROPOSAL_UUID} (slug \`${SLUG}\`) has been admin-verified.
+
+ACTION REQUIRED: archive the OpenSpec change locally and mirror updated specs back to the Chorus Documents. Run the steps below in order; HALT immediately on any error (canonical §6 — no silent errors).
+
+1. Run \`openspec archive ${SLUG}\` in the repo root. This moves \`openspec/changes/${SLUG}/\` under \`openspec/changes/archive/<date>-${SLUG}/\` and emits/updates one \`openspec/specs/<capability>/spec.md\` per capability. If the CLI prompts interactively and a \`--yes\`/\`--no-confirm\` flag is available, use it (verify with \`openspec archive --help\`).
+
+2. For EACH newly-emitted \`openspec/specs/<capability>/spec.md\`:
+   - List all spec-type Documents in this project: \`chorus_get_documents({projectUuid: \"${PROJECT_UUID}\", type: \"spec\"})\`. The \`type\` filter is the only server-side filter — do client-side title matching against the documents you get back.
+   - Find the Document whose title matches the capability (canonical §3.8 mirror-back contract; typical title shape \`Spec: <capability>\`).
+   - Call \`chorus_pm_update_document\` with the new content from the on-disk spec.md.
+
+3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: \"proposal\", targetUuid: \"${PROPOSAL_UUID}\", content: \"...\"})\`), and HALT. No retry, no silent skip.
+
+4. Confirm success by listing \`openspec/specs/<capability>/spec.md\` files and verifying they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+
+References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors)."
+
+# Step 12: Inject CONTEXT as additionalContext.
+"$API" hook-output "" "$CONTEXT" "PostToolUse"
+
+# Step 13: exit 0 (set -e already enforces this on success).
+exit 0

--- a/public/chorus-plugin/bin/on-session-start.sh
+++ b/public/chorus-plugin/bin/on-session-start.sh
@@ -61,6 +61,36 @@ if command -v jq >/dev/null 2>&1; then
 
 fi
 
+# Detect OpenSpec mode for this repo, once per session.
+# Both conditions are required for OpenSpec mode to be usable:
+#   (a) an openspec/ directory at the project root (this repo was inited via `openspec init`), AND
+#   (b) the `openspec` CLI on PATH (so we can `openspec new change`, `validate`, `archive`).
+# Overrides (precedence high -> low, first match wins):
+#   1. enableOpenSpec userConfig toggle (default true) — UI-level switch.
+#   2. CHORUS_OPENSPEC_MODE=off env var — env-level explicit opt-out.
+# When the folder is present but the CLI is missing, surface that as a
+# specific reason so the user-visible toast can hint at the install step
+# instead of silently falling back.
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+OPENSPEC_HINT=""
+if [ "${CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC:-true}" != "true" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_REASON="enableOpenSpec userConfig=false (plugin-level opt-out)"
+elif [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_REASON="CHORUS_OPENSPEC_MODE=off (explicit opt-out)"
+elif [ ! -d "${PROJECT_ROOT}/openspec" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_REASON="no openspec/ directory at ${PROJECT_ROOT}/openspec"
+elif ! command -v openspec >/dev/null 2>&1; then
+  CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_REASON="openspec/ directory present but \`openspec\` CLI not on PATH"
+  OPENSPEC_HINT="install with: npm i -g @fission-ai/openspec"
+else
+  CHORUS_OPENSPEC_ACTIVE=1
+  OPENSPEC_REASON="openspec/ directory + openspec CLI both present"
+fi
+
 # Build context for Claude (additionalContext)
 CONTEXT="# Chorus Plugin — Active
 
@@ -69,6 +99,29 @@ Chorus is connected at ${CHORUS_URL}. Session lifecycle hooks are enabled.
 ## Checkin
 
 ${CHECKIN_RESULT}
+
+## OpenSpec Mode
+
+CHORUS_OPENSPEC_ACTIVE=${CHORUS_OPENSPEC_ACTIVE} (${OPENSPEC_REASON})"
+
+if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
+  CONTEXT="${CONTEXT}
+
+OpenSpec mode is **active** for this session. When the proposal / develop / yolo skills reach an OpenSpec-aware step, load the openspec-aware skill at \`.claude/skills/openspec-aware/SKILL.md\` and follow §3 (OpenSpec authoring) — do NOT re-run the §1 detection block, the answer is already known.
+
+Critical rule (openspec-aware §2 Rule 1): document mirror calls (\`chorus_pm_add_document_draft\` / \`chorus_pm_update_document_draft\` / \`chorus_pm_update_document\`) MUST go through \`chorus-api.sh mcp-tool\` with \`content\` produced by \`json_encode_file\`. Do NOT invoke these MCP tools directly with hand-typed \`content\` in OpenSpec mode."
+else
+  CONTEXT="${CONTEXT}
+
+OpenSpec mode is **inactive** for this session. The proposal / develop / yolo skills follow their free-form path; do NOT scaffold \`openspec/changes/\`, do NOT add an \`OpenSpec change slug:\` line to proposal descriptions, and do NOT route document mirror calls through \`chorus-api.sh\`."
+  if [ -n "$OPENSPEC_HINT" ]; then
+    CONTEXT="${CONTEXT}
+
+Note: this repo has an \`openspec/\` directory, so the user likely intends to use OpenSpec mode but the \`openspec\` CLI is not installed. Surface this to the user (e.g. \"This repo is OpenSpec-init'd but the \\\`openspec\\\` CLI isn't installed locally — ${OPENSPEC_HINT}\") before authoring documents so they can install it and re-launch the session if they want spec-driven mode."
+  fi
+fi
+
+CONTEXT="${CONTEXT}
 
 ## Quick Reference
 
@@ -88,6 +141,11 @@ fi
 
 # Build user-visible message
 USER_MSG="Chorus connected at ${CHORUS_URL}"
+if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec Enabled)"
+elif [ -n "$OPENSPEC_HINT" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec repo detected — ${OPENSPEC_HINT})"
+fi
 if [ -n "$MAIN_SESSION" ]; then
   USER_MSG="${USER_MSG} (resumed session)"
 fi

--- a/public/chorus-plugin/bin/test-syntax.sh
+++ b/public/chorus-plugin/bin/test-syntax.sh
@@ -72,6 +72,7 @@ run_test "on-task-completed.sh"  '{"task_id":"task-001"}'
 # --- PostToolUse hooks ---
 run_test "on-post-submit-proposal.sh"  '{"tool_input":{"proposalUuid":"test-uuid"},"tool_response":{"uuid":"test-uuid","status":"pending","title":"Test proposal"}}'
 run_test "on-post-submit-for-verify.sh" '{"tool_input":{"taskUuid":"test-uuid"},"tool_response":{"uuid":"test-uuid","status":"to_verify","title":"Test task"}}'
+run_test "on-post-verify-task.sh" '{"tool_input":{"taskUuid":"test-uuid"},"tool_response":{"uuid":"test-uuid","status":"done","title":"Test task"}}'
 
 # --- Session hooks ---
 run_test "on-session-start.sh"   '{}'

--- a/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# test-on-post-verify-task.sh — Fixture-based shell test for the
+# on-post-verify-task.sh hooks (Claude Code + Codex variants).
+#
+# We can't talk to a real Chorus backend in CI, so we shim out the MCP
+# wrapper and the openspec CLI: the test creates a sandbox PATH and a
+# replacement "chorus-api.sh" / "chorus-mcp-call.sh" that echo canned JSON
+# responses keyed off the (tool_name, fixture_id) pair carried via the
+# CHORUS_FIXTURE env var. The replacement scripts are invoked because the
+# hook resolves them by directory next to itself (Claude Code) or sources
+# hook-output.sh by directory (Codex). We exploit this by COPYING the
+# hook into a sandbox dir alongside our shim wrapper — the hook's
+# `dirname "$0"` lookup then picks up our shim, not the real wrapper.
+#
+# Fixtures cover all gating branches:
+#   positive       — last task verified, slug present, openspec/ folder + CLI both present
+#                    -> stdout MUST contain `openspec archive my-feature`
+#   not-last-task  — slug present, both signals present, but one task still in_progress
+#                    -> stdout MUST NOT contain `openspec archive`
+#   no-slug        — proposal description has no `OpenSpec change slug:` line
+#                    -> stdout MUST NOT contain `openspec archive`
+#   no-cli         — openspec/ folder present but `openspec` CLI not on PATH
+#                    -> stdout MUST NOT contain `openspec archive`
+#   no-folder      — CLI on PATH but no openspec/ directory in project root
+#                    -> stdout MUST NOT contain `openspec archive`
+#   mode-off       — CHORUS_OPENSPEC_MODE=off (explicit opt-out), even with both signals present
+#                    -> stdout MUST NOT contain `openspec archive`
+#
+# All fixtures must end with exit 0.
+#
+# Bash 3.2 compatible. Run:
+#   /bin/bash public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+CLAUDE_HOOK="$REPO_ROOT/public/chorus-plugin/bin/on-post-verify-task.sh"
+CODEX_HOOK="$REPO_ROOT/plugins/chorus/hooks/on-post-verify-task.sh"
+CODEX_HOOK_OUTPUT="$REPO_ROOT/plugins/chorus/hooks/hook-output.sh"
+
+[ -x "$CLAUDE_HOOK" ] || { echo "FAIL: $CLAUDE_HOOK is not executable" >&2; exit 1; }
+[ -x "$CODEX_HOOK" ]  || { echo "FAIL: $CODEX_HOOK is not executable" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+FAILED=""
+
+# ----- Build sandbox -----
+
+SANDBOX=$(mktemp -d)
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+# Sandbox layout:
+#   $SANDBOX/claude/    — copy of Claude hook + shim chorus-api.sh
+#   $SANDBOX/codex/     — copy of Codex hook + shim chorus-mcp-call.sh + real hook-output.sh
+#   $SANDBOX/bin/       — fake openspec CLI on PATH
+#   $SANDBOX/project/   — synthetic project root (contains openspec/ for fixtures
+#                         that need the folder signal to be present)
+mkdir -p "$SANDBOX/claude" "$SANDBOX/codex" "$SANDBOX/bin" "$SANDBOX/project/openspec"
+
+cp "$CLAUDE_HOOK" "$SANDBOX/claude/on-post-verify-task.sh"
+cp "$CODEX_HOOK"  "$SANDBOX/codex/on-post-verify-task.sh"
+cp "$CODEX_HOOK_OUTPUT" "$SANDBOX/codex/hook-output.sh"
+chmod +x "$SANDBOX/claude/on-post-verify-task.sh" "$SANDBOX/codex/on-post-verify-task.sh"
+
+# ----- Shim: chorus-api.sh (Claude Code shape) -----
+# Subcommand interface:
+#   chorus-api.sh mcp-tool <tool> <json_args>   -> echo canned JSON
+#   chorus-api.sh hook-output "" "$CONTEXT" "PostToolUse"
+# We delegate hook-output to a real jq invocation so the emitted JSON
+# matches the production wrapper's shape.
+cat > "$SANDBOX/claude/chorus-api.sh" <<'SHIM_CLAUDE'
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  mcp-tool)
+    tool="$1"
+    # CHORUS_FIXTURE picks the canned response set. Some fixtures
+    # (mode-off / no-folder / no-cli) test the OpenSpec gates that fire
+    # BEFORE any MCP call; we route them to the same canned data as
+    # "positive" so that if a gate is silently broken the hook reaches
+    # MCP, gets a positive result, and emits an archive reminder —
+    # failing the "no archive reminder" assertion. Without this aliasing
+    # the test would pass for the wrong reason (silent-skip at empty
+    # TASK_JSON instead of at the gate).
+    fixture="${CHORUS_FIXTURE:-positive}"
+    case "$fixture" in
+      mode-off|no-folder|no-cli) fixture=positive ;;
+    esac
+    case "${fixture}:${tool}" in
+      positive:chorus_get_task)
+        echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      positive:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-1","title":"P1","description":"Some intro line.\nOpenSpec change slug: my-feature\nMore body.","inputUuids":["idea-1"]}'
+        ;;
+      positive:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
+        ;;
+      not-last-task:chorus_get_task)
+        echo '{"uuid":"task-2","title":"Task 2","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      not-last-task:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-1","title":"P1","description":"Intro.\nOpenSpec change slug: my-feature\nMore.","inputUuids":["idea-1"]}'
+        ;;
+      not-last-task:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"in_progress"}],"total":3,"page":1,"pageSize":200}'
+        ;;
+      no-slug:chorus_get_task)
+        echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-2","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      no-slug:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-2","title":"P2","description":"Free-form proposal description with no slug marker.","inputUuids":["idea-2"]}'
+        ;;
+      no-slug:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
+        ;;
+      *)
+        # Unhandled (tool, fixture) — return empty, hook should silent-skip.
+        echo ""
+        ;;
+    esac
+    ;;
+  hook-output)
+    sm="${1:-}"; ac="${2:-}"; hen="${3:-}"
+    if [ -n "$ac" ]; then
+      jq -n --arg sm "$sm" --arg ac "$ac" --arg hen "$hen" \
+        '{systemMessage:$sm, hookSpecificOutput:{hookEventName:$hen, additionalContext:$ac}}'
+    else
+      jq -n --arg sm "$sm" '{systemMessage:$sm}'
+    fi
+    ;;
+  *)
+    echo "shim chorus-api.sh: unknown cmd $cmd" >&2; exit 2 ;;
+esac
+SHIM_CLAUDE
+chmod +x "$SANDBOX/claude/chorus-api.sh"
+
+# ----- Shim: chorus-mcp-call.sh (Codex shape) -----
+# Codex wrapper interface:
+#   chorus-mcp-call.sh <tool> <json_args>   -> echo canned JSON
+cat > "$SANDBOX/codex/chorus-mcp-call.sh" <<'SHIM_CODEX'
+#!/usr/bin/env bash
+set -euo pipefail
+tool="${1:-}"
+# Alias gate-test fixtures to "positive" canned data so a broken gate
+# would let the hook proceed and emit an archive reminder, failing the
+# "no archive reminder" assertion. See claude shim for full rationale.
+fixture="${CHORUS_FIXTURE:-positive}"
+case "$fixture" in
+  mode-off|no-folder|no-cli) fixture=positive ;;
+esac
+case "${fixture}:${tool}" in
+  positive:chorus_get_task)
+    echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  positive:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-1","title":"P1","description":"Some intro line.\nOpenSpec change slug: my-feature\nMore body.","inputUuids":["idea-1"]}'
+    ;;
+  positive:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
+    ;;
+  not-last-task:chorus_get_task)
+    echo '{"uuid":"task-2","title":"Task 2","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  not-last-task:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-1","title":"P1","description":"Intro.\nOpenSpec change slug: my-feature\nMore.","inputUuids":["idea-1"]}'
+    ;;
+  not-last-task:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"in_progress"}],"total":3,"page":1,"pageSize":200}'
+    ;;
+  no-slug:chorus_get_task)
+    echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-2","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  no-slug:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-2","title":"P2","description":"Free-form proposal description with no slug marker.","inputUuids":["idea-2"]}'
+    ;;
+  no-slug:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
+    ;;
+  *)
+    echo "" ;;
+esac
+SHIM_CODEX
+chmod +x "$SANDBOX/codex/chorus-mcp-call.sh"
+
+# ----- Fake `openspec` on PATH -----
+# Default behavior: `openspec --version` exits 0. The "no-openspec"
+# fixture rebuilds PATH without this dir to simulate CLI absence.
+cat > "$SANDBOX/bin/openspec" <<'OPENSPEC_FAKE'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "openspec 0.0.0-fixture"; exit 0 ;;
+  *) echo "openspec fixture: ignoring $*"; exit 0 ;;
+esac
+OPENSPEC_FAKE
+chmod +x "$SANDBOX/bin/openspec"
+
+# ----- Synthetic PostToolUse event JSON -----
+EVENT_JSON='{"tool_name":"chorus_admin_verify_task","tool_input":{"taskUuid":"task-3"},"tool_response":{"uuid":"task-3","status":"done","title":"Task 3"}}'
+
+# ----- Test runner -----
+
+# Args: name fixture variant expected_substring should_contain
+# variant in {claude, codex}
+# should_contain: "yes" -> stdout MUST contain expected_substring
+# should_contain: "no"  -> stdout MUST NOT contain "openspec archive"
+run_one() {
+  local name="$1"
+  local fixture="$2"
+  local variant="$3"
+  local should_contain="$4"
+  local expected="$5"
+
+  local hook_dir
+  if [ "$variant" = "claude" ]; then
+    hook_dir="$SANDBOX/claude"
+  else
+    hook_dir="$SANDBOX/codex"
+  fi
+
+  # Build PATH:
+  # - default fixtures get $SANDBOX/bin (where the fake openspec lives)
+  #   prepended in front of the inherited PATH;
+  # - "no-cli" needs to actually have NO openspec on PATH. Just removing
+  #   $SANDBOX/bin isn't enough — the dev machine often has a real
+  #   openspec under ~/.nvm/.../bin or similar. So for no-cli we strip
+  #   every PATH entry that contains an `openspec` executable.
+  local PATH_FOR_RUN
+  if [ "$fixture" = "no-cli" ]; then
+    local _filtered=""
+    local _entry
+    for _entry in $(printf '%s' "$PATH" | tr ':' '\n'); do
+      if [ -z "$_entry" ]; then continue; fi
+      if [ -x "$_entry/openspec" ]; then continue; fi
+      if [ -n "$_filtered" ]; then
+        _filtered="$_filtered:$_entry"
+      else
+        _filtered="$_entry"
+      fi
+    done
+    PATH_FOR_RUN="$_filtered"
+  else
+    PATH_FOR_RUN="$SANDBOX/bin:$PATH"
+  fi
+
+  # Pick the working directory + CLAUDE_PROJECT_DIR. The "no-folder"
+  # fixture points the hook at $SANDBOX (which contains no openspec/),
+  # everything else uses $SANDBOX/project (which has openspec/).
+  local PROJECT_DIR_FOR_RUN
+  if [ "$fixture" = "no-folder" ]; then
+    PROJECT_DIR_FOR_RUN="$SANDBOX"
+  else
+    PROJECT_DIR_FOR_RUN="$SANDBOX/project"
+  fi
+
+  # The "mode-off" fixture sets the explicit-opt-out env var; everything
+  # else leaves it unset.
+  local MODE_VAR_FOR_RUN=""
+  if [ "$fixture" = "mode-off" ]; then
+    MODE_VAR_FOR_RUN="off"
+  fi
+
+  local stdout_file
+  stdout_file=$(mktemp)
+  local stderr_file
+  stderr_file=$(mktemp)
+  local rc=0
+
+  printf '%s' "$EVENT_JSON" \
+    | env -i \
+        HOME="$HOME" \
+        CHORUS_FIXTURE="$fixture" \
+        PATH="$PATH_FOR_RUN" \
+        CLAUDE_PROJECT_DIR="$PROJECT_DIR_FOR_RUN" \
+        CHORUS_OPENSPEC_MODE="$MODE_VAR_FOR_RUN" \
+        /bin/bash -c "cd \"$PROJECT_DIR_FOR_RUN\" && /bin/bash \"$hook_dir/on-post-verify-task.sh\"" \
+        >"$stdout_file" 2>"$stderr_file" || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    echo "  FAIL  $name [$variant] exit=$rc"
+    sed 's/^/         /' "$stderr_file"
+    FAIL=$((FAIL + 1))
+    FAILED="$FAILED $name[$variant]"
+    rm -f "$stdout_file" "$stderr_file"
+    return
+  fi
+
+  local stdout
+  stdout=$(cat "$stdout_file")
+  rm -f "$stdout_file" "$stderr_file"
+
+  if [ "$should_contain" = "yes" ]; then
+    if printf '%s' "$stdout" | grep -q "$expected"; then
+      echo "  PASS  $name [$variant]"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL  $name [$variant]: stdout missing '$expected'"
+      printf '%s\n' "$stdout" | sed 's/^/         /'
+      FAIL=$((FAIL + 1))
+      FAILED="$FAILED $name[$variant]"
+    fi
+  else
+    # should_contain == "no": archive reminder MUST be absent.
+    if printf '%s' "$stdout" | grep -q "openspec archive"; then
+      echo "  FAIL  $name [$variant]: stdout unexpectedly contains 'openspec archive'"
+      printf '%s\n' "$stdout" | sed 's/^/         /'
+      FAIL=$((FAIL + 1))
+      FAILED="$FAILED $name[$variant]"
+    else
+      echo "  PASS  $name [$variant]"
+      PASS=$((PASS + 1))
+    fi
+  fi
+}
+
+echo "Sandbox: $SANDBOX"
+echo ""
+
+# ----- Branch 1: positive (slug + last task + CLI) -----
+run_one "positive"      "positive"      "claude" "yes" "openspec archive my-feature"
+run_one "positive"      "positive"      "codex"  "yes" "openspec archive my-feature"
+
+# ----- Branch 2: not-last-task -----
+run_one "not-last-task" "not-last-task" "claude" "no"  ""
+run_one "not-last-task" "not-last-task" "codex"  "no"  ""
+
+# ----- Branch 3: no-slug (free-form proposal) -----
+run_one "no-slug"       "no-slug"       "claude" "no"  ""
+run_one "no-slug"       "no-slug"       "codex"  "no"  ""
+
+# ----- Branch 4: no-cli (folder present, CLI absent) -----
+# Strip $SANDBOX/bin from PATH so `command -v openspec` fails. Folder is
+# still there in $SANDBOX/project/openspec. Hook must short-circuit at
+# step 4 (CLI gate) and emit no archive reminder.
+run_one "no-cli"        "no-cli"        "claude" "no"  ""
+run_one "no-cli"        "no-cli"        "codex"  "no"  ""
+
+# ----- Branch 5: no-folder (CLI present, folder absent) -----
+# CLAUDE_PROJECT_DIR points at $SANDBOX (no openspec/ dir there). Hook
+# must short-circuit at step 4 (folder gate) before trying any MCP calls.
+# We don't actually exercise any MCP fixture here — the hook should bail
+# before reaching the wrappers. We pass "positive" only because the
+# unhandled-fixture branch in the shim returns an empty body and the hook
+# would then silent-skip on get_task. Either way the assertion ("no
+# archive reminder") holds.
+run_one "no-folder"     "no-folder"     "claude" "no"  ""
+run_one "no-folder"     "no-folder"     "codex"  "no"  ""
+
+# ----- Branch 6: mode-off (explicit opt-out via env) -----
+# Both folder and CLI are present, but CHORUS_OPENSPEC_MODE=off. Hook
+# must honor the opt-out and exit silently.
+run_one "mode-off"      "mode-off"      "claude" "no"  ""
+run_one "mode-off"      "mode-off"      "codex"  "no"  ""
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed:$FAILED"
+  exit 1
+fi
+exit 0

--- a/public/chorus-plugin/hooks/hooks.json
+++ b/public/chorus-plugin/hooks/hooks.json
@@ -39,6 +39,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/bin/on-post-submit-for-verify.sh"
           }
         ]
+      },
+      {
+        "matcher": ".*chorus_admin_verify_task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/on-post-verify-task.sh"
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -387,6 +387,7 @@ This is the core overview skill. For stage-specific workflows, use:
 | **Planning** | `/proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
 | **Development** | `/develop` | Claim Tasks, report work, session & sub-agent management, Agent Teams integration |
 | **Review** | `/review` | Approve/reject Proposals, verify Tasks, project governance |
+| **OpenSpec mode** | `openspec-aware` | Opt-in **shared sub-procedure** invoked by `/proposal`, `/develop`, and `/yolo` whenever the user has the `openspec` CLI installed. Scaffolds `openspec/changes/<slug>/` on disk and mirrors files into Chorus document drafts via the `chorus-api.sh` wrapper. Skips silently in fallback mode. See `.claude/skills/openspec-aware/SKILL.md`. |
 
 ### Getting Started
 

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -132,6 +132,14 @@ Each task and proposal includes a `commentCount` field — use it to decide whic
    ```
    chorus_get_documents({ projectUuid: "<project-uuid>" })
    ```
+
+> **Document update flow (OpenSpec mode):** if the originating proposal `description` contains a line `OpenSpec change slug: <slug>`, the project's PRD / tech_design / spec Documents are **mirrors** of files under `openspec/changes/<slug>/`. To update such a Document (e.g. clarify an AC, fix a spec scenario before resubmitting), load the `openspec-aware` skill at `.claude/skills/openspec-aware/SKILL.md` and follow §3.8: edit the local `.md` file first, then mirror through the `chorus-api.sh` wrapper with `json_encode_file` and `chorus_check_response`.
+>
+> **⛔ Do not** call `chorus_pm_update_document` directly from the MCP harness with a hand-typed `content` field in OpenSpec mode. The local file is the source of truth; agent-typed content drifts and burns tokens (`openspec-aware` §2 Rule 1).
+>
+> When the LAST task of an OpenSpec idea is verified, the plugin's PostToolUse hook injects an archive reminder (`openspec-aware` §3.9) — run `openspec archive <slug> --yes`, then mirror each emitted `openspec/specs/<capability>/spec.md` back via §3.8.
+>
+> In the no-OpenSpec fallback (no slug line, or no `openspec` CLI), edit the Document content directly via the existing MCP tool with no wrapper, no local file step.
 
 ### Step 5: Start Working
 

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: openspec-aware
+description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Code. Detects the local `openspec` CLI, scaffolds `openspec/changes/<slug>/` on disk, and mirrors Markdown files into Chorus document drafts via the `chorus-api.sh` wrapper. Required reading for the proposal, develop, and yolo skills whenever the user has the `openspec` CLI installed.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.8.1"
+  category: project-management
+  mcp_server: chorus
+---
+
+# OpenSpec-aware Authoring (Claude Code plugin)
+
+This skill is a **shared sub-procedure** invoked by the Chorus stage skills (proposal, develop, yolo) whenever the user wants spec-driven authoring through the [OpenSpec CLI](https://github.com/Fission-AI/OpenSpec). It is opt-in:
+
+- Activates when **all three** signals hold (see §1): `CHORUS_OPENSPEC_MODE` is not `off`, an `openspec/` directory exists at the project root, and the `openspec` CLI is on `PATH`.
+- Otherwise the calling skill falls back to its existing free-form behavior.
+
+When you reach a point in proposal / develop / yolo where this skill is referenced, **read the value of `CHORUS_OPENSPEC_ACTIVE` from the SessionStart context** (see §1) and branch on it. Do not re-run the detection block — the SessionStart hook has already done it once for this session.
+
+---
+
+## §1. Detection — already done at SessionStart
+
+The Chorus plugin's SessionStart hook (`bin/on-session-start.sh`) computes `CHORUS_OPENSPEC_ACTIVE` once when the session opens and writes a `## OpenSpec Mode` section into the plugin's injected context. The value of `CHORUS_OPENSPEC_ACTIVE` is `1` only when **all three** of these hold:
+
+1. `CHORUS_OPENSPEC_MODE` is **not** set to `off` (explicit opt-out wins).
+2. The project root contains an `openspec/` directory (i.e. someone ran `openspec init` here).
+3. The `openspec` CLI is on `PATH`.
+
+Both signals (2) and (3) are required because the OpenSpec authoring path needs the working directory **and** the CLI — having one without the other leaves the workflow unrunnable. If signal (2) holds but (3) does not, the SessionStart hook surfaces a "OpenSpec repo detected — install with: `npm i -g @fission-ai/openspec`" hint to the user; the agent should pass this through if asked rather than silently choosing free-form.
+
+### How to read the value
+
+You should already see something like this in your context (look for the `## OpenSpec Mode` section near the top of the conversation):
+
+```
+## OpenSpec Mode
+
+CHORUS_OPENSPEC_ACTIVE=1 (openspec/ directory + openspec CLI both present)
+```
+
+or:
+
+```
+## OpenSpec Mode
+
+CHORUS_OPENSPEC_ACTIVE=0 (no openspec/ directory at /path/to/repo/openspec)
+```
+
+Branch:
+
+- `CHORUS_OPENSPEC_ACTIVE=1` → follow §3 (OpenSpec authoring).
+- `CHORUS_OPENSPEC_ACTIVE=0` → return to the calling skill's free-form path. **Do not** scaffold `openspec/changes/`. **Do not** add the slug line to the proposal description.
+
+### Manual fallback
+
+If you're in a sub-shell, sub-agent, or session that did not see SessionStart context (e.g. you were spawned mid-session and the parent's context was not forwarded), reconstruct the value yourself with the same three checks:
+
+```bash
+if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+elif [ ! -d "${CLAUDE_PROJECT_DIR:-$PWD}/openspec" ]; then
+  CHORUS_OPENSPEC_ACTIVE=0
+elif ! openspec --version >/dev/null 2>&1; then
+  CHORUS_OPENSPEC_ACTIVE=0
+else
+  CHORUS_OPENSPEC_ACTIVE=1
+fi
+```
+
+Use this only when SessionStart context is genuinely unavailable — duplicating the detection is wasteful when the hook already computed it.
+
+---
+
+## §2. ⛔ Two non-negotiable rules
+
+Both are enforced at review time. Both have caused incidents in past releases.
+
+### Rule 1 — Mirror via the wrapper, never re-type document content from agent output
+
+Document/draft mirror calls (`chorus_pm_add_document_draft`, `chorus_pm_update_document_draft`, `chorus_pm_update_document`) **MUST** go through:
+
+```
+"$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/chorus-api.sh" mcp-tool <tool_name> "$PAYLOAD"
+```
+
+with `$PAYLOAD` built using `json_encode_file` (defined in §3.4). Calling these tools directly from the agent's MCP harness with a hand-typed `content` field is a **protocol violation** for OpenSpec mode and will fail review. Reasons:
+
+1. **Token cost.** Re-typing a multi-thousand-line markdown body through the LLM burns input + output tokens for every draft. The wrapper streams bytes through `jq -Rs '.'` — content never enters LLM context. A typical 3-doc proposal mirror via the script costs roughly zero content-tokens; via direct MCP it routinely costs 20k+.
+2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. LLM re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The byte-equality guarantee (modulo trailing `\n`) holds **only** on the wrapper path.
+3. **Single source of truth.** With the wrapper, the local `openspec/changes/<slug>/*.md` is authoritative and Chorus is a mirror. With agent re-typing, authority splits between local file and whatever the LLM happened to output — a future diff cannot tell which one is correct.
+
+### Rule 2 — Halt on error via `chorus_check_response`
+
+Every wrapper call must check three signals: wrapper exit code, `"error":` in body, empty body. Bare `RC=$?` is **insufficient** — the wrapper exits 0 on HTTP 401 (auth failure) with empty body, so a single-signal check silently misses the most common runtime failure. See §6 for the helper definition.
+
+---
+
+## §3. OpenSpec mode authoring
+
+### 3.1 Pick a slug
+
+`openspec/changes/<slug>/` is the local change folder. The slug must be:
+
+- kebab-case (`add-export-csv`, not `addExportCsv` or `add_export_csv`),
+- derived from the source Idea title,
+- unique within `openspec/changes/`.
+
+Record it for later steps:
+
+```bash
+SLUG="add-export-csv"
+```
+
+### 3.2 Scaffold the change folder
+
+```bash
+openspec new change "$SLUG" --description "<one-line idea summary>"
+```
+
+This creates `openspec/changes/$SLUG/` with `README.md` and `.openspec.yaml`. Then author by hand:
+
+| Local file | Purpose | Mirror as `Document.type` |
+|---|---|---|
+| `proposal.md` | Why + What Changes + Capabilities + Impact | `prd` |
+| `design.md` | Architecture, contracts, risks | `tech_design` |
+| `specs/<capability>/spec.md` | Delta spec (`## ADDED Requirements` + Scenarios) | `spec` (one draft per capability) |
+| `tasks.md` | OpenSpec tasks list | _(not mirrored — Chorus task drafts are source of truth)_ |
+
+Use `openspec instructions <artifact> --change "$SLUG"` (artifacts: `proposal`, `specs`, `design`, `tasks`) for templates.
+
+### 3.3 Spec file shape (verified against `openspec instructions specs`)
+
+A delta spec lists one or more block headers — `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`, `## RENAMED Requirements` — and within each, `### Requirement:` entries. Mix freely in the same file; only include the blocks you actually need.
+
+#### `## ADDED Requirements`
+
+Append a brand-new Requirement to the long-term spec.
+
+```
+## ADDED Requirements
+
+### Requirement: <name>
+<requirement text — use SHALL / MUST for normative behavior>
+
+#### Scenario: <name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+```
+
+#### `## MODIFIED Requirements`
+
+**Whole-block replacement, not merge.** Whatever you write here completely replaces the existing same-named Requirement in the long-term spec — title, description, and *all* scenarios. Half-writing it deletes the rest.
+
+```
+## MODIFIED Requirements
+
+### Requirement: <existing name>
+<full updated requirement text>
+
+#### Scenario: <name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+
+#### Scenario: <other name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+```
+
+Always include every scenario you want the post-archive spec to have, even ones that were already present and unchanged.
+
+#### `## REMOVED Requirements`
+
+Delete a Requirement from the long-term spec. The block under the heading is just the requirement name(s) you're removing — no scenarios needed.
+
+```
+## REMOVED Requirements
+
+### Requirement: <existing name>
+```
+
+#### `## RENAMED Requirements`
+
+Rename a Requirement's title. Body and scenarios are preserved as-is in the long-term spec; use `MODIFIED` instead if you need to change anything besides the title.
+
+```
+## RENAMED Requirements
+
+### Requirement: <old name> -> <new name>
+```
+
+**Critical formatting rules (verified):**
+
+- Scenarios MUST use **exactly 4 hashtags** (`#### Scenario:`). 3 hashtags or a bullet list silently fail validation.
+- Every `### Requirement:` under `ADDED` or `MODIFIED` MUST have at least one `#### Scenario:`.
+- `MODIFIED` blocks MUST include the **full updated content** — they overwrite, not patch.
+- Use `SHALL` / `MUST` for normative requirements; avoid `should` / `may`.
+- The merge into `openspec/specs/<capability>/spec.md` happens at `openspec archive` time (§3.9), not at proposal time. While the proposal is in flight, Chorus only sees the delta file as one `spec` Document — there is no half-merged state for the skill to reason about.
+
+Optional:
+
+```bash
+openspec validate "$SLUG"
+```
+
+### 3.4 Helper: `json_encode_file`
+
+Define once at the top of the authoring session. With `jq` available it streams the file into a JSON string; the fallback matches `chorus-api.sh`'s own escaping when `jq` is missing.
+
+```bash
+json_encode_file() {
+  local _path="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rs '.' < "$_path"
+  else
+    local _content
+    _content=$(cat "$_path")
+    _content=${_content//\\/\\\\}
+    _content=${_content//\"/\\\"}
+    _content=${_content//$'\n'/\\n}
+    printf '"%s"' "$_content"
+  fi
+}
+```
+
+Round-trip: the Chorus backend appends a single `\n` to draft content on write, so server `content` is **byte-equal modulo a trailing newline**. Reviewers diffing local file vs server should ignore that one byte.
+
+### 3.5 Create the proposal container with the slug provenance line
+
+Use the regular `chorus_pm_create_proposal` MCP tool (no wrapper required for this single call — the description is short, the LLM-emitted version is fine). The description **must** carry exactly one line:
+
+```
+OpenSpec change slug: <slug>
+```
+
+- on its own line (no other text on that line),
+- literal prefix `OpenSpec change slug: ` (capital O, capital S, single space after colon),
+- no trailing punctuation,
+- value matches the slug passed to `openspec new change`.
+
+This line is machine-grep-able by future runs of this skill and by the §3.9 archive trigger.
+
+### 3.6 Mirror each document draft via the wrapper
+
+> **Rule 1 reminder:** these calls go through `chorus-api.sh`, not direct MCP. The agent must not retype the document body.
+
+Define the halt-on-error helper from §6 once at the top, then run one call per file:
+
+```bash
+API="$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/chorus-api.sh"
+
+# PRD draft
+CONTENT=$(json_encode_file "openspec/changes/$SLUG/proposal.md")
+PAYLOAD=$(cat <<JSON
+{
+  "proposalUuid": "$PROPOSAL_UUID",
+  "type": "prd",
+  "title": "PRD: $HUMAN_TITLE",
+  "content": $CONTENT
+}
+JSON
+)
+RESULT=$("$API" mcp-tool chorus_pm_add_document_draft "$PAYLOAD")
+RC=$?
+chorus_check_response "chorus_pm_add_document_draft (prd)" "$RC" "$RESULT"
+PRD_DRAFT_UUID=$(printf '%s' "$RESULT" | grep -o '"draftUuid"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+```
+
+Repeat with `type: "tech_design"` for `design.md`, and one call per capability with `type: "spec"` for each `specs/<capability>/spec.md`. Do **not** mirror `tasks.md` — Chorus task drafts (created via the `chorus_pm_add_task_draft` MCP tool, no wrapper needed) are the source of truth for tasks.
+
+> Why parsing uses `printf '%s' "$RESULT" | grep` not `echo "$RESULT" | jq`: `echo` interprets backslash sequences inside the captured JSON, turning embedded `\n` into a real newline. `jq` then aborts with `Invalid string: control characters from U+0000 through U+001F must be escaped`. `printf '%s'` emits the captured bytes verbatim. Same pattern applies to all wrapper-result parsing in this skill.
+
+### 3.7 Editing a draft after the first mirror
+
+Local file changes propagate via `chorus_pm_update_document_draft` — same wrapper, same `json_encode_file`, same halt check.
+
+```bash
+CONTENT=$(json_encode_file "openspec/changes/$SLUG/proposal.md")
+PAYLOAD=$(cat <<JSON
+{
+  "proposalUuid": "$PROPOSAL_UUID",
+  "draftUuid": "$PRD_DRAFT_UUID",
+  "content": $CONTENT
+}
+JSON
+)
+RESULT=$("$API" mcp-tool chorus_pm_update_document_draft "$PAYLOAD")
+RC=$?
+chorus_check_response "chorus_pm_update_document_draft" "$RC" "$RESULT"
+```
+
+### 3.8 Editing a Document after proposal approval
+
+Once the proposal is approved, drafts materialize into Documents with their own UUIDs. To keep `openspec/changes/$SLUG/` and the Chorus Document in sync, mirror file edits via `chorus_pm_update_document`:
+
+```bash
+CONTENT=$(json_encode_file "openspec/changes/$SLUG/specs/<capability>/spec.md")
+PAYLOAD=$(cat <<JSON
+{
+  "documentUuid": "$SPEC_DOCUMENT_UUID",
+  "content": $CONTENT
+}
+JSON
+)
+RESULT=$("$API" mcp-tool chorus_pm_update_document "$PAYLOAD")
+RC=$?
+chorus_check_response "chorus_pm_update_document" "$RC" "$RESULT"
+```
+
+To re-derive `$SPEC_DOCUMENT_UUID` from a fresh shell, look it up via `chorus_get_documents` for the proposal's project and match by `title` + `type`. Re-derive `$SLUG` by grepping the proposal's `description` for `^OpenSpec change slug: `.
+
+### 3.9 Archive after the last task is verified
+
+When the **LAST** task of an OpenSpec-mode idea is admin-verified via `chorus_admin_verify_task`, the plugin's PostToolUse hook (`bin/on-post-verify-task.sh`) injects an `additionalContext` reminder containing the literal substring `openspec archive <slug>` so you can act without re-reading the slug.
+
+The hook is read-only; you (the agent) perform the archive:
+
+1. **Run archive locally.** Use `--yes` for non-interactive mode. Do NOT pass `--skip-specs` (defeats the mirror-back) or `--no-validate` (lets malformed deltas corrupt cumulative specs).
+
+   ```bash
+   openspec archive "$SLUG" --yes
+   ```
+
+   This moves `openspec/changes/$SLUG/` under `openspec/changes/archive/<date>-<slug>/` and emits/updates `openspec/specs/<capability>/spec.md` for each capability. (Run `openspec archive --help` against your installed version to confirm the current flag set — flags can drift between releases.)
+
+2. **Mirror each updated `openspec/specs/<capability>/spec.md` back** to the matching post-approval Chorus Document (§3.8 contract). `chorus_get_documents` only supports `projectUuid` + `type` server-side filters; filter by title client-side. One `chorus_pm_update_document` call per capability.
+
+3. **Halt on any error** from `openspec archive` or `chorus_pm_update_document`. Print stderr verbatim, post a comment on the proposal recording the failure (`chorus_add_comment` with `targetType: "proposal"`, `targetUuid: <proposalUuid>`), then stop. No retry. Matches §6 "no silent errors." (Comment on the proposal, not the idea: the failure is in archiving proposal-derived specs, and proposals can be `inputType: "document"` with no idea attached.)
+
+4. **Confirm success.** List `openspec/specs/<capability>/spec.md` files and verify they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+
+**Strict opt-in:** if the verified task is not the last of its idea, OR the proposal description carries no `OpenSpec change slug: <slug>` line, OR the local shell has no `openspec` CLI, the hook exits 0 silently and no archive reminder is injected. Existing free-form behavior is preserved.
+
+---
+
+## §4. Fallback authoring (no openspec)
+
+When detection puts the agent in fallback mode (`CHORUS_OPENSPEC_ACTIVE=0`), this skill is a **no-op**. Return to the calling skill's free-form path:
+
+- No `openspec/changes/` folder is created or referenced.
+- No `OpenSpec change slug: …` line is added to the proposal description.
+- Document drafts are authored via direct MCP `chorus_pm_add_document_draft` calls with inline `content` — same as before this skill existed.
+- Rule 1 (wrapper-only mirror) does not apply — there is no local file source of truth.
+- The §3.9 archive hook does nothing (no slug → silent exit).
+
+---
+
+## §5. Document type mapping (reference table)
+
+| Local file | Chorus `Document.type` | Mirrored? |
+|---|---|---|
+| `openspec/changes/<slug>/proposal.md` | `prd` | yes |
+| `openspec/changes/<slug>/design.md` | `tech_design` | yes |
+| `openspec/changes/<slug>/specs/<capability>/spec.md` | `spec` | yes (one draft per capability) |
+| `openspec/changes/<slug>/tasks.md` | _(not mapped)_ | **no** — Chorus task drafts are source of truth |
+
+`prd`, `tech_design`, `spec` are pre-existing valid `Document.type` values — no schema change required.
+
+---
+
+## §6. Failure visibility — the `chorus_check_response` helper
+
+There is a known wrapper edge case: when the server returns HTTP 4xx (e.g. 401 from a bad `CHORUS_API_KEY`), `chorus-api.sh mcp-tool` captures the JSON-RPC error body internally, pipes it through a `.result.content[]?` jq filter that produces no output when `.result` is absent, and exits 0 with empty stdout. A bare `RC=$?` check would not halt on this — the most common runtime failure mode would be invisible.
+
+Define this helper **once** at the top of the authoring session and use it after every wrapper call:
+
+```bash
+chorus_check_response() {
+  local _tool="$1"
+  local _rc="$2"
+  local _body="$3"
+  local _has_error=0
+  local _is_empty=0
+
+  local _trimmed
+  _trimmed=$(printf '%s' "$_body" | tr -d ' \t\n\r')
+  [ -z "$_trimmed" ] && _is_empty=1
+
+  if [ "$_is_empty" -eq 0 ]; then
+    if command -v jq >/dev/null 2>&1; then
+      if printf '%s' "$_body" | jq -e 'try ([.. | objects | has("error")] | any) catch false' >/dev/null 2>&1; then
+        _has_error=1
+      fi
+    else
+      printf '%s' "$_body" | grep -qE '"error"[[:space:]]*:' && _has_error=1
+    fi
+  fi
+
+  if [ "$_rc" -ne 0 ] || [ "$_has_error" -eq 1 ] || [ "$_is_empty" -eq 1 ]; then
+    echo "ERROR: $_tool failed (exit=$_rc, error_in_body=$_has_error, empty_body=$_is_empty)" >&2
+    echo "Output: $_body" >&2
+    [ "$_rc" -ne 0 ] && exit "$_rc" || exit 1
+  fi
+}
+```
+
+**Anti-patterns** — do **not**:
+
+- Collapse to `|| true`.
+- Redirect stderr to `/dev/null`.
+- Bury the wrapper call inside a pipeline (masks `$?`).
+- Skip capturing `$RESULT` into a variable; the helper needs the body.
+- Use only `if [ "$RC" -ne 0 ]; then ...` — that misses the HTTP-error path.
+
+**Minimal call site shape:**
+
+```bash
+RESULT=$("$API" mcp-tool <tool_name> "$PAYLOAD")
+RC=$?
+chorus_check_response "<tool_name>" "$RC" "$RESULT"
+# ...if we reach here, the call succeeded; parse RESULT and continue.
+```
+
+This is project-wide policy: no silent errors.
+
+---
+
+## §7. Quick reference checklist
+
+When invoked from a stage skill (proposal / develop / yolo):
+
+1. Read `CHORUS_OPENSPEC_ACTIVE` from the `## OpenSpec Mode` section in the SessionStart context (§1). If it isn't there, fall back to the manual probe in §1.
+2. If `CHORUS_OPENSPEC_ACTIVE=0` → return to caller's free-form path (§4).
+3. Otherwise:
+   a. Pick `$SLUG` (§3.1).
+   b. `openspec new change "$SLUG"` (§3.2).
+   c. Author `proposal.md`, `design.md`, `specs/<capability>/spec.md` (§3.2–§3.3). Mix `ADDED` / `MODIFIED` / `REMOVED` / `RENAMED` blocks as needed; remember `MODIFIED` overwrites the whole Requirement.
+   d. Optional: `openspec validate "$SLUG"`.
+   e. `chorus_pm_create_proposal` (direct MCP) with the `OpenSpec change slug: $SLUG` line in description (§3.5).
+   f. Define `$API`, `json_encode_file`, `chorus_check_response` helpers.
+   g. For each row in §5 with "yes" — mirror via `"$API" mcp-tool chorus_pm_add_document_draft` (§3.6). Record each `$DRAFT_UUID`.
+   h. On any failed `chorus_check_response` — halt, surface the error, do NOT proceed.
+4. Edits before approval → §3.7. Edits after approval → §3.8.
+5. Last task verified → hook fires → run §3.9 archive flow.

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -83,6 +83,16 @@ chorus_pm_create_proposal({
 ```
 
 **Multiple Ideas:** You can combine multiple ideas into one proposal by passing multiple UUIDs in `inputUuids`.
+
+### Step 1.5: Detect OpenSpec mode
+
+Before authoring document drafts, **load the `openspec-aware` skill at `.claude/skills/openspec-aware/SKILL.md`** and run its §1 detection contract. Branch on the result:
+
+- **`CHORUS_OPENSPEC_ACTIVE=1`** → follow `openspec-aware` §3. Pick `$SLUG`, scaffold `openspec/changes/<slug>/`, author `proposal.md` / `design.md` / `specs/<capability>/spec.md` locally, then create the proposal container (Step 1 above) with the literal line `OpenSpec change slug: <slug>` in `description`, and mirror each local file into a document draft.
+
+  > **⛔ Mandatory in OpenSpec mode:** mirror calls go through the `chorus-api.sh` wrapper with `content` produced by `json_encode_file` — see `openspec-aware` §3.6. Do **not** call `chorus_pm_add_document_draft` directly from the MCP harness with a hand-typed `content` field. Re-typing thousands of lines through the LLM burns 20k+ content tokens per proposal and breaks byte-equality with the local source of truth (`openspec-aware` §2 Rule 1 explains the full reasoning). Skip Step 2 below when in OpenSpec mode — the wrapper-based flow in `openspec-aware` §3.6 replaces it for documents.
+
+- **`CHORUS_OPENSPEC_ACTIVE=0`** (CLI absent or `CHORUS_OPENSPEC_MODE=off`) → proceed with Step 2 unchanged. Author drafts inline as free-form Markdown via direct MCP `chorus_pm_add_document_draft`.
 
 ### Step 2: Add Document Drafts
 

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.8.0
+version: 0.8.1
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.0"
+  version: "0.8.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -181,18 +181,40 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
 
 #### Step 1.4: Create Proposal
 
-1. **Create empty container:**
+1. **Detect OpenSpec mode.** Load the `openspec-aware` skill at `.claude/skills/openspec-aware/SKILL.md` and run its §1 detection contract. The result determines how the rest of this step authors documents:
+
+   - `CHORUS_OPENSPEC_ACTIVE=1` → spec-driven branch (sub-step 2a below).
+   - `CHORUS_OPENSPEC_ACTIVE=0` → free-form branch (sub-step 2b below).
+
+   This is mandatory — yolo runs unattended, so silently picking the wrong mode is exactly the failure scenario the detection contract exists to prevent.
+
+2. **Create the empty proposal container.** In OpenSpec mode, the `description` MUST contain the literal line `OpenSpec change slug: <slug>` (use the `$SLUG` you'll pick in 2a); in free-form mode, omit that line.
+
    ```
    chorus_pm_create_proposal({
      projectUuid: "<project-uuid>",
      title: "<feature name>",
-     description: "<summary of what the proposal covers>",
+     description: "<summary>\n\nOpenSpec change slug: <slug>",   // OpenSpec mode
+     // description: "<summary>",                                 // free-form mode
      inputType: "idea",
      inputUuids: ["<idea-uuid>"]
    })
    ```
 
-2. **Add tech design document draft:**
+   Then branch:
+
+   **2a. OpenSpec mode (`CHORUS_OPENSPEC_ACTIVE=1`).** Follow `openspec-aware` §3 end-to-end:
+   - Pick `$SLUG`, run `openspec new change "$SLUG"` (§3.1–§3.2).
+   - Author `proposal.md`, `design.md`, and one `specs/<capability>/spec.md` per capability locally on disk (§3.3). ADDED Requirements only; per-spec fallback to free-form Markdown if MODIFIED/REMOVED is needed.
+   - Define `$API`, `json_encode_file`, `chorus_check_response` helpers (§3.4, §6).
+   - Mirror each local file via `"$API" mcp-tool chorus_pm_add_document_draft "$PAYLOAD"` (§3.6) — one call per file, with the document type from `openspec-aware` §5.
+
+   > **⛔ Do not** invoke `chorus_pm_add_document_draft` / `chorus_pm_update_document_draft` / `chorus_pm_update_document` from the MCP harness with a hand-typed `content` field in this branch. Re-typing the markdown body wastes 20k+ tokens per proposal and breaks byte-equality with the local files. See `openspec-aware` §2 Rule 1.
+
+   Then continue to step 3 (task drafts).
+
+   **2b. Free-form mode (`CHORUS_OPENSPEC_ACTIVE=0`).** Add a tech design document draft directly via MCP, content authored inline:
+
    ```
    chorus_pm_add_document_draft({
      proposalUuid: "<proposal-uuid>",

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -348,14 +348,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_my_assignments",
     {
-      description: "Get all Ideas and Tasks claimed by the current Agent",
+      description:
+        "Get the agent's idea/task tracker, grouped by project — same shape as checkin.ideaTracker. Returns { ideaTracker, taskTracker } where ideaTracker carries derivedStatus + proposal/task counts and taskTracker carries acceptance criteria progress.",
       inputSchema: z.object({}),
     },
     async () => {
-      const { ideas, tasks } = await assignmentService.getMyAssignments(auth, auth.projectUuids);
+      const result = await assignmentService.getMyAssignments(auth, auth.projectUuids);
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ ideas, tasks }, null, 2) }],
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       };
     }
   );

--- a/src/services/__tests__/assignment.service.test.ts
+++ b/src/services/__tests__/assignment.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// ===== Prisma mock =====
+// ===== Prisma mock (used by getAvailableItems only) =====
 const mockPrisma = vi.hoisted(() => ({
   idea: {
     findMany: vi.fn(),
@@ -11,11 +11,17 @@ const mockPrisma = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
-const mockFormatAssignee = vi.fn();
 const mockFormatCreatedBy = vi.fn();
 vi.mock("@/lib/uuid-resolver", () => ({
-  formatAssignee: (...args: unknown[]) => mockFormatAssignee(...args),
   formatCreatedBy: (...args: unknown[]) => mockFormatCreatedBy(...args),
+}));
+
+// ===== idea-tracker.service mock (used by getMyAssignments) =====
+const mockBuildIdeaTracker = vi.hoisted(() => vi.fn());
+const mockBuildTaskTracker = vi.hoisted(() => vi.fn());
+vi.mock("@/services/idea-tracker.service", () => ({
+  buildIdeaTracker: mockBuildIdeaTracker,
+  buildTaskTracker: mockBuildTaskTracker,
 }));
 
 import { getMyAssignments, getAvailableItems } from "@/services/assignment.service";
@@ -34,14 +40,9 @@ function makeIdea(overrides: Record<string, unknown> = {}) {
     uuid: "idea-0000-0000-0000-000000000001",
     title: "Test Idea",
     content: "Idea content",
-    status: "claimed",
-    assigneeType: "user",
-    assigneeUuid: userUuid,
-    assignedAt: now,
-    project: { uuid: projectUuid, name: "Test Project" },
-    createdAt: now,
-    updatedAt: now,
+    status: "open",
     createdByUuid: userUuid,
+    createdAt: now,
     ...overrides,
   };
 }
@@ -51,90 +52,67 @@ function makeTask(overrides: Record<string, unknown> = {}) {
     uuid: "task-0000-0000-0000-000000000001",
     title: "Test Task",
     description: "Task description",
-    status: "assigned",
+    status: "open",
     priority: "high",
-    assigneeType: "user",
-    assigneeUuid: userUuid,
-    assignedAt: now,
-    project: { uuid: projectUuid, name: "Test Project" },
-    createdAt: now,
-    updatedAt: now,
     createdByUuid: userUuid,
+    createdAt: now,
     ...overrides,
   };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockFormatAssignee.mockResolvedValue({
-    type: "user",
-    uuid: userUuid,
-    name: "Test User",
-  });
   mockFormatCreatedBy.mockResolvedValue({
     type: "user",
     uuid: userUuid,
     name: "Test User",
   });
+  mockBuildIdeaTracker.mockResolvedValue({});
+  mockBuildTaskTracker.mockResolvedValue({});
 });
 
 // ===== getMyAssignments =====
 describe("getMyAssignments", () => {
-  it("should return user's claimed ideas and tasks", async () => {
+  it("returns { ideaTracker, taskTracker } shaped result", async () => {
     const userAuth: AuthContext = {
       type: "user",
       companyUuid,
       actorUuid: userUuid,
     };
 
-    const idea = makeIdea();
-    const task = makeTask();
+    const ideaTracker = {
+      [projectUuid]: {
+        name: "Test Project",
+        ideas: [
+          { uuid: "i1", title: "I1", status: "in_progress" as const, proposals: 1, tasks: 2 },
+        ],
+      },
+    };
+    const taskTracker = {
+      [projectUuid]: {
+        name: "Test Project",
+        tasks: [
+          {
+            uuid: "t1",
+            title: "T1",
+            status: "assigned",
+            priority: "high",
+            assignedAt: now.toISOString(),
+            ac: { passed: 1, total: 3 },
+          },
+        ],
+      },
+    };
 
-    mockPrisma.idea.findMany.mockResolvedValue([idea]);
-    mockPrisma.task.findMany.mockResolvedValue([task]);
+    mockBuildIdeaTracker.mockResolvedValue(ideaTracker);
+    mockBuildTaskTracker.mockResolvedValue(taskTracker);
 
     const result = await getMyAssignments(userAuth);
 
-    expect(result.ideas).toHaveLength(1);
-    expect(result.tasks).toHaveLength(1);
-    expect(result.ideas[0].uuid).toBe(idea.uuid);
-    expect(result.tasks[0].uuid).toBe(task.uuid);
+    expect(result).toEqual({ ideaTracker, taskTracker });
   });
 
-  it("should query with user assignment condition", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-          status: { notIn: ["completed", "closed"] },
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-          status: { notIn: ["done", "closed"] },
-        }),
-      })
-    );
-  });
-
-  it("should query with agent assignment conditions (agent + owner)", async () => {
+  it("delegates to buildIdeaTracker / buildTaskTracker with auth", async () => {
     const agentAuth: AuthContext = {
       type: "agent",
       companyUuid,
@@ -143,229 +121,13 @@ describe("getMyAssignments", () => {
       ownerUuid,
     };
 
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
     await getMyAssignments(agentAuth);
 
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [
-            { assigneeType: "agent", assigneeUuid: agentUuid },
-            { assigneeType: "user", assigneeUuid: ownerUuid },
-          ],
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          OR: [
-            { assigneeType: "agent", assigneeUuid: agentUuid },
-            { assigneeType: "user", assigneeUuid: ownerUuid },
-          ],
-        }),
-      })
-    );
+    expect(mockBuildIdeaTracker).toHaveBeenCalledWith(agentAuth, { projectUuids: undefined });
+    expect(mockBuildTaskTracker).toHaveBeenCalledWith(agentAuth, { projectUuids: undefined });
   });
 
-  it("should exclude completed ideas and done tasks", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          status: { notIn: ["completed", "closed"] },
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          status: { notIn: ["done", "closed"] },
-        }),
-      })
-    );
-  });
-
-  it("should format ideas with assignee info", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    const idea = makeIdea();
-    mockPrisma.idea.findMany.mockResolvedValue([idea]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    mockFormatAssignee.mockResolvedValue({
-      type: "user",
-      uuid: userUuid,
-      name: "John Doe",
-    });
-
-    const result = await getMyAssignments(userAuth);
-
-    expect(result.ideas[0].assignee).toEqual({
-      type: "user",
-      uuid: userUuid,
-      name: "John Doe",
-    });
-    expect(mockFormatAssignee).toHaveBeenCalledWith("user", userUuid);
-  });
-
-  it("should format tasks with assignee info", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    const task = makeTask();
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([task]);
-
-    mockFormatAssignee.mockResolvedValue({
-      type: "agent",
-      uuid: agentUuid,
-      name: "Bot Agent",
-    });
-
-    const result = await getMyAssignments(userAuth);
-
-    expect(result.tasks[0].assignee).toEqual({
-      type: "agent",
-      uuid: agentUuid,
-      name: "Bot Agent",
-    });
-  });
-
-  it("should return ISO date strings for timestamps", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    const idea = makeIdea();
-    const task = makeTask();
-    mockPrisma.idea.findMany.mockResolvedValue([idea]);
-    mockPrisma.task.findMany.mockResolvedValue([task]);
-
-    const result = await getMyAssignments(userAuth);
-
-    expect(result.ideas[0].createdAt).toBe(now.toISOString());
-    expect(result.ideas[0].assignedAt).toBe(now.toISOString());
-    expect(result.tasks[0].createdAt).toBe(now.toISOString());
-    expect(result.tasks[0].assignedAt).toBe(now.toISOString());
-  });
-
-  it("should order ideas by assignedAt desc", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orderBy: { assignedAt: "desc" },
-      })
-    );
-  });
-
-  it("should order tasks by priority desc, then assignedAt desc", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
-      })
-    );
-  });
-
-  it("should filter by projectUuids when provided", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth, [projectUuid]);
-
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
-
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
-  });
-
-  it("should not filter by projectUuids when not provided", async () => {
-    const userAuth: AuthContext = {
-      type: "user",
-      companyUuid,
-      actorUuid: userUuid,
-    };
-
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
-    await getMyAssignments(userAuth);
-
-    const ideaWhere = mockPrisma.idea.findMany.mock.calls[0][0].where;
-    const taskWhere = mockPrisma.task.findMany.mock.calls[0][0].where;
-
-    expect(ideaWhere).not.toHaveProperty("projectUuid");
-    expect(taskWhere).not.toHaveProperty("projectUuid");
-  });
-
-  it("should filter by multiple projectUuids", async () => {
+  it("forwards projectUuids when provided", async () => {
     const userAuth: AuthContext = {
       type: "user",
       companyUuid,
@@ -374,38 +136,65 @@ describe("getMyAssignments", () => {
 
     const projectUuid2 = "project-0000-0000-0000-000000000002";
 
-    mockPrisma.idea.findMany.mockResolvedValue([]);
-    mockPrisma.task.findMany.mockResolvedValue([]);
-
     await getMyAssignments(userAuth, [projectUuid, projectUuid2]);
 
-    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid, projectUuid2] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
+    expect(mockBuildIdeaTracker).toHaveBeenCalledWith(userAuth, {
+      projectUuids: [projectUuid, projectUuid2],
+    });
+    expect(mockBuildTaskTracker).toHaveBeenCalledWith(userAuth, {
+      projectUuids: [projectUuid, projectUuid2],
+    });
+  });
 
-    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          companyUuid,
-          projectUuid: { in: [projectUuid, projectUuid2] },
-          OR: [{ assigneeType: "user", assigneeUuid: userUuid }],
-        }),
-      })
-    );
+  it("invokes both helpers in parallel (Promise.all)", async () => {
+    const userAuth: AuthContext = {
+      type: "user",
+      companyUuid,
+      actorUuid: userUuid,
+    };
+
+    // Configure each mock to resolve after a microtask delay so we can detect
+    // that the result waits for both — i.e. neither call is sequential.
+    let ideaResolved = false;
+    let taskResolved = false;
+    mockBuildIdeaTracker.mockImplementation(async () => {
+      ideaResolved = true;
+      return {};
+    });
+    mockBuildTaskTracker.mockImplementation(async () => {
+      taskResolved = true;
+      return {};
+    });
+
+    const result = await getMyAssignments(userAuth);
+
+    expect(ideaResolved).toBe(true);
+    expect(taskResolved).toBe(true);
+    expect(result).toEqual({ ideaTracker: {}, taskTracker: {} });
+  });
+
+  it("returns empty trackers when helpers return empty objects", async () => {
+    const userAuth: AuthContext = {
+      type: "user",
+      companyUuid,
+      actorUuid: userUuid,
+    };
+
+    mockBuildIdeaTracker.mockResolvedValue({});
+    mockBuildTaskTracker.mockResolvedValue({});
+
+    const result = await getMyAssignments(userAuth);
+
+    expect(result.ideaTracker).toEqual({});
+    expect(result.taskTracker).toEqual({});
   });
 });
 
-// ===== getAvailableItems =====
+// ===== getAvailableItems (unchanged in 0.7.2) =====
 describe("getAvailableItems", () => {
   it("should return available ideas and tasks when both allowed", async () => {
-    const idea = makeIdea({ status: "open", assigneeType: null, assigneeUuid: null });
-    const task = makeTask({ status: "open", assigneeType: null, assigneeUuid: null });
+    const idea = makeIdea();
+    const task = makeTask();
 
     mockPrisma.idea.findMany.mockResolvedValue([idea]);
     mockPrisma.task.findMany.mockResolvedValue([task]);

--- a/src/services/__tests__/idea-tracker.service.test.ts
+++ b/src/services/__tests__/idea-tracker.service.test.ts
@@ -1,0 +1,607 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Prisma mock (hoisted) =====
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    idea: { findMany: vi.fn() },
+    proposal: { findMany: vi.fn() },
+    task: { findMany: vi.fn() },
+    project: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+import { buildIdeaTracker, buildTaskTracker } from "@/services/idea-tracker.service";
+import type { AuthContext } from "@/types/auth";
+
+// ===== Fixtures =====
+const COMPANY_UUID = "company-1111-1111-1111-111111111111";
+const AGENT_UUID = "agent-2222-2222-2222-222222222222";
+const OWNER_UUID = "owner-3333-3333-3333-333333333333";
+const OTHER_USER_UUID = "user-9999-9999-9999-999999999999";
+const PROJECT_A = "project-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PROJECT_B = "project-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const now = new Date("2026-05-01T10:00:00Z");
+
+const agentAuth: AuthContext = {
+  type: "agent",
+  companyUuid: COMPANY_UUID,
+  actorUuid: AGENT_UUID,
+  ownerUuid: OWNER_UUID,
+  roles: ["developer_agent"],
+};
+
+const userAuth: AuthContext = {
+  type: "user",
+  companyUuid: COMPANY_UUID,
+  actorUuid: OTHER_USER_UUID,
+};
+
+function makeIdea(
+  uuid: string,
+  projectUuid: string,
+  status: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    uuid,
+    title: `Idea ${uuid}`,
+    status,
+    elaborationStatus: null,
+    projectUuid,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeProposal(
+  uuid: string,
+  projectUuid: string,
+  status: string,
+  inputUuids: string[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    uuid,
+    projectUuid,
+    status,
+    inputType: "idea",
+    inputUuids,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.idea.findMany.mockResolvedValue([]);
+  mockPrisma.proposal.findMany.mockResolvedValue([]);
+  mockPrisma.task.findMany.mockResolvedValue([]);
+  mockPrisma.project.findMany.mockResolvedValue([]);
+});
+
+// ============================================================
+// buildIdeaTracker
+// ============================================================
+
+describe("buildIdeaTracker — assignee conditions", () => {
+  it("agent without owner: only matches agent.actorUuid", async () => {
+    const noOwnerAuth: AuthContext = {
+      type: "agent",
+      companyUuid: COMPANY_UUID,
+      actorUuid: AGENT_UUID,
+      roles: ["developer_agent"],
+    };
+
+    await buildIdeaTracker(noOwnerAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ assigneeType: "agent", assigneeUuid: AGENT_UUID }],
+        }),
+      }),
+    );
+  });
+
+  it("agent with owner: matches both agent and owner-as-user", async () => {
+    await buildIdeaTracker(agentAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { assigneeType: "agent", assigneeUuid: AGENT_UUID },
+            { assigneeType: "user", assigneeUuid: OWNER_UUID },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("user auth: only matches user.actorUuid", async () => {
+    await buildIdeaTracker(userAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ assigneeType: "user", assigneeUuid: OTHER_USER_UUID }],
+        }),
+      }),
+    );
+  });
+});
+
+describe("buildIdeaTracker — filters", () => {
+  it("excludes status=closed at the DB layer", async () => {
+    await buildIdeaTracker(agentAuth);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { not: "closed" },
+        }),
+      }),
+    );
+  });
+
+  it("filters out ideas whose derivedStatus === done (all tasks done)", async () => {
+    const proposalUuid = "proposal-done";
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal(proposalUuid, PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid, status: "done" },
+      { proposalUuid, status: "closed" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker).toEqual({});
+  });
+
+  it("returns empty object when there are no ideas at all", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([]);
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker).toEqual({});
+    expect(mockPrisma.proposal.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildIdeaTracker — derivedStatus mapping", () => {
+  it("status=open maps to derivedStatus=todo", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("todo");
+  });
+
+  it("status=elaborating + pending_answers maps to human_conduct_required", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborating", { elaborationStatus: "pending_answers" }),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("human_conduct_required");
+  });
+
+  it("status=elaborated + pending proposal maps to human_conduct_required", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "pending", ["i1"]),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("human_conduct_required");
+  });
+
+  it("status=elaborated + approved proposal + tasks in progress maps to in_progress", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p1", status: "in_progress" },
+      { proposalUuid: "p1", status: "open" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("in_progress");
+  });
+
+  it("status=elaborated + approved proposal + a task in to_verify -> human_conduct_required", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p1", status: "to_verify" },
+      { proposalUuid: "p1", status: "done" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("human_conduct_required");
+  });
+});
+
+describe("buildIdeaTracker — proposal/task counts", () => {
+  it("proposals counts both pending and approved attached to the idea", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "pending", ["i1"]),
+      makeProposal("p2", PROJECT_A, "approved", ["i1"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p2", status: "in_progress" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].proposals).toBe(2);
+    expect(tracker[PROJECT_A].ideas[0].tasks).toBe(1);
+  });
+
+  it("tasks count is based on the most-recently-approved proposal only", async () => {
+    const old = new Date("2026-04-01T00:00:00Z");
+    const recent = new Date("2026-04-15T00:00:00Z");
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p_old", PROJECT_A, "approved", ["i1"], { createdAt: old }),
+      makeProposal("p_recent", PROJECT_A, "approved", ["i1"], { createdAt: recent }),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      // p_old has 5 tasks (irrelevant)
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      { proposalUuid: "p_old", status: "in_progress" },
+      // p_recent has 2 tasks (counted)
+      { proposalUuid: "p_recent", status: "in_progress" },
+      { proposalUuid: "p_recent", status: "open" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    // task query is filtered by approvedProposalUuids — implementation will fetch
+    // tasks for both p_old and p_recent, but only p_recent's count is reported.
+    expect(tracker[PROJECT_A].ideas[0].tasks).toBe(2);
+  });
+
+  it("ignores proposals with non-array inputUuids gracefully", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      // malformed inputUuids — should be skipped
+      { ...makeProposal("p1", PROJECT_A, "approved", []), inputUuids: null },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].proposals).toBe(0);
+    expect(tracker[PROJECT_A].ideas[0].tasks).toBe(0);
+  });
+
+  it("ignores proposal entries that don't reference any of the agent's ideas", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "elaborated"),
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p1", PROJECT_A, "approved", ["unrelated-idea-uuid"]),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].proposals).toBe(0);
+  });
+});
+
+describe("buildIdeaTracker — grouping & ordering & options", () => {
+  it("groups ideas by project and uses project.name", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "open"),
+      makeIdea("i2", PROJECT_B, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([
+      { uuid: PROJECT_A, name: "A" },
+      { uuid: PROJECT_B, name: "B" },
+    ]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("A");
+    expect(tracker[PROJECT_A].ideas).toHaveLength(1);
+    expect(tracker[PROJECT_B].name).toBe("B");
+    expect(tracker[PROJECT_B].ideas).toHaveLength(1);
+  });
+
+  it("falls back to empty string when project name is missing", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i1", PROJECT_A, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([]); // no project rows
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("");
+  });
+
+  it("orderBy updatedAt desc is requested at the prisma layer", async () => {
+    await buildIdeaTracker(agentAuth);
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { updatedAt: "desc" } }),
+    );
+  });
+
+  it("respects options.maxIdeas cap (keeps the first N visited, which are most recent)", async () => {
+    const ideas = Array.from({ length: 5 }, (_, i) =>
+      makeIdea(`i${i}`, PROJECT_A, "open"),
+    );
+    mockPrisma.idea.findMany.mockResolvedValue(ideas);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth, { maxIdeas: 3 });
+    expect(tracker[PROJECT_A].ideas.map((i) => i.uuid)).toEqual(["i0", "i1", "i2"]);
+  });
+
+  it("default maxIdeas=Infinity returns the full set", async () => {
+    const ideas = Array.from({ length: 25 }, (_, i) =>
+      makeIdea(`i${i}`, PROJECT_A, "open"),
+    );
+    mockPrisma.idea.findMany.mockResolvedValue(ideas);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas).toHaveLength(25);
+  });
+
+  it("forwards options.projectUuids as a prisma 'in' filter", async () => {
+    await buildIdeaTracker(agentAuth, { projectUuids: [PROJECT_A] });
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ projectUuid: { in: [PROJECT_A] } }),
+      }),
+    );
+  });
+
+  it("does NOT add projectUuid filter when projectUuids is empty array", async () => {
+    await buildIdeaTracker(agentAuth, { projectUuids: [] });
+    const callArg = mockPrisma.idea.findMany.mock.calls[0][0];
+    expect(callArg.where).not.toHaveProperty("projectUuid");
+  });
+});
+
+// ============================================================
+// buildTaskTracker
+// ============================================================
+
+describe("buildTaskTracker — assignee conditions", () => {
+  it("agent with owner: matches both", async () => {
+    await buildTaskTracker(agentAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { assigneeType: "agent", assigneeUuid: AGENT_UUID },
+            { assigneeType: "user", assigneeUuid: OWNER_UUID },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("user auth: matches user only", async () => {
+    await buildTaskTracker(userAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ assigneeType: "user", assigneeUuid: OTHER_USER_UUID }],
+        }),
+      }),
+    );
+  });
+});
+
+describe("buildTaskTracker — filters & ordering", () => {
+  it("excludes status in [done, closed]", async () => {
+    await buildTaskTracker(agentAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { notIn: ["done", "closed"] },
+        }),
+      }),
+    );
+  });
+
+  it("orders by [priority desc, assignedAt desc]", async () => {
+    await buildTaskTracker(agentAuth);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
+      }),
+    );
+  });
+
+  it("returns empty object when there are no tasks", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([]);
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker).toEqual({});
+  });
+
+  it("forwards options.projectUuids as a prisma 'in' filter", async () => {
+    await buildTaskTracker(agentAuth, { projectUuids: [PROJECT_A, PROJECT_B] });
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          projectUuid: { in: [PROJECT_A, PROJECT_B] },
+        }),
+      }),
+    );
+  });
+});
+
+describe("buildTaskTracker — ac progress", () => {
+  function makeTask(uuid: string, projectUuid: string, items: Array<{ status: string }>) {
+    return {
+      uuid,
+      title: `Task ${uuid}`,
+      status: "in_progress",
+      priority: "high",
+      assignedAt: now,
+      projectUuid,
+      project: { uuid: projectUuid, name: projectUuid === PROJECT_A ? "A" : "B" },
+      acceptanceCriteriaItems: items,
+    };
+  }
+
+  it("counts admin-verified passes only", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, [
+        { status: "passed" },
+        { status: "passed" },
+        { status: "failed" },
+        { status: "pending" },
+      ]),
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].ac).toEqual({ passed: 2, total: 4 });
+  });
+
+  it("returns ac:{0,0} when items array is empty", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, []),
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].ac).toEqual({ passed: 0, total: 0 });
+  });
+
+  it("returns ac:{0,0} when acceptanceCriteriaItems is missing entirely (null/undefined defensiveness)", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      {
+        ...makeTask("t1", PROJECT_A, []),
+        acceptanceCriteriaItems: null,
+      },
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].ac).toEqual({ passed: 0, total: 0 });
+  });
+
+  it("groups tasks by project and uses task.project.name", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, [{ status: "passed" }]),
+      makeTask("t2", PROJECT_B, [{ status: "pending" }]),
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("A");
+    expect(tracker[PROJECT_A].tasks).toHaveLength(1);
+    expect(tracker[PROJECT_B].name).toBe("B");
+    expect(tracker[PROJECT_B].tasks).toHaveLength(1);
+  });
+
+  it("includes assignedAt as ISO string and falls back to null", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      makeTask("t1", PROJECT_A, []),
+      { ...makeTask("t2", PROJECT_A, []), assignedAt: null },
+    ]);
+
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].tasks[0].assignedAt).toBe(now.toISOString());
+    expect(tracker[PROJECT_A].tasks[1].assignedAt).toBeNull();
+  });
+
+  it("falls back to empty string when task.project is missing", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      { ...makeTask("t1", PROJECT_A, []), project: null },
+    ]);
+    const tracker = await buildTaskTracker(agentAuth);
+    expect(tracker[PROJECT_A].name).toBe("");
+  });
+});
+
+// ============================================================
+// Consistency: checkin vs my_assignments
+// ============================================================
+//
+// Both call buildIdeaTracker on the same auth + same prisma mock.
+// my_assignments calls with no maxIdeas (Infinity), checkin with maxIdeas:10.
+// The expected invariant: the my_assignments idea set is the same as the
+// checkin idea set when total <=10, and a strict superset when >10.
+
+describe("consistency: checkin.ideaTracker ⊆ my_assignments.ideaTracker", () => {
+  it("with 4 ideas (1 done, 1 closed): both surfaces return the same 2 ideas", async () => {
+    mockPrisma.idea.findMany.mockImplementation(async (args: { where: { status?: unknown } }) => {
+      // The DB layer filters status:{not:"closed"} — so "closed" never returns.
+      // We honor that filter in the mock by returning only the 3 non-closed ideas.
+      void args;
+      return [
+        makeIdea("i_in_progress", PROJECT_A, "elaborating", { elaborationStatus: "validated" }),
+        makeIdea("i_open", PROJECT_A, "open"),
+        // i_done has approved proposal where all tasks are done — should be filtered
+        makeIdea("i_done", PROJECT_A, "elaborated"),
+      ];
+    });
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      makeProposal("p_done", PROJECT_A, "approved", ["i_done"]),
+    ]);
+    mockPrisma.task.findMany.mockResolvedValue([
+      { proposalUuid: "p_done", status: "done" },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const myAssignments = await buildIdeaTracker(agentAuth);
+    const checkin = await buildIdeaTracker(agentAuth, { maxIdeas: 10 });
+
+    // Same uuid set
+    const myIds = (myAssignments[PROJECT_A]?.ideas ?? []).map((i) => i.uuid).sort();
+    const ckIds = (checkin[PROJECT_A]?.ideas ?? []).map((i) => i.uuid).sort();
+    expect(myIds).toEqual(["i_in_progress", "i_open"]);
+    expect(ckIds).toEqual(myIds);
+
+    // Same status / counts per idea
+    expect(myAssignments[PROJECT_A].ideas).toEqual(checkin[PROJECT_A].ideas);
+  });
+
+  it("with 12 active ideas: my_assignments returns all 12, checkin caps to 10", async () => {
+    const ideas = Array.from({ length: 12 }, (_, i) =>
+      makeIdea(`i${i}`, PROJECT_A, "open"),
+    );
+    mockPrisma.idea.findMany.mockResolvedValue(ideas);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const myAssignments = await buildIdeaTracker(agentAuth);
+    const checkin = await buildIdeaTracker(agentAuth, { maxIdeas: 10 });
+
+    expect(myAssignments[PROJECT_A].ideas).toHaveLength(12);
+    expect(checkin[PROJECT_A].ideas).toHaveLength(10);
+
+    // checkin set is a strict prefix (most-recent 10) of my_assignments
+    const myFirst10 = myAssignments[PROJECT_A].ideas.slice(0, 10).map((i) => i.uuid);
+    const ckIds = checkin[PROJECT_A].ideas.map((i) => i.uuid);
+    expect(ckIds).toEqual(myFirst10);
+  });
+});

--- a/src/services/assignment.service.ts
+++ b/src/services/assignment.service.ts
@@ -4,37 +4,15 @@
 
 import { prisma } from "@/lib/prisma";
 import type { AuthContext } from "@/types/auth";
-import { isAgent } from "@/lib/auth";
-import { formatAssignee, formatCreatedBy } from "@/lib/uuid-resolver";
+import { formatCreatedBy } from "@/lib/uuid-resolver";
+import {
+  buildIdeaTracker,
+  buildTaskTracker,
+  type IdeaTrackerProject,
+  type TaskTrackerProject,
+} from "@/services/idea-tracker.service";
 
 // ===== Type Definitions =====
-
-// Claimed Idea response format
-export interface AssignedIdeaResponse {
-  uuid: string;
-  title: string;
-  content: string | null;
-  status: string;
-  assignee: { type: string; uuid: string; name: string } | null;
-  assignedAt: string | null;
-  project: { uuid: string; name: string };
-  createdAt: string;
-  updatedAt: string;
-}
-
-// Claimed Task response format
-export interface AssignedTaskResponse {
-  uuid: string;
-  title: string;
-  description: string | null;
-  status: string;
-  priority: string;
-  assignee: { type: string; uuid: string; name: string } | null;
-  assignedAt: string | null;
-  project: { uuid: string; name: string };
-  createdAt: string;
-  updatedAt: string;
-}
 
 // Available Idea response format
 export interface AvailableIdeaResponse {
@@ -57,10 +35,12 @@ export interface AvailableTaskResponse {
   createdAt: string;
 }
 
-// My assignments response
+// My assignments response — 0.7.2: aligned with chorus_checkin.ideaTracker.
+// Idea data is grouped by project with derivedStatus + proposal/task counts.
+// Task data is similarly grouped, with admin-verified acceptance progress.
 export interface MyAssignmentsResponse {
-  ideas: AssignedIdeaResponse[];
-  tasks: AssignedTaskResponse[];
+  ideaTracker: Record<string, IdeaTrackerProject>;
+  taskTracker: Record<string, TaskTrackerProject>;
 }
 
 // Available items response
@@ -70,83 +50,6 @@ export interface AvailableItemsResponse {
 }
 
 // ===== Internal Helper Functions =====
-
-// Get assignment conditions for the current user/Agent
-function getAssignmentConditions(auth: AuthContext) {
-  const conditions: Array<{ assigneeType: string; assigneeUuid: string }> = [];
-
-  if (isAgent(auth)) {
-    // Directly claimed by Agent
-    conditions.push({ assigneeType: "agent", assigneeUuid: auth.actorUuid });
-    // Claimed by Agent's Owner ("Assign to myself")
-    if (auth.ownerUuid) {
-      conditions.push({ assigneeType: "user", assigneeUuid: auth.ownerUuid });
-    }
-  } else {
-    // Directly claimed by user
-    conditions.push({ assigneeType: "user", assigneeUuid: auth.actorUuid });
-  }
-
-  return conditions;
-}
-
-// Format claimed Idea
-async function formatAssignedIdea(idea: {
-  uuid: string;
-  title: string;
-  content: string | null;
-  status: string;
-  assigneeType: string | null;
-  assigneeUuid: string | null;
-  assignedAt: Date | null;
-  project: { uuid: string; name: string };
-  createdAt: Date;
-  updatedAt: Date;
-}): Promise<AssignedIdeaResponse> {
-  const assignee = await formatAssignee(idea.assigneeType, idea.assigneeUuid);
-
-  return {
-    uuid: idea.uuid,
-    title: idea.title,
-    content: idea.content,
-    status: idea.status,
-    assignee,
-    assignedAt: idea.assignedAt?.toISOString() ?? null,
-    project: idea.project,
-    createdAt: idea.createdAt.toISOString(),
-    updatedAt: idea.updatedAt.toISOString(),
-  };
-}
-
-// Format claimed Task
-async function formatAssignedTask(task: {
-  uuid: string;
-  title: string;
-  description: string | null;
-  status: string;
-  priority: string;
-  assigneeType: string | null;
-  assigneeUuid: string | null;
-  assignedAt: Date | null;
-  project: { uuid: string; name: string };
-  createdAt: Date;
-  updatedAt: Date;
-}): Promise<AssignedTaskResponse> {
-  const assignee = await formatAssignee(task.assigneeType, task.assigneeUuid);
-
-  return {
-    uuid: task.uuid,
-    title: task.title,
-    description: task.description,
-    status: task.status,
-    priority: task.priority,
-    assignee,
-    assignedAt: task.assignedAt?.toISOString() ?? null,
-    project: task.project,
-    createdAt: task.createdAt.toISOString(),
-    updatedAt: task.updatedAt.toISOString(),
-  };
-}
 
 // Format available Idea
 async function formatAvailableIdea(idea: {
@@ -194,67 +97,24 @@ async function formatAvailableTask(task: {
 
 // ===== Service Methods =====
 
-// Get my claimed Ideas + Tasks
+/**
+ * Get the agent's idea + task trackers, grouped by project. Aligned 1:1 with
+ * chorus_checkin.ideaTracker (no maxIdeas cap here — checkin returns at most
+ * 10 for compactness; my_assignments returns the full set).
+ *
+ * BREAKING (Chorus 0.7.2): the previous flat `{ ideas: [], tasks: [] }` shape
+ * is replaced by `{ ideaTracker, taskTracker }`.
+ */
 export async function getMyAssignments(
   auth: AuthContext,
   projectUuids?: string[],
 ): Promise<MyAssignmentsResponse> {
-  const conditions = getAssignmentConditions(auth);
-
-  const [rawIdeas, rawTasks] = await Promise.all([
-    // Get claimed Ideas
-    prisma.idea.findMany({
-      where: {
-        companyUuid: auth.companyUuid,
-        ...(projectUuids && projectUuids.length > 0 && { projectUuid: { in: projectUuids } }),
-        OR: conditions,
-        status: { notIn: ["completed", "closed"] },
-      },
-      select: {
-        uuid: true,
-        title: true,
-        content: true,
-        status: true,
-        assigneeType: true,
-        assigneeUuid: true,
-        assignedAt: true,
-        project: { select: { uuid: true, name: true } },
-        createdAt: true,
-        updatedAt: true,
-      },
-      orderBy: { assignedAt: "desc" },
-    }),
-    // Get claimed Tasks
-    prisma.task.findMany({
-      where: {
-        companyUuid: auth.companyUuid,
-        ...(projectUuids && projectUuids.length > 0 && { projectUuid: { in: projectUuids } }),
-        OR: conditions,
-        status: { notIn: ["done", "closed"] },
-      },
-      select: {
-        uuid: true,
-        title: true,
-        description: true,
-        status: true,
-        priority: true,
-        assigneeType: true,
-        assigneeUuid: true,
-        assignedAt: true,
-        project: { select: { uuid: true, name: true } },
-        createdAt: true,
-        updatedAt: true,
-      },
-      orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
-    }),
+  const [ideaTracker, taskTracker] = await Promise.all([
+    buildIdeaTracker(auth, { projectUuids }),
+    buildTaskTracker(auth, { projectUuids }),
   ]);
 
-  const [ideas, tasks] = await Promise.all([
-    Promise.all(rawIdeas.map(formatAssignedIdea)),
-    Promise.all(rawTasks.map(formatAssignedTask)),
-  ]);
-
-  return { ideas, tasks };
+  return { ideaTracker, taskTracker };
 }
 
 // Get available Ideas + Tasks in a project

--- a/src/services/checkin.service.ts
+++ b/src/services/checkin.service.ts
@@ -1,11 +1,12 @@
 // src/services/checkin.service.ts
 // Checkin service — builds the agent checkin response with ideaTracker + notifications.
-// Uses an agent-centric batch (3 queries + project-name lookup) to avoid per-project N+1.
+// The idea-tracker logic lives in idea-tracker.service so that chorus_get_my_assignments
+// stays in lockstep with checkin (see Chorus 0.7.2).
 
 import { prisma } from "@/lib/prisma";
 import type { AuthContext } from "@/types/auth";
-import { computeDerivedStatus } from "@/services/idea.service";
 import type { DerivedIdeaStatus } from "@/services/idea.service";
+import { buildIdeaTracker as buildIdeaTrackerService } from "@/services/idea-tracker.service";
 import * as notificationService from "@/services/notification.service";
 import {
   computeEffectivePermissions,
@@ -124,158 +125,10 @@ export async function buildCheckinResponse(auth: AuthContext): Promise<CheckinRe
   };
 }
 
-// ===== Idea tracker (agent-centric 3-query batch) =====
+// ===== Idea tracker (delegates to idea-tracker.service) =====
 
 async function buildIdeaTracker(auth: AuthContext): Promise<Record<string, CheckinProject>> {
-  // Q1: Ideas assigned to the agent OR to the agent's owner.
-  // Exclude legacy "closed" status (terminal) — elaborated/completed/etc. still flow to
-  // ideaTracker so the agent sees downstream proposal/task work.
-  const assigneeConditions: Array<{ assigneeType: string; assigneeUuid: string }> = [
-    { assigneeType: "agent", assigneeUuid: auth.actorUuid },
-  ];
-  if (auth.ownerUuid) {
-    assigneeConditions.push({ assigneeType: "user", assigneeUuid: auth.ownerUuid });
-  }
-
-  const rawIdeas = await prisma.idea.findMany({
-    where: {
-      companyUuid: auth.companyUuid,
-      OR: assigneeConditions,
-      status: { not: "closed" },
-    },
-    select: {
-      uuid: true,
-      title: true,
-      status: true,
-      elaborationStatus: true,
-      projectUuid: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-    orderBy: { updatedAt: "desc" },
-  });
-
-  if (rawIdeas.length === 0) return {};
-
-  const ideaUuidSet = new Set(rawIdeas.map((i) => i.uuid));
-  const projectUuidSet = new Set(rawIdeas.map((i) => i.projectUuid));
-  const projectUuids = [...projectUuidSet];
-
-  // Q2: Pending + approved proposals in those projects, filtered in-memory by inputUuids overlap.
-  // Scoping by projectUuid keeps the fetch small; JSON overlap filtering in Prisma is awkward.
-  const rawProposals = await prisma.proposal.findMany({
-    where: {
-      companyUuid: auth.companyUuid,
-      projectUuid: { in: projectUuids },
-      status: { in: ["pending", "approved"] },
-      inputType: "idea",
-    },
-    select: {
-      uuid: true,
-      status: true,
-      inputUuids: true,
-      createdAt: true,
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
-  // Map ideaUuid → { proposalCount, latestApproved, hasPending }
-  const ideaProposalCount = new Map<string, number>();
-  const ideaHasPending = new Set<string>();
-  const ideaLatestApproved = new Map<string, { uuid: string; createdAt: Date }>();
-
-  for (const proposal of rawProposals) {
-    const inputUuids = proposal.inputUuids as unknown;
-    if (!Array.isArray(inputUuids)) continue;
-    for (const ideaUuid of inputUuids) {
-      if (typeof ideaUuid !== "string" || !ideaUuidSet.has(ideaUuid)) continue;
-      ideaProposalCount.set(ideaUuid, (ideaProposalCount.get(ideaUuid) ?? 0) + 1);
-      if (proposal.status === "pending") {
-        ideaHasPending.add(ideaUuid);
-      } else if (proposal.status === "approved") {
-        const existing = ideaLatestApproved.get(ideaUuid);
-        if (!existing || proposal.createdAt > existing.createdAt) {
-          ideaLatestApproved.set(ideaUuid, { uuid: proposal.uuid, createdAt: proposal.createdAt });
-        }
-      }
-    }
-  }
-
-  const approvedProposalUuids = [
-    ...new Set([...ideaLatestApproved.values()].map((p) => p.uuid)),
-  ];
-
-  // Q3: Tasks on the approved proposals
-  const proposalToTaskStatuses = new Map<string, string[]>();
-  if (approvedProposalUuids.length > 0) {
-    const tasks = await prisma.task.findMany({
-      where: {
-        companyUuid: auth.companyUuid,
-        proposalUuid: { in: approvedProposalUuids },
-      },
-      select: { proposalUuid: true, status: true },
-    });
-
-    for (const task of tasks) {
-      if (!task.proposalUuid) continue;
-      const statuses = proposalToTaskStatuses.get(task.proposalUuid) ?? [];
-      statuses.push(task.status);
-      proposalToTaskStatuses.set(task.proposalUuid, statuses);
-    }
-  }
-
-  // Q4: Project names (only for projects that have surviving ideas)
-  const projects = await prisma.project.findMany({
-    where: {
-      companyUuid: auth.companyUuid,
-      uuid: { in: projectUuids },
-    },
-    select: { uuid: true, name: true },
-  });
-  const projectNames = new Map(projects.map((p) => [p.uuid, p.name]));
-
-  // Compute derivedStatus + group by project, filter out "done", cap at 10 ideas
-  const MAX_IDEAS = 10;
-  const tracker: Record<string, CheckinProject> = {};
-  let count = 0;
-
-  for (const idea of rawIdeas) {
-    if (count >= MAX_IDEAS) break;
-
-    const latestApproved = ideaLatestApproved.get(idea.uuid);
-    const taskStatuses = latestApproved
-      ? proposalToTaskStatuses.get(latestApproved.uuid) ?? []
-      : [];
-
-    const { derivedStatus } = computeDerivedStatus({
-      ideaStatus: idea.status,
-      elaborationStatus: idea.elaborationStatus,
-      hasPendingProposal: ideaHasPending.has(idea.uuid),
-      hasApprovedProposal: !!latestApproved,
-      taskStatuses,
-    });
-
-    if (derivedStatus === "done") continue;
-
-    const projectUuid = idea.projectUuid;
-    if (!tracker[projectUuid]) {
-      tracker[projectUuid] = {
-        name: projectNames.get(projectUuid) ?? "",
-        ideas: [],
-      };
-    }
-
-    tracker[projectUuid].ideas.push({
-      uuid: idea.uuid,
-      title: idea.title,
-      status: derivedStatus,
-      proposals: ideaProposalCount.get(idea.uuid) ?? 0,
-      tasks: taskStatuses.length,
-    });
-    count++;
-  }
-
-  return tracker;
+  return buildIdeaTrackerService(auth, { maxIdeas: 10 });
 }
 
 // ===== Notification summary (fetch 5 unread, mark read) =====

--- a/src/services/idea-tracker.service.ts
+++ b/src/services/idea-tracker.service.ts
@@ -1,0 +1,316 @@
+// src/services/idea-tracker.service.ts
+// Single source of truth for "what work is on this agent's plate" — used by
+// both chorus_checkin (capped) and chorus_get_my_assignments (full).
+//
+// Idea-tracker logic was originally inlined in checkin.service.ts; the assignment
+// service had a parallel, divergent implementation. Both now go through here so
+// the two surfaces cannot drift again (see Chorus 0.7.2 idea-tracker proposal).
+
+import { prisma } from "@/lib/prisma";
+import type { AuthContext } from "@/types/auth";
+import { computeDerivedStatus, type DerivedIdeaStatus } from "@/services/idea.service";
+
+// ===== Idea tracker types =====
+
+export interface IdeaTrackerEntry {
+  uuid: string;
+  title: string;
+  status: DerivedIdeaStatus;
+  proposals: number;
+  tasks: number;
+}
+
+export interface IdeaTrackerProject {
+  name: string;
+  ideas: IdeaTrackerEntry[];
+}
+
+export interface BuildIdeaTrackerOptions {
+  /** Restrict to specific project UUIDs. Empty/undefined = all projects. */
+  projectUuids?: string[];
+  /** Cap total ideas returned across projects. Default: Number.POSITIVE_INFINITY. */
+  maxIdeas?: number;
+}
+
+// ===== Task tracker types =====
+
+export interface TaskAcceptanceProgress {
+  passed: number;
+  total: number;
+}
+
+export interface TaskTrackerEntry {
+  uuid: string;
+  title: string;
+  status: string;
+  priority: string;
+  assignedAt: string | null;
+  ac: TaskAcceptanceProgress;
+}
+
+export interface TaskTrackerProject {
+  name: string;
+  tasks: TaskTrackerEntry[];
+}
+
+export interface BuildTaskTrackerOptions {
+  projectUuids?: string[];
+}
+
+// ===== Internal helpers =====
+
+// Assignee conditions for the current agent/user. For agents, also match the
+// owner-as-assignee path so "owner claims for themselves" shows up under the
+// agent's tracker too.
+function getAssigneeConditions(
+  auth: AuthContext,
+): Array<{ assigneeType: string; assigneeUuid: string }> {
+  const conditions: Array<{ assigneeType: string; assigneeUuid: string }> = [];
+  if (auth.type === "agent") {
+    conditions.push({ assigneeType: "agent", assigneeUuid: auth.actorUuid });
+    if (auth.ownerUuid) {
+      conditions.push({ assigneeType: "user", assigneeUuid: auth.ownerUuid });
+    }
+  } else {
+    conditions.push({ assigneeType: "user", assigneeUuid: auth.actorUuid });
+  }
+  return conditions;
+}
+
+// ===== Idea tracker =====
+
+/**
+ * Build the agent's idea tracker — assigned-to-me ideas grouped by project,
+ * each carrying derivedStatus + proposal/task counts.
+ *
+ * Filters: excludes status="closed" (terminal) and derivedStatus="done"
+ * (rolled-up completion of the proposal/task chain).
+ *
+ * Ordering: ideas are visited in `updatedAt desc` so the cap, when applied,
+ * keeps the most-recently-touched work.
+ *
+ * Query budget: 4 prisma calls (ideas → proposals → tasks → projects).
+ */
+export async function buildIdeaTracker(
+  auth: AuthContext,
+  options: BuildIdeaTrackerOptions = {},
+): Promise<Record<string, IdeaTrackerProject>> {
+  const maxIdeas = options.maxIdeas ?? Number.POSITIVE_INFINITY;
+  const projectFilter =
+    options.projectUuids && options.projectUuids.length > 0
+      ? { projectUuid: { in: options.projectUuids } }
+      : {};
+
+  // Q1: Ideas assigned to the agent OR to the agent's owner.
+  // Exclude legacy "closed" (terminal) — elaborated/completed/etc. still flow
+  // through so the agent sees downstream proposal/task work.
+  const rawIdeas = await prisma.idea.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      OR: getAssigneeConditions(auth),
+      status: { not: "closed" },
+      ...projectFilter,
+    },
+    select: {
+      uuid: true,
+      title: true,
+      status: true,
+      elaborationStatus: true,
+      projectUuid: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  if (rawIdeas.length === 0) return {};
+
+  const ideaUuidSet = new Set(rawIdeas.map((i) => i.uuid));
+  const projectUuids = [...new Set(rawIdeas.map((i) => i.projectUuid))];
+
+  // Q2: Pending + approved proposals in those projects, filtered in-memory by
+  // inputUuids overlap. Scoping by projectUuid keeps the fetch small; JSON
+  // overlap filtering in Prisma is awkward.
+  const rawProposals = await prisma.proposal.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      projectUuid: { in: projectUuids },
+      status: { in: ["pending", "approved"] },
+      inputType: "idea",
+    },
+    select: {
+      uuid: true,
+      status: true,
+      inputUuids: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const ideaProposalCount = new Map<string, number>();
+  const ideaHasPending = new Set<string>();
+  const ideaLatestApproved = new Map<string, { uuid: string; createdAt: Date }>();
+
+  for (const proposal of rawProposals) {
+    const inputUuids = proposal.inputUuids as unknown;
+    if (!Array.isArray(inputUuids)) continue;
+    for (const ideaUuid of inputUuids) {
+      if (typeof ideaUuid !== "string" || !ideaUuidSet.has(ideaUuid)) continue;
+      ideaProposalCount.set(ideaUuid, (ideaProposalCount.get(ideaUuid) ?? 0) + 1);
+      if (proposal.status === "pending") {
+        ideaHasPending.add(ideaUuid);
+      } else if (proposal.status === "approved") {
+        const existing = ideaLatestApproved.get(ideaUuid);
+        if (!existing || proposal.createdAt > existing.createdAt) {
+          ideaLatestApproved.set(ideaUuid, { uuid: proposal.uuid, createdAt: proposal.createdAt });
+        }
+      }
+    }
+  }
+
+  const approvedProposalUuids = [
+    ...new Set([...ideaLatestApproved.values()].map((p) => p.uuid)),
+  ];
+
+  // Q3: Tasks on the latest-approved proposals
+  const proposalToTaskStatuses = new Map<string, string[]>();
+  if (approvedProposalUuids.length > 0) {
+    const tasks = await prisma.task.findMany({
+      where: {
+        companyUuid: auth.companyUuid,
+        proposalUuid: { in: approvedProposalUuids },
+      },
+      select: { proposalUuid: true, status: true },
+    });
+    for (const task of tasks) {
+      if (!task.proposalUuid) continue;
+      const statuses = proposalToTaskStatuses.get(task.proposalUuid) ?? [];
+      statuses.push(task.status);
+      proposalToTaskStatuses.set(task.proposalUuid, statuses);
+    }
+  }
+
+  // Q4: Project names (only for projects that have surviving ideas)
+  const projects = await prisma.project.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      uuid: { in: projectUuids },
+    },
+    select: { uuid: true, name: true },
+  });
+  const projectNames = new Map(projects.map((p) => [p.uuid, p.name]));
+
+  const tracker: Record<string, IdeaTrackerProject> = {};
+  let count = 0;
+
+  for (const idea of rawIdeas) {
+    if (count >= maxIdeas) break;
+
+    const latestApproved = ideaLatestApproved.get(idea.uuid);
+    const taskStatuses = latestApproved
+      ? proposalToTaskStatuses.get(latestApproved.uuid) ?? []
+      : [];
+
+    const { derivedStatus } = computeDerivedStatus({
+      ideaStatus: idea.status,
+      elaborationStatus: idea.elaborationStatus,
+      hasPendingProposal: ideaHasPending.has(idea.uuid),
+      hasApprovedProposal: !!latestApproved,
+      taskStatuses,
+    });
+
+    if (derivedStatus === "done") continue;
+
+    const projectUuid = idea.projectUuid;
+    if (!tracker[projectUuid]) {
+      tracker[projectUuid] = {
+        name: projectNames.get(projectUuid) ?? "",
+        ideas: [],
+      };
+    }
+
+    tracker[projectUuid].ideas.push({
+      uuid: idea.uuid,
+      title: idea.title,
+      status: derivedStatus,
+      proposals: ideaProposalCount.get(idea.uuid) ?? 0,
+      tasks: taskStatuses.length,
+    });
+    count++;
+  }
+
+  return tracker;
+}
+
+// ===== Task tracker =====
+
+/**
+ * Build the agent's task tracker — assigned-to-me tasks grouped by project,
+ * each carrying admin-verified acceptance-criteria progress.
+ *
+ * Filters: excludes status in ["done","closed"].
+ *
+ * Ordering: [priority desc, assignedAt desc] — preserves the original
+ * getMyAssignments ordering so the BREAKING schema change does not also
+ * reshuffle the user's mental order.
+ *
+ * `ac.passed` counts admin-verified passes (`AcceptanceCriterion.status`),
+ * not dev self-checks. Tasks without acceptance items return {0,0}.
+ */
+export async function buildTaskTracker(
+  auth: AuthContext,
+  options: BuildTaskTrackerOptions = {},
+): Promise<Record<string, TaskTrackerProject>> {
+  const projectFilter =
+    options.projectUuids && options.projectUuids.length > 0
+      ? { projectUuid: { in: options.projectUuids } }
+      : {};
+
+  const rawTasks = await prisma.task.findMany({
+    where: {
+      companyUuid: auth.companyUuid,
+      OR: getAssigneeConditions(auth),
+      status: { notIn: ["done", "closed"] },
+      ...projectFilter,
+    },
+    select: {
+      uuid: true,
+      title: true,
+      status: true,
+      priority: true,
+      assignedAt: true,
+      projectUuid: true,
+      project: { select: { uuid: true, name: true } },
+      acceptanceCriteriaItems: { select: { status: true } },
+    },
+    orderBy: [{ priority: "desc" }, { assignedAt: "desc" }],
+  });
+
+  if (rawTasks.length === 0) return {};
+
+  const tracker: Record<string, TaskTrackerProject> = {};
+
+  for (const task of rawTasks) {
+    const items = task.acceptanceCriteriaItems ?? [];
+    const passed = items.filter((i) => i.status === "passed").length;
+
+    const projectUuid = task.projectUuid;
+    if (!tracker[projectUuid]) {
+      tracker[projectUuid] = {
+        name: task.project?.name ?? "",
+        tasks: [],
+      };
+    }
+
+    tracker[projectUuid].tasks.push({
+      uuid: task.uuid,
+      title: task.title,
+      status: task.status,
+      priority: task.priority,
+      assignedAt: task.assignedAt?.toISOString() ?? null,
+      ac: { passed, total: items.length },
+    });
+  }
+
+  return tracker;
+}


### PR DESCRIPTION
## Summary

Promote `develop` to `main`. Includes two PRs since the last main sync:

- **#245** — `feat(openspec)`: add OpenSpec-aware mode and archive trigger hook (0.8.1)
  - Three-signal SessionStart detection (env not off, openspec/ folder, openspec CLI on PATH) writing `CHORUS_OPENSPEC_ACTIVE` into agent context + user-visible toast
  - `openspec-aware` shared sub-skill in both plugins (Claude Code + Codex), wired into proposal/develop/yolo/chorus skills
  - Wrapper-only mirror via `chorus-api.sh` / `chorus-mcp-call.sh` (saves ~20k tokens per proposal vs. retyping through MCP, preserves byte-equality)
  - Spec-file shape covers all four delta blocks (`ADDED` / `MODIFIED` / `REMOVED` / `RENAMED`)
  - PostToolUse archive trigger on `chorus_admin_verify_task` injects `openspec archive <slug>` reminder when the last task of an OpenSpec-mode proposal is verified
  - Fixture-based shell test: 12 cases across 6 gating branches × 2 plugin variants
  - `enableOpenSpec` userConfig toggle on Claude Code as the master switch
  - Failure-comment target switched to proposal (was idea, but proposals can be `inputType: "document"` with no idea)
  - Version bump to 0.8.1 across both plugins

- **#244** — `refactor(my_assignments)`: align with `checkin.ideaTracker` via shared helper

## Test plan

- [x] CI green on #245 before merge
- [x] `/bin/bash public/chorus-plugin/bin/test-syntax.sh` — 15/15 pass
- [x] `/bin/bash public/chorus-plugin/bin/tests/test-on-post-verify-task.sh` — 12/12 pass

## Merge type

**Merge commit (no squash)** — preserve the individual feature commits on `main`.

Generated with [Claude Code](https://claude.com/claude-code)