### PR TITLE
chore(plugin): bump reviewer subagent maxTurns to 100

### DIFF
--- a/public/chorus-plugin/agents/proposal-reviewer.md
+++ b/public/chorus-plugin/agents/proposal-reviewer.md
@@ -2,7 +2,7 @@
 description: "Review submitted Chorus proposals for quality — check document completeness, task granularity, AC alignment, and cross-task dependencies. Spawn after chorus_pm_submit_proposal."
 model: inherit
 color: red
-maxTurns: 40
+maxTurns: 100
 disallowedTools:
   - Agent
   - ExitPlanMode

--- a/public/chorus-plugin/agents/task-reviewer.md
+++ b/public/chorus-plugin/agents/task-reviewer.md
@@ -2,7 +2,7 @@
 description: "Review submitted Chorus tasks — verify implementation against AC and proposal documents. Spawn after chorus_submit_for_verify."
 model: inherit
 color: red
-maxTurns: 50
+maxTurns: 100
 disallowedTools:
   - Agent
   - ExitPlanMode


### PR DESCRIPTION
## Summary
- Reviewers were running out of turn budget mid-review and leaving tasks/proposals without a VERDICT, forcing a respawn-with-hint workaround documented in the develop/review/yolo skills.
- Bump `maxTurns` so a single review pass finishes without retries.

## Changed files
| File | Change |
|------|--------|
| `public/chorus-plugin/agents/proposal-reviewer.md` | `maxTurns: 40` → `100` |
| `public/chorus-plugin/agents/task-reviewer.md` | `maxTurns: 50` → `100` |

Other PE (description, model, color, disallowedTools, criticalSystemReminder_EXPERIMENTAL, prompt body) is unchanged. Codex plugin (`plugins/chorus/`) has no equivalent `maxTurns` frontmatter — only narrative SKILL.md mentions — so it is not modified.

## Idea
放宽 Reviewer 审核轮次限制 — Chorus 0.9.0 (idea `b882f16f-738b-4dde-9c0e-e4b8c1979ac4`)

## Test plan
- [x] `git diff` confirms only the `maxTurns:` line changed in each file
- [x] task-reviewer subagent reviewed the change (round 1, VERDICT: PASS)
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)