### PR TITLE
fix(elaboration): wrap long options and add Other input ✓ confirm

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -856,6 +856,7 @@
     "otherOption": "Other",
     "otherPlaceholder": "Please specify...",
     "submitAnswers": "Submit answers",
+    "confirmAnswerAria": "Confirm answer",
     "submitting": "Submitting...",
     "submitFailed": "Failed to submit answers",
     "navCounter": "{current} of {total}",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -857,6 +857,7 @@
     "otherOption": "其他",
     "otherPlaceholder": "请说明...",
     "submitAnswers": "提交回答",
+    "confirmAnswerAria": "确认回答",
     "submitting": "提交中...",
     "submitFailed": "提交回答失败",
     "navCounter": "{current} / {total}",

--- a/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/README.md
+++ b/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/README.md
@@ -1,0 +1,3 @@
+# fix-elaboration-ui-options
+
+Fix Elaboration UI: long-option wrap + Other input inline confirm button + Enter-to-submit

--- a/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/design.md
+++ b/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/design.md
@@ -1,0 +1,99 @@
+## Architecture
+
+This is a single-component, client-only change. All work lives in `src/components/elaboration-panel.tsx`. No service-layer, MCP, REST, Prisma, or i18n-config changes beyond two new translation keys.
+
+### Component map
+
+```
+ElaborationPanel
+└── RoundCard
+    └── PendingRoundContent          ← all changes happen inside this branch
+        ├── question text + nav (left/right chevron, Enter is NOT bound here)
+        ├── options list             ← long-option wrap fix lives here
+        │     └── Button (label / description spans get whitespace-normal)
+        ├── Other input row          ← inline ✓ confirm button + Enter handler live here
+        │     ├── pencil icon (toggles Other)
+        │     ├── Input              ← onKeyDown for Enter
+        │     └── ✓ icon button      ← new
+        └── footer (category + Submit Answers big button — unchanged)
+```
+
+`AnsweredRoundContent` is read-only Q/A text and is not in scope.
+
+## Data flow
+
+The component already keeps round answers in local state:
+
+```
+answers: Record<questionId, AnswerInput>
+AnswerInput { questionId, selectedOptionId, customText }
+```
+
+A regular option click goes through `handleSelectOption(questionId, optionId)`:
+
+1. write `selectedOptionId: optionId, customText: null` into local state,
+2. schedule `goTo(currentIndex + 1, "left")` after `SLIDE_ANIMATION_MS`.
+
+Picking the Other "option" (`optionId === OTHER_OPTION_ID`) writes `selectedOptionId: null, customText: prev?.customText ?? ""` and **does not** auto-advance — that is the behavior we are extending.
+
+This change adds a new local function `handleConfirmOther(questionId)` (or inlines the same effect):
+
+1. Read the current `customText` from `answers[questionId]`.
+2. If `customText` is missing or `.trim()` is empty → no-op.
+3. If `currentIndex === questions.length - 1` (last question) → no-op (the user must use the bottom-right Submit Answers button).
+4. Otherwise → schedule `goTo(currentIndex + 1, "left")` after `SLIDE_ANIMATION_MS`. The state already has the `customText`, so nothing new needs to be written.
+
+The ✓ icon button calls `handleConfirmOther`; the Input's `onKeyDown` calls `handleConfirmOther` when `e.key === "Enter"`, after `e.preventDefault()`.
+
+Whole-round submission stays exactly as today — `Submit Answers` → `submitElaborationAnswersAction` with `Object.values(answers)`.
+
+## UI contract
+
+### Option label / description wrap
+
+The current option button uses `flex w-full items-center justify-between … h-auto`. The label / description spans inherit `whitespace-nowrap` from shadcn `Button`. Fix: apply `whitespace-normal break-words` directly on the inner text spans (lines ~424-432). Container width comes from the parent panel — no width adjustment needed. The `ArrowRight` indicator stays right-aligned via `justify-between`; with multi-line text we keep the icon top-aligned (`items-start` on the right column) so it doesn't visually drift mid-line on tall labels.
+
+### Inline ✓ button
+
+Lives inside the Other row, to the right of the `<Input>`, only when `isOtherSelected` is true. Visual style mirrors the up/down chevron buttons in the question header:
+
+- shadcn `Button variant="ghost" size="icon"`,
+- `Check` icon from `lucide-react` (already a peer dep),
+- `h-7 w-7`, neutral text color matching `#6B6B6B`,
+- `disabled` when `(answers[question.questionId]?.customText ?? "").trim() === ""`,
+- `aria-label` from `t("confirmAnswerAria")`.
+
+When the panel is on the **last question**, the ✓ button is hidden entirely (don't disable, hide). Hiding is preferred to disabling so the user is not confused into thinking the button is just temporarily unavailable — the bottom-right Submit Answers button is what they need.
+
+### Enter handler
+
+The Input gets a new `onKeyDown` handler:
+
+```ts
+function handleOtherInputKeyDown(e) {
+  if (e.key !== "Enter") return;
+  if (e.shiftKey || e.ctrlKey || e.metaKey) return;     // leave modifiers free
+  e.preventDefault();
+  if (currentIndex === questions.length - 1) return;    // last-question suppression
+  handleConfirmOther(question.questionId);
+}
+```
+
+`preventDefault()` is required because the input is `type="text"`. Although the panel is not inside a `<form>`, some browsers still emit the form-submit event when an input is the only one in its accessibility tree; preventing default is cheap insurance.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Wrap breaks the existing single-line aesthetic on common short labels | `whitespace-normal` only matters when content is long. Short labels render identically. |
+| Enter inside the input accidentally triggers ancestor `Collapsible` toggle | The Collapsible trigger is a sibling button, not an ancestor of the input. `e.preventDefault()` on Enter further insulates us. |
+| User holds Enter and rapidly advances through multiple questions | Acceptable — same as auto-advance on regular option click, which is already a single click. The user can still go back via the left chevron. |
+| Confirm fires while an animation is in flight | Same `setTimeout(..., SLIDE_ANIMATION_MS)` guard the existing path uses — no new race. |
+| New i18n key falls back to the key string when missing | We add the key to BOTH `en.json` and `zh.json` in this change; CI grep test enforced. |
+
+## Out of scope
+
+- Multi-line free-text answer (would require switching `<Input>` to `<Textarea>` and changing Enter semantics).
+- Validation of `customText` content beyond emptiness.
+- Visual redesign of the panel itself.
+- Mobile-specific layout — the wrap fix already addresses the worst case.

--- a/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/proposal.md
+++ b/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The Elaboration answer panel (`src/components/elaboration-panel.tsx`) is the surface every PM Agent and human collaborator hits during requirements gathering — and it has two friction bugs that show up on every comprehensive (10-15 question) round:
+
+1. **Long option labels truncate.** The option button is built on top of shadcn `Button`, which defaults to `whitespace-nowrap`. Any label longer than the panel width gets cut off, so the user picks an option without seeing the full text.
+2. **The "Other" free-text path has no inline confirm.** When the user picks Other, they type into the input and have nothing to do but reach for the right-arrow chevron at the top of the card. There is no inline confirm button, and pressing Enter does nothing — so a one-handed flow ("type, Enter, next question") is not possible.
+
+The cumulative effect on a 10-question elaboration is enough friction that PM Agents have started preferring `chorus_pm_skip_elaboration` even when elaboration would help. This change removes the friction without touching the data model or any MCP tool.
+
+## What Changes
+
+- **Wrap long option labels.** Apply `whitespace-normal` + `break-words` to the label/description spans so the option button height grows with the content. Both labels and descriptions wrap; selection chevron stays right-aligned at the top.
+- **Add an inline ✓ confirm button to the Other input row.** When Other is selected and the input is shown, render a small icon button to the right of the input. Clicking it commits the current `customText` and auto-advances to the next question — same effect as picking a regular option. The button is `disabled` when the input is empty (after `.trim()`).
+- **Bind Enter to the same confirm action** while the Other input has focus. Enter submits the current answer and auto-advances. Identical effect to clicking ✓.
+- **Suppress confirm/Enter on the last question.** When the user is on the last question and Other is selected, the inline ✓ MUST be hidden (or disabled) and the Enter key MUST do nothing in the input. The user is forced to click the bottom-right "Submit Answers" button to commit the whole round, which prevents accidental whole-round submission via stray Enter.
+- **i18n.** Add an aria-label key for the confirm button under `elaboration.*` in both `messages/en.json` and `messages/zh.json`.
+
+Non-goals: redesigning the panel layout, supporting multi-select on a single question, undo, mobile-specific behavior beyond the wrap (the wrap already addresses small screens).
+
+## Capabilities
+
+### New Capabilities
+
+- `elaboration-answer-ui`: client-side affordance contract for the elaboration answer panel — covers long-option wrap behavior, Other-input inline confirm button, Enter-to-advance, last-question Enter suppression, and the i18n keys for the confirm aria-label.
+
+### Modified Capabilities
+
+(none — no backend or MCP-tool change)
+
+## Impact
+
+- **Updated file**: `src/components/elaboration-panel.tsx` — wrap option spans; add inline confirm icon button + Enter `onKeyDown` handler in the Other branch; gate confirm/Enter on last-question.
+- **Updated files**: `messages/en.json`, `messages/zh.json` — add `elaboration.confirmAnswerAria` key.
+- **No backend change**: the `chorus_answer_elaboration` payload is unchanged. Submission of the whole round still happens via `submitElaborationAnswersAction` exactly as today.
+- **No data-model change**: no Prisma schema edit, no new MCP tool.
+- **Risks**: the behavior of Enter inside an input is normally "submit form"; the panel is not in a `<form>` element, so we control it. Risk is suppressed by an explicit `e.preventDefault()` in the Enter handler.

--- a/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/specs/elaboration-answer-ui/spec.md
+++ b/openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/specs/elaboration-answer-ui/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Long option labels SHALL wrap to multiple lines instead of truncating
+
+When an `ElaborationQuestion.option.label` or `option.description` is longer than the available row width inside the elaboration panel, the option button MUST render the text on multiple lines and grow its height to fit the content.
+
+#### Scenario: Option label longer than panel width
+
+- **GIVEN** an elaboration round is in `pending_answers` and the user is viewing a question whose first option has a label of ~120 characters
+- **WHEN** the question is rendered inside `PendingRoundContent`
+- **THEN** the option button MUST render the full label text without horizontal truncation or `text-overflow: ellipsis`
+- **AND** the rendered label span MUST have CSS `white-space: normal` (or equivalent — i.e. NOT `nowrap`)
+- **AND** the rendered label span MUST allow long unbroken tokens to wrap (`overflow-wrap: break-word` or `word-break: break-word`)
+- **AND** the option button height MUST grow to contain all rendered lines (no clipping, no scroll within the button)
+
+#### Scenario: Short option labels still render on a single line
+
+- **GIVEN** a question whose options all have labels under 30 characters
+- **WHEN** the question is rendered
+- **THEN** each option button MUST render its label on a single visible line (no spurious wrapping)
+- **AND** the visual height of each option button MUST be unchanged from the pre-change baseline (modulo sub-pixel rendering)
+
+### Requirement: The Other input row SHALL show an inline confirm button when an answer is being typed
+
+When the user has selected the synthetic Other option on a non-last question, the elaboration panel MUST render an inline confirm button to the right of the Other text input. The button MUST be disabled while the input is empty, and clicking it MUST commit the current `customText` answer and auto-advance to the next question.
+
+#### Scenario: User selects Other and the inline confirm button appears
+
+- **GIVEN** a question with at least one regular option AND the user clicks the pencil/Other affordance to select Other
+- **WHEN** the Other row enters its input mode
+- **THEN** an inline confirm icon button MUST be rendered to the right of the `<Input>` in the same Other row
+- **AND** the icon button MUST use the `Check` icon from `lucide-react`
+- **AND** the icon button MUST carry an accessible label sourced from `t("elaboration.confirmAnswerAria")`
+- **AND** the icon button MUST be `disabled` when `(answers[question.questionId]?.customText ?? "").trim() === ""`
+
+#### Scenario: User clicks the inline confirm button with non-empty text on a non-last question
+
+- **GIVEN** Other is selected on question N (where N is not the last question)
+- **AND** the user has typed `"hybrid approach"` into the Other input
+- **WHEN** the user clicks the inline confirm icon button
+- **THEN** local state for that question MUST already be `{ selectedOptionId: null, customText: "hybrid approach" }` (it was set on each keystroke)
+- **AND** the panel MUST advance to question N+1 within `SLIDE_ANIMATION_MS` (~200ms)
+- **AND** no network request to `submitElaborationAnswersAction` MUST be issued by this click — the round is only submitted via the bottom-right Submit Answers button
+
+#### Scenario: User clicks the inline confirm button with empty text
+
+- **GIVEN** Other is selected and the input value (post-`.trim()`) is empty
+- **WHEN** the user clicks the inline confirm icon button
+- **THEN** the click MUST be a no-op — no state change, no advance, no network call
+- **AND** the button MUST be visually `disabled` to communicate this
+
+### Requirement: Pressing Enter inside the Other input SHALL behave like clicking the inline confirm button
+
+While the Other input has focus, pressing the Enter key (without modifier keys) MUST have the same effect as clicking the inline confirm icon button — commit current `customText` and auto-advance, subject to the same emptiness and last-question rules.
+
+#### Scenario: User presses Enter with non-empty text on a non-last question
+
+- **GIVEN** Other is selected on question N (not last)
+- **AND** the user has typed `"my answer"` into the Other input
+- **WHEN** the user presses Enter without holding Shift / Ctrl / Meta
+- **THEN** the keystroke MUST call `e.preventDefault()`
+- **AND** the panel MUST advance to question N+1
+- **AND** no network request MUST be issued
+
+#### Scenario: Enter with empty text is a no-op
+
+- **GIVEN** Other is selected and the input value (post-`.trim()`) is empty
+- **WHEN** the user presses Enter
+- **THEN** the keystroke MUST call `e.preventDefault()`
+- **AND** the panel MUST NOT advance
+- **AND** no network request MUST be issued
+
+#### Scenario: Enter with a modifier key is left to default behavior
+
+- **GIVEN** Other is selected
+- **WHEN** the user presses Shift+Enter, Ctrl+Enter, or Meta+Enter
+- **THEN** the new keydown handler MUST NOT call `preventDefault`
+- **AND** the panel MUST NOT advance based on this keystroke
+
+### Requirement: On the last question with Other selected, Enter and the inline confirm SHALL be suppressed
+
+To prevent accidental whole-round submission via stray Enter or icon-button clicks when the user means to type more, the inline confirm button MUST be hidden and the Enter key MUST be a no-op when the user is on the last question of the round and Other is selected. The user is forced to click the bottom-right Submit Answers button explicitly.
+
+#### Scenario: Last question with Other selected — confirm button is hidden
+
+- **GIVEN** a round whose `currentIndex === questions.length - 1` and Other is selected on that question
+- **WHEN** the Other input mode renders
+- **THEN** the inline confirm icon button MUST NOT be rendered in the DOM (hidden, not just `disabled`)
+
+#### Scenario: Last question with Other selected — Enter does nothing
+
+- **GIVEN** the same state as above
+- **WHEN** the user presses Enter inside the Other input
+- **THEN** the new keydown handler MUST call `e.preventDefault()`
+- **AND** MUST NOT advance the panel
+- **AND** MUST NOT trigger `submitElaborationAnswersAction`
+- **AND** the user MUST still be able to click the bottom-right Submit Answers button to submit the whole round
+
+### Requirement: The new aria-label string SHALL be available in both English and Chinese locales
+
+The translation key `elaboration.confirmAnswerAria` MUST be present in both `messages/en.json` and `messages/zh.json` and MUST be referenced via `useTranslations("elaboration")` rather than hardcoded.
+
+#### Scenario: i18n key coverage
+
+- **WHEN** a reviewer greps `messages/en.json` and `messages/zh.json` for `confirmAnswerAria`
+- **THEN** the key MUST be present in BOTH locale files
+- **AND** the value in each file MUST be a non-empty string
+- **AND** the string `confirmAnswerAria` MUST NOT appear hardcoded inside any `.tsx` file under `src/` (only via `t("confirmAnswerAria")`)

--- a/openspec/specs/elaboration-answer-ui/spec.md
+++ b/openspec/specs/elaboration-answer-ui/spec.md
@@ -1,0 +1,112 @@
+# elaboration-answer-ui Specification
+
+## Purpose
+TBD - created by archiving change fix-elaboration-ui-options. Update Purpose after archive.
+## Requirements
+### Requirement: Long option labels SHALL wrap to multiple lines instead of truncating
+
+When an `ElaborationQuestion.option.label` or `option.description` is longer than the available row width inside the elaboration panel, the option button MUST render the text on multiple lines and grow its height to fit the content.
+
+#### Scenario: Option label longer than panel width
+
+- **GIVEN** an elaboration round is in `pending_answers` and the user is viewing a question whose first option has a label of ~120 characters
+- **WHEN** the question is rendered inside `PendingRoundContent`
+- **THEN** the option button MUST render the full label text without horizontal truncation or `text-overflow: ellipsis`
+- **AND** the rendered label span MUST have CSS `white-space: normal` (or equivalent — i.e. NOT `nowrap`)
+- **AND** the rendered label span MUST allow long unbroken tokens to wrap (`overflow-wrap: break-word` or `word-break: break-word`)
+- **AND** the option button height MUST grow to contain all rendered lines (no clipping, no scroll within the button)
+
+#### Scenario: Short option labels still render on a single line
+
+- **GIVEN** a question whose options all have labels under 30 characters
+- **WHEN** the question is rendered
+- **THEN** each option button MUST render its label on a single visible line (no spurious wrapping)
+- **AND** the visual height of each option button MUST be unchanged from the pre-change baseline (modulo sub-pixel rendering)
+
+### Requirement: The Other input row SHALL show an inline confirm button when an answer is being typed
+
+When the user has selected the synthetic Other option on a non-last question, the elaboration panel MUST render an inline confirm button to the right of the Other text input. The button MUST be disabled while the input is empty, and clicking it MUST commit the current `customText` answer and auto-advance to the next question.
+
+#### Scenario: User selects Other and the inline confirm button appears
+
+- **GIVEN** a question with at least one regular option AND the user clicks the pencil/Other affordance to select Other
+- **WHEN** the Other row enters its input mode
+- **THEN** an inline confirm icon button MUST be rendered to the right of the `<Input>` in the same Other row
+- **AND** the icon button MUST use the `Check` icon from `lucide-react`
+- **AND** the icon button MUST carry an accessible label sourced from `t("elaboration.confirmAnswerAria")`
+- **AND** the icon button MUST be `disabled` when `(answers[question.questionId]?.customText ?? "").trim() === ""`
+
+#### Scenario: User clicks the inline confirm button with non-empty text on a non-last question
+
+- **GIVEN** Other is selected on question N (where N is not the last question)
+- **AND** the user has typed `"hybrid approach"` into the Other input
+- **WHEN** the user clicks the inline confirm icon button
+- **THEN** local state for that question MUST already be `{ selectedOptionId: null, customText: "hybrid approach" }` (it was set on each keystroke)
+- **AND** the panel MUST advance to question N+1 within `SLIDE_ANIMATION_MS` (~200ms)
+- **AND** no network request to `submitElaborationAnswersAction` MUST be issued by this click — the round is only submitted via the bottom-right Submit Answers button
+
+#### Scenario: User clicks the inline confirm button with empty text
+
+- **GIVEN** Other is selected and the input value (post-`.trim()`) is empty
+- **WHEN** the user clicks the inline confirm icon button
+- **THEN** the click MUST be a no-op — no state change, no advance, no network call
+- **AND** the button MUST be visually `disabled` to communicate this
+
+### Requirement: Pressing Enter inside the Other input SHALL behave like clicking the inline confirm button
+
+While the Other input has focus, pressing the Enter key (without modifier keys) MUST have the same effect as clicking the inline confirm icon button — commit current `customText` and auto-advance, subject to the same emptiness and last-question rules.
+
+#### Scenario: User presses Enter with non-empty text on a non-last question
+
+- **GIVEN** Other is selected on question N (not last)
+- **AND** the user has typed `"my answer"` into the Other input
+- **WHEN** the user presses Enter without holding Shift / Ctrl / Meta
+- **THEN** the keystroke MUST call `e.preventDefault()`
+- **AND** the panel MUST advance to question N+1
+- **AND** no network request MUST be issued
+
+#### Scenario: Enter with empty text is a no-op
+
+- **GIVEN** Other is selected and the input value (post-`.trim()`) is empty
+- **WHEN** the user presses Enter
+- **THEN** the keystroke MUST call `e.preventDefault()`
+- **AND** the panel MUST NOT advance
+- **AND** no network request MUST be issued
+
+#### Scenario: Enter with a modifier key is left to default behavior
+
+- **GIVEN** Other is selected
+- **WHEN** the user presses Shift+Enter, Ctrl+Enter, or Meta+Enter
+- **THEN** the new keydown handler MUST NOT call `preventDefault`
+- **AND** the panel MUST NOT advance based on this keystroke
+
+### Requirement: On the last question with Other selected, Enter and the inline confirm SHALL be suppressed
+
+To prevent accidental whole-round submission via stray Enter or icon-button clicks when the user means to type more, the inline confirm button MUST be hidden and the Enter key MUST be a no-op when the user is on the last question of the round and Other is selected. The user is forced to click the bottom-right Submit Answers button explicitly.
+
+#### Scenario: Last question with Other selected — confirm button is hidden
+
+- **GIVEN** a round whose `currentIndex === questions.length - 1` and Other is selected on that question
+- **WHEN** the Other input mode renders
+- **THEN** the inline confirm icon button MUST NOT be rendered in the DOM (hidden, not just `disabled`)
+
+#### Scenario: Last question with Other selected — Enter does nothing
+
+- **GIVEN** the same state as above
+- **WHEN** the user presses Enter inside the Other input
+- **THEN** the new keydown handler MUST call `e.preventDefault()`
+- **AND** MUST NOT advance the panel
+- **AND** MUST NOT trigger `submitElaborationAnswersAction`
+- **AND** the user MUST still be able to click the bottom-right Submit Answers button to submit the whole round
+
+### Requirement: The new aria-label string SHALL be available in both English and Chinese locales
+
+The translation key `elaboration.confirmAnswerAria` MUST be present in both `messages/en.json` and `messages/zh.json` and MUST be referenced via `useTranslations("elaboration")` rather than hardcoded.
+
+#### Scenario: i18n key coverage
+
+- **WHEN** a reviewer greps `messages/en.json` and `messages/zh.json` for `confirmAnswerAria`
+- **THEN** the key MUST be present in BOTH locale files
+- **AND** the value in each file MUST be a non-empty string
+- **AND** the string `confirmAnswerAria` MUST NOT appear hardcoded inside any `.tsx` file under `src/` (only via `t("confirmAnswerAria")`)
+

--- a/src/components/elaboration-panel.tsx
+++ b/src/components/elaboration-panel.tsx
@@ -10,6 +10,7 @@ import {
   ArrowRight,
   Pencil,
   Loader2,
+  Check,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -359,6 +360,28 @@ function PendingRoundContent({
 
   const selectedOptionId = getSelectedOptionId(question.questionId);
   const isOtherSelected = selectedOptionId === OTHER_OPTION_ID;
+  const isLastQuestion = currentIndex === questions.length - 1;
+  const hasOtherText = Boolean(
+    (answers[question.questionId]?.customText ?? "").trim()
+  );
+
+  const handleConfirmOther = () => {
+    if (isLastQuestion || !hasOtherText) return;
+    const nextIdx = currentIndexRef.current + 1;
+    setTimeout(() => goTo(nextIdx, "left"), SLIDE_ANIMATION_MS);
+  };
+
+  const handleOtherInputKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (e.key !== "Enter") return;
+    if (e.shiftKey || e.ctrlKey || e.metaKey) return;
+    e.preventDefault();
+    if (isLastQuestion) return;
+    if (!hasOtherText) return;
+    const nextIdx = currentIndexRef.current + 1;
+    setTimeout(() => goTo(nextIdx, "left"), SLIDE_ANIMATION_MS);
+  };
 
   return (
     <div className="overflow-hidden p-3.5">
@@ -409,31 +432,31 @@ function PendingRoundContent({
                 onClick={() =>
                   handleSelectOption(question.questionId, option.id)
                 }
-                className={`flex w-full items-center justify-between px-3.5 py-3 h-auto text-left transition-colors rounded-none ${
+                className={`flex w-full items-start justify-between gap-2.5 px-3.5 py-3 h-auto text-left transition-colors rounded-none ${
                   isSelected
                     ? "bg-[#F7F6F3]"
                     : "hover:bg-[#FAF8F4]"
                 }`}
               >
-                <span className="flex items-center gap-2.5">
+                <span className="flex flex-1 min-w-0 items-start gap-2.5">
                   <span
                     className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#E5E0D8] text-xs font-medium text-[#5F5E5A]"
                   >
                     {idx + 1}
                   </span>
-                  <span className="flex flex-col items-start">
-                    <span className="text-[13px] text-[#2C2C2A]">
+                  <span className="flex min-w-0 flex-1 flex-col items-start">
+                    <span className="whitespace-normal [overflow-wrap:anywhere] text-[13px] text-[#2C2C2A]">
                       {option.label}
                     </span>
                     {option.description && (
-                      <span className="text-[11px] text-[#9A9A9A]">
+                      <span className="whitespace-normal [overflow-wrap:anywhere] text-[11px] text-[#9A9A9A]">
                         {option.description}
                       </span>
                     )}
                   </span>
                 </span>
                 {isSelected && (
-                  <ArrowRight className="h-4 w-4 text-[#888780]" />
+                  <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-[#888780]" />
                 )}
               </Button>
               {idx < question.options.length - 1 && (
@@ -461,16 +484,32 @@ function PendingRoundContent({
             <Pencil className="h-3.5 w-3.5 text-[#B4B2A9]" />
           </span>
           {isOtherSelected ? (
-            <Input
-              type="text"
-              value={answers[question.questionId]?.customText || ""}
-              onChange={(e) =>
-                handleCustomTextChange(question.questionId, e.target.value)
-              }
-              placeholder={t("somethingElse")}
-              className="flex-1 border-none bg-transparent text-[13px] text-[#2C2C2A] placeholder:italic placeholder:text-[#B4B2A9] shadow-none focus-visible:ring-0"
-              autoFocus
-            />
+            <>
+              <Input
+                type="text"
+                value={answers[question.questionId]?.customText || ""}
+                onChange={(e) =>
+                  handleCustomTextChange(question.questionId, e.target.value)
+                }
+                onKeyDown={handleOtherInputKeyDown}
+                placeholder={t("somethingElse")}
+                className="flex-1 border-none bg-transparent text-[13px] text-[#2C2C2A] placeholder:italic placeholder:text-[#B4B2A9] shadow-none focus-visible:ring-0"
+                autoFocus
+              />
+              {!isLastQuestion && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleConfirmOther}
+                  disabled={!hasOtherText}
+                  aria-label={t("confirmAnswerAria")}
+                  className="h-7 w-7 text-[#6B6B6B] disabled:opacity-30"
+                >
+                  <Check className="h-4 w-4" />
+                </Button>
+              )}
+            </>
           ) : (
             <Button
               variant="ghost"


### PR DESCRIPTION
## Summary

- Long option labels in the elaboration answer panel now wrap to multiple lines instead of truncating, including unbreakable strings (URLs, long English tokens).
- Adds an inline ✓ confirm button to the Other free-text input row, plus an Enter-to-advance keyboard binding. Both schedule the same auto-advance the regular options use.
- Suppresses ✓ and Enter on the last question to prevent accidental whole-round submission via stray Enter — the user must explicitly click the bottom-right Submit Answers button.

## Changed files

| File | Change |
|------|--------|
| `src/components/elaboration-panel.tsx` | Option spans get `whitespace-normal [overflow-wrap:anywhere]`; outer button switched to `items-start` + `min-w-0 flex-1` for proper flex shrink; ArrowRight pinned with `mt-1 shrink-0`. Adds `Check` lucide import, `handleConfirmOther` + `handleOtherInputKeyDown` (modifier-key safe), conditional `✓` button next to the Other Input. |
| `messages/en.json`, `messages/zh.json` | New `elaboration.confirmAnswerAria` key (`Confirm answer` / `确认回答`). |
| `openspec/changes/archive/2026-05-20-fix-elaboration-ui-options/` | Authored proposal/design/spec for the change, then archived. |
| `openspec/specs/elaboration-answer-ui/spec.md` | New capability spec materialized from the archive. |

## Behavior contract (matches spec)

| Scenario | Expected |
|----------|----------|
| Long label / description | Wraps via `overflow-wrap: anywhere`; button height grows |
| Short label | Single line, unchanged |
| Other selected, non-last question, non-empty text | ✓ button visible + enabled; click or plain Enter → advance |
| Other selected, empty text | ✓ disabled; Enter is `preventDefault`'d no-op |
| Shift / Ctrl / Meta + Enter inside Other | NOT preventDefaulted, NOT advanced (browser default) |
| Other selected on last question | ✓ NOT rendered in DOM; Enter is `preventDefault`'d but does not submit / advance |
| Round submission | Still only via bottom-right Submit Answers (unchanged) |

## Test plan

- [x] `npx tsc --noEmit` — clean for elaboration-panel.tsx
- [x] Each task reviewed independently by `chorus:task-reviewer` — all PASS / PASS WITH NOTES
- [x] Local Chorus instance — comprehensive 5-question round with deliberately overlong + unbreakable label confirms wrap, ✓ visibility, Enter advance, last-question suppression
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)