### PR TITLE
feat(documents): render mermaid blocks in markdown content

### DIFF
--- a/openspec/changes/archive/2026-05-20-mermaid-document-rendering/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-20-mermaid-document-rendering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-20-mermaid-document-rendering/README.md
+++ b/openspec/changes/archive/2026-05-20-mermaid-document-rendering/README.md
@@ -1,0 +1,3 @@
+# mermaid-document-rendering
+
+Render mermaid code blocks in Chorus documents via @streamdown/mermaid; bump streamdown 2.5 + shiki 4

--- a/openspec/changes/archive/2026-05-20-mermaid-document-rendering/design.md
+++ b/openspec/changes/archive/2026-05-20-mermaid-document-rendering/design.md
@@ -1,0 +1,230 @@
+# Tech Design — Mermaid in Chorus documents
+
+## Background
+
+`streamdown` is Chorus' streaming Markdown renderer (drop-in replacement
+for `react-markdown`, designed for token-by-token AI streams). In v1
+mermaid was built in; v2 (`2.4.0+`) split it into `@streamdown/mermaid`
+and stopped enabling it by default. Chorus shipped 2.4 already in package.json,
+but never wired the new plugin — hence mermaid blocks render as plain code.
+
+The reference implementation we're following is `strands-ai-sdk`
+commit `45b09ea6eaa40e57b423a108c8756c67e3eea037` ("Restore mermaid
+rendering after Streamdown v2 upgrade"). It does three things we need to
+replicate:
+
+1. Add `@streamdown/mermaid` and pass it through every `<Streamdown>`
+   call site as a plugin, with `controls={{ fullscreen, download, copy,
+   panZoom }}`.
+2. Centralize the plugin/control objects in a shared module so call
+   sites stay terse and stay consistent on later upgrades.
+3. Add `streamdown/dist` (and `@streamdown/<plugin>/dist`) to the
+   Tailwind content globs — streamdown ships pre-compiled JSX with
+   Tailwind utility classes (e.g. `min-h-[200px]`,
+   `pointer-events-auto`) that the JIT will not see otherwise; missing
+   them means the mermaid container collapses to height 0 and the
+   toolbar becomes unclickable.
+
+Chorus uses Tailwind v4 with `@import "tailwindcss"` in `globals.css`
+and the `@source` directive (already pointing at
+`../../../node_modules/streamdown/dist/*.js`). We'll need to verify
+that glob also catches `@streamdown/mermaid`'s compiled output; if not,
+extend it.
+
+## Module structure
+
+### `src/lib/streamdown-plugins.ts` (new)
+
+```ts
+"use client";
+
+import { code } from "@streamdown/code";
+import { mermaid } from "@streamdown/mermaid";
+
+export const streamdownPlugins = { code, mermaid } as const;
+
+export const streamdownControls = {
+  mermaid: {
+    fullscreen: true,
+    download: true,
+    copy: true,
+    panZoom: true,
+  },
+} as const;
+```
+
+This is a client-only module (the plugins drag in `useEffect` /
+`IntersectionObserver`); we mark it `"use client"` so any server
+component import surfaces immediately as a build error rather than at
+runtime.
+
+### `src/components/markdown-content.tsx` (modified)
+
+Becomes the single rendering entry point used by every Markdown surface
+in the app. Today it already calls `<Streamdown plugins={{ code }}>`;
+we extend it to forward both `plugins` and `controls` from the shared
+module, plus a `theme` derived from the active Chorus theme.
+
+```ts
+"use client";
+
+import { Streamdown } from "streamdown";
+import { useTheme } from "next-themes";
+import { useMemo } from "react";
+
+import {
+  streamdownPlugins,
+  streamdownControls,
+} from "@/lib/streamdown-plugins";
+
+export function MarkdownContent({ children }: { children: string }) {
+  const { resolvedTheme } = useTheme();
+  const controls = useMemo(
+    () => ({
+      ...streamdownControls,
+      mermaid: {
+        ...streamdownControls.mermaid,
+        theme: resolvedTheme === "dark" ? "dark" : "default",
+      },
+    }),
+    [resolvedTheme],
+  );
+
+  return (
+    <Streamdown plugins={streamdownPlugins} controls={controls}>
+      {children}
+    </Streamdown>
+  );
+}
+```
+
+> Note: `@streamdown/mermaid`'s control schema accepts an optional
+> `theme` that maps directly to mermaid's `themeVariables` selector.
+> Chorus' `next-themes` is already in the dependency tree (verify in
+> implementation; if not, the alternative is `useResolvedTheme` from
+> Chorus' own LocaleProvider style).
+
+### Migration across the ~14 call sites
+
+Every existing call site of the form
+
+```tsx
+<Streamdown plugins={{ code }}>{content}</Streamdown>
+```
+
+becomes
+
+```tsx
+<MarkdownContent>{content}</MarkdownContent>
+```
+
+The 14 files (per `grep -rn 'Streamdown' src --include='*.tsx'`):
+
+```
+src/components/mention-renderer.tsx                         (2 sites)
+src/app/onboarding/components/CodeBlock.tsx
+src/app/(dashboard)/projects/[uuid]/ideas/ideas-list.tsx
+src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
+src/app/(dashboard)/projects/[uuid]/dashboard/panels/document-panel.tsx
+src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx
+src/app/(dashboard)/projects/[uuid]/dashboard/panels/basic-view.tsx
+src/app/(dashboard)/projects/[uuid]/dashboard/panels/proposal-view.tsx
+src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/task-draft-detail-panel.tsx (2 sites)
+src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx
+src/app/(dashboard)/projects/[uuid]/proposals/proposal-kanban.tsx
+src/app/(dashboard)/projects/[uuid]/documents/[documentUuid]/document-content.tsx
+src/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel.tsx (2 sites)
+```
+
+`mention-renderer.tsx` is the trickiest case — it pre-processes mentions
+into placeholders and currently renders Streamdown directly twice. The
+refactor replaces both with `<MarkdownContent>` and keeps the placeholder
+pre-processing in place.
+
+## Bundle considerations
+
+`@streamdown/mermaid` is ~80KB gzipped on its own; the `mermaid` core
+adds another ~170KB. We're keeping the plugin static-imported (matches
+the reference commit) because:
+
+- `@streamdown/mermaid` already gates rendering with
+  `IntersectionObserver` — off-screen blocks pay only the JS parse
+  cost, not the diagram render cost.
+- Chorus is dashboard-style; first paint is dominated by data fetch,
+  not bundle size, on every page that ships Markdown.
+- Dynamic import would require either (a) detecting mermaid blocks
+  before deciding whether to load the plugin (defeats streaming
+  semantics) or (b) loading on every Markdown surface anyway (doesn't
+  save anything).
+
+If/when bundle becomes a concern we can revisit with route-level code
+splitting; that's a separate change.
+
+## Tailwind v4 content scanning
+
+Chorus' `globals.css` has
+
+```css
+@source "../../../node_modules/streamdown/dist/*.js";
+```
+
+This glob catches `streamdown` itself but not nested packages. We'll
+add a second `@source` line covering `@streamdown/mermaid/dist/*.js`
+once the package is installed and we can confirm its compiled output
+location.
+
+```css
+@source "../../../node_modules/@streamdown/mermaid/dist/*.js";
+```
+
+The reference repo did this in `tailwind.config.js` using `content`
+globs; the v4 equivalent is `@source` in CSS, which is what Chorus
+already uses.
+
+## Theme sync
+
+Mermaid initialization happens once per `<Streamdown>` render under
+`@streamdown/mermaid`. Re-rendering on theme change is automatic
+because we pass `controls.mermaid.theme` derived from
+`resolvedTheme` — when `next-themes` flips, the memoized `controls`
+object identity changes, React re-renders Streamdown, and the plugin
+re-initializes mermaid with the new theme.
+
+If `next-themes` is not already a dependency, the fallback is to read
+Chorus' theme from the same source the rest of the app uses (Tailwind
+`dark:` classes hang off `<html class="dark">`, so a tiny
+`useDarkClass()` hook reading `document.documentElement.classList`
+also works).
+
+## Risks
+
+- **Streamdown 2.5 minor version drift.** The reference commit was on
+  2.5.0; we'll pin to `^2.5.0` and run the existing test suite plus
+  manual smoke. No behavioral changes documented in the 2.4 → 2.5
+  changelog beyond the mermaid plugin uptake.
+
+- **Shiki 3 → 4 grammar deprecations.** Shiki v4 dropped some legacy
+  grammar names. Chorus' `@streamdown/code` plugin is the consumer;
+  if it pins shiki internally, our top-level bump may conflict.
+  Mitigation: verify pnpm dedupe shows a single shiki resolution after
+  install; if not, override or wait on `@streamdown/code` to bump.
+
+- **next-themes integration.** If next-themes isn't already wired,
+  fall back to a small DOM-class observer hook. Cost: ~10 lines, no
+  new deps.
+
+- **mention-renderer regression.** The two-render-path code in
+  `mention-renderer.tsx` exists for a reason (mention placeholder
+  substitution before vs after render). Refactor must preserve both
+  paths — the `<Streamdown>` children stay the same, only the
+  component identity changes.
+
+## Out of scope
+
+- PDF / HTML export with embedded mermaid (Chorus has no export
+  feature today).
+- Bundle code-splitting via dynamic import.
+- Custom mermaid error UI (we accept `@streamdown/mermaid`'s default:
+  error message + raw code block).
+- New mermaid block UX features (e.g. inline edit, export to PNG)
+  beyond what the upstream controls provide.

--- a/openspec/changes/archive/2026-05-20-mermaid-document-rendering/proposal.md
+++ b/openspec/changes/archive/2026-05-20-mermaid-document-rendering/proposal.md
@@ -1,0 +1,59 @@
+# Render mermaid code blocks in Chorus documents
+
+## Why
+
+Chorus' Document/Proposal rendering pipeline (`streamdown` + `shiki`) handles
+prose and code blocks but ignores ` ```mermaid ` blocks — they fall through
+the standard code path and render as plain text. Architecture diagrams,
+sequence diagrams, and state machines are everyday vocabulary in AI-DLC
+artifacts; agents currently have to fall back to ASCII art or external
+images, breaking the "Document is the source of truth" story.
+
+Streamdown 2.x already split mermaid support into a separate plugin
+(`@streamdown/mermaid`); enabling it is the obvious fix and matches the
+pattern used in `strands-ai-sdk` (commit `45b09ea6`).
+
+While we're touching the rendering stack, we'll also bump `shiki` from
+3.23 to 4.x — current major. This trims the call surface of the upgrade
+to a single, contained change and avoids a second round-trip through the
+~14 `<Streamdown>` call sites.
+
+## What Changes
+
+- Add `@streamdown/mermaid` dependency and bump `streamdown` to `^2.5.0`.
+- Bump `shiki` from `3.23.0` to `^4.1.0`.
+- Introduce `src/lib/streamdown-plugins.ts` exporting a `streamdownPlugins`
+  object (`{ code, mermaid }`) and a `streamdownControls` object enabling
+  `fullscreen`, `download`, `copy`, and `panZoom` on the mermaid block.
+- Collapse the ~14 direct `<Streamdown plugins={{ code }}>` call sites into
+  the existing `<MarkdownContent>` component, which becomes the single
+  consumer of `streamdownPlugins` / `streamdownControls`.
+- Wire mermaid theme to Chorus' light/dark theme — pass `default` / `dark`
+  to mermaid initialization and re-render on theme change.
+- Tailwind config already scans `streamdown/dist` via the `@source`
+  directive in `globals.css`; verify it covers `@streamdown/mermaid`'s
+  compiled output too and extend if needed.
+
+## Capabilities
+
+- `document-markdown-rendering` — new capability covering how Chorus
+  renders Markdown content in documents, proposals, ideas, tasks, and
+  comments. The mermaid behavior lands as the first ADDED requirement.
+
+## Impact
+
+- **Affected code:**
+  - `package.json`, `pnpm-lock.yaml`
+  - `src/lib/streamdown-plugins.ts` (new)
+  - `src/components/markdown-content.tsx` (becomes the canonical renderer)
+  - 13 other `.tsx` files that currently call `<Streamdown plugins={{ code }}>`
+  - `src/app/globals.css` (potentially extend `@source` to cover
+    `@streamdown/mermaid`)
+- **No data model changes**, no API surface changes, no schema migration.
+- **Bundle size:** mermaid + d3 are ~250KB gzipped. We accept the cost;
+  the plugin uses `IntersectionObserver` for lazy render so off-screen
+  diagrams don't pay the parse/render cost.
+- **Cross-platform:** mermaid is pure JS, no native bindings — clears
+  CLAUDE.md rule 9.
+- **Out of scope:** PDF/HTML export with embedded mermaid (Chorus has no
+  export feature today), bundle splitting via dynamic import.

--- a/openspec/changes/archive/2026-05-20-mermaid-document-rendering/specs/document-markdown-rendering/spec.md
+++ b/openspec/changes/archive/2026-05-20-mermaid-document-rendering/specs/document-markdown-rendering/spec.md
@@ -1,0 +1,103 @@
+# Document Markdown Rendering — delta
+
+## ADDED Requirements
+
+### Requirement: Mermaid code blocks render as diagrams
+
+The Chorus Markdown rendering pipeline SHALL detect ` ```mermaid ` fenced
+code blocks in document, proposal, idea, task, and comment content and
+render them as SVG diagrams via the `@streamdown/mermaid` plugin.
+
+Supported diagram kinds MUST include the standard mermaid set:
+flowchart, sequenceDiagram, classDiagram, stateDiagram, erDiagram, and
+gantt.
+
+When mermaid syntax is invalid, the plugin SHALL fall back to displaying
+the raw code block plus an inline error message — never throwing past
+the rendering boundary and crashing the surrounding page.
+
+While the markdown stream is still arriving (the closing fence has not
+yet appeared), the block SHALL render as a normal code block; the
+mermaid render only fires once the fence closes. This preserves
+streaming semantics for partial output.
+
+#### Scenario: Valid mermaid block in a Document renders as SVG
+
+- **WHEN** a Document contains a ` ```mermaid ` block with a valid
+  `flowchart TD` definition and a user opens the Document detail page
+- **THEN** the rendered output contains an `<svg>` element produced by
+  mermaid
+- **AND** the original ` ``` ` fence content is not visible as raw text
+  on the page
+
+#### Scenario: Invalid mermaid block does not crash the page
+
+- **WHEN** a Document contains a ` ```mermaid ` block with malformed
+  syntax (e.g. unterminated arrow)
+- **THEN** the page renders successfully without a React error boundary
+- **AND** an error message from mermaid is shown in place of the
+  diagram, with the original code visible for debugging
+
+#### Scenario: Streaming markdown shows code, then diagram
+
+- **WHEN** the markdown stream has emitted ` ```mermaid\nflowchart TD` but
+  not the closing fence yet
+- **THEN** the partial content renders as a code block, not as an
+  attempted diagram
+- **AND** once the closing fence arrives, the same block re-renders as
+  an SVG diagram
+
+### Requirement: Mermaid blocks expose interactive controls
+
+Each rendered mermaid block SHALL display a toolbar with **fullscreen**,
+**download**, **copy**, and **panZoom** controls, all enabled.
+
+#### Scenario: Toolbar controls are clickable
+
+- **WHEN** a user hovers a rendered mermaid block in any Markdown
+  surface
+- **THEN** the toolbar buttons for fullscreen, download, copy, and
+  panZoom are visible and respond to clicks
+- **AND** the click does not produce a console error or
+  `pointer-events: none` blockage
+
+### Requirement: Mermaid theme follows Chorus light/dark theme
+
+Mermaid diagrams SHALL render in mermaid's `default` palette when
+Chorus is in light theme and in mermaid's `dark` palette when Chorus
+is in dark theme. The theme MUST update when the user toggles theme
+without requiring a page reload.
+
+#### Scenario: Theme toggle re-renders mermaid diagram
+
+- **WHEN** a Document containing a mermaid block is open and the user
+  toggles Chorus' theme from light to dark via the theme switcher
+- **THEN** the mermaid SVG re-renders with the dark palette
+  (background and node fills change to mermaid's dark variant)
+- **AND** the user does not need to reload the page
+
+### Requirement: Markdown rendering is centralized via MarkdownContent
+
+All Markdown rendering surfaces in the application SHALL render through
+the `MarkdownContent` component (`src/components/markdown-content.tsx`),
+which is the single consumer of `streamdownPlugins` and
+`streamdownControls` from `src/lib/streamdown-plugins.ts`. No call
+site outside `MarkdownContent` SHALL import `streamdown` directly or
+construct its own `plugins` / `controls` props.
+
+#### Scenario: New Markdown surface added
+
+- **WHEN** a developer adds a new Markdown surface (e.g. a new sidebar
+  panel rendering user content)
+- **THEN** they import `MarkdownContent` and use it as
+  `<MarkdownContent>{content}</MarkdownContent>`
+- **AND** they do NOT import `streamdown` or `@streamdown/mermaid`
+  directly
+
+#### Scenario: Existing call sites use MarkdownContent
+
+- **WHEN** a reviewer greps for `Streamdown` import outside
+  `markdown-content.tsx`
+- **THEN** no `.tsx` file under `src/` contains a top-level
+  `import { Streamdown }` statement other than the canonical
+  renderer

--- a/openspec/changes/archive/2026-05-20-mermaid-document-rendering/tasks.md
+++ b/openspec/changes/archive/2026-05-20-mermaid-document-rendering/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — mermaid-document-rendering
+
+> Source of truth lives in Chorus task drafts created via
+> `chorus_pm_add_task_draft`. This file mirrors the same task list for
+> readers browsing `openspec/changes/<slug>/` directly.
+
+1. Bump streamdown / shiki and add @streamdown/mermaid
+   - update package.json: `streamdown ^2.5.0`, `shiki ^4.1.0`,
+     `@streamdown/mermaid ^1.0.2`
+   - run `pnpm install`, verify lockfile only changes the three deps
+   - confirm `pnpm dedupe` shows a single shiki resolution
+
+2. Create the shared `streamdown-plugins` module
+   - new file `src/lib/streamdown-plugins.ts`
+   - export `streamdownPlugins = { code, mermaid }`
+   - export `streamdownControls.mermaid = { fullscreen, download, copy,
+     panZoom }`
+
+3. Refactor `MarkdownContent` to be the canonical renderer
+   - import shared `streamdownPlugins` / `streamdownControls`
+   - read Chorus theme (next-themes if present, else DOM-class hook)
+   - pass theme into `controls.mermaid.theme` (default | dark)
+   - keep streaming + plain code path working
+
+4. Migrate all 14 `<Streamdown>` call sites to `<MarkdownContent>`
+   - delete per-file `import { Streamdown }` and `import { code }`
+   - replace JSX with `<MarkdownContent>{...}</MarkdownContent>`
+   - special-case `mention-renderer.tsx` — preserve placeholder paths
+
+5. Ensure Tailwind v4 scans the mermaid plugin's compiled output
+   - verify whether existing `@source` glob covers
+     `@streamdown/mermaid/dist`; extend if not
+   - manual check: open a doc with a mermaid block, confirm the
+     toolbar buttons are clickable (Tailwind classes resolved)
+
+6. Smoke test on local Chorus via Playwright
+   - dev server (`pnpm dev`), log in, navigate to a Document with a
+     mermaid block (create one for the test if none exist)
+   - verify SVG renders, toolbar buttons clickable, fullscreen works
+   - toggle theme, confirm mermaid re-renders in dark palette

--- a/openspec/specs/document-markdown-rendering/spec.md
+++ b/openspec/specs/document-markdown-rendering/spec.md
@@ -1,0 +1,105 @@
+# document-markdown-rendering Specification
+
+## Purpose
+TBD - created by archiving change mermaid-document-rendering. Update Purpose after archive.
+## Requirements
+### Requirement: Mermaid code blocks render as diagrams
+
+The Chorus Markdown rendering pipeline SHALL detect ` ```mermaid ` fenced
+code blocks in document, proposal, idea, task, and comment content and
+render them as SVG diagrams via the `@streamdown/mermaid` plugin.
+
+Supported diagram kinds MUST include the standard mermaid set:
+flowchart, sequenceDiagram, classDiagram, stateDiagram, erDiagram, and
+gantt.
+
+When mermaid syntax is invalid, the plugin SHALL fall back to displaying
+the raw code block plus an inline error message — never throwing past
+the rendering boundary and crashing the surrounding page.
+
+While the markdown stream is still arriving (the closing fence has not
+yet appeared), the block SHALL render as a normal code block; the
+mermaid render only fires once the fence closes. This preserves
+streaming semantics for partial output.
+
+#### Scenario: Valid mermaid block in a Document renders as SVG
+
+- **WHEN** a Document contains a ` ```mermaid ` block with a valid
+  `flowchart TD` definition and a user opens the Document detail page
+- **THEN** the rendered output contains an `<svg>` element produced by
+  mermaid
+- **AND** the original ` ``` ` fence content is not visible as raw text
+  on the page
+
+#### Scenario: Invalid mermaid block does not crash the page
+
+- **WHEN** a Document contains a ` ```mermaid ` block with malformed
+  syntax (e.g. unterminated arrow)
+- **THEN** the page renders successfully without a React error boundary
+- **AND** an error message from mermaid is shown in place of the
+  diagram, with the original code visible for debugging
+
+#### Scenario: Streaming markdown shows code, then diagram
+
+- **WHEN** the markdown stream has emitted ` ```mermaid\nflowchart TD` but
+  not the closing fence yet
+- **THEN** the partial content renders as a code block, not as an
+  attempted diagram
+- **AND** once the closing fence arrives, the same block re-renders as
+  an SVG diagram
+
+### Requirement: Mermaid blocks expose interactive controls
+
+Each rendered mermaid block SHALL display a toolbar with **fullscreen**,
+**download**, **copy**, and **panZoom** controls, all enabled.
+
+#### Scenario: Toolbar controls are clickable
+
+- **WHEN** a user hovers a rendered mermaid block in any Markdown
+  surface
+- **THEN** the toolbar buttons for fullscreen, download, copy, and
+  panZoom are visible and respond to clicks
+- **AND** the click does not produce a console error or
+  `pointer-events: none` blockage
+
+### Requirement: Mermaid theme follows Chorus light/dark theme
+
+Mermaid diagrams SHALL render in mermaid's `default` palette when
+Chorus is in light theme and in mermaid's `dark` palette when Chorus
+is in dark theme. The theme MUST update when the user toggles theme
+without requiring a page reload.
+
+#### Scenario: Theme toggle re-renders mermaid diagram
+
+- **WHEN** a Document containing a mermaid block is open and the user
+  toggles Chorus' theme from light to dark via the theme switcher
+- **THEN** the mermaid SVG re-renders with the dark palette
+  (background and node fills change to mermaid's dark variant)
+- **AND** the user does not need to reload the page
+
+### Requirement: Markdown rendering is centralized via MarkdownContent
+
+All Markdown rendering surfaces in the application SHALL render through
+the `MarkdownContent` component (`src/components/markdown-content.tsx`),
+which is the single consumer of `streamdownPlugins` and
+`streamdownControls` from `src/lib/streamdown-plugins.ts`. No call
+site outside `MarkdownContent` SHALL import `streamdown` directly or
+construct its own `plugins` / `controls` props.
+
+#### Scenario: New Markdown surface added
+
+- **WHEN** a developer adds a new Markdown surface (e.g. a new sidebar
+  panel rendering user content)
+- **THEN** they import `MarkdownContent` and use it as
+  `<MarkdownContent>{content}</MarkdownContent>`
+- **AND** they do NOT import `streamdown` or `@streamdown/mermaid`
+  directly
+
+#### Scenario: Existing call sites use MarkdownContent
+
+- **WHEN** a reviewer greps for `Streamdown` import outside
+  `markdown-content.tsx`
+- **THEN** no `.tsx` file under `src/` contains a top-level
+  `import { Streamdown }` statement other than the canonical
+  renderer
+

--- a/openspec/specs/document-markdown-rendering/spec.md
+++ b/openspec/specs/document-markdown-rendering/spec.md
@@ -1,7 +1,15 @@
 # document-markdown-rendering Specification
 
 ## Purpose
-TBD - created by archiving change mermaid-document-rendering. Update Purpose after archive.
+
+Defines how Chorus renders user-authored Markdown content across the
+application — Documents, Proposals, Ideas, Tasks, and Comments. The
+canonical entry point is the `MarkdownContent` component, which is the
+sole consumer of Streamdown plugins and controls. This capability covers
+mermaid diagram rendering, syntax-highlighted code blocks, theme
+behavior, and the centralization rule that keeps every Markdown surface
+on the same rendering path.
+
 ## Requirements
 ### Requirement: Mermaid code blocks render as diagrams
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@streamdown/code": "^1.1.0",
+    "@streamdown/mermaid": "^1.0.2",
     "@tiptap/extension-mention": "^3.20.0",
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",
@@ -110,9 +111,9 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-pdf": "^0.2.4",
-    "shiki": "3.23.0",
+    "shiki": "^4.1.0",
     "sonner": "^2.0.7",
-    "streamdown": "^2.4.0",
+    "streamdown": "^2.5.0",
     "tailwind-merge": "^3.4.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
@@ -147,7 +148,8 @@
   },
   "pnpm": {
     "overrides": {
-      "docx": "9.6.1"
+      "docx": "9.6.1",
+      "shiki": "^4.1.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   docx: 9.6.1
+  shiki: ^4.1.0
 
 importers:
 
@@ -65,6 +66,9 @@ importers:
       '@streamdown/code':
         specifier: ^1.1.0
         version: 1.1.0(react@19.2.3)
+      '@streamdown/mermaid':
+        specifier: ^1.0.2
+        version: 1.0.2(react@19.2.3)
       '@tiptap/extension-mention':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(@tiptap/suggestion@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))
@@ -159,14 +163,14 @@ importers:
         specifier: ^0.2.4
         version: 0.2.4
       shiki:
-        specifier: 3.23.0
-        version: 3.23.0
+        specifier: ^4.1.0
+        version: 4.1.0
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       streamdown:
-        specifier: ^2.4.0
-        version: 2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.5.0
+        version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -2369,50 +2373,32 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@shikijs/core@3.23.0':
-    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
-
-  '@shikijs/core@4.0.2':
-    resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
+  '@shikijs/core@4.1.0':
+    resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-javascript@3.23.0':
-    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
-
-  '@shikijs/engine-javascript@4.0.2':
-    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
+  '@shikijs/engine-javascript@4.1.0':
+    resolution: {integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@3.23.0':
-    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
-
-  '@shikijs/engine-oniguruma@4.0.2':
-    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+  '@shikijs/engine-oniguruma@4.1.0':
+    resolution: {integrity: sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==}
     engines: {node: '>=20'}
 
-  '@shikijs/langs@3.23.0':
-    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
-
-  '@shikijs/langs@4.0.2':
-    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+  '@shikijs/langs@4.1.0':
+    resolution: {integrity: sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==}
     engines: {node: '>=20'}
 
-  '@shikijs/primitive@4.0.2':
-    resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
+  '@shikijs/primitive@4.1.0':
+    resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@3.23.0':
-    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
-
-  '@shikijs/themes@4.0.2':
-    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+  '@shikijs/themes@4.1.0':
+    resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
     engines: {node: '>=20'}
 
-  '@shikijs/types@3.23.0':
-    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
-
-  '@shikijs/types@4.0.2':
-    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
+  '@shikijs/types@4.1.0':
+    resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -2427,6 +2413,11 @@ packages:
 
   '@streamdown/code@1.1.0':
     resolution: {integrity: sha512-swypCjtE6vv01bnEtPeaw2ew9cbL2nbsLc06HAIK3K6nYXj5WDA8VLR6GEiwdh7HLIPt5dGze+PJ0eJVkqesug==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
+  '@streamdown/mermaid@1.0.2':
+    resolution: {integrity: sha512-Fr/4sBWnAeSnxM3PcrV/+DiZe5oPMq9gOkUIAH7ZauJeuwrZ/DVzD4g0zlav6AH0axh2m/sOfrfLtY5aLT7niw==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -5900,11 +5891,11 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-parser@0.12.1:
-    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
-  oniguruma-to-es@4.3.4:
-    resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
@@ -6499,8 +6490,8 @@ packages:
   remeda@2.33.4:
     resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
 
-  remend@1.2.2:
-    resolution: {integrity: sha512-4ZJgIB9EG9fQE41mOJCRHMmnxDTKHWawQoJWZyUbZuj680wVyogu2ihnj8Edqm7vh2mo/TWHyEZpn2kqeDvS7w==}
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -6692,11 +6683,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@3.23.0:
-    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
-
-  shiki@4.0.2:
-    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+  shiki@4.1.0:
+    resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
     engines: {node: '>=20'}
 
   side-channel-list@1.0.0:
@@ -6799,8 +6787,8 @@ packages:
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
-  streamdown@2.4.0:
-    resolution: {integrity: sha512-fRk4HEYNznRLmxoVeT8wsGBwHF6/Yrdey6k+ZrE1Qtp4NyKwm7G/6e2Iw8penY4yLx31TlAHWT5Bsg1weZ9FZg==}
+  streamdown@2.5.0:
+    resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -7711,7 +7699,7 @@ snapshots:
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       retext-smartypants: 6.2.0
-      shiki: 4.0.2
+      shiki: 4.1.0
       smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
@@ -9672,71 +9660,40 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@shikijs/core@3.23.0':
+  '@shikijs/core@4.1.0':
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/primitive': 4.1.0
+      '@shikijs/types': 4.1.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/core@4.0.2':
+  '@shikijs/engine-javascript@4.1.0':
     dependencies:
-      '@shikijs/primitive': 4.0.2
-      '@shikijs/types': 4.0.2
+      '@shikijs/types': 4.1.0
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
+      oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-javascript@3.23.0':
+  '@shikijs/engine-oniguruma@4.1.0':
     dependencies:
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.4
-
-  '@shikijs/engine-javascript@4.0.2':
-    dependencies:
-      '@shikijs/types': 4.0.2
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.4
-
-  '@shikijs/engine-oniguruma@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 4.1.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@4.0.2':
+  '@shikijs/langs@4.1.0':
     dependencies:
-      '@shikijs/types': 4.0.2
-      '@shikijs/vscode-textmate': 10.0.2
+      '@shikijs/types': 4.1.0
 
-  '@shikijs/langs@3.23.0':
+  '@shikijs/primitive@4.1.0':
     dependencies:
-      '@shikijs/types': 3.23.0
-
-  '@shikijs/langs@4.0.2':
-    dependencies:
-      '@shikijs/types': 4.0.2
-
-  '@shikijs/primitive@4.0.2':
-    dependencies:
-      '@shikijs/types': 4.0.2
+      '@shikijs/types': 4.1.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/themes@3.23.0':
+  '@shikijs/themes@4.1.0':
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 4.1.0
 
-  '@shikijs/themes@4.0.2':
-    dependencies:
-      '@shikijs/types': 4.0.2
-
-  '@shikijs/types@3.23.0':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  '@shikijs/types@4.0.2':
+  '@shikijs/types@4.1.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -9750,7 +9707,12 @@ snapshots:
   '@streamdown/code@1.1.0(react@19.2.3)':
     dependencies:
       react: 19.2.3
-      shiki: 3.23.0
+      shiki: 4.1.0
+
+  '@streamdown/mermaid@1.0.2(react@19.2.3)':
+    dependencies:
+      mermaid: 11.14.0
+      react: 19.2.3
 
   '@swc/core-darwin-arm64@1.15.11':
     optional: true
@@ -10774,7 +10736,7 @@ snapshots:
       picomatch: 4.0.3
       rehype: 13.0.2
       semver: 7.7.4
-      shiki: 4.0.2
+      shiki: 4.1.0
       smol-toml: 1.6.1
       svgo: 4.0.1
       tinyclip: 0.1.12
@@ -13783,11 +13745,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-parser@0.12.1: {}
+  oniguruma-parser@0.12.2: {}
 
-  oniguruma-to-es@4.3.4:
+  oniguruma-to-es@4.3.6:
     dependencies:
-      oniguruma-parser: 0.12.1
+      oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
 
@@ -14532,7 +14494,7 @@ snapshots:
       mathml2omml: 0.5.0
       mdast-util-definitions: 6.0.0
       mermaid: 11.14.0
-      shiki: 3.23.0
+      shiki: 4.1.0
       unist-util-visit: 5.1.0
 
   remark-gfm@4.0.1:
@@ -14595,7 +14557,7 @@ snapshots:
 
   remeda@2.33.4: {}
 
-  remend@1.2.2: {}
+  remend@1.3.0: {}
 
   require-directory@2.1.1: {}
 
@@ -14919,25 +14881,14 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@3.23.0:
+  shiki@4.1.0:
     dependencies:
-      '@shikijs/core': 3.23.0
-      '@shikijs/engine-javascript': 3.23.0
-      '@shikijs/engine-oniguruma': 3.23.0
-      '@shikijs/langs': 3.23.0
-      '@shikijs/themes': 3.23.0
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  shiki@4.0.2:
-    dependencies:
-      '@shikijs/core': 4.0.2
-      '@shikijs/engine-javascript': 4.0.2
-      '@shikijs/engine-oniguruma': 4.0.2
-      '@shikijs/langs': 4.0.2
-      '@shikijs/themes': 4.0.2
-      '@shikijs/types': 4.0.2
+      '@shikijs/core': 4.1.0
+      '@shikijs/engine-javascript': 4.1.0
+      '@shikijs/engine-oniguruma': 4.1.0
+      '@shikijs/langs': 4.1.0
+      '@shikijs/themes': 4.1.0
+      '@shikijs/types': 4.1.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
@@ -15032,12 +14983,13 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
-  streamdown@2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  streamdown@2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       clsx: 2.1.1
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.1
+      mermaid: 11.14.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       rehype-harden: 1.1.8
@@ -15046,7 +14998,7 @@ snapshots:
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
-      remend: 1.2.2
+      remend: 1.3.0
       tailwind-merge: 3.4.0
       unified: 11.0.5
       unist-util-visit: 5.1.0

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/basic-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/basic-view.tsx
@@ -6,8 +6,7 @@ import { UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { motion } from "framer-motion";
 import { fadeIn } from "@/lib/animation";
 import { formatDateTime } from "@/lib/format-date";
@@ -42,7 +41,7 @@ export function BasicView({ idea, projectUuid, currentUserUuid, onRefresh }: Bas
         <div className="mt-2">
           {idea.content ? (
             <div className="prose prose-sm max-w-none text-[13px] leading-relaxed text-[#2C2C2C]">
-              <Streamdown plugins={{ code }}>{idea.content}</Streamdown>
+              <MarkdownContent>{idea.content}</MarkdownContent>
             </div>
           ) : (
             <p className="text-sm italic text-[#9A9A9A]">

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/document-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/document-panel.tsx
@@ -6,8 +6,7 @@ import { ArrowLeft, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Streamdown } from "streamdown";
-import { code as codePlugin } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { normalizeNewlines, DOC_TYPE_I18N_KEYS } from "./utils";
 import { PANEL_WIDTH_PX } from "../utils";
 
@@ -103,9 +102,7 @@ export function DocumentPanel({ title, type, content, mode = "overlay", onClose,
         {/* Content */}
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
           <div className="px-6 py-5 text-[13px] leading-relaxed text-[#2C2C2A] prose prose-sm max-w-none [&_h1]:text-lg [&_h1]:font-semibold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h3]:text-sm [&_h3]:font-medium [&_h3]:mt-2 [&_h3]:mb-1 [&_p]:text-[13px] [&_p]:text-[#4A4A4A] [&_p]:my-1.5 [&_li]:text-[13px] [&_li]:text-[#4A4A4A] [&_ul]:my-1 [&_ol]:my-1 [&_strong]:text-[#2C2C2C] [&_code]:text-[12px] [&_code]:bg-[#F5F2EC] [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-[#FAF8F4] [&_pre]:p-3 [&_pre]:rounded-lg [&_pre]:my-2">
-            <Streamdown plugins={{ code: codePlugin }}>
-              {normalizeNewlines(content)}
-            </Streamdown>
+            <MarkdownContent>{normalizeNewlines(content)}</MarkdownContent>
           </div>
         </ScrollArea>
       </div>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx
@@ -8,8 +8,7 @@ import { Separator } from "@/components/ui/separator";
 import { ElaborationPanel } from "@/components/elaboration-panel";
 import { getElaborationAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions";
 import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { motion } from "framer-motion";
 import { fadeIn } from "@/lib/animation";
 import type { IdeaResponse } from "@/services/idea.service";
@@ -116,7 +115,7 @@ export function ElaborationView({ idea, onRefresh }: ElaborationViewProps) {
             </Label>
             <div className="mt-2">
               <div className="prose prose-sm max-w-none text-[13px] leading-relaxed text-[#2C2C2C]">
-                <Streamdown plugins={{ code }}>{idea.content}</Streamdown>
+                <MarkdownContent>{idea.content}</MarkdownContent>
               </div>
             </div>
           </div>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/proposal-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/proposal-view.tsx
@@ -16,8 +16,7 @@ import { Button } from "@/components/ui/button";
 import { PresenceIndicator } from "@/components/ui/presence-indicator";
 import { usePresence, injectPresence } from "@/hooks/use-presence";
 import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
-import { Streamdown } from "streamdown";
-import { code as codePlugin } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { TaskDag, type TaskDagTask, type TaskDagEdge } from "@/components/task-dag";
 import { normalizeNewlines, DOC_TYPE_I18N_KEYS } from "./utils";
 import { getProposalsForIdeaAction, getTasksForProposalAction } from "./actions";
@@ -280,9 +279,7 @@ function ProposalContent({
       {/* Description — plain text, markdown rendered */}
       {proposal.description && (
         <div className="max-h-[120px] overflow-y-auto text-[13px] leading-relaxed text-[#4A4A4A] prose prose-sm max-w-none [&_h1]:text-sm [&_h2]:text-[13px] [&_h3]:text-xs [&_p]:text-[13px] [&_p]:text-[#4A4A4A] [&_p]:my-1.5 [&_li]:text-[13px] [&_li]:text-[#4A4A4A] [&_ul]:my-1 [&_ol]:my-1 [&_strong]:text-[#2C2C2C]">
-          <Streamdown plugins={{ code: codePlugin }}>
-            {normalizeNewlines(proposal.description)}
-          </Streamdown>
+          <MarkdownContent>{normalizeNewlines(proposal.description)}</MarkdownContent>
         </div>
       )}
 

--- a/src/app/(dashboard)/projects/[uuid]/documents/[documentUuid]/document-content.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/documents/[documentUuid]/document-content.tsx
@@ -3,8 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { updateDocumentAction } from "./actions";
@@ -91,7 +90,7 @@ export function DocumentContent({ documentUuid, projectUuid, initialContent }: D
       ) : (
         <div className="prose prose-sm max-w-none text-[#2C2C2C]">
           {initialContent ? (
-            <Streamdown plugins={{ code }}>{initialContent}</Streamdown>
+            <MarkdownContent>{initialContent}</MarkdownContent>
           ) : (
             <span className="text-[#9A9A9A] italic">{t("common.noContent")}</span>
           )}

--- a/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
@@ -42,8 +42,7 @@ import { UnifiedComments } from "@/components/unified-comments";
 import { getIdeaActivitiesAction } from "./[ideaUuid]/activity-actions";
 import { updateIdeaAction, deleteIdeaAction } from "./actions";
 import type { ActivityResponse } from "@/services/activity.service";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { ContentWithMentions } from "@/components/mention-renderer";
 import { AssignIdeaModal } from "./assign-idea-modal";
 import { ElaborationPanel } from "@/components/elaboration-panel";
@@ -555,7 +554,7 @@ export function IdeaDetailPanel({
                   <div className="mt-2">
                     {idea.content ? (
                       <div className="prose prose-sm max-w-none text-[13px] leading-relaxed text-[#2C2C2C]">
-                        <Streamdown plugins={{ code }}>{idea.content}</Streamdown>
+                        <MarkdownContent>{idea.content}</MarkdownContent>
                       </div>
                     ) : (
                       <p className="text-sm italic text-[#9A9A9A]">{t("common.noContent")}</p>

--- a/src/app/(dashboard)/projects/[uuid]/ideas/ideas-list.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/ideas-list.tsx
@@ -13,8 +13,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { IdeaDetailPanel } from "./idea-detail-panel";
 import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
 import { usePanelUrl } from "@/hooks/use-panel-url";
@@ -198,7 +197,7 @@ export function IdeasList({
                 {/* Content */}
                 {idea.content && (
                   <div className="prose prose-sm max-w-none line-clamp-3 text-[13px] leading-relaxed text-[#2C2C2C]">
-                    <Streamdown plugins={{ code }}>{idea.content}</Streamdown>
+                    <MarkdownContent>{idea.content}</MarkdownContent>
                   </div>
                 )}
               </CardContent>

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx
@@ -44,8 +44,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import {
   addDocumentDraftAction,
   updateDocumentDraftAction,
@@ -588,7 +587,7 @@ export function ProposalEditor({
                     {isExpanded && doc.content && (
                       <div className="mt-3 border-t border-[#F5F2EC] pt-4">
                         <div className="prose prose-sm max-w-none text-foreground">
-                          <Streamdown plugins={{ code }}>{doc.content}</Streamdown>
+                          <MarkdownContent>{doc.content}</MarkdownContent>
                         </div>
                       </div>
                     )}

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/task-draft-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/task-draft-detail-panel.tsx
@@ -29,8 +29,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { motion } from "framer-motion";
 import { fadeIn } from "@/lib/animation";
 import {
@@ -562,7 +561,7 @@ export function TaskDraftDetailPanel({
                   <div className="mt-2">
                     {taskDraft.description ? (
                       <div className="prose prose-sm max-w-none text-[13px] leading-relaxed text-[#2C2C2C]">
-                        <Streamdown plugins={{ code }}>{taskDraft.description}</Streamdown>
+                        <MarkdownContent>{taskDraft.description}</MarkdownContent>
                       </div>
                     ) : (
                       <p className="text-sm italic text-[#9A9A9A]">{t("common.noDescription")}</p>
@@ -578,7 +577,7 @@ export function TaskDraftDetailPanel({
                     </label>
                     <div className="mt-2">
                       <div className="prose prose-sm max-w-none text-[13px] leading-relaxed text-[#2C2C2C]">
-                        <Streamdown plugins={{ code }}>{taskDraft.acceptanceCriteria}</Streamdown>
+                        <MarkdownContent>{taskDraft.acceptanceCriteria}</MarkdownContent>
                       </div>
                     </div>
                   </div>

--- a/src/app/(dashboard)/projects/[uuid]/proposals/proposal-kanban.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/proposal-kanban.tsx
@@ -6,8 +6,7 @@ import { useTranslations } from "next-intl";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Bot, User } from "lucide-react";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import type { DocumentDraft, TaskDraft } from "@/services/proposal.service";
 import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -127,7 +126,7 @@ function ProposalCard({
         {/* Description */}
         {proposal.description && (
           <div className="prose prose-sm max-w-none mb-2 line-clamp-2 text-sm text-[#6B6B6B]">
-            <Streamdown plugins={{ code }}>{proposal.description}</Streamdown>
+            <MarkdownContent>{proposal.description}</MarkdownContent>
           </div>
         )}
 

--- a/src/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel.tsx
@@ -40,8 +40,7 @@ import {
   getTaskSourceAction,
   type ProposalSource,
 } from "./[taskUuid]/source-actions";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 import { ContentWithMentions } from "@/components/mention-renderer";
 import { AssignTaskModal } from "./assign-task-modal";
 import {
@@ -816,7 +815,7 @@ export function TaskDetailPanel({
                   <div className="mt-2">
                     {task.description ? (
                       <div className="prose prose-sm max-w-none text-[13px] leading-relaxed text-[#2C2C2C]">
-                        <Streamdown plugins={{ code }}>{task.description}</Streamdown>
+                        <MarkdownContent>{task.description}</MarkdownContent>
                       </div>
                     ) : (
                       <p className="text-sm italic text-[#9A9A9A]">{t("common.noDescription")}</p>
@@ -832,7 +831,7 @@ export function TaskDetailPanel({
                     </label>
                     <div className="mt-2">
                       <div className="prose prose-sm max-w-none text-[13px] leading-relaxed text-[#2C2C2C]">
-                        <Streamdown plugins={{ code }}>{task.acceptanceCriteria}</Streamdown>
+                        <MarkdownContent>{task.acceptanceCriteria}</MarkdownContent>
                       </div>
                     </div>
                   </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,8 @@
 
 @custom-variant dark (&:is(.dark *));
 @source "../../../node_modules/streamdown/dist/*.js";
+@source "../../../node_modules/@streamdown/mermaid/dist/*.js";
+@source "../../../node_modules/@streamdown/code/dist/*.js";
 
 @layer base {
   :root {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,6 @@
 @custom-variant dark (&:is(.dark *));
 @source "../../../node_modules/streamdown/dist/*.js";
 @source "../../../node_modules/@streamdown/mermaid/dist/*.js";
-@source "../../../node_modules/@streamdown/code/dist/*.js";
 
 @layer base {
   :root {

--- a/src/app/onboarding/components/CodeBlock.tsx
+++ b/src/app/onboarding/components/CodeBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { MarkdownContent } from "@/components/markdown-content";
 
 interface CodeBlockProps {
   code: string;
@@ -11,5 +10,5 @@ interface CodeBlockProps {
 export function CodeBlock({ code: codeContent, language }: CodeBlockProps) {
   const markdown = `\`\`\`${language || ""}\n${codeContent}\n\`\`\``;
 
-  return <Streamdown plugins={{ code }}>{markdown}</Streamdown>;
+  return <MarkdownContent>{markdown}</MarkdownContent>;
 }

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -31,9 +31,11 @@ export function MarkdownContent({ children }: { children: string }) {
     [isDark],
   );
 
-  // Mermaid renders SVGs once and caches them; the plugin's singleton `getMermaid()` call
-  // doesn't re-paint existing diagrams when theme changes. Forcing a fresh subtree per
-  // theme is the cheapest correct fix — Streamdown is light enough to remount.
+  // Mermaid caches its singleton inside Streamdown; passing a new `mermaid` prop
+  // updates config but does not re-paint already-rendered SVGs. The `key` forces
+  // React to tear down and rebuild the subtree on theme change, which is what
+  // actually triggers the repaint. Don't drop the key while keeping the prop —
+  // the prop alone won't repaint cached diagrams and the bug returns silently.
   return (
     <Streamdown
       key={isDark ? "dark" : "light"}

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -1,8 +1,47 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+
+import {
+  streamdownPlugins,
+  streamdownControls,
+} from "@/lib/streamdown-plugins";
+
+function useDarkClass(): boolean {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const update = () => setIsDark(root.classList.contains("dark"));
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}
 
 export function MarkdownContent({ children }: { children: string }) {
-  return <Streamdown plugins={{ code }}>{children}</Streamdown>;
+  const isDark = useDarkClass();
+
+  const mermaidOptions = useMemo(
+    () => ({ config: { theme: isDark ? "dark" : "default" } as const }),
+    [isDark],
+  );
+
+  // Mermaid renders SVGs once and caches them; the plugin's singleton `getMermaid()` call
+  // doesn't re-paint existing diagrams when theme changes. Forcing a fresh subtree per
+  // theme is the cheapest correct fix — Streamdown is light enough to remount.
+  return (
+    <Streamdown
+      key={isDark ? "dark" : "light"}
+      plugins={streamdownPlugins}
+      controls={streamdownControls}
+      mermaid={mermaidOptions}
+    >
+      {children}
+    </Streamdown>
+  );
 }

--- a/src/components/mention-renderer.tsx
+++ b/src/components/mention-renderer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React from "react";
-import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+
+import { MarkdownContent } from "@/components/markdown-content";
 
 /**
  * Regex to match @[DisplayName](type:uuid) patterns in text.
@@ -142,7 +142,7 @@ export function ContentWithMentions({ children }: ContentWithMentionsProps) {
   if (!hasMentionPatterns) {
     return (
       <div className="overflow-hidden [&_pre]:overflow-x-auto">
-        <Streamdown plugins={{ code }}>{children}</Streamdown>
+        <MarkdownContent>{children}</MarkdownContent>
       </div>
     );
   }
@@ -151,7 +151,7 @@ export function ContentWithMentions({ children }: ContentWithMentionsProps) {
 
   return (
     <MentionPostProcessor mentions={mentions}>
-      <Streamdown plugins={{ code }}>{processed}</Streamdown>
+      <MarkdownContent>{processed}</MarkdownContent>
     </MentionPostProcessor>
   );
 }

--- a/src/lib/streamdown-plugins.ts
+++ b/src/lib/streamdown-plugins.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { code } from "@streamdown/code";
+import { mermaid } from "@streamdown/mermaid";
+
+export const streamdownPlugins = { code, mermaid } as const;
+
+export const streamdownControls = {
+  mermaid: {
+    fullscreen: true,
+    download: true,
+    copy: true,
+    panZoom: true,
+  },
+} as const;


### PR DESCRIPTION
## Summary
- Wire `@streamdown/mermaid` plugin into Chorus' Markdown rendering pipeline so ```` ```mermaid ```` blocks in Documents, Proposals, Ideas, Tasks, and Comments render as SVG diagrams.
- Bump `streamdown` 2.4.0 → 2.5.0 and `shiki` 3.23.0 → 4.1.0; add `@streamdown/mermaid ^1.0.2`.
- Collapse 14 direct `<Streamdown plugins={{ code }}>` call sites onto a single `<MarkdownContent>` component, with shared plugin/control constants in `src/lib/streamdown-plugins.ts`.
- All four mermaid controls enabled: fullscreen, download, copy, panZoom.
- Theme-following wiring (DOM-class observer + `key={theme}` remount) — currently dormant since Chorus has no dark-mode toggle UI; ready for when one ships.

## Background

Streamdown 2.x split mermaid into a separate plugin package and stopped enabling it by default. Chorus already had `streamdown ^2.4.0` and `mermaid ^11.x` in `package.json` but never wired the plugin, so ```` ```mermaid ```` blocks were falling through to the plain code path. Reference: `strands-ai-sdk` commit `45b09ea6`.

## Changed files

| File | Change |
|------|--------|
| `package.json`, `pnpm-lock.yaml` | streamdown ^2.5.0, shiki ^4.1.0, @streamdown/mermaid ^1.0.2; pnpm.overrides.shiki = ^4.1.0 to force single resolution across `@streamdown/code` and `remark-docx` |
| `src/lib/streamdown-plugins.ts` (new) | Exports `streamdownPlugins = { code, mermaid }` and `streamdownControls.mermaid = { fullscreen, download, copy, panZoom }` |
| `src/components/markdown-content.tsx` | Becomes the canonical Markdown renderer; observes `.dark` on `<html>` via MutationObserver; `key={isDark ? "dark" : "light"}` remounts Streamdown on theme change so cached mermaid SVGs repaint |
| `src/app/globals.css` | Adds `@source` globs for `@streamdown/mermaid/dist` and `@streamdown/code/dist` (forward-compatible Tailwind v4 coverage) |
| 13 .tsx files | `<Streamdown plugins={{ code }}>` → `<MarkdownContent>`; removes per-file streamdown imports |
| `openspec/specs/document-markdown-rendering/spec.md` (new) | Cumulative spec emitted by `openspec archive` |
| `openspec/changes/archive/2026-05-20-mermaid-document-rendering/` (new) | Archived OpenSpec change folder |

## Notable

- **Shiki override.** `@streamdown/code 1.1.0` and `remark-docx 0.3.26` constrain to `shiki ^3`. Without `pnpm.overrides`, the tree resolves both `shiki@3.23.0` and `shiki@4.1.0`. The override forces 4.1.0 everywhere; if either upstream breaks under v4, surface here.
- **Theme remount approach.** `@streamdown/mermaid` caches its singleton; calling `mermaid.initialize()` with a new theme updates config but does NOT re-paint already-cached SVGs. Tearing down the Streamdown subtree on theme change is the cheapest correct fix.
- **Dark-mode UI not in scope.** Chorus has no theme toggle today. The wiring lands ahead of that and stays inert until a toggle ships.

## Test plan
- [x] `pnpm install` clean (no shiki peer warnings)
- [x] `pnpm why shiki` reports a single 4.1.0 resolution
- [x] `pnpm build:local` (full Next.js production build) passes
- [x] `npx tsc --noEmit` clean
- [x] `grep -rn 'from "streamdown"' src` returns only `markdown-content.tsx`; `@streamdown/code` / `@streamdown/mermaid` imports each only in `lib/streamdown-plugins.ts`
- [x] Playwright smoke on local dev server: flowchart + sequenceDiagram render as `<svg>`; malformed block falls back to inline parse error + raw code without crashing the page; toolbar buttons (Download / Copy / View fullscreen / Zoom in / Zoom out / Reset zoom and pan) all clickable with `pointer-events: auto`; copy click produces no console error
- [x] Theme remount verified by toggling `<html class="dark">` in DevTools — SVG id changes, palette flips from `#ECECFF`/`#9370DB` (default) to `#1f2020`/`#F9FFFE` (dark) without a page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)