### PR TITLE
feat(mcp): require non-empty acceptance criteria on task create/edit tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/.claude/skills/plugin-maintenance/SKILL.md
+++ b/.claude/skills/plugin-maintenance/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: plugin-maintenance
-description: Guide for modifying the Chorus plugin (Claude Code + Codex ports), updating skill documentation, and releasing new plugin versions.
+description: Guide for modifying the Chorus plugin (Claude Code + Codex + OpenClaw ports), updating skill documentation, and releasing new plugin versions.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.2.0"
+  version: "0.3.0"
   category: development
 ---
 
 # Chorus Plugin & Skill Maintenance
 
-How to modify the Chorus plugin, update skill documentation, and release new versions. **Two plugin packages** are maintained in parallel — Claude Code and Codex — plus the standalone skill surface.
+How to modify the Chorus plugin, update skill documentation, and release new versions. **Three plugin packages** are maintained in parallel — Claude Code, Codex, and OpenClaw — plus the standalone skill surface. That is **four skill surfaces total**; when you change skill content, sweep all four (see [Skill Content Changes — Four Surfaces](#skill-content-changes--four-surfaces)).
 
 ## File Structure
 
@@ -46,42 +46,64 @@ plugins/chorus/                 ← Codex plugin package (separate from Claude C
     chorus-proposal-reviewer/SKILL.md  ← Reviewers as skills in Codex (no agents/)
     chorus-task-reviewer/SKILL.md
 
+packages/openclaw-plugin/       ← OpenClaw plugin package (TS runtime + skills)
+  openclaw.plugin.json          ← Plugin manifest (id, skills dir, activation, configSchema) — NO version field
+  package.json                  ← npm package (version here; `openclaw` block: extensions, runtimeExtensions, install/compat)
+  src/                          ← TypeScript runtime (index.ts, mcp-client.ts, sse-listener.ts, event-router.ts, wake.ts)
+                                  — real-time SSE event bridge + MCP registration; NOT bash hooks
+  dist/                         ← Compiled JS (npm install loads this; linked install loads src/ via jiti)
+  skills/
+    chorus/SKILL.md             ← OpenClaw port — tools namespaced `chorus__<tool>`, inline OpenSpec detection
+    develop/ idea/ proposal/ quick-dev/ review/ yolo/ brainstorm/ openspec-aware/SKILL.md
+    proposal-reviewer/SKILL.md  ← Reviewers as skills (like Codex, no agents/)
+    task-reviewer/SKILL.md
+
 public/skill/                   ← Standalone skill (any MCP-compatible agent)
   chorus/SKILL.md               ← Same structure, softer language, IDE-agnostic
   proposal-chorus/SKILL.md
   quick-dev-chorus/SKILL.md
 ```
 
-### Claude Code vs Codex plugin: key differences
+### Claude Code vs Codex vs OpenClaw plugin: key differences
 
-| Aspect | `public/chorus-plugin/` (Claude Code) | `plugins/chorus/` (Codex) |
-|--------|---------------------------------------|---------------------------|
-| Skill invocation | `/chorus:develop` etc. | `$develop`, `$yolo` (no namespace) |
-| MCP config | `.mcp.json` | `~/.codex/config.toml` with `[mcp_servers.chorus.http_headers]` |
-| Session lifecycle | Auto-managed via SubagentStart/Stop hooks | **Stateless** — main agent manages sessions manually |
-| Reviewers | `agents/*.md` + spawned via Task tool | Skills mounted into `agent_type="default"` via `spawn_agent` + `items` |
-| Hook scripts | `bin/` — use `"$API" state-set` to persist data between hooks | `hooks/` — no persistence, each hook is self-contained |
-| Role/permission state | `on-session-start.sh` caches `agent_permissions`, read by `on-subagent-stop.sh` | Not cached — Codex has no subagent events so there's nowhere to read it from |
+| Aspect | `public/chorus-plugin/` (Claude Code) | `plugins/chorus/` (Codex) | `packages/openclaw-plugin/` (OpenClaw) |
+|--------|---------------------------------------|---------------------------|----------------------------------------|
+| Skill invocation | `/chorus:develop` etc. | `$develop`, `$yolo` (no namespace) | `/develop` etc. |
+| Tool names | `chorus_<tool>` | `chorus_<tool>` | **`chorus__<tool>`** (double-underscore prefix from the MCP server registration) |
+| MCP config | `.mcp.json` | `~/.codex/config.toml` with `[mcp_servers.chorus.http_headers]` | Plugin config (`chorusUrl` + `apiKey` via `configSchema`); the TS runtime registers MCP itself |
+| Session lifecycle | Auto-managed via SubagentStart/Stop hooks | **Stateless** — main agent manages sessions manually | **Manual** — no SubagentStart hook; main agent manages sessions |
+| Reviewers | `agents/*.md` + spawned via Task tool | Skills mounted into `agent_type="default"` via `spawn_agent` + `items` | `proposal-reviewer/` & `task-reviewer/` skills, spawned via `sessions_spawn` (read-only self-review fallback) |
+| User interaction | `AskUserQuestion` (MUST use) | plain-text prompt | **plain-text prompt** — no `AskUserQuestion` primitive |
+| OpenSpec detection | `CHORUS_OPENSPEC_ACTIVE` precomputed by SessionStart hook | precomputed by SessionStart hook | **inline** — run the §1 three-check detection yourself every time (no SessionStart hook) |
+| "Hooks" | `bin/*.sh` (bash, stateful) | `hooks/*.sh` (bash, stateless) | **No bash hooks** — real-time behavior is a **TypeScript SSE runtime** in `src/` (`sse-listener.ts`, `event-router.ts`, `wake.ts`) |
+| Task execution (yolo) | Wave-based Agent Teams (`TeamCreate`) | Sequential / `spawn_agent` | Sequential main-agent waves (no Agent Teams primitive) |
 
-When porting a Claude-Code change to Codex (or vice versa), preserve these intentional differences. Don't add state files to the Codex plugin and don't use `$`-prefix in Claude Code docs.
+When porting a change between plugins, preserve these intentional differences. Don't add state files to the Codex/OpenClaw plugins, don't use `$`-prefix in Claude Code/OpenClaw docs, and in OpenClaw docs keep the `chorus__` tool-name note and the "sessions are manual / detection is inline / prompts are plain-text" phrasing.
 
 ## When to Update What
 
+"All three plugin `chorus/SKILL.md`" = Claude Code + Codex + OpenClaw. "All four surfaces" additionally includes standalone `public/skill/`.
+
 | Change | Files to update |
 |--------|----------------|
-| New MCP tool added | `src/mcp/tools/*.ts` (implementation) + `docs/MCP_TOOLS.md` + both plugin `chorus/SKILL.md` files + standalone `public/skill/chorus/SKILL.md` |
+| New MCP tool added | `src/mcp/tools/*.ts` (implementation) + `docs/MCP_TOOLS.md` + all three plugin `chorus/SKILL.md` files + standalone `public/skill/chorus/SKILL.md` |
 | MCP tool description changed | `src/mcp/tools/*.ts` only (skill docs reference tool names, not descriptions) |
-| New workflow step | Both plugin stage-specific `SKILL.md` (e.g. `develop/`, `proposal/`) + standalone equivalent |
-| New Idea/Task status | Both plugin `chorus/SKILL.md` lifecycle diagrams + standalone `SKILL.md` + `messages/en.json` + `messages/zh.json` |
-| New execution rule | Both plugin `chorus/SKILL.md` execution rules + standalone `SKILL.md` (softer wording) |
-| Permission model change | Both plugin `chorus/SKILL.md` permission tables + `yolo/SKILL.md` prereq check + `quick-dev/SKILL.md` admin-verify check + all role-based checks in hook scripts (only Claude Code hooks need edits — Codex hooks are stateless) |
-| Hook script change (Claude Code) | `public/chorus-plugin/bin/*.sh` + `hooks.json` if new hook. **Never copy hook changes blindly into `plugins/chorus/hooks/`** — Codex hooks are intentionally stateless and lack subagent events. |
+| Skill content / wording (e.g. AC now required) | The matching stage skill in **all four surfaces** (see [Skill Content Changes — Four Surfaces](#skill-content-changes--four-surfaces)) |
+| New workflow step | All three plugin stage-specific `SKILL.md` (e.g. `develop/`, `proposal/`) + standalone equivalent |
+| New Idea/Task status | All three plugin `chorus/SKILL.md` lifecycle diagrams + standalone `SKILL.md` + `messages/en.json` + `messages/zh.json` |
+| New execution rule | All three plugin `chorus/SKILL.md` execution rules + standalone `SKILL.md` (softer wording) |
+| Permission model change | All three plugin `chorus/SKILL.md` permission tables + `yolo/SKILL.md` prereq check + `quick-dev/SKILL.md` admin-verify check + role-based checks in Claude Code hook scripts (Codex hooks stateless; OpenClaw has no bash hooks) |
+| Hook script change (Claude Code) | `public/chorus-plugin/bin/*.sh` + `hooks.json` if new hook. **Never copy hook changes blindly into `plugins/chorus/hooks/`** — Codex hooks are intentionally stateless and lack subagent events. OpenClaw has no bash hooks at all. |
 | Hook script change (Codex) | `plugins/chorus/hooks/*.sh` — rarely needed; session-start, post-submit-proposal, post-submit-for-verify are the only three. If bumping plugin version, also update the hardcoded `clientInfo.version` in `chorus-mcp-call.sh`. |
-| Any plugin change | Bump version in every file below |
+| OpenClaw runtime change | `packages/openclaw-plugin/src/*.ts` (TS SSE/MCP runtime) + `npm run typecheck` + `npm run test`. Not bash hooks — this is a compiled TypeScript extension. |
+| Any plugin change | Bump version in every file for that package (see Version Bump Checklist) |
 
 ## Version Bump Checklist
 
-Every time **either** plugin package changes, bump the version in **all** of that package's locations. The Claude Code plugin and the Codex plugin share a version sequence (both bump together when they ship the same feature), but they're independent files — you must edit each one.
+Every time **any** plugin package changes, bump the version in **all** of that package's locations. There are two version sequences in play:
+
+- **Skill-frontmatter sequence** (currently `0.9.x`) — shared by the skill `SKILL.md` files across **all three** plugins. When the same skill content ships to multiple plugins, bump them together.
+- **Per-package plugin sequences** — Claude Code + Codex share one (`marketplace.json` / both `plugin.json`, currently `0.9.x`); OpenClaw's `package.json` has its **own** sequence (currently `0.5.x`). These are independent files — edit each.
 
 ### Claude Code plugin — bump together
 1. `.claude-plugin/marketplace.json` — `"version": "X.Y.Z"`
@@ -93,8 +115,13 @@ Every time **either** plugin package changes, bump the version in **all** of tha
 5. Every skill under `plugins/chorus/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (or flat `version:` for `quick-dev/`). **Don't forget the two reviewer skills**: `chorus-proposal-reviewer/SKILL.md` and `chorus-task-reviewer/SKILL.md`.
 6. `plugins/chorus/hooks/chorus-mcp-call.sh` — hardcoded `clientInfo.version` string in the JSON-RPC `initialize` payload
 
+### OpenClaw plugin — bump together
+7. `packages/openclaw-plugin/package.json` — `"version": "X.Y.Z"` using OpenClaw's **own** sequence (`0.5.x`), NOT the skill sequence. `openclaw.plugin.json` has **no** version field — nothing to edit there.
+8. Every skill under `packages/openclaw-plugin/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` on the **skill sequence** (`0.9.x`, matching the other plugins' skills). Includes the two reviewer skills `proposal-reviewer/SKILL.md` and `task-reviewer/SKILL.md`.
+   - **Do NOT** touch `src/mcp-client.ts`'s `clientInfo.version` (`0.1.0`) — it is a static MCP client identifier, not the plugin version.
+
 ### Standalone skills — independent versioning
-7. `public/skill/*/SKILL.md` — bump only the standalone skills that changed, using their own version sequence (do NOT sync to the plugin version)
+9. `public/skill/*/SKILL.md` — bump only the standalone skills that changed, using their own version sequence (`0.3.x`; do NOT sync to the plugin version)
 
 Quick way to check all versions:
 ```bash
@@ -105,6 +132,8 @@ grep -rn '"version"\|^  version:\|^version:' \
   plugins/chorus/.codex-plugin/plugin.json \
   plugins/chorus/skills/*/SKILL.md \
   plugins/chorus/hooks/chorus-mcp-call.sh \
+  packages/openclaw-plugin/package.json \
+  packages/openclaw-plugin/skills/*/SKILL.md \
   public/skill/*/SKILL.md
 ```
 
@@ -112,16 +141,39 @@ Users update via:
 ```bash
 /plugin update chorus@chorus-plugins           # Claude Code
 codex plugin update chorus@chorus-plugins      # Codex
+# OpenClaw: reinstall/update via the OpenClaw plugin manager (npm spec @chorus-aidlc/chorus-openclaw-plugin)
 ```
+
+## Skill Content Changes — Four Surfaces
+
+Chorus skill content (workflow steps, tool guidance, wording like "AC is required") lives in **four parallel surfaces**. A content change must sweep all four — missing one ships inconsistent docs, and the Codex/OpenClaw `proposal` skill historically still carried a legacy example that a behavior change can silently break (e.g. the old `acceptanceCriteria` Markdown-string draft example, which now fails the required-AC enforcement and MUST become a structured `acceptanceCriteriaItems` array).
+
+1. `public/chorus-plugin/skills/<skill>/SKILL.md` — Claude Code
+2. `plugins/chorus/skills/<skill>/SKILL.md` — Codex
+3. `packages/openclaw-plugin/skills/<skill>/SKILL.md` — OpenClaw
+4. `public/skill/<skill>-chorus/SKILL.md` — standalone (note the `-chorus` suffix and flatter set)
+
+**Sweep command** — find every occurrence before editing so nothing is missed:
+```bash
+grep -rniE "<your-search-term>" \
+  public/chorus-plugin/skills/ plugins/chorus/skills/ \
+  packages/openclaw-plugin/skills/ public/skill/
+```
+
+Then bump the relevant version sequences (skill frontmatter `0.9.x` across plugins 1–3; standalone `0.3.x` for #4; per-package plugin versions as needed).
 
 ## Porting Changes Between Plugins
 
-Whenever you change content in one plugin, mirror it into the other unless the difference is intentional (see the table above). Typical workflow:
+Whenever you change content in one plugin, mirror it into the other two unless the difference is intentional (see the differences table above). Typical workflow:
 
 1. Make the change in `public/chorus-plugin/skills/<skill>/SKILL.md`
-2. Diff-check the counterpart: `diff public/chorus-plugin/skills/<skill>/SKILL.md plugins/chorus/skills/<skill>/SKILL.md`
-3. Apply the same content change to `plugins/chorus/skills/<skill>/SKILL.md`, but **preserve** Codex-specific phrasing: `.mcp.json` → `~/.codex/config.toml`, `Task tool` → `spawn_agent`, `/chorus:X` → `$X`, "sessions auto-managed" → "sessions are optional / stateless port"
-4. Bump both plugins' versions (all files above)
+2. Diff-check the counterparts:
+   - `diff public/chorus-plugin/skills/<skill>/SKILL.md plugins/chorus/skills/<skill>/SKILL.md`
+   - `diff public/chorus-plugin/skills/<skill>/SKILL.md packages/openclaw-plugin/skills/<skill>/SKILL.md`
+3. Apply the same content change to the Codex and OpenClaw copies, but **preserve** their intentional phrasing:
+   - **Codex**: `.mcp.json` → `~/.codex/config.toml`, `Task tool` → `spawn_agent`, `/chorus:X` → `$X`, "sessions auto-managed" → "sessions are optional / stateless port"
+   - **OpenClaw**: tool names `chorus_<tool>` → `chorus__<tool>`, `AskUserQuestion` → plain-text prompt, reviewers via `sessions_spawn`, OpenSpec detection is inline (no SessionStart hook), sessions are manual
+4. Bump all affected plugins' versions (all files in the Version Bump Checklist)
 5. For the Codex plugin, also verify `chorus-mcp-call.sh` `clientInfo.version` matches
 
 ## Plugin vs Standalone Skill: Tone Differences
@@ -141,12 +193,13 @@ The plugin skill targets Claude Code specifically. The standalone skill targets 
 
 1. Implement in `src/mcp/tools/*.ts` (pm.ts, public.ts, etc.)
 2. Add to `docs/MCP_TOOLS.md`
-3. Update permission tables and tool lists in:
+3. Update permission tables and tool lists in all four `chorus/SKILL.md`:
    - `public/chorus-plugin/skills/chorus/SKILL.md`
    - `plugins/chorus/skills/chorus/SKILL.md`
+   - `packages/openclaw-plugin/skills/chorus/SKILL.md` (use the `chorus__<tool>` namespaced form)
    - `public/skill/chorus/SKILL.md`
-4. If it changes a stage workflow, update the matching stage skill in all three locations (`develop/`, `idea/`, `proposal/`, `quick-dev/`, `review/`, `yolo/`)
-5. Bump both plugins' versions (see Version Bump Checklist)
+4. If it changes a stage workflow, update the matching stage skill in all four locations (`develop/`, `idea/`, `proposal/`, `quick-dev/`, `review/`, `yolo/`)
+5. Bump every affected plugin's versions (see Version Bump Checklist)
 6. Run `npx tsc --noEmit` to verify
 
 ## Modifying Hook Scripts
@@ -170,6 +223,17 @@ The plugin skill targets Claude Code specifically. The standalone skill targets 
 
 **Codex has no SubagentStart/Stop events** — do not try to port lifecycle hooks from the Claude Code plugin. Instead, session management is documented as a main-agent responsibility in `plugins/chorus/skills/develop/SKILL.md` and `$yolo`.
 
+### OpenClaw plugin — TypeScript runtime, not bash hooks (`packages/openclaw-plugin/src/`)
+
+OpenClaw has **no bash hooks at all**. Its real-time behavior is a compiled TypeScript extension declared in `package.json`'s `openclaw` block (`extensions: ["./src/index.ts"]`, `runtimeExtensions: ["./dist/index.js"]`):
+
+- `index.ts` — entry point / activation (`activation.onStartup` in `openclaw.plugin.json`)
+- `mcp-client.ts`, `mcp-registration.ts` — registers Chorus MCP tools (namespaced `chorus__<tool>`)
+- `sse-listener.ts`, `event-router.ts`, `wake.ts` — SSE event stream → agent wake (the OpenClaw analogue of the other plugins' notification hooks)
+- `config.ts`, `commands.ts` — config schema handling and slash commands
+
+After modifying the runtime: `cd packages/openclaw-plugin && npm run typecheck && npm run test`. A **linked** install loads `src/` directly via jiti; an **npm** install requires the compiled `dist/` (`npm run build`). Bash 3.2 rules do **not** apply here (it's TypeScript, not shell). Two known runtime gotchas: a linked install loads TS via jiti (no `dist`) while an npm install needs compiled `dist` + `runtimeExtensions`; and SSE→agent wake requires `activation.onStartup` + `runEmbeddedAgent` with an explicit provider/model.
+
 **CRITICAL: All hook scripts MUST be compatible with Bash 3.2.** macOS ships with `/bin/bash` 3.2 (due to GPL licensing) and Claude Code + Codex both use it to execute hooks. Do NOT use Bash 4+ features:
 
 | Bash 4+ (FORBIDDEN) | Bash 3.2 alternative |
@@ -182,20 +246,21 @@ The plugin skill targets Claude Code specifically. The standalone skill targets 
 | `&>>` (append both) | `>> file 2>&1` |
 
 After modifying:
-1. Run `/bin/bash public/chorus-plugin/bin/test-syntax.sh` on macOS to verify Bash 3.2 compatibility
+1. Run `/bin/bash public/chorus-plugin/bin/test-syntax.sh` on macOS to verify Bash 3.2 compatibility (Claude Code + Codex hooks only — OpenClaw has no bash hooks)
 2. Test locally: `claude --plugin-dir public/chorus-plugin` (Claude Code) or install the plugin via `codex plugin install` and reload (Codex)
-3. Bump plugin version for whichever packages changed (both packages if the change applies to both)
+3. Bump plugin version for whichever packages changed (all affected packages)
 4. Users must restart Claude Code / Codex and run the plugin update command
 
 ## Testing Plugin Changes
 
 ```bash
-# Load plugin locally (no install needed)
+# Claude Code — load plugin locally (no install needed)
 claude --plugin-dir public/chorus-plugin
-
 # Or update installed plugin
 /plugin update chorus@chorus-plugins
-
 # Verify plugin loaded
 /plugin list
+
+# OpenClaw — typecheck + test the TypeScript runtime
+cd packages/openclaw-plugin && npm run typecheck && npm run test
 ```

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -707,6 +707,8 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 
 Supports intra-batch dependencies via `draftUuid` + `dependsOnDraftUuids`, and dependencies on existing tasks via `dependsOnTaskUuids`.
 
+> **Acceptance criteria are required.** Every task must include `acceptanceCriteriaItems` with at least one item whose `description` is non-blank. If any task in the batch fails this check, the entire call is rejected and **no** task is created (all-or-nothing).
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -721,7 +723,7 @@ Supports intra-batch dependencies via `draftUuid` + `dependsOnDraftUuids`, and d
 | description | string | No | Task description |
 | priority | enum | No | Priority: low, medium, high |
 | storyPoints | number | No | Effort estimate (Agent hours) |
-| acceptanceCriteriaItems | array | No | Structured acceptance criteria: `[{ description: string, required?: boolean }]` |
+| acceptanceCriteriaItems | array | **Yes** | Structured acceptance criteria: `[{ description: string, required?: boolean }]`. At least one item with a non-blank `description` is required; an empty or all-blank array is rejected. |
 | draftUuid | string | No | Temporary UUID for intra-batch `dependsOnDraftUuids` references |
 | dependsOnDraftUuids | string[] | No | Intra-batch draftUuids this task depends on |
 | dependsOnTaskUuids | string[] | No | Existing Task UUIDs this task depends on |
@@ -735,7 +737,10 @@ Supports intra-batch dependencies via `draftUuid` + `dependsOnDraftUuids`, and d
       "title": "Fix login button alignment",
       "description": "On the /login page the submit button is misaligned on mobile breakpoints.",
       "priority": "medium",
-      "storyPoints": 0.5
+      "storyPoints": 0.5,
+      "acceptanceCriteriaItems": [
+        { "description": "Submit button is centered at the 375px mobile breakpoint", "required": true }
+      ]
     }
   ]
 }
@@ -751,19 +756,28 @@ Supports intra-batch dependencies via `draftUuid` + `dependsOnDraftUuids`, and d
       "draftUuid": "draft-1",
       "title": "Add database migration",
       "priority": "high",
-      "storyPoints": 1
+      "storyPoints": 1,
+      "acceptanceCriteriaItems": [
+        { "description": "Migration creates the new column and runs cleanly on a fresh DB", "required": true }
+      ]
     },
     {
       "draftUuid": "draft-2",
       "title": "Wire up service layer",
       "dependsOnDraftUuids": ["draft-1"],
-      "storyPoints": 2
+      "storyPoints": 2,
+      "acceptanceCriteriaItems": [
+        { "description": "Service reads/writes the new column with unit-test coverage", "required": true }
+      ]
     },
     {
       "title": "Add API route",
       "dependsOnDraftUuids": ["draft-2"],
       "dependsOnTaskUuids": ["existing-task-uuid"],
-      "storyPoints": 1
+      "storyPoints": 1,
+      "acceptanceCriteriaItems": [
+        { "description": "Route returns the new field and is covered by a route test", "required": true }
+      ]
     }
   ]
 }
@@ -772,14 +786,15 @@ Supports intra-batch dependencies via `draftUuid` + `dependsOnDraftUuids`, and d
 **Output**:
 ```json
 {
-  "tasks": [...],
-  "count": 3,
-  "draftToTaskUuidMap": { "draft-1": "real-uuid-1", "draft-2": "real-uuid-2" },
+  "tasks": [
+    { "uuid": "real-uuid-1", "title": "Add database migration" },
+    { "uuid": "real-uuid-2", "title": "Wire up service layer" }
+  ],
   "warnings": ["..."]
 }
 ```
-- `draftToTaskUuidMap`: Only returned when any task provides a `draftUuid`.
-- `warnings`: Only returned when there are issues creating dependencies or acceptance criteria (the tasks themselves are created successfully).
+- `tasks`: One `{ uuid, title }` entry per created task, in input order.
+- `warnings`: Only returned when there are issues creating dependencies (the tasks themselves are created successfully). Acceptance-criteria presence is validated up front — a missing/empty AC set rejects the whole call with `isError` rather than producing a warning.
 
 > Note: After `chorus_admin_approve_proposal` runs, taskDrafts are auto-materialized into Tasks. Calling `chorus_create_tasks` with the same `proposalUuid` would produce duplicates — only call this for proposal-linked tasks added outside the standard draft-and-approve flow.
 
@@ -1116,6 +1131,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Required Permission**: `proposal:write`
 
+> **Acceptance criteria are required.** `acceptanceCriteriaItems` must contain at least one item with a non-blank `description`, or the call is rejected and no draft is added.
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1124,8 +1141,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 | description | string | No | Task description |
 | storyPoints | number | No | Effort estimate (Agent hours) |
 | priority | enum | No | Priority: low, medium, high |
-| acceptanceCriteria | string | No | Acceptance criteria (Markdown, legacy) |
-| acceptanceCriteriaItems | array | No | Structured acceptance criteria: `[{ description: string, required?: boolean }]` |
+| acceptanceCriteriaItems | array | **Yes** | Structured acceptance criteria: `[{ description: string, required?: boolean }]`. At least one item with a non-blank `description` is required (materialized on approval). |
 | dependsOnDraftUuids | string[] | No | List of dependent taskDraft UUIDs (automatically converted to real dependencies upon approval) |
 
 **Output**: Updated Proposal JSON
@@ -1153,6 +1169,8 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 **Required Permission**: `proposal:write`
 
+> **Partial-update semantics for acceptance criteria.** Omit `acceptanceCriteriaItems` to leave the draft's existing criteria unchanged. If you provide it, it **replaces** the existing criteria and must contain at least one item with a non-blank `description` — an empty or all-blank array is rejected (the field cannot be used to clear acceptance criteria).
+
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -1162,7 +1180,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 | description | string | No | Task description |
 | storyPoints | number | No | Effort estimate |
 | priority | enum | No | Priority |
-| acceptanceCriteria | string | No | Acceptance criteria |
+| acceptanceCriteriaItems | array | No | Structured acceptance criteria: `[{ description: string, required?: boolean }]`. If provided, replaces existing items and must be non-empty; if omitted, existing criteria are preserved. |
 | dependsOnDraftUuids | string[] | No | List of dependent taskDraft UUIDs |
 
 **Output**: Updated Proposal JSON
@@ -1392,9 +1410,10 @@ Tools gated by `task:write`. Available to any agent whose effective permissions 
 
 > **Public tool** — not permission-gated. Available to every agent. Field edits and dependency edits require no special permission; status transitions are still gated at the handler level to the task's assignee.
 
-Two distinct edit modes can be combined in a single call:
+Three distinct edit modes can be combined in a single call:
 
 - **Field editing** (any agent): `title`, `description`, `priority`, `storyPoints`, `addDependsOn`, `removeDependsOn`.
+- **Acceptance criteria editing** (any agent): `acceptanceCriteriaItems` — **replaces** the task's acceptance criteria with the provided non-empty set. Omit it to leave criteria untouched.
 - **Status update** (assignee only): `status` (`in_progress` requires all dependencies resolved; `to_verify` submits for human verification).
 
 **Input**:
@@ -1405,12 +1424,14 @@ Two distinct edit modes can be combined in a single call:
 | description | string | No | New task description (supports @mentions) |
 | priority | enum | No | New priority: low, medium, high |
 | storyPoints | number | No | New effort estimate (agent hours) |
+| acceptanceCriteriaItems | array | No | Replace the task's acceptance criteria with this non-empty set: `[{ description: string, required?: boolean }]`. Omit to leave AC unchanged; an empty or all-blank array is rejected (cannot clear AC). |
 | addDependsOn | string[] | No | Task UUIDs to add as dependencies (incremental) |
 | removeDependsOn | string[] | No | Task UUIDs to remove from dependencies (incremental) |
 | status | enum | No | New status: in_progress, to_verify (assignee only) |
 | sessionUuid | string | No | Associated Session UUID (attributes which worker performed the action) |
 
 **Behavior**:
+- When `acceptanceCriteriaItems` is provided, the task's existing acceptance criteria are deleted and recreated from the new set. This discards any prior dev/admin verification marks on those criteria (changing the definition of done invalidates prior checks). Omitting the field leaves criteria untouched, so status transitions and dependency edits never require resending acceptance criteria.
 - When `sessionUuid` is provided, the Activity record includes session attribution, and a session heartbeat is automatically sent.
 - `addDependsOn` / `removeDependsOn` accept arrays — multiple dependency edits are applied in a single call. Each entry is validated independently (same-project check, self-dependency check, DFS cycle detection); per-entry failures surface in the `warnings` array of the response without rolling back successful edits.
 - **Dependency enforcement**: When transitioning to `in_progress`, the system checks that all `dependsOn` tasks are resolved (`done` or `closed`). If any dependency is unresolved, the request is rejected with a detailed error listing each blocker's title, status, assignee, and active session info. Use `chorus_get_unblocked_tasks` to find tasks that are ready to start.

--- a/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/README.md
+++ b/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/README.md
@@ -1,0 +1,3 @@
+# enforce-task-acceptance-criteria
+
+Make acceptance criteria mandatory for task drafts and tasks across MCP create/edit tools

--- a/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/design.md
+++ b/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/design.md
@@ -1,0 +1,148 @@
+# Design: Enforce Non-Empty Acceptance Criteria
+
+## Context
+
+Four MCP tools touch acceptance criteria; they sit at two layers and persist AC
+two different ways:
+
+| Tool | File | AC persistence today |
+|------|------|----------------------|
+| `chorus_pm_add_task_draft` | `src/mcp/tools/pm.ts` → `proposalService.addTaskDraft` | `acceptanceCriteriaItems` in the `Proposal.taskDrafts` JSON column |
+| `chorus_pm_update_task_draft` | `src/mcp/tools/pm.ts` → `proposalService.updateTaskDraft` | same JSON column (merge into existing draft) |
+| `chorus_create_tasks` | `src/mcp/tools/public.ts` (inline) | `prisma.acceptanceCriterion.createMany` — rows in `AcceptanceCriterion` |
+| `chorus_update_task` | `src/mcp/tools/public.ts` (inline) | **no AC handling today** |
+
+Real-task AC rows are created in the **tool handler** (`public.ts`), not inside
+`taskService.createTask` (which only carries the legacy `acceptanceCriteria`
+string). So the shared validator must be importable by both the proposal service
+and the `public.ts` handlers.
+
+## Goals / Non-Goals
+
+**Goals**
+- Guarantee the invariant: every task and task draft always has ≥1 AC whose
+  trimmed `description` is non-blank.
+- Fail fast at create/edit time with a clear, consistent error message.
+- Do not break `chorus_update_task`'s primary uses (status transitions,
+  dependency edits) — AC stays optional there.
+- Single source of truth for the "non-empty AC" rule.
+
+**Non-Goals**
+- No Prisma schema / migration change.
+- No backfill of existing AC-less tasks (DML in migrations is forbidden; and
+  retroactively inventing AC would be wrong). They are simply left alone.
+- No change to the `required` per-item boolean semantics (still defaults true).
+- No removal of the legacy `acceptanceCriteria` Markdown string field.
+
+## Decisions
+
+### D1 — Invariant model, not strict model
+
+Create tools require non-empty AC. Edit tools require non-empty **only if AC is
+provided**; omission preserves existing AC. Rationale: `chorus_update_task` is
+called on nearly every status change; a strict "AC required on every call" model
+would block `in_progress` / `to_verify` transitions and dependency edits. The
+invariant model still guarantees no task can ever reach a zero-AC state through
+these tools (it could only get there by being created without AC, which create
+now forbids).
+
+### D2 — Service layer is the single source of truth
+
+A shared helper module `src/lib/acceptance-criteria.ts` exports:
+
+```ts
+export interface AcceptanceCriteriaItemInput {
+  description: string;
+  required?: boolean;
+}
+
+/** Items whose trimmed description is non-blank, trimmed, in order. */
+export function normalizeAcceptanceCriteria(
+  items: AcceptanceCriteriaItemInput[] | undefined | null,
+): { description: string; required: boolean }[];
+
+/** True iff at least one item has a non-blank trimmed description. */
+export function hasNonEmptyAcceptanceCriteria(
+  items: AcceptanceCriteriaItemInput[] | undefined | null,
+): boolean;
+
+export const ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE =
+  "At least one acceptance criterion with a non-empty description is required.";
+```
+
+`proposalService.addTaskDraft` / `updateTaskDraft` and the `public.ts` handlers
+for `chorus_create_tasks` / `chorus_update_task` call these. Throwing happens in
+the service functions for the proposal path (so REST inherits it); for the
+`public.ts` inline handlers the check is performed inline and returns an
+`isError` MCP response (matching the existing handler style there). Zod schemas
+keep `.optional()` on the field — structural only, no `.min(1)`.
+
+### D3 — Enforcement matrix
+
+| Tool | AC missing/omitted | AC present but all-blank | AC present non-empty |
+|------|--------------------|--------------------------|----------------------|
+| `chorus_pm_add_task_draft` | **error** | **error** | persist normalized |
+| `chorus_create_tasks` | **error** (per task) | **error** (per task) | persist normalized rows |
+| `chorus_pm_update_task_draft` | preserve existing | **error** | replace with normalized |
+| `chorus_update_task` | preserve existing | **error** | replace rows (delete + recreate) |
+
+### D4 — `chorus_update_task` AC replace semantics
+
+New optional `acceptanceCriteriaItems`. When provided and non-empty, replace the
+task's AC rows: delete existing `AcceptanceCriterion` rows for the task, then
+`createMany` the normalized set with `sortOrder` by index and `required ?? true`.
+This mirrors `updateTaskDraft`'s "replaces existing items" semantics. Done
+outside the status-transition block so the two concerns stay independent. Note:
+replacing AC discards any prior dev/admin verification marks on those rows — this
+is acceptable because editing the definition of done invalidates prior checks.
+
+### D5 — `chorus_create_tasks` is all-or-nothing per request
+
+Because tasks are created first (via `Promise.all`) and AC added afterward,
+validate **all** tasks' AC up front and return an error before creating any task
+if any task fails the check. This avoids leaving half-created tasks when one task
+in the batch lacks AC. (Pre-validate loop over `tasks` before the
+`taskService.createTask` calls.)
+
+### D6 — Retain `E-AC` proposal validation
+
+`chorus_pm_validate_proposal`'s `E-AC` error stays as a submit-time backstop for
+drafts created before this change or hand-edited via other paths. The early
+checks and `E-AC` are complementary, not redundant — they cover different entry
+points and different times.
+
+**Two "empty" definitions coexist (intentionally).** The existing `E-AC` check
+(`proposal.service.ts`) considers a draft empty only when
+`acceptanceCriteriaItems` is absent or `length === 0` — it does **not** inspect
+whether descriptions are blank. The new create/edit checks use the stricter
+`hasNonEmptyAcceptanceCriteria`, which treats an array of all-whitespace
+descriptions as empty. Consequence: a hypothetical 1-item all-whitespace draft
+would pass the `E-AC` backstop but be rejected by the new create path. This is
+harmless because the two operate at different entry points (submit-time vs
+create-time) and the strict check is the one that runs first on every create.
+We deliberately do **not** tighten `E-AC` to the trim rule in this change to keep
+the backstop's behavior stable for already-stored drafts; the discrepancy is
+documented here and in `docs/MCP_TOOLS.md` so a future reader is not surprised.
+
+### D7 — Edit-tool handlers must distinguish "omitted" from "empty array"
+
+Partial-update semantics (D1, D3) hinge on the MCP handler forwarding an explicit
+`acceptanceCriteriaItems: []` to the service guard rather than silently dropping
+it. The existing `pm.ts` `update_task_draft` handler builds its `updates` object
+with `if (acceptanceCriteriaItems !== undefined) updates.acceptanceCriteriaItems = …`,
+which correctly forwards `[]` (an empty array is `!== undefined`). The same guard
+shape is required for `chorus_update_task`. Tests MUST assert the clear-rejection
+path is reachable through the handler — i.e. passing `[]` reaches the guard and
+errors, it is not collapsed into "omitted / preserve existing".
+
+## Risks
+
+- **Existing callers break.** Any automation creating AC-less tasks now errors.
+  Intended; surfaced in proposal Impact and the CHANGELOG.
+- **Replace-discards-verification on `update_task`.** Mitigated by D4 rationale —
+  changing AC text already invalidates prior verification. Documented in the tool
+  description.
+
+## Migration Plan
+
+None. No schema change, no data migration. Behavior change only.

--- a/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/proposal.md
+++ b/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/proposal.md
@@ -1,0 +1,68 @@
+# Enforce Non-Empty Acceptance Criteria on Tasks and Task Drafts
+
+## Why
+
+Acceptance criteria (AC) are the contract a task is verified against. Today the
+four MCP tools that create or edit tasks and task drafts all treat
+`acceptanceCriteriaItems` as **optional**:
+
+- `chorus_pm_add_task_draft` — Zod `.optional()`, no service-layer guard.
+- `chorus_pm_update_task_draft` — Zod `.optional()`, no guard.
+- `chorus_create_tasks` — Zod `.optional()`; empty/blank items are **silently
+  dropped** (`filter(d => d.description.trim().length > 0)`), so a task can be
+  created with zero AC and no warning.
+- `chorus_update_task` — has **no AC parameter at all**.
+
+The only enforcement is `chorus_pm_validate_proposal`'s `E-AC` check, which fires
+late (at submit time) and only for proposal drafts — Quick Tasks created via
+`chorus_create_tasks` bypass it entirely. The result: tasks reach developers with
+no verifiable definition of done, and the downstream task-reviewer / admin-verify
+steps have nothing concrete to check against.
+
+## What Changes
+
+Make a non-empty AC set an **invariant** of every task and task draft, enforced at
+creation and preserved on edit:
+
+- **Create tools** (`chorus_pm_add_task_draft`, `chorus_create_tasks`) MUST reject
+  a request whose acceptance criteria are missing or contain no item with a
+  non-blank `description`. The error is explicit, not a silent drop.
+- **Edit tools** (`chorus_pm_update_task_draft`, `chorus_update_task`) follow
+  partial-update semantics: if the caller passes `acceptanceCriteriaItems`, it
+  MUST be non-empty (the field cannot be used to clear AC); if the caller omits
+  it, existing AC are preserved untouched. This keeps developer status transitions
+  (`in_progress` / `to_verify`) and dependency edits — the dominant use of
+  `chorus_update_task` — working without forcing AC to be re-sent.
+- `chorus_update_task` gains a new **optional** `acceptanceCriteriaItems`
+  parameter with replace semantics (passing it replaces the task's AC rows with
+  the new non-empty set; omitting it leaves them alone).
+- "Empty" is judged after trimming: an array whose every `description` is blank is
+  treated as empty AC and rejected.
+- The existing `E-AC` proposal-validation check is **retained** as a submit-time
+  backstop for legacy/hand-edited drafts; the new early checks are complementary.
+- Validation lives in the **service layer** (single source of truth) via a shared
+  helper, so both MCP and any future REST callers inherit it. Zod keeps only
+  structural validation (no `.min(1)`, which would break the edit tools' partial
+  semantics).
+- Documentation (`docs/MCP_TOOLS.md`, `public/skill/`,
+  `public/chorus-plugin/skills/chorus/`, tool/param descriptions) is updated to
+  describe AC as required.
+
+## Capabilities
+
+- `mcp-tool-surface` — adds requirements that the task create/edit MCP tools
+  enforce a non-empty acceptance-criteria invariant.
+
+## Impact
+
+- **Code**: `src/lib/acceptance-criteria.ts` (new shared helper),
+  `src/services/proposal.service.ts` (add/update task draft),
+  `src/mcp/tools/public.ts` (`chorus_create_tasks`, `chorus_update_task`),
+  `src/mcp/tools/pm.ts` (descriptions).
+- **Tests**: new unit tests for the helper and the four enforcement paths;
+  existing AC tests updated to the new reject-on-empty behavior.
+- **Docs**: `docs/MCP_TOOLS.md`, skill docs in both skill trees.
+- **Behavioral / backward-compat**: callers that previously created tasks or
+  drafts with no AC now receive an error. This is the intended tightening. No DB
+  schema change; no migration. Existing tasks with empty AC are unaffected until
+  next edited (and edits that omit AC still preserve their current state).

--- a/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/specs/mcp-tool-surface/spec.md
+++ b/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/specs/mcp-tool-surface/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Task-creating MCP tools SHALL require non-empty acceptance criteria
+
+The MCP tools that create tasks or task drafts (`chorus_pm_add_task_draft` and `chorus_create_tasks`) MUST reject any request whose acceptance criteria are missing, an empty array, or contain no item with a non-blank `description` (after trimming). The rejection MUST be an explicit error; these tools MUST NOT silently create a task or draft with zero acceptance criteria. An acceptance-criteria set is considered satisfied when at least one provided item has a `description` that is non-empty after trimming whitespace.
+
+#### Scenario: Adding a task draft without acceptance criteria is rejected
+
+- **GIVEN** a proposal in `draft` status
+- **WHEN** an agent calls `chorus_pm_add_task_draft` omitting `acceptanceCriteriaItems` (or passing `[]`)
+- **THEN** the call MUST return an error indicating acceptance criteria are required
+- **AND** no task draft MUST be appended to the proposal's `taskDrafts`
+
+#### Scenario: Adding a task draft whose criteria are all blank is rejected
+
+- **GIVEN** a proposal in `draft` status
+- **WHEN** an agent calls `chorus_pm_add_task_draft` with `acceptanceCriteriaItems` whose every `description` is empty or whitespace-only
+- **THEN** the call MUST return an error indicating acceptance criteria are required
+- **AND** no task draft MUST be appended to the proposal's `taskDrafts`
+
+#### Scenario: Adding a task draft with at least one non-blank criterion succeeds
+
+- **GIVEN** a proposal in `draft` status
+- **WHEN** an agent calls `chorus_pm_add_task_draft` with `acceptanceCriteriaItems` containing at least one item with a non-blank `description`
+- **THEN** the call MUST succeed
+- **AND** the appended task draft MUST persist the non-blank acceptance criteria items
+
+#### Scenario: Creating a task without acceptance criteria is rejected
+
+- **WHEN** an agent calls `chorus_create_tasks` with a task entry that omits `acceptanceCriteriaItems`, passes `[]`, or provides only blank descriptions
+- **THEN** the call MUST return an error indicating acceptance criteria are required for that task
+- **AND** no task in the batch MUST be created (the request is rejected before any task is persisted)
+
+#### Scenario: Creating tasks with non-blank criteria succeeds
+
+- **WHEN** an agent calls `chorus_create_tasks` where every task entry has at least one non-blank acceptance criterion
+- **THEN** the call MUST succeed
+- **AND** each created task MUST have its acceptance criteria persisted as `AcceptanceCriterion` rows
+
+### Requirement: Task-editing MCP tools SHALL preserve the non-empty acceptance-criteria invariant
+
+The MCP tools that edit tasks or task drafts (`chorus_pm_update_task_draft` and `chorus_update_task`) MUST follow partial-update semantics for acceptance criteria. When the caller provides `acceptanceCriteriaItems`, it MUST contain at least one item with a non-blank `description`; an empty array or all-blank items MUST be rejected (the field cannot be used to clear acceptance criteria). When the caller omits `acceptanceCriteriaItems`, the existing acceptance criteria MUST be preserved unchanged, and the call MUST NOT be rejected for lack of acceptance criteria. This keeps status transitions and dependency edits via `chorus_update_task` working without resending acceptance criteria.
+
+`chorus_update_task` MUST accept an optional `acceptanceCriteriaItems` parameter with replace semantics: when provided and non-empty, it replaces the task's acceptance-criteria rows with the new set.
+
+#### Scenario: Updating a task draft with an empty criteria array is rejected
+
+- **GIVEN** a proposal in `draft` status containing a task draft with acceptance criteria
+- **WHEN** an agent calls `chorus_pm_update_task_draft` passing `acceptanceCriteriaItems: []` (or only blank descriptions)
+- **THEN** the call MUST return an error indicating acceptance criteria cannot be cleared
+- **AND** the task draft's existing acceptance criteria MUST be unchanged
+
+#### Scenario: Updating a task draft without touching criteria preserves them
+
+- **GIVEN** a proposal in `draft` status containing a task draft with acceptance criteria
+- **WHEN** an agent calls `chorus_pm_update_task_draft` changing only the title and omitting `acceptanceCriteriaItems`
+- **THEN** the call MUST succeed
+- **AND** the task draft's acceptance criteria MUST be preserved unchanged
+
+#### Scenario: Updating a task draft with new non-blank criteria replaces them
+
+- **GIVEN** a proposal in `draft` status containing a task draft with acceptance criteria
+- **WHEN** an agent calls `chorus_pm_update_task_draft` with `acceptanceCriteriaItems` containing at least one non-blank item
+- **THEN** the call MUST succeed
+- **AND** the task draft's acceptance criteria MUST be replaced with the provided non-blank items
+
+#### Scenario: Changing task status without criteria is not blocked
+
+- **GIVEN** an existing task assigned to the caller that already has acceptance criteria
+- **WHEN** the caller calls `chorus_update_task` with `status: "in_progress"` and no `acceptanceCriteriaItems`
+- **THEN** the call MUST succeed (subject to the existing dependency-resolution checks)
+- **AND** the task's acceptance criteria MUST be preserved unchanged
+
+#### Scenario: Editing task acceptance criteria with an empty array is rejected
+
+- **GIVEN** an existing task that has acceptance criteria
+- **WHEN** an agent calls `chorus_update_task` passing `acceptanceCriteriaItems: []` (or only blank descriptions)
+- **THEN** the call MUST return an error indicating acceptance criteria cannot be cleared
+- **AND** the task's existing acceptance-criteria rows MUST be unchanged
+
+#### Scenario: Editing task acceptance criteria with new non-blank items replaces them
+
+- **GIVEN** an existing task that has acceptance criteria
+- **WHEN** an agent calls `chorus_update_task` with `acceptanceCriteriaItems` containing at least one non-blank item
+- **THEN** the call MUST succeed
+- **AND** the task's `AcceptanceCriterion` rows MUST be replaced with the provided non-blank items

--- a/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/tasks.md
+++ b/openspec/changes/archive/2026-06-02-enforce-task-acceptance-criteria/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Shared validation helper
+- [ ] 1.1 Add `src/lib/acceptance-criteria.ts` with `normalizeAcceptanceCriteria`, `hasNonEmptyAcceptanceCriteria`, and `ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE`
+- [ ] 1.2 Unit tests for the helper (empty / all-blank / mixed / non-empty)
+
+## 2. Proposal task-draft enforcement
+- [ ] 2.1 `addTaskDraft` rejects missing/blank AC
+- [ ] 2.2 `updateTaskDraft`: reject when AC provided-but-blank; preserve when omitted; replace when non-empty
+- [ ] 2.3 Tests for both service functions
+
+## 3. Real task enforcement (public.ts)
+- [ ] 3.1 `chorus_create_tasks`: pre-validate all tasks' AC before creating any
+- [ ] 3.2 `chorus_update_task`: add optional `acceptanceCriteriaItems` with replace semantics + blank rejection
+- [ ] 3.3 Tests for create + update paths
+
+## 4. Documentation
+- [ ] 4.1 Update tool/param descriptions in `pm.ts` and `public.ts`
+- [ ] 4.2 Update `docs/MCP_TOOLS.md` (required markers + examples)
+- [ ] 4.3 Update `public/skill/` and `public/chorus-plugin/skills/chorus/` AC wording
+
+## 5. Verify
+- [ ] 5.1 `npx tsc --noEmit`, `pnpm lint`, `pnpm test` all green

--- a/openspec/specs/mcp-tool-surface/spec.md
+++ b/openspec/specs/mcp-tool-surface/spec.md
@@ -205,3 +205,88 @@ to receive the complete proposal, including full document and task drafts.
   `taskDrafts`, exactly as before this change
 - **AND** the REST response MUST NOT be reduced to the basic index
 
+### Requirement: Task-creating MCP tools SHALL require non-empty acceptance criteria
+
+The MCP tools that create tasks or task drafts (`chorus_pm_add_task_draft` and `chorus_create_tasks`) MUST reject any request whose acceptance criteria are missing, an empty array, or contain no item with a non-blank `description` (after trimming). The rejection MUST be an explicit error; these tools MUST NOT silently create a task or draft with zero acceptance criteria. An acceptance-criteria set is considered satisfied when at least one provided item has a `description` that is non-empty after trimming whitespace.
+
+#### Scenario: Adding a task draft without acceptance criteria is rejected
+
+- **GIVEN** a proposal in `draft` status
+- **WHEN** an agent calls `chorus_pm_add_task_draft` omitting `acceptanceCriteriaItems` (or passing `[]`)
+- **THEN** the call MUST return an error indicating acceptance criteria are required
+- **AND** no task draft MUST be appended to the proposal's `taskDrafts`
+
+#### Scenario: Adding a task draft whose criteria are all blank is rejected
+
+- **GIVEN** a proposal in `draft` status
+- **WHEN** an agent calls `chorus_pm_add_task_draft` with `acceptanceCriteriaItems` whose every `description` is empty or whitespace-only
+- **THEN** the call MUST return an error indicating acceptance criteria are required
+- **AND** no task draft MUST be appended to the proposal's `taskDrafts`
+
+#### Scenario: Adding a task draft with at least one non-blank criterion succeeds
+
+- **GIVEN** a proposal in `draft` status
+- **WHEN** an agent calls `chorus_pm_add_task_draft` with `acceptanceCriteriaItems` containing at least one item with a non-blank `description`
+- **THEN** the call MUST succeed
+- **AND** the appended task draft MUST persist the non-blank acceptance criteria items
+
+#### Scenario: Creating a task without acceptance criteria is rejected
+
+- **WHEN** an agent calls `chorus_create_tasks` with a task entry that omits `acceptanceCriteriaItems`, passes `[]`, or provides only blank descriptions
+- **THEN** the call MUST return an error indicating acceptance criteria are required for that task
+- **AND** no task in the batch MUST be created (the request is rejected before any task is persisted)
+
+#### Scenario: Creating tasks with non-blank criteria succeeds
+
+- **WHEN** an agent calls `chorus_create_tasks` where every task entry has at least one non-blank acceptance criterion
+- **THEN** the call MUST succeed
+- **AND** each created task MUST have its acceptance criteria persisted as `AcceptanceCriterion` rows
+
+### Requirement: Task-editing MCP tools SHALL preserve the non-empty acceptance-criteria invariant
+
+The MCP tools that edit tasks or task drafts (`chorus_pm_update_task_draft` and `chorus_update_task`) MUST follow partial-update semantics for acceptance criteria. When the caller provides `acceptanceCriteriaItems`, it MUST contain at least one item with a non-blank `description`; an empty array or all-blank items MUST be rejected (the field cannot be used to clear acceptance criteria). When the caller omits `acceptanceCriteriaItems`, the existing acceptance criteria MUST be preserved unchanged, and the call MUST NOT be rejected for lack of acceptance criteria. This keeps status transitions and dependency edits via `chorus_update_task` working without resending acceptance criteria.
+
+`chorus_update_task` MUST accept an optional `acceptanceCriteriaItems` parameter with replace semantics: when provided and non-empty, it replaces the task's acceptance-criteria rows with the new set.
+
+#### Scenario: Updating a task draft with an empty criteria array is rejected
+
+- **GIVEN** a proposal in `draft` status containing a task draft with acceptance criteria
+- **WHEN** an agent calls `chorus_pm_update_task_draft` passing `acceptanceCriteriaItems: []` (or only blank descriptions)
+- **THEN** the call MUST return an error indicating acceptance criteria cannot be cleared
+- **AND** the task draft's existing acceptance criteria MUST be unchanged
+
+#### Scenario: Updating a task draft without touching criteria preserves them
+
+- **GIVEN** a proposal in `draft` status containing a task draft with acceptance criteria
+- **WHEN** an agent calls `chorus_pm_update_task_draft` changing only the title and omitting `acceptanceCriteriaItems`
+- **THEN** the call MUST succeed
+- **AND** the task draft's acceptance criteria MUST be preserved unchanged
+
+#### Scenario: Updating a task draft with new non-blank criteria replaces them
+
+- **GIVEN** a proposal in `draft` status containing a task draft with acceptance criteria
+- **WHEN** an agent calls `chorus_pm_update_task_draft` with `acceptanceCriteriaItems` containing at least one non-blank item
+- **THEN** the call MUST succeed
+- **AND** the task draft's acceptance criteria MUST be replaced with the provided non-blank items
+
+#### Scenario: Changing task status without criteria is not blocked
+
+- **GIVEN** an existing task assigned to the caller that already has acceptance criteria
+- **WHEN** the caller calls `chorus_update_task` with `status: "in_progress"` and no `acceptanceCriteriaItems`
+- **THEN** the call MUST succeed (subject to the existing dependency-resolution checks)
+- **AND** the task's acceptance criteria MUST be preserved unchanged
+
+#### Scenario: Editing task acceptance criteria with an empty array is rejected
+
+- **GIVEN** an existing task that has acceptance criteria
+- **WHEN** an agent calls `chorus_update_task` passing `acceptanceCriteriaItems: []` (or only blank descriptions)
+- **THEN** the call MUST return an error indicating acceptance criteria cannot be cleared
+- **AND** the task's existing acceptance-criteria rows MUST be unchanged
+
+#### Scenario: Editing task acceptance criteria with new non-blank items replaces them
+
+- **GIVEN** an existing task that has acceptance criteria
+- **WHEN** an agent calls `chorus_update_task` with `acceptanceCriteriaItems` containing at least one non-blank item
+- **THEN** the call MUST succeed
+- **AND** the task's `AcceptanceCriterion` rows MUST be replaced with the provided non-blank items
+

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus-openclaw-plugin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "OpenClaw plugin for Chorus AI-DLC collaboration platform — native MCP + SSE real-time events",
   "license": "MIT",
   "type": "module",

--- a/packages/openclaw-plugin/skills/brainstorm/SKILL.md
+++ b/packages/openclaw-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/develop/SKILL.md
+++ b/packages/openclaw-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/idea/SKILL.md
+++ b/packages/openclaw-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
+++ b/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows on OpenClaw.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial read-only review of a submitted Chorus proposal — doc
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -127,6 +127,8 @@ chorus_pm_add_document_draft({
 
 Add task drafts one at a time. The response returns the new draft's `draftUuid` — use it directly for `dependsOnDraftUuids` in subsequent drafts.
 
+**`acceptanceCriteriaItems` is required** — every task draft must include at least one item with a non-blank `description`, or the call is rejected. Use the structured `acceptanceCriteriaItems` array (the legacy `acceptanceCriteria` Markdown string does not satisfy the requirement).
+
 ```
 # First task -> response includes { draftUuid, draftTitle }
 chorus_pm_add_task_draft({
@@ -135,7 +137,10 @@ chorus_pm_add_task_draft({
   description: "Detailed description of what to build...",
   priority: "high",
   storyPoints: 3,
-  acceptanceCriteria: "- [ ] Criteria 1\n- [ ] Criteria 2"
+  acceptanceCriteriaItems: [
+    { description: "Criteria 1", required: true },
+    { description: "Criteria 2", required: true }
+  ]
 })
 
 # Second task — depends on first
@@ -145,10 +150,14 @@ chorus_pm_add_task_draft({
   description: "Unit and integration tests...",
   priority: "medium",
   storyPoints: 2,
-  acceptanceCriteria: "- [ ] Test coverage > 80%",
+  acceptanceCriteriaItems: [
+    { description: "Test coverage > 80%", required: true }
+  ],
   dependsOnDraftUuids: ["<draftUuid-from-first-task>"]
 })
 ```
+
+> To edit a draft's criteria later via `chorus_pm_update_task_draft`, pass a non-empty `acceptanceCriteriaItems` to replace them; omit the field to leave them unchanged. The field cannot be used to clear criteria.
 
 **Task priority:** `low`, `medium`, `high`
 
@@ -361,7 +370,7 @@ Potential issues and how to address them.
 
 Good tasks are:
 - **Module-scoped** — One cohesive functional module per task, not a single function or file
-- **Testable** — Clear, cohesive acceptance criteria (max 6 items per task; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
+- **Testable** — Clear, cohesive acceptance criteria are **required** on every task (at least one non-blank item; max 6; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
 - **Sized** — 1-8 story points (hours of agent work)
 - **Ordered** — Use `dependsOnDraftUuids` / `dependsOnTaskUuids` to express execution order
 - **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC

--- a/packages/openclaw-plugin/skills/quick-dev/SKILL.md
+++ b/packages/openclaw-plugin/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -70,7 +70,7 @@ This matters because admin agents can call `chorus_admin_verify_task` to close t
 
 ### Step 1: Create a Quick Task
 
-**Always include `acceptanceCriteriaItems`** — these are the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
+**`acceptanceCriteriaItems` is required** — `chorus_create_tasks` rejects any task without at least one non-blank criterion (and rejects the whole batch if any task is missing them). These are also the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
 
 ```
 chorus_create_tasks({
@@ -100,7 +100,7 @@ chorus_claim_task({ taskUuid: "<task-uuid>" })
 
 ### Step 3: Edit Details (if needed)
 
-Use `chorus_update_task` to refine the task after creation. **If you skipped AC in Step 1, add them now** — you will need them for self-check later. Also update AC when your understanding of the task changes during development.
+Use `chorus_update_task` to refine the task after creation. Tasks always have AC (creation requires them), but **update them when your understanding changes during development**. Passing `acceptanceCriteriaItems` **replaces** the task's criteria with the provided non-empty set; omit the field to leave them unchanged (it cannot be used to clear AC).
 
 ```
 chorus_update_task({
@@ -182,7 +182,7 @@ Quick Tasks support sub-agent execution just like proposal-based tasks. **Sessio
 ## Tips
 
 - Keep Quick Tasks small — if you need more than 2-3 tasks, consider using `/proposal`
-- **Always write acceptance criteria at creation time** — they are your self-check contract. Specific, testable AC enables autonomous verification and makes the entire workflow self-contained
+- **Acceptance criteria are required at creation time** — `chorus_create_tasks` rejects tasks without them. They are your self-check contract; specific, testable AC enables autonomous verification and makes the entire workflow self-contained
 - Use `chorus_update_task` to refine tasks (including AC) after creation rather than deleting and recreating
 - Pass `proposalUuid` to attach follow-up or gap-filling tasks to an existing proposal — this keeps related work grouped in the same project context and DAG
 - Quick Tasks show up in the same project task list and DAG as proposal-based tasks

--- a/packages/openclaw-plugin/skills/review/SKILL.md
+++ b/packages/openclaw-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial verification of a submitted Chorus task against its AC 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/yolo/SKILL.md
+++ b/packages/openclaw-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -228,7 +228,7 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-3. **Add task drafts incrementally** (use returned `draftUuid` for dependency chaining):
+3. **Add task drafts incrementally** (use returned `draftUuid` for dependency chaining). `acceptanceCriteriaItems` is **required** on every draft — at least one non-blank criterion, or the call is rejected:
    ```
    # First task
    result1 = chorus_pm_add_task_draft({

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -54,7 +54,7 @@ ACCEPT="Accept: application/json, text/event-stream"
 CT="Content-Type: application/json"
 
 INIT=$(cat <<JSON
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.9.1"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.9.2"}}}
 JSON
 )
 

--- a/plugins/chorus/skills/brainstorm/SKILL.md
+++ b/plugins/chorus/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, au
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus proposal reviewer

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus task reviewer

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, and spawn
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/openspec-aware/SKILL.md
+++ b/plugins/chorus/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Codex. De
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -121,6 +121,8 @@ chorus_pm_add_document_draft({
 
 Add task drafts one at a time. The response returns the new draft's `draftUuid` — use it directly for `dependsOnDraftUuids` in subsequent drafts.
 
+**`acceptanceCriteriaItems` is required** — every task draft must include at least one item with a non-blank `description`, or the call is rejected. Use the structured `acceptanceCriteriaItems` array (the legacy `acceptanceCriteria` Markdown string does not satisfy the requirement).
+
 ```
 # First task -> response includes { draftUuid, draftTitle }
 chorus_pm_add_task_draft({
@@ -129,7 +131,10 @@ chorus_pm_add_task_draft({
   description: "Detailed description of what to build...",
   priority: "high",
   storyPoints: 3,
-  acceptanceCriteria: "- [ ] Criteria 1\n- [ ] Criteria 2"
+  acceptanceCriteriaItems: [
+    { description: "Criteria 1", required: true },
+    { description: "Criteria 2", required: true }
+  ]
 })
 
 # Second task — depends on first
@@ -139,10 +144,14 @@ chorus_pm_add_task_draft({
   description: "Unit and integration tests...",
   priority: "medium",
   storyPoints: 2,
-  acceptanceCriteria: "- [ ] Test coverage > 80%",
+  acceptanceCriteriaItems: [
+    { description: "Test coverage > 80%", required: true }
+  ],
   dependsOnDraftUuids: ["<draftUuid-from-first-task>"]
 })
 ```
+
+> To edit a draft's criteria later via `chorus_pm_update_task_draft`, pass a non-empty `acceptanceCriteriaItems` to replace them; omit the field to leave them unchanged. The field cannot be used to clear criteria.
 
 **Task priority:** `low`, `medium`, `high`
 
@@ -334,7 +343,7 @@ Potential issues and how to address them.
 
 Good tasks are:
 - **Module-scoped** — One cohesive functional module per task, not a single function or file
-- **Testable** — Clear, cohesive acceptance criteria (max 6 items per task; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
+- **Testable** — Clear, cohesive acceptance criteria are **required** on every task (at least one non-blank item; max 6; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
 - **Sized** — 1-8 story points (hours of agent work)
 - **Ordered** — Use `dependsOnDraftUuids` / `dependsOnTaskUuids` to express execution order
 - **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.9.1
+version: 0.9.2
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 
@@ -63,7 +63,7 @@ This matters because admin agents can call `chorus_admin_verify_task` to close t
 
 ### Step 1: Create a Quick Task
 
-**Always include `acceptanceCriteriaItems`** — these are the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
+**`acceptanceCriteriaItems` is required** — `chorus_create_tasks` rejects any task without at least one non-blank criterion (and rejects the whole batch if any task is missing them). These are also the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
 
 ```
 chorus_create_tasks({
@@ -93,7 +93,7 @@ chorus_claim_task({ taskUuid: "<task-uuid>" })
 
 ### Step 3: Edit Details (if needed)
 
-Use `chorus_update_task` to refine the task after creation. **If you skipped AC in Step 1, add them now** — you will need them for self-check later. Also update AC when your understanding of the task changes during development.
+Use `chorus_update_task` to refine the task after creation. Tasks always have AC (creation requires them), but **update them when your understanding changes during development**. Passing `acceptanceCriteriaItems` **replaces** the task's criteria with the provided non-empty set; omit the field to leave them unchanged (it cannot be used to clear AC).
 
 ```
 chorus_update_task({
@@ -172,7 +172,7 @@ Quick Tasks support the same optional session pattern as proposal-based tasks:
 ## Tips
 
 - Keep Quick Tasks small — if you need more than 2-3 tasks, consider using `/proposal`
-- **Always write acceptance criteria at creation time** — they are your self-check contract. Specific, testable AC enables autonomous verification and makes the entire workflow self-contained
+- **Acceptance criteria are required at creation time** — `chorus_create_tasks` rejects tasks without them. They are your self-check contract; specific, testable AC enables autonomous verification and makes the entire workflow self-contained
 - Use `chorus_update_task` to refine tasks (including AC) after creation rather than deleting and recreating
 - Pass `proposalUuid` to attach follow-up or gap-filling tasks to an existing proposal — this keeps related work grouped in the same project context and DAG
 - Quick Tasks show up in the same project task list and DAG as proposal-based tasks

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -224,7 +224,7 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-3. **Add task drafts incrementally** (use returned `draftUuid` for dependency chaining):
+3. **Add task drafts incrementally** (use returned `draftUuid` for dependency chaining). `acceptanceCriteriaItems` is **required** on every draft — at least one non-blank criterion, or the call is rejected:
    ```
    # First task
    result1 = chorus_pm_add_task_draft({

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/skills/brainstorm/SKILL.md
+++ b/public/chorus-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Co
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -121,6 +121,8 @@ chorus_pm_add_document_draft({
 
 Add task drafts one at a time. The response returns the new draft's `draftUuid` — use it directly for `dependsOnDraftUuids` in subsequent drafts.
 
+**`acceptanceCriteriaItems` is required** — every task draft must include at least one item with a non-blank `description`, or the call is rejected. Use the structured `acceptanceCriteriaItems` array (the legacy `acceptanceCriteria` Markdown string does not satisfy the requirement).
+
 ```
 # First task -> response includes { draftUuid, draftTitle }
 chorus_pm_add_task_draft({
@@ -129,7 +131,10 @@ chorus_pm_add_task_draft({
   description: "Detailed description of what to build...",
   priority: "high",
   storyPoints: 3,
-  acceptanceCriteria: "- [ ] Criteria 1\n- [ ] Criteria 2"
+  acceptanceCriteriaItems: [
+    { description: "Criteria 1", required: true },
+    { description: "Criteria 2", required: true }
+  ]
 })
 
 # Second task — depends on first
@@ -139,10 +144,14 @@ chorus_pm_add_task_draft({
   description: "Unit and integration tests...",
   priority: "medium",
   storyPoints: 2,
-  acceptanceCriteria: "- [ ] Test coverage > 80%",
+  acceptanceCriteriaItems: [
+    { description: "Test coverage > 80%", required: true }
+  ],
   dependsOnDraftUuids: ["<draftUuid-from-first-task>"]
 })
 ```
+
+> To edit a draft's criteria later via `chorus_pm_update_task_draft`, pass a non-empty `acceptanceCriteriaItems` to replace them; omit the field to leave them unchanged. The field cannot be used to clear criteria.
 
 **Task priority:** `low`, `medium`, `high`
 
@@ -334,7 +343,7 @@ Potential issues and how to address them.
 
 Good tasks are:
 - **Module-scoped** — One cohesive functional module per task, not a single function or file
-- **Testable** — Clear, cohesive acceptance criteria (max 6 items per task; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
+- **Testable** — Clear, cohesive acceptance criteria are **required** on every task (at least one non-blank item; max 6; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
 - **Sized** — 1-8 story points (hours of agent work)
 - **Ordered** — Use `dependsOnDraftUuids` / `dependsOnTaskUuids` to express execution order
 - **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.9.1
+version: 0.9.2
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 
@@ -63,7 +63,7 @@ This matters because admin agents can call `chorus_admin_verify_task` to close t
 
 ### Step 1: Create a Quick Task
 
-**Always include `acceptanceCriteriaItems`** — these are the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
+**`acceptanceCriteriaItems` is required** — `chorus_create_tasks` rejects any task without at least one non-blank criterion (and rejects the whole batch if any task is missing them). These are also the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
 
 ```
 chorus_create_tasks({
@@ -93,7 +93,7 @@ chorus_claim_task({ taskUuid: "<task-uuid>" })
 
 ### Step 3: Edit Details (if needed)
 
-Use `chorus_update_task` to refine the task after creation. **If you skipped AC in Step 1, add them now** — you will need them for self-check later. Also update AC when your understanding of the task changes during development.
+Use `chorus_update_task` to refine the task after creation. Tasks always have AC (creation requires them), but **update them when your understanding changes during development**. Passing `acceptanceCriteriaItems` **replaces** the task's criteria with the provided non-empty set; omit the field to leave them unchanged (it cannot be used to clear AC).
 
 ```
 chorus_update_task({
@@ -172,7 +172,7 @@ Quick Tasks work with Claude Code Agent Teams just like proposal-based tasks:
 ## Tips
 
 - Keep Quick Tasks small — if you need more than 2-3 tasks, consider using `/proposal`
-- **Always write acceptance criteria at creation time** — they are your self-check contract. Specific, testable AC enables autonomous verification and makes the entire workflow self-contained
+- **Acceptance criteria are required at creation time** — `chorus_create_tasks` rejects tasks without them. They are your self-check contract; specific, testable AC enables autonomous verification and makes the entire workflow self-contained
 - Use `chorus_update_task` to refine tasks (including AC) after creation rather than deleting and recreating
 - Pass `proposalUuid` to attach follow-up or gap-filling tasks to an existing proposal — this keeps related work grouped in the same project context and DAG
 - Quick Tasks show up in the same project task list and DAG as proposal-based tasks

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.1"
+  version: "0.9.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -224,7 +224,7 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-3. **Add task drafts incrementally** (use returned `draftUuid` for dependency chaining):
+3. **Add task drafts incrementally** (use returned `draftUuid` for dependency chaining). `acceptanceCriteriaItems` is **required** on every draft — at least one non-blank criterion, or the call is rejected:
    ```
    # First task
    result1 = chorus_pm_add_task_draft({

--- a/public/skill/proposal-chorus/SKILL.md
+++ b/public/skill/proposal-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.3.1"
+  version: "0.3.2"
   category: project-management
   mcp_server: chorus
 ---
@@ -111,6 +111,8 @@ chorus_pm_add_document_draft({
 
 Add task drafts one at a time. The response returns the new draft's `draftUuid` — use it directly for `dependsOnDraftUuids` in subsequent drafts.
 
+**`acceptanceCriteriaItems` is required** — every task draft must include at least one item with a non-blank `description`, or the call is rejected. Use the structured `acceptanceCriteriaItems` array (the legacy `acceptanceCriteria` Markdown string does not satisfy the requirement).
+
 ```
 # First task -> response includes { draftUuid, draftTitle }
 chorus_pm_add_task_draft({
@@ -119,7 +121,10 @@ chorus_pm_add_task_draft({
   description: "Detailed description of what to build...",
   priority: "high",
   storyPoints: 3,
-  acceptanceCriteria: "- [ ] Criteria 1\n- [ ] Criteria 2"
+  acceptanceCriteriaItems: [
+    { description: "Criteria 1", required: true },
+    { description: "Criteria 2", required: true }
+  ]
 })
 
 # Second task — depends on first
@@ -129,10 +134,14 @@ chorus_pm_add_task_draft({
   description: "Unit and integration tests...",
   priority: "medium",
   storyPoints: 2,
-  acceptanceCriteria: "- [ ] Test coverage > 80%",
+  acceptanceCriteriaItems: [
+    { description: "Test coverage > 80%", required: true }
+  ],
   dependsOnDraftUuids: ["<draftUuid-from-first-task>"]
 })
 ```
+
+> To edit a draft's criteria later via `chorus_pm_update_task_draft`, pass a non-empty `acceptanceCriteriaItems` to replace them; omit the field to leave them unchanged. The field cannot be used to clear criteria.
 
 **Task priority:** `low`, `medium`, `high`
 
@@ -302,7 +311,7 @@ Potential issues and how to address them.
 
 Good tasks are:
 - **Module-scoped** — One cohesive functional module per task, not a single function or file
-- **Testable** — Clear, cohesive acceptance criteria (max 6 items per task; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
+- **Testable** — Clear, cohesive acceptance criteria are **required** on every task (at least one non-blank item; max 6; group related checks into one criterion but list key coverage, e.g. "All tests pass: service layer unit tests, API integration tests, edge case handling")
 - **Sized** — 1-8 story points (hours of agent work)
 - **Ordered** — Use `dependsOnDraftUuids` / `dependsOnTaskUuids` to express execution order
 - **Descriptive** — Include enough context for a developer agent to start without questions. For tasks with cross-module dependencies, reference the tech design's Module Contracts in the AC

--- a/public/skill/quick-dev-chorus/SKILL.md
+++ b/public/skill/quick-dev-chorus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev-chorus
-version: 0.3.1
+version: 0.3.2
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 
@@ -63,7 +63,7 @@ This matters because admin agents can call `chorus_admin_verify_task` to close t
 
 ### Step 1: Create a Quick Task
 
-**Always include `acceptanceCriteriaItems`** — these are the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
+**`acceptanceCriteriaItems` is required** — `chorus_create_tasks` rejects any task without at least one non-blank criterion (and rejects the whole batch if any task is missing them). These are also the foundation for self-checking in Step 6. Write specific, testable criteria that you can objectively verify after development. Vague AC like "works correctly" defeats the purpose; prefer "returns 200 on GET /api/foo with valid token".
 
 ```
 chorus_create_tasks({
@@ -93,7 +93,7 @@ chorus_claim_task({ taskUuid: "<task-uuid>" })
 
 ### Step 3: Edit Details (if needed)
 
-Use `chorus_update_task` to refine the task after creation. **If you skipped AC in Step 1, add them now** — you will need them for self-check later. Also update AC when your understanding of the task changes during development.
+Use `chorus_update_task` to refine the task after creation. Tasks always have AC (creation requires them), but **update them when your understanding changes during development**. Passing `acceptanceCriteriaItems` **replaces** the task's criteria with the provided non-empty set; omit the field to leave them unchanged (it cannot be used to clear AC).
 
 ```
 chorus_update_task({
@@ -156,7 +156,7 @@ This completes the full autonomous cycle: create → develop → verify → done
 ## Tips
 
 - Keep Quick Tasks small — if you need more than 2-3 tasks, consider using a proposal
-- **Always write acceptance criteria at creation time** — they are your self-check contract. Specific, testable AC enables autonomous verification and makes the entire workflow self-contained
+- **Acceptance criteria are required at creation time** — `chorus_create_tasks` rejects tasks without them. They are your self-check contract; specific, testable AC enables autonomous verification and makes the entire workflow self-contained
 - Use `chorus_update_task` to refine tasks (including AC) after creation rather than deleting and recreating
 - Pass `proposalUuid` to attach follow-up or gap-filling tasks to an existing proposal — this keeps related work grouped in the same project context and DAG
 - Quick Tasks appear in the same project task list and DAG as proposal-based tasks

--- a/src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts
+++ b/src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts
@@ -56,6 +56,8 @@ const mockTaskService = vi.hoisted(() => ({
   addTaskDependency: vi.fn(),
   removeTaskDependency: vi.fn(),
   createTasksFromProposal: vi.fn(),
+  createAcceptanceCriteria: vi.fn(),
+  replaceAcceptanceCriteria: vi.fn(),
 }));
 
 const mockProjectService = vi.hoisted(() => ({
@@ -89,6 +91,7 @@ vi.mock("@/services/checkin.service", () => ({}));
 // Real modules under test — NOT mocked.
 import { addTaskDraft, updateTaskDraft } from "@/services/proposal.service";
 import { registerPublicTools } from "@/mcp/tools/public";
+import { normalizeAcceptanceCriteria } from "@/lib/acceptance-criteria";
 import type { AgentAuthContext } from "@/types/auth";
 
 // ===== Capture public tool handlers =====
@@ -131,7 +134,7 @@ beforeEach(() => {
     return { ...(proposalStore.current as object), project: { uuid: "project-1", name: "P" } };
   });
 
-  // prisma.acceptanceCriterion: real-ish in-memory behavior.
+  // prisma.acceptanceCriterion: real-ish in-memory behavior (proposal.service path).
   mockPrisma.acceptanceCriterion.createMany.mockImplementation(async ({ data }: { data: AcRow[] }) => {
     acStore.push(...data);
     return { count: data.length };
@@ -141,6 +144,22 @@ beforeEach(() => {
       if (acStore[i].taskUuid === where.taskUuid) acStore.splice(i, 1);
     }
     return { count: 0 };
+  });
+
+  // task.service AC fns are mocked here (real-task layer) — wire them to acStore
+  // so cross-layer assertions stay meaningful. The real transactional behavior of
+  // replaceAcceptanceCriteria is covered by its own unit test in task.service.test.ts.
+  mockTaskService.createAcceptanceCriteria.mockImplementation(async (taskUuid: string, items: { description: string; required: boolean }[]) => {
+    items.forEach((item, index) => acStore.push({ taskUuid, description: item.description, required: item.required, sortOrder: index }));
+    return [];
+  });
+  mockTaskService.replaceAcceptanceCriteria.mockImplementation(async (_companyUuid: string, taskUuid: string, items: { description: string; required?: boolean }[]) => {
+    const normalized = normalizeAcceptanceCriteria(items);
+    for (let i = acStore.length - 1; i >= 0; i--) {
+      if (acStore[i].taskUuid === taskUuid) acStore.splice(i, 1);
+    }
+    normalized.forEach((item, index) => acStore.push({ taskUuid, description: item.description, required: item.required, sortOrder: index }));
+    return [];
   });
 
   mockProjectService.projectExists.mockResolvedValue(true);
@@ -231,8 +250,7 @@ describe("AC enforcement — cross-layer integration", () => {
 
     expect(isError(result)).toBe(false);
     expect(mockTaskService.updateTask).toHaveBeenCalled();
-    expect(mockPrisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
-    expect(mockPrisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+    expect(mockTaskService.replaceAcceptanceCriteria).not.toHaveBeenCalled();
     expect(acStore).toEqual([expect.objectContaining({ description: "keep" })]);
   });
 
@@ -246,7 +264,7 @@ describe("AC enforcement — cross-layer integration", () => {
 
     expect(isError(result)).toBe(false);
     expect(mockTaskService.addTaskDependency).toHaveBeenCalledWith(COMPANY, "task-1", "dep-1");
-    expect(mockPrisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+    expect(mockTaskService.replaceAcceptanceCriteria).not.toHaveBeenCalled();
     expect(acStore).toEqual([expect.objectContaining({ description: "keep" })]);
   });
 

--- a/src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts
+++ b/src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts
@@ -1,0 +1,268 @@
+// src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts
+//
+// Integration checkpoint for the non-empty acceptance-criteria invariant
+// (BLOCKER-1 of the "Enforce Non-Empty Acceptance Criteria" change).
+//
+// Module-level unit tests prove each enforcement point in isolation. This test
+// proves the invariant holds SYSTEM-WIDE across BOTH enforcement layers wired
+// through the SAME shared helper:
+//
+//   - proposal-draft layer: the real proposal.service.addTaskDraft / updateTaskDraft
+//   - real-task layer:       the real public.ts chorus_create_tasks / chorus_update_task
+//
+// Critically, `@/lib/acceptance-criteria` is NOT mocked — the real helper runs in
+// both call sites, so a regression that unwired the helper from either layer would
+// fail here. prisma and peripheral services are stubbed; the AC store is an
+// in-memory map so we can assert rows actually land / get replaced.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== In-memory acceptance-criterion store =====
+
+type AcRow = { taskUuid: string; description: string; required: boolean; sortOrder: number };
+const acStore: AcRow[] = [];
+
+// ===== Hoisted mocks =====
+
+const { mockPrisma, mockEventBus, mockFormatCreatedBy, mockFormatReview, proposalStore } = vi.hoisted(() => {
+  const proposalStore = { current: null as Record<string, unknown> | null };
+  const mockPrisma = {
+    proposal: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    acceptanceCriterion: {
+      createMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  };
+  return {
+    mockPrisma,
+    mockEventBus: { emitChange: vi.fn() },
+    mockFormatCreatedBy: vi.fn().mockResolvedValue({ type: "agent", uuid: "actor-uuid", name: "Agent" }),
+    mockFormatReview: vi.fn().mockResolvedValue(null),
+    proposalStore,
+  };
+});
+
+// task.service is imported by BOTH proposal.service (createTasksFromProposal) and
+// public.ts (createTask, getTaskByUuid, ...). One mock satisfies both.
+const mockTaskService = vi.hoisted(() => ({
+  createTask: vi.fn(),
+  getTaskByUuid: vi.fn(),
+  updateTask: vi.fn(),
+  isValidTaskStatusTransition: vi.fn(),
+  checkDependenciesResolved: vi.fn(),
+  addTaskDependency: vi.fn(),
+  removeTaskDependency: vi.fn(),
+  createTasksFromProposal: vi.fn(),
+}));
+
+const mockProjectService = vi.hoisted(() => ({
+  projectExists: vi.fn().mockResolvedValue(true),
+  getProjectByUuid: vi.fn(),
+}));
+
+const mockActivityService = vi.hoisted(() => ({ createActivity: vi.fn() }));
+const mockSessionService = vi.hoisted(() => ({ getSession: vi.fn(), heartbeatSession: vi.fn() }));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/generated/prisma/client", () => ({ Prisma: { JsonNull: "DbNull", InputJsonValue: {} } }));
+vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
+vi.mock("@/lib/uuid-resolver", () => ({ formatCreatedBy: mockFormatCreatedBy, formatReview: mockFormatReview }));
+vi.mock("@/services/task.service", () => mockTaskService);
+vi.mock("@/services/project.service", () => ({ ...mockProjectService, projectExists: mockProjectService.projectExists }));
+vi.mock("@/services/activity.service", () => mockActivityService);
+vi.mock("@/services/session.service", () => mockSessionService);
+vi.mock("@/services/document.service", () => ({ createDocumentFromProposal: vi.fn() }));
+// Peripheral services public.ts imports but this test never exercises.
+vi.mock("@/services/idea.service", () => ({}));
+vi.mock("@/services/comment.service", () => ({}));
+vi.mock("@/services/assignment.service", () => ({}));
+vi.mock("@/services/notification.service", () => ({}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/project-group.service", () => ({}));
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/search.service", () => ({}));
+vi.mock("@/services/checkin.service", () => ({}));
+
+// Real modules under test — NOT mocked.
+import { addTaskDraft, updateTaskDraft } from "@/services/proposal.service";
+import { registerPublicTools } from "@/mcp/tools/public";
+import type { AgentAuthContext } from "@/types/auth";
+
+// ===== Capture public tool handlers =====
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<unknown>;
+const toolHandlers: Record<string, ToolHandler> = {};
+const fakeMcpServer = {
+  registerTool: (name: string, _meta: unknown, handler: ToolHandler) => {
+    toolHandlers[name] = handler;
+  },
+};
+
+const AUTH: AgentAuthContext = {
+  type: "agent",
+  companyUuid: "company-1",
+  actorUuid: "agent-1",
+  ownerUuid: "owner-1",
+  roles: ["admin"],
+  permissions: [],
+  agentName: "Integration Agent",
+};
+
+const COMPANY = "company-1";
+
+function isError(result: unknown): boolean {
+  return (result as { isError?: boolean }).isError === true;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  acStore.length = 0;
+  proposalStore.current = null;
+  Object.keys(toolHandlers).forEach((k) => delete toolHandlers[k]);
+  registerPublicTools(fakeMcpServer as never, AUTH);
+
+  // prisma.proposal: a single draft proposal whose taskDrafts live in proposalStore.
+  mockPrisma.proposal.findFirst.mockImplementation(async () => proposalStore.current);
+  mockPrisma.proposal.update.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => {
+    proposalStore.current = { ...(proposalStore.current as object), ...data };
+    return { ...(proposalStore.current as object), project: { uuid: "project-1", name: "P" } };
+  });
+
+  // prisma.acceptanceCriterion: real-ish in-memory behavior.
+  mockPrisma.acceptanceCriterion.createMany.mockImplementation(async ({ data }: { data: AcRow[] }) => {
+    acStore.push(...data);
+    return { count: data.length };
+  });
+  mockPrisma.acceptanceCriterion.deleteMany.mockImplementation(async ({ where }: { where: { taskUuid: string } }) => {
+    for (let i = acStore.length - 1; i >= 0; i--) {
+      if (acStore[i].taskUuid === where.taskUuid) acStore.splice(i, 1);
+    }
+    return { count: 0 };
+  });
+
+  mockProjectService.projectExists.mockResolvedValue(true);
+});
+
+describe("AC enforcement — cross-layer integration", () => {
+  it("proposal layer: addTaskDraft rejects missing AC but accepts a non-empty set", async () => {
+    proposalStore.current = { uuid: "prop-1", companyUuid: COMPANY, projectUuid: "project-1", status: "draft", taskDrafts: [], createdByType: "agent", createdByUuid: "agent-1", inputType: "idea", inputUuids: [], description: null, title: "P", reviewedByUuid: null, reviewNote: null, reviewedAt: null, createdAt: new Date("2026-06-02T00:00:00Z"), updatedAt: new Date("2026-06-02T00:00:00Z") };
+
+    // Missing AC → rejected by the shared helper, nothing written.
+    await expect(
+      addTaskDraft("prop-1", COMPANY, { title: "No AC" }),
+    ).rejects.toThrow("acceptance criterion");
+
+    // Non-empty AC (with a blank dropped) → persisted normalized.
+    await addTaskDraft("prop-1", COMPANY, {
+      title: "With AC",
+      acceptanceCriteriaItems: [{ description: "  real  " }, { description: "  " }],
+    });
+    const drafts = (proposalStore.current as { taskDrafts: Array<{ title: string; acceptanceCriteriaItems: unknown }> }).taskDrafts;
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].acceptanceCriteriaItems).toEqual([{ description: "real", required: true }]);
+  });
+
+  it("real-task layer: chorus_create_tasks rejects missing AC but persists rows for a non-empty set", async () => {
+    // Missing AC → isError, no task created.
+    mockTaskService.createTask.mockResolvedValue({ uuid: "task-1", title: "x" });
+    const bad = await toolHandlers["chorus_create_tasks"]({
+      projectUuid: "project-1",
+      tasks: [{ title: "No AC" }],
+    });
+    expect(isError(bad)).toBe(true);
+    expect(mockTaskService.createTask).not.toHaveBeenCalled();
+    expect(acStore).toHaveLength(0);
+
+    // Non-empty AC → task created and AC rows landed.
+    mockTaskService.createTask.mockResolvedValue({ uuid: "task-1", title: "Good" });
+    const ok = await toolHandlers["chorus_create_tasks"]({
+      projectUuid: "project-1",
+      tasks: [{ title: "Good", acceptanceCriteriaItems: [{ description: "ships" }] }],
+    });
+    expect(isError(ok)).toBe(false);
+    expect(acStore).toEqual([
+      expect.objectContaining({ taskUuid: "task-1", description: "ships", required: true, sortOrder: 0 }),
+    ]);
+  });
+
+  it("real-task layer: chorus_update_task replaces AC with a non-empty set", async () => {
+    acStore.push({ taskUuid: "task-1", description: "old", required: true, sortOrder: 0 });
+    mockTaskService.getTaskByUuid.mockResolvedValue({
+      uuid: "task-1", status: "assigned", projectUuid: "project-1", assigneeType: "agent", assigneeUuid: "agent-1",
+    });
+
+    const result = await toolHandlers["chorus_update_task"]({
+      taskUuid: "task-1",
+      acceptanceCriteriaItems: [{ description: "brand new" }],
+    });
+
+    expect(isError(result)).toBe(false);
+    // Old row deleted, new row present.
+    expect(acStore).toEqual([
+      expect.objectContaining({ taskUuid: "task-1", description: "brand new", required: true, sortOrder: 0 }),
+    ]);
+  });
+
+  it("real-task layer: chorus_update_task rejects an empty AC array and leaves rows intact", async () => {
+    acStore.push({ taskUuid: "task-1", description: "keep", required: true, sortOrder: 0 });
+    mockTaskService.getTaskByUuid.mockResolvedValue({
+      uuid: "task-1", status: "assigned", projectUuid: "project-1", assigneeType: "agent", assigneeUuid: "agent-1",
+    });
+
+    const result = await toolHandlers["chorus_update_task"]({ taskUuid: "task-1", acceptanceCriteriaItems: [] });
+
+    expect(isError(result)).toBe(true);
+    expect(acStore).toEqual([expect.objectContaining({ description: "keep" })]);
+  });
+
+  it("regression: status-only transition is not blocked and does not touch AC", async () => {
+    acStore.push({ taskUuid: "task-1", description: "keep", required: true, sortOrder: 0 });
+    mockTaskService.getTaskByUuid.mockResolvedValue({
+      uuid: "task-1", status: "assigned", projectUuid: "project-1", assigneeType: "agent", assigneeUuid: "agent-1",
+    });
+    mockTaskService.isValidTaskStatusTransition.mockReturnValue(true);
+    mockTaskService.checkDependenciesResolved.mockResolvedValue({ resolved: true, blockers: [] });
+    mockTaskService.updateTask.mockResolvedValue({ uuid: "task-1", status: "in_progress" });
+
+    const result = await toolHandlers["chorus_update_task"]({ taskUuid: "task-1", status: "in_progress" });
+
+    expect(isError(result)).toBe(false);
+    expect(mockTaskService.updateTask).toHaveBeenCalled();
+    expect(mockPrisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+    expect(acStore).toEqual([expect.objectContaining({ description: "keep" })]);
+  });
+
+  it("regression: dependency-only edit is not blocked and does not touch AC", async () => {
+    acStore.push({ taskUuid: "task-1", description: "keep", required: true, sortOrder: 0 });
+    mockTaskService.getTaskByUuid.mockResolvedValue({
+      uuid: "task-1", status: "assigned", projectUuid: "project-1", assigneeType: "agent", assigneeUuid: "agent-1",
+    });
+
+    const result = await toolHandlers["chorus_update_task"]({ taskUuid: "task-1", addDependsOn: ["dep-1"] });
+
+    expect(isError(result)).toBe(false);
+    expect(mockTaskService.addTaskDependency).toHaveBeenCalledWith(COMPANY, "task-1", "dep-1");
+    expect(mockPrisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+    expect(acStore).toEqual([expect.objectContaining({ description: "keep" })]);
+  });
+
+  it("proposal layer: updateTaskDraft preserves AC when omitted (shared invariant, no false rejection)", async () => {
+    proposalStore.current = {
+      uuid: "prop-1", companyUuid: COMPANY, projectUuid: "project-1", status: "draft",
+      taskDrafts: [{ uuid: "td-1", title: "T", acceptanceCriteriaItems: [{ description: "Done", required: true }] }],
+      createdByType: "agent", createdByUuid: "agent-1", inputType: "idea", inputUuids: [], description: null, title: "P",
+      reviewedByUuid: null, reviewNote: null, reviewedAt: null,
+      createdAt: new Date("2026-06-02T00:00:00Z"), updatedAt: new Date("2026-06-02T00:00:00Z"),
+    };
+
+    await updateTaskDraft("prop-1", COMPANY, "td-1", { title: "Renamed" });
+
+    const drafts = (proposalStore.current as { taskDrafts: Array<{ title: string; acceptanceCriteriaItems: unknown }> }).taskDrafts;
+    expect(drafts[0].title).toBe("Renamed");
+    expect(drafts[0].acceptanceCriteriaItems).toEqual([{ description: "Done", required: true }]);
+  });
+});

--- a/src/lib/__tests__/acceptance-criteria.test.ts
+++ b/src/lib/__tests__/acceptance-criteria.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeAcceptanceCriteria,
+  hasNonEmptyAcceptanceCriteria,
+  ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE,
+} from '../acceptance-criteria';
+
+describe('normalizeAcceptanceCriteria', () => {
+  it('returns [] for undefined', () => {
+    expect(normalizeAcceptanceCriteria(undefined)).toEqual([]);
+  });
+
+  it('returns [] for null', () => {
+    expect(normalizeAcceptanceCriteria(null)).toEqual([]);
+  });
+
+  it('returns [] for an empty array', () => {
+    expect(normalizeAcceptanceCriteria([])).toEqual([]);
+  });
+
+  it('drops items whose description is blank after trimming', () => {
+    const result = normalizeAcceptanceCriteria([
+      { description: '   ' },
+      { description: '\t\n' },
+      { description: '' },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it('trims surviving descriptions and defaults required to true', () => {
+    const result = normalizeAcceptanceCriteria([
+      { description: '  has trailing space  ' },
+    ]);
+    expect(result).toEqual([{ description: 'has trailing space', required: true }]);
+  });
+
+  it('preserves an explicit required: false', () => {
+    const result = normalizeAcceptanceCriteria([
+      { description: 'optional one', required: false },
+    ]);
+    expect(result).toEqual([{ description: 'optional one', required: false }]);
+  });
+
+  it('keeps non-blank items in order while dropping blanks (mixed)', () => {
+    const result = normalizeAcceptanceCriteria([
+      { description: 'first' },
+      { description: '   ' },
+      { description: 'second', required: false },
+    ]);
+    expect(result).toEqual([
+      { description: 'first', required: true },
+      { description: 'second', required: false },
+    ]);
+  });
+});
+
+describe('hasNonEmptyAcceptanceCriteria', () => {
+  it('returns false for undefined', () => {
+    expect(hasNonEmptyAcceptanceCriteria(undefined)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(hasNonEmptyAcceptanceCriteria(null)).toBe(false);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(hasNonEmptyAcceptanceCriteria([])).toBe(false);
+  });
+
+  it('returns false when every description is blank', () => {
+    expect(
+      hasNonEmptyAcceptanceCriteria([{ description: '  ' }, { description: '\n' }]),
+    ).toBe(false);
+  });
+
+  it('returns true when at least one description is non-blank', () => {
+    expect(
+      hasNonEmptyAcceptanceCriteria([{ description: '  ' }, { description: 'real' }]),
+    ).toBe(true);
+  });
+
+  it('returns true for a single non-blank item', () => {
+    expect(hasNonEmptyAcceptanceCriteria([{ description: 'done' }])).toBe(true);
+  });
+});
+
+describe('ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE', () => {
+  it('is a non-empty string', () => {
+    expect(typeof ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE).toBe('string');
+    expect(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/acceptance-criteria.ts
+++ b/src/lib/acceptance-criteria.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared acceptance-criteria validation — the single source of truth for the
+ * "every task / task draft must have at least one non-empty acceptance criterion"
+ * invariant.
+ *
+ * Used by both the proposal service (task drafts stored as JSON) and the MCP
+ * tool handlers in `src/mcp/tools/public.ts` (real-task AcceptanceCriterion rows).
+ * Keeping the rule here avoids drift between the two enforcement layers.
+ */
+
+/** Input shape accepted by the create/edit tools before normalization. */
+export interface AcceptanceCriteriaItemInput {
+  description: string;
+  required?: boolean;
+}
+
+/** Normalized acceptance-criterion item ready for persistence. */
+export interface NormalizedAcceptanceCriteriaItem {
+  description: string;
+  required: boolean;
+}
+
+/**
+ * Standard error message thrown / returned when acceptance criteria are missing
+ * or contain no non-blank description.
+ */
+export const ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE =
+  "At least one acceptance criterion with a non-empty description is required.";
+
+/**
+ * Drop items whose description is blank after trimming, trim the surviving
+ * descriptions, and default `required` to `true`. Order is preserved.
+ */
+export function normalizeAcceptanceCriteria(
+  items: AcceptanceCriteriaItemInput[] | undefined | null,
+): NormalizedAcceptanceCriteriaItem[] {
+  if (!items) return [];
+  return items
+    .filter((item) => item.description.trim().length > 0)
+    .map((item) => ({
+      description: item.description.trim(),
+      required: item.required ?? true,
+    }));
+}
+
+/**
+ * True iff at least one item has a non-blank description (after trimming).
+ * `undefined`, `null`, an empty array, and an all-blank array all return false.
+ */
+export function hasNonEmptyAcceptanceCriteria(
+  items: AcceptanceCriteriaItemInput[] | undefined | null,
+): boolean {
+  return normalizeAcceptanceCriteria(items).length > 0;
+}

--- a/src/mcp/__tests__/public-tools-task-ops.test.ts
+++ b/src/mcp/__tests__/public-tools-task-ops.test.ts
@@ -92,13 +92,15 @@ beforeEach(() => {
 // ===== chorus_create_tasks =====
 
 describe("chorus_create_tasks", () => {
+  const AC = [{ description: "It works", required: true }];
+
   it("creates a Quick Task (no proposalUuid) and logs activity", async () => {
     mockProjectService.projectExists.mockResolvedValue(true);
     mockTaskService.createTask.mockResolvedValue({ uuid: "task-1", title: "Fix bug" });
 
     const result = await toolHandlers["chorus_create_tasks"]({
       projectUuid: "project-1",
-      tasks: [{ title: "Fix bug", priority: "high" }],
+      tasks: [{ title: "Fix bug", priority: "high", acceptanceCriteriaItems: AC }],
     });
 
     expect(mockTaskService.createTask).toHaveBeenCalledWith(
@@ -117,6 +119,12 @@ describe("chorus_create_tasks", () => {
       }),
     );
 
+    expect(mockPrisma.prisma.acceptanceCriterion.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({ taskUuid: "task-1", description: "It works", required: true, sortOrder: 0 }),
+      ],
+    });
+
     const parsed = JSON.parse((result as { content: { text: string }[] }).content[0].text);
     expect(parsed.tasks).toHaveLength(1);
     expect(parsed.tasks[0].uuid).toBe("task-1");
@@ -130,7 +138,7 @@ describe("chorus_create_tasks", () => {
     await toolHandlers["chorus_create_tasks"]({
       projectUuid: "project-1",
       proposalUuid: "prop-1",
-      tasks: [{ title: "Feature" }],
+      tasks: [{ title: "Feature", acceptanceCriteriaItems: AC }],
     });
 
     expect(mockTaskService.createTask).toHaveBeenCalledWith(
@@ -150,7 +158,38 @@ describe("chorus_create_tasks", () => {
 
     const result = await toolHandlers["chorus_create_tasks"]({
       projectUuid: "nonexistent",
-      tasks: [{ title: "Test" }],
+      tasks: [{ title: "Test", acceptanceCriteriaItems: AC }],
+    });
+
+    expect(result).toEqual(expect.objectContaining({ isError: true }));
+    expect(mockTaskService.createTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects the whole batch and creates no task when any task lacks acceptance criteria", async () => {
+    mockProjectService.projectExists.mockResolvedValue(true);
+    mockTaskService.createTask.mockResolvedValue({ uuid: "task-x", title: "x" });
+
+    const result = await toolHandlers["chorus_create_tasks"]({
+      projectUuid: "project-1",
+      tasks: [
+        { title: "Has AC", acceptanceCriteriaItems: AC },
+        { title: "No AC" },
+      ],
+    });
+
+    expect(result).toEqual(expect.objectContaining({ isError: true }));
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    expect(text).toContain("No AC");
+    expect(mockTaskService.createTask).not.toHaveBeenCalled();
+    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects a task whose acceptance criteria are all blank", async () => {
+    mockProjectService.projectExists.mockResolvedValue(true);
+
+    const result = await toolHandlers["chorus_create_tasks"]({
+      projectUuid: "project-1",
+      tasks: [{ title: "Blank AC", acceptanceCriteriaItems: [{ description: "   " }] }],
     });
 
     expect(result).toEqual(expect.objectContaining({ isError: true }));
@@ -259,5 +298,74 @@ describe("chorus_update_task", () => {
     });
 
     expect(result).toEqual(expect.objectContaining({ isError: true }));
+  });
+
+  it("replaces acceptance criteria with the normalized non-empty set", async () => {
+    mockTaskService.getTaskByUuid.mockResolvedValue(TASK);
+
+    await toolHandlers["chorus_update_task"]({
+      taskUuid: "task-1",
+      acceptanceCriteriaItems: [
+        { description: "  new crit  ", required: false },
+        { description: "   " },
+      ],
+    });
+
+    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).toHaveBeenCalledWith({
+      where: { taskUuid: "task-1" },
+    });
+    expect(mockPrisma.prisma.acceptanceCriterion.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({ taskUuid: "task-1", description: "new crit", required: false, sortOrder: 0 }),
+      ],
+    });
+    expect(mockActivityService.createActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "updated",
+        value: expect.objectContaining({ acceptanceCriteriaReplaced: true }),
+      }),
+    );
+  });
+
+  it("rejects empty/all-blank acceptance criteria and touches no AC rows", async () => {
+    mockTaskService.getTaskByUuid.mockResolvedValue(TASK);
+
+    const result = await toolHandlers["chorus_update_task"]({
+      taskUuid: "task-1",
+      acceptanceCriteriaItems: [],
+    });
+
+    expect(result).toEqual(expect.objectContaining({ isError: true }));
+    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+    expect(mockTaskService.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("does not touch acceptance criteria during a status-only transition", async () => {
+    mockTaskService.getTaskByUuid.mockResolvedValue(TASK);
+    mockTaskService.isValidTaskStatusTransition.mockReturnValue(true);
+    mockTaskService.checkDependenciesResolved.mockResolvedValue({ resolved: true, blockers: [] });
+    mockTaskService.updateTask.mockResolvedValue({ ...TASK, status: "in_progress" });
+
+    await toolHandlers["chorus_update_task"]({
+      taskUuid: "task-1",
+      status: "in_progress",
+    });
+
+    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+  });
+
+  it("does not touch acceptance criteria during dependency-only edits", async () => {
+    mockTaskService.getTaskByUuid.mockResolvedValue(TASK);
+
+    await toolHandlers["chorus_update_task"]({
+      taskUuid: "task-1",
+      addDependsOn: ["dep-1"],
+    });
+
+    expect(mockTaskService.addTaskDependency).toHaveBeenCalledWith("company-1", "task-1", "dep-1");
+    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
   });
 });

--- a/src/mcp/__tests__/public-tools-task-ops.test.ts
+++ b/src/mcp/__tests__/public-tools-task-ops.test.ts
@@ -17,6 +17,8 @@ const mockTaskService = vi.hoisted(() => ({
   checkDependenciesResolved: vi.fn(),
   addTaskDependency: vi.fn(),
   removeTaskDependency: vi.fn(),
+  createAcceptanceCriteria: vi.fn(),
+  replaceAcceptanceCriteria: vi.fn(),
   TaskUpdateParams: {},
 }));
 
@@ -119,11 +121,10 @@ describe("chorus_create_tasks", () => {
       }),
     );
 
-    expect(mockPrisma.prisma.acceptanceCriterion.createMany).toHaveBeenCalledWith({
-      data: [
-        expect.objectContaining({ taskUuid: "task-1", description: "It works", required: true, sortOrder: 0 }),
-      ],
-    });
+    expect(mockTaskService.createAcceptanceCriteria).toHaveBeenCalledWith(
+      "task-1",
+      [expect.objectContaining({ description: "It works", required: true })],
+    );
 
     const parsed = JSON.parse((result as { content: { text: string }[] }).content[0].text);
     expect(parsed.tasks).toHaveLength(1);
@@ -181,7 +182,7 @@ describe("chorus_create_tasks", () => {
     const text = (result as { content: { text: string }[] }).content[0].text;
     expect(text).toContain("No AC");
     expect(mockTaskService.createTask).not.toHaveBeenCalled();
-    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+    expect(mockTaskService.createAcceptanceCriteria).not.toHaveBeenCalled();
   });
 
   it("rejects a task whose acceptance criteria are all blank", async () => {
@@ -311,14 +312,14 @@ describe("chorus_update_task", () => {
       ],
     });
 
-    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).toHaveBeenCalledWith({
-      where: { taskUuid: "task-1" },
-    });
-    expect(mockPrisma.prisma.acceptanceCriterion.createMany).toHaveBeenCalledWith({
-      data: [
-        expect.objectContaining({ taskUuid: "task-1", description: "new crit", required: false, sortOrder: 0 }),
+    expect(mockTaskService.replaceAcceptanceCriteria).toHaveBeenCalledWith(
+      "company-1",
+      "task-1",
+      [
+        expect.objectContaining({ description: "  new crit  ", required: false }),
+        expect.objectContaining({ description: "   " }),
       ],
-    });
+    );
     expect(mockActivityService.createActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "updated",
@@ -336,8 +337,7 @@ describe("chorus_update_task", () => {
     });
 
     expect(result).toEqual(expect.objectContaining({ isError: true }));
-    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
-    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+    expect(mockTaskService.replaceAcceptanceCriteria).not.toHaveBeenCalled();
     expect(mockTaskService.updateTask).not.toHaveBeenCalled();
   });
 
@@ -352,8 +352,7 @@ describe("chorus_update_task", () => {
       status: "in_progress",
     });
 
-    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
-    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+    expect(mockTaskService.replaceAcceptanceCriteria).not.toHaveBeenCalled();
   });
 
   it("does not touch acceptance criteria during dependency-only edits", async () => {
@@ -365,7 +364,6 @@ describe("chorus_update_task", () => {
     });
 
     expect(mockTaskService.addTaskDependency).toHaveBeenCalledWith("company-1", "task-1", "dep-1");
-    expect(mockPrisma.prisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
-    expect(mockPrisma.prisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
+    expect(mockTaskService.replaceAcceptanceCriteria).not.toHaveBeenCalled();
   });
 });

--- a/src/mcp/__tests__/wave3-integration-smoke.test.ts
+++ b/src/mcp/__tests__/wave3-integration-smoke.test.ts
@@ -208,7 +208,7 @@ describe("Wave 3 — MCP tool surface convergence: integration smoke", () => {
         name: "chorus_create_tasks",
         arguments: {
           projectUuid: "project-1",
-          tasks: [{ title: "Quick task", priority: "high" }],
+          tasks: [{ title: "Quick task", priority: "high", acceptanceCriteriaItems: [{ description: "Works" }] }],
         },
       });
 
@@ -252,7 +252,7 @@ describe("Wave 3 — MCP tool surface convergence: integration smoke", () => {
         arguments: {
           projectUuid: "project-1",
           proposalUuid: "prop-1",
-          tasks: [{ title: "Linked task" }],
+          tasks: [{ title: "Linked task", acceptanceCriteriaItems: [{ description: "Works" }] }],
         },
       });
 

--- a/src/mcp/__tests__/wave3-integration-smoke.test.ts
+++ b/src/mcp/__tests__/wave3-integration-smoke.test.ts
@@ -49,6 +49,8 @@ const mockTaskService = vi.hoisted(() => ({
   checkDependenciesResolved: vi.fn(),
   addTaskDependency: vi.fn(),
   removeTaskDependency: vi.fn(),
+  createAcceptanceCriteria: vi.fn(),
+  replaceAcceptanceCriteria: vi.fn(),
   TaskUpdateParams: {},
 }));
 

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -369,7 +369,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "proposal:write",
     "chorus_pm_add_task_draft",
     {
-      description: "Add a task draft to a pending Proposal container",
+      description: "Add a task draft to a pending Proposal container. Acceptance criteria are required: acceptanceCriteriaItems must contain at least one item with a non-blank description.",
       inputSchema: z.object({
         proposalUuid: z.string().describe("Proposal UUID"),
         title: z.string().describe("Task title"),
@@ -379,7 +379,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         acceptanceCriteriaItems: zArray(z.object({
           description: z.string().describe("Criterion description"),
           required: z.boolean().optional().describe("Whether this criterion is required (default: true)"),
-        })).optional().describe("Structured acceptance criteria items (materialized on approval)"),
+        })).optional().describe("Structured acceptance criteria items (materialized on approval) — REQUIRED: at least one item with a non-blank description, or the call is rejected"),
         dependsOnDraftUuids: zArray(z.string()).optional().describe("Dependent taskDraft UUID list"),
       }),
     },
@@ -452,7 +452,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "proposal:write",
     "chorus_pm_update_task_draft",
     {
-      description: "Update a task draft in a Proposal",
+      description: "Update a task draft in a Proposal. Partial-update semantics: omit acceptanceCriteriaItems to leave existing criteria unchanged; if provided it replaces them and must be non-empty (cannot clear acceptance criteria).",
       inputSchema: z.object({
         proposalUuid: z.string().describe("Proposal UUID"),
         draftUuid: z.string().describe("Task draft UUID"),
@@ -463,7 +463,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         acceptanceCriteriaItems: zArray(z.object({
           description: z.string().describe("Criterion description"),
           required: z.boolean().optional().describe("Whether this criterion is required (default: true)"),
-        })).optional().describe("Structured acceptance criteria items (replaces existing items)"),
+        })).optional().describe("Structured acceptance criteria items. If provided, replaces existing items and must be non-empty (at least one non-blank description); if omitted, existing items are preserved. Cannot be used to clear acceptance criteria."),
         dependsOnDraftUuids: zArray(z.string()).optional().describe("Dependent taskDraft UUID list"),
       }),
     },

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -22,7 +22,6 @@ import * as mentionService from "@/services/mention.service";
 import * as searchService from "@/services/search.service";
 import * as sessionService from "@/services/session.service";
 import * as checkinService from "@/services/checkin.service";
-import { prisma } from "@/lib/prisma";
 import { registerPermissionedTool } from "./register-helpers";
 import {
   ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE,
@@ -887,17 +886,10 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
           }
         }
 
-        // AC presence was pre-validated above; normalize and persist.
+        // AC presence was pre-validated above; normalize and persist via the service layer.
         const acItems = normalizeAcceptanceCriteria(task.acceptanceCriteriaItems);
         try {
-          await prisma.acceptanceCriterion.createMany({
-            data: acItems.map((item, index) => ({
-              taskUuid: realUuid,
-              description: item.description,
-              required: item.required,
-              sortOrder: index,
-            })),
-          });
+          await taskService.createAcceptanceCriteria(realUuid, acItems);
         } catch (error) {
           warnings.push(`Task "${task.title}": failed to create acceptance criteria: ${error instanceof Error ? error.message : "unknown error"}`);
         }
@@ -1069,21 +1061,13 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         }
       }
 
-      // Replace acceptance criteria (validated non-empty above). Delete the old
-      // rows then recreate from the normalized set — this discards any prior
-      // dev/admin verification marks, which is correct since the AC changed.
+      // Replace acceptance criteria (validated non-empty above). The service
+      // performs the delete + recreate atomically so a partial failure can't
+      // leave the task with zero criteria; replacing discards prior dev/admin
+      // verification marks, which is correct since the AC changed.
       let acReplaced = false;
       if (acceptanceCriteriaItems !== undefined) {
-        const acItems = normalizeAcceptanceCriteria(acceptanceCriteriaItems);
-        await prisma.acceptanceCriterion.deleteMany({ where: { taskUuid: task.uuid } });
-        await prisma.acceptanceCriterion.createMany({
-          data: acItems.map((item, index) => ({
-            taskUuid: task.uuid,
-            description: item.description,
-            required: item.required,
-            sortOrder: index,
-          })),
-        });
+        await taskService.replaceAcceptanceCriteria(auth.companyUuid, task.uuid, acceptanceCriteriaItems);
         acReplaced = true;
       }
 

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -24,6 +24,11 @@ import * as sessionService from "@/services/session.service";
 import * as checkinService from "@/services/checkin.service";
 import { prisma } from "@/lib/prisma";
 import { registerPermissionedTool } from "./register-helpers";
+import {
+  ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE,
+  hasNonEmptyAcceptanceCriteria,
+  normalizeAcceptanceCriteria,
+} from "@/lib/acceptance-criteria";
 
 export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_project - Get project details and context
@@ -787,7 +792,8 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         "Batch create tasks in a project. Two modes:\n\n" +
         "**Quick Task** (skip Idea→Proposal): omit proposalUuid. Ideal for bug fixes, small features, post-delivery patches. Flow: create → claim → execute → verify → done.\n\n" +
         "**Proposal-linked** (traditional AI-DLC): pass proposalUuid to associate with an approved proposal.\n\n" +
-        "Supports batch creation with intra-batch dependencies (draftUuid + dependsOnDraftUuids) and dependencies on existing tasks (dependsOnTaskUuids).",
+        "Supports batch creation with intra-batch dependencies (draftUuid + dependsOnDraftUuids) and dependencies on existing tasks (dependsOnTaskUuids).\n\n" +
+        "Acceptance criteria are REQUIRED: every task must include at least one acceptanceCriteriaItems entry with a non-blank description, or the entire batch is rejected (no task is created).",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         proposalUuid: z.string().optional().describe("Associated Proposal UUID (optional — omit for Quick Task mode)"),
@@ -799,7 +805,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
           acceptanceCriteriaItems: zArray(z.object({
             description: z.string().describe("Criterion description"),
             required: z.boolean().optional().describe("Whether this criterion is required (default: true)"),
-          })).optional().describe("Structured acceptance criteria items"),
+          })).optional().describe("Structured acceptance criteria items — REQUIRED: at least one item with a non-blank description per task"),
           draftUuid: z.string().optional().describe("Temporary UUID for intra-batch dependsOnDraftUuids references"),
           dependsOnDraftUuids: zArray(z.string()).optional().describe("Dependent draftUuid list within this batch"),
           dependsOnTaskUuids: zArray(z.string()).optional().describe("Dependent existing Task UUID list"),
@@ -815,6 +821,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         const proposal = await proposalService.getProposalByUuid(auth.companyUuid, proposalUuid);
         if (!proposal) {
           return { content: [{ type: "text", text: "Proposal not found" }], isError: true };
+        }
+      }
+
+      // Acceptance criteria are mandatory. Pre-validate every task BEFORE creating
+      // any, so a single AC-less task rejects the whole batch (no half-created set).
+      for (const task of tasks) {
+        if (!hasNonEmptyAcceptanceCriteria(task.acceptanceCriteriaItems)) {
+          return {
+            content: [{ type: "text", text: `Task "${task.title}": ${ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE}` }],
+            isError: true,
+          };
         }
       }
 
@@ -870,24 +887,19 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
           }
         }
 
-        if (task.acceptanceCriteriaItems && task.acceptanceCriteriaItems.length > 0) {
-          const validItems = task.acceptanceCriteriaItems.filter(
-            (item) => item.description && item.description.trim().length > 0
-          );
-          if (validItems.length > 0) {
-            try {
-              await prisma.acceptanceCriterion.createMany({
-                data: validItems.map((item, index) => ({
-                  taskUuid: realUuid,
-                  description: item.description.trim(),
-                  required: item.required ?? true,
-                  sortOrder: index,
-                })),
-              });
-            } catch (error) {
-              warnings.push(`Task "${task.title}": failed to create acceptance criteria: ${error instanceof Error ? error.message : "unknown error"}`);
-            }
-          }
+        // AC presence was pre-validated above; normalize and persist.
+        const acItems = normalizeAcceptanceCriteria(task.acceptanceCriteriaItems);
+        try {
+          await prisma.acceptanceCriterion.createMany({
+            data: acItems.map((item, index) => ({
+              taskUuid: realUuid,
+              description: item.description,
+              required: item.required,
+              sortOrder: index,
+            })),
+          });
+        } catch (error) {
+          warnings.push(`Task "${task.title}": failed to create acceptance criteria: ${error instanceof Error ? error.message : "unknown error"}`);
         }
       }
 
@@ -927,6 +939,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       description:
         "Update a task — edit fields, manage dependencies, or change status.\n\n" +
         "**Field editing** (any role): title, description, priority, storyPoints, addDependsOn/removeDependsOn (incremental dependency management).\n\n" +
+        "**Acceptance criteria editing** (any role): pass acceptanceCriteriaItems to REPLACE the task's acceptance criteria with the provided non-empty set. Omit it to leave AC untouched. It cannot be used to clear AC — an empty or all-blank array is rejected. Replacing discards any prior dev/admin verification marks on the old criteria.\n\n" +
         "**Status update** (assignee only): in_progress (requires all dependencies resolved), to_verify.\n\n" +
         "For Quick Tasks: create → claim → edit details → execute → verify → done.",
       inputSchema: z.object({
@@ -937,14 +950,28 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         description: z.string().optional().describe("New task description (supports @mentions)"),
         priority: z.enum(["low", "medium", "high"]).optional().describe("New priority"),
         storyPoints: z.number().optional().describe("New effort estimate (agent hours)"),
+        acceptanceCriteriaItems: zArray(z.object({
+          description: z.string().describe("Criterion description"),
+          required: z.boolean().optional().describe("Whether this criterion is required (default: true)"),
+        })).optional().describe("Replace the task's acceptance criteria with this non-empty set. Omit to leave AC unchanged; cannot be used to clear AC (empty/all-blank is rejected)."),
         addDependsOn: zArray(z.string()).optional().describe("Task UUIDs to add as dependencies"),
         removeDependsOn: zArray(z.string()).optional().describe("Task UUIDs to remove from dependencies"),
       }),
     },
-    async ({ taskUuid, status, sessionUuid, title, description, priority, storyPoints, addDependsOn, removeDependsOn }) => {
+    async ({ taskUuid, status, sessionUuid, title, description, priority, storyPoints, acceptanceCriteriaItems, addDependsOn, removeDependsOn }) => {
       const task = await taskService.getTaskByUuid(auth.companyUuid, taskUuid);
       if (!task) {
         return { content: [{ type: "text", text: "Task not found" }], isError: true };
+      }
+
+      // If acceptance criteria are supplied, they must be non-empty — the field
+      // replaces existing AC and cannot be used to clear them. Validate before
+      // any mutation so a bad AC payload rejects the whole call cleanly.
+      if (acceptanceCriteriaItems !== undefined && !hasNonEmptyAcceptanceCriteria(acceptanceCriteriaItems)) {
+        return {
+          content: [{ type: "text", text: ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE }],
+          isError: true,
+        };
       }
 
       // Status update requires assignee check
@@ -1042,6 +1069,24 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         }
       }
 
+      // Replace acceptance criteria (validated non-empty above). Delete the old
+      // rows then recreate from the normalized set — this discards any prior
+      // dev/admin verification marks, which is correct since the AC changed.
+      let acReplaced = false;
+      if (acceptanceCriteriaItems !== undefined) {
+        const acItems = normalizeAcceptanceCriteria(acceptanceCriteriaItems);
+        await prisma.acceptanceCriterion.deleteMany({ where: { taskUuid: task.uuid } });
+        await prisma.acceptanceCriterion.createMany({
+          data: acItems.map((item, index) => ({
+            taskUuid: task.uuid,
+            description: item.description,
+            required: item.required,
+            sortOrder: index,
+          })),
+        });
+        acReplaced = true;
+      }
+
       // Log activity — merge all changes into a single record
       const activityValue: Record<string, unknown> = {};
       if (status) activityValue.status = status;
@@ -1049,10 +1094,11 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       if (description !== undefined) activityValue.descriptionUpdated = true;
       if (priority !== undefined) activityValue.priority = priority;
       if (storyPoints !== undefined) activityValue.storyPoints = storyPoints;
+      if (acReplaced) activityValue.acceptanceCriteriaReplaced = true;
       if (addDependsOn) activityValue.addedDependencies = addDependsOn.length;
       if (removeDependsOn) activityValue.removedDependencies = removeDependsOn.length;
 
-      const hasAnyChange = status || hasFieldUpdates || addDependsOn || removeDependsOn;
+      const hasAnyChange = status || hasFieldUpdates || acReplaced || addDependsOn || removeDependsOn;
       if (hasAnyChange) {
         await activityService.createActivity({
           companyUuid: auth.companyUuid,

--- a/src/services/__tests__/proposal.service.test.ts
+++ b/src/services/__tests__/proposal.service.test.ts
@@ -287,6 +287,7 @@ describe("addTaskDraft", () => {
     await addTaskDraft("proposal-uuid", COMPANY_UUID, {
       title: "Task 2",
       description: "Second task",
+      acceptanceCriteriaItems: [{ description: "Works", required: true }],
     });
 
     const updateCall = mockPrisma.proposal.update.mock.calls[0][0];
@@ -299,7 +300,10 @@ describe("addTaskDraft", () => {
     mockPrisma.proposal.findFirst.mockResolvedValue(null);
 
     await expect(
-      addTaskDraft("proposal-uuid", COMPANY_UUID, { title: "Task" })
+      addTaskDraft("proposal-uuid", COMPANY_UUID, {
+        title: "Task",
+        acceptanceCriteriaItems: [{ description: "Works" }],
+      })
     ).rejects.toThrow("Proposal not found or not in draft status");
   });
 
@@ -308,10 +312,55 @@ describe("addTaskDraft", () => {
     mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
     mockPrisma.proposal.update.mockResolvedValue(proposal);
 
-    await addTaskDraft("proposal-uuid", COMPANY_UUID, { title: "Task 1" });
+    await addTaskDraft("proposal-uuid", COMPANY_UUID, {
+      title: "Task 1",
+      acceptanceCriteriaItems: [{ description: "Works" }],
+    });
 
     const updateCall = mockPrisma.proposal.update.mock.calls[0][0];
     expect(updateCall.data.taskDrafts).toHaveLength(1);
+  });
+
+  it("should throw when acceptance criteria are missing", async () => {
+    const proposal = dbProposal({ taskDrafts: [] });
+    mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
+
+    await expect(
+      addTaskDraft("proposal-uuid", COMPANY_UUID, { title: "No AC" })
+    ).rejects.toThrow("acceptance criterion");
+    expect(mockPrisma.proposal.update).not.toHaveBeenCalled();
+  });
+
+  it("should throw when acceptance criteria are all blank", async () => {
+    const proposal = dbProposal({ taskDrafts: [] });
+    mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
+
+    await expect(
+      addTaskDraft("proposal-uuid", COMPANY_UUID, {
+        title: "Blank AC",
+        acceptanceCriteriaItems: [{ description: "   " }, { description: "" }],
+      })
+    ).rejects.toThrow("acceptance criterion");
+    expect(mockPrisma.proposal.update).not.toHaveBeenCalled();
+  });
+
+  it("should store normalized (trimmed, required-defaulted) acceptance criteria", async () => {
+    const proposal = dbProposal({ taskDrafts: [] });
+    mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
+    mockPrisma.proposal.update.mockResolvedValue(proposal);
+
+    await addTaskDraft("proposal-uuid", COMPANY_UUID, {
+      title: "Normalize",
+      acceptanceCriteriaItems: [
+        { description: "  kept  " },
+        { description: "   " },
+      ],
+    });
+
+    const updateCall = mockPrisma.proposal.update.mock.calls[0][0];
+    expect(updateCall.data.taskDrafts[0].acceptanceCriteriaItems).toEqual([
+      { description: "kept", required: true },
+    ]);
   });
 });
 
@@ -390,6 +439,67 @@ describe("updateTaskDraft", () => {
     await expect(
       updateTaskDraft("proposal-uuid", COMPANY_UUID, "td-1", { title: "X" })
     ).rejects.toThrow("Proposal not found or not in draft status");
+  });
+
+  it("should preserve existing acceptance criteria when the field is omitted", async () => {
+    const draft = validTaskDraft({ uuid: "td-1" });
+    const proposal = dbProposal({ taskDrafts: [draft] });
+    mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
+    mockPrisma.proposal.update.mockResolvedValue(proposal);
+
+    await updateTaskDraft("proposal-uuid", COMPANY_UUID, "td-1", { title: "Renamed" });
+
+    const updateCall = mockPrisma.proposal.update.mock.calls[0][0];
+    expect(updateCall.data.taskDrafts[0].title).toBe("Renamed");
+    expect(updateCall.data.taskDrafts[0].acceptanceCriteriaItems).toEqual([
+      { description: "Done", required: true },
+    ]);
+  });
+
+  // NOTE-2: an explicit empty array must reach the guard (not be treated as
+  // "omitted") and be rejected — the field cannot clear acceptance criteria.
+  it("should throw on an explicit empty acceptance-criteria array and leave the draft unchanged", async () => {
+    const draft = validTaskDraft({ uuid: "td-1" });
+    const proposal = dbProposal({ taskDrafts: [draft] });
+    mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
+    mockPrisma.proposal.update.mockResolvedValue(proposal);
+
+    await expect(
+      updateTaskDraft("proposal-uuid", COMPANY_UUID, "td-1", { acceptanceCriteriaItems: [] })
+    ).rejects.toThrow("acceptance criterion");
+    expect(mockPrisma.proposal.update).not.toHaveBeenCalled();
+  });
+
+  it("should throw when the provided acceptance criteria are all blank", async () => {
+    const draft = validTaskDraft({ uuid: "td-1" });
+    const proposal = dbProposal({ taskDrafts: [draft] });
+    mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
+
+    await expect(
+      updateTaskDraft("proposal-uuid", COMPANY_UUID, "td-1", {
+        acceptanceCriteriaItems: [{ description: "  " }],
+      })
+    ).rejects.toThrow("acceptance criterion");
+    expect(mockPrisma.proposal.update).not.toHaveBeenCalled();
+  });
+
+  it("should replace acceptance criteria with the normalized non-empty set", async () => {
+    const draft = validTaskDraft({ uuid: "td-1" });
+    const proposal = dbProposal({ taskDrafts: [draft] });
+    mockPrisma.proposal.findFirst.mockResolvedValue(proposal);
+    mockPrisma.proposal.update.mockResolvedValue(proposal);
+
+    await updateTaskDraft("proposal-uuid", COMPANY_UUID, "td-1", {
+      acceptanceCriteriaItems: [
+        { description: "  new one  ", required: false },
+        { description: "   " },
+      ],
+    });
+
+    const updateCall = mockPrisma.proposal.update.mock.calls[0][0];
+    expect(updateCall.data.taskDrafts[0].acceptanceCriteriaItems).toEqual([
+      { description: "new one", required: false },
+    ]);
   });
 });
 

--- a/src/services/__tests__/proposal.service.test.ts
+++ b/src/services/__tests__/proposal.service.test.ts
@@ -1274,7 +1274,7 @@ describe("approveProposal", () => {
 
     await expect(
       approveProposal(proposal.uuid, COMPANY_UUID, "reviewer-uuid")
-    ).rejects.toThrow("empty or invalid description");
+    ).rejects.toThrow("no non-empty description");
   });
 
   it("should NOT auto-complete input ideas when approved (derived status handles lifecycle)", async () => {

--- a/src/services/__tests__/task.service.test.ts
+++ b/src/services/__tests__/task.service.test.ts
@@ -37,8 +37,10 @@ const mockPrisma = vi.hoisted(() => {
       findMany: vi.fn(),
       findFirst: vi.fn(),
       create: vi.fn(),
+      createMany: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn(),
+      deleteMany: vi.fn(),
     },
     taskDependency: {
       findMany: vi.fn(),
@@ -97,6 +99,7 @@ import {
   reportCriteriaSelfCheck,
   checkAcceptanceCriteriaGate,
   createAcceptanceCriteria,
+  replaceAcceptanceCriteria,
 } from "@/services/task.service";
 import { AlreadyClaimedError, NotClaimedError } from "@/lib/errors";
 
@@ -766,6 +769,56 @@ describe("markAcceptanceCriteria", () => {
         action: "updated",
       }),
     );
+  });
+});
+
+// ---------- replaceAcceptanceCriteria ----------
+
+describe("replaceAcceptanceCriteria", () => {
+  it("deletes existing rows and recreates the normalized set inside a transaction", async () => {
+    mockPrisma.task.findFirst.mockResolvedValue(rawTask());
+    mockPrisma.acceptanceCriterion.findMany.mockResolvedValue([
+      makeAcceptanceCriterion({ uuid: "new-1", description: "new crit", taskUuid: TASK_UUID }),
+    ]);
+
+    await replaceAcceptanceCriteria(COMPANY_UUID, TASK_UUID, [
+      { description: "  new crit  ", required: false },
+      { description: "   " }, // blank dropped by normalization
+    ]);
+
+    // Ran inside a transaction (single atomic unit).
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+    // Old rows deleted before new rows created.
+    expect(mockPrisma.acceptanceCriterion.deleteMany).toHaveBeenCalledWith({ where: { taskUuid: TASK_UUID } });
+    expect(mockPrisma.acceptanceCriterion.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({ taskUuid: TASK_UUID, description: "new crit", required: false, sortOrder: 0 }),
+      ],
+    });
+    expect(mockEventBus.emitChange).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "task", entityUuid: TASK_UUID, action: "updated" }),
+    );
+  });
+
+  it("throws and writes nothing when the task is not found", async () => {
+    mockPrisma.task.findFirst.mockResolvedValue(null);
+
+    await expect(
+      replaceAcceptanceCriteria(COMPANY_UUID, TASK_UUID, [{ description: "x" }]),
+    ).rejects.toThrow("Task not found");
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    expect(mockPrisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("throws on an empty / all-blank set without deleting existing rows", async () => {
+    mockPrisma.task.findFirst.mockResolvedValue(rawTask());
+
+    await expect(
+      replaceAcceptanceCriteria(COMPANY_UUID, TASK_UUID, [{ description: "   " }]),
+    ).rejects.toThrow("acceptance criterion");
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    expect(mockPrisma.acceptanceCriterion.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.acceptanceCriterion.createMany).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/proposal.service.ts
+++ b/src/services/proposal.service.ts
@@ -800,17 +800,14 @@ export async function approveProposal(
 
     // 3. Batch create tasks (1 SQL)
     if (taskDrafts && taskDrafts.length > 0) {
-      // Validate AC items before materializing
+      // Validate AC items before materializing — every draft with AC must have
+      // at least one non-blank criterion (shared helper = single source of truth).
       for (const draft of taskDrafts) {
-        if (draft.acceptanceCriteriaItems && draft.acceptanceCriteriaItems.length > 0) {
-          for (let i = 0; i < draft.acceptanceCriteriaItems.length; i++) {
-            const item = draft.acceptanceCriteriaItems[i];
-            if (!item.description || typeof item.description !== "string" || item.description.trim().length === 0) {
-              throw new Error(
-                `Task draft "${draft.title}": acceptanceCriteriaItems[${i}] has an empty or invalid description`
-              );
-            }
-          }
+        if (draft.acceptanceCriteriaItems && draft.acceptanceCriteriaItems.length > 0
+          && !hasNonEmptyAcceptanceCriteria(draft.acceptanceCriteriaItems)) {
+          throw new Error(
+            `Task draft "${draft.title}": acceptanceCriteriaItems has no non-empty description`
+          );
         }
       }
 
@@ -857,19 +854,12 @@ export async function approveProposal(
       // 5. Batch create ALL acceptance criteria (1 SQL)
       const allAC: Array<{ taskUuid: string; description: string; required: boolean; sortOrder: number }> = [];
       for (const draft of taskDrafts) {
-        if (draft.acceptanceCriteriaItems && draft.acceptanceCriteriaItems.length > 0) {
-          const taskUuid = draftToTaskUuidMap.get(draft.uuid);
-          if (!taskUuid) continue;
-          for (let i = 0; i < draft.acceptanceCriteriaItems.length; i++) {
-            const item = draft.acceptanceCriteriaItems[i];
-            allAC.push({
-              taskUuid,
-              description: item.description.trim(),
-              required: item.required ?? true,
-              sortOrder: i,
-            });
-          }
-        }
+        const taskUuid = draftToTaskUuidMap.get(draft.uuid);
+        if (!taskUuid) continue;
+        const normalized = normalizeAcceptanceCriteria(draft.acceptanceCriteriaItems);
+        normalized.forEach((item, i) => {
+          allAC.push({ taskUuid, description: item.description, required: item.required, sortOrder: i });
+        });
       }
       if (allAC.length > 0) {
         await tx.acceptanceCriterion.createMany({ data: allAC });

--- a/src/services/proposal.service.ts
+++ b/src/services/proposal.service.ts
@@ -10,6 +10,11 @@ import { formatCreatedBy, formatReview } from "@/lib/uuid-resolver";
 import { eventBus } from "@/lib/event-bus";
 import { createDocumentFromProposal } from "./document.service";
 import { createTasksFromProposal } from "./task.service";
+import {
+  ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE,
+  hasNonEmptyAcceptanceCriteria,
+  normalizeAcceptanceCriteria,
+} from "@/lib/acceptance-criteria";
 
 // ===== UUID Helper Functions =====
 
@@ -1149,8 +1154,17 @@ export async function addTaskDraft(
     throw new Error("Proposal not found or not in draft status");
   }
 
+  // Acceptance criteria are mandatory on creation: a task draft must carry at
+  // least one criterion with a non-blank description.
+  if (!hasNonEmptyAcceptanceCriteria(draft.acceptanceCriteriaItems)) {
+    throw new Error(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE);
+  }
+
   const existingDrafts = (proposal.taskDrafts as unknown as TaskDraft[]) || [];
-  const newDraft = ensureTaskDraftUuid(draft);
+  const newDraft = ensureTaskDraftUuid({
+    ...draft,
+    acceptanceCriteriaItems: normalizeAcceptanceCriteria(draft.acceptanceCriteriaItems),
+  });
   const updatedDrafts = [...existingDrafts, newDraft];
 
   const updated = await prisma.proposal.update({
@@ -1227,7 +1241,18 @@ export async function updateTaskDraft(
     throw new Error("Task draft not found");
   }
 
-  existingDrafts[draftIndex] = { ...existingDrafts[draftIndex], ...updates };
+  // Partial-update semantics for acceptance criteria: if the caller supplied the
+  // field (including an explicit empty array), it must be non-empty — the field
+  // cannot be used to clear AC. If the caller omitted it, existing AC are kept.
+  const appliedUpdates = { ...updates };
+  if ("acceptanceCriteriaItems" in updates) {
+    if (!hasNonEmptyAcceptanceCriteria(updates.acceptanceCriteriaItems)) {
+      throw new Error(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE);
+    }
+    appliedUpdates.acceptanceCriteriaItems = normalizeAcceptanceCriteria(updates.acceptanceCriteriaItems);
+  }
+
+  existingDrafts[draftIndex] = { ...existingDrafts[draftIndex], ...appliedUpdates };
 
   const updated = await prisma.proposal.update({
     where: { uuid: proposalUuid },

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -10,6 +10,12 @@ import { batchCommentCounts } from "@/services/comment.service";
 import * as mentionService from "@/services/mention.service";
 import * as activityService from "@/services/activity.service";
 import logger from "@/lib/logger";
+import {
+  ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE,
+  hasNonEmptyAcceptanceCriteria,
+  normalizeAcceptanceCriteria,
+  type AcceptanceCriteriaItemInput,
+} from "@/lib/acceptance-criteria";
 
 // ===== Type Definitions =====
 
@@ -737,6 +743,44 @@ export async function createAcceptanceCriteria(
   );
 
   const created = await Promise.all(createPromises);
+  return created.map(formatCriterionResponse);
+}
+
+// Replace a task's acceptance criteria with a new non-empty set, atomically.
+// Used by chorus_update_task's AC-edit branch. The delete + recreate run in a
+// single transaction so a partial failure can never leave the task with zero
+// criteria — which would violate the "every task always has >=1 AC" invariant.
+// Replacing discards any prior dev/admin verification marks (the definition of
+// done changed, so prior checks no longer apply).
+export async function replaceAcceptanceCriteria(
+  companyUuid: string,
+  taskUuid: string,
+  items: AcceptanceCriteriaItemInput[],
+): Promise<AcceptanceCriterionResponse[]> {
+  const task = await prisma.task.findFirst({ where: { uuid: taskUuid, companyUuid } });
+  if (!task) throw new Error("Task not found");
+
+  if (!hasNonEmptyAcceptanceCriteria(items)) {
+    throw new Error(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE);
+  }
+  const normalized = normalizeAcceptanceCriteria(items);
+
+  const created = await prisma.$transaction(async (tx) => {
+    await tx.acceptanceCriterion.deleteMany({ where: { taskUuid } });
+    if (normalized.length > 0) {
+      await tx.acceptanceCriterion.createMany({
+        data: normalized.map((item, index) => ({
+          taskUuid,
+          description: item.description,
+          required: item.required,
+          sortOrder: index,
+        })),
+      });
+    }
+    return tx.acceptanceCriterion.findMany({ where: { taskUuid }, orderBy: { sortOrder: "asc" } });
+  });
+
+  eventBus.emitChange({ companyUuid, projectUuid: task.projectUuid, entityType: "task", entityUuid: taskUuid, action: "updated" });
   return created.map(formatCriterionResponse);
 }
 


### PR DESCRIPTION
## Summary
Make a **non-empty acceptance-criteria set an invariant** of every task and task draft, enforced at creation and preserved on edit. A shared validator (`src/lib/acceptance-criteria.ts`) is the single source of truth, used by both the proposal service and the `public.ts` MCP tool handlers.

- **Create tools** (`chorus_pm_add_task_draft`, `chorus_create_tasks`) reject missing/all-blank AC. `create_tasks` is all-or-nothing — one bad task rejects the whole batch, no task is created.
- **Edit tools** (`chorus_pm_update_task_draft`, `chorus_update_task`) use partial semantics: AC provided → must be non-empty (replaces existing); AC omitted → preserved. Status transitions and dependency edits via `chorus_update_task` keep working without resending AC.
- `chorus_update_task` gains an optional `acceptanceCriteriaItems` param (replace semantics).
- The `E-AC` proposal-validation check is retained as a submit-time backstop.
- Validation lives in the service layer; Zod stays `.optional()` (no `.min(1)`). No DB schema/migration change; existing AC-less tasks are untouched until next edited.

Plus: documentation synced across **all four skill surfaces** (Claude Code, Codex, OpenClaw, standalone) — including replacing the legacy `acceptanceCriteria` Markdown-string example (which would now fail enforcement) with a structured `acceptanceCriteriaItems` array — and the `plugin-maintenance` skill updated to document the OpenClaw plugin as the fourth surface.

## Changed files
| Area | Change |
|------|--------|
| `src/lib/acceptance-criteria.ts` (+test) | New shared validator: `normalizeAcceptanceCriteria`, `hasNonEmptyAcceptanceCriteria`, `ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE` |
| `src/services/proposal.service.ts` (+test) | Enforce AC in `addTaskDraft` (required) / `updateTaskDraft` (partial-replace) |
| `src/mcp/tools/public.ts` (+tests) | `chorus_create_tasks` all-or-nothing pre-validation; `chorus_update_task` optional AC with replace semantics |
| `src/mcp/tools/pm.ts` | Tool/param descriptions reflect required + partial semantics |
| `src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts` | Cross-layer integration test (real helper, both layers) |
| `docs/MCP_TOOLS.md`, `openspec/specs/mcp-tool-surface/spec.md` | Spec + reference docs |
| plugin skills (×3) + standalone (×1) | AC-required wording, structured-array examples, version bumps |
| `.claude/skills/plugin-maintenance/SKILL.md` | Document OpenClaw as the 4th skill surface (0.2.0 → 0.3.0) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 1745 passed / 1 skipped / 0 failed (98 files)
- [x] `npx vitest run --coverage` exit 0 — 96.24% lines / 89.07% branches (above 95%/85% thresholds)
- [x] `pnpm lint` clean on changed files
- [x] OpenSpec change validated + archived; cumulative spec mirrored back byte-equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)