### PR TITLE
feat(sessions): active/closed lifecycle + lastActiveAt filter (0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.9.0] - Unreleased
+
+### Changed (Breaking)
+- **Session lifecycle simplified to `{active, closed}`**: dropped the `inactive` status and the unused `expiresAt` field on `AgentSession`. "Stale" is now a query-time predicate on `lastActiveAt` (cutoff: 1h). Default UI listings (Settings page per-agent sessions, project worker-avatar header) only show active+fresh sessions; MCP-facing reads (`chorus_list_sessions`, `chorus_get_session`) and Activity-stream lookups remain unfiltered so plugin reuse and audit-trail navigation continue to see everything. Every session-touching MCP tool now refreshes `lastActiveAt` as a side effect of success — plugins no longer need standalone heartbeats during normal operation. The standalone `chorus_session_heartbeat` is retained for explicit keep-alives. The `expiresAt` parameter on `chorus_create_session` is removed.
+
+---
+
 ## [0.8.2] - 2026-05-21
 
 ### Added

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -779,6 +779,14 @@ Supports intra-batch dependencies via `draftUuid` + `dependsOnDraftUuids`, and d
 
 Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent workers in swarm mode).
 
+### Lifecycle and staleness
+
+The persisted state space is exactly `{active, closed}`. There is no `inactive` status — staleness is a derived predicate on `lastActiveAt`, not a stored value. Default UI listings (Settings page per-agent sessions, project worker-avatar header) only show sessions matching `status='active' AND lastActiveAt > now - 1h`. MCP-facing reads (`chorus_list_sessions`, `chorus_get_session`) and the audit-trail dereferences (Activity stream) are NOT filtered — plugins and history navigation see every session regardless of age or status.
+
+### Implicit-heartbeat contract
+
+Every Session tool that takes a `sessionUuid` parameter and successfully resolves the session refreshes `lastActiveAt = now()` as a side effect of success — except when the session's `status='closed'`, in which case the refresh is skipped to preserve the historical timestamp. Tools covered: `chorus_get_session`, `chorus_close_session`, `chorus_reopen_session`, `chorus_session_checkin_task`, `chorus_session_checkout_task`, `chorus_session_heartbeat`. As a result, plugins do not need to send standalone heartbeats during normal operation — any other session tool call already counts as one. The `chorus_session_heartbeat` tool remains as an explicit keep-alive for idle sub-agents.
+
 ### chorus_create_session
 
 **Description**: Create a new Agent Session (e.g., representing a sub-agent worker)
@@ -788,7 +796,6 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 |-----------|------|----------|-------------|
 | name | string | Yes | Session name (e.g., "frontend-worker") |
 | description | string | No | Session description |
-| expiresAt | string | No | Expiration time (ISO timestamp) |
 
 **Output**:
 ```json
@@ -799,7 +806,6 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
   "description": "...",
   "status": "active",
   "lastActiveAt": "ISO timestamp",
-  "expiresAt": null,
   "createdAt": "ISO timestamp",
   "activeCheckins": []
 }
@@ -807,12 +813,12 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 
 ### chorus_list_sessions
 
-**Description**: List all Sessions for the current Agent
+**Description**: List all Sessions for the current Agent. **Unfiltered** — returns sessions regardless of staleness or closed status (use this for plugin reuse logic and audit-trail navigation).
 
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| status | string | No | Filter by status: active, inactive, closed |
+| status | string | No | Filter by status: `active` or `closed` |
 
 **Output**:
 ```json
@@ -824,7 +830,7 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 
 ### chorus_get_session
 
-**Description**: Get Session details and its active Task checkins
+**Description**: Get Session details and its active Task checkins. Refreshes the session's `lastActiveAt` as a side effect of success unless the session is `closed`.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -835,7 +841,7 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 
 ### chorus_close_session
 
-**Description**: Close a Session (active/inactive → closed). Automatically checks out all active Task checkins.
+**Description**: Close a Session (any status → closed). Automatically checks out all active Task checkins. Does not alter the underlying Tasks' `status`.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -846,7 +852,7 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 
 ### chorus_reopen_session
 
-**Description**: Reopen a closed Session (closed → active). Used to reuse a previous session without creating a new one.
+**Description**: Reopen a closed Session (closed → active). Used to reuse a previous session without creating a new one. `lastActiveAt` is refreshed as part of the reopen.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -857,7 +863,7 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 
 ### chorus_session_checkin_task
 
-**Description**: Check in a Session to a Task, indicating work has started
+**Description**: Check in a Session to a Task, indicating work has started. Refreshes `lastActiveAt`.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -869,7 +875,7 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 
 ### chorus_session_checkout_task
 
-**Description**: Check out a Session from a Task, indicating work has ended
+**Description**: Check out a Session from a Task, indicating work has ended. Refreshes `lastActiveAt`.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -881,7 +887,7 @@ Available to all Agents. Used to manage Agent work sessions (e.g., sub-agent wor
 
 ### chorus_session_heartbeat
 
-**Description**: Session heartbeat, updates lastActiveAt. Active sessions with no heartbeat for 1 hour are automatically marked as inactive.
+**Description**: Explicit Session heartbeat — refreshes `lastActiveAt`. Most callers don't need this since every other session tool also refreshes; it exists for idle sub-agents that want to stay visible in the Settings UI without otherwise touching the session.
 
 **Input**:
 | Parameter | Type | Required | Description |

--- a/messages/en.json
+++ b/messages/en.json
@@ -788,7 +788,7 @@
   "sessions": {
     "title": "Sessions",
     "activeSessions": "Active Sessions",
-    "noSessions": "No sessions",
+    "noSessions": "No active sessions in the last hour",
     "close": "Close",
     "reopen": "Reopen",
     "closeConfirm": "Are you sure you want to close this session?",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -789,7 +789,7 @@
   "sessions": {
     "title": "会话",
     "activeSessions": "活跃会话",
-    "noSessions": "暂无会话",
+    "noSessions": "近 1 小时内无活跃会话",
     "close": "关闭",
     "reopen": "重新打开",
     "closeConfirm": "确定要关闭此会话吗？",

--- a/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/README.md
+++ b/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/README.md
@@ -1,0 +1,3 @@
+# session-lifecycle-active-only
+
+Refactor AgentSession lifecycle to active/closed only; replace inactive concept with lastActiveAt query filter; bake heartbeat into all session-touching MCP tools

--- a/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/design.md
+++ b/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/design.md
@@ -1,0 +1,155 @@
+# Technical Design: session-lifecycle-active-only
+
+## Overview
+
+Collapse `AgentSession.status` to `{active, closed}`, retire the unused `expiresAt` field, and express "stale" as a query-time predicate on `lastActiveAt` rather than a persisted state. Make every session-touching MCP tool implicitly refresh `lastActiveAt`, so the plugin no longer needs to remember to send standalone heartbeats during normal operation.
+
+This is a one-shot migration plus a small surface-area refactor; there is no feature-flag or staged rollout because the persisted-state simplification is one-way and the affected views (Settings sessions list, project worker avatars) are improved by the filter, not destabilized by it.
+
+## Architecture
+
+### State machine (after change)
+
+```
+                +------------+
+   (create) --> |   active   | --(closeSession)--> +--------+
+                +------------+                     | closed |
+                       ^   ^                       +--------+
+                       |   |                            |
+                       |   +---- (any session-touching  |
+                       |          tool refreshes        |
+                       |          lastActiveAt = now)   |
+                       +-------- (reopenSession) -------+
+```
+
+Two persisted states. `inactive` is gone. "Staleness" is computed at read time as `lastActiveAt < now - SESSION_STALE_THRESHOLD_MS` (1 hour).
+
+### Read-path matrix (which queries apply the filter)
+
+| Caller | Path | Filter applied? |
+|---|---|---|
+| Settings page per-agent session list | service: `listAgentSessionsForUI` (new dedicated entry point) | **YES** — `status='active' AND lastActiveAt > now - 1h` |
+| Project page worker-avatar header | service: `getActiveSessionsForProject` | **YES** |
+| MCP `chorus_list_sessions` | service: `listAgentSessions` | **NO** (plugin reuse depends on seeing all) |
+| MCP `chorus_get_session`, REST `GET /api/sessions/[uuid]` | service: `getSession` | **NO** (history navigation) |
+| Activity-stream `sessionUuid` deref | service: `getSessionName` | **NO** (denormalized link integrity) |
+| Service-layer joins from Task views | service: `batchGetWorkerCountsForTasks` | **YES** — count of active+fresh checkins only |
+
+The filter is enforced in service-layer functions, not in route handlers. New helper:
+
+```ts
+const SESSION_STALE_THRESHOLD_MS = 60 * 60 * 1000;
+const freshSessionWhereClause = () => ({
+  status: "active",
+  lastActiveAt: { gt: new Date(Date.now() - SESSION_STALE_THRESHOLD_MS) },
+});
+```
+
+Two distinct list functions live in the service so we never accidentally leak the filter into the audit-trail path:
+
+```ts
+listAgentSessions(...)        // no filter, MCP-facing, plugin reuse
+listAgentSessionsForUI(...)   // filtered, Settings page only
+```
+
+### Heartbeat-as-side-effect
+
+Every session-touching service function gains an unconditional `lastActiveAt: new Date()` write at the end of its successful path:
+
+| Service function | Triggered by | Refresh? |
+|---|---|---|
+| `getSession` | `chorus_get_session`, REST GET | YES (read-but-touch is acceptable: this is how plugins implicitly heartbeat by polling their own session) |
+| `closeSession` | `chorus_close_session` | YES (then transitions to `closed` — the refresh is semantically irrelevant once closed but cheap and uniform) |
+| `reopenSession` | `chorus_reopen_session` | YES (already does this; codify) |
+| `sessionCheckinToTask` | `chorus_session_checkin_task` | YES (already does this; codify) |
+| `sessionCheckoutFromTask` | `chorus_session_checkout_task` | YES (new) |
+| `heartbeatSession` | `chorus_session_heartbeat` | YES (the original purpose, retained as explicit keep-alive) |
+
+Implementation pattern: extract a single private helper `touchLastActiveAt(tx, sessionUuid)` and call it from every entry point above. `getSession` is the controversial one — read operations don't usually mutate — but the alternative is to ask plugins to keep sending standalone heartbeats, which was the original failure mode. The cost of one extra `UPDATE` per session read is negligible and pays for itself by eliminating a whole class of "session looks dead but isn't" bugs.
+
+> **Trade-off recorded.** A read mutating `updatedAt` is a minor breach of REST hygiene. We accept it because the alternative (plugin discipline) is what produced the current bug. If a future caller needs a strictly read-only fetch (e.g. an audit/export job), they should use a new dedicated `getSessionWithoutTouch` rather than re-add inactive-status logic.
+
+## Data Model
+
+### Migration
+
+```sql
+-- Step 1: collapse inactive rows to active (their lastActiveAt already encodes staleness)
+UPDATE "AgentSession" SET status = 'active' WHERE status = 'inactive';
+
+-- Step 2: drop the unused field
+ALTER TABLE "AgentSession" DROP COLUMN "expiresAt";
+
+-- Step 3: support the new staleness filter
+CREATE INDEX "AgentSession_lastActiveAt_idx" ON "AgentSession"("lastActiveAt");
+```
+
+Prisma schema delta:
+
+```prisma
+model AgentSession {
+  id              Int       @id @default(autoincrement())
+  uuid            String    @unique @default(uuid())
+  companyUuid     String
+  agentUuid       String
+  name            String
+  description     String?
+  status          String    @default("active")  // active | closed   (was: active | inactive | closed)
+  lastActiveAt    DateTime  @default(now())
+  // expiresAt    DateTime?                    -- REMOVED
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  taskCheckins    SessionTaskCheckin[]
+
+  @@index([companyUuid])
+  @@index([agentUuid])
+  @@index([status])
+  @@index([lastActiveAt])  // NEW
+}
+```
+
+We do **not** add an enum constraint at the DB level (the project keeps these as strings everywhere else). The TypeScript type `SessionStatus = "active" | "closed"` enforces it at the application boundary.
+
+## API Design
+
+No new MCP tools. No new REST endpoints. The observable surface change is exclusively the new filter on the two default-list paths and the implicit `lastActiveAt` refresh on the side-effect tools. Tool input/output schemas are unchanged.
+
+> **Naming nit:** the existing `chorus_session_heartbeat` tool stays. It's redundant during normal operation now, but useful for plugin background pingers and idle-timeout extension. Removing it is a separate cleanup — out of scope.
+
+## Module Contracts
+
+Cross-module contract that all session reads must respect:
+
+1. **"Default-list" reads** (Settings page list, project worker avatars, anywhere a list of "currently working sessions" is shown by default) MUST go through a service function whose name ends in `ForUI` and which applies `freshSessionWhereClause`. Calling `listAgentSessions` from a default-list view is a code smell.
+2. **"By UUID" reads** (`getSession`, Activity dereference) MUST NOT apply the filter. The caller already has the UUID; filtering would only break history.
+3. **"Refresh on touch"**: every service function that takes a `sessionUuid` parameter and successfully resolves it MUST call `touchLastActiveAt` before returning, with the single exception of any future explicit-read-only entry point (none today).
+
+These contracts are recorded in the spec scenarios so that `task-reviewer` can verify them post-implementation.
+
+## Implementation Plan
+
+1. **DB + schema** — migration script; `prisma generate`; restart.
+2. **Service layer** — delete dead code (`markInactiveSessions`, the `inactive→active` branch in `heartbeatSession`, all `'inactive'` string literals); add `SESSION_STALE_THRESHOLD_MS`, `freshSessionWhereClause`, `touchLastActiveAt`; split `listAgentSessions` into `listAgentSessions` (unfiltered, MCP) + `listAgentSessionsForUI` (filtered); wire `touchLastActiveAt` into every session-touching path.
+3. **MCP tool layer** — verify each `src/mcp/tools/session.ts` handler calls the correct (unfiltered) service function; nothing here changes if the service layer is correct.
+4. **REST + UI layer** — point Settings page's session loader at `listAgentSessionsForUI`; verify project worker-avatar header still passes through `getActiveSessionsForProject`'s now-stricter filter. Make sure the per-agent count badge in Settings reflects the filtered count.
+5. **Tests** — remove `markInactiveSessions` tests; remove `heartbeatSession` `inactive` recovery test; add tests for: filter cutoff at exactly 1h, default-list paths applying filter, MCP paths not applying filter, side-effect refresh on each session-touching tool.
+6. **Docs** — update `docs/MCP_TOOLS.md`, `public/skill/` and `public/chorus-plugin/skills/chorus/` to remove `inactive`-status references and document the implicit-heartbeat contract.
+
+These map 1:1 to task drafts.
+
+## Risks & Mitigations
+
+- **Risk**: existing rows with `status='inactive'` get migrated to `active`, and if any of them have a recent `lastActiveAt` they'll suddenly reappear as "active and fresh" in Settings.
+  **Mitigation**: in practice nothing has been calling `markInactiveSessions` so there should be near-zero `inactive` rows in production. The migration log records the row count for audit.
+
+- **Risk**: read-but-touch on `getSession` causes a hot-row write contention if the same session is polled concurrently from many clients.
+  **Mitigation**: in current usage a session has at most one writer (the plugin) plus the human user clicking around. Concurrency is bounded by single-digit RPS per session. If we ever hit contention, we add a debounce in `touchLastActiveAt` ("skip update if `now - lastActiveAt < 30s`"). Not adding it preemptively — premature optimization.
+
+- **Risk**: a future read path forgets the `ForUI` naming convention and calls `listAgentSessions` from a default-list view, leaking stale sessions back.
+  **Mitigation**: the spec scenarios pin the contract; `task-reviewer` checks both directions (filter applied where required, filter NOT applied where forbidden).
+
+- **Risk**: someone re-introduces an `inactive` literal in a future feature.
+  **Mitigation**: TS string-union type makes this a type error at compile time; lint rule unnecessary.
+
+- **Risk**: plugin reuse depends on seeing closed/old sessions by name. If the filter accidentally creeps into `chorus_list_sessions`, plugins will spam-create new sessions on every sub-agent start.
+  **Mitigation**: explicit spec scenario forbidding the filter on `chorus_list_sessions`. Reviewer checks.

--- a/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/proposal.md
+++ b/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The current AgentSession lifecycle is broken: `markInactiveSessions()` is dead code (never called in production), the `expiresAt` schema field is read by nothing, and closed sessions accumulate indefinitely with no cleanup. As a result, the Settings page lists every historical session ever created, the project worker-avatar header shows zombies that have not heartbeated in days, and the `inactive` status — meant as a stale-detector — never fires. Users see a session graveyard and no useful "who is currently working" signal.
+
+We want to collapse the lifecycle to the two states that actually matter (`active`, `closed`), express "stale" as a query-time filter on `lastActiveAt` rather than a persisted status, and make every session-touching MCP tool implicitly refresh `lastActiveAt` so heartbeat is no longer a separate ritual the plugin must remember to perform.
+
+## What Changes
+
+- **BREAKING**: Remove the `inactive` status from `AgentSession.status`. The persisted state space becomes `{active, closed}` only. Existing rows with `status='inactive'` are migrated to `active` (their `lastActiveAt` already encodes whether they are stale).
+- **BREAKING**: Remove the `expiresAt` column from `AgentSession`. It was never read.
+- Remove the `markInactiveSessions()` service function and its tests; the function is unreferenced in production code.
+- Remove the `inactive → active` recovery branch inside `heartbeatSession()`; with no `inactive` state, the branch is dead.
+- Add a `lastActiveAt` index on `AgentSession` to support the new filter.
+- Introduce a single staleness threshold constant (1h) used by the new query filter.
+- **UI behavior change**: list endpoints that drive the Settings page's per-agent session list and the project page's worker-avatar header MUST filter to `status='active' AND lastActiveAt > now - 1h`. Stale-but-not-closed sessions disappear from these defaults.
+- **Audit-trail preservation**: `chorus_list_sessions`, `chorus_get_session`, the session detail page, and Activity-stream `sessionUuid` lookups are NOT filtered. Plugin reuse and history navigation continue to see every session.
+- **Heartbeat-as-side-effect**: every MCP tool that takes a `sessionUuid` (`chorus_session_checkin_task`, `chorus_session_checkout_task`, `chorus_get_session`, `chorus_close_session`, `chorus_reopen_session`) MUST refresh `lastActiveAt = now()` on the session as part of its successful path. The standalone `chorus_session_heartbeat` tool stays as an explicit keep-alive but is no longer required for correctness.
+- **No task-state coupling.** `closeSession` continues to checkout active task checkins but does NOT alter task `status`. Out of scope.
+- **No closed-session deletion.** Closed sessions live forever in the database. The hide-from-default behavior is achieved entirely by the filter, not by deletion.
+
+## Capabilities
+
+### New Capabilities
+
+- `session-lifecycle`: persisted state machine (`active`, `closed`), allowed transitions, what each transition does to checked-in tasks, and the "default-list staleness filter" contract that defines which read paths apply the `lastActiveAt > now - 1h` rule and which do not. Also covers the heartbeat-as-side-effect contract for session-touching MCP tools.
+
+### Modified Capabilities
+
+_None._ No existing `openspec/specs/<capability>/spec.md` covers session lifecycle today, so this is a brand-new capability.
+
+## Impact
+
+- **DB migration**: drop `expiresAt` column; backfill `inactive` rows to `active`; add `@@index([lastActiveAt])`. One-way; no rollback path needed because `expiresAt` was never read and `inactive` had no semantic load.
+- **Service layer**: `src/services/session.service.ts` — delete `markInactiveSessions`, prune `inactive` branch from `heartbeatSession`, add filter helper, wire `touchLastActiveAt` into all session-touching service calls.
+- **MCP tools**: `src/mcp/tools/session.ts` — every handler that resolves a session by UUID gains the side-effect refresh.
+- **Default-list endpoints**: REST + service paths that feed the Settings sessions panel and the project worker-avatar header (`getActiveSessionsForProject`, `listAgentSessions` when called from Settings) start applying the staleness filter.
+- **Tests**: drop `markInactiveSessions` tests; update `heartbeatSession` tests to remove the `inactive → active` case; add tests for the staleness filter and for the side-effect refresh in each touched tool.
+- **Plugin**: no plugin-side changes required. `on-subagent-start.sh`'s reuse query continues to work because `chorus_list_sessions` is unfiltered.
+- **Skill / Plugin docs**: `public/skill/`, `public/chorus-plugin/skills/chorus/`, `docs/MCP_TOOLS.md` — remove any mention of `inactive` and `expiresAt`; document the side-effect heartbeat contract.
+- **No public API contract break for existing agents.** Tool names and shapes are unchanged; the only observable change is that idle sessions disappear from the Settings list after 1 hour.

--- a/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/specs/session-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/specs/session-lifecycle/spec.md
@@ -1,0 +1,180 @@
+## ADDED Requirements
+
+### Requirement: AgentSession persisted state space SHALL be exactly `{active, closed}`
+
+The `AgentSession.status` column MUST persist only the values `active` or `closed` from this change forward. The `inactive` value MUST NOT appear as a default and MUST NOT be written by any service code after this change lands. "Stale" is a derived predicate on `lastActiveAt`, never a stored state.
+
+Project policy bars DML in Prisma migrations, so pre-existing rows carrying `status='inactive'` are NOT actively rewritten. Instead, the new state machine and read paths treat any residual `'inactive'` row as semantically equivalent to a closed session — it never matches the `status='active'` filter that gates default-list visibility, and it never re-enters circulation because the only code path that previously revived it (`heartbeatSession`'s `inactive → active` branch) is removed by this change.
+
+#### Scenario: Pre-existing inactive rows are excluded from default-list reads
+
+- **GIVEN** a database that already contains one or more `AgentSession` rows with `status='inactive'` (residue from a prior version)
+- **WHEN** the Settings page per-agent session list, the project worker-avatar header, or any other default-list read path is loaded
+- **THEN** none of those `'inactive'` rows MUST appear in the response
+- **AND** no migration or runtime code path MUST issue an `UPDATE` to rewrite their `status` value (DDL-only migration policy)
+
+#### Scenario: No service code path produces an inactive row
+
+- **GIVEN** any happy-path or error-path call to a function in `src/services/session.service.ts`
+- **WHEN** the call completes
+- **THEN** the resulting row's `status` MUST be one of `active` or `closed`
+- **AND** the source code of `src/services/session.service.ts` MUST NOT contain the literal string `"inactive"` after this change
+
+#### Scenario: heartbeatSession does not contain a status-recovery branch
+
+- **GIVEN** the function `heartbeatSession` in `src/services/session.service.ts`
+- **WHEN** the file is read
+- **THEN** the function body MUST NOT contain any branch whose effect is to transition a row from any status to `active` based on the prior status value
+- **AND** the function body MUST refresh `lastActiveAt` unconditionally on the resolved session
+
+### Requirement: The unused `expiresAt` field SHALL be removed
+
+The `AgentSession.expiresAt` column MUST be removed from the Prisma schema and the underlying PostgreSQL table. No application code reads it today, so removing it has no behavioral side-effect; the removal eliminates a misleading affordance ("looks like sessions auto-expire" — they don't).
+
+#### Scenario: Prisma schema no longer declares expiresAt
+
+- **GIVEN** the file `prisma/schema.prisma`
+- **WHEN** the file is read
+- **THEN** the `AgentSession` model MUST NOT declare a field named `expiresAt`
+
+#### Scenario: Database migration drops the column
+
+- **GIVEN** a Postgres database upgraded through this change's migration
+- **WHEN** the table `AgentSession` is inspected with `\d "AgentSession"`
+- **THEN** the column `expiresAt` MUST NOT appear
+
+#### Scenario: Service layer no longer references expiresAt
+
+- **GIVEN** the file `src/services/session.service.ts`
+- **WHEN** the file is read
+- **THEN** it MUST NOT contain the identifier `expiresAt` in any function signature, body, or type
+- **AND** the function `createSession` MUST NOT accept an `expiresAt` parameter
+
+### Requirement: Default-list session reads SHALL filter by `status='active' AND lastActiveAt > now - 1h`
+
+Read paths whose purpose is "show currently working sessions" — specifically the Settings page's per-agent session list and the project page's worker-avatar header — MUST apply a staleness filter so that sessions whose `lastActiveAt` is older than 1 hour are not surfaced even if their persisted status is still `active`. The threshold is a single named constant (`SESSION_STALE_THRESHOLD_MS = 60 * 60 * 1000`).
+
+#### Scenario: Settings page list excludes stale active sessions
+
+- **GIVEN** an agent with two `active` sessions: session A with `lastActiveAt = now - 10min`, session B with `lastActiveAt = now - 2h`
+- **WHEN** the Settings page loads the agent's session list (via the dedicated UI-facing service entry point)
+- **THEN** the response MUST include session A
+- **AND** the response MUST NOT include session B
+- **AND** the response MUST NOT include any `closed` session
+
+#### Scenario: Project worker-avatar header excludes stale active sessions
+
+- **GIVEN** a project with three `active` sessions checked into its tasks: session X with `lastActiveAt = now - 5min`, session Y with `lastActiveAt = now - 90min`, session Z with `lastActiveAt = now - 30min`
+- **WHEN** `getActiveSessionsForProject` is called for that project
+- **THEN** the returned worker list MUST include the agents behind sessions X and Z
+- **AND** the returned worker list MUST NOT include the agent behind session Y solely on the basis of session Y
+
+#### Scenario: Threshold cutoff is exactly 1 hour
+
+- **GIVEN** a session with `status='active'` and `lastActiveAt = now - exactly 1h - 1ms`
+- **WHEN** the Settings UI list is loaded
+- **THEN** the session MUST NOT be returned
+- **AND** if the same session's `lastActiveAt` is bumped to `now - 1h + 1ms` and the list is re-loaded, the session MUST be returned
+
+### Requirement: Audit-trail and plugin-reuse session reads SHALL NOT apply the staleness filter
+
+Read paths whose purpose is "navigate session history" or "look up a specific session by UUID" MUST NOT apply the staleness filter. This explicitly covers the `chorus_list_sessions` MCP tool (used by the plugin's sub-agent reuse logic), the `chorus_get_session` MCP tool, the REST `GET /api/sessions/[uuid]` endpoint, and the Activity-stream's denormalized `sessionUuid` dereference. Filtering these would either break plugin reuse (forcing spam-creation of new sessions) or break the audit trail (history links 404).
+
+#### Scenario: chorus_list_sessions returns stale and closed sessions
+
+- **GIVEN** an agent with three sessions: one active+fresh, one active+stale (last active 3h ago), one closed
+- **WHEN** the agent calls `chorus_list_sessions` with no `status` filter argument
+- **THEN** all three sessions MUST appear in the response
+- **AND** when the agent calls `chorus_list_sessions({ status: "active" })` both active sessions (fresh and stale) MUST appear
+
+#### Scenario: chorus_get_session returns a stale session by UUID
+
+- **GIVEN** a session with `status='active'` and `lastActiveAt = now - 4h`
+- **WHEN** the agent calls `chorus_get_session({ sessionUuid: <that uuid> })`
+- **THEN** the call MUST succeed with that session in the response
+
+#### Scenario: Activity-stream session dereference resolves stale sessions
+
+- **GIVEN** an Activity row whose denormalized `sessionUuid` points to a session that has been stale for 24h
+- **WHEN** the Activity stream is rendered and the session name is resolved through `getSessionName`
+- **THEN** `getSessionName` MUST return the session's name string, not null
+
+### Requirement: Every session-touching MCP tool SHALL refresh `lastActiveAt` on its successful path
+
+Each MCP tool that takes a `sessionUuid` parameter and successfully resolves the session MUST update that session's `lastActiveAt` to `new Date()` before returning. This bakes "any session activity counts as a heartbeat" into the protocol so plugins no longer need to remember to call `chorus_session_heartbeat` explicitly during normal operation.
+
+The tools in scope are: `chorus_get_session`, `chorus_close_session`, `chorus_reopen_session`, `chorus_session_checkin_task`, `chorus_session_checkout_task`, `chorus_session_heartbeat`. The standalone `chorus_session_heartbeat` is preserved for explicit keep-alive (e.g. an idle plugin pinging itself).
+
+#### Scenario: chorus_session_checkin_task refreshes lastActiveAt
+
+- **GIVEN** an active session whose `lastActiveAt` is `T0`
+- **WHEN** the agent calls `chorus_session_checkin_task` for that session at time `T1 > T0`
+- **THEN** the call MUST succeed
+- **AND** a subsequent fetch of the session MUST report `lastActiveAt >= T1`
+
+#### Scenario: chorus_session_checkout_task refreshes lastActiveAt
+
+- **GIVEN** a session that has previously checked into a task and whose `lastActiveAt` is `T0`
+- **WHEN** the agent calls `chorus_session_checkout_task` for that session at time `T1 > T0`
+- **THEN** the call MUST succeed
+- **AND** a subsequent fetch MUST report `lastActiveAt >= T1`
+
+#### Scenario: chorus_get_session refreshes lastActiveAt
+
+- **GIVEN** an active session whose `lastActiveAt` is `T0`
+- **WHEN** the agent calls `chorus_get_session` for that session at time `T1 > T0`
+- **THEN** the response MUST include the session
+- **AND** a subsequent independent fetch of the same session MUST report `lastActiveAt >= T1`
+
+#### Scenario: chorus_reopen_session refreshes lastActiveAt and transitions to active
+
+- **GIVEN** a session with `status='closed'` and `lastActiveAt = T0`
+- **WHEN** the agent calls `chorus_reopen_session` at time `T1 > T0`
+- **THEN** the session's `status` MUST become `active`
+- **AND** the session's `lastActiveAt` MUST be `>= T1`
+
+### Requirement: closeSession SHALL preserve task status (no zombie-cleanup coupling)
+
+`closeSession` MUST checkout every active session-task checkin (set `checkoutAt = now`) but MUST NOT alter the `status` of any underlying `Task`. Task lifecycle and session lifecycle are deliberately decoupled: a task that was being worked on by a now-closed session remains in whatever status it was in (e.g. `in_progress`, `to_verify`) so another agent or a human can pick it up. This is a contract pinning, not a behavior change — current code already satisfies it; the requirement exists to prevent regressions during this refactor.
+
+#### Scenario: Closing a session leaves checked-in task statuses unchanged
+
+- **GIVEN** an active session checked into a task whose `status='in_progress'`
+- **WHEN** `chorus_close_session` is called for that session
+- **THEN** the session's `status` MUST become `closed`
+- **AND** the corresponding `SessionTaskCheckin.checkoutAt` MUST be set to `now`
+- **AND** the task's `status` MUST remain `in_progress`
+- **AND** no task-level state-change Activity MUST be emitted as a side effect of the session close
+
+### Requirement: Closed sessions SHALL be retained indefinitely (no auto-deletion)
+
+Closed sessions MUST NOT be hard-deleted, soft-deleted, archived, or pruned by any sweeper, cron job, or migration introduced by this change. The accumulation problem is solved exclusively by the default-list filter (preceding requirement) plus the `status='active'` clause within it. Historical closed sessions remain queryable indefinitely for audit and Activity-stream link integrity.
+
+#### Scenario: No sweeper exists that deletes closed sessions
+
+- **GIVEN** the entire repository after this change
+- **WHEN** `src/`, `prisma/migrations/`, and any `bin/` or worker entry points are searched
+- **THEN** no code path MUST exist that calls `prisma.agentSession.delete*` on rows whose `status` is `closed`
+- **AND** no scheduled job, cron entry, or `setInterval` MUST exist that targets `AgentSession` rows for deletion
+
+#### Scenario: An old closed session is still fetchable by UUID
+
+- **GIVEN** a session with `status='closed'` and `closedAt` 90 days in the past
+- **WHEN** the agent calls `chorus_get_session({ sessionUuid: <that uuid> })`
+- **THEN** the call MUST succeed and return that session
+
+### Requirement: A `lastActiveAt` index SHALL exist on `AgentSession`
+
+The `AgentSession` model in `prisma/schema.prisma` MUST declare a non-unique index on `lastActiveAt`, and the corresponding Postgres index MUST exist after migration. The default-list filter's `lastActiveAt > now - 1h` predicate is hot enough (every Settings page load, every project page worker-avatar load) that a sequential scan would degrade noticeably as `AgentSession` row count grows.
+
+#### Scenario: Prisma schema declares the index
+
+- **GIVEN** the `AgentSession` model in `prisma/schema.prisma`
+- **WHEN** the file is read
+- **THEN** the model MUST contain `@@index([lastActiveAt])`
+
+#### Scenario: Database has the matching index
+
+- **GIVEN** a Postgres database upgraded through this change's migration
+- **WHEN** `\di "AgentSession"*` is run
+- **THEN** an index whose definition references the `lastActiveAt` column MUST be present

--- a/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/tasks.md
+++ b/openspec/changes/archive/2026-05-25-session-lifecycle-active-only/tasks.md
@@ -1,0 +1,9 @@
+# Tasks (mirror of Chorus task drafts)
+
+These are the implementation tasks. The Chorus task drafts inside the proposal are the source of truth; this file is a local mirror for `openspec validate` / `openspec archive` parity.
+
+- [ ] 1. **DB migration + schema delta** — drop `expiresAt`, backfill `inactive → active`, add `@@index([lastActiveAt])`. Run `pnpm db:migrate:dev`, regenerate Prisma client, restart dev server.
+- [ ] 2. **Service layer refactor** — delete `markInactiveSessions` and its tests; remove `inactive→active` branch from `heartbeatSession`; introduce `SESSION_STALE_THRESHOLD_MS`, `freshSessionWhereClause`, `touchLastActiveAt`; split `listAgentSessions` into unfiltered (MCP) + `listAgentSessionsForUI` (filtered); wire `touchLastActiveAt` into every session-touching service function. Remove all `'inactive'` literal references.
+- [ ] 3. **UI wiring + filter enforcement** — point Settings page session loader at `listAgentSessionsForUI`; verify project worker-avatar header passes through the now-stricter `getActiveSessionsForProject`; verify per-agent count badge reflects filtered count.
+- [ ] 4. **Tests** — add tests for: 1h cutoff boundary, default-list filter, MCP non-filtered paths, side-effect refresh on each session-touching tool, closeSession not mutating task status, no-op on existing tests for removed code paths.
+- [ ] 5. **Docs sync** — update `docs/MCP_TOOLS.md`, `public/skill/`, `public/chorus-plugin/skills/chorus/` to remove `inactive` and `expiresAt` references and document the implicit-heartbeat contract.

--- a/openspec/specs/session-lifecycle/spec.md
+++ b/openspec/specs/session-lifecycle/spec.md
@@ -1,7 +1,9 @@
 # session-lifecycle Specification
 
 ## Purpose
-TBD - created by archiving change session-lifecycle-active-only. Update Purpose after archive.
+
+Defines the persisted state machine and read-path semantics for `AgentSession` rows. The capability covers: (a) the two-state model `{active, closed}` with no `inactive` state, (b) the query-time staleness filter (`status='active' AND lastActiveAt > now - 1h`) applied on default UI listings only, (c) the unfiltered MCP / audit-trail reads that preserve plugin-reuse and history navigation, (d) the implicit-heartbeat contract whereby every session-touching MCP tool refreshes `lastActiveAt` on success (with a closed-session guard), and (e) the deliberate decoupling of session lifecycle from task status — closing a session checks out task checkins but does not mutate `Task.status`.
+
 ## Requirements
 ### Requirement: AgentSession persisted state space SHALL be exactly `{active, closed}`
 

--- a/openspec/specs/session-lifecycle/spec.md
+++ b/openspec/specs/session-lifecycle/spec.md
@@ -1,0 +1,184 @@
+# session-lifecycle Specification
+
+## Purpose
+TBD - created by archiving change session-lifecycle-active-only. Update Purpose after archive.
+## Requirements
+### Requirement: AgentSession persisted state space SHALL be exactly `{active, closed}`
+
+The `AgentSession.status` column MUST persist only the values `active` or `closed` from this change forward. The `inactive` value MUST NOT appear as a default and MUST NOT be written by any service code after this change lands. "Stale" is a derived predicate on `lastActiveAt`, never a stored state.
+
+Project policy bars DML in Prisma migrations, so pre-existing rows carrying `status='inactive'` are NOT actively rewritten. Instead, the new state machine and read paths treat any residual `'inactive'` row as semantically equivalent to a closed session — it never matches the `status='active'` filter that gates default-list visibility, and it never re-enters circulation because the only code path that previously revived it (`heartbeatSession`'s `inactive → active` branch) is removed by this change.
+
+#### Scenario: Pre-existing inactive rows are excluded from default-list reads
+
+- **GIVEN** a database that already contains one or more `AgentSession` rows with `status='inactive'` (residue from a prior version)
+- **WHEN** the Settings page per-agent session list, the project worker-avatar header, or any other default-list read path is loaded
+- **THEN** none of those `'inactive'` rows MUST appear in the response
+- **AND** no migration or runtime code path MUST issue an `UPDATE` to rewrite their `status` value (DDL-only migration policy)
+
+#### Scenario: No service code path produces an inactive row
+
+- **GIVEN** any happy-path or error-path call to a function in `src/services/session.service.ts`
+- **WHEN** the call completes
+- **THEN** the resulting row's `status` MUST be one of `active` or `closed`
+- **AND** the source code of `src/services/session.service.ts` MUST NOT contain the literal string `"inactive"` after this change
+
+#### Scenario: heartbeatSession does not contain a status-recovery branch
+
+- **GIVEN** the function `heartbeatSession` in `src/services/session.service.ts`
+- **WHEN** the file is read
+- **THEN** the function body MUST NOT contain any branch whose effect is to transition a row from any status to `active` based on the prior status value
+- **AND** the function body MUST refresh `lastActiveAt` unconditionally on the resolved session
+
+### Requirement: The unused `expiresAt` field SHALL be removed
+
+The `AgentSession.expiresAt` column MUST be removed from the Prisma schema and the underlying PostgreSQL table. No application code reads it today, so removing it has no behavioral side-effect; the removal eliminates a misleading affordance ("looks like sessions auto-expire" — they don't).
+
+#### Scenario: Prisma schema no longer declares expiresAt
+
+- **GIVEN** the file `prisma/schema.prisma`
+- **WHEN** the file is read
+- **THEN** the `AgentSession` model MUST NOT declare a field named `expiresAt`
+
+#### Scenario: Database migration drops the column
+
+- **GIVEN** a Postgres database upgraded through this change's migration
+- **WHEN** the table `AgentSession` is inspected with `\d "AgentSession"`
+- **THEN** the column `expiresAt` MUST NOT appear
+
+#### Scenario: Service layer no longer references expiresAt
+
+- **GIVEN** the file `src/services/session.service.ts`
+- **WHEN** the file is read
+- **THEN** it MUST NOT contain the identifier `expiresAt` in any function signature, body, or type
+- **AND** the function `createSession` MUST NOT accept an `expiresAt` parameter
+
+### Requirement: Default-list session reads SHALL filter by `status='active' AND lastActiveAt > now - 1h`
+
+Read paths whose purpose is "show currently working sessions" — specifically the Settings page's per-agent session list and the project page's worker-avatar header — MUST apply a staleness filter so that sessions whose `lastActiveAt` is older than 1 hour are not surfaced even if their persisted status is still `active`. The threshold is a single named constant (`SESSION_STALE_THRESHOLD_MS = 60 * 60 * 1000`).
+
+#### Scenario: Settings page list excludes stale active sessions
+
+- **GIVEN** an agent with two `active` sessions: session A with `lastActiveAt = now - 10min`, session B with `lastActiveAt = now - 2h`
+- **WHEN** the Settings page loads the agent's session list (via the dedicated UI-facing service entry point)
+- **THEN** the response MUST include session A
+- **AND** the response MUST NOT include session B
+- **AND** the response MUST NOT include any `closed` session
+
+#### Scenario: Project worker-avatar header excludes stale active sessions
+
+- **GIVEN** a project with three `active` sessions checked into its tasks: session X with `lastActiveAt = now - 5min`, session Y with `lastActiveAt = now - 90min`, session Z with `lastActiveAt = now - 30min`
+- **WHEN** `getActiveSessionsForProject` is called for that project
+- **THEN** the returned worker list MUST include the agents behind sessions X and Z
+- **AND** the returned worker list MUST NOT include the agent behind session Y solely on the basis of session Y
+
+#### Scenario: Threshold cutoff is exactly 1 hour
+
+- **GIVEN** a session with `status='active'` and `lastActiveAt = now - exactly 1h - 1ms`
+- **WHEN** the Settings UI list is loaded
+- **THEN** the session MUST NOT be returned
+- **AND** if the same session's `lastActiveAt` is bumped to `now - 1h + 1ms` and the list is re-loaded, the session MUST be returned
+
+### Requirement: Audit-trail and plugin-reuse session reads SHALL NOT apply the staleness filter
+
+Read paths whose purpose is "navigate session history" or "look up a specific session by UUID" MUST NOT apply the staleness filter. This explicitly covers the `chorus_list_sessions` MCP tool (used by the plugin's sub-agent reuse logic), the `chorus_get_session` MCP tool, the REST `GET /api/sessions/[uuid]` endpoint, and the Activity-stream's denormalized `sessionUuid` dereference. Filtering these would either break plugin reuse (forcing spam-creation of new sessions) or break the audit trail (history links 404).
+
+#### Scenario: chorus_list_sessions returns stale and closed sessions
+
+- **GIVEN** an agent with three sessions: one active+fresh, one active+stale (last active 3h ago), one closed
+- **WHEN** the agent calls `chorus_list_sessions` with no `status` filter argument
+- **THEN** all three sessions MUST appear in the response
+- **AND** when the agent calls `chorus_list_sessions({ status: "active" })` both active sessions (fresh and stale) MUST appear
+
+#### Scenario: chorus_get_session returns a stale session by UUID
+
+- **GIVEN** a session with `status='active'` and `lastActiveAt = now - 4h`
+- **WHEN** the agent calls `chorus_get_session({ sessionUuid: <that uuid> })`
+- **THEN** the call MUST succeed with that session in the response
+
+#### Scenario: Activity-stream session dereference resolves stale sessions
+
+- **GIVEN** an Activity row whose denormalized `sessionUuid` points to a session that has been stale for 24h
+- **WHEN** the Activity stream is rendered and the session name is resolved through `getSessionName`
+- **THEN** `getSessionName` MUST return the session's name string, not null
+
+### Requirement: Every session-touching MCP tool SHALL refresh `lastActiveAt` on its successful path
+
+Each MCP tool that takes a `sessionUuid` parameter and successfully resolves the session MUST update that session's `lastActiveAt` to `new Date()` before returning. This bakes "any session activity counts as a heartbeat" into the protocol so plugins no longer need to remember to call `chorus_session_heartbeat` explicitly during normal operation.
+
+The tools in scope are: `chorus_get_session`, `chorus_close_session`, `chorus_reopen_session`, `chorus_session_checkin_task`, `chorus_session_checkout_task`, `chorus_session_heartbeat`. The standalone `chorus_session_heartbeat` is preserved for explicit keep-alive (e.g. an idle plugin pinging itself).
+
+#### Scenario: chorus_session_checkin_task refreshes lastActiveAt
+
+- **GIVEN** an active session whose `lastActiveAt` is `T0`
+- **WHEN** the agent calls `chorus_session_checkin_task` for that session at time `T1 > T0`
+- **THEN** the call MUST succeed
+- **AND** a subsequent fetch of the session MUST report `lastActiveAt >= T1`
+
+#### Scenario: chorus_session_checkout_task refreshes lastActiveAt
+
+- **GIVEN** a session that has previously checked into a task and whose `lastActiveAt` is `T0`
+- **WHEN** the agent calls `chorus_session_checkout_task` for that session at time `T1 > T0`
+- **THEN** the call MUST succeed
+- **AND** a subsequent fetch MUST report `lastActiveAt >= T1`
+
+#### Scenario: chorus_get_session refreshes lastActiveAt
+
+- **GIVEN** an active session whose `lastActiveAt` is `T0`
+- **WHEN** the agent calls `chorus_get_session` for that session at time `T1 > T0`
+- **THEN** the response MUST include the session
+- **AND** a subsequent independent fetch of the same session MUST report `lastActiveAt >= T1`
+
+#### Scenario: chorus_reopen_session refreshes lastActiveAt and transitions to active
+
+- **GIVEN** a session with `status='closed'` and `lastActiveAt = T0`
+- **WHEN** the agent calls `chorus_reopen_session` at time `T1 > T0`
+- **THEN** the session's `status` MUST become `active`
+- **AND** the session's `lastActiveAt` MUST be `>= T1`
+
+### Requirement: closeSession SHALL preserve task status (no zombie-cleanup coupling)
+
+`closeSession` MUST checkout every active session-task checkin (set `checkoutAt = now`) but MUST NOT alter the `status` of any underlying `Task`. Task lifecycle and session lifecycle are deliberately decoupled: a task that was being worked on by a now-closed session remains in whatever status it was in (e.g. `in_progress`, `to_verify`) so another agent or a human can pick it up. This is a contract pinning, not a behavior change — current code already satisfies it; the requirement exists to prevent regressions during this refactor.
+
+#### Scenario: Closing a session leaves checked-in task statuses unchanged
+
+- **GIVEN** an active session checked into a task whose `status='in_progress'`
+- **WHEN** `chorus_close_session` is called for that session
+- **THEN** the session's `status` MUST become `closed`
+- **AND** the corresponding `SessionTaskCheckin.checkoutAt` MUST be set to `now`
+- **AND** the task's `status` MUST remain `in_progress`
+- **AND** no task-level state-change Activity MUST be emitted as a side effect of the session close
+
+### Requirement: Closed sessions SHALL be retained indefinitely (no auto-deletion)
+
+Closed sessions MUST NOT be hard-deleted, soft-deleted, archived, or pruned by any sweeper, cron job, or migration introduced by this change. The accumulation problem is solved exclusively by the default-list filter (preceding requirement) plus the `status='active'` clause within it. Historical closed sessions remain queryable indefinitely for audit and Activity-stream link integrity.
+
+#### Scenario: No sweeper exists that deletes closed sessions
+
+- **GIVEN** the entire repository after this change
+- **WHEN** `src/`, `prisma/migrations/`, and any `bin/` or worker entry points are searched
+- **THEN** no code path MUST exist that calls `prisma.agentSession.delete*` on rows whose `status` is `closed`
+- **AND** no scheduled job, cron entry, or `setInterval` MUST exist that targets `AgentSession` rows for deletion
+
+#### Scenario: An old closed session is still fetchable by UUID
+
+- **GIVEN** a session with `status='closed'` and `closedAt` 90 days in the past
+- **WHEN** the agent calls `chorus_get_session({ sessionUuid: <that uuid> })`
+- **THEN** the call MUST succeed and return that session
+
+### Requirement: A `lastActiveAt` index SHALL exist on `AgentSession`
+
+The `AgentSession` model in `prisma/schema.prisma` MUST declare a non-unique index on `lastActiveAt`, and the corresponding Postgres index MUST exist after migration. The default-list filter's `lastActiveAt > now - 1h` predicate is hot enough (every Settings page load, every project page worker-avatar load) that a sequential scan would degrade noticeably as `AgentSession` row count grows.
+
+#### Scenario: Prisma schema declares the index
+
+- **GIVEN** the `AgentSession` model in `prisma/schema.prisma`
+- **WHEN** the file is read
+- **THEN** the model MUST contain `@@index([lastActiveAt])`
+
+#### Scenario: Database has the matching index
+
+- **GIVEN** a Postgres database upgraded through this change's migration
+- **WHEN** `\di "AgentSession"*` is run
+- **THEN** an index whose definition references the `lastActiveAt` column MUST be present
+

--- a/prisma/migrations/20260524144057_remove_session_expires_at/migration.sql
+++ b/prisma/migrations/20260524144057_remove_session_expires_at/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `expiresAt` on the `AgentSession` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "AgentSession" DROP COLUMN "expiresAt";
+
+-- CreateIndex
+CREATE INDEX "AgentSession_lastActiveAt_idx" ON "AgentSession"("lastActiveAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -354,9 +354,8 @@ model AgentSession {
   agent           Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
   name            String
   description     String?
-  status          String    @default("active")  // active | inactive | closed
+  status          String    @default("active")  // active | closed
   lastActiveAt    DateTime  @default(now())
-  expiresAt       DateTime?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
   taskCheckins    SessionTaskCheckin[]
@@ -364,6 +363,7 @@ model AgentSession {
   @@index([companyUuid])
   @@index([agentUuid])
   @@index([status])
+  @@index([lastActiveAt])
 }
 
 // Session-Task checkin relation (many-to-many)

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -360,7 +360,7 @@ Sub-agents need MCP configured at **project level** (`.mcp.json` or `.claude/set
 |---------|----------|
 | Sub-agent can't access Chorus MCP tools | Verify MCP is configured at project level, API key has developer role |
 | UI doesn't show active workers | Sub-agent forgot `chorus_session_checkin_task`. Check: `chorus_get_session` |
-| Session shows "inactive" (yellow) | No heartbeat in 1h. TeammateIdle hook should auto-send. Agent may have crashed |
+| Session disappears from Settings | No activity for 1h (default lists hide stale sessions). The session row still exists — it's reachable via MCP `chorus_list_sessions` / `chorus_get_session`. Send a heartbeat (or any session-touching tool) to make it visible again, or check whether the agent crashed |
 | Task stuck in wrong status | Spawn new sub-agent with same name (plugin auto-reopens session), or use `chorus_update_task` to reset |
 | Duplicate sessions | Never call `chorus_create_session` — plugin handles all session creation. Close extras via Settings page |
 | Sub-agent didn't receive session | Check plugin is loaded (`/plugin list`) and `CHORUS_URL` is set. Ensure `name` parameter is set |

--- a/src/app/(dashboard)/settings/actions.ts
+++ b/src/app/(dashboard)/settings/actions.ts
@@ -12,7 +12,7 @@ import {
   syncApiKeyNames,
 } from "@/services/agent.service";
 import {
-  listAgentSessions,
+  listAgentSessionsForUI,
   closeSession,
   reopenSession,
   type SessionResponse,
@@ -163,7 +163,7 @@ export async function getAgentSessionsAction(agentUuid: string): Promise<{
   }
 
   try {
-    const sessions = await listAgentSessions(auth.companyUuid, agentUuid);
+    const sessions = await listAgentSessionsForUI(auth.companyUuid, agentUuid);
     return { success: true, data: sessions };
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch agent sessions");

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -409,7 +409,7 @@ export default function SettingsPage() {
                     <span>{t("sessions.title")}</span>
                     {agentSessions[key.agentUuid] && (
                       <Badge variant="secondary" className="ml-1 h-4 px-1.5 text-[10px]">
-                        {agentSessions[key.agentUuid].filter((s) => s.status === "active").length}
+                        {agentSessions[key.agentUuid].length}
                       </Badge>
                     )}
                   </button>
@@ -435,9 +435,7 @@ export default function SettingsPage() {
                                 className={`h-2 w-2 rounded-full flex-shrink-0 ${
                                   session.status === "active"
                                     ? "bg-green-500"
-                                    : session.status === "inactive"
-                                      ? "bg-yellow-500"
-                                      : "bg-gray-400"
+                                    : "bg-gray-400"
                                 }`}
                               />
                               <span className="font-medium truncate">{session.name}</span>
@@ -446,9 +444,7 @@ export default function SettingsPage() {
                                 className={`text-[10px] h-4 px-1 ${
                                   session.status === "active"
                                     ? "border-green-300 text-green-700"
-                                    : session.status === "inactive"
-                                      ? "border-yellow-300 text-yellow-700"
-                                      : "border-gray-300 text-gray-500"
+                                    : "border-gray-300 text-gray-500"
                                 }`}
                               >
                                 {t(`sessions.status${session.status.charAt(0).toUpperCase() + session.status.slice(1)}`)}

--- a/src/app/api/agents/[uuid]/sessions/route.ts
+++ b/src/app/api/agents/[uuid]/sessions/route.ts
@@ -1,5 +1,5 @@
 // src/app/api/agents/[uuid]/sessions/route.ts
-// Agent Sessions API - list sessions for an agent
+// Agent Sessions API - list sessions for an agent (UI-facing: filtered)
 // UUID-Based Architecture: All operations use UUIDs
 
 import { NextRequest } from "next/server";
@@ -7,11 +7,14 @@ import { prisma } from "@/lib/prisma";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
 import { getAuthContext, isUser } from "@/lib/auth";
-import { listAgentSessions } from "@/services/session.service";
+import { listAgentSessionsForUI } from "@/services/session.service";
 
 type RouteContext = { params: Promise<{ uuid: string }> };
 
 // GET /api/agents/[uuid]/sessions - List sessions for an agent
+// This is the Settings-page-facing endpoint and applies the staleness filter
+// (status='active' AND lastActiveAt > now - 1h). MCP-facing reads use
+// /api/sessions/[uuid] / chorus_list_sessions which remain unfiltered.
 export const GET = withErrorHandler<{ uuid: string }>(
   async (request: NextRequest, context: RouteContext) => {
     const auth = await getAuthContext(request);
@@ -35,8 +38,7 @@ export const GET = withErrorHandler<{ uuid: string }>(
       return errors.notFound("Agent");
     }
 
-    const status = new URL(request.url).searchParams.get("status") || undefined;
-    const sessions = await listAgentSessions(auth.companyUuid, uuid, status);
+    const sessions = await listAgentSessionsForUI(auth.companyUuid, uuid);
 
     return success(sessions);
   }

--- a/src/mcp/tools/session.ts
+++ b/src/mcp/tools/session.ts
@@ -14,7 +14,7 @@ export function registerSessionTools(server: McpServer, auth: AgentAuthContext) 
     {
       description: "List all Sessions for the current Agent",
       inputSchema: z.object({
-        status: z.enum(["active", "inactive", "closed"]).optional().describe("Filter by status"),
+        status: z.enum(["active", "closed"]).optional().describe("Filter by status"),
       }),
     },
     async ({ status }) => {
@@ -63,16 +63,14 @@ export function registerSessionTools(server: McpServer, auth: AgentAuthContext) 
       inputSchema: z.object({
         name: z.string().describe("Session name (e.g. 'frontend-worker')"),
         description: z.string().optional().describe("Session description"),
-        expiresAt: z.string().optional().describe("Expiration time (ISO 8601)"),
       }),
     },
-    async ({ name, description, expiresAt }) => {
+    async ({ name, description }) => {
       const session = await sessionService.createSession({
         companyUuid: auth.companyUuid,
         agentUuid: auth.actorUuid,
         name,
         description,
-        expiresAt: expiresAt ? new Date(expiresAt) : null,
       });
 
       return {

--- a/src/services/__tests__/session.service.test.ts
+++ b/src/services/__tests__/session.service.test.ts
@@ -7,6 +7,7 @@ const mockPrisma = vi.hoisted(() => ({
     findFirst: vi.fn(),
     findMany: vi.fn(),
     findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
     update: vi.fn(),
     updateMany: vi.fn(),
   },
@@ -42,9 +43,11 @@ import {
   sessionCheckinToTask,
   sessionCheckoutFromTask,
   heartbeatSession,
-  markInactiveSessions,
   batchGetWorkerCountsForTasks,
   getSessionName,
+  listAgentSessions,
+  listAgentSessionsForUI,
+  SESSION_STALE_THRESHOLD_MS,
 } from "@/services/session.service";
 import { eventBus } from "@/lib/event-bus";
 import { claimTask } from "@/services/task.service";
@@ -66,7 +69,6 @@ function makeSession(overrides: Record<string, unknown> = {}) {
     description: null,
     status: "active",
     lastActiveAt: now,
-    expiresAt: null,
     createdAt: now,
     updatedAt: now,
     ...overrides,
@@ -75,6 +77,9 @@ function makeSession(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default for touchLastActiveAt's status precheck — most tests operate on
+  // active sessions and expect the lastActiveAt write to fire.
+  mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
 });
 
 // ===== createSession =====
@@ -98,9 +103,8 @@ describe("createSession", () => {
     expect(mockPrisma.agentSession.create).toHaveBeenCalledOnce();
   });
 
-  it("should pass description and expiresAt when provided", async () => {
-    const expires = new Date("2026-04-01T00:00:00Z");
-    const session = makeSession({ description: "desc", expiresAt: expires });
+  it("should pass description when provided", async () => {
+    const session = makeSession({ description: "desc" });
     mockPrisma.agentSession.create.mockResolvedValue(session);
 
     await createSession({
@@ -108,14 +112,12 @@ describe("createSession", () => {
       agentUuid,
       name: "test-session",
       description: "desc",
-      expiresAt: expires,
     });
 
     expect(mockPrisma.agentSession.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           description: "desc",
-          expiresAt: expires,
         }),
       })
     );
@@ -185,6 +187,7 @@ describe("reopenSession", () => {
     mockPrisma.agentSession.findFirst.mockResolvedValue(makeSession({ status: "closed" }));
     const reopened = makeSession({ status: "active", taskCheckins: [] });
     mockPrisma.agentSession.update.mockResolvedValue(reopened);
+    mockPrisma.agentSession.findUniqueOrThrow.mockResolvedValue(reopened);
 
     const result = await reopenSession(companyUuid, sessionUuid);
     expect(result.status).toBe("active");
@@ -324,39 +327,9 @@ describe("heartbeatSession", () => {
     );
   });
 
-  it("should restore inactive session to active", async () => {
-    mockPrisma.agentSession.findFirst.mockResolvedValue(makeSession({ status: "inactive" }));
-    mockPrisma.agentSession.update.mockResolvedValue(makeSession({ status: "active" }));
-
-    await heartbeatSession(companyUuid, sessionUuid);
-
-    expect(mockPrisma.agentSession.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ status: "active" }),
-      })
-    );
-  });
-
   it("should throw when session not found", async () => {
     mockPrisma.agentSession.findFirst.mockResolvedValue(null);
     await expect(heartbeatSession(companyUuid, "missing")).rejects.toThrow("Session not found");
-  });
-});
-
-// ===== markInactiveSessions =====
-describe("markInactiveSessions", () => {
-  it("should mark stale active sessions as inactive", async () => {
-    mockPrisma.agentSession.updateMany.mockResolvedValue({ count: 3 });
-
-    const count = await markInactiveSessions();
-
-    expect(count).toBe(3);
-    expect(mockPrisma.agentSession.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ status: "active" }),
-        data: { status: "inactive" },
-      })
-    );
   });
 });
 
@@ -639,5 +612,270 @@ describe("getActiveSessionsForProject", () => {
     const result = await getActiveSessionsForProject(companyUuid, projectUuid);
 
     expect(result).toHaveLength(0); // skipped due to missing agent name
+  });
+});
+
+// ===== Staleness filter contract =====
+describe("staleness filter (1h cutoff)", () => {
+  it("SESSION_STALE_THRESHOLD_MS is exactly 1 hour", () => {
+    expect(SESSION_STALE_THRESHOLD_MS).toBe(60 * 60 * 1000);
+  });
+
+  it("listAgentSessionsForUI applies status='active' AND lastActiveAt > now - 1h filter", async () => {
+    mockPrisma.agentSession.findMany.mockResolvedValue([]);
+
+    await listAgentSessionsForUI(companyUuid, agentUuid);
+
+    const call = mockPrisma.agentSession.findMany.mock.calls[0]?.[0];
+    expect(call.where.companyUuid).toBe(companyUuid);
+    expect(call.where.agentUuid).toBe(agentUuid);
+    expect(call.where.status).toBe("active");
+    expect(call.where.lastActiveAt).toBeDefined();
+    expect(call.where.lastActiveAt.gt).toBeInstanceOf(Date);
+    // Lower-bound timestamp must be ~ now - 1h (within a small wall-clock margin)
+    const cutoff = (call.where.lastActiveAt.gt as Date).getTime();
+    const expected = Date.now() - SESSION_STALE_THRESHOLD_MS;
+    expect(Math.abs(cutoff - expected)).toBeLessThan(2_000);
+  });
+
+  it("listAgentSessions does NOT apply the staleness filter (MCP-facing audit-trail path)", async () => {
+    mockPrisma.agentSession.findMany.mockResolvedValue([]);
+
+    await listAgentSessions(companyUuid, agentUuid);
+
+    const call = mockPrisma.agentSession.findMany.mock.calls[0]?.[0];
+    // lastActiveAt is intentionally absent so the caller sees every row regardless of age.
+    expect(call.where.lastActiveAt).toBeUndefined();
+    // status filter is also absent unless explicitly passed.
+    expect(call.where.status).toBeUndefined();
+  });
+
+  it("getActiveSessionsForProject uses the freshSessionWhereClause shape on the session join", async () => {
+    mockPrisma.sessionTaskCheckin.findMany.mockResolvedValue([]);
+    mockPrisma.task.findMany.mockResolvedValue([]);
+
+    const { getActiveSessionsForProject } = await import("@/services/session.service");
+    await getActiveSessionsForProject(companyUuid, projectUuid);
+
+    const call = mockPrisma.sessionTaskCheckin.findMany.mock.calls[0]?.[0];
+    expect(call.where.session.status).toBe("active");
+    expect(call.where.session.lastActiveAt.gt).toBeInstanceOf(Date);
+  });
+
+  it("batchGetWorkerCountsForTasks uses the freshSessionWhereClause shape on the session join", async () => {
+    mockPrisma.sessionTaskCheckin.groupBy.mockResolvedValue([]);
+
+    await batchGetWorkerCountsForTasks(companyUuid, [taskUuid]);
+
+    const call = mockPrisma.sessionTaskCheckin.groupBy.mock.calls[0]?.[0];
+    expect(call.where.session.status).toBe("active");
+    expect(call.where.session.lastActiveAt.gt).toBeInstanceOf(Date);
+  });
+
+  it("getSession (MCP/audit-trail path) does NOT filter on lastActiveAt — a 4h-stale session is still returned", async () => {
+    const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(
+      makeSession({ lastActiveAt: fourHoursAgo, taskCheckins: [] }),
+    );
+
+    const result = await getSession(companyUuid, sessionUuid);
+
+    expect(result).not.toBeNull();
+    // The where clause used must NOT carry lastActiveAt
+    const call = mockPrisma.agentSession.findFirst.mock.calls[0]?.[0];
+    expect(call.where.lastActiveAt).toBeUndefined();
+  });
+
+  it("getSessionName resolves a 24h-stale session name (Activity-stream contract)", async () => {
+    const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    mockPrisma.agentSession.findUnique.mockResolvedValueOnce({ name: "old-session" });
+    // Note: getSessionName doesn't actually read lastActiveAt; we only assert
+    // that no filter is added that would drop a stale row.
+    void dayAgo;
+
+    const result = await getSessionName(sessionUuid);
+
+    expect(result).toBe("old-session");
+    const call = mockPrisma.agentSession.findUnique.mock.calls[0]?.[0];
+    expect(call.where.lastActiveAt).toBeUndefined();
+  });
+});
+
+// ===== Heartbeat side-effect contract =====
+//
+// Each session-touching service function must refresh `lastActiveAt = now()`
+// on its successful path via `touchLastActiveAt`. The helper checks the row
+// status first and skips the write when status='closed'. We exercise that
+// contract via the indirect signature: `prisma.agentSession.update` is called
+// with `data.lastActiveAt` set to a Date strictly after the original
+// `lastActiveAt`. Tests intentionally use the wall-clock side-effect rather
+// than spying on the helper because the helper is module-private.
+
+describe("heartbeat side-effect (lastActiveAt refresh on session-touching tools)", () => {
+  // Capture every prisma.agentSession.update call so we can scan all of them
+  // for the heartbeat write — services may issue multiple updates (e.g.
+  // closeSession also flips status), so we look for ANY update whose data
+  // contains a fresh `lastActiveAt`.
+  const expectHeartbeatCall = (priorActiveAt: Date) => {
+    const calls = mockPrisma.agentSession.update.mock.calls.map(
+      (c) => c[0] as { data?: { lastActiveAt?: Date } },
+    );
+    const hasFreshTouch = calls.some(
+      (c) =>
+        c.data?.lastActiveAt instanceof Date &&
+        c.data.lastActiveAt.getTime() > priorActiveAt.getTime(),
+    );
+    expect(hasFreshTouch).toBe(true);
+  };
+
+  it("getSession refreshes lastActiveAt on success", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000); // 30 min ago
+    mockPrisma.agentSession.findFirst.mockResolvedValue(
+      makeSession({ lastActiveAt: old, taskCheckins: [] }),
+    );
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
+
+    await getSession(companyUuid, sessionUuid);
+    expectHeartbeatCall(old);
+  });
+
+  it("closeSession refreshes lastActiveAt as part of the close path", async () => {
+    // closeSession's heartbeat fires BEFORE the status flip; the helper
+    // sees status='active' at that moment and writes lastActiveAt.
+    const old = new Date(Date.now() - 30 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(makeSession({ lastActiveAt: old }));
+    mockPrisma.sessionTaskCheckin.findMany.mockResolvedValue([]);
+    mockPrisma.sessionTaskCheckin.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.agentSession.update.mockResolvedValue(
+      makeSession({ status: "closed", lastActiveAt: old, taskCheckins: [] }),
+    );
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
+
+    await closeSession(companyUuid, sessionUuid);
+    expectHeartbeatCall(old);
+  });
+
+  it("reopenSession refreshes lastActiveAt as part of the reopen path", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(
+      makeSession({ status: "closed", lastActiveAt: old }),
+    );
+    mockPrisma.agentSession.update.mockResolvedValue(
+      makeSession({ status: "active", lastActiveAt: new Date(), taskCheckins: [] }),
+    );
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
+
+    await reopenSession(companyUuid, sessionUuid);
+    expectHeartbeatCall(old);
+  });
+
+  it("sessionCheckinToTask refreshes lastActiveAt on success", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(makeSession({ lastActiveAt: old }));
+    mockPrisma.task.findFirst.mockResolvedValue({
+      uuid: taskUuid,
+      companyUuid,
+      projectUuid,
+      assigneeUuid: agentUuid,
+    });
+    mockPrisma.sessionTaskCheckin.upsert.mockResolvedValue({
+      taskUuid,
+      checkinAt: now,
+      checkoutAt: null,
+    });
+    mockPrisma.agentSession.update.mockResolvedValue(makeSession());
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
+
+    await sessionCheckinToTask(companyUuid, sessionUuid, taskUuid);
+    expectHeartbeatCall(old);
+  });
+
+  it("sessionCheckoutFromTask refreshes lastActiveAt on success", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(makeSession({ lastActiveAt: old }));
+    mockPrisma.task.findFirst.mockResolvedValue({ projectUuid });
+    mockPrisma.sessionTaskCheckin.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.agentSession.update.mockResolvedValue(makeSession());
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
+
+    await sessionCheckoutFromTask(companyUuid, sessionUuid, taskUuid);
+    expectHeartbeatCall(old);
+  });
+
+  it("heartbeatSession refreshes lastActiveAt on success", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(makeSession({ lastActiveAt: old }));
+    mockPrisma.agentSession.update.mockResolvedValue(makeSession());
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
+
+    await heartbeatSession(companyUuid, sessionUuid);
+    expectHeartbeatCall(old);
+  });
+
+  it("touchLastActiveAt skips refresh when status='closed' (closed-session guard)", async () => {
+    // Calling getSession on a closed row should NOT trigger an update.
+    const old = new Date(Date.now() - 30 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(
+      makeSession({ status: "closed", lastActiveAt: old, taskCheckins: [] }),
+    );
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "closed" });
+
+    await getSession(companyUuid, sessionUuid);
+
+    // No update call should carry a lastActiveAt write
+    const writes = mockPrisma.agentSession.update.mock.calls
+      .map((c) => c[0] as { data?: { lastActiveAt?: Date } })
+      .filter((c) => c.data?.lastActiveAt instanceof Date);
+    expect(writes.length).toBe(0);
+  });
+});
+
+// ===== closeSession does NOT mutate task status =====
+describe("closeSession task-status preservation", () => {
+  it("closes the session, sets checkoutAt on checkins, but does not write to Task.status", async () => {
+    mockPrisma.agentSession.findFirst.mockResolvedValue(makeSession());
+    mockPrisma.sessionTaskCheckin.findMany.mockResolvedValue([
+      { task: { uuid: taskUuid, projectUuid } },
+    ]);
+    mockPrisma.sessionTaskCheckin.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.agentSession.update.mockResolvedValue(
+      makeSession({
+        status: "closed",
+        taskCheckins: [{ taskUuid, checkinAt: now, checkoutAt: now }],
+      }),
+    );
+    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
+
+    const result = await closeSession(companyUuid, sessionUuid);
+
+    expect(result.status).toBe("closed");
+    // Checkin is checked out:
+    expect(mockPrisma.sessionTaskCheckin.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { sessionUuid, checkoutAt: null },
+        data: expect.objectContaining({ checkoutAt: expect.any(Date) }),
+      }),
+    );
+    // Service deliberately does not touch Task.status — we have NOT mocked
+    // any prisma.task.* writer in this test, and the result is still "closed".
+    // The asserted contract: no `data.status` on any prisma.task.update call.
+    // (We don't even mock prisma.task.update — so any unexpected call would
+    // throw `mockReturnValue is undefined`-style errors and fail the test.)
+    void claimTask;
+    void eventBus;
+  });
+});
+
+// ===== Regression guard: `inactive` literal must not reappear in session.service.ts =====
+describe("regression guard", () => {
+  it("does not contain the literal string 'inactive' in src/services/session.service.ts", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const path = (await import("node:path")).resolve(
+      __dirname,
+      "../session.service.ts",
+    );
+    const src = await readFile(path, "utf8");
+    expect(src.includes('"inactive"')).toBe(false);
+    expect(src.includes("'inactive'")).toBe(false);
   });
 });

--- a/src/services/__tests__/session.service.test.ts
+++ b/src/services/__tests__/session.service.test.ts
@@ -728,15 +728,36 @@ describe("heartbeat side-effect (lastActiveAt refresh on session-touching tools)
     expect(hasFreshTouch).toBe(true);
   };
 
-  it("getSession refreshes lastActiveAt on success", async () => {
+  it("getSession refreshes lastActiveAt on success and the returned snapshot reflects the touch", async () => {
     const old = new Date(Date.now() - 30 * 60 * 1000); // 30 min ago
     mockPrisma.agentSession.findFirst.mockResolvedValue(
       makeSession({ lastActiveAt: old, taskCheckins: [] }),
     );
     mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
 
-    await getSession(companyUuid, sessionUuid);
+    const result = await getSession(companyUuid, sessionUuid);
     expectHeartbeatCall(old);
+    // The returned snapshot must carry the post-touch timestamp so a UI
+    // rendering result.lastActiveAt is not off-by-one heartbeat.
+    expect(result).not.toBeNull();
+    expect(new Date(result!.lastActiveAt).getTime()).toBeGreaterThan(old.getTime());
+  });
+
+  it("getSession does NOT touch lastActiveAt when the session is closed", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000);
+    mockPrisma.agentSession.findFirst.mockResolvedValue(
+      makeSession({ status: "closed", lastActiveAt: old, taskCheckins: [] }),
+    );
+
+    const result = await getSession(companyUuid, sessionUuid);
+
+    // No update call should carry a lastActiveAt write
+    const writes = mockPrisma.agentSession.update.mock.calls
+      .map((c) => c[0] as { data?: { lastActiveAt?: Date } })
+      .filter((c) => c.data?.lastActiveAt instanceof Date);
+    expect(writes.length).toBe(0);
+    // Returned snapshot keeps the closed row's original timestamp.
+    expect(result!.lastActiveAt).toBe(old.toISOString());
   });
 
   it("closeSession refreshes lastActiveAt as part of the close path", async () => {
@@ -755,7 +776,7 @@ describe("heartbeat side-effect (lastActiveAt refresh on session-touching tools)
     expectHeartbeatCall(old);
   });
 
-  it("reopenSession refreshes lastActiveAt as part of the reopen path", async () => {
+  it("reopenSession atomically flips status AND refreshes lastActiveAt in a single update", async () => {
     const old = new Date(Date.now() - 30 * 60 * 1000);
     mockPrisma.agentSession.findFirst.mockResolvedValue(
       makeSession({ status: "closed", lastActiveAt: old }),
@@ -763,10 +784,18 @@ describe("heartbeat side-effect (lastActiveAt refresh on session-touching tools)
     mockPrisma.agentSession.update.mockResolvedValue(
       makeSession({ status: "active", lastActiveAt: new Date(), taskCheckins: [] }),
     );
-    mockPrisma.agentSession.findUnique.mockResolvedValue({ status: "active" });
 
     await reopenSession(companyUuid, sessionUuid);
-    expectHeartbeatCall(old);
+
+    // Exactly one update call, carrying BOTH status and lastActiveAt — protects
+    // against concurrent closeSession seeing a half-applied state.
+    expect(mockPrisma.agentSession.update.mock.calls.length).toBe(1);
+    const updateData = mockPrisma.agentSession.update.mock.calls[0][0].data;
+    expect(updateData.status).toBe("active");
+    expect(updateData.lastActiveAt).toBeInstanceOf(Date);
+    expect((updateData.lastActiveAt as Date).getTime()).toBeGreaterThan(old.getTime());
+    // No separate touchLastActiveAt findUnique probe is performed in the atomic path.
+    expect(mockPrisma.agentSession.findUnique.mock.calls.length).toBe(0);
   });
 
   it("sessionCheckinToTask refreshes lastActiveAt on success", async () => {

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -13,7 +13,6 @@ export interface SessionCreateParams {
   agentUuid: string;
   name: string;
   description?: string | null;
-  expiresAt?: Date | null;
 }
 
 export interface SessionCheckinInfo {
@@ -29,7 +28,6 @@ export interface SessionResponse {
   description: string | null;
   status: string;
   lastActiveAt: string;
-  expiresAt: string | null;
   createdAt: string;
   updatedAt: string;
   checkins: SessionCheckinInfo[];
@@ -43,6 +41,37 @@ export interface TaskSessionInfo {
   checkinAt: string;
 }
 
+// ===== Staleness Primitives =====
+
+// A session is "fresh" if its lastActiveAt is within this window.
+// Default-list reads (UI) hide stale active sessions; audit-trail reads
+// (MCP listAgentSessions, getSession) ignore this filter.
+export const SESSION_STALE_THRESHOLD_MS = 60 * 60 * 1000;
+
+// Where-clause fragment matching active+fresh sessions.
+function freshSessionWhereClause() {
+  return {
+    status: "active",
+    lastActiveAt: { gt: new Date(Date.now() - SESSION_STALE_THRESHOLD_MS) },
+  };
+}
+
+// Single source of truth for refreshing lastActiveAt as a side-effect of
+// any session-touching operation. Skips the write when the session row is
+// already closed so closed sessions retain their final lastActiveAt.
+async function touchLastActiveAt(sessionUuid: string): Promise<void> {
+  const session = await prisma.agentSession.findUnique({
+    where: { uuid: sessionUuid },
+    select: { status: true },
+  });
+  if (!session || session.status === "closed") return;
+
+  await prisma.agentSession.update({
+    where: { uuid: sessionUuid },
+    data: { lastActiveAt: new Date() },
+  });
+}
+
 // ===== Internal Helper Functions =====
 
 function formatSessionResponse(
@@ -53,7 +82,6 @@ function formatSessionResponse(
     description: string | null;
     status: string;
     lastActiveAt: Date;
-    expiresAt: Date | null;
     createdAt: Date;
     updatedAt: Date;
     taskCheckins?: Array<{
@@ -70,7 +98,6 @@ function formatSessionResponse(
     description: session.description,
     status: session.status,
     lastActiveAt: session.lastActiveAt.toISOString(),
-    expiresAt: session.expiresAt?.toISOString() ?? null,
     createdAt: session.createdAt.toISOString(),
     updatedAt: session.updatedAt.toISOString(),
     checkins: (session.taskCheckins || []).map((c) => ({
@@ -92,14 +119,14 @@ export async function createSession(params: SessionCreateParams): Promise<Sessio
       name: params.name,
       description: params.description ?? null,
       status: "active",
-      expiresAt: params.expiresAt ?? null,
     },
   });
 
   return formatSessionResponse(session);
 }
 
-// Get Session details (including active checkins)
+// Get Session details (including active checkins). Audit-trail read — does
+// NOT apply the staleness filter; refreshes lastActiveAt as a side effect.
 export async function getSession(
   companyUuid: string,
   sessionUuid: string
@@ -115,10 +142,15 @@ export async function getSession(
   });
 
   if (!session) return null;
+
+  await touchLastActiveAt(sessionUuid);
+
   return formatSessionResponse(session);
 }
 
-// List Agent's Sessions
+// List Agent's Sessions — unfiltered MCP/audit-trail entry point. Returns
+// every session for the agent regardless of staleness; status filter is
+// optional and exact-match.
 export async function listAgentSessions(
   companyUuid: string,
   agentUuid: string,
@@ -142,7 +174,32 @@ export async function listAgentSessions(
   return sessions.map(formatSessionResponse);
 }
 
-// Close Session (status->closed, batch checkout all checkins)
+// List Agent's Sessions for the Settings UI — filtered to active+fresh only.
+export async function listAgentSessionsForUI(
+  companyUuid: string,
+  agentUuid: string
+): Promise<SessionResponse[]> {
+  const sessions = await prisma.agentSession.findMany({
+    where: {
+      companyUuid,
+      agentUuid,
+      ...freshSessionWhereClause(),
+    },
+    include: {
+      taskCheckins: {
+        where: { checkoutAt: null },
+        select: { taskUuid: true, checkinAt: true, checkoutAt: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return sessions.map(formatSessionResponse);
+}
+
+// Close Session (status->closed, batch checkout all checkins).
+// Refreshes lastActiveAt before flipping to closed so the row's last
+// activity timestamp reflects the close itself.
 export async function closeSession(
   companyUuid: string,
   sessionUuid: string
@@ -164,6 +221,11 @@ export async function closeSession(
     where: { sessionUuid, checkoutAt: null },
     data: { checkoutAt: new Date() },
   });
+
+  // Refresh lastActiveAt while the row is still open, then flip to closed.
+  // touchLastActiveAt itself will no-op once status='closed', so this
+  // ordering is the correct way to capture the close timestamp.
+  await touchLastActiveAt(sessionUuid);
 
   const updated = await prisma.agentSession.update({
     where: { uuid: sessionUuid },
@@ -223,11 +285,7 @@ export async function sessionCheckinToTask(
     update: { checkoutAt: null, checkinAt: new Date() },
   });
 
-  // Update lastActiveAt
-  await prisma.agentSession.update({
-    where: { uuid: sessionUuid },
-    data: { lastActiveAt: new Date() },
-  });
+  await touchLastActiveAt(sessionUuid);
 
   eventBus.emitChange({ companyUuid, projectUuid: task.projectUuid, entityType: "task", entityUuid: taskUuid, action: "updated" });
 
@@ -260,12 +318,14 @@ export async function sessionCheckoutFromTask(
     data: { checkoutAt: new Date() },
   });
 
+  await touchLastActiveAt(sessionUuid);
+
   if (task) {
     eventBus.emitChange({ companyUuid, projectUuid: task.projectUuid, entityType: "task", entityUuid: taskUuid, action: "updated" });
   }
 }
 
-// Get all active Sessions for a Task
+// Get all active+fresh Sessions for a Task
 export async function getSessionsForTask(
   companyUuid: string,
   taskUuid: string
@@ -274,7 +334,7 @@ export async function getSessionsForTask(
     where: {
       taskUuid,
       checkoutAt: null,
-      session: { companyUuid, status: { in: ["active", "inactive"] } },
+      session: { companyUuid, ...freshSessionWhereClause() },
     },
     include: {
       session: {
@@ -297,24 +357,19 @@ export async function getSessionsForTask(
   }));
 }
 
-// Heartbeat update lastActiveAt
+// Heartbeat — refresh lastActiveAt unconditionally on the resolved session.
+// No status mutation; staleness is computed at read time, not stored.
 export async function heartbeatSession(
   companyUuid: string,
   sessionUuid: string
 ): Promise<void> {
   const session = await prisma.agentSession.findFirst({
     where: { uuid: sessionUuid, companyUuid },
+    select: { uuid: true },
   });
   if (!session) throw new Error("Session not found");
 
-  await prisma.agentSession.update({
-    where: { uuid: sessionUuid },
-    data: {
-      lastActiveAt: new Date(),
-      // If status is inactive, restore to active after heartbeat
-      ...(session.status === "inactive" && { status: "active" }),
-    },
-  });
+  await touchLastActiveAt(sessionUuid);
 }
 
 // Reopen a closed Session (closed -> active)
@@ -329,12 +384,16 @@ export async function reopenSession(
   if (!session) throw new Error("Session not found");
   if (session.status !== "closed") throw new Error("Only closed sessions can be reopened");
 
-  const updated = await prisma.agentSession.update({
+  // Flip status to active first so touchLastActiveAt won't no-op.
+  await prisma.agentSession.update({
     where: { uuid: sessionUuid },
-    data: {
-      status: "active",
-      lastActiveAt: new Date(),
-    },
+    data: { status: "active" },
+  });
+
+  await touchLastActiveAt(sessionUuid);
+
+  const updated = await prisma.agentSession.findUniqueOrThrow({
+    where: { uuid: sessionUuid },
     include: {
       taskCheckins: {
         where: { checkoutAt: null },
@@ -346,7 +405,8 @@ export async function reopenSession(
   return formatSessionResponse(updated);
 }
 
-// Batch get active worker counts for multiple tasks (1 groupBy query instead of N individual queries)
+// Batch get active+fresh worker counts for multiple tasks (1 groupBy query
+// instead of N individual queries).
 export async function batchGetWorkerCountsForTasks(
   companyUuid: string,
   taskUuids: string[]
@@ -358,7 +418,7 @@ export async function batchGetWorkerCountsForTasks(
     where: {
       taskUuid: { in: taskUuids },
       checkoutAt: null,
-      session: { companyUuid, status: { in: ["active", "inactive"] } },
+      session: { companyUuid, ...freshSessionWhereClause() },
     },
     _count: { taskUuid: true },
   });
@@ -368,21 +428,6 @@ export async function batchGetWorkerCountsForTasks(
     result[checkin.taskUuid] = checkin._count.taskUuid;
   }
   return result;
-}
-
-// Batch mark inactive sessions (no heartbeat for 1 hour)
-export async function markInactiveSessions(): Promise<number> {
-  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-
-  const result = await prisma.agentSession.updateMany({
-    where: {
-      status: "active",
-      lastActiveAt: { lt: oneHourAgo },
-    },
-    data: { status: "inactive" },
-  });
-
-  return result.count;
 }
 
 // Get Session name (for Activity display)
@@ -399,7 +444,7 @@ export async function getSessionName(sessionUuid: string): Promise<string | null
  * Returns up to 5 unique workers (for PixelCanvas slots).
  *
  * Sources (merged, session-based workers listed first):
- * 1. Session-based: each unique session with active checkins = one sub-agent worker
+ * 1. Session-based: each unique active+fresh session with active checkins = one sub-agent worker
  * 2. Sessionless: agents with in_progress tasks that have NO active session checkin
  *    on those tasks = the main agent working directly (e.g. OpenClaw single-agent mode).
  *    Even if the same agent has sessions on other tasks, the main agent still counts
@@ -409,12 +454,12 @@ export async function getActiveSessionsForProject(
   companyUuid: string,
   projectUuid: string
 ): Promise<TaskSessionInfo[]> {
-  // 1. Session-based workers: each unique session = one sub-agent worker
+  // 1. Session-based workers: each unique active+fresh session = one sub-agent worker
   const checkins = await prisma.sessionTaskCheckin.findMany({
     where: {
       checkoutAt: null,
       task: { projectUuid },
-      session: { companyUuid, status: { in: ["active", "inactive"] } },
+      session: { companyUuid, ...freshSessionWhereClause() },
     },
     include: {
       session: {

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -126,7 +126,8 @@ export async function createSession(params: SessionCreateParams): Promise<Sessio
 }
 
 // Get Session details (including active checkins). Audit-trail read — does
-// NOT apply the staleness filter; refreshes lastActiveAt as a side effect.
+// NOT apply the staleness filter; refreshes lastActiveAt as a side effect on
+// non-closed rows so the returned timestamp reflects the touch.
 export async function getSession(
   companyUuid: string,
   sessionUuid: string
@@ -143,7 +144,16 @@ export async function getSession(
 
   if (!session) return null;
 
-  await touchLastActiveAt(sessionUuid);
+  // Reflect the heartbeat on the returned snapshot. Closed sessions skip the
+  // touch (preserves their final timestamp); active sessions take the new one.
+  if (session.status !== "closed") {
+    const fresh = new Date();
+    await prisma.agentSession.update({
+      where: { uuid: sessionUuid },
+      data: { lastActiveAt: fresh },
+    });
+    session.lastActiveAt = fresh;
+  }
 
   return formatSessionResponse(session);
 }
@@ -372,7 +382,10 @@ export async function heartbeatSession(
   await touchLastActiveAt(sessionUuid);
 }
 
-// Reopen a closed Session (closed -> active)
+// Reopen a closed Session (closed -> active). Atomic single-statement: flips
+// status and refreshes lastActiveAt in one update so a concurrent closeSession
+// can't observe a half-applied "active row with stale timestamp" or, worse,
+// flip us back to closed between our two writes.
 export async function reopenSession(
   companyUuid: string,
   sessionUuid: string
@@ -384,16 +397,9 @@ export async function reopenSession(
   if (!session) throw new Error("Session not found");
   if (session.status !== "closed") throw new Error("Only closed sessions can be reopened");
 
-  // Flip status to active first so touchLastActiveAt won't no-op.
-  await prisma.agentSession.update({
+  const updated = await prisma.agentSession.update({
     where: { uuid: sessionUuid },
-    data: { status: "active" },
-  });
-
-  await touchLastActiveAt(sessionUuid);
-
-  const updated = await prisma.agentSession.findUniqueOrThrow({
-    where: { uuid: sessionUuid },
+    data: { status: "active", lastActiveAt: new Date() },
     include: {
       taskCheckins: {
         where: { checkoutAt: null },


### PR DESCRIPTION
## Summary
- Collapse `AgentSession.status` to `{active, closed}`; drop the unused `expiresAt` field; remove dead code (`markInactiveSessions`, `inactive→active` recovery branch, every `inactive` literal).
- Add a 1h `lastActiveAt` staleness filter applied **only** on default UI lists (Settings sessions list, project worker-avatar header). MCP reads (`chorus_list_sessions`, `chorus_get_session`), the REST `/api/sessions/[uuid]` route, and Activity-stream session-name lookups remain unfiltered so plugin reuse and audit-trail links keep working.
- Bake heartbeat into every session-touching MCP tool (`getSession`, `closeSession`, `reopenSession`, `sessionCheckinToTask`, `sessionCheckoutFromTask`, `heartbeatSession`) with a guard that skips the refresh when `status='closed'`. Plugins no longer need standalone heartbeats during normal operation.

Implements idea 8f39105e via OpenSpec change `session-lifecycle-active-only` (archived under `openspec/changes/archive/2026-05-25-…/`); new long-term capability spec at `openspec/specs/session-lifecycle/spec.md`.

## Changed files
| File | Change |
|------|--------|
| `prisma/schema.prisma` | Drop `expiresAt`; comment now says `active \| closed`; `@@index([lastActiveAt])` added |
| `prisma/migrations/20260524144057_remove_session_expires_at/migration.sql` | Pure DDL — `DROP COLUMN expiresAt` + `CREATE INDEX AgentSession_lastActiveAt_idx`. No DML per project policy; residual `inactive` rows are excluded by the filter. |
| `src/services/session.service.ts` | Add `SESSION_STALE_THRESHOLD_MS`, `freshSessionWhereClause`, `touchLastActiveAt` (with closed-guard); split `listAgentSessions` (unfiltered, MCP) vs new `listAgentSessionsForUI` (filtered); wire `touchLastActiveAt` into all session-touching paths; delete `markInactiveSessions`, `inactive` literals, and `inactive→active` heartbeat recovery branch |
| `src/mcp/tools/session.ts` | Drop `expiresAt` from `chorus_create_session`; drop `inactive` from `chorus_list_sessions` status enum |
| `src/app/(dashboard)/settings/actions.ts` | Server action now calls `listAgentSessionsForUI` |
| `src/app/api/agents/[uuid]/sessions/route.ts` | Route now calls `listAgentSessionsForUI`; doc comment clarifies UI-vs-MCP filtering split |
| `src/app/(dashboard)/settings/page.tsx` | Count badge drops the post-filter; remove `inactive` styling branches; closed-reopen branch left defensively |
| `messages/{en,zh}.json` | `sessions.noSessions` empty-state message updated to "No active sessions in the last hour" / "近 1 小时内无活跃会话" |
| `src/services/__tests__/session.service.test.ts` | +16 tests: 1h cutoff boundary, filter applied vs not, getActiveSessionsForProject + batchGetWorkerCountsForTasks shape, heartbeat side-effect for each tool, closed-session guard, closeSession does not mutate Task.status, regression guard against `inactive` reintroduction |
| `docs/MCP_TOOLS.md` | New "Lifecycle and staleness" + "Implicit-heartbeat contract" sections; per-tool descriptions updated |
| `CHANGELOG.md` | 0.9.0 Unreleased "Changed (Breaking)" entry |
| `openspec/specs/session-lifecycle/spec.md` | New long-term capability spec (8 ADDED Requirements with scenarios) |
| `openspec/changes/archive/2026-05-25-session-lifecycle-active-only/` | Archived OpenSpec change (proposal, design, delta spec, tasks, README) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test src/services/__tests__/session.service.test.ts` — 48/48 pass
- [x] `pnpm test` full suite — 1588 pass / 1 skipped (pre-existing)
- [x] Coverage 95.91 lines / 88.55 branches (above 95/85 thresholds); session.service.ts at 99.07/98.14
- [x] `pnpm build` clean
- [x] Manual browser smoke on local stack (Playwright + local Chorus MCP):
  1. Create fresh session → visible in Settings (count=1, status=活跃)
  2. `UPDATE lastActiveAt = NOW() - 2h` → session hidden, new empty-state i18n key renders
  3. `chorus_session_heartbeat` → session reappears
- [x] OpenSpec validate passes; archive completed and mirrored back to Chorus document

## Notes for reviewers
- Migration is **DDL-only** (no `UPDATE` to backfill `inactive` rows). Per project policy, residual `inactive` rows from prior versions are handled by exclusion: the `status='active'` filter naturally excludes them, and the `heartbeatSession` recovery branch that previously revived them is removed.
- `touchLastActiveAt` includes a guard that skips the refresh when `status='closed'`, preserving the historical timestamp on closed sessions (raised by proposal-reviewer, implemented during execution, pinned by a unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)