### PR TITLE
fix(openspec): call chorus-api.sh by name (on PATH); bump 0.8.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/docs/OPENSPEC_MODE.md
+++ b/docs/OPENSPEC_MODE.md
@@ -124,7 +124,7 @@ This is the rule most likely to bite you, so it gets its own section.
 
 When `CHORUS_OPENSPEC_ACTIVE=1`, **every** call to `chorus_pm_add_document_draft`, `chorus_pm_update_document_draft`, or `chorus_pm_update_document` MUST go through the plugin's wrapper script with `content` produced by `json_encode_file` (defined in the skill's §3.4):
 
-- Claude Code: `"$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/chorus-api.sh" mcp-tool <tool_name> "$PAYLOAD"`
+- Claude Code: `chorus-api.sh mcp-tool <tool_name> "$PAYLOAD"` (on `PATH`)
 - Codex: `"$CHORUS_PLUGIN_DIR/hooks/chorus-mcp-call.sh" <tool_name> "$PAYLOAD"`
 
 Calling these tools directly from the agent's MCP harness with a hand-typed `content` field is a **protocol violation** in OpenSpec mode and will fail review. Three reasons (full version in skill §2 Rule 1):

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -54,7 +54,7 @@ ACCEPT="Accept: application/json, text/event-stream"
 CT="Content-Type: application/json"
 
 INIT=$(cat <<JSON
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.8.1"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.8.2"}}}
 JSON
 )
 

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, au
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus proposal reviewer

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus task reviewer

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, and spawn
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/openspec-aware/SKILL.md
+++ b/plugins/chorus/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Codex. De
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.8.1
+version: 0.8.2
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Co
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -82,8 +82,10 @@ Both are enforced at review time. Both have caused incidents in past releases.
 Document/draft mirror calls (`chorus_pm_add_document_draft`, `chorus_pm_update_document_draft`, `chorus_pm_update_document`) **MUST** go through:
 
 ```
-"$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/chorus-api.sh" mcp-tool <tool_name> "$PAYLOAD"
+chorus-api.sh mcp-tool <tool_name> "$PAYLOAD"
 ```
+
+`chorus-api.sh` is on `PATH` — call it by name.
 
 with `$PAYLOAD` built using `json_encode_file` (defined in §3.4). Calling these tools directly from the agent's MCP harness with a hand-typed `content` field is a **protocol violation** for OpenSpec mode and will fail review. Reasons:
 
@@ -248,8 +250,7 @@ This line is machine-grep-able by future runs of this skill and by the §3.9 arc
 Define the halt-on-error helper from §6 once at the top, then run one call per file:
 
 ```bash
-API="$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/chorus-api.sh"
-
+# chorus-api.sh is on PATH — no absolute path needed.
 # PRD draft
 CONTENT=$(json_encode_file "openspec/changes/$SLUG/proposal.md")
 PAYLOAD=$(cat <<JSON
@@ -261,7 +262,7 @@ PAYLOAD=$(cat <<JSON
 }
 JSON
 )
-RESULT=$("$API" mcp-tool chorus_pm_add_document_draft "$PAYLOAD")
+RESULT=$(chorus-api.sh mcp-tool chorus_pm_add_document_draft "$PAYLOAD")
 RC=$?
 chorus_check_response "chorus_pm_add_document_draft (prd)" "$RC" "$RESULT"
 PRD_DRAFT_UUID=$(printf '%s' "$RESULT" | grep -o '"draftUuid"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
@@ -285,7 +286,7 @@ PAYLOAD=$(cat <<JSON
 }
 JSON
 )
-RESULT=$("$API" mcp-tool chorus_pm_update_document_draft "$PAYLOAD")
+RESULT=$(chorus-api.sh mcp-tool chorus_pm_update_document_draft "$PAYLOAD")
 RC=$?
 chorus_check_response "chorus_pm_update_document_draft" "$RC" "$RESULT"
 ```
@@ -303,7 +304,7 @@ PAYLOAD=$(cat <<JSON
 }
 JSON
 )
-RESULT=$("$API" mcp-tool chorus_pm_update_document "$PAYLOAD")
+RESULT=$(chorus-api.sh mcp-tool chorus_pm_update_document "$PAYLOAD")
 RC=$?
 chorus_check_response "chorus_pm_update_document" "$RC" "$RESULT"
 ```
@@ -406,7 +407,7 @@ chorus_check_response() {
 **Minimal call site shape:**
 
 ```bash
-RESULT=$("$API" mcp-tool <tool_name> "$PAYLOAD")
+RESULT=$(chorus-api.sh mcp-tool <tool_name> "$PAYLOAD")
 RC=$?
 chorus_check_response "<tool_name>" "$RC" "$RESULT"
 # ...if we reach here, the call succeeded; parse RESULT and continue.
@@ -428,8 +429,8 @@ When invoked from a stage skill (proposal / develop / yolo):
    c. Author `proposal.md`, `design.md`, `specs/<capability>/spec.md` (§3.2–§3.3). Mix `ADDED` / `MODIFIED` / `REMOVED` / `RENAMED` blocks as needed; remember `MODIFIED` overwrites the whole Requirement.
    d. Optional: `openspec validate "$SLUG"`.
    e. `chorus_pm_create_proposal` (direct MCP) with the `OpenSpec change slug: $SLUG` line in description (§3.5).
-   f. Define `$API`, `json_encode_file`, `chorus_check_response` helpers.
-   g. For each row in §5 with "yes" — mirror via `"$API" mcp-tool chorus_pm_add_document_draft` (§3.6). Record each `$DRAFT_UUID`.
+   f. Define `json_encode_file`, `chorus_check_response` helpers. (`chorus-api.sh` is on PATH — no `$API` variable needed.)
+   g. For each row in §5 with "yes" — mirror via `chorus-api.sh mcp-tool chorus_pm_add_document_draft` (§3.6). Record each `$DRAFT_UUID`.
    h. On any failed `chorus_check_response` — halt, surface the error, do NOT proceed.
 4. Edits before approval → §3.7. Edits after approval → §3.8.
 5. Last task verified → hook fires → run §3.9 archive flow.

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.8.1
+version: 0.8.2
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.1"
+  version: "0.8.2"
   category: project-management
   mcp_server: chorus
 ---


### PR DESCRIPTION
## Summary

Hot-fix for #245: the OpenSpec-aware skill was instructing agents to call

```
$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/chorus-api.sh
```

but marketplace-installed plugins don't live in the project tree — they live under `~/.claude/plugins/cache/chorus-plugins/chorus/<version>/bin/`. The hard-coded path always failed, and agents fell back to `find /home/ubuntu -name chorus-api.sh`, which is a multi-second home-directory scan on every mirror call.

The plugin's `bin/` is auto-added to `PATH` on install. Verified:

```bash
$ command -v chorus-api.sh
/home/ubuntu/.claude/plugins/cache/chorus-plugins/chorus/0.8.1/bin/chorus-api.sh

$ chorus-api.sh mcp-tool chorus_checkin '{}'
{ "checkinTime": "...", "agent": { ... } }   # exit 0
```

Switched every skill example and the docs reference to plain `chorus-api.sh`. Codex's `chorus-mcp-call.sh` is left at `$CHORUS_PLUGIN_DIR/hooks/...` because that wrapper is not on PATH in the Codex install layout.

## Changed files

| File | Change |
|------|--------|
| `public/chorus-plugin/skills/openspec-aware/SKILL.md` | All 6 wrapper invocations + Rule 1 banner + checklist |
| `docs/OPENSPEC_MODE.md` | Reference path |
| `*.json` + all `SKILL.md` + `chorus-mcp-call.sh` | Version bump 0.8.1 → 0.8.2 |

## Test plan

- [x] `command -v chorus-api.sh` resolves
- [x] `chorus-api.sh mcp-tool chorus_checkin '{}'` returns valid JSON, exit 0
- [x] No remaining `$CLAUDE_PROJECT_DIR/.claude/plugins/chorus/bin/` references in skill or docs

Generated with [Claude Code](https://claude.com/claude-code)