### PR TITLE
chore(plugin): double reviewer maxTurns; bump Claude Code plugin to 0.8.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/agents/proposal-reviewer.md
+++ b/public/chorus-plugin/agents/proposal-reviewer.md
@@ -2,7 +2,7 @@
 description: "Review submitted Chorus proposals for quality — check document completeness, task granularity, AC alignment, and cross-task dependencies. Spawn after chorus_pm_submit_proposal."
 model: inherit
 color: red
-maxTurns: 20
+maxTurns: 40
 disallowedTools:
   - Agent
   - ExitPlanMode

--- a/public/chorus-plugin/agents/task-reviewer.md
+++ b/public/chorus-plugin/agents/task-reviewer.md
@@ -2,7 +2,7 @@
 description: "Review submitted Chorus tasks — verify implementation against AC and proposal documents. Spawn after chorus_submit_for_verify."
 model: inherit
 color: red
-maxTurns: 25
+maxTurns: 50
 disallowedTools:
   - Agent
   - ExitPlanMode

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.2"
+  version: "0.8.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.2"
+  version: "0.8.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.2"
+  version: "0.8.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Co
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.2"
+  version: "0.8.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.2"
+  version: "0.8.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.8.2
+version: 0.8.3
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.2"
+  version: "0.8.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.8.2"
+  version: "0.8.3"
   category: project-management
   mcp_server: chorus
 ---


### PR DESCRIPTION
## Summary
- Promotes #249 from `develop` to `main`.
- Reviewer agents (`proposal-reviewer`, `task-reviewer`) double their `maxTurns` ceiling. Prompts unchanged.
- Claude Code plugin (`public/chorus-plugin/`) bumps to **0.8.3**. Codex plugin is intentionally unchanged.

## Changed files
| File | Change |
|------|--------|
| `public/chorus-plugin/agents/proposal-reviewer.md` | `maxTurns: 20` → `40` |
| `public/chorus-plugin/agents/task-reviewer.md` | `maxTurns: 25` → `50` |
| `.claude-plugin/marketplace.json` | `0.8.2` → `0.8.3` |
| `public/chorus-plugin/.claude-plugin/plugin.json` | `0.8.2` → `0.8.3` |
| `public/chorus-plugin/skills/*/SKILL.md` (8 files) | `version: 0.8.2` → `0.8.3` |

## Test plan
- [x] `develop` CI green (#249)
- [ ] Users run `/plugin update chorus@chorus-plugins` after merge

Generated with [Claude Code](https://claude.com/claude-code)