### PR TITLE
fix(dashboard): make status group headers feel clickable

### DIFF
--- a/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
@@ -15,7 +15,7 @@ export async function DashboardContent({ projectUuid, initialSelectedIdeaUuid }:
   const { project, trackerData, stats, activities, currentUserUuid } = await getDashboardData(projectUuid);
 
   return (
-    <div className="flex h-full flex-col gap-5 bg-[#F7F6F3] p-5 md:p-6">
+    <div className="flex h-full flex-col gap-5 p-5 md:p-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-medium text-[#2C2C2A]">{t("ideaTracker.overview")}</h1>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/idea-status-group.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/idea-status-group.tsx
@@ -48,11 +48,11 @@ export function IdeaStatusGroup({
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex w-full items-center gap-2 px-0 pb-1.5 pt-0">
+      <CollapsibleTrigger className="group flex w-full cursor-pointer items-center gap-2 px-0 pb-1.5 pt-0">
         {isOpen ? (
-          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[#888780]" />
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[#888780] transition-colors group-hover:text-[#2C2C2A]" />
         ) : (
-          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-[#888780]" />
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-[#888780] transition-colors group-hover:text-[#2C2C2A]" />
         )}
         {/* Status dot */}
         <span
@@ -62,10 +62,10 @@ export function IdeaStatusGroup({
             border: dotStyle.stroke ? `1.5px solid ${dotStyle.stroke}` : undefined,
           }}
         />
-        <span className={`text-[13px] font-medium ${hasIdeas ? "text-[#5F5E5A]" : "text-[#B4B2A9]"}`}>
+        <span className={`text-[13px] font-medium transition-colors group-hover:text-[#2C2C2A] ${hasIdeas ? "text-[#5F5E5A]" : "text-[#B4B2A9]"}`}>
           {t(`status.${statusKey}`)}
         </span>
-        <span className="text-[12px] text-[#888780]">
+        <span className="text-[12px] text-[#888780] transition-colors group-hover:text-[#2C2C2A]">
           {ideas.length}
         </span>
       </CollapsibleTrigger>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/idea-tracker.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/idea-tracker.tsx
@@ -47,7 +47,7 @@ export function IdeaTracker({ projectUuid, currentUserUuid, initialTrackerData, 
       {/* Header: Tabs + New Idea button */}
       {!isEmpty && (
         <div className="mb-4 flex items-center justify-between">
-          <div className="flex gap-0.5 rounded-lg border border-[#E5E0D8] bg-[#F7F6F3] p-0.5">
+          <div className="flex gap-0.5 rounded-lg border border-[#E5E0D8] p-0.5">
             <Button
               variant="ghost"
               size="sm"


### PR DESCRIPTION
## Summary
- Status group triggers in the project dashboard (Todo / In Progress / Human Conduct Required / Done) had no `cursor: pointer` and no hover affordance — users couldn't tell the rows were collapsible.
- Adds `cursor-pointer` + `group-hover` color transitions on the chevron, label, and count so hovering darkens the whole row.
- Drops the redundant `bg-[#F7F6F3]` on the dashboard wrapper and tab pill — it matched the surrounding page background and added no visual separation.

## Changed files
| File | Change |
|------|--------|
| `src/app/(dashboard)/projects/[uuid]/dashboard/idea-status-group.tsx` | `CollapsibleTrigger` → `group cursor-pointer`; chevron / label / count now darken to `#2C2C2A` on hover via `group-hover` |
| `src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx` | Remove `bg-[#F7F6F3]` from the outer wrapper |
| `src/app/(dashboard)/projects/[uuid]/dashboard/idea-tracker.tsx` | Remove `bg-[#F7F6F3]` from the tab-pill container |

## Test plan
- [x] Hover each status group on `/projects/{uuid}/dashboard` → cursor becomes pointer, text darkens
- [x] Click toggles collapsed/expanded
- [x] Visual: dashboard background and tab pill render correctly without the inner gray fill

Generated with [Claude Code](https://claude.com/claude-code)