### PR TITLE
fix(ui): make @-mention popup clickable inside modal dialogs

### DIFF
--- a/src/components/mention-editor.tsx
+++ b/src/components/mention-editor.tsx
@@ -308,6 +308,7 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
     const suggestionItemsRef = useRef<Mentionable[]>([]);
     const suggestionLoadingRef = useRef(false);
     const keyDownRef = useRef<KeyDownHandler | null>(null);
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
     const popupRef = useRef<HTMLDivElement | null>(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const currentCommandRef = useRef<((attrs: any) => void) | null>(null);
@@ -406,7 +407,18 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
                     }
                   }
 
-                  document.body.appendChild(popup);
+                  // Mount inside the editor wrapper (not document.body) so the
+                  // popup lives within the same DOM subtree as the editor. When
+                  // the editor is hosted inside a modal Radix Dialog (e.g. the
+                  // proposal comments Sheet), the dialog sets
+                  // `pointer-events: none` on <body> and treats clicks outside
+                  // its subtree as "interact outside" dismissals. A body-level
+                  // popup would inherit the disabled pointer-events (clicks dead)
+                  // and would dismiss the dialog on click. Keeping it inside the
+                  // wrapper inherits `pointer-events: auto` and is recognized as
+                  // inside the dialog. `position: fixed` still positions it
+                  // against the viewport so it escapes any overflow clipping.
+                  (wrapperRef.current ?? document.body).appendChild(popup);
 
                   createSuggestionPopupRenderer(
                     suggestionItemsRef.current,
@@ -528,6 +540,7 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
 
     return (
       <div
+        ref={wrapperRef}
         className={cn(
           "relative rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow]",
           "focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]",


### PR DESCRIPTION
## Summary
- The `@`-mention suggestion popup in the comment editor could be navigated with the keyboard but **not clicked with the mouse** when the editor lived inside a modal Radix Dialog — most visibly the proposal comments `Sheet` sidebar.
- Root cause: the popup was appended to `document.body`. A modal Radix Dialog sets `pointer-events: none` on `<body>` and re-enables pointer events only within its own subtree. A body-level popup inherited `pointer-events: none` (clicks dead), and was also treated as an "interact outside" target, which would dismiss the dialog on click.
- Fix: mount the popup inside the editor's own wrapper (a descendant of the dialog content). It then inherits `pointer-events: auto` and is recognized as inside the dialog. `position: fixed` still positions it against the viewport, so it keeps escaping any overflow clipping for the non-dialog mount points (idea/task detail panels, inline comments).

## Why keyboard worked but mouse didn't
Arrow/Enter navigation routes through the Tiptap suggestion `onKeyDown` handler, which never touches DOM hit-testing. Mouse clicks rely on hit-testing, which `pointer-events: none` skips.

## Changed files
| File | Change |
|------|--------|
| `src/components/mention-editor.tsx` | Append the suggestion popup to the editor wrapper (`wrapperRef`) instead of `document.body`; add a `wrapperRef` and wire it to the root container. |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `eslint src/components/mention-editor.tsx` clean
- [x] Manually verified: `@`-mention items are now clickable with the mouse inside the proposal comments sidebar, and clicking no longer closes the Sheet.

Generated with [Claude Code](https://claude.com/claude-code)