### PR TITLE
fix(windows): make published tarball runnable on Windows

### DIFF
--- a/chorus.mjs
+++ b/chorus.mjs
@@ -12,7 +12,7 @@ import {
 import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -279,8 +279,11 @@ async function main() {
   }
 
   // 8. Start Next.js standalone server
+  // Use pathToFileURL — on Windows, dynamic import() rejects bare drive paths
+  // like "C:\…\server.js" with ERR_UNSUPPORTED_ESM_URL_SCHEME. file:// URLs
+  // work on every platform.
   process.chdir(standaloneDir);
-  await import(join(standaloneDir, "server.js"));
+  await import(pathToFileURL(join(standaloneDir, "server.js")).href);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/prepack-pglite.mjs
+++ b/scripts/prepack-pglite.mjs
@@ -17,8 +17,10 @@ import {
   cpSync,
   lstatSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 
@@ -106,5 +108,64 @@ const publicSrc = join(process.cwd(), "public");
 const publicDst = join(standaloneDir, "public");
 cpSync(publicSrc, publicDst, { recursive: true });
 console.log("  copied public/");
+
+// --- 4. Rewrite Prisma's hardcoded build-host __dirname in server chunks ---
+// Prisma 7's generated client.ts contains:
+//   globalThis['__dirname'] = path.dirname(fileURLToPath(import.meta.url))
+// webpack inlines `import.meta.url` at build time as the absolute file:// URL
+// of the source on the build host, e.g.
+//   file:///home/ubuntu/dev/ai-pm/src/generated/prisma/client.ts
+// On Windows, fileURLToPath() rejects this Unix-style URL with
+// ERR_INVALID_FILE_URL_PATH, breaking page rendering. Replace it with a
+// platform-portable runtime expression that uses the chunk's own __filename.
+//
+// The regex tolerates webpack's minified variable names (\w+ for d/e/f/etc.)
+// and any build-host path. Anchored on the unique client.ts suffix so it
+// cannot match unrelated code.
+
+console.log("Patching Prisma __dirname in standalone chunks...");
+const chunksDir = join(standaloneDir, ".next", "server", "chunks");
+const prismaDirnameRe =
+  /globalThis\.__dirname\s*=\s*\w+\.dirname\(\s*\(0,\s*\w+\.fileURLToPath\)\s*\(\s*"file:\/\/[^"]+\/src\/generated\/prisma\/client\.ts"\s*\)\s*\)/g;
+const prismaDirnameRep =
+  'globalThis.__dirname=require("path").dirname(__filename)';
+
+let chunkFiles;
+try {
+  chunkFiles = readdirSync(chunksDir);
+} catch {
+  chunkFiles = [];
+}
+
+let patchedCount = 0;
+for (const name of chunkFiles) {
+  if (!name.endsWith(".js")) continue;
+  const fullPath = join(chunksDir, name);
+  const original = readFileSync(fullPath, "utf8");
+  if (!prismaDirnameRe.test(original)) continue;
+  prismaDirnameRe.lastIndex = 0;
+  const patched = original.replace(prismaDirnameRe, prismaDirnameRep);
+  writeFileSync(fullPath, patched);
+  patchedCount++;
+  console.log(`  patched chunks/${name}`);
+}
+
+if (patchedCount === 0) {
+  // If we ship a tarball without this patch on Windows it breaks at runtime.
+  // Fail loudly so a Prisma upgrade that changes the generated shape can't
+  // silently slip through.
+  console.error(
+    "ERROR: prepack found 0 chunks containing the Prisma __dirname pattern."
+  );
+  console.error(
+    "       The hardcoded build-host path makes the tarball unusable on Windows."
+  );
+  console.error(
+    "       Inspect .next/standalone/.next/server/chunks/*.js and update the"
+  );
+  console.error("       regex in scripts/prepack-pglite.mjs.");
+  process.exit(1);
+}
+console.log(`  patched ${patchedCount} chunk(s)`);
 
 console.log("Prepack complete.");


### PR DESCRIPTION
Closes #36

## Summary
Fix two Linux-build-host paths that get baked into the npm-published standalone server and break on Windows. A user running v0.7.1 on Windows 11 + nvm-windows hit both; manually-patched install verified both fixes are sufficient.

- `chorus.mjs` — pass the standalone `server.js` entry through `pathToFileURL` before dynamic `import()`. Windows rejects `C:\…\server.js` with `ERR_UNSUPPORTED_ESM_URL_SCHEME`; `file://` URLs work on every platform.
- `scripts/prepack-pglite.mjs` — rewrite the Prisma 7 generated `client.ts` `__dirname` injection in standalone server chunks. Webpack inlines `import.meta.url` at build time as the build-host file URL (e.g. `file:///home/ubuntu/dev/ai-pm/src/generated/prisma/client.ts`), and `fileURLToPath` rejects this Unix-style URL on Windows with `ERR_INVALID_FILE_URL_PATH`, breaking page rendering. Replace with a runtime-safe form using `__filename`.

The prepack regex is anchored to the prisma `client.ts` suffix so it cannot match unrelated code. Prepack now **exits non-zero if zero chunks match** — a future Prisma upgrade that changes the generated shape will fail the release rather than silently ship a broken Windows tarball.

## Changed files
| File | Change |
|------|--------|
| `chorus.mjs` | Wrap `import(server.js)` with `pathToFileURL().href`. |
| `scripts/prepack-pglite.mjs` | New step 4: scan `.next/standalone/.next/server/chunks/*.js`, rewrite the Prisma `__dirname` inline, fail prepack if zero chunks match. |

## Impact on other hosts
- **Linux / macOS**: no behavior change. The hardcoded path was a dead value (no module ever resolves it); rewriting it to `path.dirname(__filename)` is equally inert.
- **Docker**: unaffected. Docker builds inside the container, so the build-host path equals the runtime path; and Docker doesn't run `prepack`.
- **Source dev (`pnpm dev` / Turbopack)**: unaffected. `prepack` only runs on `npm pack`.
- **Windows**: goes from broken to working.

## Test plan
- [x] Built tarball locally (`pnpm pack`); confirmed:
  - `chorus.mjs:286` uses `pathToFileURL(...).href`
  - No `file:///home/ubuntu/dev/ai-pm` strings remain in `server/chunks/`
  - Three chunks (`937.js`, `1871.js`, `2618.js`) now contain `globalThis.__dirname=require("path").dirname(__filename)`
- [ ] Installed tarball verified on Linux
- [ ] Installed tarball verified on macOS
- [ ] Installed tarball verified on Windows 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
