### PR TITLE
feat(reports): idea-completion summary reports + idea-level surfacing

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -47,6 +47,7 @@ The following table summarizes every permission-gated MCP tool. Each tool has ex
 | `chorus_pm_assign_task` | `proposal:write` |
 | `chorus_pm_create_document` | `document:write` |
 | `chorus_pm_update_document` | `document:write` |
+| `chorus_create_report` | `document:write` |
 | `chorus_claim_task` | `task:write` |
 | `chorus_release_task` | `task:write` |
 | `chorus_submit_for_verify` | `task:write` |
@@ -238,7 +239,7 @@ Tools available to all Agents.
 
 ### chorus_get_ideas
 
-**Description**: Get the list of Ideas for a project
+**Description**: Get the list of Ideas for a project. Each row includes `reportCount` — number of completion reports for the idea.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -251,7 +252,7 @@ Tools available to all Agents.
 **Output**:
 ```json
 {
-  "ideas": [...],
+  "ideas": [{ ..., "reportCount": 0 }],
   "total": 10,
   "page": 1,
   "pageSize": 20
@@ -260,14 +261,14 @@ Tools available to all Agents.
 
 ### chorus_get_idea
 
-**Description**: Get detailed information for a single Idea
+**Description**: Get detailed information for a single Idea. Includes `reports[]` — full content of the idea's completion reports, newest first.
 
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | ideaUuid | string | Yes | Idea UUID |
 
-**Output**: Idea details JSON
+**Output**: Idea details JSON, with `reports: DocumentResponse[]` (full Markdown content, sorted by `createdAt` desc; empty when none).
 
 ### chorus_get_documents
 
@@ -277,7 +278,7 @@ Tools available to all Agents.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
-| type | string | No | Filter by type: prd, tech_design, adr, etc. |
+| type | string | No | Filter by type: prd, tech_design, adr, spec, guide, report |
 | page | number | No | Page number |
 | pageSize | number | No | Items per page |
 
@@ -773,6 +774,45 @@ Supports intra-batch dependencies via `draftUuid` + `dependsOnDraftUuids`, and d
 
 > Note: After `chorus_admin_approve_proposal` runs, taskDrafts are auto-materialized into Tasks. Calling `chorus_create_tasks` with the same `proposalUuid` would produce duplicates — only call this for proposal-linked tasks added outside the standard draft-and-approve flow.
 
+### chorus_create_report
+
+**Description**: Persist an idea-completion summary as a Document with `type="report"` linked to the given Proposal. Call once, at end-of-Idea, after the last task verifies. This is a summary, not a detailed write-up — keep it short.
+
+The Markdown `content` MUST use these three sections in this order (the server stores bytes verbatim — these headers are a constraint, not a schema):
+
+```markdown
+## Summary
+1-3 sentences on what shipped. Plain prose. No bullet lists here.
+
+## Decisions
+Terse bullets — the key calls made during elaboration / proposal review and why this option not the alternative.
+
+## Follow-ups
+What's still open — link to a new Idea / blog / doc-update if tracked elsewhere; write "None" if there are no follow-ups.
+```
+
+**Required Permission**: `document:write` (the tool lives in the public-namespaced module — no `pm_` prefix — but is permission-gated; granted via the `pm_agent` / `admin_agent` presets, or via a custom permission added to a developer agent).
+
+**Input**:
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| proposalUuid | string (UUID) | Yes | Proposal UUID whose tasks have all reached a terminal state (`done`/`closed`) |
+| title | string (1-200 chars) | Yes | Report title (e.g. `"Idea X — completion report"`) |
+| content | string (non-empty Markdown) | Yes | Markdown body — Summary / Decisions / Follow-ups |
+
+**Output**:
+```json
+{
+  "documentUuid": "...",
+  "projectUuid": "...",
+  "version": 1
+}
+```
+
+The created Document has `type="report"` (the tool name encodes the type — agents cannot mislabel reports), `proposalUuid` set to the provided value, and `projectUuid` resolved from the Proposal. Multiple reports per Proposal are allowed by design; the body is preserved byte-faithfully (modulo the Document content path's existing trailing-newline normalization). To revise a report, use `chorus_pm_update_document` (which increments `version`).
+
+**When to author**: at the end of an Idea pipeline — once every Task linked to the Idea (across all approved Proposals) has been admin-verified to `done`. The `/yolo` skill authors a report as a mandatory end-step; the `/develop` skill prompts for one as an advisory end-step; and the Chorus plugin's PostToolUse hook injects a reminder substring after the last `chorus_admin_verify_task` of an Idea when no `report` Document yet exists.
+
 ---
 
 ## Session Tools
@@ -1020,7 +1060,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
-| type | enum | Yes | Document type: prd, tech_design, adr, spec, guide |
+| type | enum | Yes | Document type: prd, tech_design, adr, spec, guide, report |
 | title | string | Yes | Document title |
 | content | string | No | Document content (Markdown) |
 | proposalUuid | string | No | Associated Proposal UUID |

--- a/docs/design.pen
+++ b/docs/design.pen
@@ -84748,6 +84748,2528 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "whWtH",
+      "x": 0,
+      "y": 21581,
+      "name": "Idea Tracker - Overview Tab with Reports List",
+      "width": 1900,
+      "height": 1100,
+      "fill": "#F7F6F3",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "yzPTb",
+          "x": 0,
+          "y": 0,
+          "name": "Content Area",
+          "clip": true,
+          "width": 980,
+          "height": 1100,
+          "fill": "#FAF8F4",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rZ8MT",
+              "name": "Sidebar",
+              "width": 240,
+              "height": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#E5E0D8"
+              },
+              "layout": "vertical",
+              "gap": 48,
+              "padding": [
+                32,
+                24
+              ],
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RkKHt",
+                  "name": "Sidebar Top",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 48,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MYVCv",
+                      "name": "Logo",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 4,
+                          "id": "PNSBn",
+                          "name": "logoMark",
+                          "fill": "#C67A52",
+                          "width": 24,
+                          "height": 24
+                        },
+                        {
+                          "type": "text",
+                          "id": "zBFzb",
+                          "name": "logoTxt",
+                          "fill": "#2C2C2C",
+                          "content": "Chorus",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 18,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DwKBY",
+                      "name": "Navigation",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "uB73o",
+                          "name": "Back to Projects",
+                          "width": "fill_container",
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "UBc31",
+                              "name": "backIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "arrow-left",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9A9A9A"
+                            },
+                            {
+                              "type": "text",
+                              "id": "oIdym",
+                              "name": "backTxt",
+                              "fill": "#9A9A9A",
+                              "content": "Projects",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "dbToM",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "padding": [
+                            12,
+                            0,
+                            6,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "aULxp",
+                              "name": "projName",
+                              "fill": "#2C2C2C",
+                              "content": "Project Alpha",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "WoeD3",
+                          "name": "Nav Overview",
+                          "width": "fill_container",
+                          "fill": "#F5F2EC",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Kkagt",
+                              "name": "ovIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "layout-dashboard",
+                              "iconFontFamily": "lucide",
+                              "fill": "#C67A52"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Ai7Lf",
+                              "name": "ovTxt",
+                              "fill": "#C67A52",
+                              "content": "Overview",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cMV8K",
+                          "name": "Nav Ideas",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "SH6RC",
+                              "name": "ideasIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "lightbulb",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "DT9af",
+                              "name": "ideasTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Ideas",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jU6mK",
+                          "name": "Nav Documents",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "BiLIo",
+                              "name": "docsIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "file-text",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "IVD1N",
+                              "name": "docsTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Documents",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FVLWA",
+                          "name": "Nav Proposals",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Xm367",
+                              "name": "propIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "git-pull-request",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "LfkOw",
+                              "name": "propTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Proposals",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "coSJP",
+                          "name": "Nav Tasks",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "BvhTl",
+                              "name": "tasksIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "square-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Skt8d",
+                              "name": "tasksTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Tasks",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vrYK7",
+                          "name": "Nav Activity",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "jfrSH",
+                              "name": "actIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "activity",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "FmGg0",
+                              "name": "actTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Activity",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pVTdC",
+                  "name": "Sidebar Bottom",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pCAFx",
+                      "name": "User Profile",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "sWSBJ",
+                          "name": "avatar",
+                          "fill": "#E5E0D8",
+                          "width": 32,
+                          "height": 32
+                        },
+                        {
+                          "type": "text",
+                          "id": "TP6Wp",
+                          "name": "userName",
+                          "fill": "#2C2C2C",
+                          "content": "John Doe",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eAa7m",
+              "name": "Main Content",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 20,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "kgjLl",
+                  "name": "Top Bar",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "F3aot",
+                      "name": "breadcrumb",
+                      "fill": "#888780",
+                      "content": "Project Alpha / Overview",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hJnzu",
+                      "name": "topActions",
+                      "gap": 16,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "eR5vy",
+                          "name": "searchIcon",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "search",
+                          "iconFontFamily": "lucide",
+                          "fill": "#888780"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "aQ1qL",
+                          "name": "bellIcon",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "bell",
+                          "iconFontFamily": "lucide",
+                          "fill": "#888780"
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "iZrqT",
+                          "name": "topAvatar",
+                          "fill": "#E5E0D8",
+                          "width": 32,
+                          "height": 32
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bJDTh",
+                  "name": "Title Section",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pezKu",
+                      "name": "titleLeft",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VMaww",
+                          "name": "titleTxt",
+                          "fill": "#2C2C2A",
+                          "content": "Overview",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 20,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Cv3ig",
+                          "name": "subtitleTxt",
+                          "fill": "#5F5E5A",
+                          "content": "Track ideas, proposals, and tasks at a glance",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cg9pP",
+                      "name": "titleActions",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "QPGdp",
+                          "name": "titleActions",
+                          "fill": "#d9d9d9ff",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "hjfR1",
+                              "name": "newIdeaBtn",
+                              "fill": "#c67a52",
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                8,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "k4tKe",
+                                  "name": "newIdeaIcon",
+                                  "width": 14,
+                                  "height": 14,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#FFFFFF"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "B0XZ2Y",
+                                  "name": "newIdeaTxt",
+                                  "fill": "#FFFFFF",
+                                  "content": "New Idea",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "g84mMr",
+                  "name": "Ideas Area",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c7Nf9p",
+                      "name": "In Review Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "knJ99",
+                          "name": "h1",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "xJbpe",
+                              "name": "a9",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "kGi6K",
+                              "fill": "#7F77DD",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "Mki2q",
+                              "fill": "#5F5E5A",
+                              "content": "In Review",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "SiGyv",
+                              "fill": "#888780",
+                              "content": "2",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "J1zcg7",
+                          "name": "b1",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "WMiIZ",
+                              "name": "r1",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "jC6tR",
+                                  "name": "r1l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "OvBMW",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-5",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "DDnkp",
+                                      "fill": "#2C2C2A",
+                                      "content": "CLI 工具重构",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "J6hY75",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "WxzMK",
+                                          "fill": "#888780",
+                                          "content": "Proposal",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "MKNDV",
+                                  "fill": "#888780",
+                                  "content": "Mar 13",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "hwIb1",
+                              "fill": "#F0EEEA",
+                              "width": "fill_container",
+                              "height": 1
+                            },
+                            {
+                              "type": "frame",
+                              "id": "zNLeW",
+                              "name": "r2",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "GMFJJ",
+                                  "name": "r2l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "r4uvBy",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-3",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "S9lrn9",
+                                      "fill": "#2C2C2A",
+                                      "content": "新建 quick-dev skill",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "fNp0b",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "OGOmF",
+                                          "fill": "#888780",
+                                          "content": "Work done",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "dbeyA",
+                                  "fill": "#888780",
+                                  "content": "Mar 13",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZFV7A",
+                      "name": "In Progress Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "jYKQx",
+                          "name": "h2",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "FCEKG",
+                              "name": "a10",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "mDHOX",
+                              "fill": "#378ADD",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "ZtU1H",
+                              "fill": "#5F5E5A",
+                              "content": "In Progress",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "nz3GM",
+                              "fill": "#888780",
+                              "content": "1",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "oVMKJ",
+                          "name": "b2",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "k9PJRe",
+                              "name": "r3",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "oXvTA",
+                                  "name": "r3l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "h2C6ev",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-24",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "E48bXt",
+                                      "fill": "#2C2C2A",
+                                      "content": "T5: 测试验证",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "uAmFB",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "HBgaa",
+                                          "fill": "#888780",
+                                          "content": "Working",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "bVldy",
+                                  "fill": "#888780",
+                                  "content": "Mar 13",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QXW2K",
+                      "name": "Todo Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "exVlk",
+                          "name": "h3",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "ubGkC",
+                              "name": "a11",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "rESyM",
+                              "width": 8,
+                              "height": 8,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1.5,
+                                "fill": "#888780"
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "ApMEg",
+                              "fill": "#5F5E5A",
+                              "content": "Todo",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Knspn",
+                              "fill": "#888780",
+                              "content": "6",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XGj1F",
+                          "name": "b3",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "EyIkw",
+                              "name": "r4",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "Z0xcJs",
+                                  "name": "r4l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "x9h8m",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-7",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "V2V9Qz",
+                                      "fill": "#2C2C2A",
+                                      "content": "优化错误提示信息",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "twI65",
+                                  "fill": "#888780",
+                                  "content": "Jan 17",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "H5IcH",
+                              "fill": "#F0EEEA",
+                              "width": "fill_container",
+                              "height": 1
+                            },
+                            {
+                              "type": "frame",
+                              "id": "tBli6",
+                              "name": "r5",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "gfls1",
+                                  "name": "r5l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "tZPaJ",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-1",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "QS2pg",
+                                      "fill": "#2C2C2A",
+                                      "content": "Get familiar with Linear",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Q5fSzG",
+                                  "fill": "#888780",
+                                  "content": "Jan 17",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bpr3A",
+                      "name": "Done Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "kfcom",
+                          "name": "dh2",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "KaNhd",
+                              "name": "a12",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "Gnnyp",
+                              "fill": "#1D9E75",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "p8vdZ",
+                              "fill": "#5F5E5A",
+                              "content": "Done",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "SMDl0",
+                              "fill": "#888780",
+                              "content": "1",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "tIC8N",
+                          "name": "db2",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "n2oJKx",
+                              "name": "dr2",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "ZrQn6",
+                                  "name": "dr2l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "sdLTk",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-2",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "ZkcZF",
+                                      "fill": "#2C2C2A",
+                                      "content": "OpenClaw Plugin 工具迁移",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "oLyys",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "v1OuO",
+                                          "fill": "#1D9E75",
+                                          "content": "Completed",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "o5WJo",
+                                  "fill": "#888780",
+                                  "content": "Mar 10",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Vd8I7",
+          "layoutPosition": "absolute",
+          "x": 1440,
+          "y": 0,
+          "name": "Detail Panel - Report",
+          "width": 460,
+          "height": 1100,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "left": 1
+            },
+            "fill": "#E5E0D8"
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Qjnhh",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#F5F2EC"
+              },
+              "padding": [
+                20,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "gy3f4",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "BIiVJ",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "arrow-left",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B6B6B"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oGHpy",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XhyPf",
+                          "fill": "#2C2C2C",
+                          "content": "Idea: 完成后增加总结概览 — completion report",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "DdXCg",
+                          "fill": "#FCEFE6",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Pz84k",
+                              "fill": "#C67A52",
+                              "content": "REPORT",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 9,
+                              "fontWeight": "600",
+                              "letterSpacing": 0.5
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "icon_font",
+                  "id": "MtXNl",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9A9A"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "J3dAF",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 14,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "I2AiH7",
+                  "fill": "#2C2C2C",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Idea: 完成后增加总结概览功能 — completion report",
+                  "lineHeight": 1.3,
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "TwO77",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CkWXI",
+                      "fill": "#2C2C2C",
+                      "content": "Background",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "nrTHo",
+                      "fill": "#4A4A4A",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Pipeline 结束时把背景 / 决策路径 / 已交付 / 计划差异 / 开放跟进合到一份 markdown，覆盖团队回顾、内部同步、agent 复盘三类读者。",
+                      "lineHeight": 1.55,
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "u5gxXd",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "H9qYok",
+                      "fill": "#2C2C2C",
+                      "content": "Decision path",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "n1tedN",
+                      "fill": "#4A4A4A",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "• 实体复用 Document（type=report）— 不动 Idea schema\n• MCP 工具 chorus_create_report — 无 pm_ 前缀，门 document:write\n• 内容由 skill 拼好整段 markdown 后传入；服务层只存\n• yolo 末步必做 · develop 提示 · PostToolUse hook 注入提醒",
+                      "lineHeight": 1.6,
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oQGYz",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "djc9r",
+                      "fill": "#2C2C2C",
+                      "content": "What was delivered",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "hzkQo",
+                      "fill": "#4A4A4A",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "7 task 全部 done — 后端 enum 注册、MCP 工具、UI Reports 段、yolo/develop 末步语料、hook 分支、文档 sweep、集成 smoke。",
+                      "lineHeight": 1.55,
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "L4wgwK",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "cixLl",
+                      "fill": "#2C2C2C",
+                      "content": "Variance from plan",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "B9p62g",
+                      "fill": "#4A4A4A",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Reports 段最终落在 proposal-tab 内每个 Proposal 块下，而非独立 Tab — proposal/task 进展的同侧位置阅读体验更顺。",
+                      "lineHeight": 1.55,
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m28hPN",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "a7gKFH",
+                      "fill": "#2C2C2C",
+                      "content": "Open follow-ups",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "eZRQU",
+                      "fill": "#4A4A4A",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "• 对 reviewer skill 的 'no report exists' 软信号集成（独立 idea）\n• Codex 与 OpenClaw plugin 的 hook 分支同步",
+                      "lineHeight": 1.6,
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "G5jY9",
+          "layoutPosition": "absolute",
+          "x": 980,
+          "y": 0,
+          "name": "Detail Panel - Overview",
+          "width": 460,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "left": 1
+            },
+            "fill": "#E5E0D8"
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "TzEUo",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#F5F2EC"
+              },
+              "padding": [
+                20,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JYRCL",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tDixt",
+                      "fill": "#2C2C2C",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Idea: 完成后增加总结概览功能",
+                      "lineHeight": 1.3,
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qgImV",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "h954Z",
+                          "fill": "#E0F2F1",
+                          "cornerRadius": 4,
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mPSkA",
+                              "fill": "#00796B",
+                              "content": "Done",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "XZYz5",
+                          "fill": "#9A9A9A",
+                          "content": "IDEA-80c",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WndoX",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "tvbuL",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "arrow-right-left",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B6B6B"
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "Px7F0",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9A9A"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "O9pma",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#F5F2EC"
+              },
+              "padding": [
+                0,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "SVVPD",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 2
+                    },
+                    "fill": "#C67A52"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "kChlx",
+                      "fill": "#C67A52",
+                      "content": "Overview",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wD5Eb",
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "x3xVSU",
+                      "fill": "#9A9A9A",
+                      "content": "Elaboration",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rVaeq",
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SQwYI",
+                      "fill": "#9A9A9A",
+                      "content": "Proposal",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LR3Li",
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "uFvdL",
+                      "fill": "#9A9A9A",
+                      "content": "Tasks",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "w5nkG",
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OFp5e",
+                      "fill": "#9A9A9A",
+                      "content": "Activity",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nKM92",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 20,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "PlmtV",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "TBuzO",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        0,
+                        12,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "gObIX",
+                          "width": 20,
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "O1jFYj",
+                              "width": 20,
+                              "height": 20,
+                              "fill": "#E0F2F1",
+                              "cornerRadius": 10,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "UsNvV",
+                                  "x": 5,
+                                  "y": 5,
+                                  "width": 10,
+                                  "height": 10,
+                                  "iconFontName": "check",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#00796B"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "RDuML",
+                              "fill": "#E5E0D8",
+                              "width": 1,
+                              "height": 18
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iiOhH",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "W33BW",
+                              "width": "fill_container",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "LRaxS",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-right",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9A9A9A"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "l7QUHo",
+                                  "fill": "#2C2C2C",
+                                  "content": "Idea created",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "XSgu4",
+                              "fill": "#9A9A9A",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "yfeichen · 3d ago",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bk4ON",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        0,
+                        12,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "L5VS0",
+                          "width": 20,
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "mS6EC",
+                              "width": 20,
+                              "height": 20,
+                              "fill": "#E0F2F1",
+                              "cornerRadius": 10,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "e58BS",
+                                  "x": 5,
+                                  "y": 5,
+                                  "width": 10,
+                                  "height": 10,
+                                  "iconFontName": "check",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#00796B"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "yoFAe",
+                              "fill": "#E5E0D8",
+                              "width": 1,
+                              "height": 18
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "yJgB9",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "GRE11",
+                              "width": "fill_container",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "I2Negx",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-right",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9A9A9A"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Da6PM",
+                                  "fill": "#2C2C2C",
+                                  "content": "Elaboration",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "zuTFG",
+                              "fill": "#9A9A9A",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "9 questions resolved · standard",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "c0AZS",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        0,
+                        12,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "OXWiV",
+                          "width": 20,
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "z4s9F",
+                              "width": 20,
+                              "height": 20,
+                              "fill": "#E0F2F1",
+                              "cornerRadius": 10,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "BPwqa",
+                                  "x": 5,
+                                  "y": 5,
+                                  "width": 10,
+                                  "height": 10,
+                                  "iconFontName": "check",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#00796B"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "WQlHe",
+                              "fill": "#E5E0D8",
+                              "width": 1,
+                              "height": 18
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "w6kk7D",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "xwE7p",
+                              "width": "fill_container",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "WMYAA",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-right",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9A9A9A"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "uOH2Y",
+                                  "fill": "#2C2C2C",
+                                  "content": "Proposal",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "kOhKa",
+                              "fill": "#9A9A9A",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "1 approved",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mrjw7",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        0,
+                        12,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "EhIai",
+                          "width": 20,
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "VTlSY",
+                              "width": 20,
+                              "height": 20,
+                              "fill": "#E0F2F1",
+                              "cornerRadius": 10,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "uM4l8",
+                                  "x": 5,
+                                  "y": 5,
+                                  "width": 10,
+                                  "height": 10,
+                                  "iconFontName": "check",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#00796B"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "KyiQv",
+                              "fill": "#E5E0D8",
+                              "width": 1,
+                              "height": 18
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "VSYF0",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "pARAK",
+                              "width": "fill_container",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "TFCAa",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-right",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9A9A9A"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "M4AGe8",
+                                  "fill": "#2C2C2C",
+                                  "content": "Tasks",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "h8BLQ",
+                              "fill": "#9A9A9A",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "7/7 complete",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wPWv6",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    0,
+                    0,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "RbsBZ",
+                      "fill": "#E5E0D8",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yLGlD",
+                      "width": "fill_container",
+                      "padding": [
+                        6,
+                        0,
+                        0,
+                        0
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "UnWQi",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "nH2vo",
+                              "fill": "#888780",
+                              "content": "REPORTS",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "600",
+                              "letterSpacing": 1
+                            },
+                            {
+                              "type": "text",
+                              "id": "s58zfR",
+                              "fill": "#9A9A9A",
+                              "content": "2",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "nFMlH",
+                          "fill": "#9A9A9A",
+                          "content": "across all approved proposals",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "normal",
+                          "fontStyle": "italic"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ycg8U",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#E5E0D8"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "XCi6N",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-left",
+                          "iconFontFamily": "lucide",
+                          "fill": "#B4B2A9"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "C500a",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "#FCEFE6",
+                          "cornerRadius": 8,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "KsCLN",
+                              "x": 8,
+                              "y": 8,
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "file-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "#C67A52"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JdpwX",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "fG2ET",
+                              "width": "fill_container",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "R0EwYx",
+                                  "fill": "#2C2C2A",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Idea: 完成后增加总结概览 — completion report",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "lMJ3j",
+                                  "fill": "#FCEFE6",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "W0C6I",
+                                      "fill": "#C67A52",
+                                      "content": "REPORT",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "600",
+                                      "letterSpacing": 0.5
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "eqit7",
+                              "fill": "#888780",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Background · Decision path · Delivered · Variance · Open follow-ups · 2h ago",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ogNSF",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#E5E0D8"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Iq4VZ",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-left",
+                          "iconFontFamily": "lucide",
+                          "fill": "#B4B2A9"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vxzQU",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "#FCEFE6",
+                          "cornerRadius": 8,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "z9eqb",
+                              "x": 8,
+                              "y": 8,
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "file-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "#C67A52"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uC62Y",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zqSpo",
+                              "width": "fill_container",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "i0yGc",
+                                  "fill": "#2C2C2A",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Supplemental: hook trigger learnings",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "bYRSB",
+                                  "fill": "#FCEFE6",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "U3PIP",
+                                      "fill": "#C67A52",
+                                      "content": "REPORT",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "600",
+                                      "letterSpacing": 0.5
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "ZNE3H",
+                              "fill": "#888780",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Variance angle · 2d ago",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "themes": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -651,6 +651,7 @@
     "typeAdr": "ADR",
     "typeGuide": "Guide",
     "typeNote": "Note",
+    "typeReport": "Report",
     "typeOther": "Other",
     "deleteDocument": "Delete Document",
     "deleteDocumentDescription": "This will permanently delete \"{title}\". This action cannot be undone.",
@@ -1304,5 +1305,9 @@
         "custom": "Pick individual permissions. Admin-column actions (approve / verify / close) are only reachable in Custom mode."
       }
     }
+  },
+  "idea": {
+    "reportsList": "REPORTS",
+    "reportsAcrossProposals": "across all approved proposals"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -652,6 +652,7 @@
     "typeAdr": "ADR",
     "typeGuide": "指南",
     "typeNote": "笔记",
+    "typeReport": "总结报告",
     "typeOther": "其他",
     "deleteDocument": "删除文档",
     "deleteDocumentDescription": "此操作将永久删除文档「{title}」，无法恢复。",
@@ -1305,5 +1306,9 @@
         "custom": "自由勾选权限位。只有在自定义模式下，才能开启「管理」列的审批 / 验收 / 关闭动作。"
       }
     }
+  },
+  "idea": {
+    "reportsList": "总结报告",
+    "reportsAcrossProposals": "覆盖所有已审批提案"
   }
 }

--- a/openspec/changes/add-idea-completion-report/.openspec.yaml
+++ b/openspec/changes/add-idea-completion-report/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/add-idea-completion-report/README.md
+++ b/openspec/changes/add-idea-completion-report/README.md
@@ -1,0 +1,3 @@
+# add-idea-completion-report
+
+Add idea-completion report Document type + chorus_create_report MCP tool + idea-tracker UI panel + yolo/develop end-step + post-verify hook prompt

--- a/openspec/changes/add-idea-completion-report/design.md
+++ b/openspec/changes/add-idea-completion-report/design.md
@@ -1,0 +1,176 @@
+# Design: Idea-completion summary report
+
+## Overview
+
+This change introduces a new Document subtype, `report`, that captures the post-delivery summary of a finished Idea. The Document is created by the agent (skill-driven) once all Tasks linked to an Idea (transitively, via Proposals) reach a terminal state. The Markdown body is fully authored by the calling skill; the service layer is a thin wrapper around `documentService.createDocument` with `type=report`. UI surfaces reports under the existing `IdeaDetailPanel` `proposal` tab, reusing the doc-row + side-panel pattern.
+
+The design intentionally avoids:
+
+- a new Prisma model or schema migration,
+- structured fields on `Document` for report metadata (Summary, Decisions, etc.) — those are markdown sections in `content`, governed by the tool-description template,
+- a server-side autogen path (the service layer does not synthesize the body),
+- coupling reports to the Idea's stored status (`open` / `elaborating` / `elaborated`); reports attach to a Proposal and aggregate up to the Idea via `Proposal.inputUuids`.
+
+## Architecture
+
+### Entity model
+
+```
+Idea (uuid)
+ └── Proposal (status=approved, inputUuids: [ideaUuid])
+      ├── Document (type=prd)         ← existing
+      ├── Document (type=tech_design) ← existing
+      ├── Document (type=spec)        ← existing
+      └── Document (type=report)      ← NEW (1..N per Proposal)
+```
+
+A `report` Document is created with `proposalUuid` set to the Proposal whose Tasks are now all done. Aggregation up to the Idea is done client-side: the existing `getProposalsForIdeaAction` already returns all Proposals for an Idea, and each Proposal's documents are reachable via existing endpoints.
+
+### Authoring path
+
+```
+last_task_verified
+        │
+        ├── (yolo skill end-step)        → mandatory: skill composes report → chorus_create_report
+        ├── (develop skill end-step)     → advisory: skill prompts agent → chorus_create_report
+        └── (PostToolUse hook reminder)  → read-only: appends "create the idea report" reminder to next prompt
+```
+
+The three triggers all funnel through the same MCP tool. The hook never authors content; it nudges. Skipping at yolo's end-step is a protocol violation surfaced in reviewer notes.
+
+### MCP tool contract
+
+```
+chorus_create_report(input: {
+  proposalUuid: string,
+  title: string,
+  content: string,         // full Markdown, byte-faithful — wrapper path matches openspec-aware §2 Rule 1
+}) -> { documentUuid: string, projectUuid: string, version: 1 }
+```
+
+- **Permission gate**: `document:write` (existing bit). Available to PM and admin presets out of the box; available to developer agents only if explicitly granted.
+- **Tool description (LLM-visible)** carries the report section template: Summary, Decisions, Follow-ups. The template is a constraint, not a schema — the body is free-form Markdown.
+- **No `ideaUuid` parameter**. The Idea is implied by `Proposal.inputUuids`; service layer reads it. This avoids the agent passing inconsistent `(proposalUuid, ideaUuid)` pairs.
+- **No `type` parameter**. The tool name encodes the type; the service writes `type="report"` unconditionally. Prevents agents from creating reports under the wrong type label.
+
+### UI rendering
+
+The Reports list lives on the **overview tab** of `IdeaDetailPanel`, **below** `OverviewTimeline`, aggregated across all approved Proposals of the Idea. The `proposal` tab is **not** modified.
+
+Component layout in `idea-detail-panel.tsx` (overview-tab body):
+
+```tsx
+<OverviewTimeline ... />
+<ReportsList
+  ideaUuid={idea.uuid}
+  proposals={proposals}
+  onDocClick={openDoc}   // existing setter that opens DocumentPanel side-by-side
+/>
+```
+
+`ReportsList` is a new component at `src/app/(dashboard)/projects/[uuid]/dashboard/panels/reports-list.tsx`. It:
+
+1. Receives `proposals` (already fetched at the panel level via `getProposalsForIdeaAction` and lifted into `IdeaDetailPanel` state) and filters to `status === "approved"`.
+2. Fetches Documents for each approved Proposal via the existing `getDocumentsByProposalAction`-equivalent (or a new aggregated server action `getReportsForIdeaAction(ideaUuid)` that merges across proposals — pick whichever keeps the data path simplest).
+3. Filters to `type === "report"`, sorts by `createdAt` descending.
+4. Renders a section header + count + one row per report (same row styling as the proposal-tab document rows: chevron-left + type badge + title).
+5. On row click, calls `onDocClick({ title, type, content })` which the parent already wires to the existing `DocumentPanel` side panel (no `DocumentPanel` changes needed).
+
+Visual differentiation:
+
+- The doc-type badge shows `Report` (i18n: `documents.typeReport`).
+- The Reports section header reads "Reports" (i18n: `idea.reportsList`) with the count to its right.
+- A small subhead clarifies that reports cover the whole Idea, not a single Proposal (i18n: `idea.reportsAcrossProposals`).
+
+Empty / loading states:
+
+- Reports list is **hidden entirely** (no header, no empty-state copy) when zero `report` Documents exist across all approved Proposals of the Idea — this matches the project convention used elsewhere (e.g. how `proposal-view.tsx` handles its "no proposals" branch as a precedent for hiding empty section headers).
+- When loading, render a small spinner consistent with the panel's existing pattern.
+
+Why overview, not proposal-tab:
+
+- The Reports list is an Idea-level artifact (one finished Idea may span multiple Proposals; the report cluster is the recap of the whole Idea). Per-proposal placement would force users to fan out across proposal blocks just to find what shipped.
+- The overview tab already presents the Idea as a coherent timeline; the Reports list is the natural "after delivery" cap below the timeline.
+
+### Section template (lives in the LLM-visible tool description; skills point at it rather than re-stating)
+
+```markdown
+# <Idea title> — completion report
+
+## Summary
+1-3 sentences on what shipped. Plain prose.
+
+## Decisions
+Terse bullets — the key calls made during elaboration / proposal review and why this option not the alternative.
+
+## Follow-ups
+What's still open — link to a new Idea / blog / doc-update if tracked elsewhere; "None" if there are no follow-ups.
+```
+
+## Module Contracts
+
+- **`documentService.createReport(input)`** (new, optional thin wrapper) returns the created Document. May be inlined into `documentService.createDocument` if the caller already passes `type="report"` correctly — no business value to a separate function unless we add type-specific validation later.
+- **MCP tool registration** (in `src/mcp/tools/public.ts` since the tool has no `pm_` prefix and is gated on `document:write`):
+
+  ```typescript
+  server.registerTool("chorus_create_report", {
+    description: "<template-bearing description, see skill template above>",
+    inputSchema: z.object({
+      proposalUuid: z.string().uuid(),
+      title: z.string().min(1).max(200),
+      content: z.string().min(1),
+    }),
+  }, async (params) => {
+    requireAgentPermission(auth, "document", "write");
+    const proposal = await proposalService.getByUuid(auth.companyUuid, params.proposalUuid);
+    if (!proposal) throw new Error("Proposal not found");
+    const doc = await documentService.createDocument(auth.companyUuid, {
+      projectUuid: proposal.projectUuid,
+      proposalUuid: params.proposalUuid,
+      type: "report",
+      title: params.title,
+      content: params.content,
+      createdByUuid: auth.actorUuid,
+    });
+    return { content: [{ type: "text", text: JSON.stringify({ documentUuid: doc.uuid, projectUuid: doc.projectUuid, version: doc.version }, null, 2) }] };
+  });
+  ```
+
+- **Permission map entry** (`src/mcp/tools/permission-map.ts`): `"chorus_create_report" → { resource: "document", action: "write" }`.
+- **No new REST endpoint.** Existing `GET /api/documents/[uuid]` and `GET /api/projects/[uuid]/documents` cover read paths; existing list-by-proposal already returns reports because they live as `Document` rows.
+
+## Hook contract
+
+`bin/on-post-verify-task.sh` (Claude Code plugin) and the Codex equivalent get a new branch with **two** checks:
+
+1. After `chorus_admin_verify_task` succeeds, look at the verified task's Proposal:
+   - Is `inputType=="idea"`? (skip otherwise)
+   - Are all this Proposal's tasks in `done`/`closed`?
+   - Does this Proposal have any `type="report"` Document? (skip if yes)
+2. If all three pass, emit `additionalContext` containing the literal substring `create idea-completion report` plus a one-line example call.
+3. Otherwise exit silently.
+
+Scope is intentionally proposal-local — the hook does not aggregate across multiple Proposals of the same Idea. That case is `/yolo`'s mandatory end-step's responsibility. Keeping the hook proposal-scoped means it costs ~2 cheap MCP reads per `chorus_admin_verify_task` and is easy to reason about; the trade-off is a missed reminder when an Idea spans multiple proposals and the user is using `/develop` (not `/yolo`) — that path is rare and the user can still author the report manually.
+
+The hook is **read-only**: it does not call `chorus_create_report` itself; the agent decides whether and how to author the body.
+
+## Risks & Mitigations
+
+- **Risk: agents skip the yolo end-step.** Mitigation: review-time check — the proposal-reviewer skill (`chorus:proposal-reviewer`) is not in scope, but the develop-task verification flow can include "no report exists for finished Idea" as a soft signal in the next idea-tracker checkin.
+- **Risk: agents author thin / generic reports.** Mitigation: skill template is concrete (Summary / Decisions / Follow-ups), short by design — it's a recap, not a detail dump. The LLM-visible tool description carries it.
+- **Risk: report duplication when multiple agents independently trigger end-step.** Mitigation: hook checks "Idea has zero `report` Documents" before injecting reminder. The MCP tool itself permits N reports per Proposal — that is the explicit answer to elaboration q4 ("不限基数"), so duplicates are not a *correctness* failure, just a quality smell. Out-of-scope to dedupe at write time.
+- **Risk: UI clutter for Ideas with many proposals × many reports.** Mitigation: Reports list aggregates at idea level under the overview tab, sorted by `createdAt` descending so the most-recent report is on top; truncate to first N (e.g. 5) with a "show all" affordance if N grows large in practice. Re-evaluate after the first real Idea finishes.
+- **Risk: the "last task" predicate is wrong when Tasks span multiple Proposals.** Mitigation: the yolo end-step uses the Idea-level predicate (all Tasks across all approved Proposals for this Idea are terminal). The hook deliberately uses a simpler proposal-local predicate — see "Hook contract" above for the rationale.
+- **Risk: report content drift if regenerated.** Mitigation: each `chorus_create_report` call creates a new Document (version 1). Multiple reports per Proposal is allowed by design; UI lists them in createdAt order. Authors can update via existing `chorus_pm_update_document` if they own it.
+
+## Implementation Plan
+
+1. **Backend tool**: register `chorus_create_report` in `src/mcp/tools/public.ts`; add permission map entry; verify `documentService.createDocument` accepts `type="report"` without changes (it should — type is a free-form string).
+2. **Tool description copy**: write the LLM-visible description with the section template baked in. This is the single source of truth for the report shape.
+3. **MCP tool docs**: append entry to `docs/MCP_TOOLS.md`; mirror to `public/skill/chorus/SKILL.md` and `public/chorus-plugin/skills/chorus/SKILL.md` and Codex / OpenClaw equivalents.
+4. **Frontend**: add `report` to `DOC_TYPE_I18N_KEYS` and locale files (`messages/en.json`, `messages/zh.json`) for the badge label. Add `idea.reportsList` and `idea.reportsAcrossProposals` keys. Create `reports-list.tsx` and wire it into the `overview` tab of `IdeaDetailPanel` directly under `OverviewTimeline`.
+5. **`docs/design.pen` update**: add the Reports list mock on the overview-tab body directly under `OverviewTimeline` (frame `Idea Tracker - Overview Tab with Reports List`, id `whWtH`); reuse the existing doc-row visual; include a sibling `Detail Panel - Report` mock showing the click-row → side-panel expansion.
+6. **Skill end-step copy**: update `yolo` and `develop` skills in 4 plugin packages with the end-step language. Bilingual where the skill is bilingual.
+7. **Hook**: add the post-verify branch to `bin/on-post-verify-task.sh` and the Codex hook. Reuse the same predicate-tools as the existing OpenSpec branch.
+8. **Tests**: pure tests for the tool registration (permission gating, type pin), service-layer test that report Documents survive `getDocumentsByProposal`, and a render test for `<ReportsList>` covering: shows below `OverviewTimeline` when `report` Documents exist, hidden when zero exist, click-row opens `DocumentPanel`, and the `proposal` tab is unchanged.
+9. **Integration**: end-to-end smoke — create an Idea, run a fake yolo flow that creates one report, verify it shows up in the idea-tracker overview Reports list and opens in `DocumentPanel`.

--- a/openspec/changes/add-idea-completion-report/proposal.md
+++ b/openspec/changes/add-idea-completion-report/proposal.md
@@ -1,0 +1,45 @@
+# Proposal: Idea-completion summary report
+
+## Why
+
+When an Idea finishes its full AI-DLC pipeline (elaboration → proposal → tasks all verified), the working state lives scattered across Chorus: the original Idea body captures the framing-time intent, ElaborationRound captures decision-point Q&A, the Proposal carries the plan-time PRD/tech-design, and Tasks + AcceptanceCriteria capture what was actually built and verified. There is no single artifact that ties those four surfaces together at delivery time.
+
+Three concrete pain points:
+
+1. **Team retro.** Going back two weeks later to "what did we ship for Idea X?" requires opening four entities and stitching the story by hand. PMs and engineering leads do this often enough that we want a one-click recap.
+2. **Internal sync (zh: 内部同步).** Cross-team handoffs and Friday updates currently re-explain the same Idea each week because the persisted record is fragmented.
+3. **Agent recall.** Future agents working on related Ideas have no compact "what we decided last time and why" to read; they re-derive context from scratch and routinely re-litigate decisions.
+
+We want a single Markdown artifact per finished Idea that covers all three readers in one document — explicitly **not** a PR description, blog post, or external launch material; those have different audiences and editorial standards.
+
+## What Changes
+
+- **New `Document.type = "report"`** — one new value on the existing `Document.type` free-form string. No schema migration; no other Document field changes.
+- **New MCP tool `chorus_create_report`** — public-namespaced (no `pm_` prefix), gated on `document:write`. Skill (the caller) authors the full Markdown body and submits it; the service layer only stores. The tool's LLM-visible description carries the section-template constraint (Summary / Decisions / Follow-ups) — short by design, since this is a recap not a detail dump. Skills only mention the tool; they do not re-state the template.
+- **No basis cardinality** — a Proposal can carry any number of `report` Documents (regenerate, supplemental angle, etc.).
+- **Idea-tracker UI: Report list on the overview tab, below the timeline.** In `IdeaDetailPanel`'s `overview` tab, render a Reports list **below** `OverviewTimeline`, aggregated across all approved Proposals of the Idea (not per-proposal). Each row uses the same list-row + click-to-side-panel pattern that documents already use; clicking opens the existing `DocumentPanel` to the left of the idea panel (side-by-side on wide screens, overlay otherwise). No separate top-level tab. The `proposal` tab is **not** modified.
+- **`yolo` skill end-step (mandatory).** When yolo finishes verifying the last task of an Idea, it composes the Markdown using full pipeline context and calls `chorus_create_report`. Skipping this step is a yolo protocol violation.
+- **`develop` skill end-step (advisory).** When a developer agent verifies a task that turns out to be the last one for its Idea, the skill prompts the agent (via injected reminder text) to create a report.
+- **PostToolUse hook injection.** Mirrors the existing `openspec-aware` archive-trigger pattern: after `chorus_admin_verify_task`, if the task was the last one of its Idea and no `report` document yet exists for that Idea, inject a reminder containing a literal substring the skill can grep for. Hook is read-only; the agent does the work.
+- **No proposal cardinality cap.** A Proposal may have 0..N reports.
+- **No basis change to existing flows.** Elaboration, proposal validate/submit/approve, task verify — all unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `idea-completion-report`: Idea-completion summary report concept — what a `report` Document is, when it's authored, who authors it, what it must contain, and how it surfaces in the idea-tracker UI.
+
+### Modified Capabilities
+
+- `mcp-tool-surface`: Add a new `chorus_create_report` tool to the public-namespaced surface gated on `document:write`. (The mcp-tool-surface spec already governs which tools are exposed, by what permission gate, and under what name; this change adds one row.)
+
+## Impact
+
+- **Schema**: zero migrations. `Document.type` is a free-form string in Prisma — adding one value is a doc/contract change, not a DB change.
+- **Backend code**: `src/services/document.service.ts` (one new helper or none — existing `createDocument` may suffice), `src/mcp/tools/public.ts` or `pm.ts` (new tool registration), `src/mcp/tools/permission-map.ts` (new entry: `chorus_create_report` → `document:write`).
+- **Frontend code**: a new `reports-list.tsx` sibling component rendered inside the `overview` tab of `IdeaDetailPanel` directly **below** `OverviewTimeline` (i.e. modify `idea-detail-panel.tsx`'s overview-tab body to include `<ReportsList>` under `<OverviewTimeline>`); the new component aggregates `type="report"` Documents across all approved Proposals of the Idea via the existing `getDocumentsByProposal` query path. Reuse `document-panel.tsx` unchanged for the side panel.
+- **Plugin / skill code**: 4 plugin packages have `yolo`/`develop` skills (Claude Code, Codex, public/skill, OpenClaw if present); each gets the new end-step language. Plugin hook script under `public/chorus-plugin/bin/` (and Codex equivalent) gets the post-verify branch — same shape as `on-post-verify-task.sh`'s existing OpenSpec archive trigger.
+- **Docs**: `docs/MCP_TOOLS.md` adds `chorus_create_report`. `public/skill/chorus/SKILL.md` and `public/chorus-plugin/skills/chorus/SKILL.md` get a Reports section. `docs/design.pen` gets the idea-tracker overview Report list mock.
+- **Runtime**: no new dependencies, no migrations, no new MCP transport surface, no new permissions (reuses existing `document:write`).
+- **Backward compat**: fully additive. Existing `Document.type` values keep working; the new tool is purely additive.

--- a/openspec/changes/add-idea-completion-report/specs/idea-completion-report/spec.md
+++ b/openspec/changes/add-idea-completion-report/specs/idea-completion-report/spec.md
@@ -1,0 +1,135 @@
+# idea-completion-report Specification
+
+## ADDED Requirements
+
+### Requirement: Idea-completion reports SHALL be stored as Documents with `type="report"`
+
+A `report` is a Markdown summary of a finished Idea, stored as a `Document` row whose `type` field equals the literal string `report`. The Document's `proposalUuid` MUST point to the Proposal whose tasks have all reached a terminal state (`done` or `closed`). Reports MUST NOT introduce a new Prisma model, a new Document column, or a schema migration. Multiple reports per Proposal are permitted.
+
+#### Scenario: A report is created with the correct type label
+
+- **GIVEN** an Idea whose all linked Tasks (across all approved Proposals) are in `done` or `closed` status
+- **WHEN** an agent calls `chorus_create_report` with a valid `proposalUuid`, `title`, and `content`
+- **THEN** the server MUST persist a new `Document` row with `type = "report"` and `proposalUuid` set to the provided value
+- **AND** the row's `version` MUST be `1`
+- **AND** the row's `projectUuid` MUST equal the Proposal's `projectUuid`
+- **AND** the response MUST include the new `documentUuid`
+
+#### Scenario: Multiple reports may exist for the same Proposal
+
+- **GIVEN** a Proposal that already has one Document with `type = "report"`
+- **WHEN** an agent calls `chorus_create_report` again for the same `proposalUuid` with a different `title`
+- **THEN** the call MUST succeed
+- **AND** the Proposal MUST now be reachable to two distinct `report`-typed Documents via existing list endpoints
+
+#### Scenario: Reports use existing Document update / read paths
+
+- **GIVEN** a `report` Document created via `chorus_create_report`
+- **WHEN** the author calls `chorus_pm_update_document` with the new `documentUuid` and updated `content`
+- **THEN** the call MUST behave identically to update on any other Document type (version increments, content replaces)
+- **AND** the row's `type` MUST remain `report`
+
+### Requirement: The yolo skill SHALL author a report at end-step when an Idea finishes
+
+When the `yolo` skill verifies the last task of an Idea (i.e. all Tasks linked to the Idea are now in a terminal state), it MUST compose a Markdown report covering Summary, Decisions, and Follow-ups, then call `chorus_create_report`. Skipping this step is a yolo protocol violation.
+
+#### Scenario: yolo emits a report after the last task verifies
+
+- **GIVEN** a yolo-driven Idea pipeline whose final task has just been admin-verified
+- **WHEN** the `yolo` skill reaches its end-step
+- **THEN** the skill MUST call `chorus_create_report` exactly once with `proposalUuid` set to the Proposal whose final task just verified
+- **AND** the `content` MUST contain at minimum the three section headers `## Summary`, `## Decisions`, `## Follow-ups`
+- **AND** the call MUST succeed before yolo claims the Idea is done
+
+#### Scenario: yolo does not author a report when the Idea is not yet finished
+
+- **GIVEN** a yolo-driven Idea pipeline where some tasks remain in non-terminal status
+- **WHEN** the `yolo` skill is mid-pipeline
+- **THEN** the skill MUST NOT call `chorus_create_report`
+
+### Requirement: The develop skill SHALL prompt for a report when an Idea finishes
+
+When a `develop`-driven agent verifies a task that turns out to be the last one of its Idea, the skill MUST emit guidance that prompts the agent to call `chorus_create_report`. Unlike `yolo`'s mandatory end-step, the develop guidance is advisory — the skill MUST present the option but MUST NOT block on it.
+
+#### Scenario: develop surfaces the report prompt at last-task verification
+
+- **GIVEN** a `develop`-driven session where the agent has just successfully called `chorus_admin_verify_task` and the verified task is the last one of its Idea
+- **WHEN** the develop skill reaches its post-verify branch
+- **THEN** the skill instructions MUST include language directing the agent to consider calling `chorus_create_report`
+- **AND** the skill MUST NOT exit-error if the agent declines
+
+### Requirement: The PostToolUse hook SHALL inject a report-creation reminder
+
+After `chorus_admin_verify_task` succeeds, the Chorus plugin's PostToolUse hook (`bin/on-post-verify-task.sh` for the Claude Code plugin and the Codex equivalent) MUST check whether the verified task's Proposal is idea-rooted, has all its Tasks in a terminal state, AND has no `type="report"` Document yet. If all three hold, the hook MUST inject an `additionalContext` reminder containing the literal substring `create idea-completion report`. The hook MUST be read-only and MUST NOT call `chorus_create_report` itself. The hook intentionally checks only the verified task's own Proposal — multi-proposal-per-Idea aggregation is `/yolo`'s mandatory end-step's responsibility, not the hook's.
+
+#### Scenario: Hook injects a reminder when the proposal is finished and has no report
+
+- **GIVEN** an idea-rooted Proposal whose Tasks are all now `done` or `closed` after a `chorus_admin_verify_task` call
+- **AND** the Proposal has zero Documents with `type = "report"`
+- **WHEN** the PostToolUse hook fires
+- **THEN** the hook MUST emit `additionalContext` containing the literal substring `create idea-completion report`
+- **AND** the hook MUST NOT call any Chorus mutation tool
+
+#### Scenario: Hook stays silent when a report already exists
+
+- **GIVEN** an idea-rooted Proposal whose Tasks are all `done` and which already has at least one `type = "report"` Document
+- **WHEN** the PostToolUse hook fires
+- **THEN** the hook MUST exit 0 silently
+- **AND** MUST NOT inject any reminder
+
+#### Scenario: Hook stays silent when not all tasks are done
+
+- **GIVEN** an idea-rooted Proposal where the just-verified task was not the last (other Tasks still in non-terminal status)
+- **WHEN** the PostToolUse hook fires
+- **THEN** the hook MUST exit 0 silently
+
+#### Scenario: Hook stays silent when the Proposal is not idea-rooted
+
+- **GIVEN** a Proposal whose `inputType` is not `"idea"` (e.g. a manually-rooted Proposal)
+- **WHEN** the PostToolUse hook fires
+- **THEN** the hook MUST exit 0 silently regardless of task or Document state
+
+### Requirement: The idea-tracker IdeaDetailPanel SHALL surface reports on the overview tab below the timeline
+
+In the Chorus dashboard's `IdeaDetailPanel`, the `overview` tab MUST render a Reports list directly **below** `OverviewTimeline`, aggregated across all approved Proposals of the Idea (not per-proposal). When one or more `type="report"` Documents exist across the Idea's approved Proposals, the UI MUST render a Reports section header with the count and one row per report, sorted by `createdAt` descending. Each report row MUST be clickable and MUST open the existing `DocumentPanel` side panel with the report's content rendered as Markdown. The Reports list MUST NOT appear when zero reports exist across all approved Proposals of the Idea, and the `proposal` tab MUST NOT be modified by this requirement.
+
+#### Scenario: Reports list renders below the timeline when reports exist
+
+- **GIVEN** an Idea with two approved Proposals — Proposal A has one `type = "report"` Document, Proposal B has two `type = "report"` Documents
+- **WHEN** the user opens the Idea's detail panel and the `overview` tab is active (the default for finished Ideas)
+- **THEN** the overview tab body MUST render `OverviewTimeline` first, immediately followed by a Reports list section
+- **AND** the Reports list MUST contain three rows in `createdAt` descending order, each labeled with its Document's `title`
+- **AND** each row MUST display a doc-type badge with the localized label for `report`
+- **AND** the section header count MUST be `3`
+
+#### Scenario: Clicking a report row opens the side panel
+
+- **GIVEN** the Reports list visible with at least one row on the overview tab
+- **WHEN** the user clicks a report row
+- **THEN** the existing `DocumentPanel` MUST open as a side panel (side-by-side on wide screens, overlay otherwise)
+- **AND** it MUST render the report's `content` as Markdown using the existing `MarkdownContent` component
+- **AND** it MUST display the report's `title` and the `report` type badge
+
+#### Scenario: Reports list is hidden when no reports exist
+
+- **GIVEN** an Idea whose approved Proposals collectively carry zero `type = "report"` Documents
+- **WHEN** the user opens the `overview` tab
+- **THEN** the panel MUST render `OverviewTimeline` as before
+- **AND** the panel MUST NOT render a Reports list (no header, no empty-state copy) below the timeline
+
+#### Scenario: The proposal tab is unchanged
+
+- **GIVEN** an Idea whose approved Proposals carry one or more `type = "report"` Documents
+- **WHEN** the user opens the `proposal` tab
+- **THEN** the proposal tab MUST render exactly as it did before this change — no Reports section is added under any Proposal block on the proposal tab
+
+### Requirement: Report content SHALL be authored by the calling skill, not the server
+
+The `chorus_create_report` MCP tool MUST persist `content` byte-faithfully and MUST NOT modify, augment, prepend, or append to the body. Skill prose and the tool's LLM-visible description provide the section template; the server enforces no structural validation on `content` beyond the existing `Document.content` non-empty check.
+
+#### Scenario: Server preserves report content byte-faithfully
+
+- **GIVEN** an agent supplies a multi-section Markdown body with code fences, tables, and CJK characters
+- **WHEN** the agent calls `chorus_create_report` with that body as `content`
+- **THEN** the persisted Document's `content` MUST equal the input bytes (modulo a single trailing newline normalization, consistent with the server's existing `Document.content` write path)
+- **AND** the server MUST NOT inject report-section headers, frontmatter, or any other structural markup

--- a/openspec/changes/add-idea-completion-report/specs/mcp-tool-surface/spec.md
+++ b/openspec/changes/add-idea-completion-report/specs/mcp-tool-surface/spec.md
@@ -1,0 +1,44 @@
+# mcp-tool-surface delta — add `chorus_create_report`
+
+## ADDED Requirements
+
+### Requirement: The Chorus MCP server SHALL expose `chorus_create_report`
+
+The MCP tool `chorus_create_report` MUST be registered in the public-namespaced tool surface (no `pm_` prefix) and gated on the `document:write` permission bit. Its input schema MUST accept `proposalUuid` (string, UUID), `title` (string, 1-200 chars), and `content` (string, non-empty); it MUST NOT accept a `type` parameter, since the type label `"report"` is encoded by the tool name and written unconditionally by the service. On success the tool MUST return `documentUuid`, `projectUuid`, and `version`.
+
+#### Scenario: Listing tools surfaces `chorus_create_report` for an agent with `document:write`
+
+- **GIVEN** an agent whose effective permission set contains `document:write`
+- **WHEN** the agent calls `tools/list` against `/api/mcp`
+- **THEN** the response MUST include a tool whose `name` field equals `chorus_create_report`
+- **AND** the tool's input schema MUST require `proposalUuid`, `title`, and `content`
+- **AND** the tool's input schema MUST NOT include a `type` parameter
+
+#### Scenario: Listing tools omits `chorus_create_report` when permission is absent
+
+- **GIVEN** an agent whose effective permission set does not contain `document:write`
+- **WHEN** the agent calls `tools/list` against `/api/mcp`
+- **THEN** the response MUST NOT include any tool whose `name` field equals `chorus_create_report`
+
+#### Scenario: Successful call writes a report Document
+
+- **GIVEN** an authenticated agent with `document:write`
+- **AND** an existing Proposal `P` in the agent's company
+- **WHEN** the agent calls `tools/call` with `name: "chorus_create_report"` and `arguments: { proposalUuid: "<P-uuid>", title: "Idea X — completion report", content: "## Background\n..." }`
+- **THEN** the call MUST succeed
+- **AND** a new `Document` row MUST exist with `type = "report"`, `proposalUuid = <P-uuid>`, `projectUuid = P.projectUuid`, `version = 1`, and the supplied `title` and `content`
+- **AND** the response MUST include `documentUuid`, `projectUuid`, and `version`
+
+#### Scenario: Calling for a non-existent Proposal errors
+
+- **GIVEN** an authenticated agent with `document:write`
+- **WHEN** the agent calls `chorus_create_report` with a `proposalUuid` that does not exist in the agent's company
+- **THEN** the server MUST return an error indicating the Proposal was not found
+- **AND** MUST NOT create a Document
+
+#### Scenario: The permission map gates `chorus_create_report` on `document:write`
+
+- **GIVEN** the permission gate file `src/mcp/tools/permission-map.ts`
+- **WHEN** the file is read
+- **THEN** it MUST contain an entry mapping `chorus_create_report` to a permission of `{ resource: "document", action: "write" }`
+- **AND** the tool MUST NOT be exposed by any code path that bypasses the permission gate

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -84,16 +84,20 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_ideas` | List project Ideas (filterable by status, paginated) |
-| `chorus_get_idea` | Get a single Idea's details |
+| `chorus_get_ideas` | List project Ideas (filterable by status, paginated; rows include `reportCount`) |
+| `chorus_get_idea` | Get a single Idea's details (includes `reports[]` with full content) |
 | `chorus_get_available_ideas` | Get claimable Ideas (status=open) |
 
 ### Documents
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide) |
+| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide, report) |
 | `chorus_get_document` | Get a single document's content |
+
+### Reports
+
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. The `yolo` skill writes one mandatorily; the `develop` skill offers it advisorily on last-task verify.
 
 ### Proposals
 

--- a/packages/openclaw-plugin/skills/develop/SKILL.md
+++ b/packages/openclaw-plugin/skills/develop/SKILL.md
@@ -210,6 +210,10 @@ If the task is reopened (verification failed), **all acceptance criteria are res
 
 Once Admin verifies (status: `done`), move to the next available task (back to Step 2).
 
+### Step 11: Idea Completion Report (advisory)
+
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, prompt the user and call `chorus_create_report` on accept. The tool description carries the section template. Skip on decline.
+
 ---
 
 ## SSE Wake Events

--- a/packages/openclaw-plugin/src/tools/common-tools.ts
+++ b/packages/openclaw-plugin/src/tools/common-tools.ts
@@ -245,7 +245,7 @@ export function registerCommonTools(api: any, mcpClient: ChorusMcpClient) {
       type: "object",
       properties: {
         projectUuid: { type: "string", description: "Project UUID" },
-        type: { type: "string", description: "Filter by type: prd | tech_design | adr | spec | guide" },
+        type: { type: "string", description: "Filter by type: prd | tech_design | adr | spec | guide | report" },
         page: { type: "number", description: "Page number (default: 1)" },
         pageSize: { type: "number", description: "Items per page (default: 20)" },
       },

--- a/packages/openclaw-plugin/src/tools/pm-tools.ts
+++ b/packages/openclaw-plugin/src/tools/pm-tools.ts
@@ -139,7 +139,7 @@ export function registerPmTools(api: any, mcpClient: ChorusMcpClient) {
       type: "object",
       properties: {
         proposalUuid: { type: "string", description: "Proposal UUID" },
-        type: { type: "string", description: "Document type (prd, tech_design, adr, spec, guide)" },
+        type: { type: "string", description: "Document type (prd, tech_design, adr, spec, guide, report)" },
         title: { type: "string", description: "Document title" },
         content: { type: "string", description: "Document content (Markdown)" },
       },
@@ -215,7 +215,7 @@ export function registerPmTools(api: any, mcpClient: ChorusMcpClient) {
         proposalUuid: { type: "string", description: "Proposal UUID" },
         draftUuid: { type: "string", description: "Document draft UUID to update" },
         title: { type: "string", description: "New document title" },
-        type: { type: "string", description: "New document type (prd, tech_design, adr, spec, guide)" },
+        type: { type: "string", description: "New document type (prd, tech_design, adr, spec, guide, report)" },
         content: { type: "string", description: "New document content (Markdown)" },
       },
       required: ["proposalUuid", "draftUuid"],

--- a/plugins/chorus/hooks/on-post-verify-task.sh
+++ b/plugins/chorus/hooks/on-post-verify-task.sh
@@ -194,13 +194,6 @@ CTX
 #   2. no Document with type="report" attached to this proposal
 # Read-only — the hook never calls chorus_create_report.
 branch_idea_report_reminder() {
-  # Per-branch opt-out. Default enabled; set CHORUS_REPORT_REMINDER=off to
-  # silence just this branch without affecting Branch A's OpenSpec archive
-  # reminder.
-  if [ "${CHORUS_REPORT_REMINDER:-}" = "off" ]; then
-    return 0
-  fi
-
   # Only idea-rooted proposals get a completion report.
   local input_type
   input_type=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.inputType // empty' 2>/dev/null) || true

--- a/plugins/chorus/hooks/on-post-verify-task.sh
+++ b/plugins/chorus/hooks/on-post-verify-task.sh
@@ -194,6 +194,13 @@ CTX
 #   2. no Document with type="report" attached to this proposal
 # Read-only — the hook never calls chorus_create_report.
 branch_idea_report_reminder() {
+  # Per-branch opt-out. Default enabled; set CHORUS_REPORT_REMINDER=off to
+  # silence just this branch without affecting Branch A's OpenSpec archive
+  # reminder.
+  if [ "${CHORUS_REPORT_REMINDER:-}" = "off" ]; then
+    return 0
+  fi
+
   # Only idea-rooted proposals get a completion report.
   local input_type
   input_type=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.inputType // empty' 2>/dev/null) || true
@@ -202,17 +209,34 @@ branch_idea_report_reminder() {
   fi
 
   # Check 1: all tasks of this proposal are terminal.
-  local tasks_json non_terminal_count
-  tasks_json=$("$MCP" chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"]}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
+  # pageSize=200 + a total>returned guard so a wide proposal can't fool the
+  # check by happening to fit "done" tasks on page 1 while non-terminals
+  # remain on later pages. (Same belt-and-suspenders pattern as Branch A.)
+  local tasks_json non_terminal_count tasks_total tasks_returned
+  tasks_json=$("$MCP" chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
   [ -n "$tasks_json" ] || return 0
-  non_terminal_count=$(printf '%s' "$tasks_json" | jq -r '[.tasks[] | select(.status != "done" and .status != "closed")] | length' 2>/dev/null) || return 0
+  tasks_total=$(printf '%s' "$tasks_json" | jq -r '.total // 0' 2>/dev/null) || return 0
+  tasks_returned=$(printf '%s' "$tasks_json" | jq -r '(.tasks // []) | length' 2>/dev/null) || return 0
+  if [ -n "$tasks_total" ] && [ -n "$tasks_returned" ] && [ "$tasks_total" -gt "$tasks_returned" ]; then
+    return 0
+  fi
+  non_terminal_count=$(printf '%s' "$tasks_json" | jq -r '[(.tasks // [])[] | select(.status != "done" and .status != "closed")] | length' 2>/dev/null) || return 0
   [ "$non_terminal_count" = "0" ] || return 0
 
   # Check 2: no report Document on this proposal yet.
-  local docs_json existing_report_count
-  docs_json=$("$MCP" chorus_get_documents "$(printf '{"projectUuid":"%s","type":"report"}' "$PROJECT_UUID")" 2>/dev/null) || return 0
+  # chorus_get_documents only filters by type server-side; we do the
+  # proposalUuid filter client-side. pageSize=200 + total>returned guard
+  # avoids a false "no report" when the proposal's existing report is on
+  # a later page in a long-lived project.
+  local docs_json existing_report_count docs_total docs_returned
+  docs_json=$("$MCP" chorus_get_documents "$(printf '{"projectUuid":"%s","type":"report","pageSize":200}' "$PROJECT_UUID")" 2>/dev/null) || return 0
   [ -n "$docs_json" ] || return 0
-  existing_report_count=$(printf '%s' "$docs_json" | jq -r --arg p "$PROPOSAL_UUID" '[.documents[] | select(.proposalUuid==$p)] | length' 2>/dev/null) || return 0
+  docs_total=$(printf '%s' "$docs_json" | jq -r '.total // 0' 2>/dev/null) || return 0
+  docs_returned=$(printf '%s' "$docs_json" | jq -r '(.documents // []) | length' 2>/dev/null) || return 0
+  if [ -n "$docs_total" ] && [ -n "$docs_returned" ] && [ "$docs_total" -gt "$docs_returned" ]; then
+    return 0
+  fi
+  existing_report_count=$(printf '%s' "$docs_json" | jq -r --arg p "$PROPOSAL_UUID" '[(.documents // [])[] | select(.proposalUuid==$p)] | length' 2>/dev/null) || return 0
   [ "$existing_report_count" = "0" ] || return 0
 
   # Emit the reminder. The literal substring `create idea-completion

--- a/plugins/chorus/hooks/on-post-verify-task.sh
+++ b/plugins/chorus/hooks/on-post-verify-task.sh
@@ -2,23 +2,28 @@
 # on-post-verify-task.sh — Codex PostToolUse hook for chorus_admin_verify_task.
 #
 # Mirrors the Claude Code variant at
-# public/chorus-plugin/bin/on-post-verify-task.sh: detects "last task
-# verified for an OpenSpec-mode idea" and reminds the main agent to
-# `openspec archive <slug>` + mirror updated specs back to Chorus
-# Documents.
+# public/chorus-plugin/bin/on-post-verify-task.sh. Two independent
+# reminder branches share the post-verify trigger:
 #
-# Detection contract (all signals must hold to fire):
-#   1. CHORUS_OPENSPEC_MODE != "off" — explicit opt-out wins.
-#   2. The project root contains an `openspec/` directory — this repo is
-#      OpenSpec-init'd. Probed via $PWD/openspec.
-#   3. `openspec` CLI is on PATH — needed for the agent's later
-#      `openspec archive` step. Both (2) and (3) are required because
-#      either alone leaves the archive workflow unrunnable.
-#   4. The verified task's proposal description contains a line matching
-#      ^OpenSpec change slug: <slug>$ (slug provenance from §3.5).
-#   5. Every task under the same proposal has status === "done".
+#   Branch A — OpenSpec archive trigger (legacy)
+#     Detects "last task verified for an OpenSpec-mode proposal" and
+#     tells the agent to run `openspec archive <slug>` plus mirror
+#     updated specs back into Chorus Documents.
+#     Gates (all must hold): CHORUS_OPENSPEC_MODE!=off, $PWD/openspec/
+#     exists, `openspec` CLI on PATH, proposal description matches
+#     ^OpenSpec change slug:, every task under that proposal is done.
 #
-# If any signal fails, the hook exits 0 silently (strict opt-in).
+#   Branch B — Idea-completion report reminder
+#     Tells the agent to call `chorus_create_report` when this proposal
+#     is finished and has no report Document yet. Two checks: all tasks
+#     of THIS proposal are done/closed, and THIS proposal has no
+#     `type="report"` Document yet. The multi-proposal-per-Idea case is
+#     handled by $yolo's mandatory end-step, not by this hook.
+#
+# Each branch is computed independently into its own context variable;
+# any non-empty contexts are concatenated and emitted as one
+# `additionalContext` payload at the end. Branch B is read-only — it
+# never calls `chorus_create_report` or any other mutation tool.
 #
 # Bash 3.2 compatible (per CLAUDE.md pitfall #10).
 #
@@ -34,6 +39,8 @@ source "${DIR}/hook-output.sh"
 
 MCP="${DIR}/chorus-mcp-call.sh"
 
+# ===== Shared: event parse =====
+
 # Read event JSON from stdin (PostToolUse hook input)
 EVENT=""
 if [ ! -t 0 ]; then
@@ -44,8 +51,8 @@ if [ -z "$EVENT" ]; then
   exit 0
 fi
 
-# Step 2: Extract taskUuid — Codex's tool_response is a content[0].text
-# JSON blob; fall back to tool_input.taskUuid (mirrors the existing
+# Extract taskUuid — Codex's tool_response is a content[0].text JSON
+# blob; fall back to tool_input.taskUuid (mirrors the existing
 # on-post-submit-for-verify.sh pattern).
 TASK_UUID=""
 if command -v jq >/dev/null 2>&1; then
@@ -56,32 +63,14 @@ if command -v jq >/dev/null 2>&1; then
   ' 2>/dev/null) || true
 fi
 
-# Step 3: If taskUuid is empty -> exit 0 silently
+# If taskUuid is empty -> exit 0 silently
 if [ -z "$TASK_UUID" ]; then
   exit 0
 fi
 
-# Step 4: OpenSpec gate — explicit opt-out, then folder + CLI both required.
-# Both folder-presence and CLI-presence are necessary: the agent will run
-# `openspec archive <slug>` on receipt of the injected reminder, and that
-# command needs the openspec/ working directory AND the CLI on PATH. If
-# either is missing, the reminder would point the agent at a dead end, so
-# we silently skip injection and let the verify pass through unannotated.
-if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
-  exit 0
-fi
-PROJECT_ROOT="$PWD"
-if [ ! -d "${PROJECT_ROOT}/openspec" ]; then
-  exit 0
-fi
-if ! command -v openspec >/dev/null 2>&1; then
-  exit 0
-fi
-if ! openspec --version >/dev/null 2>&1; then
-  exit 0
-fi
-
-# Step 5: chorus_get_task -> proposalUuid + project.uuid
+# Resolve the verified task once — both branches need proposalUuid +
+# project.uuid. If the lookup fails or returns no proposalUuid (Quick
+# Tasks), neither branch can fire, so we exit silently.
 TASK_JSON=$("$MCP" chorus_get_task "$(printf '{"taskUuid":"%s"}' "$TASK_UUID")" 2>/dev/null) || exit 0
 if [ -z "$TASK_JSON" ]; then
   exit 0
@@ -90,86 +79,171 @@ fi
 PROPOSAL_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.proposalUuid // empty' 2>/dev/null) || true
 PROJECT_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.project.uuid // empty' 2>/dev/null) || true
 
-# Step 6: If proposalUuid empty -> exit 0 silently (Quick Tasks have no proposal)
-if [ -z "$PROPOSAL_UUID" ]; then
+if [ -z "$PROPOSAL_UUID" ] || [ -z "$PROJECT_UUID" ]; then
   exit 0
 fi
 
-# Step 7: chorus_get_proposal -> description (for slug grep)
+# Both branches need the proposal's full record; fetch once.
 PROPOSAL_JSON=$("$MCP" chorus_get_proposal "$(printf '{"proposalUuid":"%s"}' "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
 if [ -z "$PROPOSAL_JSON" ]; then
   exit 0
 fi
 
-PROPOSAL_DESC=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.description // empty' 2>/dev/null) || true
-
-# Step 9: grep description for ^OpenSpec change slug: (.+)$ — first match wins
-SLUG=""
-if [ -n "$PROPOSAL_DESC" ]; then
-  SLUG_LINE=$(printf '%s\n' "$PROPOSAL_DESC" | grep -E '^OpenSpec change slug: .+' | head -1 || true)
-  if [ -n "$SLUG_LINE" ]; then
-    SLUG=$(printf '%s' "$SLUG_LINE" | sed -e 's/^OpenSpec change slug:[[:space:]]*//' -e 's/[[:space:]]*$//')
+# ===== Branch A: OpenSpec archive trigger =====
+#
+# Returns the archive-reminder context on stdout when all conditions
+# hold; returns empty (silent skip) otherwise.
+branch_openspec_archive() {
+  # OpenSpec gate — explicit opt-out, then folder + CLI both required.
+  # Both folder-presence and CLI-presence are necessary: the agent will
+  # run `openspec archive <slug>` on receipt of the injected reminder,
+  # and that command needs the openspec/ working directory AND the CLI
+  # on PATH. If either is missing, the reminder would point the agent
+  # at a dead end, so we silently skip injection.
+  if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+    return 0
   fi
-fi
+  local project_root="$PWD"
+  if [ ! -d "${project_root}/openspec" ]; then
+    return 0
+  fi
+  if ! command -v openspec >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! openspec --version >/dev/null 2>&1; then
+    return 0
+  fi
 
-# Step 10: If $SLUG is empty -> exit 0 silently (free-form proposal)
-if [ -z "$SLUG" ]; then
-  exit 0
-fi
+  local proposal_desc
+  proposal_desc=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.description // empty' 2>/dev/null) || true
 
-# Step 8: chorus_list_tasks (filtered by proposalUuid) -> verify every task
-# is "done". Pagination guard: if total > returned, exit silently.
-TASKS_JSON=$("$MCP" chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
-if [ -z "$TASKS_JSON" ]; then
-  exit 0
-fi
+  # grep description for ^OpenSpec change slug: (.+)$ — first match wins
+  local slug=""
+  if [ -n "$proposal_desc" ]; then
+    local slug_line
+    slug_line=$(printf '%s\n' "$proposal_desc" | grep -E '^OpenSpec change slug: .+' | head -1 || true)
+    if [ -n "$slug_line" ]; then
+      slug=$(printf '%s' "$slug_line" | sed -e 's/^OpenSpec change slug:[[:space:]]*//' -e 's/[[:space:]]*$//')
+    fi
+  fi
 
-TOTAL_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.total // 0' 2>/dev/null) || true
-RETURNED_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.tasks | length' 2>/dev/null) || true
+  # If slug empty -> silent skip (free-form proposal)
+  if [ -z "$slug" ]; then
+    return 0
+  fi
 
-if [ -n "$TOTAL_TASKS" ] && [ -n "$RETURNED_TASKS" ] && [ "$TOTAL_TASKS" -gt "$RETURNED_TASKS" ]; then
-  exit 0
-fi
+  # chorus_list_tasks (filtered by proposalUuid) -> verify every task is
+  # "done". Pagination guard: if total > returned, exit silently.
+  local tasks_json
+  tasks_json=$("$MCP" chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
+  if [ -z "$tasks_json" ]; then
+    return 0
+  fi
 
-# Defensive: zero-task proposal would otherwise fall through with
-# NOT_DONE_COUNT=0. Proposal-submit validation prevents this in practice;
-# this guard makes the gate complete.
-if [ -z "$RETURNED_TASKS" ] || [ "$RETURNED_TASKS" -eq 0 ]; then
-  exit 0
-fi
+  local total_tasks returned_tasks
+  total_tasks=$(printf '%s' "$tasks_json" | jq -r '.total // 0' 2>/dev/null) || true
+  returned_tasks=$(printf '%s' "$tasks_json" | jq -r '.tasks | length' 2>/dev/null) || true
 
-NOT_DONE_COUNT=$(printf '%s' "$TASKS_JSON" | jq -r '[.tasks[] | select(.status != "done")] | length' 2>/dev/null) || true
+  if [ -n "$total_tasks" ] && [ -n "$returned_tasks" ] && [ "$total_tasks" -gt "$returned_tasks" ]; then
+    return 0
+  fi
 
-if [ -z "$NOT_DONE_COUNT" ] || [ "$NOT_DONE_COUNT" != "0" ]; then
-  exit 0
-fi
+  # Defensive: zero-task proposal would otherwise fall through with
+  # not_done_count=0. Proposal-submit validation prevents this in
+  # practice; this guard makes the gate complete.
+  if [ -z "$returned_tasks" ] || [ "$returned_tasks" -eq 0 ]; then
+    return 0
+  fi
 
-# Step 11: Build CONTEXT — instruct the agent to run `openspec archive
-# <SLUG>` and mirror the resulting specs back to the matching Chorus
-# Documents. (chorus_get_documents only supports projectUuid + type as
-# server-side filters — title matching is client-side, canonical §3.8.)
+  local not_done_count
+  not_done_count=$(printf '%s' "$tasks_json" | jq -r '[.tasks[] | select(.status != "done")] | length' 2>/dev/null) || true
 
-CTX="[Chorus — OpenSpec Archive Trigger]
-The last task of OpenSpec-mode proposal ${PROPOSAL_UUID} (slug \`${SLUG}\`) has been admin-verified.
+  if [ -z "$not_done_count" ] || [ "$not_done_count" != "0" ]; then
+    return 0
+  fi
+
+  # Build the archive reminder. (chorus_get_documents only supports
+  # projectUuid + type as server-side filters — title matching is
+  # client-side, canonical §3.8.)
+  cat <<CTX
+[Chorus — OpenSpec Archive Trigger]
+The last task of OpenSpec-mode proposal ${PROPOSAL_UUID} (slug \`${slug}\`) has been admin-verified.
 
 ACTION REQUIRED: archive the OpenSpec change locally and mirror updated specs back to the Chorus Documents. Run the steps below in order; HALT immediately on any error (canonical §6 — no silent errors).
 
-1. Run \`openspec archive ${SLUG}\` in the repo root. This moves \`openspec/changes/${SLUG}/\` under \`openspec/changes/archive/<date>-${SLUG}/\` and emits/updates one \`openspec/specs/<capability>/spec.md\` per capability. If the CLI prompts interactively and a \`--yes\`/\`--no-confirm\` flag is available, use it (verify with \`openspec archive --help\`).
+1. Run \`openspec archive ${slug}\` in the repo root. This moves \`openspec/changes/${slug}/\` under \`openspec/changes/archive/<date>-${slug}/\` and emits/updates one \`openspec/specs/<capability>/spec.md\` per capability. If the CLI prompts interactively and a \`--yes\`/\`--no-confirm\` flag is available, use it (verify with \`openspec archive --help\`).
 
 2. For EACH newly-emitted \`openspec/specs/<capability>/spec.md\`:
-   - List all spec-type Documents in this project: \`chorus_get_documents({projectUuid: \"${PROJECT_UUID}\", type: \"spec\"})\`. The \`type\` filter is the only server-side filter — do client-side title matching against the documents you get back.
+   - List all spec-type Documents in this project: \`chorus_get_documents({projectUuid: "${PROJECT_UUID}", type: "spec"})\`. The \`type\` filter is the only server-side filter — do client-side title matching against the documents you get back.
    - Find the Document whose title matches the capability (canonical §3.8 mirror-back contract; typical title shape \`Spec: <capability>\`).
    - Call \`chorus_pm_update_document\` with the new content from the on-disk spec.md.
 
-3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: \"proposal\", targetUuid: \"${PROPOSAL_UUID}\", content: \"...\"})\`), and HALT. No retry, no silent skip.
+3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: "proposal", targetUuid: "${PROPOSAL_UUID}", content: "..."})\`), and HALT. No retry, no silent skip.
 
 4. Confirm success by listing \`openspec/specs/<capability>/spec.md\` files and verifying they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
 
-References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors)."
+References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors).
+CTX
+}
 
-# Step 12: Inject CTX as additionalContext (Codex hook_output emits the
-# JSON envelope expected by Codex hook host).
-hook_output "" "$CTX" "PostToolUse"
+# ===== Branch B: Idea-completion report reminder =====
+#
+# Fires when this Proposal is finished AND has no report Document yet.
+# Two checks only:
+#   1. all tasks of this proposal in {done, closed}
+#   2. no Document with type="report" attached to this proposal
+# Read-only — the hook never calls chorus_create_report.
+branch_idea_report_reminder() {
+  # Only idea-rooted proposals get a completion report.
+  local input_type
+  input_type=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.inputType // empty' 2>/dev/null) || true
+  if [ "$input_type" != "idea" ]; then
+    return 0
+  fi
 
-# Step 13: exit 0
+  # Check 1: all tasks of this proposal are terminal.
+  local tasks_json non_terminal_count
+  tasks_json=$("$MCP" chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"]}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
+  [ -n "$tasks_json" ] || return 0
+  non_terminal_count=$(printf '%s' "$tasks_json" | jq -r '[.tasks[] | select(.status != "done" and .status != "closed")] | length' 2>/dev/null) || return 0
+  [ "$non_terminal_count" = "0" ] || return 0
+
+  # Check 2: no report Document on this proposal yet.
+  local docs_json existing_report_count
+  docs_json=$("$MCP" chorus_get_documents "$(printf '{"projectUuid":"%s","type":"report"}' "$PROJECT_UUID")" 2>/dev/null) || return 0
+  [ -n "$docs_json" ] || return 0
+  existing_report_count=$(printf '%s' "$docs_json" | jq -r --arg p "$PROPOSAL_UUID" '[.documents[] | select(.proposalUuid==$p)] | length' 2>/dev/null) || return 0
+  [ "$existing_report_count" = "0" ] || return 0
+
+  # Emit the reminder. The literal substring `create idea-completion
+  # report` is the contract grep target asserted by both the spec
+  # scenarios and the regression test.
+  cat <<CTX
+[Chorus — Idea-Completion Report Trigger]
+All tasks of proposal ${PROPOSAL_UUID} are now done; no completion report yet.
+
+ACTION REQUESTED: create idea-completion report for this Idea. Call \`chorus_create_report\` with proposalUuid="${PROPOSAL_UUID}". The tool description carries the Summary / Decisions / Follow-ups template.
+CTX
+}
+
+# ===== Run both branches and emit combined output =====
+
+OPENSPEC_CONTEXT=$(branch_openspec_archive || true)
+REPORT_CONTEXT=$(branch_idea_report_reminder || true)
+
+COMBINED=""
+if [ -n "$OPENSPEC_CONTEXT" ] && [ -n "$REPORT_CONTEXT" ]; then
+  COMBINED="${OPENSPEC_CONTEXT}
+
+${REPORT_CONTEXT}"
+elif [ -n "$OPENSPEC_CONTEXT" ]; then
+  COMBINED="$OPENSPEC_CONTEXT"
+elif [ -n "$REPORT_CONTEXT" ]; then
+  COMBINED="$REPORT_CONTEXT"
+fi
+
+if [ -n "$COMBINED" ]; then
+  hook_output "" "$COMBINED" "PostToolUse"
+fi
+
 exit 0

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -129,16 +129,20 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_ideas` | List project Ideas (filterable by status, paginated) |
-| `chorus_get_idea` | Get a single Idea's details |
+| `chorus_get_ideas` | List project Ideas (filterable by status, paginated; rows include `reportCount`) |
+| `chorus_get_idea` | Get a single Idea's details (includes `reports[]` with full content) |
 | `chorus_get_available_ideas` | Get claimable Ideas (status=open) |
 
 ### Documents
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide) |
+| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide, report) |
 | `chorus_get_document` | Get a single document's content |
+
+### Reports
+
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `$yolo` writes one mandatorily; `$develop` offers it advisorily on last-task verify; a post-verify hook reminds if neither fired.
 
 ### Proposals
 
@@ -285,7 +289,7 @@ The table below shows default tool availability for each preset (no custom permi
 | `chorus_claim_task` / `chorus_release_task` / `chorus_submit_for_verify` / `chorus_report_work` / `chorus_report_criteria_self_check` | `task:write` | Yes | **Yes** (0.7.0+) | Yes |
 | `chorus_claim_idea` / `chorus_release_idea` / `chorus_move_idea` / `chorus_pm_create_idea` / `chorus_pm_*_elaboration` | `idea:write` | No | Yes | Yes |
 | `chorus_pm_create_proposal` / `chorus_pm_*_proposal` / `chorus_pm_*_draft` / `chorus_create_tasks` / `chorus_pm_assign_task` | `proposal:write` | No | Yes | Yes |
-| `chorus_pm_create_document` / `chorus_pm_update_document` | `document:write` | No | Yes | Yes |
+| `chorus_pm_create_document` / `chorus_pm_update_document` / `chorus_create_report` | `document:write` | No | Yes | Yes |
 | `chorus_admin_create_project` / `chorus_admin_*_project_group` / `chorus_admin_move_project_to_group` | `project:write` | No | **Yes** (0.7.0+) | Yes |
 | `chorus_admin_approve_proposal` / `chorus_admin_close_proposal` | `proposal:admin` | No | No | Yes |
 | `chorus_admin_verify_task` / `chorus_admin_reopen_task` / `chorus_admin_close_task` / `chorus_mark_acceptance_criteria` / `chorus_admin_delete_task` | `task:admin` | No | No | Yes |

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -266,6 +266,10 @@ If the reviewer returns **FAIL**, or the task is reopened after verification:
 
 Once Admin verifies (status: `done`), move to the next available task (back to Step 2).
 
+### Step 11: Idea Completion Report (advisory)
+
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, prompt the user and call `chorus_create_report` on accept. The tool description carries the section template. Skip on decline — the PostToolUse hook will remind on the next run.
+
 ---
 
 ## Session (Optional, Codex Port)

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -501,6 +501,12 @@ After all waves complete, output a markdown summary:
 
 ---
 
+### Phase 5b: Idea Completion Report (mandatory)
+
+A successful `$yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The tool's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
+
+---
+
 ## Error Handling
 
 | Scenario | Action |

--- a/public/chorus-plugin/bin/on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/on-post-verify-task.sh
@@ -200,16 +200,6 @@ CTX
 #   2. no Document with type="report" attached to this proposal
 # Read-only — the hook never calls chorus_create_report.
 branch_idea_report_reminder() {
-  # Per-branch opt-out. Default is enabled; users who don't want the
-  # report-creation reminder can set this to "false" in their plugin config.
-  # Pre-PR the broader CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC toggle silenced
-  # the entire hook; that toggle now scopes Branch A only, so a separate
-  # toggle is needed for users to silence Branch B without giving up the
-  # OpenSpec archive reminder.
-  if [ "${CLAUDE_PLUGIN_OPTION_ENABLEREPORTREMINDER:-true}" != "true" ]; then
-    return 0
-  fi
-
   # Only idea-rooted proposals get a completion report.
   local input_type
   input_type=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.inputType // empty' 2>/dev/null) || true

--- a/public/chorus-plugin/bin/on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/on-post-verify-task.sh
@@ -1,24 +1,32 @@
 #!/usr/bin/env bash
 # on-post-verify-task.sh — PostToolUse hook for chorus_admin_verify_task
 #
-# Detects the "last task verified for an OpenSpec-mode idea" condition and
-# injects an additionalContext reminder telling the main agent to run
-# `openspec archive <slug>` and mirror the resulting
-# openspec/specs/<capability>/spec.md files back to the matching Chorus
-# Documents.
+# Two independent reminder branches share the post-verify trigger:
 #
-# Detection contract (all signals must hold to fire):
-#   1. CHORUS_OPENSPEC_MODE != "off" — explicit opt-out wins.
-#   2. The project root contains an `openspec/` directory — this repo is
-#      OpenSpec-init'd. Probed via $CLAUDE_PROJECT_DIR/openspec.
-#   3. `openspec` CLI is on PATH — needed for the agent's later
-#      `openspec archive` step. Both (2) and (3) are required because
-#      either alone leaves the archive workflow unrunnable.
-#   4. The verified task's proposal description contains a line matching
-#      ^OpenSpec change slug: <slug>$ (slug provenance from §3.5).
-#   5. Every task under the same proposal has status === "done".
+#   Branch A — OpenSpec archive trigger (legacy)
+#     Detects "last task verified for an OpenSpec-mode proposal" and tells
+#     the agent to run `openspec archive <slug>` plus mirror updated specs
+#     back into Chorus Documents.
+#     Gates (all must hold): CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC=true,
+#     CHORUS_OPENSPEC_MODE!=off, $CLAUDE_PROJECT_DIR/openspec/ exists,
+#     `openspec` CLI on PATH, proposal description matches
+#     ^OpenSpec change slug:, every task under that proposal is done.
 #
-# If any signal fails, the hook exits 0 silently (strict opt-in).
+#   Branch B — Idea-completion report reminder
+#     Tells the agent to call `chorus_create_report` when this proposal
+#     is finished and has no report Document yet. Two checks: all tasks
+#     of THIS proposal are done/closed, and THIS proposal has no
+#     `type="report"` Document yet. The multi-proposal-per-Idea case is
+#     handled by yolo's mandatory end-step, not by this hook.
+#
+# Each branch is computed independently into its own context variable;
+# any non-empty contexts are concatenated and emitted as one
+# `additionalContext` payload at the end. Either branch firing on its
+# own produces exactly one reminder; both firing produces both reminders
+# joined by a blank line.
+#
+# Branch B is read-only — it never calls `chorus_create_report` or any
+# other mutation tool.
 #
 # Bash 3.2 compatible (per CLAUDE.md pitfall #10): no ${VAR,,}, no
 # ${VAR^^}, no `declare -A`, no `mapfile`, no `readarray`, no `|&`,
@@ -30,16 +38,10 @@
 
 set -euo pipefail
 
-# Check userConfig toggle — default enabled. The same `enableOpenSpec`
-# switch gates SessionStart detection; if it's off, we skip the archive
-# reminder too. (Env-level CHORUS_OPENSPEC_MODE=off is checked separately
-# at step 4 for symmetry with the SessionStart gate.)
-if [ "${CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC:-true}" != "true" ]; then
-  exit 0
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 API="${SCRIPT_DIR}/chorus-api.sh"
+
+# ===== Shared: event parse =====
 
 # Read event JSON from stdin (PostToolUse hook input)
 EVENT=""
@@ -51,35 +53,17 @@ if [ -z "$EVENT" ]; then
   exit 0
 fi
 
-# Step 2: Extract taskUuid from .tool_input
+# Extract taskUuid from .tool_input
 TASK_UUID=$(printf '%s' "$EVENT" | jq -r '.tool_input.taskUuid // empty' 2>/dev/null) || true
 
-# Step 3: If taskUuid is empty -> exit 0 silently
+# If taskUuid is empty -> exit 0 silently
 if [ -z "$TASK_UUID" ]; then
   exit 0
 fi
 
-# Step 4: OpenSpec gate — explicit opt-out, then folder + CLI both required.
-# Both folder-presence and CLI-presence are necessary: the agent will run
-# `openspec archive <slug>` on receipt of the injected reminder, and that
-# command needs the openspec/ working directory AND the CLI on PATH. If
-# either is missing, the reminder would point the agent at a dead end, so
-# we silently skip injection and let the verify pass through unannotated.
-if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
-  exit 0
-fi
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
-if [ ! -d "${PROJECT_ROOT}/openspec" ]; then
-  exit 0
-fi
-if ! command -v openspec >/dev/null 2>&1; then
-  exit 0
-fi
-if ! openspec --version >/dev/null 2>&1; then
-  exit 0
-fi
-
-# Step 5: chorus_get_task -> proposalUuid
+# Resolve the verified task once — both branches need proposalUuid +
+# project.uuid. If the lookup fails or returns no proposalUuid (Quick
+# Tasks), neither branch can fire, so we exit silently.
 TASK_JSON=$("$API" mcp-tool chorus_get_task "$(printf '{"taskUuid":"%s"}' "$TASK_UUID")" 2>/dev/null) || exit 0
 if [ -z "$TASK_JSON" ]; then
   exit 0
@@ -88,103 +72,185 @@ fi
 PROPOSAL_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.proposalUuid // empty' 2>/dev/null) || true
 PROJECT_UUID=$(printf '%s' "$TASK_JSON" | jq -r '.project.uuid // empty' 2>/dev/null) || true
 
-# Step 6: If proposalUuid empty -> exit 0 silently (Quick Tasks have no proposal)
-if [ -z "$PROPOSAL_UUID" ]; then
+if [ -z "$PROPOSAL_UUID" ] || [ -z "$PROJECT_UUID" ]; then
   exit 0
 fi
 
-# Step 7: chorus_get_proposal -> description (for slug grep)
+# Both branches need the proposal's full record; fetch once.
 PROPOSAL_JSON=$("$API" mcp-tool chorus_get_proposal "$(printf '{"proposalUuid":"%s"}' "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
 if [ -z "$PROPOSAL_JSON" ]; then
   exit 0
 fi
 
-PROPOSAL_DESC=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.description // empty' 2>/dev/null) || true
-
-# Step 9: grep description for ^OpenSpec change slug: (.+)$ — first match wins
-SLUG=""
-if [ -n "$PROPOSAL_DESC" ]; then
-  # POSIX-portable: print description with embedded newlines via printf %s
-  # then grep line-anchored for the slug marker.
-  SLUG_LINE=$(printf '%s\n' "$PROPOSAL_DESC" | grep -E '^OpenSpec change slug: .+' | head -1 || true)
-  if [ -n "$SLUG_LINE" ]; then
-    # Strip the prefix; trim trailing whitespace.
-    SLUG=$(printf '%s' "$SLUG_LINE" | sed -e 's/^OpenSpec change slug:[[:space:]]*//' -e 's/[[:space:]]*$//')
+# ===== Branch A: OpenSpec archive trigger =====
+#
+# Returns the archive-reminder context on stdout when all conditions
+# hold; returns empty (silent skip) otherwise. Designed to be captured
+# via command substitution: OPENSPEC_CONTEXT=$(branch_openspec_archive)
+branch_openspec_archive() {
+  # OpenSpec userConfig toggle — default enabled. The same `enableOpenSpec`
+  # switch gates SessionStart detection; if it's off, we skip the archive
+  # reminder too. (Env-level CHORUS_OPENSPEC_MODE=off is checked separately
+  # below for symmetry with the SessionStart gate.)
+  if [ "${CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC:-true}" != "true" ]; then
+    return 0
   fi
-fi
 
-# Step 10: If $SLUG is empty -> exit 0 silently (free-form proposal)
-if [ -z "$SLUG" ]; then
-  exit 0
-fi
+  # OpenSpec gate — explicit opt-out, then folder + CLI both required.
+  # Both folder-presence and CLI-presence are necessary: the agent will
+  # run `openspec archive <slug>` on receipt of the injected reminder,
+  # and that command needs the openspec/ working directory AND the CLI
+  # on PATH. If either is missing, the reminder would point the agent
+  # at a dead end, so we silently skip injection.
+  if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
+    return 0
+  fi
+  local project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
+  if [ ! -d "${project_root}/openspec" ]; then
+    return 0
+  fi
+  if ! command -v openspec >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! openspec --version >/dev/null 2>&1; then
+    return 0
+  fi
 
-# Step 8: chorus_list_tasks (filtered by proposalUuid) -> verify every task is "done".
-# (The proposal-design assumed chorus_get_idea returned tasks[], but the
-# actual MCP tool only returns IdeaResponse; chorus_list_tasks with the
-# proposalUuids filter is the closest equivalent and is the documented
-# contract.)
-#
-# We page through up to 200 tasks (pageSize=200) — far above the design
-# expectation of ~10-20 tasks per proposal. If a proposal exceeds 200
-# tasks the hook conservatively exits 0 silently, matching the
-# Tech Design "Risk: chorus_get_idea is paginated" mitigation.
-TASKS_JSON=$("$API" mcp-tool chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || exit 0
-if [ -z "$TASKS_JSON" ]; then
-  exit 0
-fi
+  local proposal_desc
+  proposal_desc=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.description // empty' 2>/dev/null) || true
 
-TOTAL_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.total // 0' 2>/dev/null) || true
-RETURNED_TASKS=$(printf '%s' "$TASKS_JSON" | jq -r '.tasks | length' 2>/dev/null) || true
+  # grep description for ^OpenSpec change slug: (.+)$ — first match wins
+  local slug=""
+  if [ -n "$proposal_desc" ]; then
+    local slug_line
+    slug_line=$(printf '%s\n' "$proposal_desc" | grep -E '^OpenSpec change slug: .+' | head -1 || true)
+    if [ -n "$slug_line" ]; then
+      slug=$(printf '%s' "$slug_line" | sed -e 's/^OpenSpec change slug:[[:space:]]*//' -e 's/[[:space:]]*$//')
+    fi
+  fi
 
-# Pagination guard: if total exceeds what we fetched, exit silently (better
-# safe than fire prematurely).
-if [ -n "$TOTAL_TASKS" ] && [ -n "$RETURNED_TASKS" ] && [ "$TOTAL_TASKS" -gt "$RETURNED_TASKS" ]; then
-  exit 0
-fi
+  # If slug empty -> silent skip (free-form proposal)
+  if [ -z "$slug" ]; then
+    return 0
+  fi
 
-# Defensive: zero-task proposal would otherwise fall through with
-# NOT_DONE_COUNT=0. Proposal-submit validation prevents this in practice;
-# this guard makes the gate complete.
-if [ -z "$RETURNED_TASKS" ] || [ "$RETURNED_TASKS" -eq 0 ]; then
-  exit 0
-fi
+  # chorus_list_tasks (filtered by proposalUuid) -> verify every task is "done".
+  # Pagination guard: if total > returned, exit silently (better safe than
+  # fire prematurely). pageSize=200 is far above the design expectation
+  # of ~10-20 tasks per proposal.
+  local tasks_json
+  tasks_json=$("$API" mcp-tool chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
+  if [ -z "$tasks_json" ]; then
+    return 0
+  fi
 
-NOT_DONE_COUNT=$(printf '%s' "$TASKS_JSON" | jq -r '[.tasks[] | select(.status != "done")] | length' 2>/dev/null) || true
+  local total_tasks returned_tasks
+  total_tasks=$(printf '%s' "$tasks_json" | jq -r '.total // 0' 2>/dev/null) || true
+  returned_tasks=$(printf '%s' "$tasks_json" | jq -r '.tasks | length' 2>/dev/null) || true
 
-if [ -z "$NOT_DONE_COUNT" ] || [ "$NOT_DONE_COUNT" != "0" ]; then
-  exit 0
-fi
+  if [ -n "$total_tasks" ] && [ -n "$returned_tasks" ] && [ "$total_tasks" -gt "$returned_tasks" ]; then
+    return 0
+  fi
 
-# Step 11: Build CONTEXT — instruct the agent to run `openspec archive <SLUG>`
-# and mirror the resulting specs/<capability>/spec.md files back to the
-# matching Chorus Documents.
-#
-# Note on chorus_get_documents: the canonical §3.8 mirror-back step uses
-# `chorus_get_documents(projectUuid)` (the only filter the tool supports
-# server-side is `type` — there is NO server-side title-prefix filter).
-# The agent must list all `type:"spec"` documents and filter client-side
-# by title prefix `Spec:` to find the matching capability.
+  # Defensive: zero-task proposal would otherwise fall through with
+  # not_done_count=0. Proposal-submit validation prevents this in practice;
+  # this guard makes the gate complete.
+  if [ -z "$returned_tasks" ] || [ "$returned_tasks" -eq 0 ]; then
+    return 0
+  fi
 
-CONTEXT="[Chorus Plugin — OpenSpec Archive Trigger]
-The last task of OpenSpec-mode proposal ${PROPOSAL_UUID} (slug \`${SLUG}\`) has been admin-verified.
+  local not_done_count
+  not_done_count=$(printf '%s' "$tasks_json" | jq -r '[.tasks[] | select(.status != "done")] | length' 2>/dev/null) || true
+
+  if [ -z "$not_done_count" ] || [ "$not_done_count" != "0" ]; then
+    return 0
+  fi
+
+  # Build the archive reminder. Note on chorus_get_documents: the
+  # canonical §3.8 mirror-back step uses chorus_get_documents(projectUuid)
+  # — the only filter the tool supports server-side is `type` (no title
+  # filter). The agent must list all type:"spec" documents and filter
+  # client-side by title prefix `Spec:` to find the matching capability.
+  cat <<CTX
+[Chorus Plugin — OpenSpec Archive Trigger]
+The last task of OpenSpec-mode proposal ${PROPOSAL_UUID} (slug \`${slug}\`) has been admin-verified.
 
 ACTION REQUIRED: archive the OpenSpec change locally and mirror updated specs back to the Chorus Documents. Run the steps below in order; HALT immediately on any error (canonical §6 — no silent errors).
 
-1. Run \`openspec archive ${SLUG}\` in the repo root. This moves \`openspec/changes/${SLUG}/\` under \`openspec/changes/archive/<date>-${SLUG}/\` and emits/updates one \`openspec/specs/<capability>/spec.md\` per capability. If the CLI prompts interactively and a \`--yes\`/\`--no-confirm\` flag is available, use it (verify with \`openspec archive --help\`).
+1. Run \`openspec archive ${slug}\` in the repo root. This moves \`openspec/changes/${slug}/\` under \`openspec/changes/archive/<date>-${slug}/\` and emits/updates one \`openspec/specs/<capability>/spec.md\` per capability. If the CLI prompts interactively and a \`--yes\`/\`--no-confirm\` flag is available, use it (verify with \`openspec archive --help\`).
 
 2. For EACH newly-emitted \`openspec/specs/<capability>/spec.md\`:
-   - List all spec-type Documents in this project: \`chorus_get_documents({projectUuid: \"${PROJECT_UUID}\", type: \"spec\"})\`. The \`type\` filter is the only server-side filter — do client-side title matching against the documents you get back.
+   - List all spec-type Documents in this project: \`chorus_get_documents({projectUuid: "${PROJECT_UUID}", type: "spec"})\`. The \`type\` filter is the only server-side filter — do client-side title matching against the documents you get back.
    - Find the Document whose title matches the capability (canonical §3.8 mirror-back contract; typical title shape \`Spec: <capability>\`).
    - Call \`chorus_pm_update_document\` with the new content from the on-disk spec.md.
 
-3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: \"proposal\", targetUuid: \"${PROPOSAL_UUID}\", content: \"...\"})\`), and HALT. No retry, no silent skip.
+3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: "proposal", targetUuid: "${PROPOSAL_UUID}", content: "..."})\`), and HALT. No retry, no silent skip.
 
 4. Confirm success by listing \`openspec/specs/<capability>/spec.md\` files and verifying they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
 
-References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors)."
+References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors).
+CTX
+}
 
-# Step 12: Inject CONTEXT as additionalContext.
-"$API" hook-output "" "$CONTEXT" "PostToolUse"
+# ===== Branch B: Idea-completion report reminder =====
+#
+# Fires when this Proposal is finished AND has no report Document yet.
+# Two checks only:
+#   1. all tasks of this proposal in {done, closed}
+#   2. no Document with type="report" attached to this proposal
+# Read-only — the hook never calls chorus_create_report.
+branch_idea_report_reminder() {
+  # Only idea-rooted proposals get a completion report.
+  local input_type
+  input_type=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.inputType // empty' 2>/dev/null) || true
+  if [ "$input_type" != "idea" ]; then
+    return 0
+  fi
 
-# Step 13: exit 0 (set -e already enforces this on success).
+  # Check 1: all tasks of this proposal are terminal.
+  local tasks_json non_terminal_count
+  tasks_json=$("$API" mcp-tool chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"]}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
+  [ -n "$tasks_json" ] || return 0
+  non_terminal_count=$(printf '%s' "$tasks_json" | jq -r '[.tasks[] | select(.status != "done" and .status != "closed")] | length' 2>/dev/null) || return 0
+  [ "$non_terminal_count" = "0" ] || return 0
+
+  # Check 2: no report Document on this proposal yet.
+  local docs_json existing_report_count
+  docs_json=$("$API" mcp-tool chorus_get_documents "$(printf '{"projectUuid":"%s","type":"report"}' "$PROJECT_UUID")" 2>/dev/null) || return 0
+  [ -n "$docs_json" ] || return 0
+  existing_report_count=$(printf '%s' "$docs_json" | jq -r --arg p "$PROPOSAL_UUID" '[.documents[] | select(.proposalUuid==$p)] | length' 2>/dev/null) || return 0
+  [ "$existing_report_count" = "0" ] || return 0
+
+  # Emit the reminder. The literal substring `create idea-completion
+  # report` is the contract grep target asserted by both the spec
+  # scenarios and the regression test.
+  cat <<CTX
+[Chorus Plugin — Idea-Completion Report Trigger]
+All tasks of proposal ${PROPOSAL_UUID} are now done; no completion report yet.
+
+ACTION REQUESTED: create idea-completion report for this Idea. Call \`chorus_create_report\` with proposalUuid="${PROPOSAL_UUID}". The tool description carries the Summary / Decisions / Follow-ups template.
+CTX
+}
+
+# ===== Run both branches and emit combined output =====
+
+OPENSPEC_CONTEXT=$(branch_openspec_archive || true)
+REPORT_CONTEXT=$(branch_idea_report_reminder || true)
+
+COMBINED=""
+if [ -n "$OPENSPEC_CONTEXT" ] && [ -n "$REPORT_CONTEXT" ]; then
+  # Two reminders — separate them with a blank line.
+  COMBINED="${OPENSPEC_CONTEXT}
+
+${REPORT_CONTEXT}"
+elif [ -n "$OPENSPEC_CONTEXT" ]; then
+  COMBINED="$OPENSPEC_CONTEXT"
+elif [ -n "$REPORT_CONTEXT" ]; then
+  COMBINED="$REPORT_CONTEXT"
+fi
+
+if [ -n "$COMBINED" ]; then
+  "$API" hook-output "" "$COMBINED" "PostToolUse"
+fi
+
 exit 0

--- a/public/chorus-plugin/bin/on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/on-post-verify-task.sh
@@ -200,6 +200,16 @@ CTX
 #   2. no Document with type="report" attached to this proposal
 # Read-only — the hook never calls chorus_create_report.
 branch_idea_report_reminder() {
+  # Per-branch opt-out. Default is enabled; users who don't want the
+  # report-creation reminder can set this to "false" in their plugin config.
+  # Pre-PR the broader CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC toggle silenced
+  # the entire hook; that toggle now scopes Branch A only, so a separate
+  # toggle is needed for users to silence Branch B without giving up the
+  # OpenSpec archive reminder.
+  if [ "${CLAUDE_PLUGIN_OPTION_ENABLEREPORTREMINDER:-true}" != "true" ]; then
+    return 0
+  fi
+
   # Only idea-rooted proposals get a completion report.
   local input_type
   input_type=$(printf '%s' "$PROPOSAL_JSON" | jq -r '.inputType // empty' 2>/dev/null) || true
@@ -208,17 +218,34 @@ branch_idea_report_reminder() {
   fi
 
   # Check 1: all tasks of this proposal are terminal.
-  local tasks_json non_terminal_count
-  tasks_json=$("$API" mcp-tool chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"]}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
+  # pageSize=200 + a total>returned guard so a wide proposal can't fool the
+  # check by happening to fit "done" tasks on page 1 while non-terminals
+  # remain on later pages. (Same belt-and-suspenders pattern as Branch A.)
+  local tasks_json non_terminal_count tasks_total tasks_returned
+  tasks_json=$("$API" mcp-tool chorus_list_tasks "$(printf '{"projectUuid":"%s","proposalUuids":["%s"],"pageSize":200}' "$PROJECT_UUID" "$PROPOSAL_UUID")" 2>/dev/null) || return 0
   [ -n "$tasks_json" ] || return 0
-  non_terminal_count=$(printf '%s' "$tasks_json" | jq -r '[.tasks[] | select(.status != "done" and .status != "closed")] | length' 2>/dev/null) || return 0
+  tasks_total=$(printf '%s' "$tasks_json" | jq -r '.total // 0' 2>/dev/null) || return 0
+  tasks_returned=$(printf '%s' "$tasks_json" | jq -r '(.tasks // []) | length' 2>/dev/null) || return 0
+  if [ -n "$tasks_total" ] && [ -n "$tasks_returned" ] && [ "$tasks_total" -gt "$tasks_returned" ]; then
+    return 0
+  fi
+  non_terminal_count=$(printf '%s' "$tasks_json" | jq -r '[(.tasks // [])[] | select(.status != "done" and .status != "closed")] | length' 2>/dev/null) || return 0
   [ "$non_terminal_count" = "0" ] || return 0
 
   # Check 2: no report Document on this proposal yet.
-  local docs_json existing_report_count
-  docs_json=$("$API" mcp-tool chorus_get_documents "$(printf '{"projectUuid":"%s","type":"report"}' "$PROJECT_UUID")" 2>/dev/null) || return 0
+  # chorus_get_documents only filters by type server-side; we do the
+  # proposalUuid filter client-side. pageSize=200 + total>returned guard
+  # avoids a false "no report" when the proposal's existing report is on
+  # a later page in a long-lived project.
+  local docs_json existing_report_count docs_total docs_returned
+  docs_json=$("$API" mcp-tool chorus_get_documents "$(printf '{"projectUuid":"%s","type":"report","pageSize":200}' "$PROJECT_UUID")" 2>/dev/null) || return 0
   [ -n "$docs_json" ] || return 0
-  existing_report_count=$(printf '%s' "$docs_json" | jq -r --arg p "$PROPOSAL_UUID" '[.documents[] | select(.proposalUuid==$p)] | length' 2>/dev/null) || return 0
+  docs_total=$(printf '%s' "$docs_json" | jq -r '.total // 0' 2>/dev/null) || return 0
+  docs_returned=$(printf '%s' "$docs_json" | jq -r '(.documents // []) | length' 2>/dev/null) || return 0
+  if [ -n "$docs_total" ] && [ -n "$docs_returned" ] && [ "$docs_total" -gt "$docs_returned" ]; then
+    return 0
+  fi
+  existing_report_count=$(printf '%s' "$docs_json" | jq -r --arg p "$PROPOSAL_UUID" '[(.documents // [])[] | select(.proposalUuid==$p)] | length' 2>/dev/null) || return 0
   [ "$existing_report_count" = "0" ] || return 0
 
   # Emit the reminder. The literal substring `create idea-completion

--- a/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
@@ -44,6 +44,19 @@
 #                        non-idea-rooted proposal); branch B must skip
 #                        regardless of task status
 #                        -> stdout MUST NOT contain `create idea-completion report`
+#   report-task-overflow — chorus_list_tasks returns total > tasks.length
+#                          (page-1 of a wider task set, all returned tasks
+#                          are done but more remain). Hook MUST refuse to
+#                          conclude "all done" — silent skip.
+#                          -> stdout MUST NOT contain `create idea-completion report`
+#   report-doc-overflow  — chorus_get_documents returns total > documents.length
+#                          (existing report sits on a later page). Hook MUST
+#                          refuse to conclude "no report" — silent skip.
+#                          -> stdout MUST NOT contain `create idea-completion report`
+#   report-opt-out       — same shape as report-positive, but the per-branch
+#                          opt-out env var is set. Hook MUST silent-skip even
+#                          though all conditions otherwise pass.
+#                          -> stdout MUST NOT contain `create idea-completion report`
 #
 # All fixtures must end with exit 0.
 #
@@ -204,6 +217,53 @@ case "$cmd" in
         echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
         ;;
 
+      # report-task-overflow: chorus_list_tasks returns 5 done tasks but
+      # total=25 — more tasks exist on later pages. Hook MUST refuse to
+      # conclude "all done" and silent-skip Branch B.
+      report-task-overflow:chorus_get_task)
+        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      report-task-overflow:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+        ;;
+      report-task-overflow:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"t1","status":"done","proposalUuid":"prop-9"},{"uuid":"t2","status":"done","proposalUuid":"prop-9"},{"uuid":"t3","status":"done","proposalUuid":"prop-9"},{"uuid":"t4","status":"done","proposalUuid":"prop-9"},{"uuid":"t5","status":"done","proposalUuid":"prop-9"}],"total":25,"page":1,"pageSize":200}'
+        ;;
+      report-task-overflow:chorus_get_documents)
+        echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+        ;;
+
+      # report-doc-overflow: chorus_get_documents returns 1 unrelated
+      # report but total=25 — this proposal's existing report sits on a
+      # later page. Hook MUST refuse to conclude "no report" and silent-skip.
+      report-doc-overflow:chorus_get_task)
+        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      report-doc-overflow:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+        ;;
+      report-doc-overflow:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"closed","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+        ;;
+      report-doc-overflow:chorus_get_documents)
+        echo '{"documents":[{"uuid":"doc-other","type":"report","title":"Some other report","proposalUuid":"prop-OTHER"}],"total":25,"page":1,"pageSize":200}'
+        ;;
+
+      # report-opt-out: same shape as report-positive. Branch B MUST
+      # silent-skip because the per-branch toggle is off.
+      report-opt-out:chorus_get_task)
+        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      report-opt-out:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+        ;;
+      report-opt-out:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
+        ;;
+      report-opt-out:chorus_get_documents)
+        echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+        ;;
+
       *)
         # Unhandled (tool, fixture) — return empty, hook should silent-skip.
         echo ""
@@ -322,6 +382,48 @@ case "${fixture}:${tool}" in
     echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
     ;;
 
+  # report-task-overflow: tasks total > returned -> silent skip.
+  report-task-overflow:chorus_get_task)
+    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  report-task-overflow:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+    ;;
+  report-task-overflow:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"t1","status":"done","proposalUuid":"prop-9"},{"uuid":"t2","status":"done","proposalUuid":"prop-9"},{"uuid":"t3","status":"done","proposalUuid":"prop-9"},{"uuid":"t4","status":"done","proposalUuid":"prop-9"},{"uuid":"t5","status":"done","proposalUuid":"prop-9"}],"total":25,"page":1,"pageSize":200}'
+    ;;
+  report-task-overflow:chorus_get_documents)
+    echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+    ;;
+
+  # report-doc-overflow: docs total > returned -> silent skip.
+  report-doc-overflow:chorus_get_task)
+    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  report-doc-overflow:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+    ;;
+  report-doc-overflow:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"closed","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+    ;;
+  report-doc-overflow:chorus_get_documents)
+    echo '{"documents":[{"uuid":"doc-other","type":"report","title":"Some other report","proposalUuid":"prop-OTHER"}],"total":25,"page":1,"pageSize":200}'
+    ;;
+
+  # report-opt-out: env opt-out set; Branch B MUST silent-skip.
+  report-opt-out:chorus_get_task)
+    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  report-opt-out:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+    ;;
+  report-opt-out:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
+    ;;
+  report-opt-out:chorus_get_documents)
+    echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+    ;;
+
   *)
     echo "" ;;
 esac
@@ -409,6 +511,16 @@ run_one() {
     MODE_VAR_FOR_RUN="off"
   fi
 
+  # Branch B per-branch opt-out. report-opt-out flips it; Claude variant
+  # uses CLAUDE_PLUGIN_OPTION_ENABLEREPORTREMINDER=false, Codex uses
+  # CHORUS_REPORT_REMINDER=off.
+  local REPORT_OPT_CLAUDE=""
+  local REPORT_OPT_CODEX=""
+  if [ "$fixture" = "report-opt-out" ]; then
+    REPORT_OPT_CLAUDE="false"
+    REPORT_OPT_CODEX="off"
+  fi
+
   local stdout_file
   stdout_file=$(mktemp)
   local stderr_file
@@ -422,6 +534,8 @@ run_one() {
         PATH="$PATH_FOR_RUN" \
         CLAUDE_PROJECT_DIR="$PROJECT_DIR_FOR_RUN" \
         CHORUS_OPENSPEC_MODE="$MODE_VAR_FOR_RUN" \
+        CLAUDE_PLUGIN_OPTION_ENABLEREPORTREMINDER="$REPORT_OPT_CLAUDE" \
+        CHORUS_REPORT_REMINDER="$REPORT_OPT_CODEX" \
         /bin/bash -c "cd \"$PROJECT_DIR_FOR_RUN\" && /bin/bash \"$hook_dir/on-post-verify-task.sh\"" \
         >"$stdout_file" 2>"$stderr_file" || rc=$?
 
@@ -525,6 +639,23 @@ run_one "report-not-last"   "report-not-last"   "codex"  "must-not-contain" "" "
 # manually-created proposal) -> reminder MUST be silent at first gate.
 run_one "report-quick-task" "report-quick-task" "claude" "must-not-contain" "" "create idea-completion report"
 run_one "report-quick-task" "report-quick-task" "codex"  "must-not-contain" "" "create idea-completion report"
+
+# B5: report-task-overflow — chorus_list_tasks total > returned (more
+# tasks remain on later pages). Hook must refuse to assume "all done"
+# and silent-skip Branch B.
+run_one "report-task-overflow" "report-task-overflow" "claude" "must-not-contain" "" "create idea-completion report"
+run_one "report-task-overflow" "report-task-overflow" "codex"  "must-not-contain" "" "create idea-completion report"
+
+# B6: report-doc-overflow — chorus_get_documents total > returned (the
+# proposal's existing report could be on a later page). Hook must refuse
+# to assume "no report" and silent-skip Branch B.
+run_one "report-doc-overflow" "report-doc-overflow" "claude" "must-not-contain" "" "create idea-completion report"
+run_one "report-doc-overflow" "report-doc-overflow" "codex"  "must-not-contain" "" "create idea-completion report"
+
+# B7: report-opt-out — per-branch opt-out env var set, otherwise valid
+# positive conditions. Hook must honor the toggle and silent-skip.
+run_one "report-opt-out"      "report-opt-out"      "claude" "must-not-contain" "" "create idea-completion report"
+run_one "report-opt-out"      "report-opt-out"      "codex"  "must-not-contain" "" "create idea-completion report"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
@@ -53,10 +53,6 @@
 #                          (existing report sits on a later page). Hook MUST
 #                          refuse to conclude "no report" — silent skip.
 #                          -> stdout MUST NOT contain `create idea-completion report`
-#   report-opt-out       — same shape as report-positive, but the per-branch
-#                          opt-out env var is set. Hook MUST silent-skip even
-#                          though all conditions otherwise pass.
-#                          -> stdout MUST NOT contain `create idea-completion report`
 #
 # All fixtures must end with exit 0.
 #
@@ -249,21 +245,6 @@ case "$cmd" in
         echo '{"documents":[{"uuid":"doc-other","type":"report","title":"Some other report","proposalUuid":"prop-OTHER"}],"total":25,"page":1,"pageSize":200}'
         ;;
 
-      # report-opt-out: same shape as report-positive. Branch B MUST
-      # silent-skip because the per-branch toggle is off.
-      report-opt-out:chorus_get_task)
-        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
-        ;;
-      report-opt-out:chorus_get_proposal)
-        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
-        ;;
-      report-opt-out:chorus_list_tasks)
-        echo '{"tasks":[{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
-        ;;
-      report-opt-out:chorus_get_documents)
-        echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
-        ;;
-
       *)
         # Unhandled (tool, fixture) — return empty, hook should silent-skip.
         echo ""
@@ -410,20 +391,6 @@ case "${fixture}:${tool}" in
     echo '{"documents":[{"uuid":"doc-other","type":"report","title":"Some other report","proposalUuid":"prop-OTHER"}],"total":25,"page":1,"pageSize":200}'
     ;;
 
-  # report-opt-out: env opt-out set; Branch B MUST silent-skip.
-  report-opt-out:chorus_get_task)
-    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
-    ;;
-  report-opt-out:chorus_get_proposal)
-    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
-    ;;
-  report-opt-out:chorus_list_tasks)
-    echo '{"tasks":[{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
-    ;;
-  report-opt-out:chorus_get_documents)
-    echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
-    ;;
-
   *)
     echo "" ;;
 esac
@@ -511,16 +478,6 @@ run_one() {
     MODE_VAR_FOR_RUN="off"
   fi
 
-  # Branch B per-branch opt-out. report-opt-out flips it; Claude variant
-  # uses CLAUDE_PLUGIN_OPTION_ENABLEREPORTREMINDER=false, Codex uses
-  # CHORUS_REPORT_REMINDER=off.
-  local REPORT_OPT_CLAUDE=""
-  local REPORT_OPT_CODEX=""
-  if [ "$fixture" = "report-opt-out" ]; then
-    REPORT_OPT_CLAUDE="false"
-    REPORT_OPT_CODEX="off"
-  fi
-
   local stdout_file
   stdout_file=$(mktemp)
   local stderr_file
@@ -534,8 +491,6 @@ run_one() {
         PATH="$PATH_FOR_RUN" \
         CLAUDE_PROJECT_DIR="$PROJECT_DIR_FOR_RUN" \
         CHORUS_OPENSPEC_MODE="$MODE_VAR_FOR_RUN" \
-        CLAUDE_PLUGIN_OPTION_ENABLEREPORTREMINDER="$REPORT_OPT_CLAUDE" \
-        CHORUS_REPORT_REMINDER="$REPORT_OPT_CODEX" \
         /bin/bash -c "cd \"$PROJECT_DIR_FOR_RUN\" && /bin/bash \"$hook_dir/on-post-verify-task.sh\"" \
         >"$stdout_file" 2>"$stderr_file" || rc=$?
 
@@ -651,11 +606,6 @@ run_one "report-task-overflow" "report-task-overflow" "codex"  "must-not-contain
 # to assume "no report" and silent-skip Branch B.
 run_one "report-doc-overflow" "report-doc-overflow" "claude" "must-not-contain" "" "create idea-completion report"
 run_one "report-doc-overflow" "report-doc-overflow" "codex"  "must-not-contain" "" "create idea-completion report"
-
-# B7: report-opt-out — per-branch opt-out env var set, otherwise valid
-# positive conditions. Hook must honor the toggle and silent-skip.
-run_one "report-opt-out"      "report-opt-out"      "claude" "must-not-contain" "" "create idea-completion report"
-run_one "report-opt-out"      "report-opt-out"      "codex"  "must-not-contain" "" "create idea-completion report"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/tests/test-on-post-verify-task.sh
@@ -12,7 +12,11 @@
 # hook into a sandbox dir alongside our shim wrapper — the hook's
 # `dirname "$0"` lookup then picks up our shim, not the real wrapper.
 #
-# Fixtures cover all gating branches:
+# Two independent reminder branches share the post-verify trigger:
+#   - Branch A (OpenSpec archive trigger) — emits `openspec archive`
+#   - Branch B (Idea-completion report)   — emits `create idea-completion report`
+#
+# Fixtures for Branch A (legacy):
 #   positive       — last task verified, slug present, openspec/ folder + CLI both present
 #                    -> stdout MUST contain `openspec archive my-feature`
 #   not-last-task  — slug present, both signals present, but one task still in_progress
@@ -25,6 +29,21 @@
 #                    -> stdout MUST NOT contain `openspec archive`
 #   mode-off       — CHORUS_OPENSPEC_MODE=off (explicit opt-out), even with both signals present
 #                    -> stdout MUST NOT contain `openspec archive`
+#
+# Fixtures for Branch B (idea-completion report — see spec
+# idea-completion-report scenarios "Hook injects a reminder ..."):
+#   report-positive    — idea-rooted proposal, all its tasks are
+#                        done|closed, no report Document on this proposal
+#                        -> stdout MUST contain `create idea-completion report`
+#   report-existing    — same as report-positive but a `type=report`
+#                        Document already exists on this proposal
+#                        -> stdout MUST NOT contain `create idea-completion report`
+#   report-not-last    — idea-rooted, but one task is still in_progress
+#                        -> stdout MUST NOT contain `create idea-completion report`
+#   report-quick-task  — proposal's inputType is not "idea" (e.g. a
+#                        non-idea-rooted proposal); branch B must skip
+#                        regardless of task status
+#                        -> stdout MUST NOT contain `create idea-completion report`
 #
 # All fixtures must end with exit 0.
 #
@@ -90,11 +109,18 @@ case "$cmd" in
       mode-off|no-folder|no-cli) fixture=positive ;;
     esac
     case "${fixture}:${tool}" in
+      # ----- Branch A fixtures (existing) -----
+      # NOTE: Branch B's idea-rooted check requires `inputType:"idea"`. We
+      # set it on the OpenSpec fixtures too because real proposals always
+      # carry inputType. To keep Branch A fixtures independent of Branch B,
+      # we deliberately DO NOT register chorus_get_proposals /
+      # chorus_get_documents responses for them — Branch B hits the default
+      # "unhandled" case (empty body) and silent-skips.
       positive:chorus_get_task)
         echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
         ;;
       positive:chorus_get_proposal)
-        printf '%s' '{"uuid":"prop-1","title":"P1","description":"Some intro line.\nOpenSpec change slug: my-feature\nMore body.","inputUuids":["idea-1"]}'
+        printf '%s' '{"uuid":"prop-1","title":"P1","description":"Some intro line.\nOpenSpec change slug: my-feature\nMore body.","inputType":"idea","inputUuids":["idea-1"]}'
         ;;
       positive:chorus_list_tasks)
         echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
@@ -103,7 +129,7 @@ case "$cmd" in
         echo '{"uuid":"task-2","title":"Task 2","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
         ;;
       not-last-task:chorus_get_proposal)
-        printf '%s' '{"uuid":"prop-1","title":"P1","description":"Intro.\nOpenSpec change slug: my-feature\nMore.","inputUuids":["idea-1"]}'
+        printf '%s' '{"uuid":"prop-1","title":"P1","description":"Intro.\nOpenSpec change slug: my-feature\nMore.","inputType":"idea","inputUuids":["idea-1"]}'
         ;;
       not-last-task:chorus_list_tasks)
         echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"in_progress"}],"total":3,"page":1,"pageSize":200}'
@@ -112,11 +138,72 @@ case "$cmd" in
         echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-2","project":{"uuid":"proj-1","name":"P"}}'
         ;;
       no-slug:chorus_get_proposal)
-        printf '%s' '{"uuid":"prop-2","title":"P2","description":"Free-form proposal description with no slug marker.","inputUuids":["idea-2"]}'
+        printf '%s' '{"uuid":"prop-2","title":"P2","description":"Free-form proposal description with no slug marker.","inputType":"idea","inputUuids":["idea-2"]}'
         ;;
       no-slug:chorus_list_tasks)
         echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
         ;;
+
+      # ----- Branch B fixtures (idea-completion report reminder) -----
+      # report-positive: idea-rooted proposal whose tasks are all
+      # done|closed, no report Document on it -> emit.
+      report-positive:chorus_get_task)
+        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      report-positive:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal — no OpenSpec slug here.","inputType":"idea","inputUuids":["idea-9"]}'
+        ;;
+      report-positive:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"closed","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+        ;;
+      report-positive:chorus_get_documents)
+        echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+        ;;
+
+      # report-existing: same as positive but a report Document already
+      # exists on this proposal -> silent skip.
+      report-existing:chorus_get_task)
+        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      report-existing:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+        ;;
+      report-existing:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"closed","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+        ;;
+      report-existing:chorus_get_documents)
+        echo '{"documents":[{"uuid":"doc-r1","type":"report","title":"Idea 9 — completion report","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
+        ;;
+
+      # report-not-last: a task is still in_progress -> silent skip.
+      report-not-last:chorus_get_task)
+        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      report-not-last:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+        ;;
+      report-not-last:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"in_progress","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+        ;;
+      report-not-last:chorus_get_documents)
+        echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+        ;;
+
+      # report-quick-task: proposal.inputType != "idea" -> Branch B must
+      # skip at the first gate, before any further calls.
+      report-quick-task:chorus_get_task)
+        echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+        ;;
+      report-quick-task:chorus_get_proposal)
+        printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"manual","inputUuids":[]}'
+        ;;
+      report-quick-task:chorus_list_tasks)
+        echo '{"tasks":[{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
+        ;;
+      report-quick-task:chorus_get_documents)
+        echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+        ;;
+
       *)
         # Unhandled (tool, fixture) — return empty, hook should silent-skip.
         echo ""
@@ -153,11 +240,12 @@ case "$fixture" in
   mode-off|no-folder|no-cli) fixture=positive ;;
 esac
 case "${fixture}:${tool}" in
+  # ----- Branch A fixtures (existing) -----
   positive:chorus_get_task)
     echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
     ;;
   positive:chorus_get_proposal)
-    printf '%s' '{"uuid":"prop-1","title":"P1","description":"Some intro line.\nOpenSpec change slug: my-feature\nMore body.","inputUuids":["idea-1"]}'
+    printf '%s' '{"uuid":"prop-1","title":"P1","description":"Some intro line.\nOpenSpec change slug: my-feature\nMore body.","inputType":"idea","inputUuids":["idea-1"]}'
     ;;
   positive:chorus_list_tasks)
     echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
@@ -166,7 +254,7 @@ case "${fixture}:${tool}" in
     echo '{"uuid":"task-2","title":"Task 2","status":"done","proposalUuid":"prop-1","project":{"uuid":"proj-1","name":"P"}}'
     ;;
   not-last-task:chorus_get_proposal)
-    printf '%s' '{"uuid":"prop-1","title":"P1","description":"Intro.\nOpenSpec change slug: my-feature\nMore.","inputUuids":["idea-1"]}'
+    printf '%s' '{"uuid":"prop-1","title":"P1","description":"Intro.\nOpenSpec change slug: my-feature\nMore.","inputType":"idea","inputUuids":["idea-1"]}'
     ;;
   not-last-task:chorus_list_tasks)
     echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"in_progress"}],"total":3,"page":1,"pageSize":200}'
@@ -175,11 +263,65 @@ case "${fixture}:${tool}" in
     echo '{"uuid":"task-3","title":"Task 3","status":"done","proposalUuid":"prop-2","project":{"uuid":"proj-1","name":"P"}}'
     ;;
   no-slug:chorus_get_proposal)
-    printf '%s' '{"uuid":"prop-2","title":"P2","description":"Free-form proposal description with no slug marker.","inputUuids":["idea-2"]}'
+    printf '%s' '{"uuid":"prop-2","title":"P2","description":"Free-form proposal description with no slug marker.","inputType":"idea","inputUuids":["idea-2"]}'
     ;;
   no-slug:chorus_list_tasks)
     echo '{"tasks":[{"uuid":"task-1","status":"done"},{"uuid":"task-2","status":"done"},{"uuid":"task-3","status":"done"}],"total":3,"page":1,"pageSize":200}'
     ;;
+
+  # ----- Branch B fixtures (idea-completion report reminder) -----
+  report-positive:chorus_get_task)
+    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  report-positive:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal — no OpenSpec slug here.","inputType":"idea","inputUuids":["idea-9"]}'
+    ;;
+  report-positive:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"closed","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+    ;;
+  report-positive:chorus_get_documents)
+    echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+    ;;
+
+  report-existing:chorus_get_task)
+    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  report-existing:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+    ;;
+  report-existing:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"closed","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+    ;;
+  report-existing:chorus_get_documents)
+    echo '{"documents":[{"uuid":"doc-r1","type":"report","title":"Idea 9 — completion report","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
+    ;;
+
+  report-not-last:chorus_get_task)
+    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  report-not-last:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"idea","inputUuids":["idea-9"]}'
+    ;;
+  report-not-last:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-7","status":"done","proposalUuid":"prop-9"},{"uuid":"task-8","status":"in_progress","proposalUuid":"prop-9"},{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":3,"page":1,"pageSize":200}'
+    ;;
+  report-not-last:chorus_get_documents)
+    echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+    ;;
+
+  report-quick-task:chorus_get_task)
+    echo '{"uuid":"task-9","title":"Task 9","status":"done","proposalUuid":"prop-9","project":{"uuid":"proj-1","name":"P"}}'
+    ;;
+  report-quick-task:chorus_get_proposal)
+    printf '%s' '{"uuid":"prop-9","title":"P9","description":"Free-form proposal.","inputType":"manual","inputUuids":[]}'
+    ;;
+  report-quick-task:chorus_list_tasks)
+    echo '{"tasks":[{"uuid":"task-9","status":"done","proposalUuid":"prop-9"}],"total":1,"page":1,"pageSize":200}'
+    ;;
+  report-quick-task:chorus_get_documents)
+    echo '{"documents":[],"total":0,"page":1,"pageSize":200}'
+    ;;
+
   *)
     echo "" ;;
 esac
@@ -203,16 +345,20 @@ EVENT_JSON='{"tool_name":"chorus_admin_verify_task","tool_input":{"taskUuid":"ta
 
 # ----- Test runner -----
 
-# Args: name fixture variant expected_substring should_contain
+# Args: name fixture variant assertion_mode expected_substring forbidden_substring
 # variant in {claude, codex}
-# should_contain: "yes" -> stdout MUST contain expected_substring
-# should_contain: "no"  -> stdout MUST NOT contain "openspec archive"
+# assertion_mode:
+#   "must-contain"  -> stdout MUST contain $expected_substring
+#   "must-not-contain" -> stdout MUST NOT contain $forbidden_substring
+# (For Branch B fixtures, $forbidden_substring is `create idea-completion report`.
+#  For Branch A "no" fixtures, $forbidden_substring is `openspec archive`.)
 run_one() {
   local name="$1"
   local fixture="$2"
   local variant="$3"
-  local should_contain="$4"
+  local assertion_mode="$4"
   local expected="$5"
+  local forbidden="${6:-openspec archive}"
 
   local hook_dir
   if [ "$variant" = "claude" ]; then
@@ -292,7 +438,7 @@ run_one() {
   stdout=$(cat "$stdout_file")
   rm -f "$stdout_file" "$stderr_file"
 
-  if [ "$should_contain" = "yes" ]; then
+  if [ "$assertion_mode" = "must-contain" ]; then
     if printf '%s' "$stdout" | grep -q "$expected"; then
       echo "  PASS  $name [$variant]"
       PASS=$((PASS + 1))
@@ -303,9 +449,9 @@ run_one() {
       FAILED="$FAILED $name[$variant]"
     fi
   else
-    # should_contain == "no": archive reminder MUST be absent.
-    if printf '%s' "$stdout" | grep -q "openspec archive"; then
-      echo "  FAIL  $name [$variant]: stdout unexpectedly contains 'openspec archive'"
+    # must-not-contain: $forbidden MUST be absent.
+    if printf '%s' "$stdout" | grep -q "$forbidden"; then
+      echo "  FAIL  $name [$variant]: stdout unexpectedly contains '$forbidden'"
       printf '%s\n' "$stdout" | sed 's/^/         /'
       FAIL=$((FAIL + 1))
       FAILED="$FAILED $name[$variant]"
@@ -319,41 +465,66 @@ run_one() {
 echo "Sandbox: $SANDBOX"
 echo ""
 
-# ----- Branch 1: positive (slug + last task + CLI) -----
-run_one "positive"      "positive"      "claude" "yes" "openspec archive my-feature"
-run_one "positive"      "positive"      "codex"  "yes" "openspec archive my-feature"
+# ===== Branch A: OpenSpec archive trigger fixtures =====
+# (assertion: must-contain `openspec archive my-feature` / must-not-contain `openspec archive`)
 
-# ----- Branch 2: not-last-task -----
-run_one "not-last-task" "not-last-task" "claude" "no"  ""
-run_one "not-last-task" "not-last-task" "codex"  "no"  ""
+# A1: positive (slug + last task + CLI)
+run_one "positive"      "positive"      "claude" "must-contain" "openspec archive my-feature"
+run_one "positive"      "positive"      "codex"  "must-contain" "openspec archive my-feature"
 
-# ----- Branch 3: no-slug (free-form proposal) -----
-run_one "no-slug"       "no-slug"       "claude" "no"  ""
-run_one "no-slug"       "no-slug"       "codex"  "no"  ""
+# A2: not-last-task
+run_one "not-last-task" "not-last-task" "claude" "must-not-contain" "" "openspec archive"
+run_one "not-last-task" "not-last-task" "codex"  "must-not-contain" "" "openspec archive"
 
-# ----- Branch 4: no-cli (folder present, CLI absent) -----
-# Strip $SANDBOX/bin from PATH so `command -v openspec` fails. Folder is
-# still there in $SANDBOX/project/openspec. Hook must short-circuit at
-# step 4 (CLI gate) and emit no archive reminder.
-run_one "no-cli"        "no-cli"        "claude" "no"  ""
-run_one "no-cli"        "no-cli"        "codex"  "no"  ""
+# A3: no-slug (free-form proposal)
+run_one "no-slug"       "no-slug"       "claude" "must-not-contain" "" "openspec archive"
+run_one "no-slug"       "no-slug"       "codex"  "must-not-contain" "" "openspec archive"
 
-# ----- Branch 5: no-folder (CLI present, folder absent) -----
-# CLAUDE_PROJECT_DIR points at $SANDBOX (no openspec/ dir there). Hook
-# must short-circuit at step 4 (folder gate) before trying any MCP calls.
-# We don't actually exercise any MCP fixture here — the hook should bail
-# before reaching the wrappers. We pass "positive" only because the
-# unhandled-fixture branch in the shim returns an empty body and the hook
-# would then silent-skip on get_task. Either way the assertion ("no
-# archive reminder") holds.
-run_one "no-folder"     "no-folder"     "claude" "no"  ""
-run_one "no-folder"     "no-folder"     "codex"  "no"  ""
+# A4: no-cli (folder present, CLI absent). Strip $SANDBOX/bin from PATH
+# so `command -v openspec` fails. Folder is still there in
+# $SANDBOX/project/openspec. Hook must short-circuit at the CLI gate.
+run_one "no-cli"        "no-cli"        "claude" "must-not-contain" "" "openspec archive"
+run_one "no-cli"        "no-cli"        "codex"  "must-not-contain" "" "openspec archive"
 
-# ----- Branch 6: mode-off (explicit opt-out via env) -----
-# Both folder and CLI are present, but CHORUS_OPENSPEC_MODE=off. Hook
-# must honor the opt-out and exit silently.
-run_one "mode-off"      "mode-off"      "claude" "no"  ""
-run_one "mode-off"      "mode-off"      "codex"  "no"  ""
+# A5: no-folder (CLI present, folder absent). CLAUDE_PROJECT_DIR points
+# at $SANDBOX (no openspec/ dir there). Hook must short-circuit at the
+# folder gate before reaching any MCP call.
+run_one "no-folder"     "no-folder"     "claude" "must-not-contain" "" "openspec archive"
+run_one "no-folder"     "no-folder"     "codex"  "must-not-contain" "" "openspec archive"
+
+# A6: mode-off (explicit opt-out via env). Both folder and CLI are
+# present, but CHORUS_OPENSPEC_MODE=off. Hook must honor the opt-out.
+run_one "mode-off"      "mode-off"      "claude" "must-not-contain" "" "openspec archive"
+run_one "mode-off"      "mode-off"      "codex"  "must-not-contain" "" "openspec archive"
+
+# ===== Branch B: Idea-completion report reminder fixtures =====
+# (assertion: must-contain `create idea-completion report` /
+#  must-not-contain `create idea-completion report`)
+# These fixtures all use a non-OpenSpec proposal description (no slug
+# line), so Branch A silent-skips. The PATH still has the fake openspec
+# CLI and the synthetic project dir still has openspec/ so Branch A's
+# folder/CLI gates pass — the slug gate is what blocks Branch A here,
+# isolating the assertion to Branch B's behavior.
+
+# B1: report-positive — last task of an Idea verified, no report
+# Document yet -> reminder MUST fire.
+run_one "report-positive"   "report-positive"   "claude" "must-contain" "create idea-completion report"
+run_one "report-positive"   "report-positive"   "codex"  "must-contain" "create idea-completion report"
+
+# B2: report-existing — same conditions but a report Document already
+# exists for the Idea -> reminder MUST be silent.
+run_one "report-existing"   "report-existing"   "claude" "must-not-contain" "" "create idea-completion report"
+run_one "report-existing"   "report-existing"   "codex"  "must-not-contain" "" "create idea-completion report"
+
+# B3: report-not-last — at least one task is still in_progress
+# (non-terminal) -> reminder MUST be silent.
+run_one "report-not-last"   "report-not-last"   "claude" "must-not-contain" "" "create idea-completion report"
+run_one "report-not-last"   "report-not-last"   "codex"  "must-not-contain" "" "create idea-completion report"
+
+# B4: report-quick-task — proposal.inputType != "idea" (e.g. a
+# manually-created proposal) -> reminder MUST be silent at first gate.
+run_one "report-quick-task" "report-quick-task" "claude" "must-not-contain" "" "create idea-completion report"
+run_one "report-quick-task" "report-quick-task" "codex"  "must-not-contain" "" "create idea-completion report"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -136,16 +136,20 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_ideas` | List project Ideas (filterable by status, paginated) |
-| `chorus_get_idea` | Get a single Idea's details |
+| `chorus_get_ideas` | List project Ideas (filterable by status, paginated; rows include `reportCount`) |
+| `chorus_get_idea` | Get a single Idea's details (includes `reports[]` with full content) |
 | `chorus_get_available_ideas` | Get claimable Ideas (status=open) |
 
 ### Documents
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide) |
+| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide, report) |
 | `chorus_get_document` | Get a single document's content |
+
+### Reports
+
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `/yolo` writes one mandatorily; `/develop` offers it advisorily on last-task verify; a PostToolUse hook reminds if neither fired.
 
 ### Proposals
 
@@ -295,7 +299,7 @@ The table below shows default tool availability for each preset (no custom permi
 | `chorus_claim_task` / `chorus_release_task` / `chorus_submit_for_verify` / `chorus_report_work` / `chorus_report_criteria_self_check` | `task:write` | Yes | **Yes** (0.7.0+) | Yes |
 | `chorus_claim_idea` / `chorus_release_idea` / `chorus_move_idea` / `chorus_pm_create_idea` / `chorus_pm_*_elaboration` | `idea:write` | No | Yes | Yes |
 | `chorus_pm_create_proposal` / `chorus_pm_*_proposal` / `chorus_pm_*_draft` / `chorus_create_tasks` / `chorus_pm_assign_task` / `chorus_update_task` (dependency edits via `addDependsOn`/`removeDependsOn`) | `proposal:write` | No | Yes | Yes |
-| `chorus_pm_create_document` / `chorus_pm_update_document` | `document:write` | No | Yes | Yes |
+| `chorus_pm_create_document` / `chorus_pm_update_document` / `chorus_create_report` | `document:write` | No | Yes | Yes |
 | `chorus_admin_create_project` / `chorus_admin_*_project_group` / `chorus_admin_move_project_to_group` | `project:write` | No | **Yes** (0.7.0+) | Yes |
 | `chorus_admin_approve_proposal` / `chorus_admin_close_proposal` | `proposal:admin` | No | No | Yes |
 | `chorus_admin_verify_task` / `chorus_admin_reopen_task` / `chorus_admin_close_task` / `chorus_mark_acceptance_criteria` / `chorus_admin_delete_task` | `task:admin` | No | No | Yes |

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -254,6 +254,10 @@ If the reviewer returns **FAIL**, or the task is reopened after verification:
 
 Once Admin verifies (status: `done`), move to the next available task (back to Step 2).
 
+### Step 11: Idea Completion Report (advisory)
+
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, offer to call `chorus_create_report` via `AskUserQuestion`. The tool description carries the section template. Skip on decline — the PostToolUse hook will remind on the next run.
+
 ---
 
 ## Session (Sub-Agents Only)

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -467,6 +467,12 @@ After all waves complete, output a markdown summary:
 
 ---
 
+### Phase 5b: Idea Completion Report (mandatory)
+
+A successful `/yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The tool's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
+
+---
+
 ## Error Handling
 
 | Scenario | Action |

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -165,16 +165,20 @@ Results can be filtered by project(s) using optional HTTP headers in your MCP co
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_ideas` | List project Ideas (filterable by status, paginated) |
-| `chorus_get_idea` | Get a single Idea's details |
+| `chorus_get_ideas` | List project Ideas (filterable by status, paginated; rows include `reportCount`) |
+| `chorus_get_idea` | Get a single Idea's details (includes `reports[]` with full content) |
 | `chorus_get_available_ideas` | Get claimable Ideas (status=open) |
 
 ### Documents
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide) |
+| `chorus_get_documents` | List project documents (filterable by type: prd, tech_design, adr, spec, guide, report) |
 | `chorus_get_document` | Get a single document's content |
+
+### Reports
+
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. The `yolo` skill writes one mandatorily; the `develop` skill offers it advisorily on last-task verify.
 
 ### Proposals
 
@@ -329,7 +333,7 @@ The table below shows default tool availability for each preset (no custom permi
 | `chorus_claim_task` / `chorus_release_task` / `chorus_submit_for_verify` / `chorus_report_work` / `chorus_report_criteria_self_check` | `task:write` | Yes | **Yes** (0.7.0+) | Yes |
 | `chorus_claim_idea` / `chorus_release_idea` / `chorus_move_idea` / `chorus_pm_create_idea` / `chorus_pm_*_elaboration` | `idea:write` | No | Yes | Yes |
 | `chorus_pm_create_proposal` / `chorus_pm_*_proposal` / `chorus_pm_*_draft` / `chorus_create_tasks` / `chorus_pm_assign_task` | `proposal:write` | No | Yes | Yes |
-| `chorus_pm_create_document` / `chorus_pm_update_document` | `document:write` | No | Yes | Yes |
+| `chorus_pm_create_document` / `chorus_pm_update_document` / `chorus_create_report` | `document:write` | No | Yes | Yes |
 | `chorus_admin_create_project` / `chorus_admin_*_project_group` / `chorus_admin_move_project_to_group` | `project:write` | No | **Yes** (0.7.0+) | Yes |
 | `chorus_admin_approve_proposal` / `chorus_admin_close_proposal` | `proposal:admin` | No | No | Yes |
 | `chorus_admin_verify_task` / `chorus_admin_reopen_task` / `chorus_admin_close_task` / `chorus_mark_acceptance_criteria` / `chorus_admin_delete_task` | `task:admin` | No | No | Yes |

--- a/public/skill/develop-chorus/SKILL.md
+++ b/public/skill/develop-chorus/SKILL.md
@@ -198,6 +198,10 @@ If reopened (verification failed), **all acceptance criteria are reset to pendin
 
 Once Admin verifies (status: `done`), move to the next available task (back to Step 2).
 
+### Step 11: Idea Completion Report (advisory)
+
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, prompt the user and call `chorus_create_report` on accept. The tool description carries the section template. Skip on decline.
+
 ---
 
 ## Work Report Best Practices

--- a/src/__tests__/integration/idea-completion-report.integration.test.ts
+++ b/src/__tests__/integration/idea-completion-report.integration.test.ts
@@ -431,24 +431,28 @@ describe("idea-completion-report end-to-end (AC #1)", () => {
     expect(action.data).toEqual([]);
   });
 
-  it("does NOT surface a report that is attached to a non-approved proposal", async () => {
+  it("rejects writes targeting a non-approved proposal (tool returns isError, no Document persists)", async () => {
     seedFinishedIdea();
 
     const server = makeServer();
     registerPublicTools(server as never, makeAgentAuth(["document:write"]));
 
-    // Caller misroutes the report to a draft proposal — server has no business
-    // rule against it (draft proposals are still real proposals), but the
-    // dashboard's overview-tab Reports list MUST exclude them since it only
-    // aggregates across approved proposals (spec: "aggregated across all
-    // approved Proposals of the Idea").
-    await tools["chorus_create_report"].handler({
+    // Server-side gate (added during PR review): only proposals whose
+    // status==='approved' can bear a completion report. A misrouted call
+    // against a draft proposal must be rejected — not silently persisted
+    // and then hidden by the dashboard filter. The tool short-circuits
+    // BEFORE the createDocument call.
+    const result = await tools["chorus_create_report"].handler({
       proposalUuid: DRAFT_PROPOSAL_UUID,
       title: "Misrouted to draft",
       content: REPORT_BODY,
     });
 
-    expect(store.documents.length).toBe(1);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("'draft'");
+    // No Document was persisted.
+    expect(store.documents.length).toBe(0);
+    // Reports list (which already filters to approved proposals) stays empty.
     const action = await getReportsForIdeaAction(PROJECT_UUID, IDEA_UUID);
     expect(action.success).toBe(true);
     if (!action.success) return;

--- a/src/__tests__/integration/idea-completion-report.integration.test.ts
+++ b/src/__tests__/integration/idea-completion-report.integration.test.ts
@@ -1,0 +1,475 @@
+// src/__tests__/integration/idea-completion-report.integration.test.ts
+//
+// Integration smoke for the idea-completion-report change (T7 / AC #1).
+//
+// Drives the full end-to-end flow that ships with the feature:
+//   1. The MCP tool `chorus_create_report` (registered by registerPublicTools,
+//      gated on document:write) is invoked with a 5-section Markdown body.
+//   2. The Document row is asserted to have type="report", proposalUuid set,
+//      version=1, and content stored byte-faithfully.
+//   3. The server action `getReportsForIdeaAction(projectUuid, ideaUuid)`
+//      that powers the overview-tab Reports list is asserted to return the
+//      newly-created report.
+//
+// Why integration: each piece (tool, service, action) has its own pure unit
+// test; this test wires them together against a single in-memory Prisma stub
+// to catch any seam mismatch — e.g. type label, proposalUuid plumbing,
+// approved-only filter in the action, sort order. We don't spin up real
+// Postgres for unit-suite speed.
+
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// ===== In-memory Prisma stub =====
+//
+// Stores just enough state for the three operations the flow exercises:
+//   - proposal.findFirst (used by tool's Proposal lookup; proposal.findMany used by action via getProposalsByIdeaUuid)
+//   - document.create    (used by createDocument)
+//   - document.findMany  (used by listDocumentsByProposalUuids)
+
+interface ProposalRow {
+  uuid: string;
+  companyUuid: string;
+  projectUuid: string;
+  title: string;
+  description: string | null;
+  inputType: string;
+  inputUuids: string[];
+  documentDrafts: unknown;
+  taskDrafts: unknown;
+  status: string;
+  createdByUuid: string;
+  createdByType: string;
+  reviewedByUuid: string | null;
+  reviewNote: string | null;
+  reviewedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface DocumentRow {
+  uuid: string;
+  companyUuid: string;
+  projectUuid: string;
+  type: string;
+  title: string;
+  content: string | null;
+  version: number;
+  proposalUuid: string | null;
+  createdByUuid: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const store = vi.hoisted(() => ({
+  proposals: [] as Array<{
+    uuid: string;
+    companyUuid: string;
+    projectUuid: string;
+    title: string;
+    description: string | null;
+    inputType: string;
+    inputUuids: string[];
+    documentDrafts: unknown;
+    taskDrafts: unknown;
+    status: string;
+    createdByUuid: string;
+    createdByType: string;
+    reviewedByUuid: string | null;
+    reviewNote: string | null;
+    reviewedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }>,
+  documents: [] as Array<{
+    uuid: string;
+    companyUuid: string;
+    projectUuid: string;
+    type: string;
+    title: string;
+    content: string | null;
+    version: number;
+    proposalUuid: string | null;
+    createdByUuid: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }>,
+  docCounter: 0,
+}));
+
+const mockPrisma = vi.hoisted(() => {
+  // Defined lazily so each call sees the live mutated `store`.
+  return {
+    prisma: {
+      proposal: {
+        findFirst: vi.fn(async ({ where }: { where: { uuid: string; companyUuid: string } }) => {
+          // store is captured via closure — use globalThis to dodge hoisting init order
+          const all = (globalThis as unknown as { __reportStore?: typeof store }).__reportStore;
+          if (!all) return null;
+          return (
+            all.proposals.find(
+              (p) => p.uuid === where.uuid && p.companyUuid === where.companyUuid,
+            ) ?? null
+          );
+        }),
+        findMany: vi.fn(async ({ where }: { where: { projectUuid: string; companyUuid: string } }) => {
+          const all = (globalThis as unknown as { __reportStore?: typeof store }).__reportStore;
+          if (!all) return [];
+          return all.proposals.filter(
+            (p) => p.projectUuid === where.projectUuid && p.companyUuid === where.companyUuid,
+          );
+        }),
+      },
+      document: {
+        create: vi.fn(async ({ data, select }: { data: Omit<DocumentRow, "createdAt" | "updatedAt" | "version"> & { version?: number }; select?: Record<string, boolean> }) => {
+          const all = (globalThis as unknown as { __reportStore?: typeof store }).__reportStore;
+          if (!all) throw new Error("store not initialized");
+          all.docCounter += 1;
+          const now = new Date(`2026-05-25T07:0${all.docCounter % 10}:00.000Z`);
+          const row: DocumentRow = {
+            uuid: data.uuid ?? `doc-${all.docCounter}`,
+            companyUuid: data.companyUuid,
+            projectUuid: data.projectUuid,
+            type: data.type,
+            title: data.title,
+            content: data.content ?? null,
+            version: data.version ?? 1,
+            proposalUuid: data.proposalUuid ?? null,
+            createdByUuid: data.createdByUuid,
+            createdAt: now,
+            updatedAt: now,
+          };
+          all.documents.push(row);
+          // Honor `select` shape just enough — service uses `select` with all
+          // fields we already populate, so a shallow copy is sufficient.
+          if (select) {
+            const out: Record<string, unknown> = {};
+            for (const key of Object.keys(select)) {
+              if (select[key]) out[key] = (row as unknown as Record<string, unknown>)[key];
+            }
+            return out;
+          }
+          return row;
+        }),
+        findMany: vi.fn(async ({ where, orderBy, select }: {
+          where: { companyUuid: string; proposalUuid?: { in: string[] }; type?: string };
+          orderBy?: { createdAt?: "asc" | "desc" };
+          select?: Record<string, boolean>;
+        }) => {
+          const all = (globalThis as unknown as { __reportStore?: typeof store }).__reportStore;
+          if (!all) return [];
+          let rows = all.documents.filter((d) => d.companyUuid === where.companyUuid);
+          if (where.proposalUuid?.in) {
+            const inSet = new Set(where.proposalUuid.in);
+            rows = rows.filter((d) => d.proposalUuid !== null && inSet.has(d.proposalUuid));
+          }
+          if (where.type) {
+            rows = rows.filter((d) => d.type === where.type);
+          }
+          if (orderBy?.createdAt === "desc") {
+            rows = [...rows].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+          }
+          if (select) {
+            return rows.map((row) => {
+              const out: Record<string, unknown> = {};
+              for (const key of Object.keys(select)) {
+                if (select[key]) out[key] = (row as unknown as Record<string, unknown>)[key];
+              }
+              return out;
+            });
+          }
+          return rows;
+        }),
+        count: vi.fn(async () => 0),
+      },
+    },
+  };
+});
+
+// Make the store reachable from the prisma stub closure without hitting
+// hoisted-init ordering issues.
+(globalThis as unknown as { __reportStore?: typeof store }).__reportStore = store;
+
+vi.mock("@/lib/prisma", () => mockPrisma);
+
+// formatCreatedBy hits the user/agent table; stub the whole resolver module
+// so neither user nor proposal-review formatting touches Prisma.
+vi.mock("@/lib/uuid-resolver", () => ({
+  formatCreatedBy: vi.fn(async (uuid: string) => ({
+    type: "agent",
+    uuid,
+    name: "Test Agent",
+  })),
+  formatAssigneeComplete: vi.fn(async () => null),
+  formatAssignee: vi.fn(async () => null),
+  formatReview: vi.fn(async () => null),
+  getActorName: vi.fn(async () => "Test Actor"),
+  batchGetActorNames: vi.fn(async () => new Map()),
+  batchFormatCreatedBy: vi.fn(async () => new Map()),
+  getSessionName: vi.fn(async () => null),
+  validateTargetExists: vi.fn(async () => true),
+}));
+
+// The server action calls getServerAuthContext (cookie-backed). Replace it
+// with a deterministic user identity scoped to the same companyUuid as the
+// agent that created the report — this is the realistic shape of "agent
+// writes report, user opens dashboard and the page-action loads it".
+const HUMAN_USER_UUID = "44444444-4444-4444-8444-444444444444";
+const COMPANY_UUID = "11111111-1111-4111-8111-111111111111";
+
+vi.mock("@/lib/auth-server", () => ({
+  getServerAuthContext: vi.fn(async () => ({
+    type: "user",
+    companyUuid: COMPANY_UUID,
+    actorUuid: HUMAN_USER_UUID,
+    email: "human@example.com",
+    name: "Human",
+  })),
+}));
+
+// Capture tool registrations so we can drive the chorus_create_report handler
+// directly (same pattern as src/mcp/tools/__tests__/create-report.test.ts).
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}>;
+type ToolConfig = {
+  description?: string;
+  inputSchema?: { parse?: (input: unknown) => unknown };
+};
+const tools: Record<string, { config: ToolConfig; handler: ToolHandler }> = {};
+function makeServer() {
+  return {
+    registerTool: (name: string, config: ToolConfig, handler: ToolHandler) => {
+      tools[name] = { config, handler };
+    },
+  };
+}
+
+import type { AgentAuthContext } from "@/types/auth";
+import { registerPublicTools } from "@/mcp/tools/public";
+import { getReportsForIdeaAction } from "@/app/(dashboard)/projects/[uuid]/dashboard/panels/actions";
+
+// Test fixture identity bag.
+const PROJECT_UUID = "22222222-2222-4222-8222-222222222222";
+const IDEA_UUID = "33333333-3333-4333-8333-333333333333";
+const APPROVED_PROPOSAL_UUID = "55555555-5555-4555-8555-555555555555";
+const SECOND_APPROVED_PROPOSAL_UUID = "66666666-6666-4666-8666-666666666666";
+const DRAFT_PROPOSAL_UUID = "77777777-7777-4777-8777-777777777777";
+const AGENT_UUID = "88888888-8888-4888-8888-888888888888";
+
+function makeAgentAuth(permissions: string[]): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid: COMPANY_UUID,
+    actorUuid: AGENT_UUID,
+    agentName: "Yolo Agent",
+    roles: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    permissions: permissions as any,
+  };
+}
+
+function seedFinishedIdea() {
+  const baseProposal = {
+    companyUuid: COMPANY_UUID,
+    projectUuid: PROJECT_UUID,
+    title: "Approved proposal",
+    description: null,
+    inputType: "idea",
+    inputUuids: [IDEA_UUID],
+    documentDrafts: null,
+    taskDrafts: null,
+    createdByUuid: HUMAN_USER_UUID,
+    createdByType: "user",
+    reviewedByUuid: null,
+    reviewNote: null,
+    reviewedAt: null,
+    createdAt: new Date("2026-05-20T00:00:00Z"),
+    updatedAt: new Date("2026-05-20T00:00:00Z"),
+  };
+  store.proposals.push(
+    { ...baseProposal, uuid: APPROVED_PROPOSAL_UUID, status: "approved", title: "Proposal A" },
+    { ...baseProposal, uuid: SECOND_APPROVED_PROPOSAL_UUID, status: "approved", title: "Proposal B" },
+    // Draft proposal — same Idea — must be filtered out by the action.
+    { ...baseProposal, uuid: DRAFT_PROPOSAL_UUID, status: "draft", title: "Proposal Draft" },
+  );
+}
+
+const REPORT_BODY = [
+  "## Summary",
+  "Shipped feature X. Some 中文 characters and a code fence.",
+  "",
+  "```ts",
+  "const k = 'value';",
+  "```",
+  "",
+  "## Decisions",
+  "- Chose A over B because of latency.",
+  "",
+  "## Follow-ups",
+  "None.",
+].join("\n");
+
+beforeEach(() => {
+  // Reset store + tool registry between tests; do NOT clearAllMocks because
+  // that would also wipe the prisma stub implementations.
+  store.proposals.length = 0;
+  store.documents.length = 0;
+  store.docCounter = 0;
+  Object.keys(tools).forEach((k) => delete tools[k]);
+});
+
+describe("idea-completion-report end-to-end (AC #1)", () => {
+  it("chorus_create_report writes a Document(type=report, version=1, byte-faithful) and getReportsForIdeaAction surfaces it", async () => {
+    seedFinishedIdea();
+
+    // ----- 1. Register tools with document:write permission -----
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+    expect(tools["chorus_create_report"]).toBeDefined();
+
+    // ----- 2. Drive the MCP tool with a real Markdown body -----
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "Idea X — completion report",
+      content: REPORT_BODY,
+    });
+
+    // Tool returns success envelope (not an error).
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    const payload = JSON.parse(result.content[0].text) as {
+      documentUuid: string;
+      projectUuid: string;
+      version: number;
+    };
+    expect(payload.projectUuid).toBe(PROJECT_UUID);
+    expect(payload.version).toBe(1);
+    expect(payload.documentUuid).toBeTypeOf("string");
+
+    // ----- 3. Inspect the persisted Document row directly -----
+    expect(store.documents.length).toBe(1);
+    const persisted = store.documents[0];
+    expect(persisted.type).toBe("report");
+    expect(persisted.title).toBe("Idea X — completion report");
+    expect(persisted.proposalUuid).toBe(APPROVED_PROPOSAL_UUID);
+    expect(persisted.projectUuid).toBe(PROJECT_UUID);
+    expect(persisted.companyUuid).toBe(COMPANY_UUID);
+    expect(persisted.version).toBe(1);
+    expect(persisted.createdByUuid).toBe(AGENT_UUID);
+
+    // Byte-faithful: the persisted body equals the input bytes verbatim.
+    // The tool MUST NOT mutate, prefix, or suffix content (spec: "Server
+    // preserves report content byte-faithfully").
+    expect(persisted.content).toBe(REPORT_BODY);
+    // The three required headers are all present in the persisted body.
+    for (const header of [
+      "## Summary",
+      "## Decisions",
+      "## Follow-ups",
+    ]) {
+      expect(persisted.content).toContain(header);
+    }
+
+    // ----- 4. The dashboard's server action returns the report -----
+    const action = await getReportsForIdeaAction(PROJECT_UUID, IDEA_UUID);
+    expect(action.success).toBe(true);
+    if (!action.success) return; // type-narrow
+
+    // Single approved-proposal-rooted report; draft proposal is filtered out.
+    expect(action.data.length).toBe(1);
+    expect(action.data[0].uuid).toBe(payload.documentUuid);
+    expect(action.data[0].type).toBe("report");
+    expect(action.data[0].title).toBe("Idea X — completion report");
+    expect(action.data[0].content).toBe(REPORT_BODY);
+    expect(action.data[0].version).toBe(1);
+  });
+
+  it("aggregates across multiple approved Proposals of the same Idea (createdAt desc)", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    // First report on Proposal A.
+    const firstResult = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "First wave recap",
+      content: REPORT_BODY,
+    });
+    const firstUuid = JSON.parse(firstResult.content[0].text).documentUuid;
+
+    // Second report on Proposal B — later createdAt (store mock increments
+    // a deterministic counter into the timestamp).
+    const secondResult = await tools["chorus_create_report"].handler({
+      proposalUuid: SECOND_APPROVED_PROPOSAL_UUID,
+      title: "Second wave recap",
+      content: REPORT_BODY,
+    });
+    const secondUuid = JSON.parse(secondResult.content[0].text).documentUuid;
+
+    // Both reports persist with type=report.
+    expect(store.documents.length).toBe(2);
+    expect(store.documents.every((d) => d.type === "report")).toBe(true);
+
+    // Action aggregates across all approved proposals and returns
+    // newest-first.
+    const action = await getReportsForIdeaAction(PROJECT_UUID, IDEA_UUID);
+    expect(action.success).toBe(true);
+    if (!action.success) return;
+    expect(action.data.length).toBe(2);
+    expect(action.data[0].uuid).toBe(secondUuid); // newest first
+    expect(action.data[1].uuid).toBe(firstUuid);
+  });
+
+  it("returns an empty list before any report is written (UI hides the section)", async () => {
+    seedFinishedIdea();
+
+    const action = await getReportsForIdeaAction(PROJECT_UUID, IDEA_UUID);
+    expect(action.success).toBe(true);
+    if (!action.success) return;
+    expect(action.data).toEqual([]);
+  });
+
+  it("does NOT surface a report that is attached to a non-approved proposal", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    // Caller misroutes the report to a draft proposal — server has no business
+    // rule against it (draft proposals are still real proposals), but the
+    // dashboard's overview-tab Reports list MUST exclude them since it only
+    // aggregates across approved proposals (spec: "aggregated across all
+    // approved Proposals of the Idea").
+    await tools["chorus_create_report"].handler({
+      proposalUuid: DRAFT_PROPOSAL_UUID,
+      title: "Misrouted to draft",
+      content: REPORT_BODY,
+    });
+
+    expect(store.documents.length).toBe(1);
+    const action = await getReportsForIdeaAction(PROJECT_UUID, IDEA_UUID);
+    expect(action.success).toBe(true);
+    if (!action.success) return;
+    expect(action.data).toEqual([]);
+  });
+
+  it("rejects when proposalUuid does not exist (tool surfaces 'Proposal not found', no Document persists)", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    const bogusProposalUuid = "99999999-9999-4999-8999-999999999999";
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: bogusProposalUuid,
+      title: "Should fail",
+      content: REPORT_BODY,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Proposal not found");
+    expect(store.documents.length).toBe(0);
+  });
+});

--- a/src/__tests__/integration/permissions.test.ts
+++ b/src/__tests__/integration/permissions.test.ts
@@ -113,6 +113,7 @@ vi.mock("@/services/task.service", () => ({
 // Remaining services imported transitively by the MCP tool modules — stubbed empty
 // because registration never reaches any handler body.
 vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/checkin.service", () => ({}));
 vi.mock("@/services/document.service", () => ({}));
 vi.mock("@/services/comment.service", () => ({}));
 vi.mock("@/services/assignment.service", () => ({}));
@@ -130,6 +131,8 @@ import { POST as approveProposalHandler } from "@/app/api/proposals/[uuid]/appro
 import { registerPmTools } from "@/mcp/tools/pm";
 import { registerDeveloperTools } from "@/mcp/tools/developer";
 import { registerAdminTools } from "@/mcp/tools/admin";
+import { registerPublicTools } from "@/mcp/tools/public";
+import { TOOL_PERMISSIONS } from "@/mcp/tools/permission-map";
 import { ROLE_PRESETS } from "@/lib/authz/presets";
 import type { AgentAuthContext } from "@/types/auth";
 import type { Permission } from "@/lib/authz/types";
@@ -180,8 +183,11 @@ function makeAgentAuth(permissions: Permission[], roles: string[] = []): AgentAu
 }
 
 // Run every permission-gated MCP registration module with the supplied auth
-// and return the set of registered tool names. This is the same enumeration
-// path /api/mcp takes when it constructs a server for a live session.
+// and return the set of gated tool names. This is the same enumeration path
+// /api/mcp takes when it constructs a server for a live session, then we keep
+// only names that go through `registerPermissionedTool` (TOOL_PERMISSIONS) so
+// non-gated public tools (chorus_get_project, chorus_add_comment, etc.) don't
+// pollute the assertions below.
 function enumerateGatedMcpTools(auth: AgentAuthContext): Set<string> {
   const { server, names } = makeCapturingServer();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -190,7 +196,10 @@ function enumerateGatedMcpTools(auth: AgentAuthContext): Set<string> {
   registerDeveloperTools(server as any, auth);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registerAdminTools(server as any, auth);
-  return new Set(names);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerPublicTools(server as any, auth);
+  const gated = new Set(Object.keys(TOOL_PERMISSIONS));
+  return new Set(names.filter((n) => gated.has(n)));
 }
 
 // Frozen 0.6.x tool-name baselines — the source of truth for preset parity assertions.
@@ -267,6 +276,13 @@ const PM_AGENT_ADDED_IN_0_7_0 = [
   "chorus_submit_for_verify",
   "chorus_report_criteria_self_check",
   "chorus_report_work",
+];
+
+// The +1 diff from add-idea-completion-report (0.9.0): public-namespaced
+// chorus_create_report tool gated on document:write — pm_agent preset
+// carries document:write so it appears in the pm visibility set.
+const PM_AGENT_ADDED_IN_0_9_0 = [
+  "chorus_create_report",
 ];
 
 // ===== Shared beforeEach =====
@@ -428,13 +444,15 @@ describe("Scenario 2: preset parity with 0.6.x baseline (AC2)", () => {
     expect(tools).toEqual(new Set(OLD_DEVELOPER_TOOLS));
   });
 
-  it("admin_agent preset registers exactly the 0.6.x admin ∪ pm ∪ developer tool set", () => {
+  it("admin_agent preset registers exactly the 0.6.x admin ∪ pm ∪ developer tool set plus 0.9.0 chorus_create_report", () => {
     const auth = makeAgentAuth([...ROLE_PRESETS.admin_agent], ["admin_agent"]);
     const tools = enumerateGatedMcpTools(auth);
     const expected = new Set([
       ...OLD_ADMIN_TOOLS,
       ...OLD_PM_TOOLS,
       ...OLD_DEVELOPER_TOOLS,
+      // 0.9.0 addition (document:write-gated, public-namespaced).
+      "chorus_create_report",
     ]);
     expect(tools).toEqual(expected);
   });
@@ -453,12 +471,12 @@ describe("Scenario 2: preset parity with 0.6.x baseline (AC2)", () => {
     }
   });
 
-  it("pm_agent diff vs 0.6.x pm baseline is exactly the 10 expected tools (5 project + 5 developer)", () => {
+  it("pm_agent diff vs 0.6.x pm baseline is exactly the 10 expected 0.7.0 tools plus the 0.9.0 chorus_create_report", () => {
     const auth = makeAgentAuth([...ROLE_PRESETS.pm_agent], ["pm_agent"]);
     const tools = enumerateGatedMcpTools(auth);
     const baseline = new Set(OLD_PM_TOOLS);
     const diff = Array.from(tools).filter((t) => !baseline.has(t)).sort();
-    expect(diff).toEqual([...PM_AGENT_ADDED_IN_0_7_0].sort());
+    expect(diff).toEqual([...PM_AGENT_ADDED_IN_0_7_0, ...PM_AGENT_ADDED_IN_0_9_0].sort());
   });
 
   it("pm_agent preset does not leak any *:admin-gated tool", () => {

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/reports-list.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/reports-list.test.tsx
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+//
+// UI tests for ReportsList — covers the user-visible contract from the
+// idea-completion-report spec: hidden when zero reports, renders rows in
+// createdAt-desc order with a Report badge when reports exist, click-row
+// calls onDocClick with the {title, type:"report", content} shape that
+// IdeaDetailPanel wires to the existing DocumentPanel.
+
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { getReportsForIdeaActionMock } = vi.hoisted(() => ({
+  getReportsForIdeaActionMock: vi.fn(),
+}));
+
+vi.mock("../actions", () => ({
+  getReportsForIdeaAction: (...args: unknown[]) =>
+    getReportsForIdeaActionMock(...args),
+}));
+
+// Realtime context fires fetches via useRealtimeEntityTypeEvent. The hook
+// itself just registers a subscriber — we no-op it for these tests so the
+// initial fetch is the only one we observe.
+vi.mock("@/contexts/realtime-context", () => ({
+  useRealtimeEntityTypeEvent: () => undefined,
+}));
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolveKey(ns: string, key: string): string {
+    const path = ns ? `${ns}.${key}`.split(".") : key.split(".");
+    let node: unknown = en;
+    for (const p of path) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return `${ns ? ns + "." : ""}${key}`;
+      }
+    }
+    return typeof node === "string" ? node : `${ns ? ns + "." : ""}${key}`;
+  }
+  function format(template: string, values?: Record<string, unknown>): string {
+    if (!values) return template;
+    return template.replace(/\{(\w+)\}/g, (_, name) =>
+      name in values ? String(values[name]) : `{${name}}`,
+    );
+  }
+  const tCache = new Map<string, (key: string, values?: Record<string, unknown>) => string>();
+  return {
+    useTranslations: (ns?: string) => {
+      const k = ns ?? "";
+      let fn = tCache.get(k);
+      if (!fn) {
+        fn = (key, values) => format(resolveKey(k, key), values);
+        tCache.set(k, fn);
+      }
+      return fn;
+    },
+  };
+});
+
+import { ReportsList } from "../reports-list";
+import type { ProposalData } from "../proposal-view";
+
+const PROJECT_UUID = "00000000-0000-4000-8000-00000000aaaa";
+const IDEA_UUID = "00000000-0000-4000-8000-000000000111";
+
+const APPROVED_PROPOSAL: ProposalData = {
+  uuid: "00000000-0000-4000-8000-00000000bbbb",
+  title: "Approved Proposal",
+  description: null,
+  status: "approved",
+  documentDrafts: null,
+  taskDrafts: null,
+  createdAt: "2026-05-01T00:00:00Z",
+};
+
+const PENDING_PROPOSAL: ProposalData = {
+  uuid: "00000000-0000-4000-8000-00000000cccc",
+  title: "Pending Proposal",
+  description: null,
+  status: "pending",
+  documentDrafts: null,
+  taskDrafts: null,
+  createdAt: "2026-05-01T00:00:00Z",
+};
+
+function makeReport(opts: {
+  uuid: string;
+  title: string;
+  createdAt: string;
+  content?: string;
+  proposalUuid?: string;
+}) {
+  return {
+    uuid: opts.uuid,
+    type: "report",
+    title: opts.title,
+    content: opts.content ?? "# body",
+    version: 1,
+    proposalUuid: opts.proposalUuid ?? APPROVED_PROPOSAL.uuid,
+    createdBy: null,
+    createdAt: opts.createdAt,
+    updatedAt: opts.createdAt,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ReportsList", () => {
+  it("renders nothing when no proposals are approved (skips the fetch entirely)", async () => {
+    const onDocClick = vi.fn();
+    const { container } = render(
+      <ReportsList
+        projectUuid={PROJECT_UUID}
+        ideaUuid={IDEA_UUID}
+        proposals={[PENDING_PROPOSAL]}
+        onDocClick={onDocClick}
+      />,
+    );
+    // Wait a tick to be sure nothing rendered after effects ran.
+    await waitFor(() => {
+      expect(getReportsForIdeaActionMock).not.toHaveBeenCalled();
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when approved proposals exist but the action returns zero reports", async () => {
+    getReportsForIdeaActionMock.mockResolvedValue({ success: true, data: [] });
+    const onDocClick = vi.fn();
+    const { container } = render(
+      <ReportsList
+        projectUuid={PROJECT_UUID}
+        ideaUuid={IDEA_UUID}
+        proposals={[APPROVED_PROPOSAL]}
+        onDocClick={onDocClick}
+      />,
+    );
+    await waitFor(() => {
+      expect(getReportsForIdeaActionMock).toHaveBeenCalledWith(
+        PROJECT_UUID,
+        IDEA_UUID,
+      );
+    });
+    // No header, no empty-state copy. The container ends up with no children
+    // once the loading state clears.
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders rows in createdAt-desc order with the localized Report badge", async () => {
+    getReportsForIdeaActionMock.mockResolvedValue({
+      success: true,
+      data: [
+        // Server returns out-of-order — the component must resort.
+        makeReport({
+          uuid: "r-old",
+          title: "Older Report",
+          createdAt: "2026-05-10T00:00:00Z",
+        }),
+        makeReport({
+          uuid: "r-new",
+          title: "Newer Report",
+          createdAt: "2026-05-20T00:00:00Z",
+        }),
+      ],
+    });
+
+    render(
+      <ReportsList
+        projectUuid={PROJECT_UUID}
+        ideaUuid={IDEA_UUID}
+        proposals={[APPROVED_PROPOSAL]}
+        onDocClick={vi.fn()}
+      />,
+    );
+
+    // Section header + count
+    await waitFor(() => {
+      expect(screen.getByText("REPORTS")).toBeTruthy();
+    });
+    expect(screen.getByText("2")).toBeTruthy();
+    // Subtitle mentions all approved proposals
+    expect(screen.getByText(/across all approved proposals/)).toBeTruthy();
+
+    // At least one Report badge is localized
+    const badges = screen.getAllByText("Report");
+    expect(badges.length).toBe(2);
+
+    // Order: newest first
+    const titles = screen.getAllByRole("button").map((b) => b.textContent || "");
+    const newerIdx = titles.findIndex((t) => t.includes("Newer Report"));
+    const olderIdx = titles.findIndex((t) => t.includes("Older Report"));
+    expect(newerIdx).toBeGreaterThanOrEqual(0);
+    expect(olderIdx).toBeGreaterThanOrEqual(0);
+    expect(newerIdx).toBeLessThan(olderIdx);
+  });
+
+  it("aggregates reports across multiple approved proposals (1 + 2 = 3 rows)", async () => {
+    // Spec scenario: an Idea with two approved Proposals (A and B). Proposal A
+    // has 1 report; Proposal B has 2. The list must show all 3 rows in one
+    // section, count = 3, sorted by createdAt desc regardless of proposal.
+    const SECOND_APPROVED_PROPOSAL: ProposalData = {
+      uuid: "00000000-0000-4000-8000-00000000dddd",
+      title: "Second Approved Proposal",
+      description: null,
+      status: "approved",
+      documentDrafts: null,
+      taskDrafts: null,
+      createdAt: "2026-05-02T00:00:00Z",
+    };
+
+    getReportsForIdeaActionMock.mockResolvedValue({
+      success: true,
+      data: [
+        // Proposal A → 1 report (oldest)
+        makeReport({
+          uuid: "r-A1",
+          title: "Proposal A — completion report",
+          createdAt: "2026-05-10T00:00:00Z",
+          proposalUuid: APPROVED_PROPOSAL.uuid,
+        }),
+        // Proposal B → 2 reports (one middle, one newest)
+        makeReport({
+          uuid: "r-B1",
+          title: "Proposal B — first cut",
+          createdAt: "2026-05-15T00:00:00Z",
+          proposalUuid: SECOND_APPROVED_PROPOSAL.uuid,
+        }),
+        makeReport({
+          uuid: "r-B2",
+          title: "Proposal B — final report",
+          createdAt: "2026-05-22T00:00:00Z",
+          proposalUuid: SECOND_APPROVED_PROPOSAL.uuid,
+        }),
+      ],
+    });
+
+    render(
+      <ReportsList
+        projectUuid={PROJECT_UUID}
+        ideaUuid={IDEA_UUID}
+        proposals={[APPROVED_PROPOSAL, SECOND_APPROVED_PROPOSAL]}
+        onDocClick={vi.fn()}
+      />,
+    );
+
+    // Section header renders, count is the sum across proposals (1 + 2 = 3).
+    await waitFor(() => {
+      expect(screen.getByText("REPORTS")).toBeTruthy();
+    });
+    expect(screen.getByText("3")).toBeTruthy();
+    // Subtitle reads "across all approved proposals" — single section, plural.
+    expect(screen.getByText(/across all approved proposals/)).toBeTruthy();
+
+    // All three Report badges render — confirms rows from BOTH proposals are
+    // surfaced together (no per-proposal grouping/limit).
+    expect(screen.getAllByText("Report").length).toBe(3);
+
+    // Order: newest (r-B2) → middle (r-B1) → oldest (r-A1). Confirms the
+    // global createdAt-desc sort survives the cross-proposal aggregation.
+    const titles = screen.getAllByRole("button").map((b) => b.textContent || "");
+    const idxA1 = titles.findIndex((t) => t.includes("Proposal A — completion report"));
+    const idxB1 = titles.findIndex((t) => t.includes("Proposal B — first cut"));
+    const idxB2 = titles.findIndex((t) => t.includes("Proposal B — final report"));
+    expect(idxA1).toBeGreaterThanOrEqual(0);
+    expect(idxB1).toBeGreaterThanOrEqual(0);
+    expect(idxB2).toBeGreaterThanOrEqual(0);
+    expect(idxB2).toBeLessThan(idxB1);
+    expect(idxB1).toBeLessThan(idxA1);
+
+    // Server action is called once with the Idea-level pair — single round-trip
+    // for the aggregated list, regardless of how many approved proposals.
+    expect(getReportsForIdeaActionMock).toHaveBeenCalledTimes(1);
+    expect(getReportsForIdeaActionMock).toHaveBeenCalledWith(
+      PROJECT_UUID,
+      IDEA_UUID,
+    );
+  });
+
+  it("clicking a report row calls onDocClick with {title, type:'report', content}", async () => {
+    const user = userEvent.setup();
+    getReportsForIdeaActionMock.mockResolvedValue({
+      success: true,
+      data: [
+        makeReport({
+          uuid: "r-1",
+          title: "Idea X — completion report",
+          createdAt: "2026-05-20T00:00:00Z",
+          content: "# Idea X\n\nDelivered.",
+        }),
+      ],
+    });
+    const onDocClick = vi.fn();
+
+    render(
+      <ReportsList
+        projectUuid={PROJECT_UUID}
+        ideaUuid={IDEA_UUID}
+        proposals={[APPROVED_PROPOSAL]}
+        onDocClick={onDocClick}
+      />,
+    );
+
+    const row = await screen.findByRole("button", {
+      name: /Idea X — completion report/,
+    });
+    await user.click(row);
+
+    expect(onDocClick).toHaveBeenCalledWith({
+      title: "Idea X — completion report",
+      type: "report",
+      content: "# Idea X\n\nDelivered.",
+    });
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/actions.ts
@@ -8,6 +8,7 @@ import {
   getIdeaByUuid,
 } from "@/services/idea.service";
 import { getProposalsByIdeaUuid } from "@/services/proposal.service";
+import { listDocumentsByProposalUuids } from "@/services/document.service";
 import { getTask, listTasks } from "@/services/task.service";
 import { listProjects } from "@/services/project.service";
 import { listProjectGroups } from "@/services/project-group.service";
@@ -130,6 +131,43 @@ export async function getTasksForProposalAction(
   });
 
   return { success: true as const, data: tasks };
+}
+
+// Aggregate `type="report"` Documents across an Idea's approved Proposals.
+// Server-side aggregation avoids the client doing N round-trips, and keeps
+// the Idea-level "reports" surface consistent regardless of how many
+// approved Proposals an Idea has.
+export async function getReportsForIdeaAction(
+  projectUuid: string,
+  ideaUuid: string,
+) {
+  const auth = await getServerAuthContext();
+  if (!auth) {
+    return { success: false as const, error: "Unauthorized" };
+  }
+
+  const proposals = await getProposalsByIdeaUuid(
+    auth.companyUuid,
+    projectUuid,
+    ideaUuid,
+  );
+  const approvedUuids = proposals
+    .filter((p) => p.status === "approved")
+    .map((p) => p.uuid);
+
+  const reports = await listDocumentsByProposalUuids(
+    auth.companyUuid,
+    approvedUuids,
+    "report",
+  );
+
+  // Sort newest-first — service already returns desc, but resort defensively
+  // so callers don't depend on implementation order.
+  reports.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return { success: true as const, data: reports };
 }
 
 export async function getProjectsAndGroupsAction() {

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -26,6 +26,7 @@ import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
 import { ElaborationView } from "./elaboration-view";
 import { ProposalView, type ProposalData } from "./proposal-view";
 import { OverviewTimeline } from "./overview-timeline";
+import { ReportsList } from "./reports-list";
 import { TaskListView } from "./task-list-view";
 import { ActivityCommentsView } from "./activity-comments-view";
 import { TaskDetailPanel } from "@/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel";
@@ -644,6 +645,12 @@ export function IdeaDetailPanel({
                         proposals={proposals}
                         tasks={tasks}
                         onSelectTask={openTask}
+                      />
+                      <ReportsList
+                        projectUuid={projectUuid}
+                        ideaUuid={idea.uuid}
+                        proposals={proposals}
+                        onDocClick={openDoc}
                       />
                     </div>
                   )}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/reports-list.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/reports-list.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronLeft, Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
+import { clientLogger } from "@/lib/logger-client";
+import { DOC_TYPE_I18N_KEYS } from "./utils";
+import { getReportsForIdeaAction } from "./actions";
+import type { ProposalData } from "./proposal-view";
+
+interface ReportItem {
+  uuid: string;
+  title: string;
+  type: string;
+  content: string | null;
+  createdAt: string;
+}
+
+interface ReportsListProps {
+  /** Project UUID — required for the server action's project-scoped lookup. */
+  projectUuid: string;
+  /** Idea UUID — used to aggregate reports across the Idea's approved proposals. */
+  ideaUuid: string;
+  /**
+   * Approved proposals already loaded by the parent. We use this list as a
+   * cheap pre-filter: when no proposal is approved, we know there are no
+   * reports and skip the round-trip entirely.
+   */
+  proposals: ProposalData[];
+  /**
+   * Click handler that opens the parent's existing DocumentPanel. The panel
+   * already knows how to render the content as Markdown via MarkdownContent.
+   */
+  onDocClick: (doc: { title: string; type: string; content: string }) => void;
+}
+
+/**
+ * Idea-level Reports list rendered on the overview tab below OverviewTimeline.
+ *
+ * Aggregates `type="report"` Documents across all approved Proposals of an
+ * Idea (server-side via `getReportsForIdeaAction`). Hidden entirely when no
+ * reports exist — no header, no empty-state copy, per the spec.
+ */
+export function ReportsList({
+  projectUuid,
+  ideaUuid,
+  proposals,
+  onDocClick,
+}: ReportsListProps) {
+  const tIdea = useTranslations("idea");
+  const tDocs = useTranslations("documents");
+
+  const [reports, setReports] = useState<ReportItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Cheap precondition: any approved proposals at all? If not, skip the fetch
+  // and render nothing — saves a server round-trip on every open of an Idea
+  // that hasn't reached the post-approval stage.
+  const hasApprovedProposal = proposals.some((p) => p.status === "approved");
+
+  const fetchReports = useCallback(async () => {
+    if (!hasApprovedProposal) {
+      setReports([]);
+      setIsLoading(false);
+      return;
+    }
+    try {
+      const result = await getReportsForIdeaAction(projectUuid, ideaUuid);
+      if (result.success) {
+        // Defensive resort by createdAt desc — server already sorts but the
+        // contract is small enough to make explicit on the rendering side.
+        const sorted = [...result.data].sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+        setReports(
+          sorted.map((d) => ({
+            uuid: d.uuid,
+            title: d.title,
+            type: d.type,
+            content: d.content ?? null,
+            createdAt: d.createdAt,
+          })),
+        );
+      }
+    } catch (e) {
+      clientLogger.error("Failed to fetch reports for idea:", e);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectUuid, ideaUuid, hasApprovedProposal]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    fetchReports();
+  }, [fetchReports]);
+
+  // SSE: re-fetch when a Document changes — covers the "agent just created
+  // a new report" case so the list updates without a manual reload.
+  useRealtimeEntityTypeEvent("document", fetchReports);
+
+  // Hidden entirely when no reports — no header, no empty-state copy. Loading
+  // also renders nothing to avoid a flash of header/spinner before the
+  // typical zero-report case settles.
+  if (isLoading) {
+    if (!hasApprovedProposal) return null;
+    return (
+      <div className="flex items-center justify-center py-3">
+        <Loader2 className="h-4 w-4 animate-spin text-[#C67A52]" />
+      </div>
+    );
+  }
+
+  if (reports.length === 0) return null;
+
+  return (
+    <div className="mt-6 space-y-3">
+      {/* Section header — REPORTS · count · subtitle */}
+      <div className="flex items-baseline gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-[1px] text-[#9A9A9A]">
+          {tIdea("reportsList")}
+        </span>
+        <span className="text-[11px] text-[#9A9A9A]">{reports.length}</span>
+        <span className="text-[11px] text-[#B4B2A9]">
+          · {tIdea("reportsAcrossProposals")}
+        </span>
+      </div>
+
+      {/* Rows — chevron-left + Report badge + title, same shape as proposal-view doc rows */}
+      <div className="space-y-0">
+        {reports.map((r) => (
+          <Button
+            key={r.uuid}
+            variant="ghost"
+            className="w-full justify-start h-auto text-left flex items-center gap-2.5 py-3.5 hover:bg-[#FAF8F4] transition-colors cursor-pointer -mx-1 px-1 rounded-lg"
+            onClick={() =>
+              onDocClick({
+                title: r.title,
+                type: "report",
+                content: r.content ?? "",
+              })
+            }
+          >
+            <ChevronLeft className="h-3.5 w-3.5 shrink-0 text-[#B4B2A9]" />
+            <Badge
+              variant="outline"
+              className="shrink-0 text-[10px] font-medium border-[#E5E0D8] text-[#6B6B6B] bg-[#F5F2EC] px-2 py-0.5 font-mono"
+            >
+              {tDocs(DOC_TYPE_I18N_KEYS[r.type] || "typeOther")}
+            </Badge>
+            <span className="flex-1 min-w-0 text-left text-[13px] text-[#2C2C2A] truncate">
+              {r.title}
+            </span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/utils.ts
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/utils.ts
@@ -12,5 +12,6 @@ export const DOC_TYPE_I18N_KEYS: Record<string, string> = {
   guide: "typeGuide",
   design: "typeDesign",
   note: "typeNote",
+  report: "typeReport",
   other: "typeOther",
 };

--- a/src/app/(dashboard)/projects/[uuid]/documents/[documentUuid]/page.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/documents/[documentUuid]/page.tsx
@@ -20,6 +20,7 @@ const docTypeConfig: Record<string, { labelKey: string; color: string; icon: Luc
   spec: { labelKey: "documents.typeSpec", color: "bg-[#E8F5E9] text-[#5A9E6F]", icon: FileEdit },
   design: { labelKey: "documents.typeDesign", color: "bg-[#F3E5F5] text-[#7B1FA2]", icon: Palette },
   note: { labelKey: "documents.typeNote", color: "bg-[#FFF3E0] text-[#E65100]", icon: BookOpen },
+  report: { labelKey: "documents.typeReport", color: "bg-[#FFF8E1] text-[#9A6B00]", icon: FileText },
   other: { labelKey: "documents.typeOther", color: "bg-[#F5F5F5] text-[#6B6B6B]", icon: FileText },
 };
 

--- a/src/app/(dashboard)/projects/[uuid]/documents/doc-type-config.ts
+++ b/src/app/(dashboard)/projects/[uuid]/documents/doc-type-config.ts
@@ -5,5 +5,6 @@ export const docTypeConfig: Record<string, { labelKey: string; color: string; ic
   spec: { labelKey: "documents.typeSpec", color: "bg-[#E8F5E9] text-[#5A9E6F]", icon: FileEdit },
   design: { labelKey: "documents.typeDesign", color: "bg-[#F3E5F5] text-[#7B1FA2]", icon: Palette },
   note: { labelKey: "documents.typeNote", color: "bg-[#FFF3E0] text-[#E65100]", icon: BookOpen },
+  report: { labelKey: "documents.typeReport", color: "bg-[#FFF8E1] text-[#9A6B00]", icon: FileText },
   other: { labelKey: "documents.typeOther", color: "bg-[#F5F5F5] text-[#6B6B6B]", icon: FileText },
 };

--- a/src/i18n/__tests__/report-locale-keys.test.ts
+++ b/src/i18n/__tests__/report-locale-keys.test.ts
@@ -1,0 +1,91 @@
+// Locale-key contract for the idea-completion-report feature.
+//
+// The Reports surface relies on three i18n keys that MUST exist with non-empty
+// values in BOTH `en` and `zh` — losing any of them would render the
+// reports-list with raw key strings as fallback (verified visually + via the
+// reports-list render tests). This test pins the contract so a translation
+// drift can't ship silently.
+//
+// Note: the original task description referenced `proposals.reports`, but the
+// actual surface (T2) lives on the Idea overview tab and uses `idea.reportsList`
+// + `idea.reportsAcrossProposals` instead. We assert against the keys that
+// were actually shipped, not the placeholder names from the task spec.
+
+import { describe, expect, it } from "vitest";
+import enMessages from "../../../messages/en.json";
+import zhMessages from "../../../messages/zh.json";
+
+type MessageNode = string | { [key: string]: MessageNode };
+
+function resolveDeep(messages: Record<string, MessageNode>, path: string): unknown {
+  let node: unknown = messages;
+  for (const segment of path.split(".")) {
+    if (
+      node &&
+      typeof node === "object" &&
+      segment in (node as Record<string, unknown>)
+    ) {
+      node = (node as Record<string, unknown>)[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return node;
+}
+
+const REQUIRED_KEYS = [
+  "documents.typeReport",
+  "idea.reportsList",
+  "idea.reportsAcrossProposals",
+] as const;
+
+const LOCALES = [
+  ["en", enMessages as Record<string, MessageNode>],
+  ["zh", zhMessages as Record<string, MessageNode>],
+] as const;
+
+describe("idea-completion-report locale keys", () => {
+  for (const [localeName, messages] of LOCALES) {
+    describe(`${localeName}.json`, () => {
+      for (const key of REQUIRED_KEYS) {
+        it(`has a non-empty string at "${key}"`, () => {
+          const value = resolveDeep(messages, key);
+          expect(value, `missing key ${key} in ${localeName}.json`).toBeDefined();
+          expect(
+            typeof value,
+            `key ${key} in ${localeName}.json must be a string`,
+          ).toBe("string");
+          // Non-empty AND not just whitespace — an empty translation in either
+          // locale is functionally a missing key for the UI.
+          expect(
+            (value as string).trim().length,
+            `key ${key} in ${localeName}.json must be non-empty`,
+          ).toBeGreaterThan(0);
+        });
+      }
+    });
+  }
+
+  it("documents.typeReport renders the same Document type across locales", () => {
+    // Both locales must define typeReport (we assert the value is a string
+    // above) — here we just confirm the en and zh entries are independent
+    // strings, not accidentally cross-pointed at the same fallback constant.
+    const en = resolveDeep(enMessages as Record<string, MessageNode>, "documents.typeReport");
+    const zh = resolveDeep(zhMessages as Record<string, MessageNode>, "documents.typeReport");
+    expect(typeof en).toBe("string");
+    expect(typeof zh).toBe("string");
+    // Sanity: en should be the English label "Report".
+    expect(en).toBe("Report");
+  });
+
+  it("idea.reportsList is a SCREAMING-CASE label in en (matches reports-list header expectation)", () => {
+    // The reports-list render test asserts the header text is "REPORTS" — this
+    // pins that contract at the locale layer so a future translation edit
+    // can't quietly break the UI test by lowercasing the label.
+    const value = resolveDeep(
+      enMessages as Record<string, MessageNode>,
+      "idea.reportsList",
+    );
+    expect(value).toBe("REPORTS");
+  });
+});

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/services/task.service", () => ({}));
 vi.mock("@/services/proposal.service", () => ({}));
 vi.mock("@/services/activity.service", () => ({}));
 vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/checkin.service", () => ({}));
 vi.mock("@/services/idea.service", () => ({}));
 vi.mock("@/services/document.service", () => ({}));
 vi.mock("@/services/comment.service", () => ({}));
@@ -31,6 +32,7 @@ import { ROLE_PRESETS } from "@/lib/authz/presets";
 import { registerPmTools } from "@/mcp/tools/pm";
 import { registerDeveloperTools } from "@/mcp/tools/developer";
 import { registerAdminTools } from "@/mcp/tools/admin";
+import { registerPublicTools } from "@/mcp/tools/public";
 import { TOOL_PERMISSIONS } from "@/mcp/tools/permission-map";
 
 // Minimal McpServer stand-in: records every tool name that gets registered.
@@ -55,8 +57,12 @@ function makeAuth(permissions: Permission[]): AgentAuthContext {
   };
 }
 
-// Register all three gated tool modules with the given permissions and return
-// the set of registered tool names (names only, deterministic order doesn't matter).
+// Register every gated tool module (pm/developer/admin and the public-namespaced
+// gated tools in public.ts) with the given permissions, then keep only the names
+// that appear in TOOL_PERMISSIONS — i.e. tools that go through
+// `registerPermissionedTool`. Non-gated public.ts tools (chorus_get_project,
+// chorus_add_comment, etc.) are intentionally filtered out so the assertions
+// below stay focused on the gated surface.
 function registeredFor(permissions: Permission[]): Set<string> {
   const { server, names } = makeCapturingServer();
   const auth = makeAuth(permissions);
@@ -66,7 +72,10 @@ function registeredFor(permissions: Permission[]): Set<string> {
   registerDeveloperTools(server as any, auth);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registerAdminTools(server as any, auth);
-  return new Set(names);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerPublicTools(server as any, auth);
+  const gated = new Set(Object.keys(TOOL_PERMISSIONS));
+  return new Set(names.filter((n) => gated.has(n)));
 }
 
 // 0.6.x tool lists captured from pm.ts / developer.ts / admin.ts before this
@@ -189,12 +198,15 @@ describe("MCP tool permission wiring", () => {
   });
 
   describe("backward-compat: admin_agent preset (AC6)", () => {
-    it("admin_agent sees exactly the union of 0.6.x admin + pm + developer tool sets", () => {
+    it("admin_agent sees exactly the union of 0.6.x admin + pm + developer tool sets plus 0.9.0 chorus_create_report", () => {
       const registered = registeredFor([...ROLE_PRESETS.admin_agent]);
       const expected = new Set([
         ...OLD_ADMIN_TOOLS,
         ...OLD_PM_TOOLS,
         ...OLD_DEVELOPER_TOOLS,
+        // 0.9.0: public-namespaced, document:write-gated. admin_agent carries
+        // document:write so the tool is visible to admin presets.
+        "chorus_create_report",
       ]);
       expect(registered).toEqual(expected);
     });
@@ -240,6 +252,10 @@ describe("MCP tool permission wiring", () => {
       expect(TOOL_PERMISSIONS.chorus_admin_update_project_group).toBe("project:write");
       expect(TOOL_PERMISSIONS.chorus_admin_delete_project_group).toBe("project:write");
       expect(TOOL_PERMISSIONS.chorus_admin_move_project_to_group).toBe("project:write");
+    });
+
+    it("chorus_create_report is gated on document:write (AC2 of add-idea-completion-report)", () => {
+      expect(TOOL_PERMISSIONS.chorus_create_report).toBe("document:write");
     });
   });
 });

--- a/src/mcp/tools/__tests__/create-report.test.ts
+++ b/src/mcp/tools/__tests__/create-report.test.ts
@@ -224,6 +224,7 @@ describe("chorus_create_report handler", () => {
       uuid: PROPOSAL_UUID,
       projectUuid: PROJECT_UUID,
       companyUuid: COMPANY_UUID,
+      status: "approved",
     });
     mockDocumentService.createDocument.mockResolvedValue({
       uuid: DOC_UUID,
@@ -321,6 +322,33 @@ describe("chorus_create_report handler", () => {
       COMPANY_UUID,
       PROPOSAL_UUID
     );
+    expect(mockDocumentService.createDocument).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["draft"],
+    ["pending"],
+    ["rejected"],
+    ["closed"],
+  ])("rejects the call when proposal.status='%s' (only 'approved' may bear a completion report)", async (status) => {
+    mockProposalService.getProposalByUuid.mockResolvedValue({
+      uuid: PROPOSAL_UUID,
+      projectUuid: PROJECT_UUID,
+      companyUuid: COMPANY_UUID,
+      status,
+    });
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: PROPOSAL_UUID,
+      title: "Should fail",
+      content: "## Summary\nbody\n",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(`'${status}'`);
     expect(mockDocumentService.createDocument).not.toHaveBeenCalled();
   });
 });

--- a/src/mcp/tools/__tests__/create-report.test.ts
+++ b/src/mcp/tools/__tests__/create-report.test.ts
@@ -1,0 +1,326 @@
+// Pure tests for the public-namespaced, document:write-gated tool
+// `chorus_create_report` (add-idea-completion-report Tech Design §"MCP tool
+// contract"). Mocks every transitive service so registerPublicTools never
+// touches a real DB; the suite captures the registered handler/config and
+// drives it directly.
+
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// ===== Module mocks (hoisted) =====
+
+const mockProposalService = vi.hoisted(() => ({
+  getProposalByUuid: vi.fn(),
+}));
+
+const mockDocumentService = vi.hoisted(() => ({
+  createDocument: vi.fn(),
+}));
+
+const mockPrisma = vi.hoisted(() => ({
+  prisma: {
+    acceptanceCriterion: { createMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/services/proposal.service", () => mockProposalService);
+vi.mock("@/services/document.service", () => mockDocumentService);
+vi.mock("@/lib/prisma", () => mockPrisma);
+
+// Empty stubs for every other service registerPublicTools imports — none of
+// their methods get called in these tests.
+vi.mock("@/services/project.service", () => ({}));
+vi.mock("@/services/idea.service", () => ({}));
+vi.mock("@/services/task.service", () => ({}));
+vi.mock("@/services/activity.service", () => ({}));
+vi.mock("@/services/comment.service", () => ({}));
+vi.mock("@/services/assignment.service", () => ({}));
+vi.mock("@/services/notification.service", () => ({}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/project-group.service", () => ({}));
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/search.service", () => ({}));
+vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/checkin.service", () => ({}));
+
+// Capture tool registrations: name -> { config, handler }
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}>;
+type ToolConfig = {
+  description?: string;
+  inputSchema?: { parse?: (input: unknown) => unknown };
+};
+
+const tools: Record<string, { config: ToolConfig; handler: ToolHandler }> = {};
+
+function makeServer() {
+  return {
+    registerTool: (name: string, config: ToolConfig, handler: ToolHandler) => {
+      tools[name] = { config, handler };
+    },
+  };
+}
+
+import type { AgentAuthContext } from "@/types/auth";
+import { registerPublicTools } from "@/mcp/tools/public";
+import { TOOL_PERMISSIONS } from "@/mcp/tools/permission-map";
+
+const COMPANY_UUID = "company-0000-0000-0000-000000000001";
+const ACTOR_UUID = "agent-0000-0000-0000-000000000001";
+const PROPOSAL_UUID = "11111111-1111-4111-8111-111111111111";
+const PROJECT_UUID = "22222222-2222-4222-8222-222222222222";
+const DOC_UUID = "33333333-3333-4333-8333-333333333333";
+
+function makeAuth(permissions: string[]): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid: COMPANY_UUID,
+    actorUuid: ACTOR_UUID,
+    agentName: "Test Agent",
+    roles: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    permissions: permissions as any,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.keys(tools).forEach((k) => delete tools[k]);
+});
+
+// ============================================================
+// Permission map entry
+// ============================================================
+
+describe("permission-map entry", () => {
+  it("maps chorus_create_report to document:write (AC: permission gate)", () => {
+    expect(TOOL_PERMISSIONS.chorus_create_report).toBe("document:write");
+  });
+});
+
+// ============================================================
+// Tool registration: visibility under different permission sets
+// ============================================================
+
+describe("chorus_create_report registration gating", () => {
+  it("registers the tool when auth carries document:write", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+    expect(tools["chorus_create_report"]).toBeDefined();
+  });
+
+  it("does NOT register the tool when auth lacks document:write (only document:read)", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:read"]));
+    expect(tools["chorus_create_report"]).toBeUndefined();
+  });
+
+  it("does NOT register the tool when auth has zero permissions", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth([]));
+    expect(tools["chorus_create_report"]).toBeUndefined();
+  });
+
+  it("does NOT register the tool for an agent with only task:write (developer-style custom set)", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["task:read", "task:write"]));
+    expect(tools["chorus_create_report"]).toBeUndefined();
+  });
+});
+
+// ============================================================
+// Tool description: 3 section headers required by the report template
+// ============================================================
+
+describe("chorus_create_report description (template constraint)", () => {
+  it("description carries the three report section headers", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+    const desc = tools["chorus_create_report"].config.description ?? "";
+
+    // Each header must appear verbatim in the LLM-visible description so the
+    // calling agent has a single source of truth for the report shape.
+    expect(desc).toContain("Summary");
+    expect(desc).toContain("Decisions");
+    expect(desc).toContain("Follow-ups");
+  });
+});
+
+// ============================================================
+// Input schema: required fields, no `type` parameter
+// ============================================================
+
+describe("chorus_create_report input schema (spec delta mcp-tool-surface)", () => {
+  it("requires proposalUuid (UUID), title, and content", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+    const schema = tools["chorus_create_report"].config.inputSchema as {
+      parse: (input: unknown) => unknown;
+    };
+
+    // Empty input fails validation.
+    expect(() => schema.parse({})).toThrow();
+
+    // Non-UUID proposalUuid fails.
+    expect(() =>
+      schema.parse({ proposalUuid: "not-a-uuid", title: "t", content: "c" })
+    ).toThrow();
+
+    // Empty title fails (min length 1).
+    expect(() =>
+      schema.parse({ proposalUuid: PROPOSAL_UUID, title: "", content: "c" })
+    ).toThrow();
+
+    // Empty content fails (min length 1).
+    expect(() =>
+      schema.parse({ proposalUuid: PROPOSAL_UUID, title: "t", content: "" })
+    ).toThrow();
+
+    // Title over 200 chars fails.
+    expect(() =>
+      schema.parse({
+        proposalUuid: PROPOSAL_UUID,
+        title: "x".repeat(201),
+        content: "c",
+      })
+    ).toThrow();
+
+    // Valid input passes.
+    expect(() =>
+      schema.parse({
+        proposalUuid: PROPOSAL_UUID,
+        title: "Idea X — completion report",
+        content: "## Summary\nbody",
+      })
+    ).not.toThrow();
+  });
+
+  it("does NOT accept a type parameter (the tool name encodes type=report)", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+    const schema = tools["chorus_create_report"].config.inputSchema as {
+      parse: (input: unknown) => { type?: unknown };
+    };
+
+    const parsed = schema.parse({
+      proposalUuid: PROPOSAL_UUID,
+      title: "t",
+      content: "c",
+      // Extra "type" field — Zod object schemas strip unknown keys by default,
+      // so we assert the parsed result has no `type` key surfaced to the handler.
+    });
+    expect((parsed as Record<string, unknown>).type).toBeUndefined();
+  });
+});
+
+// ============================================================
+// Handler behavior: load Proposal, write Document with type=report
+// ============================================================
+
+describe("chorus_create_report handler", () => {
+  it("creates a Document with type=report and the supplied title/content (AC: byte-faithful create)", async () => {
+    mockProposalService.getProposalByUuid.mockResolvedValue({
+      uuid: PROPOSAL_UUID,
+      projectUuid: PROJECT_UUID,
+      companyUuid: COMPANY_UUID,
+    });
+    mockDocumentService.createDocument.mockResolvedValue({
+      uuid: DOC_UUID,
+      type: "report",
+      title: "Idea X — completion report",
+      content: "## Summary\nbody\n",
+      version: 1,
+      proposalUuid: PROPOSAL_UUID,
+      createdBy: { type: "agent", uuid: ACTOR_UUID, name: "Test Agent" },
+      createdAt: new Date("2026-05-25T00:00:00Z").toISOString(),
+      updatedAt: new Date("2026-05-25T00:00:00Z").toISOString(),
+    });
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const reportContent =
+      "## Summary\nShipped feature X.\n\n" +
+      "## Decisions\n- Chose A over B.\n\n" +
+      "## Follow-ups\nNone.\n";
+
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: PROPOSAL_UUID,
+      title: "Idea X — completion report",
+      content: reportContent,
+    });
+
+    // Proposal lookup is scoped to the agent's company.
+    expect(mockProposalService.getProposalByUuid).toHaveBeenCalledWith(
+      COMPANY_UUID,
+      PROPOSAL_UUID
+    );
+
+    // Document is created with the right primitives. The service receives
+    // type="report" unconditionally (the tool name pins it) and the
+    // projectUuid is read from the loaded Proposal.
+    expect(mockDocumentService.createDocument).toHaveBeenCalledTimes(1);
+    const createCall = mockDocumentService.createDocument.mock.calls[0][0];
+    expect(createCall).toMatchObject({
+      companyUuid: COMPANY_UUID,
+      projectUuid: PROJECT_UUID,
+      proposalUuid: PROPOSAL_UUID,
+      type: "report",
+      title: "Idea X — completion report",
+      createdByUuid: ACTOR_UUID,
+    });
+    // content passes through byte-faithfully to the service layer.
+    expect(createCall.content).toBe(reportContent);
+
+    // Response shape: { documentUuid, projectUuid, version }.
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toEqual({
+      documentUuid: DOC_UUID,
+      projectUuid: PROJECT_UUID,
+      version: 1,
+    });
+  });
+
+  it("returns 'Proposal not found' and creates no Document when the Proposal is missing (AC4)", async () => {
+    mockProposalService.getProposalByUuid.mockResolvedValue(null);
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: PROPOSAL_UUID,
+      title: "Will fail",
+      content: "## Summary\nshould not persist",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Proposal not found");
+    expect(mockDocumentService.createDocument).not.toHaveBeenCalled();
+  });
+
+  it("scopes Proposal lookup to the agent's companyUuid (multi-tenancy)", async () => {
+    // Even with a valid-looking UUID, a Proposal in another company yields null
+    // from getProposalByUuid (scoped query). The handler must surface the
+    // not-found path, not silently leak a cross-tenant row.
+    mockProposalService.getProposalByUuid.mockResolvedValue(null);
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: PROPOSAL_UUID,
+      title: "Cross-tenant probe",
+      content: "## Summary",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockProposalService.getProposalByUuid).toHaveBeenCalledWith(
+      COMPANY_UUID,
+      PROPOSAL_UUID
+    );
+    expect(mockDocumentService.createDocument).not.toHaveBeenCalled();
+  });
+});

--- a/src/mcp/tools/__tests__/yolo-end-step-predicates.test.ts
+++ b/src/mcp/tools/__tests__/yolo-end-step-predicates.test.ts
@@ -1,0 +1,407 @@
+// src/mcp/tools/__tests__/yolo-end-step-predicates.test.ts
+//
+// Mock-driven test for the yolo end-step report contract (T7 / AC #2).
+//
+// We can't replay a real /chorus:yolo run inside CI — the skill is consumed
+// by an LLM agent and a real run takes minutes and an API budget. Instead,
+// this suite encodes the documented predicates verbatim and asserts that
+// across the predicate truth table the skill would call `chorus_create_report`
+// EXACTLY ONCE — no more, no fewer — under the conditions the skill claims to
+// be deterministic.
+//
+// Predicates (lifted from public/chorus-plugin/skills/yolo/SKILL.md
+// "Phase 5b: Idea Completion Report"):
+//
+//   1. The yolo run has just verified a task. (Phase 5 reached.)
+//   2. Every Task across every approved Proposal whose inputUuids contains
+//      this Idea's UUID is now in {done, closed}.
+//   3. The Idea currently has zero Documents with type="report" linked to
+//      any of those approved Proposals.
+//   4. The yolo run has not already issued a chorus_create_report call.
+//
+// All four MUST hold for the call to fire. The call MUST be made exactly
+// once per run, with proposalUuid = the LAST verified Proposal's UUID.
+//
+// What this test catches:
+//   - Predicate-logic regression: skipping AC because of a partial-completion
+//     state (e.g. one task still in_progress).
+//   - Idempotency: a second pipeline pass on the same Idea (with a report
+//     already present) doesn't double-write.
+//   - Quick-task / non-idea proposal: the skill doesn't author a report
+//     for a proposal that isn't idea-rooted.
+//   - Dispatch correctness: when fired, the call shape matches the tool
+//     contract (proposalUuid, title, content with the 5 required headers).
+
+import { describe, it, expect, vi } from "vitest";
+
+// ===== Predicate-logic implementation under test =====
+//
+// This is a faithful translation of the SKILL.md pseudocode into TypeScript.
+// The skill itself is interpreted by the LLM at runtime, but the contract is
+// mechanical enough that we encode it here as the "logic the skill claims to
+// execute" and exercise it via the same tool-call shape the agent would emit.
+
+interface FakeTask {
+  uuid: string;
+  proposalUuid: string;
+  status: "todo" | "in_progress" | "to_verify" | "done" | "closed" | "blocked";
+}
+
+interface FakeProposal {
+  uuid: string;
+  status: "draft" | "submitted" | "approved" | "rejected";
+  inputType: "idea" | "free-form";
+  inputUuids: string[]; // ideaUuid for idea-rooted proposals
+}
+
+interface FakeReportDoc {
+  uuid: string;
+  type: string; // "report" or other
+  proposalUuid: string;
+}
+
+interface CreateReportCall {
+  proposalUuid: string;
+  title: string;
+  content: string;
+}
+
+interface YoloEndStepInput {
+  ideaUuid: string;
+  ideaTitle: string;
+  proposals: FakeProposal[];
+  tasks: FakeTask[];
+  existingDocuments: FakeReportDoc[];
+  // The Proposal whose last task was just verified — passed to
+  // chorus_create_report when the predicate fires.
+  lastVerifiedProposalUuid: string;
+  // Spy / mock the skill would invoke. We pass it in so tests can count calls
+  // and assert the exact dispatch shape.
+  createReport: (call: CreateReportCall) => unknown;
+}
+
+/**
+ * Encodes the SKILL.md "Phase 5b" decision logic. Returns true iff the call
+ * was dispatched. The function is stateless — callers wanting to test "second
+ * run on same Idea" should construct a new input where existingDocuments
+ * already includes a report.
+ */
+function runYoloEndStep(input: YoloEndStepInput): boolean {
+  // Predicate (1): we are at end-of-pipeline by virtue of being called
+  // from Phase 5 — the runner contract gates this.
+
+  // Predicate (2): all tasks across approved-Proposals-of-this-Idea are
+  // terminal.
+  const ideaProposals = input.proposals.filter(
+    (p) =>
+      p.status === "approved" &&
+      p.inputType === "idea" &&
+      p.inputUuids.includes(input.ideaUuid),
+  );
+  if (ideaProposals.length === 0) {
+    // No approved idea-rooted proposal — nothing to recap.
+    return false;
+  }
+  const ideaProposalUuids = new Set(ideaProposals.map((p) => p.uuid));
+  const ideaTasks = input.tasks.filter((t) => ideaProposalUuids.has(t.proposalUuid));
+  const allTerminal = ideaTasks.every(
+    (t) => t.status === "done" || t.status === "closed",
+  );
+  if (!allTerminal) return false;
+
+  // Predicate (3): no existing report Document linked to any of those
+  // approved Proposals.
+  const existingReportCount = input.existingDocuments.filter(
+    (d) => d.type === "report" && ideaProposalUuids.has(d.proposalUuid),
+  ).length;
+  if (existingReportCount > 0) return false;
+
+  // All gates pass — dispatch the call exactly once.
+  const body = [
+    `# ${input.ideaTitle} — completion report`,
+    "",
+    "## Summary",
+    "Synthetic body (test).",
+    "",
+    "## Decisions",
+    "- Synthetic decision.",
+    "",
+    "## Follow-ups",
+    "None.",
+  ].join("\n");
+
+  input.createReport({
+    proposalUuid: input.lastVerifiedProposalUuid,
+    title: `${input.ideaTitle} — completion report`,
+    content: body,
+  });
+
+  return true;
+}
+
+// ===== Fixture helpers =====
+
+const IDEA_UUID = "idea-0000-0000-0000-000000000001";
+const APPROVED_PROPOSAL_A = "prop-0000-0000-0000-00000000000a";
+const APPROVED_PROPOSAL_B = "prop-0000-0000-0000-00000000000b";
+const REJECTED_PROPOSAL = "prop-0000-0000-0000-00000000000r";
+const FREEFORM_PROPOSAL = "prop-0000-0000-0000-00000000000f";
+
+function approvedIdeaProposal(uuid: string): FakeProposal {
+  return {
+    uuid,
+    status: "approved",
+    inputType: "idea",
+    inputUuids: [IDEA_UUID],
+  };
+}
+
+function task(uuid: string, proposalUuid: string, status: FakeTask["status"]): FakeTask {
+  return { uuid, proposalUuid, status };
+}
+
+// ============================================================
+// Truth table — the predicate must produce 0 or 1 dispatch.
+// ============================================================
+
+describe("yolo end-step report predicate (AC #2)", () => {
+  it("fires exactly ONE chorus_create_report when all idea tasks are done and no report exists", () => {
+    const createReport = vi.fn();
+    const fired = runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [approvedIdeaProposal(APPROVED_PROPOSAL_A)],
+      tasks: [
+        task("t1", APPROVED_PROPOSAL_A, "done"),
+        task("t2", APPROVED_PROPOSAL_A, "done"),
+      ],
+      existingDocuments: [],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    expect(fired).toBe(true);
+    expect(createReport).toHaveBeenCalledTimes(1);
+    const call = createReport.mock.calls[0][0] as CreateReportCall;
+    expect(call.proposalUuid).toBe(APPROVED_PROPOSAL_A);
+    // Dispatch shape: title + 3-section Markdown body verbatim.
+    expect(call.title).toBe("Idea X — completion report");
+    for (const header of [
+      "## Summary",
+      "## Decisions",
+      "## Follow-ups",
+    ]) {
+      expect(call.content).toContain(header);
+    }
+  });
+
+  it("fires exactly ONE call across MULTI-proposal idea (proposalUuid = last verified)", () => {
+    const createReport = vi.fn();
+    const fired = runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Multi-prop Idea",
+      proposals: [
+        approvedIdeaProposal(APPROVED_PROPOSAL_A),
+        approvedIdeaProposal(APPROVED_PROPOSAL_B),
+      ],
+      tasks: [
+        task("t1", APPROVED_PROPOSAL_A, "done"),
+        task("t2", APPROVED_PROPOSAL_A, "closed"),
+        task("t3", APPROVED_PROPOSAL_B, "done"),
+      ],
+      existingDocuments: [],
+      // The runner reaches end-step on the LAST proposal — that's the one
+      // whose UUID gets attached to the report (per SKILL.md "Predicate"
+      // section, Multi-proposal Idea note).
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_B,
+      createReport,
+    });
+    expect(fired).toBe(true);
+    expect(createReport).toHaveBeenCalledTimes(1);
+    expect((createReport.mock.calls[0][0] as CreateReportCall).proposalUuid).toBe(
+      APPROVED_PROPOSAL_B,
+    );
+  });
+
+  it("fires ZERO calls when even ONE task is still in_progress (predicate 2 fails)", () => {
+    const createReport = vi.fn();
+    const fired = runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [approvedIdeaProposal(APPROVED_PROPOSAL_A)],
+      tasks: [
+        task("t1", APPROVED_PROPOSAL_A, "done"),
+        task("t2", APPROVED_PROPOSAL_A, "in_progress"), // <-- non-terminal
+      ],
+      existingDocuments: [],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    expect(fired).toBe(false);
+    expect(createReport).not.toHaveBeenCalled();
+  });
+
+  it("fires ZERO calls when one task is in to_verify (still non-terminal)", () => {
+    const createReport = vi.fn();
+    runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [approvedIdeaProposal(APPROVED_PROPOSAL_A)],
+      tasks: [
+        task("t1", APPROVED_PROPOSAL_A, "done"),
+        task("t2", APPROVED_PROPOSAL_A, "to_verify"),
+      ],
+      existingDocuments: [],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    expect(createReport).not.toHaveBeenCalled();
+  });
+
+  it("fires ZERO calls when a report Document already exists for the Idea (idempotency)", () => {
+    const createReport = vi.fn();
+    const fired = runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [approvedIdeaProposal(APPROVED_PROPOSAL_A)],
+      tasks: [
+        task("t1", APPROVED_PROPOSAL_A, "done"),
+        task("t2", APPROVED_PROPOSAL_A, "done"),
+      ],
+      existingDocuments: [
+        {
+          uuid: "doc-existing-report",
+          type: "report",
+          proposalUuid: APPROVED_PROPOSAL_A,
+        },
+      ],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    expect(fired).toBe(false);
+    expect(createReport).not.toHaveBeenCalled();
+  });
+
+  it("fires ZERO calls for free-form (non-idea-rooted) proposals", () => {
+    const createReport = vi.fn();
+    runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [
+        // free-form proposal (e.g. quick-dev) — same UUID nominally pointed at
+        // by the verified task. inputType !== "idea" so the skill must skip.
+        {
+          uuid: FREEFORM_PROPOSAL,
+          status: "approved",
+          inputType: "free-form",
+          inputUuids: [],
+        },
+      ],
+      tasks: [task("t1", FREEFORM_PROPOSAL, "done")],
+      existingDocuments: [],
+      lastVerifiedProposalUuid: FREEFORM_PROPOSAL,
+      createReport,
+    });
+    expect(createReport).not.toHaveBeenCalled();
+  });
+
+  it("fires ZERO calls for an Idea whose proposals are rejected (no approved proposal)", () => {
+    const createReport = vi.fn();
+    runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [
+        // Same shape as approvedIdeaProposal but status=rejected — must skip.
+        {
+          uuid: REJECTED_PROPOSAL,
+          status: "rejected",
+          inputType: "idea",
+          inputUuids: [IDEA_UUID],
+        },
+      ],
+      tasks: [task("t1", REJECTED_PROPOSAL, "done")],
+      existingDocuments: [],
+      lastVerifiedProposalUuid: REJECTED_PROPOSAL,
+      createReport,
+    });
+    expect(createReport).not.toHaveBeenCalled();
+  });
+
+  it("a SECOND yolo run on the same Idea (replay) fires ZERO calls", () => {
+    // Simulates the scenario where the first run completed and persisted a
+    // report; a second /yolo invocation against the same Idea (e.g. user
+    // accidentally re-runs) must NOT double-write. The state difference
+    // between "first run" and "second run" is exactly: existingDocuments now
+    // contains the previously-written report.
+    const createReport = vi.fn();
+    const proposals = [approvedIdeaProposal(APPROVED_PROPOSAL_A)];
+    const tasks = [
+      task("t1", APPROVED_PROPOSAL_A, "done"),
+      task("t2", APPROVED_PROPOSAL_A, "done"),
+    ];
+
+    // First run — fires once.
+    runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals,
+      tasks,
+      existingDocuments: [],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    expect(createReport).toHaveBeenCalledTimes(1);
+
+    // Second run — same input minus a now-persisted report.
+    runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals,
+      tasks,
+      existingDocuments: [
+        { uuid: "doc-from-first-run", type: "report", proposalUuid: APPROVED_PROPOSAL_A },
+      ],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    // Still 1 — second run did NOT add another call.
+    expect(createReport).toHaveBeenCalledTimes(1);
+  });
+
+  it("a non-report Document (e.g. type='spec') does NOT count as 'report exists' (predicate 3 narrowness)", () => {
+    const createReport = vi.fn();
+    const fired = runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [approvedIdeaProposal(APPROVED_PROPOSAL_A)],
+      tasks: [task("t1", APPROVED_PROPOSAL_A, "done")],
+      existingDocuments: [
+        // A spec/doc-style Document with the same proposalUuid — must NOT
+        // be conflated with a "report" Document.
+        { uuid: "doc-spec", type: "spec", proposalUuid: APPROVED_PROPOSAL_A },
+      ],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    expect(fired).toBe(true);
+    expect(createReport).toHaveBeenCalledTimes(1);
+  });
+
+  it("a report attached to a DIFFERENT Idea's proposal does not block the current Idea's report", () => {
+    const createReport = vi.fn();
+    const OTHER_PROPOSAL_UUID = "prop-other-0000-0000-000000000099";
+    const fired = runYoloEndStep({
+      ideaUuid: IDEA_UUID,
+      ideaTitle: "Idea X",
+      proposals: [approvedIdeaProposal(APPROVED_PROPOSAL_A)],
+      tasks: [task("t1", APPROVED_PROPOSAL_A, "done")],
+      // Existing report on a different proposal — irrelevant to this Idea.
+      existingDocuments: [
+        { uuid: "doc-other-report", type: "report", proposalUuid: OTHER_PROPOSAL_UUID },
+      ],
+      lastVerifiedProposalUuid: APPROVED_PROPOSAL_A,
+      createReport,
+    });
+    expect(fired).toBe(true);
+    expect(createReport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/mcp/tools/permission-map.ts
+++ b/src/mcp/tools/permission-map.ts
@@ -3,15 +3,20 @@
 // Coverage contract for permission-gated MCP tools.
 //
 // This map is the *source of truth for tests* (src/mcp/__tests__/server.test.ts):
-// it lets the suite assert that every tool in pm.ts / developer.ts / admin.ts
+// it lets the suite assert that every tool gated via `registerPermissionedTool`
 // is registered under the expected Permission, and catches drift when someone
-// adds a new tool without a gate. Production tool registration in pm.ts /
-// developer.ts / admin.ts uses `registerPermissionedTool` with its Permission
-// inlined at the call site — the map is intentionally not consulted at runtime
-// so the permission for each tool stays visible next to the handler.
+// adds a new tool without a gate. Production tool registration uses
+// `registerPermissionedTool` with its Permission inlined at the call site — the
+// map is intentionally not consulted at runtime so the permission for each tool
+// stays visible next to the handler.
 //
-// Public tools (public.ts) and session tools (session.ts) are NOT gated and
-// are intentionally absent from this map. See Tech Design §5.3.
+// Most public-namespaced tools in public.ts (read-only discovery, comments,
+// session, notifications) are NOT gated and are intentionally absent from this
+// map. The exception is `chorus_create_report`, which is public-namespaced
+// (no `pm_` prefix per add-idea-completion-report Tech Design §"MCP tool
+// contract") but IS gated on `document:write` — it appears here because it
+// goes through `registerPermissionedTool`. Session tools (session.ts) remain
+// ungated. See Tech Design §5.3.
 
 import type { Permission } from "@/lib/authz/types";
 
@@ -41,6 +46,9 @@ export const TOOL_PERMISSIONS = {
   // Document writes
   chorus_pm_create_document: "document:write",
   chorus_pm_update_document: "document:write",
+  // Idea-completion report (public-namespaced, gated on document:write).
+  // See add-idea-completion-report spec delta `mcp-tool-surface`.
+  chorus_create_report: "document:write",
   // Task-editing tools historically on the PM surface.
   // Mapped to proposal:write to preserve 0.6.x dev boundaries (AC4): dev has
   // task:write but not proposal:write, so dev keeps exactly its 0.6.x tool set.

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -253,10 +253,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "document:write",
     "chorus_pm_create_document",
     {
-      description: "Create a document (PRD, tech design, ADR, etc.)",
+      description: "Create a document (type is one of: prd, tech_design, adr, spec, guide, report). Reports are normally authored via chorus_create_report at end-of-Idea — use this tool for non-report types.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        type: z.enum(["prd", "tech_design", "adr", "spec", "guide"]).describe("Document type"),
+        type: z.enum(["prd", "tech_design", "adr", "spec", "guide", "report"]).describe("Document type"),
         title: z.string().describe("Document title"),
         content: z.string().optional().describe("Document content (Markdown)"),
         proposalUuid: z.string().optional().describe("Associated Proposal UUID (optional)"),
@@ -336,7 +336,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
       description: "Add a document draft to a pending Proposal container",
       inputSchema: z.object({
         proposalUuid: z.string().describe("Proposal UUID"),
-        type: z.string().describe("Document type (prd, tech_design, adr, spec, guide)"),
+        type: z.string().describe("Document type (prd, tech_design, adr, spec, guide, report)"),
         title: z.string().describe("Document title"),
         content: z.string().describe("Document content (Markdown)"),
       }),

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -253,10 +253,10 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "document:write",
     "chorus_pm_create_document",
     {
-      description: "Create a document (type is one of: prd, tech_design, adr, spec, guide, report). Reports are normally authored via chorus_create_report at end-of-Idea — use this tool for non-report types.",
+      description: "Create a document (type is one of: prd, tech_design, adr, spec, guide). Idea-completion reports use a dedicated tool (`chorus_create_report`) and are not creatable here.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        type: z.enum(["prd", "tech_design", "adr", "spec", "guide", "report"]).describe("Document type"),
+        type: z.enum(["prd", "tech_design", "adr", "spec", "guide"]).describe("Document type"),
         title: z.string().describe("Document title"),
         content: z.string().optional().describe("Document content (Markdown)"),
         proposalUuid: z.string().optional().describe("Associated Proposal UUID (optional)"),

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -1096,6 +1096,19 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         return { content: [{ type: "text", text: "Proposal not found" }], isError: true };
       }
 
+      // A completion report only makes sense once the proposal's drafts have
+      // materialized into real Tasks. Reject draft / pending / rejected /
+      // closed states explicitly so a misfiring agent can't write reports
+      // under unmaterialized or revoked proposals. Re-authoring a report on
+      // an approved proposal is allowed — multiple reports per proposal are
+      // by design (see proposal.md Q4).
+      if (proposal.status !== "approved") {
+        return {
+          content: [{ type: "text", text: `Proposal status must be 'approved' to author a completion report (got '${proposal.status}')` }],
+          isError: true,
+        };
+      }
+
       const document = await documentService.createDocument({
         companyUuid: auth.companyUuid,
         projectUuid: proposal.projectUuid,

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -23,6 +23,7 @@ import * as searchService from "@/services/search.service";
 import * as sessionService from "@/services/session.service";
 import * as checkinService from "@/services/checkin.service";
 import { prisma } from "@/lib/prisma";
+import { registerPermissionedTool } from "./register-helpers";
 
 export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_project - Get project details and context
@@ -72,7 +73,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_ideas",
     {
-      description: "Get the list of Ideas for a project",
+      description: "Get the list of Ideas for a project. Each row includes `reportCount` — number of completion reports for the idea.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         status: z.string().optional().describe("Filter by status: open, elaborating, proposal_created, completed, closed"),
@@ -109,7 +110,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       description: "Get the list of Documents for a project",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        type: z.string().optional().describe("Filter by type: prd, tech_design, adr, etc."),
+        type: z.string().optional().describe("Filter by type: prd, tech_design, adr, spec, guide, report"),
         page: z.number().optional().default(1),
         pageSize: z.number().optional().default(20),
       }),
@@ -425,7 +426,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_idea",
     {
-      description: "Get detailed information for a single Idea",
+      description: "Get detailed information for a single Idea. Includes `reports[]` — full content of the idea's completion reports, newest first.",
       inputSchema: z.object({
         ideaUuid: z.string().describe("Idea UUID"),
       }),
@@ -1055,6 +1056,71 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
 
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  // chorus_create_report - Author an idea-completion summary Document.
+  //
+  // Public-namespaced (no pm_ prefix) but gated on document:write — see
+  // add-idea-completion-report Tech Design §"MCP tool contract" and
+  // spec delta `mcp-tool-surface`. The tool name encodes type="report"; the
+  // service writes that label unconditionally so agents cannot mislabel reports.
+  // The body is preserved byte-faithfully (modulo the Document.content write
+  // path's existing trailing-newline normalization).
+  registerPermissionedTool(
+    server,
+    auth,
+    "document:write",
+    "chorus_create_report",
+    {
+      description:
+        "Persist an idea-completion summary as a Document (type=\"report\") under the given Proposal. Call once, at end-of-Idea, after the last task verifies. This is a summary, not a detailed write-up — keep it short.\n\n" +
+        "Markdown `content` MUST use these three sections in this order:\n\n" +
+        "## Summary\n" +
+        "1-3 sentences on what shipped. Plain prose. No bullet lists here.\n\n" +
+        "## Decisions\n" +
+        "Terse bullets — the key calls made during elaboration / proposal review and why this option not the alternative. Skip obvious / trivial decisions; capture the ones a future reader would want context on.\n\n" +
+        "## Follow-ups\n" +
+        "What's still open — link to a new Idea / blog / doc-update if tracked elsewhere; write \"None\" if there are no follow-ups.\n\n" +
+        "Section bodies are free-form Markdown (links and inline code are fine). The three headers are the contract — keep them verbatim, top-level (`##`), in this order.",
+      inputSchema: z.object({
+        proposalUuid: z.string().uuid().describe("Proposal UUID whose tasks have all reached a terminal state"),
+        title: z.string().min(1).max(200).describe("Report title (e.g. 'Idea X — completion report')"),
+        content: z.string().min(1).describe("Markdown body — Summary / Decisions / Follow-ups"),
+      }),
+    },
+    async ({ proposalUuid, title, content }) => {
+      const proposal = await proposalService.getProposalByUuid(auth.companyUuid, proposalUuid);
+      if (!proposal) {
+        return { content: [{ type: "text", text: "Proposal not found" }], isError: true };
+      }
+
+      const document = await documentService.createDocument({
+        companyUuid: auth.companyUuid,
+        projectUuid: proposal.projectUuid,
+        type: "report",
+        title,
+        content,
+        proposalUuid,
+        createdByUuid: auth.actorUuid,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                documentUuid: document.uuid,
+                projectUuid: proposal.projectUuid,
+                version: document.version,
+              },
+              null,
+              2
+            ),
+          },
+        ],
       };
     }
   );

--- a/src/services/__tests__/document.service.test.ts
+++ b/src/services/__tests__/document.service.test.ts
@@ -98,6 +98,108 @@ describe("createDocument", () => {
 
     expect(result.proposalUuid).toBe(proposalUuid);
   });
+
+  // Coverage for add-idea-completion-report spec idea-completion-report:
+  // "A report is created with the correct type label" + "Server preserves
+  // report content byte-faithfully". `Document.type` is a free-form string,
+  // so the report subtype rides the existing createDocument code path.
+  it("should round-trip type='report' byte-faithfully (add-idea-completion-report)", async () => {
+    const proposalUuid = "proposal-0000-0000-0000-000000000099";
+    const reportTitle = "Idea X — completion report";
+    const reportContent =
+      "## Summary\nShipped feature X — T1+T2.\n\n" +
+      "## Decisions\n- Chose A over B because reasons.\n\n" +
+      "## Follow-ups\nNone.\n";
+
+    mockPrisma.document.create.mockResolvedValue(
+      makeDocRecord({
+        type: "report",
+        title: reportTitle,
+        content: reportContent,
+        proposalUuid,
+      })
+    );
+
+    const result = await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: reportTitle,
+      content: reportContent,
+      proposalUuid,
+      createdByUuid,
+    });
+
+    // Output preserves type, title, content, proposalUuid, version=1.
+    expect(result.type).toBe("report");
+    expect(result.title).toBe(reportTitle);
+    expect(result.content).toBe(reportContent);
+    expect(result.proposalUuid).toBe(proposalUuid);
+    expect(result.version).toBe(1);
+
+    // Prisma was asked to persist exactly what we sent — no synthesis,
+    // augmentation, or mutation by the service layer.
+    expect(mockPrisma.document.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "report",
+          title: reportTitle,
+          content: reportContent,
+          proposalUuid,
+          version: 1,
+        }),
+      })
+    );
+  });
+
+  it("should accept multiple report Documents per Proposal (no service-side dedupe)", async () => {
+    const proposalUuid = "proposal-0000-0000-0000-000000000100";
+
+    // First write.
+    mockPrisma.document.create.mockResolvedValueOnce(
+      makeDocRecord({
+        uuid: "doc-report-1",
+        type: "report",
+        title: "First report",
+        content: "## Summary\nA",
+        proposalUuid,
+      })
+    );
+    const first = await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: "First report",
+      content: "## Summary\nA",
+      proposalUuid,
+      createdByUuid,
+    });
+    expect(first.type).toBe("report");
+
+    // Second write to the same Proposal — service must not error.
+    mockPrisma.document.create.mockResolvedValueOnce(
+      makeDocRecord({
+        uuid: "doc-report-2",
+        type: "report",
+        title: "Second report",
+        content: "## Summary\nB",
+        proposalUuid,
+      })
+    );
+    const second = await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: "Second report",
+      content: "## Summary\nB",
+      proposalUuid,
+      createdByUuid,
+    });
+    expect(second.type).toBe("report");
+    expect(second.uuid).toBe("doc-report-2");
+
+    expect(mockPrisma.document.create).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ===== getDocument =====

--- a/src/services/__tests__/idea.service.test.ts
+++ b/src/services/__tests__/idea.service.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ===== Mocks (hoisted so vi.mock factories can reference them) =====
 
-const { mockPrisma, mockEventBus, mockFormatAssigneeComplete, mockFormatCreatedBy, mockCreateActivity, mockParseMentions, mockCreateMentions } = vi.hoisted(() => ({
+const { mockPrisma, mockEventBus, mockFormatAssigneeComplete, mockFormatCreatedBy, mockFormatReview, mockCreateActivity, mockParseMentions, mockCreateMentions } = vi.hoisted(() => ({
   mockPrisma: {
     idea: {
       create: vi.fn(),
       findFirst: vi.fn(),
       findUnique: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
     },
@@ -23,6 +25,7 @@ const { mockPrisma, mockEventBus, mockFormatAssigneeComplete, mockFormatCreatedB
       findMany: vi.fn(),
       updateMany: vi.fn(),
       count: vi.fn(),
+      groupBy: vi.fn(),
     },
     task: {
       findMany: vi.fn(),
@@ -38,6 +41,7 @@ const { mockPrisma, mockEventBus, mockFormatAssigneeComplete, mockFormatCreatedB
   mockEventBus: { emitChange: vi.fn() },
   mockFormatAssigneeComplete: vi.fn().mockResolvedValue(null),
   mockFormatCreatedBy: vi.fn().mockResolvedValue({ type: "user", uuid: "creator-uuid", name: "Creator" }),
+  mockFormatReview: vi.fn().mockResolvedValue(null),
   mockCreateActivity: vi.fn().mockResolvedValue(undefined),
   mockParseMentions: vi.fn().mockReturnValue([]),
   mockCreateMentions: vi.fn().mockResolvedValue(undefined),
@@ -48,6 +52,7 @@ vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
 vi.mock("@/lib/uuid-resolver", () => ({
   formatAssigneeComplete: mockFormatAssigneeComplete,
   formatCreatedBy: mockFormatCreatedBy,
+  formatReview: mockFormatReview,
 }));
 vi.mock("@/services/mention.service", () => ({
   parseMentions: mockParseMentions,
@@ -57,7 +62,7 @@ vi.mock("@/services/activity.service", () => ({
   createActivity: mockCreateActivity,
 }));
 
-import { createIdea, claimIdea, assignIdea, releaseIdea, moveIdea, moveIdeaPreview, deleteIdea, updateIdea } from "@/services/idea.service";
+import { createIdea, claimIdea, assignIdea, releaseIdea, moveIdea, moveIdeaPreview, deleteIdea, updateIdea, listIdeas, getIdea } from "@/services/idea.service";
 import { AlreadyClaimedError } from "@/lib/errors";
 
 // ===== Test Data =====
@@ -1001,5 +1006,263 @@ describe("deleteIdea", () => {
       })
     );
     expect(result.uuid).toBe(IDEA_UUID);
+  });
+});
+
+// ===== listIdeas / getIdea — reportCount + reports[] aggregation =====
+
+describe("listIdeas — reportCount aggregation", () => {
+  it("returns reportCount=0 on every row when project has no proposals (early-return)", async () => {
+    const ideaA = makeIdeaRecord({ uuid: "idea-A" });
+    const ideaB = makeIdeaRecord({ uuid: "idea-B" });
+    mockPrisma.idea.findMany.mockResolvedValue([ideaA, ideaB]);
+    mockPrisma.idea.count.mockResolvedValue(2);
+    // Step 1 short-circuit: no proposals at all.
+    mockPrisma.proposal.findMany.mockResolvedValue([]);
+
+    const result = await listIdeas({
+      companyUuid: COMPANY_UUID,
+      projectUuid: PROJECT_UUID,
+      skip: 0,
+      take: 20,
+    });
+
+    expect(result.ideas).toHaveLength(2);
+    expect(result.ideas[0].reportCount).toBe(0);
+    expect(result.ideas[1].reportCount).toBe(0);
+    // groupBy must NOT have been called when step 1 short-circuits.
+    expect(mockPrisma.document.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("returns reportCount=0 when proposals exist but none point at this page's ideas (step-2 short-circuit)", async () => {
+    const ideaA = makeIdeaRecord({ uuid: "idea-A" });
+    mockPrisma.idea.findMany.mockResolvedValue([ideaA]);
+    mockPrisma.idea.count.mockResolvedValue(1);
+    // Proposal exists but its inputUuids reference a different idea.
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "prop-other", inputUuids: ["idea-OTHER"] },
+    ]);
+
+    const result = await listIdeas({
+      companyUuid: COMPANY_UUID,
+      projectUuid: PROJECT_UUID,
+      skip: 0,
+      take: 20,
+    });
+
+    expect(result.ideas[0].reportCount).toBe(0);
+    expect(mockPrisma.document.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("tolerates non-array inputUuids (defensive; legacy / drift)", async () => {
+    const ideaA = makeIdeaRecord({ uuid: "idea-A" });
+    mockPrisma.idea.findMany.mockResolvedValue([ideaA]);
+    mockPrisma.idea.count.mockResolvedValue(1);
+    // Mix of bad data + a good row pointing at idea-A.
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "prop-bad-1", inputUuids: null },
+      { uuid: "prop-bad-2", inputUuids: {} },
+      { uuid: "prop-bad-3", inputUuids: "not-an-array" },
+      { uuid: "prop-good", inputUuids: ["idea-A"] },
+    ]);
+    mockPrisma.document.groupBy.mockResolvedValue([
+      { proposalUuid: "prop-good", _count: { _all: 2 } },
+    ]);
+
+    const result = await listIdeas({
+      companyUuid: COMPANY_UUID,
+      projectUuid: PROJECT_UUID,
+      skip: 0,
+      take: 20,
+    });
+
+    // Bad rows ignored; good row counted: 2 reports under idea-A.
+    expect(result.ideas[0].reportCount).toBe(2);
+  });
+
+  it("folds report counts back to ideas across multi-input proposals", async () => {
+    const ideaA = makeIdeaRecord({ uuid: "idea-A" });
+    const ideaB = makeIdeaRecord({ uuid: "idea-B" });
+    mockPrisma.idea.findMany.mockResolvedValue([ideaA, ideaB]);
+    mockPrisma.idea.count.mockResolvedValue(2);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "prop-AB", inputUuids: ["idea-A", "idea-B"] }, // shared
+      { uuid: "prop-A", inputUuids: ["idea-A"] },
+    ]);
+    mockPrisma.document.groupBy.mockResolvedValue([
+      { proposalUuid: "prop-AB", _count: { _all: 1 } },
+      { proposalUuid: "prop-A", _count: { _all: 3 } },
+    ]);
+
+    const result = await listIdeas({
+      companyUuid: COMPANY_UUID,
+      projectUuid: PROJECT_UUID,
+      skip: 0,
+      take: 20,
+    });
+
+    const a = result.ideas.find((i) => i.uuid === "idea-A");
+    const b = result.ideas.find((i) => i.uuid === "idea-B");
+    expect(a?.reportCount).toBe(4); // 1 (shared) + 3 (own)
+    expect(b?.reportCount).toBe(1); // 1 (shared)
+  });
+
+  it("includes both approved and closed proposals when computing report-bearing set", async () => {
+    const ideaA = makeIdeaRecord({ uuid: "idea-A" });
+    mockPrisma.idea.findMany.mockResolvedValue([ideaA]);
+    mockPrisma.idea.count.mockResolvedValue(1);
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      { uuid: "prop-approved", inputUuids: ["idea-A"] },
+      { uuid: "prop-closed", inputUuids: ["idea-A"] },
+    ]);
+    mockPrisma.document.groupBy.mockResolvedValue([
+      { proposalUuid: "prop-approved", _count: { _all: 1 } },
+      { proposalUuid: "prop-closed", _count: { _all: 1 } },
+    ]);
+
+    const result = await listIdeas({
+      companyUuid: COMPANY_UUID,
+      projectUuid: PROJECT_UUID,
+      skip: 0,
+      take: 20,
+    });
+
+    expect(result.ideas[0].reportCount).toBe(2);
+    // Sanity check: the proposal status filter actually requested both.
+    expect(mockPrisma.proposal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["approved", "closed"] },
+        }),
+      }),
+    );
+  });
+});
+
+describe("getIdea — reports[] aggregation", () => {
+  it("returns reports=[] when no report-bearing proposals exist", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdeaRecord());
+    // No proposals point at this idea.
+    mockPrisma.proposal.findMany.mockResolvedValue([]);
+
+    const result = await getIdea(COMPANY_UUID, IDEA_UUID);
+
+    expect(result?.reports).toEqual([]);
+    // Skipped the document fetch entirely.
+    expect(mockPrisma.document.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns full content of reports under approved AND closed proposals", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdeaRecord());
+    // getProposalsByIdeaUuid does the wide findMany + JS filter; we mock
+    // the wide return.
+    mockPrisma.proposal.findMany.mockResolvedValue([
+      {
+        uuid: "prop-approved",
+        title: "Approved",
+        description: "",
+        inputType: "idea",
+        inputUuids: [IDEA_UUID],
+        documentDrafts: [],
+        taskDrafts: [],
+        status: "approved",
+        createdByUuid: "creator-uuid",
+        createdByType: "agent",
+        reviewedByUuid: null,
+        reviewNote: null,
+        reviewedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        uuid: "prop-closed",
+        title: "Closed",
+        description: "",
+        inputType: "idea",
+        inputUuids: [IDEA_UUID],
+        documentDrafts: [],
+        taskDrafts: [],
+        status: "closed",
+        createdByUuid: "creator-uuid",
+        createdByType: "agent",
+        reviewedByUuid: null,
+        reviewNote: null,
+        reviewedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        uuid: "prop-pending",
+        title: "Pending — must be excluded",
+        description: "",
+        inputType: "idea",
+        inputUuids: [IDEA_UUID],
+        documentDrafts: [],
+        taskDrafts: [],
+        status: "pending",
+        createdByUuid: "creator-uuid",
+        createdByType: "agent",
+        reviewedByUuid: null,
+        reviewNote: null,
+        reviewedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    // Two reports total — one under approved, one under closed.
+    mockPrisma.document.findMany.mockResolvedValue([
+      {
+        uuid: "doc-approved",
+        type: "report",
+        title: "Approved report",
+        content: "## Summary\nA\n## Decisions\n## Follow-ups\n",
+        version: 1,
+        proposalUuid: "prop-approved",
+        createdByUuid: "creator-uuid",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        uuid: "doc-closed",
+        type: "report",
+        title: "Closed report",
+        content: "## Summary\nB\n## Decisions\n## Follow-ups\n",
+        version: 1,
+        proposalUuid: "prop-closed",
+        createdByUuid: "creator-uuid",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    const result = await getIdea(COMPANY_UUID, IDEA_UUID);
+
+    expect(result?.reports).toHaveLength(2);
+    expect(result?.reports?.map((r) => r.uuid).sort()).toEqual(
+      ["doc-approved", "doc-closed"].sort(),
+    );
+    // Content carried byte-faithfully.
+    expect(result?.reports?.find((r) => r.uuid === "doc-approved")?.content).toContain("## Summary\nA");
+    // Document fetch was scoped to the report-bearing proposals only —
+    // pending proposal was excluded from the proposalUuid filter.
+    expect(mockPrisma.document.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          proposalUuid: { in: expect.arrayContaining(["prop-approved", "prop-closed"]) },
+          type: "report",
+        }),
+      }),
+    );
+    const docFilter = mockPrisma.document.findMany.mock.calls[0][0].where.proposalUuid.in;
+    expect(docFilter).not.toContain("prop-pending");
+  });
+
+  it("returns null when the idea does not exist", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(null);
+
+    const result = await getIdea(COMPANY_UUID, IDEA_UUID);
+
+    expect(result).toBeNull();
+    expect(mockPrisma.proposal.findMany).not.toHaveBeenCalled();
   });
 });

--- a/src/services/document.service.ts
+++ b/src/services/document.service.ts
@@ -129,6 +129,41 @@ export async function listDocuments({
   return { documents, total };
 }
 
+// List Documents tied to one or more Proposals (e.g. all reports across an
+// Idea's approved Proposals). Returned with content so callers can render
+// Markdown without a follow-up `getDocument` per row.
+export async function listDocumentsByProposalUuids(
+  companyUuid: string,
+  proposalUuids: string[],
+  type?: string,
+): Promise<DocumentResponse[]> {
+  if (proposalUuids.length === 0) return [];
+
+  const where = {
+    companyUuid,
+    proposalUuid: { in: proposalUuids },
+    ...(type && { type }),
+  };
+
+  const rawDocuments = await prisma.document.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    select: {
+      uuid: true,
+      type: true,
+      title: true,
+      content: true,
+      version: true,
+      proposalUuid: true,
+      createdByUuid: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  return Promise.all(rawDocuments.map((doc) => formatDocumentResponse(doc, true)));
+}
+
 // Get Document details
 export async function getDocument(
   companyUuid: string,

--- a/src/services/idea.service.ts
+++ b/src/services/idea.service.ts
@@ -9,6 +9,8 @@ import { AlreadyClaimedError, NotClaimedError, isPrismaNotFound } from "@/lib/er
 import { ApiError } from "@/lib/api-handler";
 import * as mentionService from "@/services/mention.service";
 import * as activityService from "@/services/activity.service";
+import * as documentService from "@/services/document.service";
+import * as proposalService from "@/services/proposal.service";
 import logger from "@/lib/logger";
 
 // ===== Derived Status =====
@@ -65,6 +67,13 @@ export interface IdeaResponse {
   createdBy: { type: string; uuid: string; name: string } | null;
   createdAt: string;
   updatedAt: string;
+  // Number of completion-report Documents (type="report") under this idea's
+  // approved proposals. Always present on list rows; 0 when none exist.
+  reportCount?: number;
+  // Full content of completion-report Documents under this idea's approved
+  // proposals, sorted by createdAt descending. Only emitted by getIdea
+  // (single-entity reads), not by listIdeas — list rows carry the count only.
+  reports?: import("./document.service").DocumentResponse[];
 }
 
 // Cascade-move counts — emitted by moveIdea / moveIdeaPreview so REST/MCP/UI
@@ -219,10 +228,88 @@ export async function listIdeas({
   ]);
 
   const ideas = await Promise.all(rawIdeas.map(formatIdeaResponse));
+
+  // Attach reportCount to every row. Two extra queries per page (independent
+  // of page size) with early returns when there's nothing to count.
+  if (ideas.length > 0) {
+    const counts = await getReportCountsForIdeas(
+      companyUuid,
+      projectUuid,
+      ideas.map((i) => i.uuid),
+    );
+    for (const idea of ideas) {
+      idea.reportCount = counts.get(idea.uuid) ?? 0;
+    }
+  }
+
   return { ideas, total };
 }
 
-// Get Idea details
+// Batch-resolve `type="report"` Document counts grouped by Idea, used by
+// listIdeas. Fully short-circuited at every step so we don't pay the cost
+// when there are no idea-rooted approved proposals or no reports anywhere
+// in the project. Returns a Map for caller-side fold-back.
+async function getReportCountsForIdeas(
+  companyUuid: string,
+  projectUuid: string,
+  ideaUuids: string[],
+): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  if (ideaUuids.length === 0) return out;
+
+  // Step 1: idea-rooted approved proposals in this project. JSON
+  // Proposal.inputUuids forces a project-scoped scan, but `status="approved"`
+  // + `inputType="idea"` + same companyUuid keeps the row count tight.
+  const proposals = await prisma.proposal.findMany({
+    where: {
+      projectUuid,
+      companyUuid,
+      status: "approved",
+      inputType: "idea",
+    },
+    select: { uuid: true, inputUuids: true },
+  });
+  if (proposals.length === 0) return out;
+
+  // Step 2: keep only proposals that point at one of THIS PAGE's ideas.
+  // Build proposalUuid -> set of pageIdeaUuid associations along the way.
+  const ideaSet = new Set(ideaUuids);
+  const proposalUuidToIdeaUuids = new Map<string, string[]>();
+  for (const p of proposals) {
+    const inputs = (p.inputUuids as string[]) || [];
+    const matched = inputs.filter((u) => ideaSet.has(u));
+    if (matched.length > 0) proposalUuidToIdeaUuids.set(p.uuid, matched);
+  }
+  if (proposalUuidToIdeaUuids.size === 0) return out;
+
+  // Step 3: count reports grouped by proposalUuid, then fold to ideaUuid.
+  const grouped = await prisma.document.groupBy({
+    by: ["proposalUuid"],
+    where: {
+      companyUuid,
+      type: "report",
+      proposalUuid: { in: Array.from(proposalUuidToIdeaUuids.keys()) },
+    },
+    _count: { _all: true },
+  });
+
+  for (const g of grouped) {
+    if (!g.proposalUuid) continue;
+    const ideas = proposalUuidToIdeaUuids.get(g.proposalUuid);
+    if (!ideas) continue;
+    for (const ideaUuid of ideas) {
+      out.set(ideaUuid, (out.get(ideaUuid) ?? 0) + g._count._all);
+    }
+  }
+
+  return out;
+}
+
+// Get Idea details, including full content of any completion-report
+// Documents (type="report") attached to this idea's approved proposals.
+// Reports are sorted by createdAt descending. Each step short-circuits when
+// there's nothing to do, so the worst case for an idea with no proposals or
+// no reports is one extra cheap proposal lookup.
 export async function getIdea(
   companyUuid: string,
   uuid: string
@@ -235,7 +322,29 @@ export async function getIdea(
   });
 
   if (!idea) return null;
-  return formatIdeaResponse(idea);
+  const response = await formatIdeaResponse(idea);
+
+  // Step 1: idea-rooted approved proposals.
+  const proposals = await proposalService.getProposalsByIdeaUuid(
+    companyUuid,
+    idea.projectUuid,
+    uuid,
+  );
+  const approved = proposals.filter((p) => p.status === "approved");
+  if (approved.length === 0) {
+    response.reports = [];
+    return response;
+  }
+
+  // Step 2: pull report Documents across those proposals; helper already
+  // includes content + sorts by createdAt desc.
+  const reports = await documentService.listDocumentsByProposalUuids(
+    companyUuid,
+    approved.map((p) => p.uuid),
+    "report",
+  );
+  response.reports = reports;
+  return response;
 }
 
 // Get raw Idea data by UUID (internal use, for permission checks etc.)

--- a/src/services/idea.service.ts
+++ b/src/services/idea.service.ts
@@ -245,10 +245,17 @@ export async function listIdeas({
   return { ideas, total };
 }
 
-// Batch-resolve `type="report"` Document counts grouped by Idea, used by
+// Proposals carrying a completion report — i.e. those an Idea's reports
+// can live under. Approved is the live state; closed is post-cleanup. We
+// treat them symmetrically because reports are durable artifacts: closing
+// the proposal is housekeeping, not retraction. See proposal.service.ts
+// closeProposal — the report Document remains.
+const REPORT_BEARING_PROPOSAL_STATUSES = ["approved", "closed"] as const;
+
+// Batch-resolve completion-report Document counts grouped by Idea, used by
 // listIdeas. Fully short-circuited at every step so we don't pay the cost
-// when there are no idea-rooted approved proposals or no reports anywhere
-// in the project. Returns a Map for caller-side fold-back.
+// when there are no idea-rooted report-bearing proposals or no reports
+// anywhere in the project. Returns a Map for caller-side fold-back.
 async function getReportCountsForIdeas(
   companyUuid: string,
   projectUuid: string,
@@ -257,14 +264,14 @@ async function getReportCountsForIdeas(
   const out = new Map<string, number>();
   if (ideaUuids.length === 0) return out;
 
-  // Step 1: idea-rooted approved proposals in this project. JSON
-  // Proposal.inputUuids forces a project-scoped scan, but `status="approved"`
-  // + `inputType="idea"` + same companyUuid keeps the row count tight.
+  // Step 1: idea-rooted report-bearing proposals in this project. JSON
+  // Proposal.inputUuids forces a project-scoped scan; status filter +
+  // inputType + same companyUuid keep the row count tight.
   const proposals = await prisma.proposal.findMany({
     where: {
       projectUuid,
       companyUuid,
-      status: "approved",
+      status: { in: [...REPORT_BEARING_PROPOSAL_STATUSES] },
       inputType: "idea",
     },
     select: { uuid: true, inputUuids: true },
@@ -273,11 +280,13 @@ async function getReportCountsForIdeas(
 
   // Step 2: keep only proposals that point at one of THIS PAGE's ideas.
   // Build proposalUuid -> set of pageIdeaUuid associations along the way.
+  // Defensive: tolerate non-array inputUuids (legacy / drift) — a thrown
+  // TypeError here would 500 the entire idea list.
   const ideaSet = new Set(ideaUuids);
   const proposalUuidToIdeaUuids = new Map<string, string[]>();
   for (const p of proposals) {
-    const inputs = (p.inputUuids as string[]) || [];
-    const matched = inputs.filter((u) => ideaSet.has(u));
+    if (!Array.isArray(p.inputUuids)) continue;
+    const matched = (p.inputUuids as string[]).filter((u) => ideaSet.has(u));
     if (matched.length > 0) proposalUuidToIdeaUuids.set(p.uuid, matched);
   }
   if (proposalUuidToIdeaUuids.size === 0) return out;
@@ -324,14 +333,17 @@ export async function getIdea(
   if (!idea) return null;
   const response = await formatIdeaResponse(idea);
 
-  // Step 1: idea-rooted approved proposals.
+  // Step 1: idea-rooted report-bearing proposals (approved or closed —
+  // see REPORT_BEARING_PROPOSAL_STATUSES rationale).
   const proposals = await proposalService.getProposalsByIdeaUuid(
     companyUuid,
     idea.projectUuid,
     uuid,
   );
-  const approved = proposals.filter((p) => p.status === "approved");
-  if (approved.length === 0) {
+  const reportBearing = proposals.filter((p) =>
+    (REPORT_BEARING_PROPOSAL_STATUSES as readonly string[]).includes(p.status),
+  );
+  if (reportBearing.length === 0) {
     response.reports = [];
     return response;
   }
@@ -340,7 +352,7 @@ export async function getIdea(
   // includes content + sorts by createdAt desc.
   const reports = await documentService.listDocumentsByProposalUuids(
     companyUuid,
-    approved.map((p) => p.uuid),
+    reportBearing.map((p) => p.uuid),
     "report",
   );
   response.reports = reports;


### PR DESCRIPTION
## Summary
- Adds a `report` Document subtype that captures the post-delivery summary of a finished Idea — no schema migration, `Document.type` is already a free-form string column.
- New MCP tool `chorus_create_report` (gated on `document:write`) writes the report; `chorus_get_idea` returns full `reports[]`, `chorus_get_ideas` adds `reportCount` per row.
- UI: Reports list on `IdeaDetailPanel` overview tab, below `OverviewTimeline`, aggregated across approved proposals; click-row opens existing `DocumentPanel`. Proposal tab untouched.
- Skills + hooks: `/yolo` Phase 5b mandatory call, `/develop` advisory prompt, PostToolUse Branch B injects a one-line reminder when the verified task's idea-rooted proposal is finished and has no report yet.
- Section template (Summary / Decisions / Follow-ups) lives in the LLM-visible tool description, not in skill prose, so agents have one source of truth.

## Why one commit
Squash-merge collapses anyway; logical separation between the core feature and the read-side `get_idea`/`get_ideas` surface is preserved in the OpenSpec change folder.

## Verified
- End-to-end against local 0.9.0: project → idea → elaboration → proposal → approve → claim/work/submit → verify (Branch B fires `create idea-completion report` reminder) → report persisted v1, visible via both new fields.
- `npx tsc --noEmit` clean.
- 1631/1631 vitest pass (1 skipped, pre-existing).
- `openspec validate add-idea-completion-report` passes.
- Hook regression suite 20/20 pass.

## Notable design calls
- Hook Branch B is **proposal-local** (just two checks: this proposal's tasks done? this proposal has no report yet?) — not idea-aggregated. Multi-proposal-per-Idea is `/yolo` end-step's job. Trade-off documented in `design.md`.
- `chorus_get_idea` always returns full report content (per user direction "report 内容不多的"). For long-tail safety, all aggregation paths short-circuit at every step.
- No new REST endpoint and no new Prisma model; existing list/get paths absorb the new field.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `pnpm vitest run`
- [x] `bash public/chorus-plugin/bin/tests/test-on-post-verify-task.sh`
- [x] `openspec validate add-idea-completion-report`
- [x] Live end-to-end: `chorus_create_report` → `chorus_get_idea` returns `reports[]` with full body; `chorus_get_ideas` returns matching `reportCount`
- [x] Live end-to-end: empty-state path (project with no reports) returns `reportCount: 0` everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)