### PR TITLE
feat(reports): real-time SSE + notification for report creation

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -835,7 +835,8 @@
       "elaboration_requested": "Elaboration requested",
       "elaboration_answered": "Elaboration answered",
       "mentioned": "You were mentioned",
-      "agent_checkin": "Agent connected successfully"
+      "agent_checkin": "Agent connected successfully",
+      "report_created": "New report"
     },
     "preferences": {
       "title": "Notification Preferences",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -836,7 +836,8 @@
       "elaboration_requested": "需求澄清已请求",
       "elaboration_answered": "需求澄清已回答",
       "mentioned": "你被提及了",
-      "agent_checkin": "Agent 已成功连接"
+      "agent_checkin": "Agent 已成功连接",
+      "report_created": "新报告"
     },
     "preferences": {
       "title": "通知偏好",

--- a/openspec/changes/archive/2026-05-26-add-report-realtime-notification/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-26-add-report-realtime-notification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/archive/2026-05-26-add-report-realtime-notification/README.md
+++ b/openspec/changes/archive/2026-05-26-add-report-realtime-notification/README.md
@@ -1,0 +1,3 @@
+# add-report-realtime-notification
+
+Real-time SSE + notification fan-out when an idea-completion Report is created

--- a/openspec/changes/archive/2026-05-26-add-report-realtime-notification/design.md
+++ b/openspec/changes/archive/2026-05-26-add-report-realtime-notification/design.md
@@ -1,0 +1,206 @@
+# Design: Real-time Report SSE + Notification
+
+## Context
+
+`v0.9.0` shipped idea-completion reports via the `chorus_create_report` MCP tool, which writes a `Document` row with `type="report"` (no separate model). All other Chorus mutation paths fan out a `RealtimeEvent` through the in-process `EventBus`/Redis bridge so SSE-subscribed clients refetch automatically — but the document path doesn't. As of v0.9.0:
+
+- `src/services/document.service.ts` contains **zero** `eventBus.emitChange()` calls (`grep` confirms).
+- `src/components/idea-tracker/reports-list.tsx` (Idea overview pane) already calls `useRealtimeEntityTypeEvent("document", fetchReports)`, so a `document/created` event would be picked up *for free* — but the source-side emit doesn't exist.
+- `src/components/idea-tracker/idea-tracker-list.tsx` only subscribes to `useRealtimeEntityTypeEvent("idea", ...)`, so its `reportCount` badge will not update on a `document/created` event without a parallel `idea/updated` event.
+- `src/services/notification-listener.ts` is a single subscriber on the activity stream that does the recipient resolution + `t('notifications.types.<action>')` lookup. Adding a notification means: extend `resolveNotificationType`, add a recipient case, add a `buildMessage` case, optional `PREF_FIELD_MAP` entry, and add the i18n key in both `messages/{en,zh}.json`.
+
+The user also chose: **no schema change**, **no UI highlight**, **deep-link to `panel=overview`** (not a Reports panel — the overview already renders reports inline below the timeline per `add-idea-completion-report` Requirement 5).
+
+## Architecture
+
+```
+chorus_create_report (MCP tool, src/mcp/tools/public.ts)
+    └─> documentService.createDocument({ ..., type: "report", proposalUuid })
+            ├─> prisma.document.create(...)
+            └─> NEW: if type === "report" {
+                  ├─ eventBus.emitChange({ entityType: "document", action: "created", entityUuid: doc.uuid, projectUuid, companyUuid, actorUuid })
+                  ├─ resolve ideaUuid from proposal.inputUuids[]
+                  ├─ if ideaUuid resolved:
+                  │    └─ eventBus.emitChange({ entityType: "idea", action: "updated", entityUuid: ideaUuid, ... })
+                  └─ activity.recordActivity({
+                       targetType: "idea", targetUuid: ideaUuid,
+                       action: "report_created",
+                       value: { reportUuid: doc.uuid, proposalUuid, reportTitle }
+                     })
+                       │  (ActivityEvent flows through eventBus "activity" channel)
+                       ▼
+                 notification-listener.ts.handleActivity
+                   ├─ resolveNotificationType("idea", "report_created") → "report_created"
+                   ├─ resolveRecipients() → [ideaCreator, ideaAssignee]
+                   ├─ buildMessage("report_created", actorName, ideaTitle) → English fallback
+                   └─ notificationService.createBatch([...])  (already emits per-recipient SSE)
+                }
+```
+
+Why route through Activity rather than calling `notificationService.createBatch` directly from the document path: every other notifiable mutation in the codebase routes through Activity → notification-listener. Doing the same keeps the recipient-resolution + dedup + preference-filter logic in one place. The cost is one extra event on the bus per report — acceptable.
+
+## Component contracts
+
+### document.service.ts (modified)
+
+```ts
+export async function createDocument(params: {
+  companyUuid: string;
+  projectUuid: string;
+  type: string;
+  title: string;
+  content: string;
+  proposalUuid?: string;
+  createdByUuid: string;
+}): Promise<Document> {
+  const doc = await prisma.document.create(...);
+
+  if (params.type === "report") {
+    // 1. Document-level SSE — picked up by ReportsList in IdeaDetailPanel
+    eventBus.emitChange({
+      companyUuid: params.companyUuid,
+      projectUuid: params.projectUuid,
+      entityType: "document",
+      entityUuid: doc.uuid,
+      action: "created",
+      actorUuid: params.createdByUuid,
+    });
+
+    // 2. Resolve parent idea via proposal.inputUuids
+    const ideaUuid = await resolveIdeaUuidFromProposal(params.proposalUuid);
+    if (ideaUuid) {
+      // 2a. Idea-level SSE — picked up by IdeaTrackerList for reportCount badge
+      eventBus.emitChange({
+        companyUuid: params.companyUuid,
+        projectUuid: params.projectUuid,
+        entityType: "idea",
+        entityUuid: ideaUuid,
+        action: "updated",
+        actorUuid: params.createdByUuid,
+      });
+
+      // 2b. Activity event — drives notification-listener
+      await activityService.recordActivity({
+        companyUuid: params.companyUuid,
+        projectUuid: params.projectUuid,
+        targetType: "idea",
+        targetUuid: ideaUuid,
+        actorType: resolveActorType(params.createdByUuid),
+        actorUuid: params.createdByUuid,
+        action: "report_created",
+        value: { reportUuid: doc.uuid, proposalUuid: params.proposalUuid, reportTitle: params.title },
+      });
+    }
+  }
+
+  return doc;
+}
+```
+
+`resolveIdeaUuidFromProposal` reads `proposal.inputType` and `proposal.inputUuids` (a `Json` column already storing `string[]` of idea UUIDs for `inputType: "idea"`). Reports under non-idea-rooted proposals do not produce notifications — but they still emit the `document/created` event so the Reports panel refetches.
+
+Failure semantics: any error inside the report-only branch is caught and logged via the existing module logger (`logger.child({ module: "document.service" })`). It does NOT roll back the Document insert — the Document is the source of truth, the side effects are best-effort. This matches `idea.service.ts`'s pattern (eventBus errors don't fail the write). Logged at `warn` so they are visible without crashing the request.
+
+### notification-listener.ts (modified)
+
+Three additions:
+
+```ts
+// resolveNotificationType()
+const mapping = {
+  // ... existing entries ...
+  "idea:report_created": "report_created",
+};
+
+// resolveRecipients() — new case
+case "report_created": {
+  const idea = await prisma.idea.findUnique({
+    where: { uuid: targetUuid },
+    select: {
+      createdByUuid: true,
+      assigneeType: true,
+      assigneeUuid: true,
+    },
+  });
+  if (!idea) return [];
+  const recipients: Recipient[] = [
+    { type: "user", uuid: idea.createdByUuid },
+  ];
+  if (idea.assigneeType && idea.assigneeUuid) {
+    recipients.push({
+      type: idea.assigneeType as "user" | "agent",
+      uuid: idea.assigneeUuid,
+    });
+  }
+  return recipients;
+  // dedup + actor-exclusion happens upstream in handleActivity
+}
+
+// buildMessage() — new case
+case "report_created":
+  return `${actorName} generated a new report on idea "${entityTitle}"`;
+```
+
+No `PREF_FIELD_MAP` entry this iteration — that was decided in elaboration as "no new preference toggle". Recipients always get the notification (subject to the global dedup + actor-exclusion).
+
+### messages/en.json + messages/zh.json
+
+```json
+// en
+"notifications.types.report_created": "New report"
+// zh
+"notifications.types.report_created": "新报告"
+```
+
+The bell popup renders this as the row title; the row body uses `actorName` + `entityTitle` from the notification payload, also already-i18n'd.
+
+### notification-popup.tsx (modified)
+
+The deep-link router builds the URL based on the row's `entityType` + `entityUuid`. For `action === "report_created"` we want **the notification's parent Idea**, not the Document. Since the activity stream uses `targetType: "idea"`, `targetUuid: ideaUuid`, the existing entity-type lookup already produces the right Idea pointer. The new branch:
+
+```ts
+if (notif.action === "report_created") {
+  return `/projects/${notif.projectUuid}/dashboard?ideaUuid=${notif.entityUuid}&panel=overview`;
+}
+```
+
+The `IdeaDetailPanel` already supports `panel=overview` as the default tab — verified via reading `idea-detail-panel.tsx`.
+
+## Data model
+
+**No Prisma schema change.** The `Notification.action` column is `String` (not enum), so adding `"report_created"` requires only application-code changes.
+
+## Failure / error handling
+
+| Source | Handling |
+|---|---|
+| `eventBus.emitChange` throws | Caught in service code, logged at `warn`. Document insert succeeds. Subscribers will not refetch — user sees the report on next manual refresh. |
+| `activityService.recordActivity` throws | Same — caught, logged, no rollback. |
+| `notification-listener.handleActivity` throws | Already wrapped in `try/catch` upstream (line ~570). |
+| Idea cannot be resolved (proposal not idea-rooted) | Skip notification path entirely. Document event still fires. |
+
+## Testing
+
+| Test | File | What it asserts |
+|---|---|---|
+| Service-layer unit | `src/services/__tests__/document.service.test.ts` | Calling `createDocument({ type: "report", ... })` invokes `eventBus.emitChange` with `entityType: "document"` AND `entityType: "idea"`, and `activityService.recordActivity` with `action: "report_created"`. Calling with `type: "prd"` emits NEITHER. |
+| Notification-listener unit | `src/services/__tests__/notification-listener.test.ts` | Activity event with `action: "report_created"` resolves recipients to `[ideaCreator, ideaAssignee]` (deduped, actor excluded), produces `notification.action === "report_created"`. |
+| i18n smoke | `src/components/__tests__/notification-popup.test.tsx` | Mounted popup renders the i18n string for both `en` and `zh` locales given a `report_created` notification fixture. |
+| Frontend hook integration | `src/contexts/__tests__/realtime-context.test.tsx` | Mount a component using `useRealtimeEntityTypeEvent("document", cb)`, dispatch a fake `change` event with `entityType: "document"`, assert `cb` runs (debounced). |
+
+E2E with real DB + browser is **out of scope** per elaboration Q7 = (b).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Adding `idea/updated` events on every report creation triggers extra refetches on IdeaTrackerList. | Acceptable — the tracker list is small (≤ 50 ideas) and fetches are cheap. |
+| `notification-listener.ts` recipient resolution is centralized; an error in the new case could break unrelated notifications. | The `try/catch` in `handleActivity` already isolates failures; the new case is added in the per-action `switch` so its scope is narrow. |
+| Future "report update" feature (out of scope today) would need a parallel emit on `chorus_pm_update_document` when the underlying type is `report`. | Documented in the spec scenario "Updates do not produce a notification (out of scope)" so the constraint is explicit, not implicit. |
+
+## Out of scope
+
+- Report `update`/`delete` events (Q1 = "only create").
+- New `NotificationPreference` toggle (Q2 = creator + assignee, no opt-out).
+- "X new" highlight banner (Q5 = "no highlight").
+- E2E test (Q7 = "service + frontend hook").

--- a/openspec/changes/archive/2026-05-26-add-report-realtime-notification/proposal.md
+++ b/openspec/changes/archive/2026-05-26-add-report-realtime-notification/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Idea-completion reports added in v0.9.0 land via the `chorus_create_report` MCP tool — but creating one produces no real-time feedback for the user. The dashboard already wires SSE for comments, mentions, task changes, and even document changes elsewhere; the report-creation path is the only one that requires a manual page refresh to see the new artifact. Users miss new reports unless they happen to be looking at the right page at the right time.
+
+## What Changes
+
+- Creating a `Document` with `type="report"` SHALL fan out two `RealtimeEvent`s through the existing `EventBus`: one for the document itself (so the Idea overview's `ReportsList` refetches) and one for the parent Idea (so the Idea Tracker's `reportCount` badge refetches).
+- Creating a `Document` with `type="report"` SHALL produce one `Notification` per (Idea creator, Idea assignee) — deduplicated, excluding the actor themselves — using the existing `notification-listener.ts` machinery and the new action value `report_created`.
+- The notification's display text SHALL be rendered client-side via the existing `t('notifications.types.<action>')` pattern. Two i18n strings (en + zh) are added under that key. **No Prisma schema change.**
+- The bell-popup's notification row for `report_created` SHALL deep-link to `/projects/<projectUuid>/dashboard?ideaUuid=<ideaUuid>&panel=overview` — the Idea overview panel already renders `ReportsList` inline.
+
+## Capabilities
+
+### New Capabilities
+- `report-realtime`: Real-time SSE fan-out and notification production triggered when an idea-completion Report is created.
+
+### Modified Capabilities
+- _(none)_ — `idea-completion-report` is in-flight (not yet archived to `openspec/specs/`); this change therefore introduces a separate capability rather than modifying a spec that doesn't exist long-term yet.
+
+## Impact
+
+- `src/services/document.service.ts` (or `chorus_create_report` tool path) — emit `eventBus.emitChange()` twice and call notification creation, **only when `type === "report"`**.
+- `src/services/notification.service.ts` (or `notification-listener.ts`) — extend the action enum with `report_created`; add a `buildMessage()` branch.
+- `messages/en.json` + `messages/zh.json` — add `notifications.types.report_created`.
+- `src/components/notification-popup.tsx` — extend the deep-link router so `action === "report_created"` builds the dashboard URL with `panel=overview`.
+- Tests:
+  - service-layer unit test: report create emits both events + creates notifications for the right recipients.
+  - frontend hook integration test: mount `useRealtimeEntityTypeEvent` with a fake event source and assert the refetch callback fires.
+- No schema migration. No new Prisma model. No new MCP tool.

--- a/openspec/changes/archive/2026-05-26-add-report-realtime-notification/specs/report-realtime/spec.md
+++ b/openspec/changes/archive/2026-05-26-add-report-realtime-notification/specs/report-realtime/spec.md
@@ -1,0 +1,135 @@
+# report-realtime Specification
+
+## ADDED Requirements
+
+### Requirement: Creating a report-typed Document SHALL fan out a `document/created` `RealtimeEvent`
+
+When `documentService.createDocument` persists a row with `type === "report"`, the service MUST publish exactly one `RealtimeEvent` on the `change` channel of the shared `eventBus`. The event MUST carry `entityType: "document"`, `action: "created"`, `entityUuid` equal to the new document's UUID, and `companyUuid` + `projectUuid` matching the document's company and project. The event MUST be published after the database insert succeeds and before the function returns. Failures of the publish step MUST NOT roll back the document insert; they MUST be logged at `warn` level with the document UUID.
+
+#### Scenario: Report creation publishes a document `created` event
+
+- **GIVEN** an approved Proposal `P` whose tasks have all reached a terminal state
+- **WHEN** an authenticated agent calls `chorus_create_report` with `proposalUuid = P.uuid`, a non-empty `title`, and a non-empty Markdown `content`
+- **THEN** the server MUST persist a `Document` row with `type = "report"` and `proposalUuid = P.uuid`
+- **AND** the server MUST emit one `RealtimeEvent` with `entityType = "document"`, `action = "created"`, `entityUuid` equal to the new document's UUID, `projectUuid` equal to `P.projectUuid`, and `actorUuid` equal to the calling agent's UUID
+
+#### Scenario: Non-report Document creation does not publish a document `created` event from this code path
+
+- **WHEN** an authenticated PM agent calls `chorus_pm_create_document` with `type = "tech_design"` (or `prd`, `adr`, `spec`, `guide`)
+- **THEN** the report-realtime emit branch in `documentService.createDocument` MUST NOT fire
+- **AND** any unrelated `RealtimeEvent` emissions for non-report documents (added by future changes) are out of scope for this requirement
+
+#### Scenario: A failure in the SSE publish does not undo the Document insert
+
+- **GIVEN** an approved Proposal and a configured Redis publisher whose `publish()` rejects with an error
+- **WHEN** an agent calls `chorus_create_report`
+- **THEN** the `Document` row MUST be persisted in the database
+- **AND** the tool MUST return a successful response with the new `documentUuid`
+- **AND** the failure MUST be recorded in the application log at `warn` level
+
+### Requirement: Creating an idea-rooted report SHALL also fan out an `idea/updated` `RealtimeEvent`
+
+When the report-typed Document being created is linked to a Proposal whose `inputType === "idea"` (i.e. an idea-rooted Proposal), `documentService.createDocument` MUST publish a second `RealtimeEvent` on the `change` channel with `entityType: "idea"`, `action: "updated"`, and `entityUuid` set to the resolved Idea UUID (the first entry of `proposal.inputUuids`). When the Proposal is not idea-rooted, this second event MUST NOT be published.
+
+#### Scenario: Report creation under an idea-rooted Proposal emits the idea event
+
+- **GIVEN** an approved Proposal whose `inputType = "idea"` and `inputUuids = [I.uuid]`
+- **WHEN** an agent calls `chorus_create_report` referencing that Proposal
+- **THEN** the server MUST publish a second `RealtimeEvent` with `entityType = "idea"`, `action = "updated"`, `entityUuid = I.uuid`, and `projectUuid = I.projectUuid`
+- **AND** this event MUST be published in addition to the `document/created` event from the previous Requirement
+
+#### Scenario: Report creation under a non-idea-rooted Proposal does not emit an idea event
+
+- **GIVEN** an approved Proposal whose `inputType = "document"` (no Idea ancestor)
+- **WHEN** an agent calls `chorus_create_report` referencing that Proposal
+- **THEN** the server MUST NOT publish any `entityType = "idea"` event from the report-realtime code path
+- **AND** the `document/created` event from the previous Requirement MUST still be published
+
+### Requirement: Creating an idea-rooted report SHALL produce a `report_created` `Notification` for the Idea creator and assignee
+
+When a report is created under an idea-rooted Proposal, `documentService.createDocument` MUST emit an Activity event with `targetType: "idea"`, `targetUuid` equal to the resolved Idea UUID, and `action: "report_created"`. The `notification-listener` SHALL recognize `action: "report_created"` and produce one `Notification` row per (Idea creator, Idea assignee) recipient pair, deduplicated, excluding the actor themselves. The persisted `Notification.action` MUST equal the literal string `"report_created"`. Reports under non-idea-rooted Proposals MUST NOT produce notifications. No new `NotificationPreference` field is introduced; recipients always receive the notification subject only to the existing dedup + actor-exclusion logic.
+
+#### Scenario: Notifications are sent to creator and assignee, dedup-aware
+
+- **GIVEN** an Idea `I` whose `createdByUuid = U_creator` and whose `assigneeType = "agent"`, `assigneeUuid = A`
+- **AND** an approved idea-rooted Proposal `P` referencing `I`
+- **WHEN** an agent `A_actor` (where `A_actor != A`) calls `chorus_create_report` for `P`
+- **THEN** exactly two `Notification` rows MUST be created — one with `recipientType = "user"`, `recipientUuid = U_creator`; the other with `recipientType = "agent"`, `recipientUuid = A`
+- **AND** both rows MUST have `action = "report_created"`, `entityType = "idea"`, `entityUuid = I.uuid`, `actorUuid = A_actor.uuid`
+
+#### Scenario: The actor is excluded from their own notification
+
+- **GIVEN** an Idea `I` whose `createdByUuid = U` and whose `assigneeType = "user"`, `assigneeUuid = U` (creator and assignee are the same human)
+- **WHEN** that same user `U` calls `chorus_create_report` for an approved Proposal under `I`
+- **THEN** zero `Notification` rows MUST be created (after dedup + actor-exclusion both recipients collapse to the actor)
+
+#### Scenario: Reports under non-idea-rooted Proposals do not produce notifications
+
+- **GIVEN** an approved Proposal `P` with `inputType = "document"`, no Idea ancestor
+- **WHEN** an agent calls `chorus_create_report` for `P`
+- **THEN** no `Notification` row MUST be created
+- **AND** no `Activity` event with `action = "report_created"` MUST be emitted
+
+### Requirement: Notification text for `report_created` SHALL be rendered client-side via the existing i18n key pattern
+
+The `notification-listener.buildMessage` function MUST produce an English fallback string for `action: "report_created"` (used as the persisted `Notification.message` column). The bell-popup UI MUST render the row's primary label by calling `t('notifications.types.report_created')` against the i18n provider, identical to every other notification row. The two i18n catalogs MUST gain the new key.
+
+#### Scenario: English catalog carries the new i18n key
+
+- **GIVEN** the file `messages/en.json`
+- **WHEN** the file is read and the path `notifications.types.report_created` is resolved
+- **THEN** the resolved value MUST be a non-empty English string
+
+#### Scenario: Chinese catalog carries the new i18n key
+
+- **GIVEN** the file `messages/zh.json`
+- **WHEN** the file is read and the path `notifications.types.report_created` is resolved
+- **THEN** the resolved value MUST be a non-empty Chinese string
+
+#### Scenario: The bell popup renders the i18n label, not the stored message
+
+- **GIVEN** a `report_created` `Notification` row whose `message` column contains an English fallback
+- **WHEN** the user opens the notification popup with the locale set to `zh`
+- **THEN** the row's primary label MUST display the Chinese string from `messages/zh.json` under the path `notifications.types.report_created`
+- **AND** the row MUST NOT display the raw English `message` column value
+
+### Requirement: The bell-popup deep-link for a `report_created` row SHALL land on the Idea overview panel
+
+When the user clicks a notification row whose `action === "report_created"`, the bell popup MUST navigate the browser to `/projects/<projectUuid>/dashboard?ideaUuid=<entityUuid>&panel=overview`, where `<projectUuid>` is the notification's `projectUuid`, `<entityUuid>` is the notification's `entityUuid` (i.e. the parent Idea's UUID), and `panel=overview` is the literal query-string token that drives the dashboard's `IdeaDetailPanel` to open the overview tab.
+
+#### Scenario: Click on a `report_created` row opens the Idea overview
+
+- **GIVEN** a `report_created` notification with `projectUuid = P` and `entityUuid = I`
+- **WHEN** the user clicks the notification row
+- **THEN** the application MUST navigate to the URL `/projects/P/dashboard?ideaUuid=I&panel=overview`
+- **AND** on landing, the `IdeaDetailPanel` MUST render with the `overview` tab active and the Reports list visible inline below the timeline
+
+### Requirement: The Idea Tracker page SHALL refresh report counts on idea events
+
+The existing `IdeaTrackerList` component subscribes to `useRealtimeEntityTypeEvent("idea", ...)`. Because Requirement 2 emits an `entityType: "idea"`, `action: "updated"` event whenever a report is created under an idea-rooted Proposal, the list MUST refetch idea data and the per-Idea `reportCount` badge MUST reflect the new count without a manual page refresh. No new client-side subscription is added.
+
+#### Scenario: Tracker badge updates after a report is created on an Idea
+
+- **GIVEN** a user has the Idea Tracker page open for project `P` with Idea `I` showing `reportCount = 0`
+- **AND** an agent (in another session) calls `chorus_create_report` for an approved Proposal under `I`
+- **WHEN** the resulting `entityType = "idea"`, `action = "updated"` SSE event reaches the user's browser
+- **THEN** the IdeaTrackerList MUST refetch the project's idea-tracker data
+- **AND** the row for `I` MUST display `reportCount = 1` within the existing 300ms event-debounce window
+
+#### Scenario: Tracker badge does NOT update after a non-report Document creation under the same Idea
+
+- **GIVEN** the same Idea Tracker context
+- **AND** an agent calls `chorus_pm_create_document` with `type = "tech_design"` referencing `I`'s approved Proposal
+- **WHEN** the request completes
+- **THEN** the report-realtime code path MUST NOT emit any `entityType = "idea"` event from this code path
+
+### Requirement: Updating or deleting a report-typed Document SHALL NOT produce a notification under this change
+
+This change is scoped to **creation** only. `chorus_pm_update_document` and any future delete path on `type === "report"` Documents MUST NOT trigger the `report_created` notification or activity event introduced by this change. The Reports list refetch on those paths is governed by whatever events those existing tools already emit, not by this requirement.
+
+#### Scenario: Updating an existing report does not produce a `report_created` notification
+
+- **GIVEN** an existing Document with `type = "report"`, UUID `D`
+- **WHEN** an agent calls `chorus_pm_update_document` with `documentUuid = D` and a non-empty `content`
+- **THEN** no new `Notification` row with `action = "report_created"` MUST be created
+- **AND** no `Activity` event with `action = "report_created"` MUST be emitted from this code path

--- a/openspec/specs/report-realtime/spec.md
+++ b/openspec/specs/report-realtime/spec.md
@@ -1,7 +1,9 @@
 # report-realtime Specification
 
 ## Purpose
-TBD - created by archiving change add-report-realtime-notification. Update Purpose after archive.
+
+Hook idea-completion report creation into Chorus's existing real-time SSE + notification pipeline. When an agent calls `chorus_create_report`, the system emits two `RealtimeEvent`s (document/created + idea/updated) and produces bell-popup notifications for the people invested in the Idea — so the bell, the Idea overview's Reports list, and the Idea Tracker's `reportCount` badge all update without a manual refresh.
+
 ## Requirements
 ### Requirement: Creating a report-typed Document SHALL fan out a `document/created` `RealtimeEvent`
 
@@ -46,17 +48,23 @@ When the report-typed Document being created is linked to a Proposal whose `inpu
 - **THEN** the server MUST NOT publish any `entityType = "idea"` event from the report-realtime code path
 - **AND** the `document/created` event from the previous Requirement MUST still be published
 
-### Requirement: Creating an idea-rooted report SHALL produce a `report_created` `Notification` for the Idea creator and assignee
+### Requirement: Creating an idea-rooted report SHALL produce a `report_created` `Notification` for the Idea creator, assignee, and their human owners
 
-When a report is created under an idea-rooted Proposal, `documentService.createDocument` MUST emit an Activity event with `targetType: "idea"`, `targetUuid` equal to the resolved Idea UUID, and `action: "report_created"`. The `notification-listener` SHALL recognize `action: "report_created"` and produce one `Notification` row per (Idea creator, Idea assignee) recipient pair, deduplicated, excluding the actor themselves. The persisted `Notification.action` MUST equal the literal string `"report_created"`. Reports under non-idea-rooted Proposals MUST NOT produce notifications. No new `NotificationPreference` field is introduced; recipients always receive the notification subject only to the existing dedup + actor-exclusion logic.
+When a report is created under an idea-rooted Proposal, `documentService.createDocument` MUST emit an Activity event with `targetType: "idea"`, `targetUuid` equal to the resolved Idea UUID, and `action: "report_created"`. The `notification-listener` SHALL recognize `action: "report_created"` and produce one `Notification` row per recipient in the set: (Idea creator, Idea assignee, creator's human owner if creator is an agent, assignee's human owner if assignee is an agent), deduplicated, excluding the actor themselves. The creator's `recipientType` MUST be resolved dynamically (`"user"` or `"agent"`) — `Idea.createdByUuid` can refer to either. The persisted `Notification.action` MUST equal the literal string `"report_created"`. Reports under non-idea-rooted Proposals MUST NOT produce notifications. No new `NotificationPreference` field is introduced; recipients always receive the notification subject only to the existing dedup + actor-exclusion logic.
 
-#### Scenario: Notifications are sent to creator and assignee, dedup-aware
+#### Scenario: Notifications are sent to creator, assignee, and assignee's owner; dedup-aware
 
-- **GIVEN** an Idea `I` whose `createdByUuid = U_creator` and whose `assigneeType = "agent"`, `assigneeUuid = A`
+- **GIVEN** an Idea `I` whose `createdByUuid = U_creator` (a user) and whose `assigneeType = "agent"`, `assigneeUuid = A`, where agent `A` has human owner `U_owner`
 - **AND** an approved idea-rooted Proposal `P` referencing `I`
-- **WHEN** an agent `A_actor` (where `A_actor != A`) calls `chorus_create_report` for `P`
-- **THEN** exactly two `Notification` rows MUST be created — one with `recipientType = "user"`, `recipientUuid = U_creator`; the other with `recipientType = "agent"`, `recipientUuid = A`
-- **AND** both rows MUST have `action = "report_created"`, `entityType = "idea"`, `entityUuid = I.uuid`, `actorUuid = A_actor.uuid`
+- **WHEN** an agent `A_actor` (where `A_actor != A` and `A_actor != U_owner`) calls `chorus_create_report` for `P`
+- **THEN** exactly three `Notification` rows MUST be created — `recipientType = "user"` for `U_creator`; `recipientType = "agent"` for `A`; `recipientType = "user"` for `U_owner`
+- **AND** all three rows MUST have `action = "report_created"`, `entityType = "idea"`, `entityUuid = I.uuid`, `actorUuid = A_actor.uuid`
+
+#### Scenario: An agent Idea creator surfaces both the agent and its human owner
+
+- **GIVEN** an Idea `I` whose `createdByUuid = A_creator` is an agent with human owner `U_creator_owner`, and whose `assigneeType = null`
+- **WHEN** an agent `A_actor` (where `A_actor != A_creator` and `A_actor != U_creator_owner`) calls `chorus_create_report` for an approved Proposal under `I`
+- **THEN** exactly two `Notification` rows MUST be created — `recipientType = "agent"` for `A_creator`; `recipientType = "user"` for `U_creator_owner`
 
 #### Scenario: The actor is excluded from their own notification
 

--- a/openspec/specs/report-realtime/spec.md
+++ b/openspec/specs/report-realtime/spec.md
@@ -1,0 +1,137 @@
+# report-realtime Specification
+
+## Purpose
+TBD - created by archiving change add-report-realtime-notification. Update Purpose after archive.
+## Requirements
+### Requirement: Creating a report-typed Document SHALL fan out a `document/created` `RealtimeEvent`
+
+When `documentService.createDocument` persists a row with `type === "report"`, the service MUST publish exactly one `RealtimeEvent` on the `change` channel of the shared `eventBus`. The event MUST carry `entityType: "document"`, `action: "created"`, `entityUuid` equal to the new document's UUID, and `companyUuid` + `projectUuid` matching the document's company and project. The event MUST be published after the database insert succeeds and before the function returns. Failures of the publish step MUST NOT roll back the document insert; they MUST be logged at `warn` level with the document UUID.
+
+#### Scenario: Report creation publishes a document `created` event
+
+- **GIVEN** an approved Proposal `P` whose tasks have all reached a terminal state
+- **WHEN** an authenticated agent calls `chorus_create_report` with `proposalUuid = P.uuid`, a non-empty `title`, and a non-empty Markdown `content`
+- **THEN** the server MUST persist a `Document` row with `type = "report"` and `proposalUuid = P.uuid`
+- **AND** the server MUST emit one `RealtimeEvent` with `entityType = "document"`, `action = "created"`, `entityUuid` equal to the new document's UUID, `projectUuid` equal to `P.projectUuid`, and `actorUuid` equal to the calling agent's UUID
+
+#### Scenario: Non-report Document creation does not publish a document `created` event from this code path
+
+- **WHEN** an authenticated PM agent calls `chorus_pm_create_document` with `type = "tech_design"` (or `prd`, `adr`, `spec`, `guide`)
+- **THEN** the report-realtime emit branch in `documentService.createDocument` MUST NOT fire
+- **AND** any unrelated `RealtimeEvent` emissions for non-report documents (added by future changes) are out of scope for this requirement
+
+#### Scenario: A failure in the SSE publish does not undo the Document insert
+
+- **GIVEN** an approved Proposal and a configured Redis publisher whose `publish()` rejects with an error
+- **WHEN** an agent calls `chorus_create_report`
+- **THEN** the `Document` row MUST be persisted in the database
+- **AND** the tool MUST return a successful response with the new `documentUuid`
+- **AND** the failure MUST be recorded in the application log at `warn` level
+
+### Requirement: Creating an idea-rooted report SHALL also fan out an `idea/updated` `RealtimeEvent`
+
+When the report-typed Document being created is linked to a Proposal whose `inputType === "idea"` (i.e. an idea-rooted Proposal), `documentService.createDocument` MUST publish a second `RealtimeEvent` on the `change` channel with `entityType: "idea"`, `action: "updated"`, and `entityUuid` set to the resolved Idea UUID (the first entry of `proposal.inputUuids`). When the Proposal is not idea-rooted, this second event MUST NOT be published.
+
+#### Scenario: Report creation under an idea-rooted Proposal emits the idea event
+
+- **GIVEN** an approved Proposal whose `inputType = "idea"` and `inputUuids = [I.uuid]`
+- **WHEN** an agent calls `chorus_create_report` referencing that Proposal
+- **THEN** the server MUST publish a second `RealtimeEvent` with `entityType = "idea"`, `action = "updated"`, `entityUuid = I.uuid`, and `projectUuid = I.projectUuid`
+- **AND** this event MUST be published in addition to the `document/created` event from the previous Requirement
+
+#### Scenario: Report creation under a non-idea-rooted Proposal does not emit an idea event
+
+- **GIVEN** an approved Proposal whose `inputType = "document"` (no Idea ancestor)
+- **WHEN** an agent calls `chorus_create_report` referencing that Proposal
+- **THEN** the server MUST NOT publish any `entityType = "idea"` event from the report-realtime code path
+- **AND** the `document/created` event from the previous Requirement MUST still be published
+
+### Requirement: Creating an idea-rooted report SHALL produce a `report_created` `Notification` for the Idea creator and assignee
+
+When a report is created under an idea-rooted Proposal, `documentService.createDocument` MUST emit an Activity event with `targetType: "idea"`, `targetUuid` equal to the resolved Idea UUID, and `action: "report_created"`. The `notification-listener` SHALL recognize `action: "report_created"` and produce one `Notification` row per (Idea creator, Idea assignee) recipient pair, deduplicated, excluding the actor themselves. The persisted `Notification.action` MUST equal the literal string `"report_created"`. Reports under non-idea-rooted Proposals MUST NOT produce notifications. No new `NotificationPreference` field is introduced; recipients always receive the notification subject only to the existing dedup + actor-exclusion logic.
+
+#### Scenario: Notifications are sent to creator and assignee, dedup-aware
+
+- **GIVEN** an Idea `I` whose `createdByUuid = U_creator` and whose `assigneeType = "agent"`, `assigneeUuid = A`
+- **AND** an approved idea-rooted Proposal `P` referencing `I`
+- **WHEN** an agent `A_actor` (where `A_actor != A`) calls `chorus_create_report` for `P`
+- **THEN** exactly two `Notification` rows MUST be created — one with `recipientType = "user"`, `recipientUuid = U_creator`; the other with `recipientType = "agent"`, `recipientUuid = A`
+- **AND** both rows MUST have `action = "report_created"`, `entityType = "idea"`, `entityUuid = I.uuid`, `actorUuid = A_actor.uuid`
+
+#### Scenario: The actor is excluded from their own notification
+
+- **GIVEN** an Idea `I` whose `createdByUuid = U` and whose `assigneeType = "user"`, `assigneeUuid = U` (creator and assignee are the same human)
+- **WHEN** that same user `U` calls `chorus_create_report` for an approved Proposal under `I`
+- **THEN** zero `Notification` rows MUST be created (after dedup + actor-exclusion both recipients collapse to the actor)
+
+#### Scenario: Reports under non-idea-rooted Proposals do not produce notifications
+
+- **GIVEN** an approved Proposal `P` with `inputType = "document"`, no Idea ancestor
+- **WHEN** an agent calls `chorus_create_report` for `P`
+- **THEN** no `Notification` row MUST be created
+- **AND** no `Activity` event with `action = "report_created"` MUST be emitted
+
+### Requirement: Notification text for `report_created` SHALL be rendered client-side via the existing i18n key pattern
+
+The `notification-listener.buildMessage` function MUST produce an English fallback string for `action: "report_created"` (used as the persisted `Notification.message` column). The bell-popup UI MUST render the row's primary label by calling `t('notifications.types.report_created')` against the i18n provider, identical to every other notification row. The two i18n catalogs MUST gain the new key.
+
+#### Scenario: English catalog carries the new i18n key
+
+- **GIVEN** the file `messages/en.json`
+- **WHEN** the file is read and the path `notifications.types.report_created` is resolved
+- **THEN** the resolved value MUST be a non-empty English string
+
+#### Scenario: Chinese catalog carries the new i18n key
+
+- **GIVEN** the file `messages/zh.json`
+- **WHEN** the file is read and the path `notifications.types.report_created` is resolved
+- **THEN** the resolved value MUST be a non-empty Chinese string
+
+#### Scenario: The bell popup renders the i18n label, not the stored message
+
+- **GIVEN** a `report_created` `Notification` row whose `message` column contains an English fallback
+- **WHEN** the user opens the notification popup with the locale set to `zh`
+- **THEN** the row's primary label MUST display the Chinese string from `messages/zh.json` under the path `notifications.types.report_created`
+- **AND** the row MUST NOT display the raw English `message` column value
+
+### Requirement: The bell-popup deep-link for a `report_created` row SHALL land on the Idea overview panel
+
+When the user clicks a notification row whose `action === "report_created"`, the bell popup MUST navigate the browser to `/projects/<projectUuid>/dashboard?panel=<entityUuid>&tab=overview`, where `<projectUuid>` is the notification's `projectUuid`, `<entityUuid>` is the notification's `entityUuid` (i.e. the parent Idea's UUID, used by the dashboard's `panel` query param to select which Idea panel to open), and `tab=overview` is the literal query-string token that drives the dashboard's `IdeaDetailPanel` to open the overview tab. This contract matches the rest of the dashboard surface (see `move-idea-dialog.tsx` and the `[ideaUuid]` redirect).
+
+#### Scenario: Click on a `report_created` row opens the Idea overview
+
+- **GIVEN** a `report_created` notification with `projectUuid = P` and `entityUuid = I`
+- **WHEN** the user clicks the notification row
+- **THEN** the application MUST navigate to the URL `/projects/P/dashboard?panel=I&tab=overview`
+- **AND** on landing, the `IdeaDetailPanel` MUST render with the `overview` tab active and the Reports list visible inline below the timeline
+
+### Requirement: The Idea Tracker page SHALL refresh report counts on idea events
+
+The existing `IdeaTrackerList` component subscribes to `useRealtimeEntityTypeEvent("idea", ...)`. Because Requirement 2 emits an `entityType: "idea"`, `action: "updated"` event whenever a report is created under an idea-rooted Proposal, the list MUST refetch idea data and the per-Idea `reportCount` badge MUST reflect the new count without a manual page refresh. No new client-side subscription is added.
+
+#### Scenario: Tracker badge updates after a report is created on an Idea
+
+- **GIVEN** a user has the Idea Tracker page open for project `P` with Idea `I` showing `reportCount = 0`
+- **AND** an agent (in another session) calls `chorus_create_report` for an approved Proposal under `I`
+- **WHEN** the resulting `entityType = "idea"`, `action = "updated"` SSE event reaches the user's browser
+- **THEN** the IdeaTrackerList MUST refetch the project's idea-tracker data
+- **AND** the row for `I` MUST display `reportCount = 1` within the existing 300ms event-debounce window
+
+#### Scenario: Tracker badge does NOT update after a non-report Document creation under the same Idea
+
+- **GIVEN** the same Idea Tracker context
+- **AND** an agent calls `chorus_pm_create_document` with `type = "tech_design"` referencing `I`'s approved Proposal
+- **WHEN** the request completes
+- **THEN** the report-realtime code path MUST NOT emit any `entityType = "idea"` event from this code path
+
+### Requirement: Updating or deleting a report-typed Document SHALL NOT produce a notification under this change
+
+This change is scoped to **creation** only. `chorus_pm_update_document` and any future delete path on `type === "report"` Documents MUST NOT trigger the `report_created` notification or activity event introduced by this change. The Reports list refetch on those paths is governed by whatever events those existing tools already emit, not by this requirement.
+
+#### Scenario: Updating an existing report does not produce a `report_created` notification
+
+- **GIVEN** an existing Document with `type = "report"`, UUID `D`
+- **WHEN** an agent calls `chorus_pm_update_document` with `documentUuid = D` and a non-empty `content`
+- **THEN** no new `Notification` row with `action = "report_created"` MUST be created
+- **AND** no `Activity` event with `action = "report_created"` MUST be emitted from this code path
+

--- a/src/components/__tests__/notification-popup.test.tsx
+++ b/src/components/__tests__/notification-popup.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+// Radix ScrollArea (used inside the popup) calls ResizeObserver during layout
+// effects; jsdom doesn't ship one, so polyfill it before the component imports.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+  ResizeObserverStub;
+
+import { NotificationPopup } from "@/components/notification-popup";
+
+// next-intl: resolve real strings from the locale JSON so we catch missing keys.
+let currentLocale: "en" | "zh" = "en";
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  const zh = (await import("../../../messages/zh.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(messages: Record<string, unknown>, namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    const parts = fullKey.split(".");
+    let node: unknown = messages;
+    for (const p of parts) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations: (namespace = "") => (key: string) =>
+      resolve(currentLocale === "en" ? en : zh, namespace, key),
+  };
+});
+
+// next/navigation: capture router.push calls.
+const pushSpy = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushSpy, replace: vi.fn(), back: vi.fn() }),
+}));
+
+// framer-motion: jsdom-safe pass-through; the popup only uses motion.div.
+vi.mock("framer-motion", async () => {
+  const ReactMod = await import("react");
+  type DivProps = React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>> & {
+    initial?: unknown;
+    animate?: unknown;
+    exit?: unknown;
+    transition?: unknown;
+    variants?: unknown;
+    whileHover?: unknown;
+    whileTap?: unknown;
+  };
+  const passthroughDiv = ReactMod.forwardRef<HTMLDivElement, DivProps>(
+    ({ children, ...rest }, ref) => {
+      // Strip motion-only props so React doesn't warn about unknown DOM attrs.
+      const {
+        initial: _initial,
+        animate: _animate,
+        exit: _exit,
+        transition: _transition,
+        variants: _variants,
+        whileHover: _wh,
+        whileTap: _wt,
+        ...domProps
+      } = rest;
+      return ReactMod.createElement("div", { ref, ...domProps }, children);
+    },
+  );
+  passthroughDiv.displayName = "MotionDiv";
+  return { motion: { div: passthroughDiv } };
+});
+
+// auth-client: stub authFetch with an in-memory notification fixture queue.
+const fixtureQueue: unknown[] = [];
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: vi.fn(async (_url: string, _opts?: unknown) => {
+    const next = fixtureQueue.shift() ?? { notifications: [], unreadCount: 0 };
+    return {
+      ok: true,
+      json: async () => ({ success: true, data: next }),
+    };
+  }),
+}));
+
+// notification-context: only refreshNotifications is consumed by the popup.
+vi.mock("@/contexts/notification-context", () => ({
+  useNotification: () => ({ refreshNotifications: vi.fn() }),
+}));
+
+const PROJECT_UUID = "11111111-1111-1111-1111-111111111111";
+const IDEA_UUID = "22222222-2222-2222-2222-222222222222";
+
+function reportNotification() {
+  return {
+    uuid: "n-1",
+    projectUuid: PROJECT_UUID,
+    projectName: "Test Project",
+    entityType: "idea",
+    entityUuid: IDEA_UUID,
+    entityTitle: "Idea: build the thing",
+    action: "report_created",
+    message: "A new report was created",
+    actorType: "agent",
+    actorUuid: "actor-1",
+    actorName: "Admin Claude",
+    readAt: null,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function primeFixtures() {
+  // The popup makes two parallel fetches on mount: all + unread.
+  // Both should return the same single report fixture so the row shows
+  // up in the default ("unread") tab.
+  fixtureQueue.push({ notifications: [reportNotification()], unreadCount: 1 });
+  fixtureQueue.push({ notifications: [reportNotification()], unreadCount: 1 });
+}
+
+describe("NotificationPopup — report_created deep link", () => {
+  beforeEach(() => {
+    pushSpy.mockReset();
+    fixtureQueue.length = 0;
+    currentLocale = "en";
+  });
+
+  it("renders the English report_created label and navigates to the dashboard URL with panel=<ideaUuid>&tab=overview", async () => {
+    primeFixtures();
+    render(<NotificationPopup onClose={vi.fn()} />);
+
+    // i18n label resolves through t('notifications.types.report_created')
+    const label = await screen.findByText("New report");
+    expect(label).toBeTruthy();
+
+    // Click the row — the button wraps the entire notification content.
+    const row = label.closest("button");
+    expect(row).not.toBeNull();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await user.click(row!);
+
+    await waitFor(() => expect(pushSpy).toHaveBeenCalledTimes(1));
+    // Exact URL — dashboard contract is panel=<ideaUuid>&tab=overview.
+    expect(pushSpy).toHaveBeenCalledWith(
+      `/projects/${PROJECT_UUID}/dashboard?panel=${IDEA_UUID}&tab=overview`,
+    );
+  });
+
+  it("renders the Chinese report_created label under the zh locale", async () => {
+    currentLocale = "zh";
+    primeFixtures();
+    render(<NotificationPopup onClose={vi.fn()} />);
+
+    const label = await screen.findByText("新报告");
+    expect(label).toBeTruthy();
+  });
+});

--- a/src/components/notification-popup.tsx
+++ b/src/components/notification-popup.tsx
@@ -12,6 +12,7 @@ import {
   Send,
   RefreshCw,
   AtSign,
+  FileText,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import { staggerItem } from "@/lib/animation";
@@ -82,6 +83,8 @@ function getTypeIcon(action: string) {
       return { Icon: Send, color: "text-blue-500" };
     case "task_status_changed":
       return { Icon: RefreshCw, color: "text-blue-500" };
+    case "report_created":
+      return { Icon: FileText, color: "text-violet-600" };
     default:
       return { Icon: Send, color: "text-muted-foreground" };
   }

--- a/src/components/notification-popup.tsx
+++ b/src/components/notification-popup.tsx
@@ -111,8 +111,15 @@ function useRelativeTime(t: ReturnType<typeof useTranslations>) {
 // ===== Entity navigation =====
 
 function getEntityPath(notification: Notification): string {
-  const { entityType, entityUuid, projectUuid } = notification;
+  const { action, entityType, entityUuid, projectUuid } = notification;
   const base = `/projects/${projectUuid}`;
+  // Reports notify on the parent Idea (entityType: "idea"). Deep-link to the
+  // dashboard's Idea panel — `panel=<ideaUuid>` selects which Idea to open and
+  // `tab=overview` opens the overview tab where ReportsList renders inline
+  // (matching `move-idea-dialog.tsx` and `[ideaUuid]/page.tsx`).
+  if (action === "report_created") {
+    return `${base}/dashboard?panel=${entityUuid}&tab=overview`;
+  }
   switch (entityType) {
     case "task":
       return `${base}/tasks/${entityUuid}`;

--- a/src/components/notification-popup.tsx
+++ b/src/components/notification-popup.tsx
@@ -12,7 +12,7 @@ import {
   Send,
   RefreshCw,
   AtSign,
-  FileText,
+  Flag,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import { staggerItem } from "@/lib/animation";
@@ -84,7 +84,7 @@ function getTypeIcon(action: string) {
     case "task_status_changed":
       return { Icon: RefreshCw, color: "text-blue-500" };
     case "report_created":
-      return { Icon: FileText, color: "text-violet-600" };
+      return { Icon: Flag, color: "text-emerald-600" };
     default:
       return { Icon: Send, color: "text-muted-foreground" };
   }

--- a/src/contexts/__tests__/realtime-context.test.tsx
+++ b/src/contexts/__tests__/realtime-context.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+//
+// Frontend hook integration test for `useRealtimeEntityTypeEvent` (Q7 = b).
+//
+// Test seam: we replace `globalThis.EventSource` with a minimal stub that
+// captures the most recently constructed instance, so the test can drive
+// `onmessage` directly. No production-code seam is required — `EventSource`
+// is the provider's only external dependency for SSE input.
+
+import React from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, render } from "@testing-library/react";
+
+import {
+  RealtimeProvider,
+  useRealtimeEntityTypeEvent,
+} from "@/contexts/realtime-context";
+
+// next/navigation is imported transitively by the provider via useRealtimeRefresh-adjacent
+// hooks; useRealtimeEntityTypeEvent itself doesn't use it, but the module-level import
+// resolves it. Provide a minimal stub.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+interface CapturedEventSource {
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: (() => void) | null;
+  readyState: number;
+  close: () => void;
+}
+
+let lastEventSource: CapturedEventSource | null = null;
+
+class MockEventSource implements CapturedEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+
+  constructor(url: string) {
+    this.url = url;
+    lastEventSource = this;
+  }
+
+  close() {
+    this.readyState = MockEventSource.CLOSED;
+  }
+}
+
+beforeEach(() => {
+  lastEventSource = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).EventSource = MockEventSource;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (globalThis as any).EventSource;
+});
+
+const PROJECT_UUID = "00000000-0000-4000-8000-0000000000aa";
+const COMPANY_UUID = "00000000-0000-4000-8000-0000000000bb";
+
+function dispatchSseMessage(payload: Record<string, unknown>) {
+  if (!lastEventSource?.onmessage) {
+    throw new Error("EventSource onmessage not yet bound");
+  }
+  // MessageEvent only needs the `.data` field for the provider's parser.
+  lastEventSource.onmessage({ data: JSON.stringify(payload) } as MessageEvent);
+}
+
+const ENTITY_DEBOUNCE_MS = 300;
+
+function HookHarness({
+  entityTypes,
+  onEvent,
+}: {
+  entityTypes: string | string[];
+  onEvent: (event: { entityType: string; entityUuid: string; action: string }) => void;
+}) {
+  useRealtimeEntityTypeEvent(entityTypes, onEvent);
+  return <div data-testid="harness">ok</div>;
+}
+
+describe("useRealtimeEntityTypeEvent", () => {
+  it("fires the callback once when a matching `document/created` event arrives", () => {
+    const cb = vi.fn();
+    render(
+      <RealtimeProvider projectUuid={PROJECT_UUID}>
+        <HookHarness entityTypes="document" onEvent={cb} />
+      </RealtimeProvider>,
+    );
+
+    expect(lastEventSource).not.toBeNull();
+    expect(lastEventSource?.url).toContain(`projectUuid=${PROJECT_UUID}`);
+
+    act(() => {
+      dispatchSseMessage({
+        companyUuid: COMPANY_UUID,
+        projectUuid: PROJECT_UUID,
+        entityType: "document",
+        entityUuid: "doc-1",
+        action: "created",
+      });
+    });
+
+    // Hook should NOT have fired yet — debounce window is 300ms.
+    expect(cb).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(ENTITY_DEBOUNCE_MS);
+    });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "document",
+        entityUuid: "doc-1",
+        action: "created",
+      }),
+    );
+  });
+
+  it("fires the callback once when a matching `idea/updated` event arrives", () => {
+    const cb = vi.fn();
+    render(
+      <RealtimeProvider projectUuid={PROJECT_UUID}>
+        <HookHarness entityTypes="idea" onEvent={cb} />
+      </RealtimeProvider>,
+    );
+
+    act(() => {
+      dispatchSseMessage({
+        companyUuid: COMPANY_UUID,
+        projectUuid: PROJECT_UUID,
+        entityType: "idea",
+        entityUuid: "idea-1",
+        action: "updated",
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(ENTITY_DEBOUNCE_MS);
+    });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "idea",
+        entityUuid: "idea-1",
+        action: "updated",
+      }),
+    );
+  });
+
+  it("does NOT fire the callback when a non-matching entityType event arrives", () => {
+    const cb = vi.fn();
+    render(
+      <RealtimeProvider projectUuid={PROJECT_UUID}>
+        <HookHarness entityTypes="document" onEvent={cb} />
+      </RealtimeProvider>,
+    );
+
+    act(() => {
+      dispatchSseMessage({
+        companyUuid: COMPANY_UUID,
+        projectUuid: PROJECT_UUID,
+        entityType: "task",
+        entityUuid: "task-1",
+        action: "updated",
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(ENTITY_DEBOUNCE_MS);
+    });
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("supports an array of entity types and only fires for matching members", () => {
+    const cb = vi.fn();
+    render(
+      <RealtimeProvider projectUuid={PROJECT_UUID}>
+        <HookHarness entityTypes={["document", "idea"]} onEvent={cb} />
+      </RealtimeProvider>,
+    );
+
+    act(() => {
+      dispatchSseMessage({
+        companyUuid: COMPANY_UUID,
+        projectUuid: PROJECT_UUID,
+        entityType: "proposal",
+        entityUuid: "p-1",
+        action: "updated",
+      });
+    });
+    act(() => {
+      vi.advanceTimersByTime(ENTITY_DEBOUNCE_MS);
+    });
+    expect(cb).not.toHaveBeenCalled();
+
+    act(() => {
+      dispatchSseMessage({
+        companyUuid: COMPANY_UUID,
+        projectUuid: PROJECT_UUID,
+        entityType: "idea",
+        entityUuid: "idea-2",
+        action: "updated",
+      });
+    });
+    act(() => {
+      vi.advanceTimersByTime(ENTITY_DEBOUNCE_MS);
+    });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "idea", entityUuid: "idea-2" }),
+    );
+  });
+});

--- a/src/services/__tests__/document.service.test.ts
+++ b/src/services/__tests__/document.service.test.ts
@@ -10,6 +10,9 @@ const mockPrisma = vi.hoisted(() => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+  proposal: {
+    findFirst: vi.fn(),
+  },
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
@@ -17,6 +20,28 @@ const mockFormatCreatedBy = vi.fn();
 vi.mock("@/lib/uuid-resolver", () => ({
   formatCreatedBy: (...args: unknown[]) => mockFormatCreatedBy(...args),
 }));
+
+// ===== Event bus mock =====
+const mockEventBus = vi.hoisted(() => ({
+  emitChange: vi.fn(),
+}));
+vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
+
+// ===== Activity service mock =====
+const mockActivityService = vi.hoisted(() => ({
+  createActivity: vi.fn(),
+}));
+vi.mock("@/services/activity.service", () => mockActivityService);
+
+// ===== Logger mock — capture warn calls so error-path tests can assert =====
+const mockLogger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  child: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => {
+  mockLogger.child.mockReturnValue(mockLogger);
+  return { default: mockLogger };
+});
 
 import {
   createDocument,
@@ -54,6 +79,11 @@ const createdByInfo = { type: "agent", uuid: createdByUuid, name: "PM Agent" };
 beforeEach(() => {
   vi.clearAllMocks();
   mockFormatCreatedBy.mockResolvedValue(createdByInfo);
+  // Default: proposal not found — non-report tests don't care, report tests
+  // override per-case.
+  mockPrisma.proposal.findFirst.mockResolvedValue(null);
+  mockActivityService.createActivity.mockResolvedValue(undefined);
+  mockLogger.child.mockReturnValue(mockLogger);
 });
 
 // ===== createDocument =====
@@ -199,6 +229,244 @@ describe("createDocument", () => {
     expect(second.uuid).toBe("doc-report-2");
 
     expect(mockPrisma.document.create).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ===== createDocument: report-realtime side effects =====
+// Covers spec `report-realtime` Requirements 1–3:
+//   (1) document/created event always fires for type=report
+//   (2) idea/updated event fires only when proposal.inputType === "idea"
+//   (3) report_created Activity fires only when an idea is resolved
+// All three are best-effort; errors must NOT roll back the document insert.
+describe("createDocument — report-realtime side effects", () => {
+  const proposalUuid = "proposal-0000-0000-0000-000000000200";
+  const ideaUuid = "idea-0000-0000-0000-000000000001";
+  const reportTitle = "Idea X — completion report";
+  const reportContent = "## Summary\nShipped.\n\n## Decisions\n-\n\n## Follow-ups\nNone.\n";
+
+  function arrangeReportCreate(overrides: Record<string, unknown> = {}) {
+    mockPrisma.document.create.mockResolvedValue(
+      makeDocRecord({
+        type: "report",
+        title: reportTitle,
+        content: reportContent,
+        proposalUuid,
+        ...overrides,
+      }),
+    );
+  }
+
+  it("emits document/created and idea/updated events + records report_created Activity for an idea-rooted proposal", async () => {
+    arrangeReportCreate();
+    mockPrisma.proposal.findFirst.mockResolvedValue({
+      inputType: "idea",
+      inputUuids: [ideaUuid],
+    });
+
+    const result = await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: reportTitle,
+      content: reportContent,
+      proposalUuid,
+      createdByUuid,
+    });
+
+    expect(result.uuid).toBe(docUuid);
+
+    // Document-level event — Requirement 1.
+    expect(mockEventBus.emitChange).toHaveBeenCalledWith({
+      companyUuid,
+      projectUuid,
+      entityType: "document",
+      entityUuid: docUuid,
+      action: "created",
+      actorUuid: createdByUuid,
+    });
+
+    // Idea-level event — Requirement 2.
+    expect(mockEventBus.emitChange).toHaveBeenCalledWith({
+      companyUuid,
+      projectUuid,
+      entityType: "idea",
+      entityUuid: ideaUuid,
+      action: "updated",
+      actorUuid: createdByUuid,
+    });
+    expect(mockEventBus.emitChange).toHaveBeenCalledTimes(2);
+
+    // Activity — Requirement 3.
+    expect(mockActivityService.createActivity).toHaveBeenCalledWith({
+      companyUuid,
+      projectUuid,
+      targetType: "idea",
+      targetUuid: ideaUuid,
+      actorType: createdByInfo.type, // resolved via formatCreatedBy
+      actorUuid: createdByUuid,
+      action: "report_created",
+      value: {
+        reportUuid: docUuid,
+        proposalUuid,
+        reportTitle,
+      },
+    });
+  });
+
+  it("does not emit any side-effect events for non-report Documents", async () => {
+    mockPrisma.document.create.mockResolvedValue(makeDocRecord({ type: "tech_design" }));
+
+    await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "tech_design",
+      title: "Tech Design",
+      content: "...",
+      proposalUuid,
+      createdByUuid,
+    });
+
+    expect(mockEventBus.emitChange).not.toHaveBeenCalled();
+    expect(mockActivityService.createActivity).not.toHaveBeenCalled();
+    // Proposal lookup is gated on type === "report", so we shouldn't even hit
+    // the DB for non-report documents.
+    expect(mockPrisma.proposal.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("emits only document/created when the parent Proposal is not idea-rooted", async () => {
+    arrangeReportCreate();
+    mockPrisma.proposal.findFirst.mockResolvedValue({
+      inputType: "document",
+      inputUuids: ["doc-0000-0000-0000-000000000999"],
+    });
+
+    await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: reportTitle,
+      content: reportContent,
+      proposalUuid,
+      createdByUuid,
+    });
+
+    // document/created fires — Requirement 1 still holds.
+    expect(mockEventBus.emitChange).toHaveBeenCalledTimes(1);
+    expect(mockEventBus.emitChange).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "document", action: "created" }),
+    );
+    // No idea event, no Activity.
+    expect(mockEventBus.emitChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "idea" }),
+    );
+    expect(mockActivityService.createActivity).not.toHaveBeenCalled();
+  });
+
+  it("skips idea-scoped side effects when proposalUuid is missing on a report-typed Document", async () => {
+    // Edge case: a report-typed Document without a proposalUuid (not produced
+    // by chorus_create_report — that tool requires a proposal — but createDocument
+    // accepts proposalUuid as optional, so the branch must be safe).
+    mockPrisma.document.create.mockResolvedValue(
+      makeDocRecord({ type: "report", proposalUuid: null }),
+    );
+
+    await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: reportTitle,
+      content: reportContent,
+      createdByUuid,
+    });
+
+    expect(mockEventBus.emitChange).toHaveBeenCalledTimes(1);
+    expect(mockEventBus.emitChange).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "document", action: "created" }),
+    );
+    expect(mockPrisma.proposal.findFirst).not.toHaveBeenCalled();
+    expect(mockActivityService.createActivity).not.toHaveBeenCalled();
+  });
+
+  it("does not throw and still returns the new document when eventBus.emitChange throws", async () => {
+    arrangeReportCreate();
+    mockPrisma.proposal.findFirst.mockResolvedValue({
+      inputType: "idea",
+      inputUuids: [ideaUuid],
+    });
+    mockEventBus.emitChange.mockImplementationOnce(() => {
+      throw new Error("redis exploded");
+    });
+
+    const result = await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: reportTitle,
+      content: reportContent,
+      proposalUuid,
+      createdByUuid,
+    });
+
+    // Document insert is the source of truth — it MUST succeed end-to-end.
+    expect(result.uuid).toBe(docUuid);
+    expect(result.type).toBe("report");
+
+    // Failure was logged at warn level (Requirement 1 failure semantics).
+    expect(mockLogger.warn).toHaveBeenCalled();
+
+    // The second emitChange (idea/updated) and the Activity still fire — a
+    // failure in step 1 must not poison subsequent best-effort steps.
+    expect(mockEventBus.emitChange).toHaveBeenCalledTimes(2);
+    expect(mockActivityService.createActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "report_created" }),
+    );
+  });
+
+  it("does not throw when activityService.createActivity rejects, and still emits SSE events", async () => {
+    arrangeReportCreate();
+    mockPrisma.proposal.findFirst.mockResolvedValue({
+      inputType: "idea",
+      inputUuids: [ideaUuid],
+    });
+    mockActivityService.createActivity.mockRejectedValueOnce(new Error("activity write failed"));
+
+    const result = await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: reportTitle,
+      content: reportContent,
+      proposalUuid,
+      createdByUuid,
+    });
+
+    expect(result.uuid).toBe(docUuid);
+    expect(mockEventBus.emitChange).toHaveBeenCalledTimes(2);
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  it("tolerates a malformed proposal.inputUuids (non-array) and emits only document/created", async () => {
+    arrangeReportCreate();
+    mockPrisma.proposal.findFirst.mockResolvedValue({
+      inputType: "idea",
+      inputUuids: null, // legacy / drift — must not throw
+    });
+
+    await createDocument({
+      companyUuid,
+      projectUuid,
+      type: "report",
+      title: reportTitle,
+      content: reportContent,
+      proposalUuid,
+      createdByUuid,
+    });
+
+    expect(mockEventBus.emitChange).toHaveBeenCalledTimes(1);
+    expect(mockEventBus.emitChange).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "document" }),
+    );
+    expect(mockActivityService.createActivity).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/__tests__/notification-listener.test.ts
+++ b/src/services/__tests__/notification-listener.test.ts
@@ -705,6 +705,262 @@ describe("notification-listener", () => {
     });
   });
 
+  describe("report_created", () => {
+    it("should map idea:report_created to report_created", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "user-creator",
+        assigneeType: "agent",
+        assigneeUuid: "agent-assignee",
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      expect(mockNotificationService.createBatch).toHaveBeenCalled();
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      expect(call[0].action).toBe("report_created");
+    });
+
+    it("should produce notifications for creator + assignee + assignee's owner when actor is neither", async () => {
+      mockPrisma.idea.findUnique.mockImplementation((opts: any) => {
+        if (opts.select?.title) {
+          return Promise.resolve({ title: "Idea Title" });
+        }
+        return Promise.resolve({
+          createdByUuid: "user-creator",
+          assigneeType: "agent",
+          assigneeUuid: "agent-assignee",
+        });
+      });
+      // Default agent.findUnique returns ownerUuid: "owner-uuid", so the assignee
+      // agent contributes its human owner as a third recipient. Creator is a user
+      // (default user.findUnique returns truthy), so no additional owner there.
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      expect(mockNotificationService.createBatch).toHaveBeenCalledTimes(1);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      expect(call).toHaveLength(3);
+      const creator = call.find((n: any) => n.recipientUuid === "user-creator");
+      const assignee = call.find((n: any) => n.recipientUuid === "agent-assignee");
+      const assigneeOwner = call.find((n: any) => n.recipientUuid === "owner-uuid");
+      expect(creator).toBeDefined();
+      expect(creator.recipientType).toBe("user");
+      expect(creator.action).toBe("report_created");
+      expect(assignee).toBeDefined();
+      expect(assignee.recipientType).toBe("agent");
+      expect(assignee.action).toBe("report_created");
+      expect(assigneeOwner).toBeDefined();
+      expect(assigneeOwner.recipientType).toBe("user");
+      // Actor should be excluded
+      expect(call.every((n: any) => n.recipientUuid !== "agent-actor")).toBe(true);
+    });
+
+    it("should produce 0 notifications when actor is same UUID as both creator and assignee", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "same-uuid",
+        assigneeType: "user",
+        assigneeUuid: "same-uuid",
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "user",
+        actorUuid: "same-uuid",
+      });
+      await handleActivity(event);
+      expect(mockNotificationService.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("should skip the assignee tuple when assigneeType or assigneeUuid is null", async () => {
+      mockPrisma.idea.findUnique.mockImplementation((opts: any) => {
+        if (opts.select?.title) {
+          return Promise.resolve({ title: "Idea Title" });
+        }
+        return Promise.resolve({
+          createdByUuid: "user-creator",
+          assigneeType: null,
+          assigneeUuid: null,
+        });
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      expect(call).toHaveLength(1);
+      expect(call[0].recipientUuid).toBe("user-creator");
+    });
+
+    it("should build a non-empty English message containing actorName and entityTitle", async () => {
+      mockPrisma.idea.findUnique.mockImplementation((opts: any) => {
+        if (opts.select?.title) {
+          return Promise.resolve({ title: "Q4 Roadmap" });
+        }
+        return Promise.resolve({
+          createdByUuid: "user-creator",
+          assigneeType: "agent",
+          assigneeUuid: "agent-assignee",
+        });
+      });
+      mockPrisma.agent.findUnique.mockResolvedValue({
+        uuid: "agent-actor",
+        name: "Reporter Bot",
+        ownerUuid: null,
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      expect(call[0].message).toContain("Reporter Bot");
+      expect(call[0].message).toContain("Q4 Roadmap");
+      expect(call[0].message.length).toBeGreaterThan(0);
+    });
+
+    it("should bypass PREF_FIELD_MAP — getPreferences is never consulted for report_created", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "user-creator",
+        assigneeType: "agent",
+        assigneeUuid: "agent-assignee",
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      // The listener short-circuits the preference filter when there is no
+      // PREF_FIELD_MAP entry, so getPreferences must never be called for
+      // a report_created notification.
+      expect(mockNotificationService.getPreferences).not.toHaveBeenCalled();
+      expect(mockNotificationService.createBatch).toHaveBeenCalled();
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      // creator + assignee + assignee's owner (default ownerUuid: "owner-uuid")
+      expect(call).toHaveLength(3);
+    });
+
+    it("should resolve agent creator as type 'agent' and pull in creator's human owner", async () => {
+      mockPrisma.idea.findUnique.mockImplementation((opts: any) => {
+        if (opts.select?.title) return Promise.resolve({ title: "Idea Title" });
+        return Promise.resolve({
+          createdByUuid: "agent-creator",
+          assigneeType: null,
+          assigneeUuid: null,
+        });
+      });
+      // Creator UUID resolves as agent (not user) — first user lookup must return null,
+      // then agent lookup returns the agent. Subsequent agent lookup returns owner info.
+      mockPrisma.user.findUnique.mockImplementation((opts: any) => {
+        if (opts.where?.uuid === "agent-creator") return Promise.resolve(null);
+        return Promise.resolve({ uuid: "user-1" });
+      });
+      mockPrisma.agent.findUnique.mockImplementation((opts: any) => {
+        if (opts.where?.uuid === "agent-creator") {
+          // resolveActorType selects { uuid: true }, resolveAgentOwner selects { ownerUuid: true }.
+          return Promise.resolve({ uuid: "agent-creator", ownerUuid: "user-creator-owner" });
+        }
+        return Promise.resolve(null);
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      const creator = call.find((n: any) => n.recipientUuid === "agent-creator");
+      const owner = call.find((n: any) => n.recipientUuid === "user-creator-owner");
+      expect(creator).toBeDefined();
+      expect(creator.recipientType).toBe("agent");
+      expect(owner).toBeDefined();
+      expect(owner.recipientType).toBe("user");
+      // Agent's creator + creator's owner — exactly 2 entries, no assignee.
+      expect(call).toHaveLength(2);
+    });
+
+    it("should pull in assignee's human owner when assignee is an agent", async () => {
+      mockPrisma.idea.findUnique.mockImplementation((opts: any) => {
+        if (opts.select?.title) return Promise.resolve({ title: "Idea Title" });
+        return Promise.resolve({
+          createdByUuid: "user-creator",
+          assigneeType: "agent",
+          assigneeUuid: "agent-assignee",
+        });
+      });
+      // user-creator resolves as user (default). agent-assignee owner = user-assignee-owner.
+      mockPrisma.agent.findUnique.mockImplementation((opts: any) => {
+        if (opts.where?.uuid === "agent-assignee") {
+          return Promise.resolve({ uuid: "agent-assignee", ownerUuid: "user-assignee-owner" });
+        }
+        return Promise.resolve(null);
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      expect(call).toHaveLength(3);
+      const owner = call.find((n: any) => n.recipientUuid === "user-assignee-owner");
+      expect(owner).toBeDefined();
+      expect(owner.recipientType).toBe("user");
+    });
+
+    it("should dedup the owner when creator and assignee are agents sharing the same human owner", async () => {
+      mockPrisma.idea.findUnique.mockImplementation((opts: any) => {
+        if (opts.select?.title) return Promise.resolve({ title: "Idea Title" });
+        return Promise.resolve({
+          createdByUuid: "agent-creator",
+          assigneeType: "agent",
+          assigneeUuid: "agent-assignee",
+        });
+      });
+      mockPrisma.user.findUnique.mockImplementation((opts: any) => {
+        if (opts.where?.uuid === "agent-creator" || opts.where?.uuid === "agent-assignee") {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve({ uuid: "user-1" });
+      });
+      // Both agents share the same owner UUID.
+      mockPrisma.agent.findUnique.mockImplementation((opts: any) => {
+        if (opts.where?.uuid === "agent-creator" || opts.where?.uuid === "agent-assignee") {
+          return Promise.resolve({ uuid: opts.where.uuid, ownerUuid: "shared-owner" });
+        }
+        return Promise.resolve(null);
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "report_created",
+        actorType: "agent",
+        actorUuid: "agent-actor",
+      });
+      await handleActivity(event);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      const ownerEntries = call.filter((n: any) => n.recipientUuid === "shared-owner");
+      expect(ownerEntries).toHaveLength(1);
+      // 2 agents + 1 dedupped shared owner = 3 entries total.
+      expect(call).toHaveLength(3);
+    });
+  });
+
   describe("recipient resolution edge cases", () => {
     it("should handle comment_added excluding comment author", async () => {
       mockPrisma.task.findUnique.mockResolvedValue({

--- a/src/services/document.service.ts
+++ b/src/services/document.service.ts
@@ -4,6 +4,11 @@
 
 import { prisma, TransactionClient } from "@/lib/prisma";
 import { formatCreatedBy } from "@/lib/uuid-resolver";
+import { eventBus } from "@/lib/event-bus";
+import * as activityService from "@/services/activity.service";
+import logger from "@/lib/logger";
+
+const docLogger = logger.child({ module: "document.service" });
 
 // ===== Type Definitions =====
 
@@ -224,7 +229,113 @@ export async function createDocument(
     },
   });
 
+  // Report-only side effects: SSE fan-out (document + idea) and Activity-driven
+  // notification. All three are best-effort — the Document insert above is the
+  // source of truth, so any failure here is logged and swallowed. See spec
+  // `report-realtime` Requirement 1 (failure semantics).
+  if (params.type === "report") {
+    await emitReportSideEffects(params, doc.uuid);
+  }
+
   return formatDocumentResponse(doc, true);
+}
+
+// Encapsulates the report-only fan-out: document/created event, idea/updated
+// event, and the report_created Activity. Each step has its own try/catch so a
+// later failure cannot suppress an earlier success (and vice versa). Resolving
+// the parent Idea is gated on (a) the proposal being idea-rooted and (b) a
+// non-empty inputUuids array — anything else skips the idea-scoped events
+// without being treated as an error.
+async function emitReportSideEffects(
+  params: DocumentCreateParams,
+  reportUuid: string,
+): Promise<void> {
+  // Step 1 — document/created. Always fires for report-typed docs, regardless
+  // of whether the parent proposal is idea-rooted.
+  try {
+    eventBus.emitChange({
+      companyUuid: params.companyUuid,
+      projectUuid: params.projectUuid,
+      entityType: "document",
+      entityUuid: reportUuid,
+      action: "created",
+      actorUuid: params.createdByUuid,
+    });
+  } catch (err) {
+    docLogger.warn(
+      { err, reportUuid, proposalUuid: params.proposalUuid },
+      "Failed to emit document/created event for report",
+    );
+  }
+
+  if (!params.proposalUuid) return;
+
+  // Step 2 — resolve idea. Direct Prisma read instead of going through
+  // proposal.service to avoid a service-layer circular import (proposal.service
+  // already imports from document.service for createDocumentFromProposal).
+  let ideaUuid: string | null = null;
+  try {
+    const proposal = await prisma.proposal.findFirst({
+      where: { uuid: params.proposalUuid, companyUuid: params.companyUuid },
+      select: { inputType: true, inputUuids: true },
+    });
+    if (proposal && proposal.inputType === "idea" && Array.isArray(proposal.inputUuids)) {
+      const first = (proposal.inputUuids as string[])[0];
+      if (typeof first === "string" && first.length > 0) ideaUuid = first;
+    }
+  } catch (err) {
+    docLogger.warn(
+      { err, reportUuid, proposalUuid: params.proposalUuid },
+      "Failed to resolve parent Idea for report side effects",
+    );
+    return;
+  }
+
+  if (!ideaUuid) return;
+
+  // Step 3 — idea/updated event. Drives IdeaTrackerList reportCount refresh.
+  try {
+    eventBus.emitChange({
+      companyUuid: params.companyUuid,
+      projectUuid: params.projectUuid,
+      entityType: "idea",
+      entityUuid: ideaUuid,
+      action: "updated",
+      actorUuid: params.createdByUuid,
+    });
+  } catch (err) {
+    docLogger.warn(
+      { err, reportUuid, ideaUuid, proposalUuid: params.proposalUuid },
+      "Failed to emit idea/updated event for report",
+    );
+  }
+
+  // Step 4 — Activity event. Routed through activity.service so the existing
+  // notification-listener picks it up; the new "report_created" action mapping
+  // lives in notification-listener.ts (separate task in this proposal).
+  try {
+    const actor = await formatCreatedBy(params.createdByUuid);
+    const actorType = actor?.type ?? "agent";
+    await activityService.createActivity({
+      companyUuid: params.companyUuid,
+      projectUuid: params.projectUuid,
+      targetType: "idea",
+      targetUuid: ideaUuid,
+      actorType,
+      actorUuid: params.createdByUuid,
+      action: "report_created",
+      value: {
+        reportUuid,
+        proposalUuid: params.proposalUuid,
+        reportTitle: params.title,
+      },
+    });
+  } catch (err) {
+    docLogger.warn(
+      { err, reportUuid, ideaUuid, proposalUuid: params.proposalUuid },
+      "Failed to record report_created Activity",
+    );
+  }
 }
 
 // Update Document

--- a/src/services/notification-listener.ts
+++ b/src/services/notification-listener.ts
@@ -35,6 +35,7 @@ function resolveNotificationType(action: string, targetType: string): string | n
     "idea:elaboration_followup": "elaboration_requested",
     "idea:elaboration_resolved": "elaboration_answered",
     "idea:elaboration_skipped": "elaboration_answered",
+    "idea:report_created": "report_created",
   };
   return mapping[key] ?? null;
 }
@@ -301,6 +302,45 @@ async function resolveRecipients(
       return reqRecipients;
     }
 
+    case "report_created": {
+      const reportIdea = await prisma.idea.findUnique({
+        where: { uuid: targetUuid },
+        select: {
+          createdByUuid: true,
+          assigneeType: true,
+          assigneeUuid: true,
+        },
+      });
+      if (!reportIdea) return [];
+      const reportRecipients: Recipient[] = [];
+
+      // Creator: resolve type — Idea.createdByUuid can refer to either a user or an agent.
+      const creatorType = await resolveActorType(reportIdea.createdByUuid);
+      if (creatorType) {
+        reportRecipients.push({ type: creatorType, uuid: reportIdea.createdByUuid });
+        // If creator is an agent, also notify their human owner (if any).
+        if (creatorType === "agent") {
+          const creatorOwner = await resolveAgentOwner("agent", reportIdea.createdByUuid);
+          if (creatorOwner) reportRecipients.push(creatorOwner);
+        }
+      }
+
+      // Assignee + (if agent) their owner.
+      if (reportIdea.assigneeType && reportIdea.assigneeUuid) {
+        reportRecipients.push({
+          type: reportIdea.assigneeType,
+          uuid: reportIdea.assigneeUuid,
+        });
+        if (reportIdea.assigneeType === "agent") {
+          const assigneeOwner = await resolveAgentOwner("agent", reportIdea.assigneeUuid);
+          if (assigneeOwner) reportRecipients.push(assigneeOwner);
+        }
+      }
+
+      return reportRecipients;
+      // Dedup + actor-exclusion happen upstream in handleActivity.
+    }
+
     case "elaboration_answered": {
       // Notify Idea assignee (the PM agent)
       const ansIdea = await prisma.idea.findUnique({
@@ -451,6 +491,8 @@ function buildMessage(
       return `${actorName} requested elaboration on idea "${entityTitle}"`;
     case "elaboration_answered":
       return `${actorName} answered elaboration questions for idea "${entityTitle}"`;
+    case "report_created":
+      return `${actorName} generated a new report on idea "${entityTitle}"`;
     default:
       return `${actorName} performed an action on "${entityTitle}"`;
   }


### PR DESCRIPTION
## Summary

Hook idea-completion report creation into the existing SSE + notification pipeline so the bell, the Idea overview's Reports list, and the Idea Tracker's reportCount badge all update in real time when a Report is written via `chorus_create_report`. No Prisma schema change — i18n stays client-side, recipient resolution reuses existing helpers.

## How it works

- `documentService.createDocument` now branches on `type === "report"` and runs four best-effort side effects (each in its own `try/catch` with `warn` log, none can roll back the document insert):
  1. `eventBus.emitChange({ entityType: "document", action: "created" })` — picked up by `ReportsList` via the existing `useRealtimeEntityTypeEvent("document")` subscription
  2. Resolve parent Idea via `proposal.inputType === "idea"` + `inputUuids[0]`
  3. Second `eventBus.emitChange({ entityType: "idea", action: "updated" })` — picked up by `IdeaTrackerList`'s existing `useRealtimeEntityTypeEvent("idea")`, refreshes the `reportCount` badge with zero frontend change
  4. `activityService.createActivity({ targetType: "idea", action: "report_created", value: { reportUuid, proposalUuid, reportTitle } })`
- `notification-listener` resolves recipients dynamically (Idea creator + creator's owner if agent + assignee + assignee's owner if agent), deduped, with the actor excluded upstream.
- `notification-popup` deep-links `report_created` rows to `/projects/<projectUuid>/dashboard?panel=<ideaUuid>&tab=overview` — same query-param contract used by `move-idea-dialog` and `[ideaUuid]/page.tsx`.

## Changed files

| File | Change |
|------|--------|
| `src/services/document.service.ts` | Emit document/idea events + record activity for `type==="report"` |
| `src/services/notification-listener.ts` | New `report_created` mapping + recipient resolver (creator/assignee + their owners) + buildMessage branch |
| `src/components/notification-popup.tsx` | Deep-link branch for `action==="report_created"` |
| `messages/en.json`, `messages/zh.json` | New `notifications.types.report_created` key |
| `src/services/__tests__/document.service.test.ts` | 7 new tests covering all 5 spec scenarios + throw-doesn't-rollback + malformed inputs |
| `src/services/__tests__/notification-listener.test.ts` | 9 new tests for `report_created` resolver, message, agent creator/owner, dedup |
| `src/components/__tests__/notification-popup.test.tsx` | New test file: i18n label rendering + exact deep-link URL |
| `src/contexts/__tests__/realtime-context.test.tsx` | New test file: `useRealtimeEntityTypeEvent` fan-out + entityType filter (zero production-code seam) |
| `openspec/changes/archive/2026-05-26-add-report-realtime-notification/` | Archived OpenSpec change |
| `openspec/specs/report-realtime/spec.md` | New long-term capability spec |

## Test plan

- [x] `pnpm test` — 1665 passed, 1 skipped, 0 failed (was 1656)
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] Smoke test on local dev server (localhost:8637): created 4 reports against an idea-rooted proposal, verified
  - Activity stream shows `report_created` rows with the right value payload
  - Bell-popup notification appears for the agent's owner with the i18n string
  - Click navigates to `?panel=<ideaUuid>&tab=overview`
- [ ] Verify on a deployed instance once merged + deployed

## Notes

- Two bugs were caught and fixed during local smoke testing and are included in this PR:
  - `resolveRecipients("report_created")` originally hardcoded `recipientType: "user"` for the Idea creator, but `Idea.createdByUuid` can be an agent. Now uses `resolveActorType` + `resolveAgentOwner` to surface the human owner.
  - The deep-link URL was `?ideaUuid=<uuid>&panel=overview` (fictional contract), corrected to `?panel=<ideaUuid>&tab=overview` to match the rest of the dashboard surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)