### PR TITLE
feat(skills): add brainstorm skill as idea-stage elaboration prelude

### DIFF
--- a/openspec/changes/archive/2026-05-25-add-brainstorm-skill/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-25-add-brainstorm-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/archive/2026-05-25-add-brainstorm-skill/README.md
+++ b/openspec/changes/archive/2026-05-25-add-brainstorm-skill/README.md
@@ -1,0 +1,3 @@
+# add-brainstorm-skill
+
+Idea-stage brainstorm skill as optional elaboration prelude

--- a/openspec/changes/archive/2026-05-25-add-brainstorm-skill/design.md
+++ b/openspec/changes/archive/2026-05-25-add-brainstorm-skill/design.md
@@ -1,0 +1,127 @@
+# Design: Idea-stage brainstorm skill
+
+## Architecture
+
+```
+chorus_claim_idea ──▶ idea skill: gather context
+                            │
+                            ▼
+              AskUserQuestion("brainstorm? yes/no")
+                            │
+              ┌─────────────┴─────────────┐
+              │                           │
+            yes                          no
+              │                           │
+              ▼                           ▼
+       brainstorm skill            structured elaboration
+       (free-form Q&A,             (existing minimal/standard/
+        2-3 directions,             comprehensive Q&A flow)
+        approve gate)
+              │
+       Decision-point synthesis
+              │
+       chorus_pm_start_elaboration(depth="standard", questions=[…])
+       chorus_answer_elaboration(answers=[…])
+              │
+       (skill terminates — no validate)
+              │
+              ▼
+       idea skill: validate or follow-up?
+              │
+        ┌─────┴─────┐
+        │           │
+   covers all   gaps remain
+        │           │
+        ▼           ▼
+ validate({   validate({
+  issues:[]    issues, followUp
+ })           Questions   ──▶ structured Round 2
+              })              (depth picked by agent)
+```
+
+The brainstorm skill is **stateless** with respect to the idea: it produces one ElaborationRound and returns. All elaboration lifecycle decisions stay in the idea skill, matching the existing skill-boundary convention.
+
+## Components
+
+### 1. `brainstorm/SKILL.md` — the new skill
+
+One source-of-truth body (~80–120 lines), distributed to four packages with platform-specific frontmatter. Section order:
+
+- `## When invoked` — only as a sub-step of the `idea` skill, only after the user opts in via `AskUserQuestion`. Never invoked standalone.
+- `## Hard rules` — (1) one question at a time via `AskUserQuestion`, (2) multi-choice preferred, (3) propose 2-3 directions with a recommendation before locking in, (4) get explicit approval before stopping the divergent phase, (5) do not write files, do not post comments, do not invoke writing-plans, do not call `validate_elaboration`.
+- `## Step-by-step` — gather context → divergent Q&A → converge to 2-3 directions → confirm direction → synthesize decision-point Q&A → `start_elaboration` + `answer_elaboration` → return.
+- `## Synthesis spec` — exact mapping from conversation to `ElaborationQuestion[]` (see "Data flow" below).
+- `## Anti-patterns` — explicit "do not" list to keep the skill from drifting toward the original superpowers contract.
+
+### 2. `idea/SKILL.md` — modified Step 4.5
+
+Insert between current Step 4 (Gather Context) and Step 5 (Elaborate). The new step:
+
+1. After `chorus_get_idea` + the gather-context calls, ask the user via `AskUserQuestion` whether to run brainstorm. The question header is "Brainstorm"; options are "Already clear, run structured elaboration" vs "Brainstorm first to explore directions".
+2. On yes → invoke the `brainstorm` skill (Claude Code: `Skill brainstorm`; Codex: equivalent skill invocation).
+3. On brainstorm return → the idea skill alone owns the choice between `validate_elaboration({ issues: [] })` and `validate_elaboration({ issues, followUpQuestions })`. The follow-up depth (minimal / standard / comprehensive) is the agent's call — the user is not asked again.
+4. On no → proceed to Step 5 unchanged.
+
+The current Step 5.6 (`chorus_pm_validate_elaboration`) wording is amended to clarify that this call is the **single commit gate** for the entire elaboration phase, not a per-round close. This was a known source of confusion (an earlier brainstorm draft assumed per-round validate) and the corrected mental model belongs in the canonical idea skill.
+
+### 3. No other components
+
+No backend changes. No `ElaborationRound.kind` field. No UI changes. No new MCP tool. No config flag. The brainstorm rounds render in the existing elaboration UI as decision-point Q&A — they are well-formed `ElaborationQuestion` rows with options, a selected option, and rationale in `customText`.
+
+## Data flow
+
+### Input (from idea skill at Step 4.5)
+- `ideaUuid` (already claimed)
+- Project context already loaded (documents, prior proposals, comment thread)
+- User has answered `yes` to the brainstorm prompt
+
+### Output (back to idea skill)
+- Exactly one `ElaborationRound` in `answered` status
+- The round's `roundUuid` (returned by `start_elaboration`)
+- Skill returns control; no comments posted, no files written
+
+### Synthesis from conversation to ElaborationQuestion
+
+Each "decision point" in the brainstorm conversation becomes one ElaborationQuestion. A decision point is any moment where the user chose between alternatives or set scope. Mapping:
+
+| ElaborationQuestion field | Source from conversation |
+|---|---|
+| `text` | The decision question, phrased neutrally (e.g. "Which depth-model placement?") |
+| `category` | Derived from the decision topic (`scope`, `functional`, `technical_context`, etc.) |
+| `options` | All directions that were considered (max 5; collapse near-duplicates) |
+| `selectedOptionId` | The direction the user approved |
+| `customText` | 1–3 sentences capturing the rationale or constraint that drove the choice |
+
+Synthesis is the responsibility of the brainstorm skill — concentrating it in one place ensures consistent shape across packages.
+
+### Where the conversation log goes
+
+It does not. By design. The chosen synthesis pattern (decision-point Q&A) preserves the *outcomes*; the running back-and-forth is intentionally not persisted. If a user wants the raw conversation, they can copy it from the IDE transcript before the session ends. We considered "decision-point Q&A + a separate full-text comment" as alternative C and rejected it — it doubles the audit surface and creates two potentially divergent records.
+
+## Error handling
+
+| Scenario | Skill behavior |
+|---|---|
+| `chorus_pm_start_elaboration` returns error | Surface the error verbatim, halt. Per project policy [no_silent_errors], we do not swallow. The idea remains in `elaborating` status; user can retry or release. |
+| `chorus_answer_elaboration` returns error | Same — surface and halt. The round exists in `pending_answers` status and will appear in the UI; the idea skill's own retry path can re-call `answer_elaboration` later if the user resumes. |
+| User abandons brainstorm mid-conversation | Out of scope this round. The idea stays in `elaborating` with no completed round. Recovery (`elaborating + no active round`) is not yet detected. We accept this gap because brainstorm is opt-in and resuming via the structured path is always available as a fallback. |
+| Synthesis collapses too many alternatives into one option | Caught by review: the `Anti-patterns` section in `SKILL.md` explicitly warns against pre-narrowing. Reviewers should reject brainstorm rounds whose `options` arrays are all length-2 with binary "yes/no" framing. |
+
+## Testing
+
+This change is documentation-only — no unit tests apply. Acceptance is **dogfood**: run the four-package skill against a deliberately fuzzy Idea (e.g. one written as a single sentence with no concrete constraints) and confirm:
+
+1. The user is offered the brainstorm choice via `AskUserQuestion`.
+2. On `yes`, the brainstorm skill is invoked, asks one question at a time, proposes 2-3 directions, and gets explicit approval.
+3. A single ElaborationRound is created, with one `ElaborationQuestion` per material decision, all answered.
+4. Returning to the idea skill, the agent autonomously chooses between resolve and follow-up.
+5. The same flow works on each of the four distribution packages.
+
+A "did the audit trail capture what we needed to know?" check at the end is the canonical pass criterion.
+
+## Risks and trade-offs
+
+- **Skill drift across the four packages.** The body is hand-synced today across `idea`, `develop`, `proposal`, etc.; same risk applies here. Mitigation: keep the `brainstorm/SKILL.md` body short and treat one of the four locations (Claude Code plugin) as canonical, copy others from it. A diff check could be added to CI but is not part of this change. Note: the byte-identity guarantee applies to `brainstorm/SKILL.md` only — `idea/SKILL.md` already differs across the four packages today on cross-skill references (the three plugin packages use `/proposal`-style invocation; `public/skill/idea-chorus/SKILL.md` uses URL-style `proposal-chorus` references). The new Step 4.5 must follow each package's existing convention, not invent a new one.
+- **Synthesis quality depends on the agent.** Fabricating an `ElaborationQuestion` with a single misleading "selected" option could pollute the audit trail. Mitigated by the `Anti-patterns` section and by the review gate that the proposal-reviewer skill applies.
+- **No `kind` field means brainstorm rounds are indistinguishable from structured rounds at the data layer.** Acceptable for now — anyone reading the round can tell from the question shape (decision-point options vs. enumerated alternatives) which kind it is. If we ever want UI to render them differently, that's a future change.
+- **The terminal contract diverges from `superpowers/brainstorming`.** Anyone familiar with the upstream skill will need to read our `Anti-patterns` section to understand we're forking the cadence, not the contract.

--- a/openspec/changes/archive/2026-05-25-add-brainstorm-skill/proposal.md
+++ b/openspec/changes/archive/2026-05-25-add-brainstorm-skill/proposal.md
@@ -1,0 +1,52 @@
+# Proposal: Idea-stage brainstorm skill
+
+## Why
+
+Chorus's existing `elaboration` flow is structured Q&A — every question must be a multi-choice `ElaborationQuestion` with 2-5 options. This works well when requirements are concrete enough to enumerate options, but it breaks down when an Idea arrives in "still rephrasing" shape: the PM agent ends up fabricating options just to satisfy the schema, and the audit trail captures forced choices instead of the actual exploration.
+
+Anthropic's `superpowers/brainstorming` skill solved this with a simple cadence — one question at a time, propose 2-3 directions with a recommendation, get user approval before locking in. We want that cadence available inside Chorus's idea workflow without:
+
+- adopting `superpowers/brainstorming`'s terminal contract (write a `docs/superpowers/specs/<topic>-design.md` and hand off to `writing-plans`),
+- adding any backend / schema / UI changes,
+- mandating it for every Idea — it's only useful when the Idea is genuinely fuzzy.
+
+## What Changes
+
+Add a new opt-in `brainstorm` skill, distributed to **all four** Chorus skill packages so all supported agents can invoke it:
+
+- `public/chorus-plugin/skills/brainstorm/` (Claude Code plugin)
+- `plugins/chorus/skills/brainstorm/` (Codex plugin)
+- `public/skill/brainstorm-chorus/` (static `/skill/` distribution)
+- `packages/openclaw-plugin/skills/brainstorm/` (OpenClaw plugin)
+
+The four `SKILL.md` bodies are byte-identical; only frontmatter (license, version, mcp_server, naming convention per platform) differs.
+
+The skill is invoked from the `idea` skill (also in all four packages) at a new **Step 4.5: Brainstorm Mode (optional prelude)** between context gathering and structured elaboration. After `chorus_claim_idea` succeeds, the idea skill asks the user via `AskUserQuestion` whether to brainstorm. On yes, it invokes the `brainstorm` skill; on no, the existing structured flow continues unchanged.
+
+The `brainstorm` skill:
+
+1. Reads idea content and project context (same gather-context pattern as the idea skill itself).
+2. Runs a one-question-at-a-time exploration via `AskUserQuestion`.
+3. Once the direction is clear, presents 2-3 approaches with a recommendation and waits for user approval.
+4. Compresses the conversation into "decision-point" Q&A: each material decision becomes one `ElaborationQuestion` whose `options` are the directions that were considered, `selectedOptionId` is the chosen one, and `customText` is a 1-3 sentence rationale.
+5. Calls `chorus_pm_start_elaboration` (depth: `"standard"`) and `chorus_answer_elaboration` to persist the round.
+6. **Does not** call `chorus_pm_validate_elaboration`. The validate / follow-up decision belongs to the calling idea skill.
+
+Returning to the idea skill, the agent decides:
+
+- Brainstorm answers cover everything → call `validate_elaboration` with `issues: []` to resolve.
+- New gaps surfaced during brainstorm → call `validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2 (depth chosen by the agent without asking the user again).
+
+## Capabilities
+
+This change adds one new capability:
+
+- **`idea-elaboration-brainstorm`** — opt-in idea-stage brainstorm prelude that synthesizes free-form exploration into ElaborationRound Q&A, with no backend/schema/UI impact.
+
+## Impact
+
+- **Affected code**: 8 files (4 new `brainstorm/SKILL.md`, 4 modified `idea/SKILL.md`); zero TypeScript / Prisma / React.
+- **Affected workflows**: PM agents claiming fuzzy ideas; existing elaboration flows are not touched.
+- **Affected runtime**: none. No migrations, no new dependencies, no MCP tool changes, no config flags.
+- **Risk**: low. The branch is opt-in (user has to say yes to brainstorm). If the brainstorm cadence misbehaves, fallback is "answer no, run structured elaboration" — identical to today.
+- **Out of scope (deferred)**: backend `ElaborationRound.kind` field; UI rendering changes for brainstorm rounds; mid-conversation recovery if user abandons brainstorm; design doc / writing-plans handoff.

--- a/openspec/changes/archive/2026-05-25-add-brainstorm-skill/specs/idea-elaboration-brainstorm/spec.md
+++ b/openspec/changes/archive/2026-05-25-add-brainstorm-skill/specs/idea-elaboration-brainstorm/spec.md
@@ -1,0 +1,128 @@
+# idea-elaboration-brainstorm Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Brainstorm skill SHALL be distributed to all four Chorus skill packages
+
+The brainstorm skill MUST be present in each of the four skill distribution paths so that any supported agent can invoke it without per-platform divergence in behavior:
+
+- `public/chorus-plugin/skills/brainstorm/SKILL.md` (Claude Code plugin)
+- `plugins/chorus/skills/brainstorm/SKILL.md` (Codex plugin)
+- `public/skill/brainstorm-chorus/SKILL.md` (static skill distribution served at `/skill/`)
+- `packages/openclaw-plugin/skills/brainstorm/SKILL.md` (OpenClaw plugin)
+
+The body content of `brainstorm/SKILL.md` MUST be byte-identical across all four locations (modulo trailing newline). The brainstorm skill body does not reference any other skill — it is invoked by name from the `idea` skill — so true byte-identity is achievable without per-package syntax translation. Frontmatter MAY differ to match each platform's manifest conventions (e.g. license, version, mcp_server, emoji, distribution-specific naming).
+
+The byte-identity requirement applies ONLY to `brainstorm/SKILL.md`. The `idea/SKILL.md` files in the four packages MAY still differ in cross-skill reference syntax (e.g. `/proposal` vs `proposal-chorus` skill at a URL), as they already do today for existing references. See the separate "Idea skill SHALL offer brainstorm as an opt-in prelude" requirement for what idea/SKILL.md must contain.
+
+#### Scenario: All four package locations contain the skill
+
+- **WHEN** a release artifact is built from `develop`
+- **THEN** each of the four `brainstorm/SKILL.md` paths above MUST exist
+- **AND** the body content (everything after the frontmatter `---` close) of `brainstorm/SKILL.md` MUST be byte-identical across all four files
+
+#### Scenario: Brainstorm skill body diverges across packages
+
+- **WHEN** a CI check or reviewer compares the four `brainstorm/SKILL.md` bodies
+- **AND** any two bodies differ in non-whitespace content (excluding trailing newlines)
+- **THEN** the divergence MUST be flagged as a blocker for merge
+
+### Requirement: Idea skill SHALL offer brainstorm as an opt-in prelude
+
+The `idea` skill in each of the four packages MUST include a "Step 4.5: Brainstorm Mode" between context gathering (current Step 4) and structured elaboration (current Step 5). The step uses `AskUserQuestion` to ask the user whether to brainstorm before structured elaboration begins.
+
+#### Scenario: User opts to brainstorm
+
+- **WHEN** the agent has just completed `chorus_claim_idea` and gather-context for an Idea
+- **AND** the agent prompts via `AskUserQuestion` with header "Brainstorm" and options "Already clear, run structured elaboration" vs "Brainstorm first to explore directions"
+- **AND** the user selects "Brainstorm first to explore directions"
+- **THEN** the agent SHALL invoke the `brainstorm` skill
+- **AND** SHALL NOT call `chorus_pm_start_elaboration` until the brainstorm skill returns
+
+#### Scenario: User opts to skip brainstorm
+
+- **WHEN** the agent prompts via `AskUserQuestion` with the brainstorm choice
+- **AND** the user selects "Already clear, run structured elaboration"
+- **THEN** the agent SHALL proceed directly to current Step 5 (structured elaboration) with no calls to the brainstorm skill
+- **AND** the existing minimal/standard/comprehensive depth flow MUST behave identically to its pre-change form
+
+### Requirement: Brainstorm skill SHALL run divergent-then-convergent dialogue
+
+The brainstorm skill MUST follow a one-question-at-a-time cadence: ask one `AskUserQuestion` at a time during the divergent phase, then propose 2-3 distinct directions with one explicitly recommended, and require explicit user approval before exiting the divergent phase.
+
+#### Scenario: Divergent phase asks one question per turn
+
+- **WHEN** the brainstorm skill is exploring requirements
+- **THEN** each `AskUserQuestion` call MUST contain exactly one `question` entry
+- **AND** the skill MUST wait for the user's answer before asking the next question
+
+#### Scenario: Convergence presents 2-3 alternatives with a recommendation
+
+- **WHEN** the brainstorm skill judges that the requirement direction is clear enough
+- **THEN** the skill MUST present 2-3 distinct approaches in a single `AskUserQuestion`
+- **AND** exactly one approach MUST be visibly marked as the recommended option to the user (the specific marking convention — e.g. ordering, label suffix — follows whatever the host tool's `AskUserQuestion` documentation prescribes; the spec does not dictate the marking format)
+
+#### Scenario: Skill exits divergent phase only after explicit approval
+
+- **WHEN** the brainstorm skill has presented 2-3 approaches
+- **AND** the user selects one
+- **THEN** the skill MAY proceed to synthesis
+- **AND** SHALL NOT proceed to synthesis if the user has not selected an option
+
+### Requirement: Brainstorm skill SHALL synthesize conversation as decision-point Q&A
+
+The brainstorm skill MUST compress the conversation into one `ElaborationQuestion` per material decision point. Each synthesized question MUST be a well-formed `ElaborationQuestion` accepted by `chorus_pm_start_elaboration`.
+
+#### Scenario: Each decision becomes one ElaborationQuestion
+
+- **WHEN** the brainstorm skill performs synthesis
+- **THEN** for each material decision the user made during the conversation, exactly one `ElaborationQuestion` MUST be produced
+- **AND** that question's `options` array MUST list the directions that were considered (2-5 options; near-duplicates collapsed)
+- **AND** `selectedOptionId` MUST identify the direction the user approved
+- **AND** `customText` MUST contain a 1-3 sentence rationale capturing the constraint or tradeoff that drove the choice
+
+#### Scenario: Synthesis preserves outcomes, not transcript
+
+- **WHEN** the brainstorm skill performs synthesis
+- **THEN** the skill MUST NOT post the raw conversation transcript as a comment, document draft, file, or `customText` blob
+- **AND** the skill MUST NOT write any file on disk
+- **AND** the skill MUST NOT invoke any `writing-plans`, `writing-skills`, or design-doc-producing skill
+
+### Requirement: Brainstorm skill SHALL persist exactly one ElaborationRound and return control
+
+The brainstorm skill is the *producer* of the brainstorm round; the calling `idea` skill is the *scheduler* that decides whether to validate or follow up. The brainstorm skill MUST NOT call `chorus_pm_validate_elaboration`.
+
+#### Scenario: Skill terminates after answer_elaboration succeeds
+
+- **WHEN** the brainstorm skill has called `chorus_pm_start_elaboration` (depth: `"standard"`) successfully
+- **AND** has called `chorus_answer_elaboration` successfully
+- **THEN** the skill MUST return control to the calling idea skill
+- **AND** SHALL NOT call `chorus_pm_validate_elaboration` itself
+
+#### Scenario: Calling idea skill chooses validate or follow-up
+
+- **WHEN** the brainstorm skill has returned to the calling idea skill
+- **AND** the synthesized round answers cover all open questions
+- **THEN** the idea skill SHALL call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration
+
+- **WHEN** the brainstorm skill has returned to the calling idea skill
+- **AND** the synthesized round answers leave gaps the agent can articulate as concrete follow-up questions
+- **THEN** the idea skill SHALL call `chorus_pm_validate_elaboration` with `issues: [...]` and `followUpQuestions: [...]` to start a structured Round 2
+- **AND** the follow-up depth (minimal / standard / comprehensive) is chosen by the agent without re-prompting the user
+
+### Requirement: Change SHALL NOT modify backend, schema, or UI
+
+This change MUST be documentation-only. No production TypeScript, Prisma migration, React component, MCP tool registration, REST endpoint, or runtime config flag SHALL be added or modified by this change.
+
+#### Scenario: Change touches only skill markdown files
+
+- **WHEN** the change diff is reviewed
+- **THEN** all modified files MUST be `*.md` under one of the four skill distribution roots
+- **AND** no file under `src/`, `prisma/`, `messages/`, `public/` (except `public/skill/` and `public/chorus-plugin/skills/`), `packages/chorus-cdk/`, `packages/openclaw-plugin/` (except `packages/openclaw-plugin/skills/`) may be modified
+- **AND** no Prisma migration may be added under `prisma/migrations/`
+
+#### Scenario: Brainstorm round is well-formed against current schema
+
+- **WHEN** the brainstorm skill calls `chorus_pm_start_elaboration` and `chorus_answer_elaboration`
+- **THEN** the resulting `ElaborationRound` and its `ElaborationQuestion` rows MUST validate against the current Prisma schema with no new fields
+- **AND** the round MUST render correctly in the existing elaboration UI without UI changes

--- a/openspec/specs/idea-elaboration-brainstorm/spec.md
+++ b/openspec/specs/idea-elaboration-brainstorm/spec.md
@@ -1,0 +1,130 @@
+# idea-elaboration-brainstorm Specification
+
+## Purpose
+TBD - created by archiving change add-brainstorm-skill. Update Purpose after archive.
+## Requirements
+### Requirement: Brainstorm skill SHALL be distributed to all four Chorus skill packages
+
+The brainstorm skill MUST be present in each of the four skill distribution paths so that any supported agent can invoke it without per-platform divergence in behavior:
+
+- `public/chorus-plugin/skills/brainstorm/SKILL.md` (Claude Code plugin)
+- `plugins/chorus/skills/brainstorm/SKILL.md` (Codex plugin)
+- `public/skill/brainstorm-chorus/SKILL.md` (static skill distribution served at `/skill/`)
+- `packages/openclaw-plugin/skills/brainstorm/SKILL.md` (OpenClaw plugin)
+
+The body content of `brainstorm/SKILL.md` MUST be byte-identical across all four locations (modulo trailing newline). The brainstorm skill body does not reference any other skill — it is invoked by name from the `idea` skill — so true byte-identity is achievable without per-package syntax translation. Frontmatter MAY differ to match each platform's manifest conventions (e.g. license, version, mcp_server, emoji, distribution-specific naming).
+
+The byte-identity requirement applies ONLY to `brainstorm/SKILL.md`. The `idea/SKILL.md` files in the four packages MAY still differ in cross-skill reference syntax (e.g. `/proposal` vs `proposal-chorus` skill at a URL), as they already do today for existing references. See the separate "Idea skill SHALL offer brainstorm as an opt-in prelude" requirement for what idea/SKILL.md must contain.
+
+#### Scenario: All four package locations contain the skill
+
+- **WHEN** a release artifact is built from `develop`
+- **THEN** each of the four `brainstorm/SKILL.md` paths above MUST exist
+- **AND** the body content (everything after the frontmatter `---` close) of `brainstorm/SKILL.md` MUST be byte-identical across all four files
+
+#### Scenario: Brainstorm skill body diverges across packages
+
+- **WHEN** a CI check or reviewer compares the four `brainstorm/SKILL.md` bodies
+- **AND** any two bodies differ in non-whitespace content (excluding trailing newlines)
+- **THEN** the divergence MUST be flagged as a blocker for merge
+
+### Requirement: Idea skill SHALL offer brainstorm as an opt-in prelude
+
+The `idea` skill in each of the four packages MUST include a "Step 4.5: Brainstorm Mode" between context gathering (current Step 4) and structured elaboration (current Step 5). The step uses `AskUserQuestion` to ask the user whether to brainstorm before structured elaboration begins.
+
+#### Scenario: User opts to brainstorm
+
+- **WHEN** the agent has just completed `chorus_claim_idea` and gather-context for an Idea
+- **AND** the agent prompts via `AskUserQuestion` with header "Brainstorm" and options "Already clear, run structured elaboration" vs "Brainstorm first to explore directions"
+- **AND** the user selects "Brainstorm first to explore directions"
+- **THEN** the agent SHALL invoke the `brainstorm` skill
+- **AND** SHALL NOT call `chorus_pm_start_elaboration` until the brainstorm skill returns
+
+#### Scenario: User opts to skip brainstorm
+
+- **WHEN** the agent prompts via `AskUserQuestion` with the brainstorm choice
+- **AND** the user selects "Already clear, run structured elaboration"
+- **THEN** the agent SHALL proceed directly to current Step 5 (structured elaboration) with no calls to the brainstorm skill
+- **AND** the existing minimal/standard/comprehensive depth flow MUST behave identically to its pre-change form
+
+### Requirement: Brainstorm skill SHALL run divergent-then-convergent dialogue
+
+The brainstorm skill MUST follow a one-question-at-a-time cadence: ask one `AskUserQuestion` at a time during the divergent phase, then propose 2-3 distinct directions with one explicitly recommended, and require explicit user approval before exiting the divergent phase.
+
+#### Scenario: Divergent phase asks one question per turn
+
+- **WHEN** the brainstorm skill is exploring requirements
+- **THEN** each `AskUserQuestion` call MUST contain exactly one `question` entry
+- **AND** the skill MUST wait for the user's answer before asking the next question
+
+#### Scenario: Convergence presents 2-3 alternatives with a recommendation
+
+- **WHEN** the brainstorm skill judges that the requirement direction is clear enough
+- **THEN** the skill MUST present 2-3 distinct approaches in a single `AskUserQuestion`
+- **AND** exactly one approach MUST be visibly marked as the recommended option to the user (the specific marking convention — e.g. ordering, label suffix — follows whatever the host tool's `AskUserQuestion` documentation prescribes; the spec does not dictate the marking format)
+
+#### Scenario: Skill exits divergent phase only after explicit approval
+
+- **WHEN** the brainstorm skill has presented 2-3 approaches
+- **AND** the user selects one
+- **THEN** the skill MAY proceed to synthesis
+- **AND** SHALL NOT proceed to synthesis if the user has not selected an option
+
+### Requirement: Brainstorm skill SHALL synthesize conversation as decision-point Q&A
+
+The brainstorm skill MUST compress the conversation into one `ElaborationQuestion` per material decision point. Each synthesized question MUST be a well-formed `ElaborationQuestion` accepted by `chorus_pm_start_elaboration`.
+
+#### Scenario: Each decision becomes one ElaborationQuestion
+
+- **WHEN** the brainstorm skill performs synthesis
+- **THEN** for each material decision the user made during the conversation, exactly one `ElaborationQuestion` MUST be produced
+- **AND** that question's `options` array MUST list the directions that were considered (2-5 options; near-duplicates collapsed)
+- **AND** `selectedOptionId` MUST identify the direction the user approved
+- **AND** `customText` MUST contain a 1-3 sentence rationale capturing the constraint or tradeoff that drove the choice
+
+#### Scenario: Synthesis preserves outcomes, not transcript
+
+- **WHEN** the brainstorm skill performs synthesis
+- **THEN** the skill MUST NOT post the raw conversation transcript as a comment, document draft, file, or `customText` blob
+- **AND** the skill MUST NOT write any file on disk
+- **AND** the skill MUST NOT invoke any `writing-plans`, `writing-skills`, or design-doc-producing skill
+
+### Requirement: Brainstorm skill SHALL persist exactly one ElaborationRound and return control
+
+The brainstorm skill is the *producer* of the brainstorm round; the calling `idea` skill is the *scheduler* that decides whether to validate or follow up. The brainstorm skill MUST NOT call `chorus_pm_validate_elaboration`.
+
+#### Scenario: Skill terminates after answer_elaboration succeeds
+
+- **WHEN** the brainstorm skill has called `chorus_pm_start_elaboration` (depth: `"standard"`) successfully
+- **AND** has called `chorus_answer_elaboration` successfully
+- **THEN** the skill MUST return control to the calling idea skill
+- **AND** SHALL NOT call `chorus_pm_validate_elaboration` itself
+
+#### Scenario: Calling idea skill chooses validate or follow-up
+
+- **WHEN** the brainstorm skill has returned to the calling idea skill
+- **AND** the synthesized round answers cover all open questions
+- **THEN** the idea skill SHALL call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration
+
+- **WHEN** the brainstorm skill has returned to the calling idea skill
+- **AND** the synthesized round answers leave gaps the agent can articulate as concrete follow-up questions
+- **THEN** the idea skill SHALL call `chorus_pm_validate_elaboration` with `issues: [...]` and `followUpQuestions: [...]` to start a structured Round 2
+- **AND** the follow-up depth (minimal / standard / comprehensive) is chosen by the agent without re-prompting the user
+
+### Requirement: Change SHALL NOT modify backend, schema, or UI
+
+This change MUST be documentation-only. No production TypeScript, Prisma migration, React component, MCP tool registration, REST endpoint, or runtime config flag SHALL be added or modified by this change.
+
+#### Scenario: Change touches only skill markdown files
+
+- **WHEN** the change diff is reviewed
+- **THEN** all modified files MUST be `*.md` under one of the four skill distribution roots
+- **AND** no file under `src/`, `prisma/`, `messages/`, `public/` (except `public/skill/` and `public/chorus-plugin/skills/`), `packages/chorus-cdk/`, `packages/openclaw-plugin/` (except `packages/openclaw-plugin/skills/`) may be modified
+- **AND** no Prisma migration may be added under `prisma/migrations/`
+
+#### Scenario: Brainstorm round is well-formed against current schema
+
+- **WHEN** the brainstorm skill calls `chorus_pm_start_elaboration` and `chorus_answer_elaboration`
+- **THEN** the resulting `ElaborationRound` and its `ElaborationQuestion` rows MUST validate against the current Prisma schema with no new fields
+- **AND** the round MUST render correctly in the existing elaboration UI without UI changes
+

--- a/openspec/specs/idea-elaboration-brainstorm/spec.md
+++ b/openspec/specs/idea-elaboration-brainstorm/spec.md
@@ -1,7 +1,8 @@
 # idea-elaboration-brainstorm Specification
 
 ## Purpose
-TBD - created by archiving change add-brainstorm-skill. Update Purpose after archive.
+
+The `brainstorm` skill provides an opt-in divergent-then-convergent dialogue cadence for Idea-stage elaboration when the Idea is too fuzzy for the existing structured multi-choice Q&A flow. The skill runs one question at a time, proposes 2-3 directions with a recommendation, gets explicit user approval, and synthesizes the conversation into one `ElaborationRound` of decision-point Q&A. It is a producer of audit-trail data, not a scheduler — the calling idea skill owns the validate / follow-up decision. The skill ships in all four Chorus skill distribution packages (Claude Code plugin, Codex plugin, public/skill/, OpenClaw plugin).
 ## Requirements
 ### Requirement: Brainstorm skill SHALL be distributed to all four Chorus skill packages
 
@@ -12,7 +13,12 @@ The brainstorm skill MUST be present in each of the four skill distribution path
 - `public/skill/brainstorm-chorus/SKILL.md` (static skill distribution served at `/skill/`)
 - `packages/openclaw-plugin/skills/brainstorm/SKILL.md` (OpenClaw plugin)
 
-The body content of `brainstorm/SKILL.md` MUST be byte-identical across all four locations (modulo trailing newline). The brainstorm skill body does not reference any other skill — it is invoked by name from the `idea` skill — so true byte-identity is achievable without per-package syntax translation. Frontmatter MAY differ to match each platform's manifest conventions (e.g. license, version, mcp_server, emoji, distribution-specific naming).
+The body content of `brainstorm/SKILL.md` MUST be byte-identical across the three Chorus-native packages (Claude Code plugin, Codex plugin, public/skill/), modulo trailing newline. The OpenClaw distribution (`packages/openclaw-plugin/skills/brainstorm/SKILL.md`) MAY diverge in two narrow cases — and ONLY these two:
+
+1. **MCP tool name prefixes.** OpenClaw re-exports the Chorus elaboration tools without the `pm_` prefix (`chorus_start_elaboration` / `chorus_validate_elaboration` instead of `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration`). The OpenClaw copy MUST substitute the unprefixed names in step 6, step 7, hard rule 8, and the anti-patterns section. `chorus_answer_elaboration` keeps the same name across packages.
+2. **Host-specific prompt-tool examples.** The Claude Code / Codex / public-skill copies MAY reference `AskUserQuestion` (Claude Code's native interactive prompt tool) by name; the OpenClaw copy MUST use host-neutral language ("user-facing prompt", "interactive prompt mechanism your host provides") since OpenClaw exposes a different prompt surface.
+
+No other content divergence is permitted in any package. Frontmatter MAY differ to match each platform's manifest conventions (e.g. license, version, mcp_server, emoji, distribution-specific naming) and is NOT subject to byte-identity.
 
 The byte-identity requirement applies ONLY to `brainstorm/SKILL.md`. The `idea/SKILL.md` files in the four packages MAY still differ in cross-skill reference syntax (e.g. `/proposal` vs `proposal-chorus` skill at a URL), as they already do today for existing references. See the separate "Idea skill SHALL offer brainstorm as an opt-in prelude" requirement for what idea/SKILL.md must contain.
 
@@ -20,13 +26,20 @@ The byte-identity requirement applies ONLY to `brainstorm/SKILL.md`. The `idea/S
 
 - **WHEN** a release artifact is built from `develop`
 - **THEN** each of the four `brainstorm/SKILL.md` paths above MUST exist
-- **AND** the body content (everything after the frontmatter `---` close) of `brainstorm/SKILL.md` MUST be byte-identical across all four files
+- **AND** the body content of the three Chorus-native packages (Claude Code plugin, Codex plugin, public/skill/) MUST be byte-identical
+- **AND** the OpenClaw body MUST be byte-identical to the Chorus-native bodies EXCEPT for the two carve-outs above (MCP tool name prefixes; host-neutral prompt language)
 
 #### Scenario: Brainstorm skill body diverges across packages
 
 - **WHEN** a CI check or reviewer compares the four `brainstorm/SKILL.md` bodies
-- **AND** any two bodies differ in non-whitespace content (excluding trailing newlines)
+- **AND** any two bodies differ in non-whitespace content beyond the two carve-outs above (modulo trailing newlines)
 - **THEN** the divergence MUST be flagged as a blocker for merge
+
+#### Scenario: OpenClaw uses Chorus-native MCP tool names
+
+- **WHEN** a CI check or reviewer reads `packages/openclaw-plugin/skills/brainstorm/SKILL.md`
+- **AND** the body references `chorus_pm_start_elaboration` or `chorus_pm_validate_elaboration` (the prefixed Chorus-native names)
+- **THEN** the divergence MUST be flagged as a blocker for merge — OpenClaw exposes these tools as `chorus_start_elaboration` / `chorus_validate_elaboration` and the prefixed names will fail at the tool-call layer.
 
 ### Requirement: Idea skill SHALL offer brainstorm as an opt-in prelude
 

--- a/packages/openclaw-plugin/skills/brainstorm/SKILL.md
+++ b/packages/openclaw-plugin/skills/brainstorm/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: brainstorm
+description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never validates elaboration.
+metadata:
+  openclaw:
+    emoji: "💭"
+---
+
+# Brainstorm Skill
+
+A divergent-then-convergent dialogue cadence for ideas whose direction is still being formed. Compresses the conversation into one `ElaborationRound` of decision-point Q&A — same shape as a structured elaboration round, but the questions, options and answers are synthesized at the end of the conversation rather than asked up front.
+
+This skill is a **producer** of one elaboration round; the **scheduler** decision (validate vs. follow-up) belongs to the calling idea skill.
+
+---
+
+## When invoked
+
+Only as a sub-step of the idea skill, only after the user has explicitly opted in via `AskUserQuestion`. Never run standalone, never run without user opt-in. The expected entry point is the idea skill's "Step 4.5: Brainstorm Mode (Optional Prelude)" — see the idea skill for the surrounding flow.
+
+---
+
+## Hard rules
+
+1. **One question at a time.** Each `AskUserQuestion` call MUST contain exactly one question entry. Wait for the answer before asking the next.
+2. **Multi-choice preferred.** Frame each question as 2-4 options where possible. Open-ended is acceptable when options would be premature, but lean toward concrete choices.
+3. **Propose 2-3 directions before stopping divergence.** Once the requirement direction is clear enough to enumerate, present 2-3 distinct approaches in a single `AskUserQuestion`. Mark exactly one as the recommended option per the host tool's `AskUserQuestion` recommendation convention (the spec does not dictate a specific marking format — follow the tool's documentation).
+4. **Explicit user approval required to exit divergence.** Do NOT proceed to synthesis until the user has selected one of the proposed directions.
+5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
+6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
+7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+
+---
+
+## Step-by-step
+
+### 1. Gather context
+
+Before asking the first divergent question, read the idea and surrounding project state. Mirror the idea skill's gather-context list:
+
+```
+chorus_get_idea({ ideaUuid })
+chorus_get_documents({ projectUuid })
+chorus_get_document({ documentUuid })   # for any document worth reading in full
+chorus_get_proposals({ projectUuid, status: "approved" })   # to understand patterns
+chorus_list_tasks({ projectUuid })   # to avoid duplicating existing work
+chorus_get_comments({ targetType: "idea", targetUuid: ideaUuid })
+```
+
+Skim each result for: stated background, stated requirements, stated constraints, and what is conspicuously NOT stated. The gaps are the questions worth asking.
+
+### 2. Divergent Q&A
+
+Ask one question at a time via `AskUserQuestion`. Aim to surface:
+
+- The **goal** the idea is trying to serve (often more abstract than the idea statement).
+- The **constraints** that exclude entire branches of solution space (deadlines, compatibility, scope).
+- The **success criteria** — how will the user know this is done.
+
+Keep each question single-purpose. If you need to ask three things, that is three rounds, not one combined `AskUserQuestion`.
+
+### 3. Propose 2-3 directions
+
+When the goal, constraints, and success criteria are clear enough that you can name distinct approaches, present them in a single `AskUserQuestion`:
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "<the convergence question>",
+      header: "<short header>",
+      options: [
+        { label: "Option A (Recommended)", description: "<what + tradeoff>" },
+        { label: "Option B", description: "<what + tradeoff>" },
+        { label: "Option C", description: "<what + tradeoff>" }
+      ],
+      multiSelect: false
+    }
+  ]
+})
+```
+
+The recommendation must be visibly marked to the user using the host tool's `AskUserQuestion` convention. State **why** you recommend it — usually a sentence about the dominant tradeoff.
+
+### 4. Wait for explicit approval
+
+Do not proceed to synthesis if the user has not selected one of the options. If the user picks "Other" with free text, treat that as a new constraint — go back to step 2 or step 3 with the refined direction.
+
+### 5. Synthesize decision-point Q&A
+
+For each material decision the user made during the conversation, build one `ElaborationQuestion`. A "material decision" is a moment where the user chose between alternatives or set scope explicitly. Map each decision per the synthesis spec below.
+
+### 6. Persist the round
+
+Call `chorus_pm_start_elaboration` with the synthesized questions:
+
+```
+chorus_pm_start_elaboration({
+  ideaUuid,
+  depth: "standard",
+  questions: [
+    { id: "q1", text: "...", category: "...", options: [...] },
+    ...
+  ]
+})
+```
+
+Then submit the answers in one call:
+
+```
+chorus_answer_elaboration({
+  ideaUuid,
+  roundUuid,
+  answers: [
+    { questionId: "q1", selectedOptionId: "...", customText: "<rationale>" },
+    ...
+  ]
+})
+```
+
+### 7. Return control
+
+Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
+
+- If the synthesized round answers cover everything → caller validates with `issues: []`.
+- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+
+The depth of any follow-up round is the caller's call, not yours.
+
+---
+
+## Synthesis spec
+
+Each material decision becomes exactly one `ElaborationQuestion` with these fields:
+
+| Field | Source |
+|---|---|
+| `text` | The decision question, phrased neutrally. Example: "Which depth-model placement?" |
+| `category` | `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, or `scope` — derived from the topic. |
+| `options` | All directions that were considered, length 2-5. Collapse near-duplicates into one option. |
+| `selectedOptionId` | The id of the option the user approved. |
+| `customText` | A 1-3 sentence rationale capturing the constraint or tradeoff that drove the choice. Not a transcript dump. |
+
+Rules:
+
+- A `customText` longer than ~3 sentences is a sign you are summarizing transcript instead of capturing rationale. Cut.
+- An `options` array of length 2 with binary "yes / no" framing is a sign you pre-narrowed alternatives. Re-examine — there are usually at least three meaningfully different paths, even if two of them get rejected quickly.
+- Skip "decisions" that were never genuinely contested. If the user agreed instantly to the only proposal, that is information for the idea content, not a decision-point Q&A.
+
+---
+
+## Anti-patterns
+
+Do not do any of the following. Each has a specific failure mode that this skill must prevent:
+
+- **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
+- **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
+- **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
+- **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
+- **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/packages/openclaw-plugin/skills/brainstorm/SKILL.md
+++ b/packages/openclaw-plugin/skills/brainstorm/SKILL.md
@@ -16,20 +16,20 @@ This skill is a **producer** of one elaboration round; the **scheduler** decisio
 
 ## When invoked
 
-Only as a sub-step of the idea skill, only after the user has explicitly opted in via `AskUserQuestion`. Never run standalone, never run without user opt-in. The expected entry point is the idea skill's "Step 4.5: Brainstorm Mode (Optional Prelude)" — see the idea skill for the surrounding flow.
+Only as a sub-step of the idea skill, only after the user has explicitly opted in. Never run standalone, never run without user opt-in. The expected entry point is the idea skill's "Step 4.5: Brainstorm Mode (Optional Prelude)" — see the idea skill for the surrounding flow.
 
 ---
 
 ## Hard rules
 
-1. **One question at a time.** Each `AskUserQuestion` call MUST contain exactly one question entry. Wait for the answer before asking the next.
+1. **One question at a time.** Each user-facing prompt MUST contain exactly one question. Wait for the answer before asking the next.
 2. **Multi-choice preferred.** Frame each question as 2-4 options where possible. Open-ended is acceptable when options would be premature, but lean toward concrete choices.
-3. **Propose 2-3 directions before stopping divergence.** Once the requirement direction is clear enough to enumerate, present 2-3 distinct approaches in a single `AskUserQuestion`. Mark exactly one as the recommended option per the host tool's `AskUserQuestion` recommendation convention (the spec does not dictate a specific marking format — follow the tool's documentation).
+3. **Propose 2-3 directions before stopping divergence.** Once the requirement direction is clear enough to enumerate, present 2-3 distinct approaches in a single prompt. Mark exactly one as the recommended option per the host's prompt convention (the spec does not dictate a specific marking format — follow the host's documentation).
 4. **Explicit user approval required to exit divergence.** Do NOT proceed to synthesis until the user has selected one of the proposed directions.
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -52,36 +52,19 @@ Skim each result for: stated background, stated requirements, stated constraints
 
 ### 2. Divergent Q&A
 
-Ask one question at a time via `AskUserQuestion`. Aim to surface:
+Ask one question at a time via your host's interactive prompt mechanism. Aim to surface:
 
 - The **goal** the idea is trying to serve (often more abstract than the idea statement).
 - The **constraints** that exclude entire branches of solution space (deadlines, compatibility, scope).
 - The **success criteria** — how will the user know this is done.
 
-Keep each question single-purpose. If you need to ask three things, that is three rounds, not one combined `AskUserQuestion`.
+Keep each question single-purpose. If you need to ask three things, that is three rounds, not one combined prompt.
 
 ### 3. Propose 2-3 directions
 
-When the goal, constraints, and success criteria are clear enough that you can name distinct approaches, present them in a single `AskUserQuestion`:
+When the goal, constraints, and success criteria are clear enough that you can name distinct approaches, present them as a single multi-choice prompt to the user — exactly one convergence question with 2-3 distinct options. Use whatever interactive prompt mechanism your host provides; if none is available, render the question + options as text and wait for the user's reply.
 
-```
-AskUserQuestion({
-  questions: [
-    {
-      question: "<the convergence question>",
-      header: "<short header>",
-      options: [
-        { label: "Option A (Recommended)", description: "<what + tradeoff>" },
-        { label: "Option B", description: "<what + tradeoff>" },
-        { label: "Option C", description: "<what + tradeoff>" }
-      ],
-      multiSelect: false
-    }
-  ]
-})
-```
-
-The recommendation must be visibly marked to the user using the host tool's `AskUserQuestion` convention. State **why** you recommend it — usually a sentence about the dominant tradeoff.
+The recommendation must be visibly marked to the user using the host's prompt convention (e.g. ordering, label suffix). State **why** you recommend it — usually a sentence about the dominant tradeoff.
 
 ### 4. Wait for explicit approval
 
@@ -93,10 +76,10 @@ For each material decision the user made during the conversation, build one `Ela
 
 ### 6. Persist the round
 
-Call `chorus_pm_start_elaboration` with the synthesized questions:
+Call `chorus_start_elaboration` with the synthesized questions:
 
 ```
-chorus_pm_start_elaboration({
+chorus_start_elaboration({
   ideaUuid,
   depth: "standard",
   questions: [
@@ -121,7 +104,7 @@ chorus_answer_elaboration({
 
 ### 7. Return control
 
-Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
+Stop here. Do **NOT** call `chorus_validate_elaboration`. The idea skill's caller now decides:
 
 - If the synthesized round answers cover everything → caller validates with `issues: []`.
 - If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
@@ -160,4 +143,4 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
-- **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.
+- **Asking multiple questions in one prompt.** The cadence is one question per turn during divergence, then one final convergence prompt with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/packages/openclaw-plugin/skills/idea/SKILL.md
+++ b/packages/openclaw-plugin/skills/idea/SKILL.md
@@ -135,6 +135,20 @@ Before elaborating, understand the full picture:
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
 
+### Step 4.5: Brainstorm Mode (Optional Prelude)
+
+If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice questions, offer a brainstorm prelude before structured elaboration. Surface the choice to the user using whatever interactive prompt mechanism your host provides — same idiom OpenClaw uses elsewhere in this skill. Two choices: `"Already clear, run structured elaboration"` and `"Brainstorm first to explore directions"`.
+
+- **"Already clear":** Skip to Step 5.
+- **"Brainstorm first":** Invoke the `/brainstorm` skill. See `/brainstorm` for the dialogue cadence and synthesis rules — do NOT re-implement them here.
+
+When `/brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
+
+- If the synthesized round answers cover everything → call `chorus_validate_elaboration` with `issues: []` to resolve elaboration.
+- If gaps remain → call `chorus_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+
+Either outcome ends Step 4.5; skip Step 5.
+
 ### Step 5: Elaborate on the Idea
 
 **Every Idea should go through elaboration.** Elaboration improves Proposal quality and reduces rejection cycles.
@@ -232,6 +246,8 @@ After answers are submitted, **@mention the answerer** with a summary of your un
    - **Unclear** — Ask clarifying questions via another comment
 
 #### Validating the Elaboration
+
+`chorus_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
 
 When answers are satisfactory:
 

--- a/plugins/chorus/skills/brainstorm/SKILL.md
+++ b/plugins/chorus/skills/brainstorm/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: brainstorm
+description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never validates elaboration.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Brainstorm Skill
+
+A divergent-then-convergent dialogue cadence for ideas whose direction is still being formed. Compresses the conversation into one `ElaborationRound` of decision-point Q&A — same shape as a structured elaboration round, but the questions, options and answers are synthesized at the end of the conversation rather than asked up front.
+
+This skill is a **producer** of one elaboration round; the **scheduler** decision (validate vs. follow-up) belongs to the calling idea skill.
+
+---
+
+## When invoked
+
+Only as a sub-step of the idea skill, only after the user has explicitly opted in via `AskUserQuestion`. Never run standalone, never run without user opt-in. The expected entry point is the idea skill's "Step 4.5: Brainstorm Mode (Optional Prelude)" — see the idea skill for the surrounding flow.
+
+---
+
+## Hard rules
+
+1. **One question at a time.** Each `AskUserQuestion` call MUST contain exactly one question entry. Wait for the answer before asking the next.
+2. **Multi-choice preferred.** Frame each question as 2-4 options where possible. Open-ended is acceptable when options would be premature, but lean toward concrete choices.
+3. **Propose 2-3 directions before stopping divergence.** Once the requirement direction is clear enough to enumerate, present 2-3 distinct approaches in a single `AskUserQuestion`. Mark exactly one as the recommended option per the host tool's `AskUserQuestion` recommendation convention (the spec does not dictate a specific marking format — follow the tool's documentation).
+4. **Explicit user approval required to exit divergence.** Do NOT proceed to synthesis until the user has selected one of the proposed directions.
+5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
+6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
+7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+
+---
+
+## Step-by-step
+
+### 1. Gather context
+
+Before asking the first divergent question, read the idea and surrounding project state. Mirror the idea skill's gather-context list:
+
+```
+chorus_get_idea({ ideaUuid })
+chorus_get_documents({ projectUuid })
+chorus_get_document({ documentUuid })   # for any document worth reading in full
+chorus_get_proposals({ projectUuid, status: "approved" })   # to understand patterns
+chorus_list_tasks({ projectUuid })   # to avoid duplicating existing work
+chorus_get_comments({ targetType: "idea", targetUuid: ideaUuid })
+```
+
+Skim each result for: stated background, stated requirements, stated constraints, and what is conspicuously NOT stated. The gaps are the questions worth asking.
+
+### 2. Divergent Q&A
+
+Ask one question at a time via `AskUserQuestion`. Aim to surface:
+
+- The **goal** the idea is trying to serve (often more abstract than the idea statement).
+- The **constraints** that exclude entire branches of solution space (deadlines, compatibility, scope).
+- The **success criteria** — how will the user know this is done.
+
+Keep each question single-purpose. If you need to ask three things, that is three rounds, not one combined `AskUserQuestion`.
+
+### 3. Propose 2-3 directions
+
+When the goal, constraints, and success criteria are clear enough that you can name distinct approaches, present them in a single `AskUserQuestion`:
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "<the convergence question>",
+      header: "<short header>",
+      options: [
+        { label: "Option A (Recommended)", description: "<what + tradeoff>" },
+        { label: "Option B", description: "<what + tradeoff>" },
+        { label: "Option C", description: "<what + tradeoff>" }
+      ],
+      multiSelect: false
+    }
+  ]
+})
+```
+
+The recommendation must be visibly marked to the user using the host tool's `AskUserQuestion` convention. State **why** you recommend it — usually a sentence about the dominant tradeoff.
+
+### 4. Wait for explicit approval
+
+Do not proceed to synthesis if the user has not selected one of the options. If the user picks "Other" with free text, treat that as a new constraint — go back to step 2 or step 3 with the refined direction.
+
+### 5. Synthesize decision-point Q&A
+
+For each material decision the user made during the conversation, build one `ElaborationQuestion`. A "material decision" is a moment where the user chose between alternatives or set scope explicitly. Map each decision per the synthesis spec below.
+
+### 6. Persist the round
+
+Call `chorus_pm_start_elaboration` with the synthesized questions:
+
+```
+chorus_pm_start_elaboration({
+  ideaUuid,
+  depth: "standard",
+  questions: [
+    { id: "q1", text: "...", category: "...", options: [...] },
+    ...
+  ]
+})
+```
+
+Then submit the answers in one call:
+
+```
+chorus_answer_elaboration({
+  ideaUuid,
+  roundUuid,
+  answers: [
+    { questionId: "q1", selectedOptionId: "...", customText: "<rationale>" },
+    ...
+  ]
+})
+```
+
+### 7. Return control
+
+Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
+
+- If the synthesized round answers cover everything → caller validates with `issues: []`.
+- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+
+The depth of any follow-up round is the caller's call, not yours.
+
+---
+
+## Synthesis spec
+
+Each material decision becomes exactly one `ElaborationQuestion` with these fields:
+
+| Field | Source |
+|---|---|
+| `text` | The decision question, phrased neutrally. Example: "Which depth-model placement?" |
+| `category` | `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, or `scope` — derived from the topic. |
+| `options` | All directions that were considered, length 2-5. Collapse near-duplicates into one option. |
+| `selectedOptionId` | The id of the option the user approved. |
+| `customText` | A 1-3 sentence rationale capturing the constraint or tradeoff that drove the choice. Not a transcript dump. |
+
+Rules:
+
+- A `customText` longer than ~3 sentences is a sign you are summarizing transcript instead of capturing rationale. Cut.
+- An `options` array of length 2 with binary "yes / no" framing is a sign you pre-narrowed alternatives. Re-examine — there are usually at least three meaningfully different paths, even if two of them get rejected quickly.
+- Skip "decisions" that were never genuinely contested. If the user agreed instantly to the only proposal, that is information for the idea content, not a decision-point Q&A.
+
+---
+
+## Anti-patterns
+
+Do not do any of the following. Each has a specific failure mode that this skill must prevent:
+
+- **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
+- **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
+- **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
+- **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
+- **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -114,6 +114,20 @@ Before elaborating, understand the full picture:
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
 
+### Step 4.5: Brainstorm Mode (Optional Prelude)
+
+If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice questions, offer the user a brainstorm prelude before structured elaboration. Present two choices to the user (existing convention used elsewhere in this skill — see Step 5's `AskUserQuestion` usage for the host-specific prompt mechanism): `"Already clear, run structured elaboration"` and `"Brainstorm first to explore directions"`.
+
+- **"Already clear":** Skip to Step 5.
+- **"Brainstorm first":** Invoke the `/brainstorm` skill. See `/brainstorm` for the dialogue cadence and synthesis rules — do NOT re-implement them here.
+
+When `/brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
+
+- If the synthesized round answers cover everything → call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration.
+- If gaps remain → call `chorus_pm_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+
+Either outcome ends Step 4.5; skip Step 5.
+
 ### Step 5: Elaborate on the Idea
 
 **Every Idea should go through elaboration.** Skip only when requirements are completely unambiguous (e.g., bug fix with clear steps). Elaboration improves Proposal quality and reduces rejection cycles.
@@ -222,6 +236,8 @@ chorus_pm_skip_elaboration({
       - **Unclear** — Ask clarifying questions via another comment
 
 6. **Validate the elaboration:**
+
+   `chorus_pm_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
 
    ```
    chorus_pm_validate_elaboration({

--- a/public/chorus-plugin/skills/brainstorm/SKILL.md
+++ b/public/chorus-plugin/skills/brainstorm/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: brainstorm
+description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never validates elaboration.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Brainstorm Skill
+
+A divergent-then-convergent dialogue cadence for ideas whose direction is still being formed. Compresses the conversation into one `ElaborationRound` of decision-point Q&A — same shape as a structured elaboration round, but the questions, options and answers are synthesized at the end of the conversation rather than asked up front.
+
+This skill is a **producer** of one elaboration round; the **scheduler** decision (validate vs. follow-up) belongs to the calling idea skill.
+
+---
+
+## When invoked
+
+Only as a sub-step of the idea skill, only after the user has explicitly opted in via `AskUserQuestion`. Never run standalone, never run without user opt-in. The expected entry point is the idea skill's "Step 4.5: Brainstorm Mode (Optional Prelude)" — see the idea skill for the surrounding flow.
+
+---
+
+## Hard rules
+
+1. **One question at a time.** Each `AskUserQuestion` call MUST contain exactly one question entry. Wait for the answer before asking the next.
+2. **Multi-choice preferred.** Frame each question as 2-4 options where possible. Open-ended is acceptable when options would be premature, but lean toward concrete choices.
+3. **Propose 2-3 directions before stopping divergence.** Once the requirement direction is clear enough to enumerate, present 2-3 distinct approaches in a single `AskUserQuestion`. Mark exactly one as the recommended option per the host tool's `AskUserQuestion` recommendation convention (the spec does not dictate a specific marking format — follow the tool's documentation).
+4. **Explicit user approval required to exit divergence.** Do NOT proceed to synthesis until the user has selected one of the proposed directions.
+5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
+6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
+7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+
+---
+
+## Step-by-step
+
+### 1. Gather context
+
+Before asking the first divergent question, read the idea and surrounding project state. Mirror the idea skill's gather-context list:
+
+```
+chorus_get_idea({ ideaUuid })
+chorus_get_documents({ projectUuid })
+chorus_get_document({ documentUuid })   # for any document worth reading in full
+chorus_get_proposals({ projectUuid, status: "approved" })   # to understand patterns
+chorus_list_tasks({ projectUuid })   # to avoid duplicating existing work
+chorus_get_comments({ targetType: "idea", targetUuid: ideaUuid })
+```
+
+Skim each result for: stated background, stated requirements, stated constraints, and what is conspicuously NOT stated. The gaps are the questions worth asking.
+
+### 2. Divergent Q&A
+
+Ask one question at a time via `AskUserQuestion`. Aim to surface:
+
+- The **goal** the idea is trying to serve (often more abstract than the idea statement).
+- The **constraints** that exclude entire branches of solution space (deadlines, compatibility, scope).
+- The **success criteria** — how will the user know this is done.
+
+Keep each question single-purpose. If you need to ask three things, that is three rounds, not one combined `AskUserQuestion`.
+
+### 3. Propose 2-3 directions
+
+When the goal, constraints, and success criteria are clear enough that you can name distinct approaches, present them in a single `AskUserQuestion`:
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "<the convergence question>",
+      header: "<short header>",
+      options: [
+        { label: "Option A (Recommended)", description: "<what + tradeoff>" },
+        { label: "Option B", description: "<what + tradeoff>" },
+        { label: "Option C", description: "<what + tradeoff>" }
+      ],
+      multiSelect: false
+    }
+  ]
+})
+```
+
+The recommendation must be visibly marked to the user using the host tool's `AskUserQuestion` convention. State **why** you recommend it — usually a sentence about the dominant tradeoff.
+
+### 4. Wait for explicit approval
+
+Do not proceed to synthesis if the user has not selected one of the options. If the user picks "Other" with free text, treat that as a new constraint — go back to step 2 or step 3 with the refined direction.
+
+### 5. Synthesize decision-point Q&A
+
+For each material decision the user made during the conversation, build one `ElaborationQuestion`. A "material decision" is a moment where the user chose between alternatives or set scope explicitly. Map each decision per the synthesis spec below.
+
+### 6. Persist the round
+
+Call `chorus_pm_start_elaboration` with the synthesized questions:
+
+```
+chorus_pm_start_elaboration({
+  ideaUuid,
+  depth: "standard",
+  questions: [
+    { id: "q1", text: "...", category: "...", options: [...] },
+    ...
+  ]
+})
+```
+
+Then submit the answers in one call:
+
+```
+chorus_answer_elaboration({
+  ideaUuid,
+  roundUuid,
+  answers: [
+    { questionId: "q1", selectedOptionId: "...", customText: "<rationale>" },
+    ...
+  ]
+})
+```
+
+### 7. Return control
+
+Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
+
+- If the synthesized round answers cover everything → caller validates with `issues: []`.
+- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+
+The depth of any follow-up round is the caller's call, not yours.
+
+---
+
+## Synthesis spec
+
+Each material decision becomes exactly one `ElaborationQuestion` with these fields:
+
+| Field | Source |
+|---|---|
+| `text` | The decision question, phrased neutrally. Example: "Which depth-model placement?" |
+| `category` | `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, or `scope` — derived from the topic. |
+| `options` | All directions that were considered, length 2-5. Collapse near-duplicates into one option. |
+| `selectedOptionId` | The id of the option the user approved. |
+| `customText` | A 1-3 sentence rationale capturing the constraint or tradeoff that drove the choice. Not a transcript dump. |
+
+Rules:
+
+- A `customText` longer than ~3 sentences is a sign you are summarizing transcript instead of capturing rationale. Cut.
+- An `options` array of length 2 with binary "yes / no" framing is a sign you pre-narrowed alternatives. Re-examine — there are usually at least three meaningfully different paths, even if two of them get rejected quickly.
+- Skip "decisions" that were never genuinely contested. If the user agreed instantly to the only proposal, that is information for the idea content, not a decision-point Q&A.
+
+---
+
+## Anti-patterns
+
+Do not do any of the following. Each has a specific failure mode that this skill must prevent:
+
+- **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
+- **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
+- **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
+- **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
+- **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -114,6 +114,20 @@ Before elaborating, understand the full picture:
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
 
+### Step 4.5: Brainstorm Mode (Optional Prelude)
+
+If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice questions, offer the user a brainstorm prelude before structured elaboration. Ask once via `AskUserQuestion` (header `"Brainstorm"`, two options: `"Already clear, run structured elaboration"` and `"Brainstorm first to explore directions"`).
+
+- **"Already clear":** Skip to Step 5.
+- **"Brainstorm first":** Invoke the `/brainstorm` skill. See `/brainstorm` for the dialogue cadence and synthesis rules — do NOT re-implement them here.
+
+When `/brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
+
+- If the synthesized round answers cover everything → call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration.
+- If gaps remain → call `chorus_pm_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+
+Either outcome ends Step 4.5; skip Step 5.
+
 ### Step 5: Elaborate on the Idea
 
 **Every Idea should go through elaboration.** Skip only when requirements are completely unambiguous (e.g., bug fix with clear steps). Elaboration improves Proposal quality and reduces rejection cycles.
@@ -222,6 +236,8 @@ chorus_pm_skip_elaboration({
       - **Unclear** — Ask clarifying questions via another comment
 
 6. **Validate the elaboration:**
+
+   `chorus_pm_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
 
    ```
    chorus_pm_validate_elaboration({

--- a/public/skill/brainstorm-chorus/SKILL.md
+++ b/public/skill/brainstorm-chorus/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: brainstorm-chorus
+description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never validates elaboration.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.3.1"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Brainstorm Skill
+
+A divergent-then-convergent dialogue cadence for ideas whose direction is still being formed. Compresses the conversation into one `ElaborationRound` of decision-point Q&A — same shape as a structured elaboration round, but the questions, options and answers are synthesized at the end of the conversation rather than asked up front.
+
+This skill is a **producer** of one elaboration round; the **scheduler** decision (validate vs. follow-up) belongs to the calling idea skill.
+
+---
+
+## When invoked
+
+Only as a sub-step of the idea skill, only after the user has explicitly opted in via `AskUserQuestion`. Never run standalone, never run without user opt-in. The expected entry point is the idea skill's "Step 4.5: Brainstorm Mode (Optional Prelude)" — see the idea skill for the surrounding flow.
+
+---
+
+## Hard rules
+
+1. **One question at a time.** Each `AskUserQuestion` call MUST contain exactly one question entry. Wait for the answer before asking the next.
+2. **Multi-choice preferred.** Frame each question as 2-4 options where possible. Open-ended is acceptable when options would be premature, but lean toward concrete choices.
+3. **Propose 2-3 directions before stopping divergence.** Once the requirement direction is clear enough to enumerate, present 2-3 distinct approaches in a single `AskUserQuestion`. Mark exactly one as the recommended option per the host tool's `AskUserQuestion` recommendation convention (the spec does not dictate a specific marking format — follow the tool's documentation).
+4. **Explicit user approval required to exit divergence.** Do NOT proceed to synthesis until the user has selected one of the proposed directions.
+5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
+6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
+7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+
+---
+
+## Step-by-step
+
+### 1. Gather context
+
+Before asking the first divergent question, read the idea and surrounding project state. Mirror the idea skill's gather-context list:
+
+```
+chorus_get_idea({ ideaUuid })
+chorus_get_documents({ projectUuid })
+chorus_get_document({ documentUuid })   # for any document worth reading in full
+chorus_get_proposals({ projectUuid, status: "approved" })   # to understand patterns
+chorus_list_tasks({ projectUuid })   # to avoid duplicating existing work
+chorus_get_comments({ targetType: "idea", targetUuid: ideaUuid })
+```
+
+Skim each result for: stated background, stated requirements, stated constraints, and what is conspicuously NOT stated. The gaps are the questions worth asking.
+
+### 2. Divergent Q&A
+
+Ask one question at a time via `AskUserQuestion`. Aim to surface:
+
+- The **goal** the idea is trying to serve (often more abstract than the idea statement).
+- The **constraints** that exclude entire branches of solution space (deadlines, compatibility, scope).
+- The **success criteria** — how will the user know this is done.
+
+Keep each question single-purpose. If you need to ask three things, that is three rounds, not one combined `AskUserQuestion`.
+
+### 3. Propose 2-3 directions
+
+When the goal, constraints, and success criteria are clear enough that you can name distinct approaches, present them in a single `AskUserQuestion`:
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "<the convergence question>",
+      header: "<short header>",
+      options: [
+        { label: "Option A (Recommended)", description: "<what + tradeoff>" },
+        { label: "Option B", description: "<what + tradeoff>" },
+        { label: "Option C", description: "<what + tradeoff>" }
+      ],
+      multiSelect: false
+    }
+  ]
+})
+```
+
+The recommendation must be visibly marked to the user using the host tool's `AskUserQuestion` convention. State **why** you recommend it — usually a sentence about the dominant tradeoff.
+
+### 4. Wait for explicit approval
+
+Do not proceed to synthesis if the user has not selected one of the options. If the user picks "Other" with free text, treat that as a new constraint — go back to step 2 or step 3 with the refined direction.
+
+### 5. Synthesize decision-point Q&A
+
+For each material decision the user made during the conversation, build one `ElaborationQuestion`. A "material decision" is a moment where the user chose between alternatives or set scope explicitly. Map each decision per the synthesis spec below.
+
+### 6. Persist the round
+
+Call `chorus_pm_start_elaboration` with the synthesized questions:
+
+```
+chorus_pm_start_elaboration({
+  ideaUuid,
+  depth: "standard",
+  questions: [
+    { id: "q1", text: "...", category: "...", options: [...] },
+    ...
+  ]
+})
+```
+
+Then submit the answers in one call:
+
+```
+chorus_answer_elaboration({
+  ideaUuid,
+  roundUuid,
+  answers: [
+    { questionId: "q1", selectedOptionId: "...", customText: "<rationale>" },
+    ...
+  ]
+})
+```
+
+### 7. Return control
+
+Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
+
+- If the synthesized round answers cover everything → caller validates with `issues: []`.
+- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+
+The depth of any follow-up round is the caller's call, not yours.
+
+---
+
+## Synthesis spec
+
+Each material decision becomes exactly one `ElaborationQuestion` with these fields:
+
+| Field | Source |
+|---|---|
+| `text` | The decision question, phrased neutrally. Example: "Which depth-model placement?" |
+| `category` | `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, or `scope` — derived from the topic. |
+| `options` | All directions that were considered, length 2-5. Collapse near-duplicates into one option. |
+| `selectedOptionId` | The id of the option the user approved. |
+| `customText` | A 1-3 sentence rationale capturing the constraint or tradeoff that drove the choice. Not a transcript dump. |
+
+Rules:
+
+- A `customText` longer than ~3 sentences is a sign you are summarizing transcript instead of capturing rationale. Cut.
+- An `options` array of length 2 with binary "yes / no" framing is a sign you pre-narrowed alternatives. Re-examine — there are usually at least three meaningfully different paths, even if two of them get rejected quickly.
+- Skip "decisions" that were never genuinely contested. If the user agreed instantly to the only proposal, that is information for the idea content, not a decision-point Q&A.
+
+---
+
+## Anti-patterns
+
+Do not do any of the following. Each has a specific failure mode that this skill must prevent:
+
+- **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
+- **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
+- **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
+- **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
+- **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/public/skill/idea-chorus/SKILL.md
+++ b/public/skill/idea-chorus/SKILL.md
@@ -114,6 +114,20 @@ Before elaborating, understand the full picture:
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
 
+### Step 4.5: Brainstorm Mode (Optional Prelude)
+
+If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice questions, offer the user a brainstorm prelude before structured elaboration. Use your IDE's interactive prompt mechanism if available, or present options as text — the same convention used elsewhere in this skill. Two choices: `"Already clear, run structured elaboration"` and `"Brainstorm first to explore directions"`.
+
+- **"Already clear":** Skip to Step 5.
+- **"Brainstorm first":** Invoke the `brainstorm-chorus` skill (`<BASE_URL>/skill/brainstorm-chorus/SKILL.md`). See that skill for the dialogue cadence and synthesis rules — do NOT re-implement them here.
+
+When the brainstorm skill returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
+
+- If the synthesized round answers cover everything → call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration.
+- If gaps remain → call `chorus_pm_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+
+Either outcome ends Step 4.5; skip Step 5.
+
 ### Step 5: Elaborate on the Idea
 
 **Every Idea should go through elaboration.** Skip only when requirements are completely unambiguous (e.g., bug fix with clear steps). Elaboration improves Proposal quality and reduces rejection cycles.
@@ -217,6 +231,8 @@ chorus_pm_skip_elaboration({
       - **Unclear** — Ask clarifying questions via another comment
 
 6. **Validate the elaboration:**
+
+   `chorus_pm_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
 
    ```
    chorus_pm_validate_elaboration({


### PR DESCRIPTION
## Summary

- Adds a new opt-in `brainstorm` skill as an optional prelude to structured elaboration when an Idea arrives in "still rephrasing" shape — runs divergent-then-convergent dialogue (one question at a time, propose 2-3 directions, get explicit approval) and synthesizes the conversation into one `ElaborationRound` of decision-point Q&A.
- Skill is a **producer**: calls `chorus_pm_start_elaboration` + `chorus_answer_elaboration` and returns. The validate / follow-up lifecycle decision stays in the calling idea skill.
- Distributed to all four packages with byte-identical body (md5 `90f8e5cc2582b49c62173b1185b5f8f5` across all four).
- Zero backend / Prisma / UI / MCP-tool changes — pure documentation.

## Why

Existing elaboration is structured Q&A — every question must be a multi-choice `ElaborationQuestion` with 2-5 options. When the idea is fuzzy, the agent ends up fabricating options to satisfy the schema, and the audit trail captures forced choices instead of actual exploration. Anthropic's `superpowers/brainstorming` skill solved this with a simple cadence; we want that cadence available inside Chorus's idea workflow without adopting its terminal contract (write a `docs/superpowers/specs/<topic>-design.md` + hand off to `writing-plans`).

## Changed files

| File | Change |
|------|--------|
| `public/chorus-plugin/skills/brainstorm/SKILL.md` | NEW (canonical body) |
| `plugins/chorus/skills/brainstorm/SKILL.md` | NEW (Codex frontmatter) |
| `public/skill/brainstorm-chorus/SKILL.md` | NEW (public/skill frontmatter, version 0.3.1) |
| `packages/openclaw-plugin/skills/brainstorm/SKILL.md` | NEW (OpenClaw frontmatter, `metadata.openclaw.emoji: 💭`) |
| `public/chorus-plugin/skills/idea/SKILL.md` | Step 4.5 brainstorm prelude + Step 5.6 single-commit-gate clarification |
| `plugins/chorus/skills/idea/SKILL.md` | Mirror of above (Codex prompt convention) |
| `public/skill/idea-chorus/SKILL.md` | Mirror of above (URL-style cross-skill refs) |
| `packages/openclaw-plugin/skills/idea/SKILL.md` | Mirror of above (host-native prompt idiom) |
| `openspec/changes/archive/2026-05-25-add-brainstorm-skill/` | OpenSpec change archive (proposal, design, spec delta, README) |
| `openspec/specs/idea-elaboration-brainstorm/spec.md` | NEW long-term capability spec |

## Test plan

- [x] All four `brainstorm/SKILL.md` bodies pairwise byte-identical (verified via `diff <(EXTRACT_BODY a) <(EXTRACT_BODY b)`, all three pairs zero output, md5 `90f8e5cc...`)
- [x] `openspec validate add-brainstorm-skill` passes
- [x] OpenSpec archive flow ran cleanly (`openspec archive add-brainstorm-skill --yes`); long-term capability `idea-elaboration-brainstorm` mirrored back to Chorus document `fcf88218` (round-trip byte-equal, 8879 bytes)
- [x] Step 4.5 in each idea skill follows the host's existing prompt convention (Claude Code: `AskUserQuestion`; Codex: pre-existing `AskUserQuestion`; public/skill: "IDE interactive prompt or text"; OpenClaw: SSE-driven prompt)
- [x] No `src/`, `prisma/`, `messages/`, or non-skill `public/` changes; no Prisma migration

## Audit trail

- Source idea: `077fc58e-4c77-47c6-8eb1-19e7e17e653d` (Chorus 0.9.0, "Idea 阶段引入 brainstorm skill")
- Proposal: `04353dc2-cd80-462a-88fc-fce1dad846f2` (approved, 6/6 tasks verified)
- Elaboration round 1: `12b6bf7c-3ea4-42c4-82ec-ae433f6c121b` (8 decision-point Q&A, all validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)