### PR TITLE
feat(reports): add force flag to chorus_create_report; default-reject duplicates

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -799,6 +799,7 @@ What's still open — link to a new Idea / blog / doc-update if tracked elsewher
 | proposalUuid | string (UUID) | Yes | Proposal UUID whose tasks have all reached a terminal state (`done`/`closed`) |
 | title | string (1-200 chars) | Yes | Report title (e.g. `"Idea X — completion report"`) |
 | content | string (non-empty Markdown) | Yes | Markdown body — Summary / Decisions / Follow-ups |
+| force | boolean | No (default `false`) | When `false`, calls against a proposal that already has a report return an error and create nothing. Set `true` only to deliberately add another report to the same proposal. |
 
 **Output**:
 ```json
@@ -809,7 +810,9 @@ What's still open — link to a new Idea / blog / doc-update if tracked elsewher
 }
 ```
 
-The created Document has `type="report"` (the tool name encodes the type — agents cannot mislabel reports), `proposalUuid` set to the provided value, and `projectUuid` resolved from the Proposal. Multiple reports per Proposal are allowed by design; the body is preserved byte-faithfully (modulo the Document content path's existing trailing-newline normalization). To revise a report, use `chorus_pm_update_document` (which increments `version`).
+The created Document has `type="report"` (the tool name encodes the type — agents cannot mislabel reports), `proposalUuid` set to the provided value, and `projectUuid` resolved from the Proposal. The body is preserved byte-faithfully (modulo the Document content path's existing trailing-newline normalization). To revise a report, use `chorus_pm_update_document` (which increments `version`).
+
+By default the tool refuses to create a second report on a proposal that already has one — the call returns an MCP error result (`isError: true`) with a message indicating that a report already exists and that `force=true` is the way to bypass. This guard fires even when the call comes from the `/yolo` Phase 5b end-step or the PostToolUse hook reminder, so duplicate completion reports per Idea become impossible regardless of caller. To intentionally author an additional report (e.g. after a major rework, separate-audience cut), pass `force: true`.
 
 **When to author**: at the end of an Idea pipeline — once every Task linked to the Idea (across all approved Proposals) has been admin-verified to `done`. The `/yolo` skill authors a report as a mandatory end-step; the `/develop` skill prompts for one as an advisory end-step; and the Chorus plugin's PostToolUse hook injects a reminder substring after the last `chorus_admin_verify_task` of an Idea when no `report` Document yet exists.
 

--- a/openspec/changes/archive/2026-05-27-create-report-force-flag/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-27-create-report-force-flag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/archive/2026-05-27-create-report-force-flag/README.md
+++ b/openspec/changes/archive/2026-05-27-create-report-force-flag/README.md
@@ -1,0 +1,3 @@
+# create-report-force-flag
+
+Add force flag to chorus_create_report; default to rejecting duplicate reports per proposal

--- a/openspec/changes/archive/2026-05-27-create-report-force-flag/design.md
+++ b/openspec/changes/archive/2026-05-27-create-report-force-flag/design.md
@@ -1,0 +1,92 @@
+# Tech Design — `chorus_create_report` `force` flag
+
+## Goal
+
+Make duplicate completion reports under one Proposal a deliberate choice rather than the current accidental side-effect of two PE paths firing in sequence. Push the policy decision down to the server so it is correct regardless of whether the caller is `/yolo`, `/develop`, the PostToolUse hook, an external client, or a future workflow we haven't written yet.
+
+## Constraints
+
+- `chorus_create_report` is a **public-namespaced** MCP tool (no `pm_` prefix), gated on `document:write`. Both properties are preserved.
+- Existing handler shape is `async ({ proposalUuid, title, content }) => { ... }` returning either `{ content: [{ type: "text", text }] }` (success — JSON serialised) or `{ content: [...], isError: true }` on failure. The two existing failure branches (`Proposal not found`, `Proposal status must be 'approved'`) are kept verbatim — the new branch matches that style.
+- `documentService.createDocument` is shared with `chorus_pm_create_document`; we do not push the duplicate gate down into the service because reports under non-`/create_report` paths (e.g. server-side `createDocumentFromProposal`) intentionally allow multiple type=report rows during proposal drafting / approval flows.
+- Bash 3.2 / no-DML-in-migration / Prisma-CLI-only invariants from `CLAUDE.md` are not relevant here (handler-only change in TS).
+
+## Non-Goals
+
+- Skill / hook text fixes (`yolo` Phase 5b, `develop` Step 11, `on-post-verify-task.sh` Branch B). The server-side fix makes those paths *self-correct* — duplicate fires return errors instead of writing extra rows. PE clean-up is a separate work item.
+- Any DB schema change or unique constraint. The `Document` table currently holds multi-report rows under prior approved proposals; adding `(proposalUuid, type='report')` UNIQUE retroactively would either fail the migration or require lossy backfill. The application-layer check has equivalent strength for the realistic concurrency profile (report creation is a once-per-Idea event, not a high-frequency racy path).
+- `chorus_pm_create_document` semantics. That tool already refuses `type="report"` (see its Zod schema). Out of scope.
+- `chorus_pm_update_document` semantics. "Edit existing report" stays as today.
+
+## API contract
+
+`chorus_create_report` accepts:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `proposalUuid` | string (UUID) | yes | unchanged |
+| `title` | string (1–200) | yes | unchanged |
+| `content` | string (≥1) | yes | unchanged |
+| `force` | boolean | no — default `false` | NEW. When `true`, bypass the duplicate-report check and always create a new report Document. |
+
+Success response (`force` defaulted, no prior report): unchanged — `{ documentUuid, projectUuid, version }` JSON in `content[0].text`, no `isError`.
+
+Success response (`force=true`, with or without prior report): identical shape; the new report is a separate row.
+
+Error response (`force` defaulted, prior report exists): `isError: true`, `content[0].text` is a short message that conveys two things — (1) a report already exists on this proposal, (2) pass `force` (or `force=true`) to bypass. Exact phrasing is the implementer's call; tests assert on the two semantic substrings (something like "report" + "force"), not on a verbatim string. No i18n layer here — the message can be in either language; UI rendering can wrap or translate as a separate concern.
+
+## Handler flow (post-change)
+
+1. `getProposalByUuid` — unchanged. Return "Proposal not found" if missing.
+2. `proposal.status === "approved"` check — unchanged. Return current message if not.
+3. **NEW** — if `force !== true`, call `documentService.listDocumentsByProposalUuids(auth.companyUuid, [proposalUuid], "report")`. If the returned array is non-empty, return the duplicate-rejected error (above). No Document is created.
+4. Otherwise (force=true OR no prior report): call `documentService.createDocument(...)` with `type="report"` exactly as today. `emitReportSideEffects` fires from inside `createDocument` for this row only — the SSE / notification fan-out is per-row, so users *do* get a fresh notification on each force=true write, which is correct.
+5. Return the documentUuid / projectUuid / version JSON exactly as today.
+
+`listDocumentsByProposalUuids` already exists (`src/services/document.service.ts:140`), already filters by `companyUuid` + `proposalUuid` + optional `type`, and is the canonical Idea-level read used by the report-realtime UI. Reusing it keeps the duplicate gate consistent with what users already see in the Idea Reports list.
+
+## Why service-layer query, not DB UNIQUE
+
+Two reasons in tension:
+
+1. Concurrency: report creation is single-actor, low-frequency (the agent firing it is the same agent whose previous tool call materialised the proposal). The realistic worst-case is two near-simultaneous calls in the same `/yolo` run; both reach the duplicate-check at the same time and both proceed. The probability is small and the cost (one extra row) matches today's status quo. A UNIQUE constraint would catch it deterministically — but at the cost of a DB migration the existing data wouldn't survive.
+2. Existing data: the production database already has multiple `type="report"` rows under several proposals. A UNIQUE constraint migration would fail on those rows, requiring a lossy data-cleanup migration. Not justifiable for a soft-policy decision.
+
+The application-level check is consistent with the rest of `public.ts` (e.g. proposal status, idempotency guards, AC checks). If usage patterns ever change such that duplicate races become real, escalating to a UNIQUE index is straightforward — the API contract doesn't change.
+
+## Description / inputSchema text
+
+Two surface points need updating so a calling agent learns the new behavior without reading the source.
+
+In the tool description (LLM-visible, currently a long template description):
+
+> Adds a paragraph near the top: *"By default this tool refuses to create a second report on a proposal that already has one — the call returns an error and writes nothing. Pass `force: true` only when intentionally authoring an additional report (e.g. after a major rework). The default-reject is the safe path; agent prompts and post-verify hooks may both attempt this call, and rejecting duplicates server-side keeps the Idea Reports list clean regardless of caller."*
+
+In the Zod schema for `force`:
+
+> `.describe("Default false. When false, calls against a proposal that already has a report return an error and create nothing. Set true only to deliberately add another report to the same proposal.")`
+
+Both surfaces match the canonical project pattern (see `chorus_pm_create_idea`, `chorus_pm_create_proposal` for example).
+
+## Test plan
+
+- **Unit** (`src/mcp/tools/__tests__/create-report.test.ts`): four cases.
+  1. `force` omitted, proposal has no prior report → success (existing happy-path stays green; the new check sees `[]` and proceeds to create).
+  2. `force` omitted, proposal has one prior report → `isError: true`, error text contains both a "report exists" signal and the literal substring `force`, `createDocument` not called.
+  3. `force=false` explicit, proposal has prior report → same as case 2 (treats explicit and default identically).
+  4. `force=true`, proposal has prior report → `createDocument` called once, success response.
+  5. `force=true`, proposal has no prior report → `createDocument` called, success (no regression for callers who always pass force=true).
+  6. Schema test: parse with extra `force: true` succeeds; parse with `force: "yes"` (string) fails.
+  7. Description / schema text assertions: description contains the new paragraph keyword (e.g. "force"), `force` field schema `_def.description` is non-empty.
+- **Integration** (`src/__tests__/integration/idea-completion-report.integration.test.ts`): one test exercising the real proposalService + documentService against the project's prisma mock — first `chorus_create_report` succeeds, second (default) fails with the expected text, third (force=true) succeeds and returns a *different* `documentUuid`. Asserts the post-state has exactly two report rows in DB.
+- **Regression**: `yolo-end-step-predicates.test.ts` is unchanged; its predicate truth table is purely client-side and oblivious to server force semantics. We assert it stays green by running it.
+
+## Risk surface
+
+- **Behavior change visible to existing automation.** `/yolo` Phase 5b will start seeing the error after the hook fires. This is the *desired* outcome and the change requester signed off on it. We don't modify the skill in this change because the error is recoverable — the agent reads it, understands "report already exists", and moves on; no Idea is left in a bad state. (A subsequent PR will tidy the skill text to short-circuit before the duplicate call, but is out of scope here.)
+- **Documentation skew.** `docs/MCP_TOOLS.md` is updated in the same change. `public/skill/chorus/SKILL.md` and `public/chorus-plugin/skills/chorus/SKILL.md` carry brief mentions of `chorus_create_report`; we audit those and refresh as needed (likely a single-sentence diff each).
+- **Test churn.** Existing happy-path assertions on `chorus_create_report` stay green because we add the duplicate check *only* when `force !== true` *and* a prior report exists. The pre-existing failure branches (`Proposal not found`, status table) trigger before the new branch — no reorder needed. Existing tests that hit the happy path will need their `documentService` mock to also stub `listDocumentsByProposalUuids` returning `[]`; this is a one-line shim per test, not a substantive change.
+
+## Migration
+
+None. No data migration, no schema change, no Prisma client regeneration.

--- a/openspec/changes/archive/2026-05-27-create-report-force-flag/proposal.md
+++ b/openspec/changes/archive/2026-05-27-create-report-force-flag/proposal.md
@@ -1,0 +1,45 @@
+# Add `force` flag to `chorus_create_report` — default to rejecting duplicate reports per proposal
+
+## Why
+
+Today `chorus_create_report` writes a `type="report"` Document on every call, with the explicit "multiple reports per proposal are by design" comment in `src/mcp/tools/public.ts:1099-1104`. In the field this is producing duplicate completion reports per Idea because the prompt-engineering layer fires the call from two independent triggers in a single `/yolo` run:
+
+1. The PostToolUse hook `on-post-verify-task.sh` Branch B injects an `ACTION REQUESTED: create idea-completion report` reminder after the last `chorus_admin_verify_task`. The hook is self-deduplicating — it skips on second fire — but it has no way to stop the agent that just received the reminder.
+2. The `/yolo` skill's Phase 5b carries an unconditional "always — skipping is a protocol violation" instruction with no preflight check.
+
+Both paths call the tool; the server happily writes both rows. Net result: the user sees two (or more) reports under one Idea / one proposal.
+
+The fix should put the "default rejects duplicates" decision on the **server**, not in skill text. PE files drift, hooks compose unpredictably with each other, and not every `chorus_create_report` caller will be Chorus-plugin-aware. A server-side guard is the only place that makes the duplicate impossible regardless of how the call arrived.
+
+## What Changes
+
+`chorus_create_report` accepts an optional `force: boolean` input field, defaulting to `false`. When `force` is unset or `false` and the target proposal already has at least one `Document` with `type="report"`, the tool returns an MCP error result (no Document created). The error message must clearly tell the caller two things: that a report already exists for this proposal, and that `force=true` is how to bypass the rejection. Exact wording is an implementation choice; tests assert on those two semantic pieces, not on a literal string.
+
+When `force=true` the existing behavior is preserved verbatim — multiple reports per proposal remain explicitly authorized for the rare case (re-author after a redo, generate a second cut for a separate audience, etc.).
+
+The implementation is **handler-only**: the duplicate check runs in the `chorus_create_report` registration in `src/mcp/tools/public.ts` against `documentService.listDocumentsByProposalUuids`. `documentService.createDocument` and `Document` Prisma schema are untouched. No data migration. The pre-existing report-realtime fan-out (`emitReportSideEffects`) is unaffected — when force=true, we reach `createDocument` exactly as today.
+
+The tool's user-visible description and Zod input schema both surface the new behavior so an agent reading the description discovers "default rejects duplicates" without needing to read the code.
+
+Tests: handler unit tests in `src/mcp/tools/__tests__/create-report.test.ts` plus end-to-end coverage in `src/__tests__/integration/idea-completion-report.integration.test.ts` to assert the second call fails by default and succeeds with `force=true`.
+
+`docs/MCP_TOOLS.md` is updated alongside.
+
+## Capabilities
+
+`create-report-force` (new) — captures the duplicate-rejection-by-default contract on `chorus_create_report`.
+
+This is a single-Requirement capability deliberately scoped narrowly. Three pre-existing capabilities were considered and rejected:
+
+- `idea-completion-report` is still in flight (the `add-idea-completion-report` change is unarchived); piggybacking on an unmaterialized capability creates archive ordering grief.
+- `mcp-tool-surface` documents tool **removals**; semantically the wrong home for new behavior on a kept tool.
+- `report-realtime` covers the post-create SSE / notification fan-out; the duplicate gate runs *before* create, on a different layer.
+
+## Impact
+
+- API surface (additive only): `chorus_create_report` gains an optional `force: boolean` parameter.
+- Behavior change: callers that today rely on the implicit "every call writes a row" semantics will start receiving an error on the second call against the same proposal. The two known callers in this repo are the `/yolo` skill (Phase 5b) and the `on-post-verify-task.sh` hook reminder; the fix is *intentionally* visible to both, since the duplicate is the bug. The skill text and hook reminder are not modified in this change — once force defaults to false, their duplicate-fire becomes a no-op error rather than a duplicate row, which is the desired containment.
+- Test surface: `create-report.test.ts` and `idea-completion-report.integration.test.ts` grow new cases. `yolo-end-step-predicates.test.ts` is unchanged (its predicate truth table doesn't depend on server-side behavior).
+- Docs: `docs/MCP_TOOLS.md` `chorus_create_report` entry adds the `force` row + the new error message.
+- No DB migration. No new Prisma model. No new dependency.
+- No CHANGELOG bump in this change — version bumps are aggregated at release time per the repo's existing release skill.

--- a/openspec/changes/archive/2026-05-27-create-report-force-flag/specs/create-report-force/spec.md
+++ b/openspec/changes/archive/2026-05-27-create-report-force-flag/specs/create-report-force/spec.md
@@ -1,0 +1,62 @@
+# create-report-force Specification
+
+## Purpose
+
+Define the duplicate-report rejection contract for the `chorus_create_report` MCP tool, gating the second-and-later calls per proposal behind an explicit `force=true` opt-in.
+
+## ADDED Requirements
+
+### Requirement: `chorus_create_report` SHALL reject duplicate calls per proposal by default
+
+The `chorus_create_report` MCP tool MUST accept an optional `force` boolean input field defaulting to `false`. When `force` is `false` (or omitted) and the target Proposal already has at least one `Document` with `type="report"` linked to it, the tool MUST return an MCP error result and MUST NOT create a new Document. The error result MUST set `isError: true` and the first text content MUST clearly indicate two things: (a) a report already exists for this proposal, and (b) `force=true` is the way to bypass the rejection. The exact wording is left to the implementation; the contract is on the two pieces of information being conveyed. When `force` is `true`, the tool MUST behave as it does today — create a new `type="report"` Document under the Proposal regardless of any pre-existing report Documents — preserving the current "multiple reports per proposal allowed" semantics for the explicit-opt-in case. The two pre-existing failure branches (`Proposal not found`, `Proposal status must be 'approved'`) MUST run before any duplicate check; they short-circuit independently of `force`.
+
+#### Scenario: First report on an approved proposal succeeds with default force
+
+- **GIVEN** an approved Proposal `P` with no `type="report"` Documents linked to it
+- **WHEN** an authenticated agent with `document:write` calls `chorus_create_report` with `proposalUuid = P.uuid`, a non-empty `title`, a non-empty Markdown `content`, and `force` omitted
+- **THEN** the tool MUST persist exactly one new `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **AND** the tool MUST return a success response carrying the new `documentUuid`, `projectUuid = P.projectUuid`, and `version`
+- **AND** `isError` MUST NOT be set on the response
+
+#### Scenario: Second report on the same proposal is rejected with a duplicate-report error when force is omitted
+
+- **GIVEN** an approved Proposal `P` that already has exactly one `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **WHEN** an authenticated agent with `document:write` calls `chorus_create_report` with `proposalUuid = P.uuid`, a non-empty `title`, a non-empty Markdown `content`, and `force` omitted
+- **THEN** the tool MUST NOT create any new `Document` row
+- **AND** the tool MUST return a response with `isError = true` whose first text content mentions both that a report already exists and that `force` is the parameter to bypass the rejection
+- **AND** no SSE event and no `report_created` Notification MUST be emitted by this rejected call
+
+#### Scenario: Second report on the same proposal is rejected when force is explicitly false
+
+- **GIVEN** an approved Proposal `P` that already has at least one `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **WHEN** an authenticated agent calls `chorus_create_report` with `proposalUuid = P.uuid`, valid `title` and `content`, and `force = false`
+- **THEN** the tool MUST behave identically to the omitted-force case — no Document is created and the response carries the same kind of duplicate-rejection error under `isError = true`
+
+#### Scenario: Second report succeeds when force is explicitly true
+
+- **GIVEN** an approved Proposal `P` that already has at least one `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **WHEN** an authenticated agent with `document:write` calls `chorus_create_report` with `proposalUuid = P.uuid`, valid `title` and `content`, and `force = true`
+- **THEN** the tool MUST persist a new `Document` with `type = "report"` and `proposalUuid = P.uuid` whose `documentUuid` differs from any existing report under `P`
+- **AND** the tool MUST return a success response carrying the new `documentUuid`, `projectUuid = P.projectUuid`, and `version`
+- **AND** the existing report-realtime fan-out (document/created event, idea/updated event when idea-rooted, and `report_created` Activity / Notification) MUST fire for this newly-created Document, identical to a first-report call
+
+#### Scenario: Force flag does not relax the proposal-status precondition
+
+- **GIVEN** a Proposal `P` whose `status` is one of `draft`, `pending`, `rejected`, or `closed`
+- **WHEN** an authenticated agent calls `chorus_create_report` with `proposalUuid = P.uuid`, valid `title` and `content`, and `force = true`
+- **THEN** the tool MUST return an error response containing the existing status-rejection message (mentioning the actual status) and MUST NOT create any Document
+- **AND** the duplicate-report check MUST NOT run (the status check short-circuits first)
+
+#### Scenario: Force flag does not relax the proposal-not-found precondition
+
+- **GIVEN** a `proposalUuid` that does not resolve to a Proposal in the calling agent's company
+- **WHEN** an authenticated agent calls `chorus_create_report` with that `proposalUuid`, valid `title` and `content`, and `force = true`
+- **THEN** the tool MUST return an error response containing `Proposal not found` and MUST NOT create any Document
+- **AND** the duplicate-report check MUST NOT run
+
+#### Scenario: Force flag does not relax the document:write permission gate
+
+- **GIVEN** an authenticated agent whose effective permission set does not include `document:write`
+- **WHEN** that agent attempts to call `chorus_create_report` with any combination of `proposalUuid`, `title`, `content`, and `force`
+- **THEN** the tool MUST NOT be registered against this agent's MCP server instance — the call surfaces as `Method not found` (the existing permission-map gating contract)
+- **AND** no Document is created and no error message about duplicates is leaked

--- a/openspec/specs/create-report-force/spec.md
+++ b/openspec/specs/create-report-force/spec.md
@@ -1,0 +1,60 @@
+# create-report-force Specification
+
+## Purpose
+TBD - created by archiving change create-report-force-flag. Update Purpose after archive.
+## Requirements
+### Requirement: `chorus_create_report` SHALL reject duplicate calls per proposal by default
+
+The `chorus_create_report` MCP tool MUST accept an optional `force` boolean input field defaulting to `false`. When `force` is `false` (or omitted) and the target Proposal already has at least one `Document` with `type="report"` linked to it, the tool MUST return an MCP error result and MUST NOT create a new Document. The error result MUST set `isError: true` and the first text content MUST clearly indicate two things: (a) a report already exists for this proposal, and (b) `force=true` is the way to bypass the rejection. The exact wording is left to the implementation; the contract is on the two pieces of information being conveyed. When `force` is `true`, the tool MUST behave as it does today — create a new `type="report"` Document under the Proposal regardless of any pre-existing report Documents — preserving the current "multiple reports per proposal allowed" semantics for the explicit-opt-in case. The two pre-existing failure branches (`Proposal not found`, `Proposal status must be 'approved'`) MUST run before any duplicate check; they short-circuit independently of `force`.
+
+#### Scenario: First report on an approved proposal succeeds with default force
+
+- **GIVEN** an approved Proposal `P` with no `type="report"` Documents linked to it
+- **WHEN** an authenticated agent with `document:write` calls `chorus_create_report` with `proposalUuid = P.uuid`, a non-empty `title`, a non-empty Markdown `content`, and `force` omitted
+- **THEN** the tool MUST persist exactly one new `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **AND** the tool MUST return a success response carrying the new `documentUuid`, `projectUuid = P.projectUuid`, and `version`
+- **AND** `isError` MUST NOT be set on the response
+
+#### Scenario: Second report on the same proposal is rejected with a duplicate-report error when force is omitted
+
+- **GIVEN** an approved Proposal `P` that already has exactly one `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **WHEN** an authenticated agent with `document:write` calls `chorus_create_report` with `proposalUuid = P.uuid`, a non-empty `title`, a non-empty Markdown `content`, and `force` omitted
+- **THEN** the tool MUST NOT create any new `Document` row
+- **AND** the tool MUST return a response with `isError = true` whose first text content mentions both that a report already exists and that `force` is the parameter to bypass the rejection
+- **AND** no SSE event and no `report_created` Notification MUST be emitted by this rejected call
+
+#### Scenario: Second report on the same proposal is rejected when force is explicitly false
+
+- **GIVEN** an approved Proposal `P` that already has at least one `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **WHEN** an authenticated agent calls `chorus_create_report` with `proposalUuid = P.uuid`, valid `title` and `content`, and `force = false`
+- **THEN** the tool MUST behave identically to the omitted-force case — no Document is created and the response carries the same kind of duplicate-rejection error under `isError = true`
+
+#### Scenario: Second report succeeds when force is explicitly true
+
+- **GIVEN** an approved Proposal `P` that already has at least one `Document` with `type = "report"` and `proposalUuid = P.uuid`
+- **WHEN** an authenticated agent with `document:write` calls `chorus_create_report` with `proposalUuid = P.uuid`, valid `title` and `content`, and `force = true`
+- **THEN** the tool MUST persist a new `Document` with `type = "report"` and `proposalUuid = P.uuid` whose `documentUuid` differs from any existing report under `P`
+- **AND** the tool MUST return a success response carrying the new `documentUuid`, `projectUuid = P.projectUuid`, and `version`
+- **AND** the existing report-realtime fan-out (document/created event, idea/updated event when idea-rooted, and `report_created` Activity / Notification) MUST fire for this newly-created Document, identical to a first-report call
+
+#### Scenario: Force flag does not relax the proposal-status precondition
+
+- **GIVEN** a Proposal `P` whose `status` is one of `draft`, `pending`, `rejected`, or `closed`
+- **WHEN** an authenticated agent calls `chorus_create_report` with `proposalUuid = P.uuid`, valid `title` and `content`, and `force = true`
+- **THEN** the tool MUST return an error response containing the existing status-rejection message (mentioning the actual status) and MUST NOT create any Document
+- **AND** the duplicate-report check MUST NOT run (the status check short-circuits first)
+
+#### Scenario: Force flag does not relax the proposal-not-found precondition
+
+- **GIVEN** a `proposalUuid` that does not resolve to a Proposal in the calling agent's company
+- **WHEN** an authenticated agent calls `chorus_create_report` with that `proposalUuid`, valid `title` and `content`, and `force = true`
+- **THEN** the tool MUST return an error response containing `Proposal not found` and MUST NOT create any Document
+- **AND** the duplicate-report check MUST NOT run
+
+#### Scenario: Force flag does not relax the document:write permission gate
+
+- **GIVEN** an authenticated agent whose effective permission set does not include `document:write`
+- **WHEN** that agent attempts to call `chorus_create_report` with any combination of `proposalUuid`, `title`, `content`, and `force`
+- **THEN** the tool MUST NOT be registered against this agent's MCP server instance — the call surfaces as `Method not found` (the existing permission-map gating contract)
+- **AND** no Document is created and no error message about duplicates is leaked
+

--- a/src/__tests__/integration/idea-completion-report.integration.test.ts
+++ b/src/__tests__/integration/idea-completion-report.integration.test.ts
@@ -477,3 +477,158 @@ describe("idea-completion-report end-to-end (AC #1)", () => {
     expect(store.documents.length).toBe(0);
   });
 });
+
+// End-to-end coverage of the duplicate-rejection gate (spec
+// `create-report-force`). Walks the same code path as the AC#1 happy-path
+// suite above but exercises the second-call-rejected and force-bypass
+// branches against the same in-memory Prisma store.
+describe("chorus_create_report duplicate-rejection gate (force flag)", () => {
+  it("first call with force omitted succeeds; exactly one report Document persists", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "First report",
+      content: REPORT_BODY,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0].text) as { documentUuid: string };
+    expect(payload.documentUuid).toBeTypeOf("string");
+
+    const reportRows = store.documents.filter(
+      (d) => d.type === "report" && d.proposalUuid === APPROVED_PROPOSAL_UUID,
+    );
+    expect(reportRows.length).toBe(1);
+    expect(reportRows[0].uuid).toBe(payload.documentUuid);
+  });
+
+  it("second call with force omitted is rejected (semantic substring match, not verbatim)", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    // First call seeds the prior report.
+    const firstResult = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "First report",
+      content: REPORT_BODY,
+    });
+    expect(firstResult.isError).toBeUndefined();
+
+    // Second call default-rejects.
+    const secondResult = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "Second report",
+      content: REPORT_BODY,
+    });
+
+    expect(secondResult.isError).toBe(true);
+    const text = secondResult.content[0].text.toLowerCase();
+    // Implementer's choice of wording — assert on two semantic substrings.
+    expect(text).toContain("force");
+    expect(text).toMatch(/report|already|exist/);
+
+    // No second row written.
+    const reportRows = store.documents.filter(
+      (d) => d.type === "report" && d.proposalUuid === APPROVED_PROPOSAL_UUID,
+    );
+    expect(reportRows.length).toBe(1);
+  });
+
+  it("explicit force=false matches the omitted-force behavior (rejected with semantic substrings)", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "First report",
+      content: REPORT_BODY,
+    });
+
+    const secondResult = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "Second report",
+      content: REPORT_BODY,
+      force: false,
+    });
+
+    expect(secondResult.isError).toBe(true);
+    const text = secondResult.content[0].text.toLowerCase();
+    expect(text).toContain("force");
+    expect(text).toMatch(/report|already|exist/);
+
+    const reportRows = store.documents.filter(
+      (d) => d.type === "report" && d.proposalUuid === APPROVED_PROPOSAL_UUID,
+    );
+    expect(reportRows.length).toBe(1);
+  });
+
+  it("force=true succeeds when a prior report exists; a second row is persisted with a different documentUuid", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    const firstResult = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "First report",
+      content: REPORT_BODY,
+    });
+    const firstUuid = JSON.parse(firstResult.content[0].text).documentUuid;
+
+    const secondResult = await tools["chorus_create_report"].handler({
+      proposalUuid: APPROVED_PROPOSAL_UUID,
+      title: "Second report (forced)",
+      content: REPORT_BODY,
+      force: true,
+    });
+
+    expect(secondResult.isError).toBeUndefined();
+    const secondUuid = JSON.parse(secondResult.content[0].text).documentUuid;
+    expect(secondUuid).not.toBe(firstUuid);
+
+    // Two report rows now under the proposal — both persisted, second is a
+    // new row, not an update of the first.
+    const reportRows = store.documents.filter(
+      (d) => d.type === "report" && d.proposalUuid === APPROVED_PROPOSAL_UUID,
+    );
+    expect(reportRows.length).toBe(2);
+    expect(new Set(reportRows.map((r) => r.uuid))).toEqual(
+      new Set([firstUuid, secondUuid]),
+    );
+
+    // The dashboard surfaces both reports under the same Idea (newest first
+    // — same ordering contract as the AC#1 multi-proposal aggregation test).
+    const action = await getReportsForIdeaAction(PROJECT_UUID, IDEA_UUID);
+    expect(action.success).toBe(true);
+    if (!action.success) return;
+    expect(action.data.length).toBe(2);
+  });
+
+  it("force=true on a fresh proposal still works (no regression for callers that always pass force=true)", async () => {
+    seedFinishedIdea();
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAgentAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      proposalUuid: SECOND_APPROVED_PROPOSAL_UUID,
+      title: "Solo forced report",
+      content: REPORT_BODY,
+      force: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const reportRows = store.documents.filter(
+      (d) => d.type === "report" && d.proposalUuid === SECOND_APPROVED_PROPOSAL_UUID,
+    );
+    expect(reportRows.length).toBe(1);
+  });
+});

--- a/src/mcp/tools/__tests__/create-report.test.ts
+++ b/src/mcp/tools/__tests__/create-report.test.ts
@@ -14,6 +14,7 @@ const mockProposalService = vi.hoisted(() => ({
 
 const mockDocumentService = vi.hoisted(() => ({
   createDocument: vi.fn(),
+  listDocumentsByProposalUuids: vi.fn(),
 }));
 
 const mockPrisma = vi.hoisted(() => ({
@@ -87,6 +88,10 @@ function makeAuth(permissions: string[]): AgentAuthContext {
 beforeEach(() => {
   vi.clearAllMocks();
   Object.keys(tools).forEach((k) => delete tools[k]);
+  // Default: no prior reports — keeps every happy-path test green under the
+  // new force-flag duplicate gate. Tests that exercise the duplicate branch
+  // override this with a non-empty mockResolvedValue.
+  mockDocumentService.listDocumentsByProposalUuids.mockResolvedValue([]);
 });
 
 // ============================================================
@@ -144,6 +149,9 @@ describe("chorus_create_report description (template constraint)", () => {
     expect(desc).toContain("Summary");
     expect(desc).toContain("Decisions");
     expect(desc).toContain("Follow-ups");
+    // Description must teach the agent about the default-reject duplicate
+    // behavior — pointing at `force: true` as the explicit opt-in.
+    expect(desc.toLowerCase()).toContain("force");
   });
 });
 
@@ -211,6 +219,68 @@ describe("chorus_create_report input schema (spec delta mcp-tool-surface)", () =
       // so we assert the parsed result has no `type` key surfaced to the handler.
     });
     expect((parsed as Record<string, unknown>).type).toBeUndefined();
+  });
+
+  it("accepts an optional force boolean (default false) and rejects non-boolean force values", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+    const schema = tools["chorus_create_report"].config.inputSchema as {
+      parse: (input: unknown) => { force?: unknown };
+    };
+
+    // Default: force omitted -> resolves to false after default-merge.
+    const parsedDefault = schema.parse({
+      proposalUuid: PROPOSAL_UUID,
+      title: "t",
+      content: "c",
+    });
+    expect((parsedDefault as Record<string, unknown>).force).toBe(false);
+
+    // Explicit force: true -> survives parse.
+    const parsedTrue = schema.parse({
+      proposalUuid: PROPOSAL_UUID,
+      title: "t",
+      content: "c",
+      force: true,
+    });
+    expect((parsedTrue as Record<string, unknown>).force).toBe(true);
+
+    // Explicit force: false -> survives parse.
+    const parsedFalse = schema.parse({
+      proposalUuid: PROPOSAL_UUID,
+      title: "t",
+      content: "c",
+      force: false,
+    });
+    expect((parsedFalse as Record<string, unknown>).force).toBe(false);
+
+    // String "yes" is not a boolean — Zod rejects it.
+    expect(() =>
+      schema.parse({
+        proposalUuid: PROPOSAL_UUID,
+        title: "t",
+        content: "c",
+        force: "yes",
+      })
+    ).toThrow();
+  });
+
+  it("force field carries a non-empty .describe text mentioning the duplicate-rejection contract", () => {
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+    // Zod v4 surfaces `.describe(...)` text via the top-level `.description`
+    // accessor on the schema itself (no _def lookup needed for v4).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const schema = tools["chorus_create_report"].config.inputSchema as any;
+    const forceField = schema.shape.force;
+    const description: string | undefined = forceField?.description;
+
+    expect(description).toBeTruthy();
+    expect((description ?? "").length).toBeGreaterThan(0);
+    // Field-level .describe explains the duplicate-rejection contract — the
+    // exact wording belongs to the implementer, but it must mention "report"
+    // (what's being rejected) so the contract is visible at the schema level.
+    expect((description ?? "").toLowerCase()).toContain("report");
   });
 });
 
@@ -350,5 +420,166 @@ describe("chorus_create_report handler", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain(`'${status}'`);
     expect(mockDocumentService.createDocument).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================
+// Duplicate-report gate (force flag, spec `create-report-force`)
+// ============================================================
+
+describe("chorus_create_report duplicate-report gate (force flag)", () => {
+  const approvedProposal = {
+    uuid: PROPOSAL_UUID,
+    projectUuid: PROJECT_UUID,
+    companyUuid: COMPANY_UUID,
+    status: "approved",
+  };
+
+  const successfulCreate = {
+    uuid: DOC_UUID,
+    type: "report",
+    title: "Idea X — completion report",
+    content: "## Summary\nbody\n",
+    version: 1,
+    proposalUuid: PROPOSAL_UUID,
+    createdBy: { type: "agent", uuid: ACTOR_UUID, name: "Test Agent" },
+    createdAt: new Date("2026-05-25T00:00:00Z").toISOString(),
+    updatedAt: new Date("2026-05-25T00:00:00Z").toISOString(),
+  };
+
+  const validInput = {
+    proposalUuid: PROPOSAL_UUID,
+    title: "Idea X — completion report",
+    content:
+      "## Summary\nbody\n\n## Decisions\n- A.\n\n## Follow-ups\nNone.\n",
+  };
+
+  it("force omitted, no prior report -> success; listDocumentsByProposalUuids checked once with (companyUuid, [proposalUuid], 'report')", async () => {
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposal);
+    mockDocumentService.listDocumentsByProposalUuids.mockResolvedValue([]);
+    mockDocumentService.createDocument.mockResolvedValue(successfulCreate);
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler(validInput);
+
+    expect(result.isError).toBeUndefined();
+    expect(mockDocumentService.listDocumentsByProposalUuids).toHaveBeenCalledTimes(1);
+    expect(mockDocumentService.listDocumentsByProposalUuids).toHaveBeenCalledWith(
+      COMPANY_UUID,
+      [PROPOSAL_UUID],
+      "report"
+    );
+    expect(mockDocumentService.createDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it("force omitted, prior report exists -> isError, message conveys 'report' + 'force'; createDocument NOT called", async () => {
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposal);
+    mockDocumentService.listDocumentsByProposalUuids.mockResolvedValue([
+      {
+        uuid: "prior-report-uuid",
+        type: "report",
+        title: "Earlier report",
+        proposalUuid: PROPOSAL_UUID,
+        version: 1,
+        createdBy: null,
+        createdAt: new Date("2026-05-20T00:00:00Z").toISOString(),
+        updatedAt: new Date("2026-05-20T00:00:00Z").toISOString(),
+      },
+    ]);
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler(validInput);
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text.toLowerCase();
+    // Implementer's choice of wording — assert on two semantic substrings.
+    expect(text).toContain("force");
+    expect(text).toMatch(/report|already|exist/);
+    expect(mockDocumentService.createDocument).not.toHaveBeenCalled();
+  });
+
+  it("force=false explicit, prior report exists -> behaves identically to omitted force", async () => {
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposal);
+    mockDocumentService.listDocumentsByProposalUuids.mockResolvedValue([
+      {
+        uuid: "prior-report-uuid",
+        type: "report",
+        title: "Earlier report",
+        proposalUuid: PROPOSAL_UUID,
+        version: 1,
+        createdBy: null,
+        createdAt: new Date("2026-05-20T00:00:00Z").toISOString(),
+        updatedAt: new Date("2026-05-20T00:00:00Z").toISOString(),
+      },
+    ]);
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      ...validInput,
+      force: false,
+    });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text.toLowerCase();
+    expect(text).toContain("force");
+    expect(text).toMatch(/report|already|exist/);
+    expect(mockDocumentService.createDocument).not.toHaveBeenCalled();
+  });
+
+  it("force=true, prior report exists -> createDocument called once, success", async () => {
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposal);
+    mockDocumentService.listDocumentsByProposalUuids.mockResolvedValue([
+      {
+        uuid: "prior-report-uuid",
+        type: "report",
+        title: "Earlier report",
+        proposalUuid: PROPOSAL_UUID,
+        version: 1,
+        createdBy: null,
+        createdAt: new Date("2026-05-20T00:00:00Z").toISOString(),
+        updatedAt: new Date("2026-05-20T00:00:00Z").toISOString(),
+      },
+    ]);
+    mockDocumentService.createDocument.mockResolvedValue(successfulCreate);
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      ...validInput,
+      force: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockDocumentService.createDocument).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toEqual({
+      documentUuid: DOC_UUID,
+      projectUuid: PROJECT_UUID,
+      version: 1,
+    });
+  });
+
+  it("force=true, no prior report -> createDocument called once, success (no regression for always-force callers)", async () => {
+    mockProposalService.getProposalByUuid.mockResolvedValue(approvedProposal);
+    mockDocumentService.listDocumentsByProposalUuids.mockResolvedValue([]);
+    mockDocumentService.createDocument.mockResolvedValue(successfulCreate);
+
+    const server = makeServer();
+    registerPublicTools(server as never, makeAuth(["document:write"]));
+
+    const result = await tools["chorus_create_report"].handler({
+      ...validInput,
+      force: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockDocumentService.createDocument).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -1075,7 +1075,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     "chorus_create_report",
     {
       description:
-        "Persist an idea-completion summary as a Document (type=\"report\") under the given Proposal. Call once, at end-of-Idea, after the last task verifies. This is a summary, not a detailed write-up — keep it short.\n\n" +
+        "Persist an idea-completion summary as a Document (type=\"report\") under the given Proposal. Only write a report once every Task in the Proposal is complete. By default a proposal already carrying a report rejects further calls — pass `force: true` to add another deliberately. Keep it short — this is a summary, not a write-up.\n\n" +
         "Markdown `content` MUST use these three sections in this order:\n\n" +
         "## Summary\n" +
         "1-3 sentences on what shipped. Plain prose. No bullet lists here.\n\n" +
@@ -1088,25 +1088,49 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         proposalUuid: z.string().uuid().describe("Proposal UUID whose tasks have all reached a terminal state"),
         title: z.string().min(1).max(200).describe("Report title (e.g. 'Idea X — completion report')"),
         content: z.string().min(1).describe("Markdown body — Summary / Decisions / Follow-ups"),
+        force: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Default false. When false, calls against a proposal that already has a report return an error and create nothing. Set true only to deliberately add another report to the same proposal."
+          ),
       }),
     },
-    async ({ proposalUuid, title, content }) => {
+    async ({ proposalUuid, title, content, force }) => {
       const proposal = await proposalService.getProposalByUuid(auth.companyUuid, proposalUuid);
       if (!proposal) {
         return { content: [{ type: "text", text: "Proposal not found" }], isError: true };
       }
 
-      // A completion report only makes sense once the proposal's drafts have
-      // materialized into real Tasks. Reject draft / pending / rejected /
-      // closed states explicitly so a misfiring agent can't write reports
-      // under unmaterialized or revoked proposals. Re-authoring a report on
-      // an approved proposal is allowed — multiple reports per proposal are
-      // by design (see proposal.md Q4).
       if (proposal.status !== "approved") {
         return {
           content: [{ type: "text", text: `Proposal status must be 'approved' to author a completion report (got '${proposal.status}')` }],
           isError: true,
         };
+      }
+
+      // Duplicate-report gate. By default a proposal carries at most one
+      // type="report" Document — see spec `create-report-force`. Callers that
+      // genuinely want a second report (re-author after a redo, separate-audience
+      // cut) opt in via force=true.
+      if (force !== true) {
+        const existingReports = await documentService.listDocumentsByProposalUuids(
+          auth.companyUuid,
+          [proposalUuid],
+          "report"
+        );
+        if (existingReports.length > 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "A report already exists for this proposal. Pass force=true to add another report to the same proposal.",
+              },
+            ],
+            isError: true,
+          };
+        }
       }
 
       const document = await documentService.createDocument({


### PR DESCRIPTION
## Summary

- Adds optional `force: boolean` (default `false`) to the `chorus_create_report` MCP tool. When omitted or false against a proposal that already has a `type="report"` Document, the tool returns an MCP error and creates nothing. `force=true` preserves the prior multi-report semantics.
- Closes a duplicate-completion-report bug observed in `/yolo` runs: the PostToolUse hook reminder and the skill's Phase 5b "always" instruction both fire `chorus_create_report` against the same proposal, and the server happily writes both rows. The fix puts the policy decision on the server.
- OpenSpec change `create-report-force-flag` archived; new capability `create-report-force` added under `openspec/specs/`.
- Reused `documentService.listDocumentsByProposalUuids` for the gate — no DB schema change, no migration.

## Changed files

| File | Change |
|------|--------|
| `src/mcp/tools/public.ts` | Added `force` Zod field; new duplicate-report gate after the proposal-status check; tool description updated to mention "only write a report once every Task is complete" + the force opt-in. |
| `src/mcp/tools/__tests__/create-report.test.ts` | Added `listDocumentsByProposalUuids` to mock; default `mockResolvedValue([])` in `beforeEach` to keep happy-path tests green; added 5 force-flag handler cases + schema test + .describe assertion. |
| `src/__tests__/integration/idea-completion-report.integration.test.ts` | Added a 5-test describe block "duplicate-rejection gate (force flag)" exercising the full code path against the in-memory Prisma store. |
| `docs/MCP_TOOLS.md` | Added `force` row to the parameter table; replaced the stale "multiple reports per Proposal are allowed by design" sentence with a paragraph explaining default-reject + force=true opt-in. |
| `openspec/specs/create-report-force/spec.md` | New capability spec with 7 scenarios. |
| `openspec/changes/archive/2026-05-27-create-report-force-flag/` | Archived in-flight change (proposal / design / spec). |

## Behavior change

Existing callers that today rely on the implicit "every call writes a row" semantics will start receiving an error on the second call against the same proposal. The two known callers in this repo are `/yolo` Phase 5b and the `on-post-verify-task.sh` Branch B reminder; the error is recoverable (no bad state), and the duplicate is the bug. Skill PE clean-up to short-circuit before the duplicate call is tracked as a follow-up.

The error message is:

> `A report already exists for this proposal. Pass force=true to add another report to the same proposal.`

Tests assert on two semantic substrings (`force` + duplicate-existence signal) rather than pinning a verbatim string, so a future wording change does not break the suite.

## Test plan

- [x] `pnpm test src/mcp/tools/__tests__/create-report.test.ts` → 22/22 passing
- [x] `pnpm test src/__tests__/integration/idea-completion-report.integration.test.ts` → 10/10 passing
- [x] `pnpm test` (full suite) → 1677 passed / 1 skipped / 0 failed
- [x] `pnpm lint src/mcp/tools/public.ts src/mcp/tools/__tests__/create-report.test.ts src/__tests__/integration/idea-completion-report.integration.test.ts` → 0 errors
- [x] `npx tsc --noEmit` → clean
- [x] End-to-end smoke test against local Chorus: first call (force omitted) succeeds → second call (force omitted) rejected with the expected message → third call (force=true) succeeds and writes a distinct documentUuid

## Out of scope

- Skill workflow text fixes (`/yolo` Phase 5b, `/develop` Step 11) — server-side guard makes those paths self-correct on duplicates; PE clean-up is a separate work item.
- `on-post-verify-task.sh` Branch B is already idempotent and remains correct.
- No CHANGELOG bump in this PR — version bumps are aggregated at release time per the repo's existing release skill.

Generated with [Claude Code](https://claude.com/claude-code)