### PR TITLE
fix(ui): wrap long notification content within the dropdown boundary

### DIFF
--- a/src/components/notification-popup.tsx
+++ b/src/components/notification-popup.tsx
@@ -267,24 +267,29 @@ export function NotificationPopup({ onClose }: NotificationPopupProps) {
 
         {/* Content */}
         <div className="min-w-0 flex-1">
-          {/* Project badge */}
+          {/* Project badge — block + max-w-full + wrapping so a long project
+              name folds onto multiple lines within the dropdown instead of
+              forcing the badge past the max-w-[360px] boundary. Override the
+              badge base `whitespace-nowrap` with `whitespace-normal`. */}
           <Badge
             variant="secondary"
-            className={`mb-1 px-1.5 py-0 text-[10px] font-medium ${projectColor.bg} ${projectColor.text} border-0`}
+            className={`mb-1 block h-auto max-w-full whitespace-normal break-words px-1.5 py-0 text-[10px] font-medium ${projectColor.bg} ${projectColor.text} border-0`}
           >
             {notification.projectName}
           </Badge>
 
-          {/* Title + action */}
-          <div className="text-[13px] font-medium text-foreground truncate">
+          {/* Title + action — wrap long content onto multiple lines instead
+              of overflowing the dropdown horizontally */}
+          <div className="text-[13px] font-medium text-foreground break-words">
             {notification.entityTitle}
           </div>
-          <div className="text-[12px] text-muted-foreground truncate">
+          <div className="text-[12px] text-muted-foreground break-words">
             {t(`types.${notification.action}` as Parameters<typeof t>[0])}
           </div>
 
-          {/* Actor + time */}
-          <div className="mt-0.5 text-[11px] text-muted-foreground">
+          {/* Actor + time — wrap so a long actor name does not overflow
+              the dropdown horizontally */}
+          <div className="mt-0.5 text-[11px] text-muted-foreground break-words">
             {notification.actorName} &middot; {relativeTime(notification.createdAt)}
           </div>
         </div>
@@ -365,7 +370,7 @@ export function NotificationPopup({ onClose }: NotificationPopupProps) {
             animate={{ opacity: 1 }}
             transition={{ duration: 0.15 }}
           >
-            <ScrollArea className="max-h-[400px] overflow-y-auto">
+            <ScrollArea className="max-h-[400px] overflow-y-auto [&_[data-slot=scroll-area-viewport]>div]:!block">
               {renderList(allNotifications, false, allTotal)}
             </ScrollArea>
           </motion.div>
@@ -378,7 +383,7 @@ export function NotificationPopup({ onClose }: NotificationPopupProps) {
             animate={{ opacity: 1 }}
             transition={{ duration: 0.15 }}
           >
-            <ScrollArea className="max-h-[400px] overflow-y-auto">
+            <ScrollArea className="max-h-[400px] overflow-y-auto [&_[data-slot=scroll-area-viewport]>div]:!block">
               {renderList(unreadNotifications, true, unreadTotal)}
             </ScrollArea>
           </motion.div>


### PR DESCRIPTION
## Summary
- Fixes a bug where notifications with very long project names, titles, or actor names overflowed the notification dropdown and were clipped off-screen, becoming invisible.
- Long content now **wraps onto multiple lines** within the dropdown instead of escaping the boundary.

## Root cause
Radix `ScrollArea`'s internal Viewport wraps its children in a `<div style="display:table; min-width:100%">`. A `display:table` box grows to its content's intrinsic width (~838px), far past the 360px popup. The viewport's `overflow-x:hidden` then clipped the overgrown content off-screen. Text-level wrapping never fired because no ancestor was actually bounded to the popup width.

## Changes
| File | Change |
|------|--------|
| `src/components/notification-popup.tsx` | Add `[&_[data-slot=scroll-area-viewport]>div]:!block` to both ScrollAreas (the existing repo idiom, used by 5 sibling panels) to bound the content column; switch badge/title/action/actor lines to `break-words` (badge also `block max-w-full whitespace-normal` to override the Badge base `whitespace-nowrap`/`w-fit`) so long content wraps. |

Tailwind/className-only; no new dependencies.

## Test plan
- [x] `npx tsc --noEmit` — exit 0
- [x] `npx eslint src/components/notification-popup.tsx` — clean
- [x] `pnpm test src/components/__tests__/notification-popup.test.tsx` — 2/2 pass
- [x] Manual: Playwright DOM measurement on the running app with extreme long strings — popup `scrollWidth` no longer overflows; badge/title/actor wrap to multiple lines and stay within the 360px column; screenshot confirmed
- [x] Independent task-reviewer agent: VERDICT PASS (validated `twMerge` precedence + live DOM probe)

Generated with [Claude Code](https://claude.com/claude-code)