### PR TITLE
feat(skill): add yolo + reviewer skills to standalone public/skill surface

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/.claude/skills/plugin-maintenance/SKILL.md
+++ b/.claude/skills/plugin-maintenance/SKILL.md
@@ -108,11 +108,11 @@ Every time **any** plugin package changes, bump the version in **all** of that p
 ### Claude Code plugin — bump together
 1. `.claude-plugin/marketplace.json` — `"version": "X.Y.Z"`
 2. `public/chorus-plugin/.claude-plugin/plugin.json` — `"version": "X.Y.Z"`
-3. Every skill under `public/chorus-plugin/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (or `version: X.Y.Z` for `quick-dev/` which uses a flat frontmatter)
+3. Every skill under `public/chorus-plugin/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (all skills, including `quick-dev/`, now use the standard nested `metadata:` block)
 
 ### Codex plugin — bump together
 4. `plugins/chorus/.codex-plugin/plugin.json` — `"version": "X.Y.Z"`
-5. Every skill under `plugins/chorus/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (or flat `version:` for `quick-dev/`). **Don't forget the two reviewer skills**: `chorus-proposal-reviewer/SKILL.md` and `chorus-task-reviewer/SKILL.md`.
+5. Every skill under `plugins/chorus/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (all skills, including `quick-dev/`, now use the standard nested `metadata:` block). **Don't forget the two reviewer skills**: `chorus-proposal-reviewer/SKILL.md` and `chorus-task-reviewer/SKILL.md`.
 6. `plugins/chorus/hooks/chorus-mcp-call.sh` — hardcoded `clientInfo.version` string in the JSON-RPC `initialize` payload
 
 ### OpenClaw plugin — bump together

--- a/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/README.md
+++ b/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/README.md
@@ -1,0 +1,3 @@
+# add-public-yolo-reviewer-skills
+
+Add yolo + two reviewer skills to public/skill and unify reviewer invocation to a framework-neutral pattern

--- a/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/design.md
+++ b/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/design.md
@@ -1,0 +1,74 @@
+# Design: Standalone yolo + reviewer skills
+
+## Context
+
+`public/skill/` is the framework-neutral skill surface. Each subdirectory holds a single `SKILL.md` with YAML frontmatter (`name`, `description`, `license`, `metadata.{author,version,category,mcp_server}`) followed by a Markdown body. `package.json` is the manifest: it maps logical skill paths to served URLs (`/skill/<dir>/SKILL.md`) under both a `chorus` and a `moltbot` key, and lists discovery `triggers`. `chorus/SKILL.md` is the entry point — it documents install commands, a Skill Files table, and a Skill Routing table that consumers read to decide which other skills to fetch.
+
+The two reviewer agents already exist in two other forms:
+
+- **Codex skill form** (`plugins/chorus/skills/chorus-{proposal,task}-reviewer/SKILL.md`): a self-contained read-only review procedure ending in a grep-able `VERDICT:` line, invoked by mounting the skill into a Codex `default` sub-agent via `spawn_agent`.
+- **Claude Code native subagent form** (`public/chorus-plugin/agents/{proposal,task}-reviewer.md`): same procedure expressed as an agent definition with `disallowedTools` and a `criticalSystemReminder`, invoked via the `chorus:{proposal,task}-reviewer` agent type.
+
+This change ports the **Codex skill form** into `public/skill/` (because the standalone surface is skill-shaped, not agent-definition-shaped) and renames per the local convention.
+
+## Goals / Non-Goals
+
+**Goals**
+- A standalone consumer can run the full yolo pipeline from `public/skill/` alone.
+- Reviewer invocation never assumes a specific agent type or harness API.
+- The reviewer review procedure (the actual quality bar) matches the Codex/CC source semantically.
+- `package.json` and `chorus/SKILL.md` stay the single source of truth for discovery.
+
+**Non-Goals**
+- Touching the other three surfaces (CC plugin, Codex plugin, OpenClaw).
+- Any runtime/backend/schema/UI change.
+- Byte-for-byte parity with the Codex reviewer bodies — semantic equivalence plus surface-appropriate phrasing is the bar (the Codex versions reference Codex-only mechanics like `spawn_agent`/`close_agent` thread slots that must not leak into the neutral surface).
+
+## Key Decisions
+
+### Decision 1 — Naming: `<stage>-chorus` suffix
+
+The three new dirs are `proposal-reviewer-chorus/`, `task-reviewer-chorus/`, `yolo-chorus/`. Every existing `public/skill/` dir uses the `<stage>-chorus` suffix; matching it keeps the install scripts, routing table, and `package.json` file map uniform. The Codex `chorus-<x>` prefix form is rejected for this surface.
+
+### Decision 2 — Framework-neutral reviewer invocation, documented once
+
+The canonical pattern lives in `chorus/SKILL.md` under a new "Independent Review" subsection. Every other reference (yolo review loops, develop Step 8, review A3.5 / B2.5) states the intent and points back to it, rather than re-describing a spawn API. The pattern:
+
+1. Spawn a **read-only** sub-agent.
+2. Have it load the matching reviewer skill (`proposal-reviewer-chorus` or `task-reviewer-chorus`) and pass it the target UUID.
+3. The reviewer posts a single `VERDICT:` comment (`PASS` / `PASS WITH NOTES` / `FAIL`).
+4. The host reads the comment via `chorus_get_comments` and acts.
+5. **Fallback:** if the harness cannot spawn sub-agents, load the reviewer skill inline and follow it as a self-review — the procedure is identical; only the isolation differs.
+
+Harness-specific spawn mechanisms (Claude Code Task/Agent tool, Codex `spawn_agent`) are mentioned only as *examples* in that one subsection, never as required calls in workflow prose.
+
+### Decision 3 — Reviewer skill bodies: ported, read-only, VERDICT contract preserved
+
+Each reviewer skill keeps the load-bearing invariants from the source:
+- READ-ONLY posture (proposal reviewer: no writes/Bash at all; task reviewer: read-only Bash limited to test/build/inspection commands, no git writes, no file mutation).
+- Batch-gather-then-analyze efficiency rule and a turn-budget rule (post current findings before running out of turns).
+- BLOCKER vs NOTE classification with the project's fixed rules (pseudocode/wording mismatches are always NOTE).
+- Exactly one of three grep-able literals: `VERDICT: PASS`, `VERDICT: PASS WITH NOTES`, `VERDICT: FAIL`.
+- Round-2+ awareness (only re-check previous BLOCKERs).
+- Output budget ~800 chars, posted via `chorus_add_comment`.
+
+Codex-only operational mechanics (`spawn_agent`/`wait_agent`/`close_agent`, thread-slot caps) are dropped — they belong to the *host*, not the reviewer, and the host pattern is now neutral.
+
+### Decision 4 — yolo-chorus mirrors the Codex/CC structure, neutralized
+
+Sections: Overview + pipeline diagram, Prerequisites (permission preflight: `idea:write`, `proposal:write+admin`, `task:write+admin`, `project:write`), Input, Phase 1 Planning (resolve project → create idea → self-elaboration → create proposal with docs+tasks), Phase 2 Proposal Review loop (neutral reviewer spawn, up to `maxProposalReviewRounds`, no-VERDICT respawn-once rule), Phase 3 wave-based Execution (neutral parallel sub-agents with a sequential main-agent fallback), Phase 4 Verification loop (neutral task-reviewer spawn, mark AC + verify or reopen, max rounds + escalation), Phase 5 Report, Phase 5b mandatory Idea Completion Report via `chorus_create_report`. `maxProposalReviewRounds` / `maxTaskReviewRounds` are described as "default 3" parameters the host may carry, not as plugin-config reads (the standalone surface has no plugin config).
+
+### Decision 5 — Version alignment to 0.9.3 + close pre-existing registration gaps
+
+`public/skill/package.json` `version` and every `public/skill/*/SKILL.md` frontmatter version are set to `0.9.3` to match the project version and end the current `0.3.1`/`0.3.2` drift. This is a docs-surface version, independent of the npm package version.
+
+While registering the three new skills, the change also fixes two pre-existing gaps discovered during review: `package.json` registers only 5 of the 7 already-shipping skills (`quick-dev-chorus` and `brainstorm-chorus` are on disk but unregistered), and `chorus/SKILL.md` lists `quick-dev-chorus` only in its routing table (not the Skill Files table or install scripts) and omits `brainstorm-chorus` entirely. The post-change manifest registers all 10 skills consistently. `quick-dev-chorus/SKILL.md` additionally uses a non-standard frontmatter shape (bare top-level `version`, no `license`/`metadata`); it is normalized to the standard block.
+
+## Risks / Trade-offs
+
+- **Duplication across surfaces.** The reviewer procedure now exists in three places (Codex skill, CC agent, standalone skill). Mitigation: this is already the status quo for the brainstorm/idea skills; cross-surface parity enforcement is explicitly deferred and owned by `plugin-maintenance`.
+- **Neutral prose is vaguer than a concrete API call.** Mitigation: the one canonical subsection gives concrete per-harness examples and a guaranteed inline fallback, so an agent always has a runnable path.
+
+## Migration / Rollout
+
+Pure additive docs. No migration. Consumers pick up the new skills on their next `curl` install or update check (`chorus/SKILL.md` documents the version-compare step).

--- a/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/proposal.md
+++ b/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/proposal.md
@@ -1,0 +1,53 @@
+# Proposal: Add yolo + reviewer skills to the standalone `public/skill/` surface
+
+## Why
+
+Chorus ships its agent-facing skills through four distribution surfaces (see project memory "Four plugin surfaces"). One of them, `public/skill/`, is the **standalone** surface: it is served as static assets at `<BASE_URL>/skill/` and consumed by *any* agent framework that `curl`-downloads the `SKILL.md` files (Claude Code project install, Moltbot, or a bare MCP client). It carries no plugin runtime, no hooks, and no custom agent types.
+
+Today that surface has two gaps:
+
+1. **No `yolo` skill.** The Codex plugin (`plugins/chorus/skills/yolo/`) and the Claude Code plugin both document the full-auto AI-DLC pipeline, but a standalone consumer has no equivalent. They have to stitch `idea` → `proposal` → `develop` → `review` together by hand.
+
+2. **No reviewer skills, and broken reviewer references.** The adversarial proposal/task reviewers are the project's core quality gate. The Codex plugin already models them *as skills* (`plugins/chorus/skills/chorus-proposal-reviewer/`, `chorus-task-reviewer/`) that a host agent mounts into a sub-agent. The Claude Code plugin models them as native subagents (`public/chorus-plugin/agents/*.md`, invoked via the `chorus:proposal-reviewer` / `chorus:task-reviewer` agent types). But `public/skill/develop-chorus` and `public/skill/review-chorus` reference `chorus:proposal-reviewer` / `chorus:task-reviewer` — a Claude-Code-plugin-specific agent type that **does not exist** for an agent that merely `curl`-downloaded the skill. The standalone experience is split: it points at machinery the consumer doesn't have.
+
+The fix is to learn from the Codex plugin's approach — express the reviewers as standalone skills — and make every reviewer reference in the standalone surface **framework-neutral**: "spawn a read-only sub-agent and have it load the reviewer skill," with a note that the exact spawn mechanism is harness-specific and an inline-self-review fallback when sub-agents are unavailable.
+
+## What Changes
+
+Scope is strictly the `public/skill/` standalone surface. No changes to the Claude Code plugin, the Codex plugin, the OpenClaw plugin, backend, schema, or UI.
+
+**New skills (3):**
+
+- `public/skill/proposal-reviewer-chorus/SKILL.md` — read-only adversarial proposal reviewer. Body ported from the Codex `chorus-proposal-reviewer` skill (review procedure, finding classification, VERDICT contract, 800-char output budget), with frontmatter and any harness-specific phrasing adapted to the standalone surface.
+- `public/skill/task-reviewer-chorus/SKILL.md` — read-only adversarial task reviewer. Body ported from the Codex `chorus-task-reviewer` skill (read-only Bash policy, per-AC verification, VERDICT contract).
+- `public/skill/yolo-chorus/SKILL.md` — full-auto AI-DLC lifecycle doc (Prerequisites → Planning → Proposal Review loop → wave-based Execution → Verification loop → Report → mandatory Idea Completion Report), with **every** sub-agent / reviewer invocation written framework-neutrally.
+
+**Naming convention:** all three follow the existing `<stage>-chorus` suffix used by every dir in `public/skill/` (`idea-chorus`, `develop-chorus`, `review-chorus`, `quick-dev-chorus`, `brainstorm-chorus`). Not the Codex `chorus-<x>` prefix form.
+
+**Framework-neutral reviewer invocation** — a single canonical pattern introduced in `chorus/SKILL.md` and referenced everywhere else:
+
+> Spawn a read-only sub-agent and have it load the reviewer skill (`proposal-reviewer-chorus` for proposals, `task-reviewer-chorus` for tasks). The sub-agent posts a `VERDICT:` comment on the target; read it with `chorus_get_comments` before acting. The exact spawn mechanism is harness-specific (e.g. Claude Code's Task/Agent tool, Codex's `spawn_agent`). If your harness cannot spawn sub-agents, load the reviewer skill inline and follow it yourself as a self-review.
+
+**Unify existing references:** rewrite the reviewer mentions in `develop-chorus` (Step 8 review-agent note) and `review-chorus` to point at this canonical pattern instead of the `chorus:proposal-reviewer` / `chorus:task-reviewer` agent types. Note the current baseline: `review-chorus` Workflow A already has an `A3.5: Independent Review` subsection (referencing `chorus:proposal-reviewer`) which is *rewritten*; Workflow B (task verification) has **no** Independent Review subsection today, so one must be **added** (e.g. `B2.5`) pointing at `task-reviewer-chorus`. `develop-chorus` Step 8 references `chorus:task-reviewer` and is rewritten.
+
+**Manifest + routing.** Current baseline (verified against the repo): `public/skill/package.json` `version` is `0.3.1` and its `chorus.files` / `moltbot.files` maps register **only 5** skills — `chorus`, `idea-chorus`, `proposal-chorus`, `develop-chorus`, `review-chorus`. The two already-shipping dirs `quick-dev-chorus` and `brainstorm-chorus` exist on disk but are **not** registered in `package.json`; `chorus/SKILL.md` mentions `quick-dev-chorus` only in its Skill Routing table (absent from the Skill Files table and both install scripts) and never mentions `brainstorm-chorus`. So registration must cover **five** previously-unregistered-or-partially-registered skills, not just the three new ones:
+
+- `public/skill/package.json` — add `quick-dev-chorus/SKILL.md`, `brainstorm-chorus/SKILL.md`, `proposal-reviewer-chorus/SKILL.md`, `task-reviewer-chorus/SKILL.md`, `yolo-chorus/SKILL.md` to both the `chorus.files` and `moltbot.files` maps (bringing the total to 10); add `triggers` (`yolo`, `review agent`, `verify`); bump `version` `0.3.1` → `0.9.3`.
+- `public/skill/chorus/SKILL.md` — make the Skill Files table, both install scripts (Claude Code + Moltbot), and the Skill Routing table consistently list **all 10** skills (i.e. also fix the pre-existing `quick-dev-chorus` / `brainstorm-chorus` gaps while adding the three new ones); add a short canonical "Independent Review" subsection documenting the reviewer skills + the neutral pattern once.
+- Bump the frontmatter version in every `public/skill/*/SKILL.md` to `0.9.3` (currently a `0.3.1` / `0.3.2` mix). Note `quick-dev-chorus/SKILL.md` uses a non-standard frontmatter shape (top-level `version: 0.3.2`, no `license`/`metadata` block); normalize it to the standard `metadata.version: "0.9.3"` block used by the others.
+
+All skill docs are written in English (project rule).
+
+## Capabilities
+
+This change adds one new capability:
+
+- **`public-skill-yolo-reviewers`** — the standalone `/skill/` distribution provides a yolo lifecycle skill and two reviewer skills, and references reviewers through a framework-neutral sub-agent pattern rather than a plugin-specific agent type.
+
+## Impact
+
+- **Affected code:** documentation only. 3 new `SKILL.md` files; modifications to `public/skill/chorus/SKILL.md`, `public/skill/develop-chorus/SKILL.md`, `public/skill/review-chorus/SKILL.md`, `public/skill/package.json`, plus a frontmatter version bump across the remaining `public/skill/*/SKILL.md` (`idea-chorus`, `proposal-chorus`, `brainstorm-chorus`, and a frontmatter-shape normalization of `quick-dev-chorus`). Zero TypeScript / Prisma / React / MCP-tool changes.
+- **Affected workflows:** standalone-skill consumers (curl install, Moltbot) gain a working yolo + reviewer experience; the reviewer references stop pointing at machinery they don't have.
+- **Affected runtime:** none. No migrations, no new dependencies, no MCP tool changes, no config flags. `public/skill/` is static assets.
+- **Risk:** low. Markdown-only; the new skills are additive and the rewritten references degrade gracefully (inline self-review fallback) on any harness.
+- **Out of scope (deferred):** propagating identical changes to the Claude Code plugin agents, the Codex plugin, or the OpenClaw plugin — the CC plugin already ships native reviewer subagents and the Codex plugin already has the reviewer skills, so cross-surface drift is a known but separate follow-up (owned by the `plugin-maintenance` doc). Any backend/schema/UI work. A CI check enforcing reviewer-body parity across surfaces.

--- a/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/specs/public-skill-yolo-reviewers/spec.md
+++ b/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/specs/public-skill-yolo-reviewers/spec.md
@@ -1,0 +1,112 @@
+# public-skill-yolo-reviewers Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Standalone surface SHALL provide a yolo lifecycle skill
+
+The `public/skill/` distribution MUST include a `yolo-chorus/SKILL.md` skill that documents the full-auto AI-DLC pipeline (Idea → Elaboration → Proposal → Review → Execute → Verify → Report) as a self-contained guide for any agent that consumes the standalone surface. The skill MUST cover, in order: a prerequisites permission preflight, project resolution, idea creation, self-elaboration, proposal creation with document and task drafts, a proposal review loop, wave-based task execution, a task verification loop, a completion report, and a mandatory idea-completion report.
+
+#### Scenario: yolo-chorus skill exists and is self-contained
+
+- **WHEN** a consumer fetches `<BASE_URL>/skill/yolo-chorus/SKILL.md`
+- **THEN** the file MUST exist with valid frontmatter (`name`, `description`, `license`, `metadata`)
+- **AND** the body MUST document each pipeline phase from Planning through the Idea Completion Report without requiring the reader to already have any plugin installed
+
+#### Scenario: yolo prerequisites preflight is documented
+
+- **WHEN** the yolo-chorus skill describes prerequisites
+- **THEN** it MUST instruct the agent to verify, before starting, that its API key carries `idea:write`, `proposal:write`, `proposal:admin`, `task:write`, `task:admin`, and `project:write`
+- **AND** it MUST instruct the agent to abort with a clear message listing any missing resource/action pairs
+
+#### Scenario: yolo mandates the idea completion report
+
+- **WHEN** the yolo-chorus skill documents pipeline completion
+- **THEN** it MUST state that a successful run finishes the Idea by calling `chorus_create_report` once with the last verified proposal
+- **AND** MUST surface the returned report document identifier in the run summary
+
+### Requirement: Standalone surface SHALL provide two read-only reviewer skills
+
+The `public/skill/` distribution MUST include `proposal-reviewer-chorus/SKILL.md` and `task-reviewer-chorus/SKILL.md`. Each MUST describe a read-only, adversarial review procedure that fetches its target via MCP, audits it, and posts exactly one grep-able `VERDICT:` comment. The reviewer bodies MUST be semantically equivalent to the existing Codex plugin reviewer skills (`plugins/chorus/skills/chorus-proposal-reviewer`, `chorus-task-reviewer`) in their review procedure, finding classification, and verdict contract.
+
+#### Scenario: Both reviewer skills exist with the `-chorus` suffix
+
+- **WHEN** a consumer fetches `<BASE_URL>/skill/proposal-reviewer-chorus/SKILL.md` and `<BASE_URL>/skill/task-reviewer-chorus/SKILL.md`
+- **THEN** both files MUST exist with valid frontmatter and a `-chorus`-suffixed `name`
+- **AND** their directory names MUST follow the existing `<stage>-chorus` convention used by every other `public/skill/` directory
+
+#### Scenario: Reviewer skills enforce a read-only posture
+
+- **WHEN** the proposal-reviewer-chorus skill describes its constraints
+- **THEN** it MUST prohibit creating, modifying, or deleting files and prohibit running shell commands
+- **WHEN** the task-reviewer-chorus skill describes its constraints
+- **THEN** it MUST permit only read-only and test/build Bash commands and MUST prohibit file mutation and git write operations
+
+#### Scenario: Reviewer skills emit one of exactly three verdict literals
+
+- **WHEN** either reviewer skill documents its output contract
+- **THEN** it MUST require the review to end with exactly one of `VERDICT: PASS`, `VERDICT: PASS WITH NOTES`, or `VERDICT: FAIL`
+- **AND** it MUST define the mapping: any BLOCKER → FAIL, only NOTEs → PASS WITH NOTES, nothing → PASS
+- **AND** it MUST require the verdict to be posted as a comment via `chorus_add_comment` on the reviewed target
+
+#### Scenario: Reviewer skills classify findings and respect round awareness
+
+- **WHEN** either reviewer skill documents finding classification
+- **THEN** it MUST distinguish BLOCKER (blocks correctness/implementation) from NOTE (non-blocking), and MUST classify pseudocode and cross-document wording mismatches as NOTE
+- **AND** it MUST instruct that on Round 2+ the reviewer focuses only on whether previously raised BLOCKERs were fixed, introducing no new NOTEs
+
+### Requirement: Reviewer invocation in the standalone surface SHALL be framework-neutral
+
+The `public/skill/` skills MUST NOT instruct consumers to invoke reviewers via a harness-specific agent type (such as `chorus:proposal-reviewer` or `chorus:task-reviewer`). Instead, the surface MUST document a single framework-neutral invocation pattern: spawn a read-only sub-agent that loads the matching reviewer skill, then read its `VERDICT:` comment. The canonical description of this pattern MUST live in `chorus/SKILL.md`, and every other reviewer reference in the surface MUST point to it.
+
+#### Scenario: Canonical pattern documented once in the core skill
+
+- **WHEN** a consumer reads `public/skill/chorus/SKILL.md`
+- **THEN** it MUST contain an "Independent Review" section that names both reviewer skills and describes the spawn-sub-agent-then-read-VERDICT pattern
+- **AND** that section MUST state that the exact spawn mechanism is harness-specific (giving at least one concrete example) and MUST provide an inline self-review fallback for harnesses that cannot spawn sub-agents
+
+#### Scenario: No plugin-specific agent type references remain in the standalone surface
+
+- **WHEN** the change diff for `public/skill/` is reviewed
+- **THEN** no `SKILL.md` under `public/skill/` may instruct the consumer to use the `chorus:proposal-reviewer` or `chorus:task-reviewer` agent type as the means of invoking a reviewer
+- **AND** the existing `A3.5: Independent Review` subsection in `review-chorus/SKILL.md` Workflow A (which today references `chorus:proposal-reviewer`) MUST be rewritten to the canonical pattern + `proposal-reviewer-chorus`
+- **AND** because `review-chorus/SKILL.md` Workflow B (task verification) has **no** Independent Review subsection today, a new one MUST be **added** pointing at the canonical pattern + `task-reviewer-chorus`
+- **AND** the Step 8 reviewer note in `develop-chorus/SKILL.md` (which today references `chorus:task-reviewer`) MUST be rewritten to the canonical pattern + `task-reviewer-chorus`
+
+#### Scenario: yolo review loops use the neutral pattern
+
+- **WHEN** the yolo-chorus skill documents its proposal review loop and its task verification loop
+- **THEN** each MUST invoke the reviewer via the framework-neutral pattern (not a hardcoded agent type)
+- **AND** each MUST handle the three verdict outcomes and include a max-rounds escalation and a no-VERDICT respawn-once rule
+
+### Requirement: Manifest and routing SHALL register every skill and align the version
+
+The `public/skill/` manifest and core skill MUST be updated so that every shipped skill — the three new ones AND the two previously-unregistered ones (`quick-dev-chorus`, `brainstorm-chorus`) — is discoverable and installable, and the surface version MUST be aligned to `0.9.3`. Baseline: `package.json` currently registers only 5 skills (`chorus`, `idea-chorus`, `proposal-chorus`, `develop-chorus`, `review-chorus`); after the change it MUST register 10.
+
+#### Scenario: package.json registers all ten skills
+
+- **WHEN** `public/skill/package.json` is inspected after the change
+- **THEN** both the `chorus.files` and `moltbot.files` maps MUST include entries for all of: `chorus/SKILL.md`, `idea-chorus/SKILL.md`, `proposal-chorus/SKILL.md`, `develop-chorus/SKILL.md`, `review-chorus/SKILL.md`, `quick-dev-chorus/SKILL.md`, `brainstorm-chorus/SKILL.md`, `proposal-reviewer-chorus/SKILL.md`, `task-reviewer-chorus/SKILL.md`, and `yolo-chorus/SKILL.md`
+- **AND** the top-level `version` MUST be `0.9.3`
+- **AND** the `triggers` lists MUST include entries enabling discovery of the yolo and reviewer skills
+
+#### Scenario: chorus/SKILL.md install and routing cover every skill
+
+- **WHEN** `public/skill/chorus/SKILL.md` is inspected after the change
+- **THEN** the Skill Files table, both install scripts (Claude Code and Moltbot), and the Skill Routing table MUST each list all ten skills consistently (closing the pre-existing gaps where `quick-dev-chorus` appeared only in routing and `brainstorm-chorus` was absent)
+- **AND** the install scripts MUST create each skill directory and curl each `SKILL.md`
+
+#### Scenario: All standalone SKILL.md frontmatter versions are aligned and well-formed
+
+- **WHEN** the frontmatter version of every `public/skill/*/SKILL.md` is inspected after the change
+- **THEN** each MUST report version `0.9.3`
+- **AND** `quick-dev-chorus/SKILL.md`, which currently uses a non-standard top-level `version` field with no `license`/`metadata` block, MUST be normalized to the standard frontmatter shape (`license` + `metadata.{author,version,category,mcp_server}`) used by the other skills, with `metadata.version: "0.9.3"`
+
+### Requirement: Change SHALL be limited to the standalone skill surface
+
+This change MUST modify only files under `public/skill/`. It MUST NOT modify the Claude Code plugin, the Codex plugin, the OpenClaw plugin, backend code, the Prisma schema, or UI.
+
+#### Scenario: Diff is confined to public/skill
+
+- **WHEN** the change diff is reviewed
+- **THEN** every added or modified file MUST be under `public/skill/` (plus the OpenSpec change folder itself)
+- **AND** no file under `src/`, `prisma/`, `messages/`, `public/chorus-plugin/`, `plugins/chorus/`, `packages/`, or any other distribution surface may be modified by this change

--- a/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/tasks.md
+++ b/openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## 1. Reviewer skills (no dependencies)
+
+- [ ] 1.1 Add `public/skill/proposal-reviewer-chorus/SKILL.md` — read-only adversarial proposal reviewer ported from the Codex `chorus-proposal-reviewer` skill, `-chorus` naming, frontmatter `version: 0.9.3`.
+- [ ] 1.2 Add `public/skill/task-reviewer-chorus/SKILL.md` — read-only adversarial task reviewer ported from the Codex `chorus-task-reviewer` skill, `-chorus` naming, frontmatter `version: 0.9.3`.
+
+## 2. yolo skill (depends on 1)
+
+- [ ] 2.1 Add `public/skill/yolo-chorus/SKILL.md` — full lifecycle doc with framework-neutral reviewer invocation referencing the two reviewer skills.
+
+## 3. Unify references + manifest + routing (depends on 1, 2)
+
+- [ ] 3.1 Add the canonical "Independent Review" section to `public/skill/chorus/SKILL.md`; update Skill Files table, both install scripts, Check-for-Updates note, and Skill Routing table; bump frontmatter version to 0.9.3.
+- [ ] 3.2 Rewrite reviewer references in `develop-chorus/SKILL.md` and `review-chorus/SKILL.md` to the neutral pattern; bump their frontmatter versions to 0.9.3.
+- [ ] 3.3 Update `public/skill/package.json` (files maps, triggers, version 0.9.3) and bump remaining `public/skill/*/SKILL.md` frontmatter versions to 0.9.3 (idea-chorus, proposal-chorus, brainstorm-chorus, quick-dev-chorus).

--- a/openspec/specs/public-skill-yolo-reviewers/spec.md
+++ b/openspec/specs/public-skill-yolo-reviewers/spec.md
@@ -1,0 +1,114 @@
+# public-skill-yolo-reviewers Specification
+
+## Purpose
+TBD - created by archiving change add-public-yolo-reviewer-skills. Update Purpose after archive.
+## Requirements
+### Requirement: Standalone surface SHALL provide a yolo lifecycle skill
+
+The `public/skill/` distribution MUST include a `yolo-chorus/SKILL.md` skill that documents the full-auto AI-DLC pipeline (Idea → Elaboration → Proposal → Review → Execute → Verify → Report) as a self-contained guide for any agent that consumes the standalone surface. The skill MUST cover, in order: a prerequisites permission preflight, project resolution, idea creation, self-elaboration, proposal creation with document and task drafts, a proposal review loop, wave-based task execution, a task verification loop, a completion report, and a mandatory idea-completion report.
+
+#### Scenario: yolo-chorus skill exists and is self-contained
+
+- **WHEN** a consumer fetches `<BASE_URL>/skill/yolo-chorus/SKILL.md`
+- **THEN** the file MUST exist with valid frontmatter (`name`, `description`, `license`, `metadata`)
+- **AND** the body MUST document each pipeline phase from Planning through the Idea Completion Report without requiring the reader to already have any plugin installed
+
+#### Scenario: yolo prerequisites preflight is documented
+
+- **WHEN** the yolo-chorus skill describes prerequisites
+- **THEN** it MUST instruct the agent to verify, before starting, that its API key carries `idea:write`, `proposal:write`, `proposal:admin`, `task:write`, `task:admin`, and `project:write`
+- **AND** it MUST instruct the agent to abort with a clear message listing any missing resource/action pairs
+
+#### Scenario: yolo mandates the idea completion report
+
+- **WHEN** the yolo-chorus skill documents pipeline completion
+- **THEN** it MUST state that a successful run finishes the Idea by calling `chorus_create_report` once with the last verified proposal
+- **AND** MUST surface the returned report document identifier in the run summary
+
+### Requirement: Standalone surface SHALL provide two read-only reviewer skills
+
+The `public/skill/` distribution MUST include `proposal-reviewer-chorus/SKILL.md` and `task-reviewer-chorus/SKILL.md`. Each MUST describe a read-only, adversarial review procedure that fetches its target via MCP, audits it, and posts exactly one grep-able `VERDICT:` comment. The reviewer bodies MUST be semantically equivalent to the existing Codex plugin reviewer skills (`plugins/chorus/skills/chorus-proposal-reviewer`, `chorus-task-reviewer`) in their review procedure, finding classification, and verdict contract.
+
+#### Scenario: Both reviewer skills exist with the `-chorus` suffix
+
+- **WHEN** a consumer fetches `<BASE_URL>/skill/proposal-reviewer-chorus/SKILL.md` and `<BASE_URL>/skill/task-reviewer-chorus/SKILL.md`
+- **THEN** both files MUST exist with valid frontmatter and a `-chorus`-suffixed `name`
+- **AND** their directory names MUST follow the existing `<stage>-chorus` convention used by every other `public/skill/` directory
+
+#### Scenario: Reviewer skills enforce a read-only posture
+
+- **WHEN** the proposal-reviewer-chorus skill describes its constraints
+- **THEN** it MUST prohibit creating, modifying, or deleting files and prohibit running shell commands
+- **WHEN** the task-reviewer-chorus skill describes its constraints
+- **THEN** it MUST permit only read-only and test/build Bash commands and MUST prohibit file mutation and git write operations
+
+#### Scenario: Reviewer skills emit one of exactly three verdict literals
+
+- **WHEN** either reviewer skill documents its output contract
+- **THEN** it MUST require the review to end with exactly one of `VERDICT: PASS`, `VERDICT: PASS WITH NOTES`, or `VERDICT: FAIL`
+- **AND** it MUST define the mapping: any BLOCKER → FAIL, only NOTEs → PASS WITH NOTES, nothing → PASS
+- **AND** it MUST require the verdict to be posted as a comment via `chorus_add_comment` on the reviewed target
+
+#### Scenario: Reviewer skills classify findings and respect round awareness
+
+- **WHEN** either reviewer skill documents finding classification
+- **THEN** it MUST distinguish BLOCKER (blocks correctness/implementation) from NOTE (non-blocking), and MUST classify pseudocode and cross-document wording mismatches as NOTE
+- **AND** it MUST instruct that on Round 2+ the reviewer focuses only on whether previously raised BLOCKERs were fixed, introducing no new NOTEs
+
+### Requirement: Reviewer invocation in the standalone surface SHALL be framework-neutral
+
+The `public/skill/` skills MUST NOT instruct consumers to invoke reviewers via a harness-specific agent type (such as `chorus:proposal-reviewer` or `chorus:task-reviewer`). Instead, the surface MUST document a single framework-neutral invocation pattern: spawn a read-only sub-agent that loads the matching reviewer skill, then read its `VERDICT:` comment. The canonical description of this pattern MUST live in `chorus/SKILL.md`, and every other reviewer reference in the surface MUST point to it.
+
+#### Scenario: Canonical pattern documented once in the core skill
+
+- **WHEN** a consumer reads `public/skill/chorus/SKILL.md`
+- **THEN** it MUST contain an "Independent Review" section that names both reviewer skills and describes the spawn-sub-agent-then-read-VERDICT pattern
+- **AND** that section MUST state that the exact spawn mechanism is harness-specific (giving at least one concrete example) and MUST provide an inline self-review fallback for harnesses that cannot spawn sub-agents
+
+#### Scenario: No plugin-specific agent type references remain in the standalone surface
+
+- **WHEN** the change diff for `public/skill/` is reviewed
+- **THEN** no `SKILL.md` under `public/skill/` may instruct the consumer to use the `chorus:proposal-reviewer` or `chorus:task-reviewer` agent type as the means of invoking a reviewer
+- **AND** the existing `A3.5: Independent Review` subsection in `review-chorus/SKILL.md` Workflow A (which today references `chorus:proposal-reviewer`) MUST be rewritten to the canonical pattern + `proposal-reviewer-chorus`
+- **AND** because `review-chorus/SKILL.md` Workflow B (task verification) has **no** Independent Review subsection today, a new one MUST be **added** pointing at the canonical pattern + `task-reviewer-chorus`
+- **AND** the Step 8 reviewer note in `develop-chorus/SKILL.md` (which today references `chorus:task-reviewer`) MUST be rewritten to the canonical pattern + `task-reviewer-chorus`
+
+#### Scenario: yolo review loops use the neutral pattern
+
+- **WHEN** the yolo-chorus skill documents its proposal review loop and its task verification loop
+- **THEN** each MUST invoke the reviewer via the framework-neutral pattern (not a hardcoded agent type)
+- **AND** each MUST handle the three verdict outcomes and include a max-rounds escalation and a no-VERDICT respawn-once rule
+
+### Requirement: Manifest and routing SHALL register every skill and align the version
+
+The `public/skill/` manifest and core skill MUST be updated so that every shipped skill — the three new ones AND the two previously-unregistered ones (`quick-dev-chorus`, `brainstorm-chorus`) — is discoverable and installable, and the surface version MUST be aligned to `0.9.3`. Baseline: `package.json` currently registers only 5 skills (`chorus`, `idea-chorus`, `proposal-chorus`, `develop-chorus`, `review-chorus`); after the change it MUST register 10.
+
+#### Scenario: package.json registers all ten skills
+
+- **WHEN** `public/skill/package.json` is inspected after the change
+- **THEN** both the `chorus.files` and `moltbot.files` maps MUST include entries for all of: `chorus/SKILL.md`, `idea-chorus/SKILL.md`, `proposal-chorus/SKILL.md`, `develop-chorus/SKILL.md`, `review-chorus/SKILL.md`, `quick-dev-chorus/SKILL.md`, `brainstorm-chorus/SKILL.md`, `proposal-reviewer-chorus/SKILL.md`, `task-reviewer-chorus/SKILL.md`, and `yolo-chorus/SKILL.md`
+- **AND** the top-level `version` MUST be `0.9.3`
+- **AND** the `triggers` lists MUST include entries enabling discovery of the yolo and reviewer skills
+
+#### Scenario: chorus/SKILL.md install and routing cover every skill
+
+- **WHEN** `public/skill/chorus/SKILL.md` is inspected after the change
+- **THEN** the Skill Files table, both install scripts (Claude Code and Moltbot), and the Skill Routing table MUST each list all ten skills consistently (closing the pre-existing gaps where `quick-dev-chorus` appeared only in routing and `brainstorm-chorus` was absent)
+- **AND** the install scripts MUST create each skill directory and curl each `SKILL.md`
+
+#### Scenario: All standalone SKILL.md frontmatter versions are aligned and well-formed
+
+- **WHEN** the frontmatter version of every `public/skill/*/SKILL.md` is inspected after the change
+- **THEN** each MUST report version `0.9.3`
+- **AND** `quick-dev-chorus/SKILL.md`, which currently uses a non-standard top-level `version` field with no `license`/`metadata` block, MUST be normalized to the standard frontmatter shape (`license` + `metadata.{author,version,category,mcp_server}`) used by the other skills, with `metadata.version: "0.9.3"`
+
+### Requirement: Change SHALL be limited to the standalone skill surface
+
+This change MUST modify only files under `public/skill/`. It MUST NOT modify the Claude Code plugin, the Codex plugin, the OpenClaw plugin, backend code, the Prisma schema, or UI.
+
+#### Scenario: Diff is confined to public/skill
+
+- **WHEN** the change diff is reviewed
+- **THEN** every added or modified file MUST be under `public/skill/` (plus the OpenSpec change folder itself)
+- **AND** no file under `src/`, `prisma/`, `messages/`, `public/chorus-plugin/`, `plugins/chorus/`, `packages/`, or any other distribution surface may be modified by this change
+

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: quick-dev
-version: 0.9.3
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.3"
+  category: project-management
+  mcp_server: chorus
 ---
 
 # Quick Dev Skill

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/skills/brainstorm/SKILL.md
+++ b/public/chorus-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Co
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: quick-dev
-version: 0.9.3
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.3"
+  category: project-management
+  mcp_server: chorus
 ---
 
 # Quick Dev Skill

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-dev
-version: 0.9.2
+version: 0.9.3
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
 ---
 

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/brainstorm-chorus/SKILL.md
+++ b/public/skill/brainstorm-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.3.1"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.3.1"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---
@@ -30,18 +30,28 @@ Skill files are hosted under the `<BASE_URL>/skill/` path.
 | **proposal-chorus** | Proposal creation, drafts, DAG, submission | `/skill/proposal-chorus/SKILL.md` |
 | **develop-chorus** | Task execution workflow | `/skill/develop-chorus/SKILL.md` |
 | **review-chorus** | Proposal approval, task verification, governance | `/skill/review-chorus/SKILL.md` |
+| **quick-dev-chorus** | Lightweight direct-to-task workflow (skips Idea→Proposal) | `/skill/quick-dev-chorus/SKILL.md` |
+| **brainstorm-chorus** | Optional divergent→convergent dialogue, prelude to elaboration | `/skill/brainstorm-chorus/SKILL.md` |
+| **proposal-reviewer-chorus** | Read-only adversarial proposal reviewer (posts VERDICT) | `/skill/proposal-reviewer-chorus/SKILL.md` |
+| **task-reviewer-chorus** | Read-only adversarial task reviewer (posts VERDICT) | `/skill/task-reviewer-chorus/SKILL.md` |
+| **yolo-chorus** | Full-auto AI-DLC pipeline — prompt to done | `/skill/yolo-chorus/SKILL.md` |
 | **package.json** | Version & download metadata | `/skill/package.json` |
 
 ### Install (Claude Code, project-level)
 
 ```bash
 BASE_URL="<BASE_URL>"
-mkdir -p .claude/skills/chorus .claude/skills/idea-chorus .claude/skills/proposal-chorus .claude/skills/develop-chorus .claude/skills/review-chorus
+mkdir -p .claude/skills/chorus .claude/skills/idea-chorus .claude/skills/proposal-chorus .claude/skills/develop-chorus .claude/skills/review-chorus .claude/skills/quick-dev-chorus .claude/skills/brainstorm-chorus .claude/skills/proposal-reviewer-chorus .claude/skills/task-reviewer-chorus .claude/skills/yolo-chorus
 curl -s $BASE_URL/skill/chorus/SKILL.md > .claude/skills/chorus/SKILL.md
 curl -s $BASE_URL/skill/idea-chorus/SKILL.md > .claude/skills/idea-chorus/SKILL.md
 curl -s $BASE_URL/skill/proposal-chorus/SKILL.md > .claude/skills/proposal-chorus/SKILL.md
 curl -s $BASE_URL/skill/develop-chorus/SKILL.md > .claude/skills/develop-chorus/SKILL.md
 curl -s $BASE_URL/skill/review-chorus/SKILL.md > .claude/skills/review-chorus/SKILL.md
+curl -s $BASE_URL/skill/quick-dev-chorus/SKILL.md > .claude/skills/quick-dev-chorus/SKILL.md
+curl -s $BASE_URL/skill/brainstorm-chorus/SKILL.md > .claude/skills/brainstorm-chorus/SKILL.md
+curl -s $BASE_URL/skill/proposal-reviewer-chorus/SKILL.md > .claude/skills/proposal-reviewer-chorus/SKILL.md
+curl -s $BASE_URL/skill/task-reviewer-chorus/SKILL.md > .claude/skills/task-reviewer-chorus/SKILL.md
+curl -s $BASE_URL/skill/yolo-chorus/SKILL.md > .claude/skills/yolo-chorus/SKILL.md
 curl -s $BASE_URL/skill/package.json > .claude/skills/chorus/package.json
 ```
 
@@ -49,12 +59,17 @@ curl -s $BASE_URL/skill/package.json > .claude/skills/chorus/package.json
 
 ```bash
 BASE_URL="<BASE_URL>"
-mkdir -p ~/.moltbot/skills/chorus ~/.moltbot/skills/idea-chorus ~/.moltbot/skills/proposal-chorus ~/.moltbot/skills/develop-chorus ~/.moltbot/skills/review-chorus
+mkdir -p ~/.moltbot/skills/chorus ~/.moltbot/skills/idea-chorus ~/.moltbot/skills/proposal-chorus ~/.moltbot/skills/develop-chorus ~/.moltbot/skills/review-chorus ~/.moltbot/skills/quick-dev-chorus ~/.moltbot/skills/brainstorm-chorus ~/.moltbot/skills/proposal-reviewer-chorus ~/.moltbot/skills/task-reviewer-chorus ~/.moltbot/skills/yolo-chorus
 curl -s $BASE_URL/skill/chorus/SKILL.md > ~/.moltbot/skills/chorus/SKILL.md
 curl -s $BASE_URL/skill/idea-chorus/SKILL.md > ~/.moltbot/skills/idea-chorus/SKILL.md
 curl -s $BASE_URL/skill/proposal-chorus/SKILL.md > ~/.moltbot/skills/proposal-chorus/SKILL.md
 curl -s $BASE_URL/skill/develop-chorus/SKILL.md > ~/.moltbot/skills/develop-chorus/SKILL.md
 curl -s $BASE_URL/skill/review-chorus/SKILL.md > ~/.moltbot/skills/review-chorus/SKILL.md
+curl -s $BASE_URL/skill/quick-dev-chorus/SKILL.md > ~/.moltbot/skills/quick-dev-chorus/SKILL.md
+curl -s $BASE_URL/skill/brainstorm-chorus/SKILL.md > ~/.moltbot/skills/brainstorm-chorus/SKILL.md
+curl -s $BASE_URL/skill/proposal-reviewer-chorus/SKILL.md > ~/.moltbot/skills/proposal-reviewer-chorus/SKILL.md
+curl -s $BASE_URL/skill/task-reviewer-chorus/SKILL.md > ~/.moltbot/skills/task-reviewer-chorus/SKILL.md
+curl -s $BASE_URL/skill/yolo-chorus/SKILL.md > ~/.moltbot/skills/yolo-chorus/SKILL.md
 curl -s $BASE_URL/skill/package.json > ~/.moltbot/skills/chorus/package.json
 ```
 
@@ -385,17 +400,54 @@ approved --> draft  (via revoke — cascade-closes tasks, deletes documents)
 
 ---
 
+## Independent Review
+
+Chorus uses **independent, read-only adversarial reviewers** at two gates: before a proposal is approved, and before a task is verified. The reviewer's job is to find what is wrong — not to rubber-stamp. Its output is **advisory**: it informs the admin's decision but does not by itself approve, reject, verify, or reopen anything.
+
+This is the **single canonical description** of the reviewer pattern. The `develop-chorus`, `review-chorus`, and `yolo-chorus` skills all point back here rather than redefining it.
+
+### The Pattern
+
+1. **Spawn a read-only sub-agent** that loads one of the two reviewer skills:
+   - `proposal-reviewer-chorus` (`<BASE_URL>/skill/proposal-reviewer-chorus/SKILL.md`) — for reviewing a **proposal** before approval. Pass it the `proposalUuid`.
+   - `task-reviewer-chorus` (`<BASE_URL>/skill/task-reviewer-chorus/SKILL.md`) — for reviewing a **task** before verification. Pass it the `taskUuid`.
+2. **The reviewer audits independently** and posts exactly **one** structured `VERDICT` comment on the proposal/task via `chorus_add_comment`. The comment ends with one literal verdict string: `VERDICT: PASS`, `VERDICT: PASS WITH NOTES`, or `VERDICT: FAIL`.
+3. **Read the verdict and act.** Fetch the comment with `chorus_get_comments({ targetType, targetUuid })`, read the BLOCKER / NOTE findings, then make the call:
+   - `PASS` / `PASS WITH NOTES` → proceed (approve the proposal / verify the task), addressing NOTEs at your discretion.
+   - `FAIL` → do **not** proceed; route the BLOCKERs back for a fix (reject/revise the proposal, or reopen/rework the task), then re-review.
+
+> The verdict is advisory: even a `FAIL` does not block the admin, and a `PASS` does not auto-approve. A human/admin makes the final decision.
+
+### Spawn Mechanism Is Harness-Specific
+
+How you spawn the read-only sub-agent depends on your agent harness — give it the reviewer skill plus the target UUID and instruct it to post a single VERDICT comment. Concrete examples:
+
+- **Claude Code** — use the Task / Agent tool to launch a sub-agent that loads `task-reviewer-chorus` (or `proposal-reviewer-chorus`) and pass the `taskUuid` / `proposalUuid`.
+- **Codex** — use `spawn_agent` with the reviewer skill and the target UUID.
+- Other harnesses: use whatever sub-agent / sub-task primitive they expose.
+
+### Inline Self-Review Fallback
+
+When sub-agents are **not** available in your harness, run the review inline yourself: load the relevant reviewer skill's procedure (`proposal-reviewer-chorus` or `task-reviewer-chorus`), audit the proposal/task against its checklist with the same adversarial posture, and post the single `VERDICT` comment yourself before acting on it. A same-agent self-review is weaker than a fresh independent reviewer, but it is far better than skipping the gate.
+
+---
+
 ## Skill Routing
 
 This is the core overview skill. For stage-specific workflows, download and read the appropriate skill:
 
 | Stage | Skill | Path |
 |-------|-------|------|
+| **Overview** (this file) | `chorus` | `<BASE_URL>/skill/chorus/SKILL.md` |
 | **Quick Dev** | `quick-dev-chorus` | `<BASE_URL>/skill/quick-dev-chorus/SKILL.md` |
+| **Brainstorm** | `brainstorm-chorus` | `<BASE_URL>/skill/brainstorm-chorus/SKILL.md` |
 | **Ideation** | `idea-chorus` | `<BASE_URL>/skill/idea-chorus/SKILL.md` |
 | **Planning** | `proposal-chorus` | `<BASE_URL>/skill/proposal-chorus/SKILL.md` |
 | **Development** | `develop-chorus` | `<BASE_URL>/skill/develop-chorus/SKILL.md` |
 | **Review** | `review-chorus` | `<BASE_URL>/skill/review-chorus/SKILL.md` |
+| **Proposal Review** | `proposal-reviewer-chorus` | `<BASE_URL>/skill/proposal-reviewer-chorus/SKILL.md` |
+| **Task Review** | `task-reviewer-chorus` | `<BASE_URL>/skill/task-reviewer-chorus/SKILL.md` |
+| **Full-Auto** | `yolo-chorus` | `<BASE_URL>/skill/yolo-chorus/SKILL.md` |
 
 ### Getting Started
 

--- a/public/skill/develop-chorus/SKILL.md
+++ b/public/skill/develop-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, self-chec
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.3.1"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---
@@ -182,7 +182,7 @@ chorus_submit_for_verify({
 
 > `to_verify` does NOT unblock downstream tasks — only `done` (after admin verification) does.
 
-> **Review Agent:** After `chorus_submit_for_verify`, consider spawning `chorus:task-reviewer` — an independent, read-only review agent that adversarially checks the implementation against AC and proposal documents. It posts a VERDICT comment on the task. Its result is advisory (does not block verification).
+> **Independent Review:** After `chorus_submit_for_verify`, run an independent review of the task before it is verified. Spawn a read-only sub-agent that loads the `task-reviewer-chorus` skill (`<BASE_URL>/skill/task-reviewer-chorus/SKILL.md`), pass it the `taskUuid`, and let it post a single `VERDICT` comment (PASS / PASS WITH NOTES / FAIL) on the task; then read it with `chorus_get_comments` and act. The verdict is **advisory** (it does not block verification). The spawn mechanism is harness-specific, and an inline self-review fallback exists when sub-agents are unavailable — see the canonical **Independent Review** section in the `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`) for the full pattern.
 
 ### Step 9: Handle Review Feedback
 

--- a/public/skill/idea-chorus/SKILL.md
+++ b/public/skill/idea-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.3.1"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/package.json
+++ b/public/skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus-skill",
-  "version": "0.3.1",
+  "version": "0.9.3",
   "description": "Chorus AI Agent collaboration platform skill. Supports PM, Developer, and Admin roles via MCP tools for the Idea-Proposal-Task workflow.",
   "author": "chorus",
   "license": "AGPL-3.0",
@@ -23,7 +23,12 @@
       "idea-chorus/SKILL.md": "/skill/idea-chorus/SKILL.md",
       "proposal-chorus/SKILL.md": "/skill/proposal-chorus/SKILL.md",
       "develop-chorus/SKILL.md": "/skill/develop-chorus/SKILL.md",
-      "review-chorus/SKILL.md": "/skill/review-chorus/SKILL.md"
+      "review-chorus/SKILL.md": "/skill/review-chorus/SKILL.md",
+      "quick-dev-chorus/SKILL.md": "/skill/quick-dev-chorus/SKILL.md",
+      "brainstorm-chorus/SKILL.md": "/skill/brainstorm-chorus/SKILL.md",
+      "proposal-reviewer-chorus/SKILL.md": "/skill/proposal-reviewer-chorus/SKILL.md",
+      "task-reviewer-chorus/SKILL.md": "/skill/task-reviewer-chorus/SKILL.md",
+      "yolo-chorus/SKILL.md": "/skill/yolo-chorus/SKILL.md"
     },
     "requires": {
       "mcp": ["chorus"]
@@ -38,7 +43,10 @@
       "report work",
       "verify task",
       "approve proposal",
-      "project management"
+      "project management",
+      "yolo",
+      "review agent",
+      "verify"
     ]
   },
   "moltbot": {
@@ -48,7 +56,12 @@
       "idea-chorus/SKILL.md": "/skill/idea-chorus/SKILL.md",
       "proposal-chorus/SKILL.md": "/skill/proposal-chorus/SKILL.md",
       "develop-chorus/SKILL.md": "/skill/develop-chorus/SKILL.md",
-      "review-chorus/SKILL.md": "/skill/review-chorus/SKILL.md"
+      "review-chorus/SKILL.md": "/skill/review-chorus/SKILL.md",
+      "quick-dev-chorus/SKILL.md": "/skill/quick-dev-chorus/SKILL.md",
+      "brainstorm-chorus/SKILL.md": "/skill/brainstorm-chorus/SKILL.md",
+      "proposal-reviewer-chorus/SKILL.md": "/skill/proposal-reviewer-chorus/SKILL.md",
+      "task-reviewer-chorus/SKILL.md": "/skill/task-reviewer-chorus/SKILL.md",
+      "yolo-chorus/SKILL.md": "/skill/yolo-chorus/SKILL.md"
     },
     "requires": {
       "mcp": ["chorus"]
@@ -63,7 +76,10 @@
       "report work",
       "verify task",
       "approve proposal",
-      "project management"
+      "project management",
+      "yolo",
+      "review agent",
+      "verify"
     ]
   }
 }

--- a/public/skill/proposal-chorus/SKILL.md
+++ b/public/skill/proposal-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.3.2"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/proposal-reviewer-chorus/SKILL.md
+++ b/public/skill/proposal-reviewer-chorus/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: proposal-reviewer-chorus
+description: Read-only adversarial Chorus proposal reviewer — audits PRD/task drafts against the originating Idea and posts a single structured VERDICT comment.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.3"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Proposal Reviewer Skill
+
+This skill is the **read-only adversarial reviewer** for a submitted Chorus proposal. You fetch the proposal and its context via MCP, audit the document drafts and task drafts against the originating Idea, and post **one** structured `VERDICT` comment back on the proposal.
+
+You are a proposal review specialist. Your job is **not** to confirm the proposal is good — it is to find what is wrong with it. The PM who wrote this is an LLM: it produces plausible-looking proposals with systematic blind spots.
+
+Two failure patterns to avoid:
+
+- **Rubber-stamping** — skimming and writing "PASS" without checking substance.
+- **Surface-level approval** — seeing a well-structured PRD and assuming the tasks match it, missing requirements gaps, vague AC, or wrong dependencies.
+
+---
+
+## READ-ONLY Posture (Hard Constraints)
+
+You are **strictly prohibited** from:
+
+- Creating, modifying, or deleting any files.
+- Running any shell commands.
+- Installing dependencies or packages.
+
+Your only side effect is posting a single comment via `chorus_add_comment`. Everything else is read-only MCP queries. Do **not** modify the project in any way.
+
+---
+
+## What You Receive
+
+A `proposalUuid` (and, in Round 2+, a review round number). Your job is to fetch and review the full proposal.
+
+---
+
+## Review Procedure
+
+**Efficiency rule:** Gather ALL data first (Step 1), then analyze. Do not alternate between fetching and writing conclusions — batch your read calls, then produce one final comment.
+
+**Turn-budget rule:** When few turns remain in your budget, STOP reading immediately and post your current findings as a comment via `chorus_add_comment`. Incomplete posted findings are strictly better than no comment at all.
+
+### Step 1: Gather Context (batch these)
+
+```
+chorus_get_proposal({ proposalUuid: "<uuid>", section: "full" })
+chorus_get_comments({ targetType: "proposal", targetUuid: "<uuid>" })
+chorus_get_idea({ ideaUuid: "<idea-uuid>" })
+chorus_get_elaboration({ ideaUuid: "<idea-uuid>" })
+```
+
+> `chorus_get_proposal` defaults to `section: "basic"` (metadata + a lightweight draft index, no bodies). A full draft review needs the document/task content, so pass `section: "full"` (or fetch `section: "documents"` and `section: "tasks"` separately if you want to stage the reads).
+
+Use `chorus_get_idea` + `chorus_get_elaboration` to recover the original intent and decision points so you can detect scope drift and missing requirements.
+
+### Step 2: Review Document Drafts
+
+For each document draft, check:
+
+- **Completeness** — Does the PRD cover functional, non-functional, error scenarios, and edge cases?
+- **Specificity** — Are requirements testable? "Should handle errors gracefully" is not testable.
+- **Tech feasibility** — Does the architecture make sense? Missing auth, race conditions, no error handling?
+- **Module contracts** — If multiple tasks share interfaces, are return formats, error patterns, and call points defined?
+- **Hallucination risk** — Flag any specific external detail that looks LLM-fabricated (API signatures, model IDs, SDK versions, CLI flags, config keys, endpoint paths) as a NOTE. The PM is an LLM — it confidently invents plausible-looking specifics.
+
+### Step 3: Review Task Drafts
+
+For each task draft, check:
+
+- **Granularity** — Each task should be cohesive and independently testable. 2-10 AC items is the sweet spot.
+- **AC quality** — Each criterion must be objectively verifiable by a different agent. "Shows details" is BAD. "Displays order ID, customer name, and status badge" is GOOD.
+- **Coverage** — Cross-reference task AC against document requirements. Any requirements with NO corresponding AC?
+- **Dependencies** — Is the DAG correct? Missing dependencies? Circular? Can each task start once its dependencies are done?
+- **Integration checkpoint** — For DAGs with **4 or more tasks**, at least one task MUST be an integration checkpoint whose AC requires end-to-end execution of the preceding modules together. If this is missing, classify it as a **BLOCKER** — without integration verification, module-level passes do not guarantee the system works.
+
+### Step 4: Cross-Reference Requirements ↔ AC
+
+- Each requirement in the PRD → at least one task AC covers it.
+- Each task AC → traceable back to a requirement.
+- No orphan tasks, no orphan requirements.
+- No scope additions absent from the original Idea; no contradictions between documents and tasks.
+
+---
+
+## Finding Classification: BLOCKER vs NOTE
+
+Classify **every** finding as exactly one of:
+
+**BLOCKER** — Blocks implementation correctness:
+
+- Missing critical AC or NFR coverage.
+- Functional scope contradiction between documents.
+- Interface design flaw causing runtime errors.
+- Incorrect task dependencies.
+- Missing integration checkpoint in a 4+ task DAG.
+
+**NOTE** — Does not block implementation:
+
+- Pseudocode signature mismatch (parameter order, naming).
+- Wording differences between PRD and tech design.
+- Style / naming suggestions.
+- Non-semantic document inconsistencies.
+- Hallucination-risk specifics (SDK versions, API paths, CLI flags).
+
+**Rules:** Pseudocode inconsistencies → **always NOTE**. Cross-document wording differences → **always NOTE**. Only semantic contradictions → BLOCKER.
+
+---
+
+## Round 2+ Awareness
+
+You may receive the current review round number in your context.
+
+- **Round 1** — Full review at normal strictness.
+- **Round 2+** — Focus ONLY on whether the previous BLOCKERs were fixed. Do NOT introduce new NOTEs on areas not flagged in earlier rounds. Round 1 already did the full-depth draft review. In Round 2+, re-fetch `chorus_get_proposal({ proposalUuid, section: "full" })` and `chorus_get_comments`, diff against the previous round, confirm each prior BLOCKER is addressed, and stop. If all previous BLOCKERs are resolved → `VERDICT: PASS` (or `VERDICT: PASS WITH NOTES` if old NOTEs remain).
+
+---
+
+## Recognize Your Own Rationalizations
+
+- "The proposal looks well-structured" — structure is not substance.
+- "The PM probably considered this" — the PM is an LLM. Check it yourself.
+- "There are enough tasks" — count is not coverage. Map requirements to tasks.
+
+---
+
+## VERDICT Contract
+
+You MUST end your comment with exactly one of these three **literal** strings (automation greps for them):
+
+- `VERDICT: PASS`
+- `VERDICT: PASS WITH NOTES`
+- `VERDICT: FAIL`
+
+Mapping:
+
+| Findings | Verdict |
+|----------|---------|
+| Any BLOCKER | `VERDICT: FAIL` |
+| Only NOTEs (no BLOCKER) | `VERDICT: PASS WITH NOTES` |
+| Nothing | `VERDICT: PASS` |
+
+Do NOT invent other verdicts like "APPROVE" or "OK" — automation greps for the three exact strings above.
+
+> The verdict is **advisory**. It informs the admin's decision in the `review-chorus` workflow; it does not by itself block or approve the proposal.
+
+---
+
+## Output Format (Required)
+
+Keep total output **under ~800 characters** — be concise. No preamble, no trailing summary paragraph. PASS items: names only. NOTE items: one-line descriptions. BLOCKER items: full evidence.
+
+```
+### Review Summary
+
+**PASS (N):** Check-1 name, Check-2 name, ...
+
+**NOTE (M):**
+- Note-1: [one-line description]
+- Note-2: [one-line description]
+
+**BLOCKER (K):**
+### Blocker-1: name
+**Evidence:** [specific finding]
+**Expected:** [what should be there]
+**Actual:** [what is there or what is missing]
+
+VERDICT: PASS
+```
+
+(or `VERDICT: PASS WITH NOTES` / `VERDICT: FAIL` — exact literal, no other variants)
+
+---
+
+## Posting Results
+
+Post the full review as a **single** comment:
+
+```
+chorus_add_comment({
+  targetType: "proposal",
+  targetUuid: "<proposal-uuid>",
+  content: "<your review>"
+})
+```
+
+---
+
+## Next
+
+- The admin reads your VERDICT comment, then approves or rejects in the `review-chorus` skill (`<BASE_URL>/skill/review-chorus/SKILL.md`).
+- For platform overview and shared tools, see `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`).
+- For Proposal creation (what you are reviewing), see `proposal-chorus` skill (`<BASE_URL>/skill/proposal-chorus/SKILL.md`).

--- a/public/skill/quick-dev-chorus/SKILL.md
+++ b/public/skill/quick-dev-chorus/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: quick-dev-chorus
-version: 0.3.2
 description: Quick Task workflow — skip Idea→Proposal, create tasks directly, execute, and verify.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.3"
+  category: project-management
+  mcp_server: chorus
 ---
 
 # Quick Dev Skill

--- a/public/skill/review-chorus/SKILL.md
+++ b/public/skill/review-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.3.1"
+  version: "0.9.3"
   category: project-management
   mcp_server: chorus
 ---
@@ -128,9 +128,11 @@ The `full` view returns: title, description, input ideas, **document drafts** (P
 chorus_get_comments({ targetType: "proposal", targetUuid: "<proposal-uuid>" })
 ```
 
-#### A3.5: Independent Review (Automatic)
+#### A3.5: Independent Review
 
-After `chorus_pm_submit_proposal`, consider spawning `chorus:proposal-reviewer` — a read-only agent that adversarially reviews the proposal's document quality, task granularity, AC alignment, and dependency DAG. Check for its VERDICT comment before approving.
+Before approving, run an independent review of the proposal. Spawn a read-only sub-agent that loads the `proposal-reviewer-chorus` skill (`<BASE_URL>/skill/proposal-reviewer-chorus/SKILL.md`), pass it the `proposalUuid`, and let it adversarially audit document quality, task granularity, AC alignment, and the dependency DAG. It posts a single `VERDICT` comment (PASS / PASS WITH NOTES / FAIL) on the proposal; read it with `chorus_get_comments` before deciding.
+
+The spawn mechanism is harness-specific, and an inline self-review fallback exists when sub-agents are unavailable — see the canonical **Independent Review** section in the `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`) for the full pattern.
 
 > **VERDICT: FAIL is advisory** — the reviewer's opinion does not block approval. The admin reads the review comment and makes the final decision.
 
@@ -194,6 +196,14 @@ Check: developer's work summary, acceptance criteria, self-check results.
 ```
 chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
 ```
+
+#### B2.5: Independent Review
+
+Before marking acceptance criteria and verifying, run an independent review of the task. Spawn a read-only sub-agent that loads the `task-reviewer-chorus` skill (`<BASE_URL>/skill/task-reviewer-chorus/SKILL.md`), pass it the `taskUuid`, and let it independently verify the implementation against the acceptance criteria and proposal documents. It posts a single `VERDICT` comment (PASS / PASS WITH NOTES / FAIL) on the task; read it with `chorus_get_comments` before deciding.
+
+The spawn mechanism is harness-specific, and an inline self-review fallback exists when sub-agents are unavailable — see the canonical **Independent Review** section in the `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`) for the full pattern.
+
+> **VERDICT is advisory** — a `FAIL` does not block verification and a `PASS` does not auto-verify. The admin reads the review comment, marks the acceptance criteria, and makes the final decision.
 
 #### B3: Mark Acceptance Criteria
 

--- a/public/skill/task-reviewer-chorus/SKILL.md
+++ b/public/skill/task-reviewer-chorus/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: task-reviewer-chorus
+description: Read-only adversarial Chorus task reviewer — independently verifies an implementation against its acceptance criteria and posts a single structured VERDICT comment.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.3"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Task Reviewer Skill
+
+This skill is the **read-only adversarial reviewer** for a submitted Chorus task. You fetch the task, its acceptance criteria (AC), and the originating proposal documents via MCP, independently verify the implementation, and post **one** structured `VERDICT` comment back on the task.
+
+You are a task review specialist. Your job is **not** to confirm the implementation works — it is to find where it does **not** match the requirements. The developer who wrote this is an LLM: its self-tests may be circular (testing mocks, not behavior), and its summaries may overstate what was actually built.
+
+Two failure patterns to avoid:
+
+- **Verification avoidance** — reading code, narrating what you *would* test, writing "PASS," and never actually running anything.
+- **Seduced by the first 80%** — seeing passing tests and clean code, missing that AC are only superficially met, the implementation diverges from proposal documents, or edge cases silently fail.
+
+---
+
+## READ-ONLY Posture (Hard Constraints)
+
+You are **strictly prohibited** from modifying the project. Specifically:
+
+- Creating, modifying, or deleting **any** files in the project directory.
+- Installing dependencies or packages.
+- Running git write operations.
+
+Your only side effect is posting a single comment via `chorus_add_comment`. Everything else is read-only MCP queries plus read-only Bash. Do **not** modify the project in any way.
+
+### Bash Policy (Read-Only)
+
+Bash is allowed **only** for running the project's own test/build/lint commands and for read-only inspection. Anything that writes to disk, mutates state, or installs software is forbidden.
+
+**Allowed (read-only + test/build/lint):**
+
+- Project test / build / lint commands (`pnpm test`, `pnpm build`, `pnpm lint`, `pytest`, `make test`, `cargo test`, …).
+- `cat` / `head` / `tail` / `wc` / `diff`.
+- `grep` / `rg` / `ls` / `find`.
+- `git diff` / `git log` / `git show`.
+
+**Strictly forbidden:**
+
+- `git add` / `git commit` / `git push` / `git checkout` / `git reset` (any git write op).
+- `rm` / `mv` / `cp`, output redirection (`>`, `>>`), `tee`, `sed -i` (any file mutation).
+- Package installs (`npm install`, `pnpm add`, `pip install`, `cargo add`, …).
+- `curl` / `wget` mutations (`curl -X POST/PUT/DELETE`, or any request that changes remote state).
+
+If a verification would require a forbidden command, do not run it — note the limitation in your findings instead.
+
+---
+
+## What You Receive
+
+A `taskUuid` (and, in Round 2+, a review round number). Your job is to fetch the task, its AC, and the originating proposal documents, then independently verify the implementation.
+
+---
+
+## Review Procedure
+
+**Efficiency rule:** Gather ALL context first (Step 1), then verify. Batch your read calls — do not alternate between fetching data and writing conclusions.
+
+**Turn-budget rule:** When few turns remain in your budget, STOP reading **and** STOP running bash immediately, and post your current findings as a comment via `chorus_add_comment`. Incomplete posted findings are strictly better than no comment at all.
+
+### Step 1: Gather Context (batch these)
+
+```
+chorus_get_task({ taskUuid: "<uuid>" })
+chorus_get_comments({ targetType: "task", targetUuid: "<uuid>" })
+chorus_get_proposal({ proposalUuid: "<task.proposalUuid>", section: "documents" })
+```
+
+> `chorus_get_proposal` defaults to `section: "basic"` (metadata + a lightweight draft index, no bodies). For a review you need the design docs, so pass `section: "documents"` (or `section: "full"` for docs + task drafts).
+
+Use the task comments for the developer's work report, prior review feedback, and (in Round 2+) the previous VERDICT.
+
+### Step 2: Run Tests / Build
+
+Run the project's declared test / build / lint commands. Record the exact command, exit code, and the relevant output. A **broken build or failing tests is an automatic `VERDICT: FAIL`**. Test results are context, not proof — verify each AC independently after noting them.
+
+### Step 3: Verify Each Acceptance Criterion Independently
+
+For **each** AC item, one at a time:
+
+1. Read what it requires — literally, word by word.
+2. Find the code (and/or test) that implements it. Cite file paths and line ranges.
+3. Run a verification command where possible (a targeted test, a grep that proves the behavior exists, a build of the affected module). If the AC says "shows X", grep for evidence that X is rendered/returned; if it says "handles error Y", find the test that triggers Y.
+4. Determine PASS or FAIL **with evidence**.
+
+Do **not** batch AC items as "all look good" — check each one separately. Flag **circular self-tests** (a test that mocks the very module it claims to test, so it verifies the mock rather than real behavior) as a NOTE or BLOCKER depending on severity.
+
+### Step 4: Cross-Reference with Proposal Documents
+
+- Does the implementation match the PRD / tech-design intent (structural match, not exact wording)?
+- Do module contracts match what other tasks expect (return formats, error patterns, call points)?
+- Does the PRD mention fields, behaviors, or error scenarios not covered by any AC, and were they silently dropped?
+- No silent divergence between what was specified and what was built.
+
+### Step 5: Adversarial Probes
+
+Pick 2-3 probes that fit the specific task — boundary values, missing fields, error paths, or concurrency — and **run them**. Do not just describe what you would check.
+
+**Hallucination check:** Flag anything that looks LLM-fabricated as a **NOTE** — API signatures, CLI flags, config keys, model IDs, endpoint URLs, package names, or any external detail the developer likely wrote from memory rather than referencing docs.
+
+---
+
+## Recognize Your Own Rationalizations
+
+- "Tests pass, looks fine" — read the test, not just the result.
+- "The code is clean" — clean code can still fail to meet an AC.
+- "This AC is probably met" — probably is not verified. Find the specific code and check it.
+- "The API call looks right" — for external API/SDK calls, demand execution evidence (run logs, test output). If none exists and you cannot run it, flag as a NOTE.
+
+---
+
+## Finding Classification: BLOCKER vs NOTE
+
+Classify **every** finding as exactly one of:
+
+**BLOCKER** — Blocks implementation correctness:
+
+- An AC is not actually implemented.
+- Build or test failures.
+- Implementation diverges from proposal documents (semantic contradiction).
+- Edge cases that cause runtime errors, or missing error handling for required scenarios.
+
+**NOTE** — Does not block implementation:
+
+- Pseudocode signature mismatch (parameter order, naming).
+- Wording differences between proposal docs and implementation comments.
+- Style / naming suggestions.
+- Hallucination-risk specifics (SDK versions, API paths, CLI flags, model IDs).
+
+**Rules:** Pseudocode inconsistencies → **always NOTE**. Cross-document wording differences → **always NOTE**. Only functional / behavioral issues → BLOCKER.
+
+---
+
+## Round 2+ Awareness
+
+You may receive the current review round number in your context.
+
+- **Round 1** — Full review at normal strictness.
+- **Round 2+** — Focus ONLY on whether the previous BLOCKERs were fixed. Do NOT introduce new NOTEs on areas not flagged in earlier rounds. Round 1 already did the full-depth review. In Round 2+, re-read only the specific files and re-run only the specific tests/commands tied to previous BLOCKERs — do not re-scan unrelated code, do not rerun the full suite, and do not probe new areas. If all previous BLOCKERs are resolved → `VERDICT: PASS` (or `VERDICT: PASS WITH NOTES` if old NOTEs remain). Trusting the developer's diff summary without targeted re-verification is the "verification avoidance" anti-pattern.
+
+---
+
+## VERDICT Contract
+
+You MUST end your comment with exactly one of these three **literal** strings (automation greps for them):
+
+- `VERDICT: PASS`
+- `VERDICT: PASS WITH NOTES`
+- `VERDICT: FAIL`
+
+Mapping:
+
+| Findings | Verdict |
+|----------|---------|
+| Any BLOCKER | `VERDICT: FAIL` |
+| Only NOTEs (no BLOCKER) | `VERDICT: PASS WITH NOTES` |
+| Nothing | `VERDICT: PASS` |
+
+Do NOT invent other verdicts like "APPROVE" or "OK" — automation greps for the three exact strings above.
+
+> The verdict is **advisory**. It informs the admin's decision in the `review-chorus` workflow; it does not by itself verify or reopen the task.
+
+---
+
+## Output Format (Required)
+
+Keep total output **under ~800 characters** — be concise. No preamble, no trailing summary paragraph. PASS items: names only. NOTE items: one-line descriptions. BLOCKER items: full evidence (command + output + expected vs actual).
+
+```
+### Review Summary
+
+**PASS (N):** AC-1 name, AC-2 name, ...
+
+**NOTE (M):**
+- Note-1: [one-line description]
+- Note-2: [one-line description]
+
+**BLOCKER (K):**
+### Blocker-1: name
+**Command run:** [exact command executed]
+**Output observed:** [actual output — copy-paste, not paraphrased]
+**Evidence:** [specific finding with file paths, line numbers]
+**Expected:** [what the AC requires]
+**Actual:** [what happened]
+
+VERDICT: PASS
+```
+
+(or `VERDICT: PASS WITH NOTES` / `VERDICT: FAIL` — exact literal, no other variants)
+
+---
+
+## Posting Results
+
+Post the full review as a **single** comment on the task:
+
+```
+chorus_add_comment({
+  targetType: "task",
+  targetUuid: "<task-uuid>",
+  content: "<your review>"
+})
+```
+
+---
+
+## Next
+
+- The admin reads your VERDICT comment, then verifies or reopens the task in the `review-chorus` skill (`<BASE_URL>/skill/review-chorus/SKILL.md`).
+- For the developer workflow (what you are reviewing), see `develop-chorus` skill (`<BASE_URL>/skill/develop-chorus/SKILL.md`).
+- For platform overview and shared tools, see `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`).

--- a/public/skill/yolo-chorus/SKILL.md
+++ b/public/skill/yolo-chorus/SKILL.md
@@ -1,0 +1,529 @@
+---
+name: yolo-chorus
+description: Full-auto AI-DLC pipeline — drive a single prompt from Idea through Proposal, Execution, and Verification to Done.
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.9.3"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Yolo Skill
+
+Full-auto AI-DLC pipeline. The user provides one prompt; you drive the entire lifecycle: Idea -> Elaboration -> Proposal -> Review -> Execute -> Verify -> Done. No interactive prompts, no human in the loop unless the pipeline gets stuck.
+
+This skill is **framework-neutral**: it never assumes a specific agent harness. Every reviewer and worker is described as "spawn a sub-agent" with a concrete example or two, and every step has an inline single-agent fallback so the pipeline still completes when sub-agents are unavailable.
+
+---
+
+## Overview
+
+You take a natural-language description of what to build, and you handle everything:
+
+1. **Planning** — resolve/create a project, create an Idea, self-elaborate, draft a Proposal (tech-design doc + task DAG), validate, submit.
+2. **Proposal Review** — adversarial review loop against the `proposal-reviewer-chorus` skill.
+3. **Execution** — dependency-ordered, wave-based task dispatch.
+4. **Verification** — adversarial review loop against the `task-reviewer-chorus` skill + admin verify.
+5. **Report** — completion summary + a mandatory Idea Completion Report.
+
+```
+<prompt>
+   |
+   v
+Project + Idea + Self-Elaboration + Proposal
+   |
+   v
+Proposal Review loop  (up to maxProposalReviewRounds, default 3)
+   |   PASS / PASS WITH NOTES -> approve ;  FAIL -> reject + revise + resubmit
+   v
+Admin Approve  -->  Documents + Tasks materialize (tasks land in `open`)
+   |
+   v
+Wave-based Execution  --  chorus_get_unblocked_tasks
+   |   dispatch one worker sub-agent per unblocked task (fallback: sequential main agent)
+   v
+Verification loop  (up to maxTaskReviewRounds, default 3)
+   |   PASS / PASS WITH NOTES -> mark AC + verify ;  FAIL -> reopen
+   |   verify unblocks dependents -> loop back to Execution
+   v
+Done  -->  Report summary + mandatory Idea Completion Report
+```
+
+**Escape hatch:** Interrupt at any time. Every created entity (project, idea, proposal, tasks, comments) persists in Chorus. Resume manually via `develop-chorus` or `review-chorus`.
+
+> **Base URL:** Skill files are hosted under `<BASE_URL>/skill/`. The user provides the Chorus access URL (e.g. `https://chorus.acme.com` or `http://localhost:8637`), referred to as `<BASE_URL>` below. See `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`) for platform overview and shared tools.
+
+---
+
+## Prerequisites
+
+Yolo touches every resource and acts as PM, developer, AND admin. The API key MUST carry write + admin on the resources it drives:
+
+| Needs | Why |
+|-------|-----|
+| `idea: [write]` | Create the Idea, run self-elaboration |
+| `proposal: [write, admin]` | Create + submit the Proposal; approve it |
+| `task: [write, admin]` | Create, execute, verify (and reopen) tasks |
+| `project: [write]` | Create the project when none is supplied |
+
+**Permission preflight — run this before doing anything else:**
+
+```
+perms = chorus_checkin().agent.permissions
+need = { idea:    ["write"],
+         proposal:["write", "admin"],
+         task:    ["write", "admin"],
+         project: ["write"] }
+
+missing = []
+for resource, actions in need:
+  for a in actions:
+    if a not in (perms[resource] or []):
+      missing.append(f"{resource}:{a}")
+
+if missing:
+  ABORT "yolo requires the following permissions, which this API key lacks: "
+        + ", ".join(missing)
+        + ". Use an Admin-preset API key (all 15 permissions) and retry."
+```
+
+List **every** missing `resource:action` pair in the abort message — do not stop at the first one — so the user can fix the key in one pass. Do not silently degrade or skip phases when a permission is missing; abort cleanly.
+
+---
+
+## Input
+
+```
+<natural language prompt of what to build>
+<prompt>   (with an optional existing-project hint, e.g. a project UUID or name)
+```
+
+- **prompt** — what you want built. Becomes the Idea content verbatim.
+- **existing-project hint** (optional) — a project UUID or name to reuse instead of creating a new project. If absent, you search for a match and create one only when none fits.
+
+Keep the prompt detailed: the richer the input, the better the auto-generated proposal, and the fewer review rounds it takes.
+
+---
+
+## Workflow
+
+### Phase 1: Planning
+
+#### Step 1.1: Resolve Project
+
+**If the user supplied a project UUID:**
+
+```
+chorus_get_project({ projectUuid: "<uuid>" })
+```
+
+Confirm it exists and reuse it.
+
+**Otherwise, search for a suitable existing project first:**
+
+```
+# Search by topic
+chorus_search({ query: "<key terms from prompt>", entityTypes: ["project"] })
+# Or list recent projects
+chorus_list_projects()
+```
+
+If a project clearly matches the user's intent (same topic, active, relevant scope), reuse it. Only when no project fits, create one:
+
+```
+chorus_admin_create_project({
+  name: "<short title derived from prompt>",
+  description: "<1-2 sentence summary of the prompt>"
+})
+```
+
+#### Step 1.2: Create the Idea
+
+```
+chorus_pm_create_idea({
+  projectUuid: "<project-uuid>",
+  title: "<concise title derived from prompt>",
+  content: "<full user prompt, as-is>"
+})
+```
+
+Then claim it so you own the elaboration:
+
+```
+chorus_claim_idea({ ideaUuid: "<idea-uuid>" })
+```
+
+#### Step 1.3: Self-Elaboration (no interactive prompts)
+
+In yolo mode you generate the elaboration questions AND answer them yourself — there are NO interactive user prompts. This preserves a decision audit trail without interrupting anyone.
+
+1. **Generate and submit questions:**
+
+   ```
+   chorus_pm_start_elaboration({
+     ideaUuid: "<idea-uuid>",
+     depth: "standard",
+     questions: [
+       {
+         id: "q1",
+         text: "<question about scope, architecture, data model, etc.>",
+         category: "functional",
+         options: [
+           { id: "a", label: "<option A>" },
+           { id: "b", label: "<option B>" }
+         ]
+       }
+       // ... 5-8 questions covering functional, technical, and scope aspects
+     ]
+   })
+   ```
+
+2. **Answer immediately** — pick the option that best fits the prompt and record your rationale:
+
+   ```
+   chorus_answer_elaboration({
+     ideaUuid: "<idea-uuid>",
+     roundUuid: "<round-uuid>",
+     answers: [
+       { questionId: "q1", selectedOptionId: "a", customText: "Rationale: ..." }
+       // ...
+     ]
+   })
+   ```
+
+3. **Validate** — in self-mode there are no outstanding human issues, so close the round clean:
+
+   ```
+   chorus_pm_validate_elaboration({
+     ideaUuid: "<idea-uuid>",
+     roundUuid: "<round-uuid>",
+     issues: []
+   })
+   ```
+
+#### Step 1.4: Create the Proposal
+
+1. **Create the empty proposal container:**
+
+   ```
+   chorus_pm_create_proposal({
+     projectUuid: "<project-uuid>",
+     title: "<feature name>",
+     description: "<summary derived from the elaborated idea>",
+     inputType: "idea",
+     inputUuids: ["<idea-uuid>"]
+   })
+   ```
+
+2. **Add a tech-design document draft.** Capture architecture, data model, API surface, and module contracts (return formats, error patterns, call points) so each task draft can reference a single source of truth:
+
+   ```
+   chorus_pm_add_document_draft({
+     proposalUuid: "<proposal-uuid>",
+     type: "tech_design",
+     title: "Tech Design: <feature>",
+     content: "<markdown tech design: architecture, data model, API, module contracts>"
+   })
+   ```
+
+3. **Add task drafts incrementally** and chain them into a `dependsOn` DAG with the returned `draftUuid` of each upstream draft. `acceptanceCriteriaItems` is **required** on every draft — at least one non-blank criterion, or the call is rejected. Each criterion must be objectively verifiable by a different agent:
+
+   ```
+   # First task
+   result1 = chorus_pm_add_task_draft({
+     proposalUuid: "<proposal-uuid>",
+     title: "<module name>",
+     description: "<what to build, referencing the tech design>",
+     priority: "high",
+     storyPoints: 3,
+     acceptanceCriteriaItems: [
+       { description: "<testable criterion>", required: true }
+       // ...
+     ]
+   })
+
+   # Second task depends on the first
+   chorus_pm_add_task_draft({
+     proposalUuid: "<proposal-uuid>",
+     title: "<dependent module>",
+     description: "...",
+     priority: "medium",
+     storyPoints: 2,
+     acceptanceCriteriaItems: [ { description: "...", required: true } ],
+     dependsOnDraftUuids: ["<result1.draftUuid>"]
+   })
+   ```
+
+   > For a DAG of **4 or more tasks**, include at least one integration-checkpoint task whose AC requires end-to-end execution of the preceding modules together. The proposal reviewer treats a missing integration checkpoint as a BLOCKER, so add one up front.
+
+4. **Validate** and fix any reported errors before submitting:
+
+   ```
+   chorus_pm_validate_proposal({ proposalUuid: "<proposal-uuid>" })
+   ```
+
+5. **Submit** for review:
+
+   ```
+   chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
+   ```
+
+   Proceed to Phase 2 — you drive the proposal review yourself; nothing reviews it automatically.
+
+---
+
+### Phase 2: Proposal Review Loop
+
+Run an adversarial review on the submitted proposal using the **Independent Review pattern** (see below). Loop until the verdict allows approval or you exhaust `maxProposalReviewRounds`.
+
+> **Independent Review pattern (framework-neutral).** Spawn a **read-only** sub-agent and have it load the `proposal-reviewer-chorus` skill (`<BASE_URL>/skill/proposal-reviewer-chorus/SKILL.md`), pass it the `proposalUuid` and the current review round number, and instruct it to post exactly one `VERDICT` comment on the proposal. The reviewer's only side effect is that comment; it makes no writes to your project. After it returns, read the verdict via `chorus_get_comments`.
+>
+> **The exact spawn mechanism is harness-specific** — these are EXAMPLES only, not a hard dependency:
+> - Claude Code: dispatch a sub-agent with the Task/Agent tool, mounting the `proposal-reviewer-chorus` skill.
+> - Codex: `spawn_agent` mounting the skill, then `wait_agent`; release the thread slot with `close_agent` afterwards.
+> - Any other harness: whatever read-only sub-agent primitive it exposes.
+>
+> **Inline self-review fallback (no sub-agents available).** If your harness cannot spawn a sub-agent, perform the review inline as the main agent: read `proposal-reviewer-chorus`, follow its procedure against this proposal (fetch the proposal `section: "full"`, the idea, and the elaboration; audit documents and task drafts; classify findings as BLOCKER vs NOTE), and post your own `VERDICT` comment via `chorus_add_comment`. The verdict semantics below are identical in either mode.
+>
+> This is the canonical pattern; `chorus` (`<BASE_URL>/skill/chorus/SKILL.md`) documents it canonically — describe it inline here so yolo is self-contained.
+
+**Review loop:**
+
+```
+round = 1
+loop:
+  # 1. Spawn the reviewer (Independent Review pattern above) with proposalUuid + round.
+  #    Fallback: inline self-review as the main agent.
+
+  # 2. Read the latest VERDICT comment.
+  comments = chorus_get_comments({ targetType: "proposal", targetUuid: "<proposal-uuid>" })
+  # Find the most recent comment containing "VERDICT:".
+
+  # 3. Act on the verdict (three outcomes).
+```
+
+1. **`VERDICT: PASS`** or **`VERDICT: PASS WITH NOTES`** — approve. Tasks and documents materialize automatically; proceed to Phase 3.
+
+   ```
+   chorus_admin_approve_proposal({
+     proposalUuid: "<proposal-uuid>",
+     reviewNote: "PASS from reviewer. <one-line summary of any NOTES>"
+   })
+   ```
+
+2. **`VERDICT: FAIL`** — read the BLOCKERs from the reviewer comment, reject, revise, and resubmit:
+
+   ```
+   chorus_pm_reject_proposal({
+     proposalUuid: "<proposal-uuid>",
+     reviewNote: "FAIL from reviewer. Fixing BLOCKERs: <list>"
+   })
+   # Revise drafts to address each BLOCKER:
+   #   chorus_pm_update_document_draft({ ... })
+   #   chorus_pm_update_task_draft({ ... })
+   chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
+   round += 1
+   # Re-run the Independent Review for the next round (pass round = current number).
+   ```
+
+3. **Max rounds escalation.** Loop up to `maxProposalReviewRounds` (default **3**). If exhausted with unresolved BLOCKERs:
+
+   ```
+   STOP: "Proposal review failed after 3 rounds. Remaining BLOCKERs: <list>.
+          Human review needed. Proposal UUID: <proposal-uuid>."
+   ```
+
+4. **No VERDICT comment after the reviewer returns?** The reviewer likely exhausted its turn budget. **Respawn it once** with a concise-budget hint: *"Stay within turn budget. Fetch the proposal + comments + idea only, skim for obvious BLOCKERs, and post your VERDICT within the first ~10 turns."* If the second attempt still posts no VERDICT, treat the proposal as **PASS WITH NOTES** and proceed — the pipeline must not loop forever on a silent reviewer.
+
+---
+
+### Phase 3: Execution (Wave-Based)
+
+After approval, tasks exist in `open`. Execute them in dependency-ordered waves. A wave is the current set of unblocked tasks; verifying a wave (Phase 4) unblocks the next.
+
+```
+wave = 1
+loop:
+  # 1. Find tasks whose dependencies are all resolved (done/closed).
+  unblocked = chorus_get_unblocked_tasks({ projectUuid: "<project-uuid>" })
+
+  if no unblocked tasks and all tasks done:
+    break   # pipeline complete
+
+  if no unblocked tasks and some tasks not done:
+    break with escalation report   # stuck: tasks failed review or are circularly blocked
+
+  # 2. Dispatch one worker per unblocked task (see worker dispatch below).
+  # 3. Wait for workers to reach `to_verify`.
+  # 4. Run Phase 4 verification for this wave's tasks.
+  wave += 1
+  # 5. Loop: re-check chorus_get_unblocked_tasks for newly unblocked tasks.
+```
+
+**Worker dispatch (framework-neutral).** For each unblocked task, dispatch a worker sub-agent that follows the developer workflow (`develop-chorus`, `<BASE_URL>/skill/develop-chorus/SKILL.md`): claim -> in_progress -> implement -> report_work -> self-check AC -> submit_for_verify. The worker prompt needs:
+
+- `taskUuid` (required)
+- `projectUuid` (required, for context lookups)
+- An explicit instruction to follow the `develop-chorus` skill and to exit after `chorus_submit_for_verify` so the main agent can run verification.
+
+> **The spawn mechanism is harness-specific** — EXAMPLES only:
+> - Claude Code: one sub-agent per task via the Task/Agent tool (parallel within the wave).
+> - Codex: `spawn_agent` per task, then `wait_agent`; `close_agent` each worker after it returns.
+> - Optionally create a `chorus_create_session` per worker for observability and `chorus_close_session` it when the worker finishes.
+
+**Sequential main-agent fallback.** If sub-agents are unavailable, or parallel execution is impractical (rate limits, token budget, simpler debugging), execute each unblocked task yourself, sequentially, as the main agent:
+
+```
+for each task in unblocked:
+  chorus_claim_task({ taskUuid: "<task-uuid>" })
+  chorus_update_task({ taskUuid: "<task-uuid>", status: "in_progress" })
+  # ... read context (task, proposal documents, upstream deps), implement, run tests ...
+  chorus_report_work({ taskUuid: "<task-uuid>", report: "..." })
+  chorus_report_criteria_self_check({ taskUuid: "<task-uuid>", criteria: [ ... ] })
+  chorus_submit_for_verify({ taskUuid: "<task-uuid>", summary: "..." })
+  # Then run Phase 4 verification for this task before moving on.
+```
+
+The fallback is slower (no parallelism) but completes the same pipeline.
+
+---
+
+### Phase 4: Verification Loop
+
+After each wave's workers reach `to_verify`, verify their tasks using the **Independent Review pattern** — the same neutral mechanism as Phase 2, pointed at the `task-reviewer-chorus` skill.
+
+> **Independent Review pattern (framework-neutral).** Spawn a **read-only** sub-agent and have it load the `task-reviewer-chorus` skill (`<BASE_URL>/skill/task-reviewer-chorus/SKILL.md`), pass it the `taskUuid` and the current review round number, and instruct it to post exactly one `VERDICT` comment on the task. The reviewer's only project side effect is that comment (it may run read-only tests/build/lint, but never writes). After it returns, read the verdict via `chorus_get_comments`.
+>
+> **The exact spawn mechanism is harness-specific** — EXAMPLES only:
+> - Claude Code: dispatch a read-only sub-agent with the Task/Agent tool, mounting the `task-reviewer-chorus` skill.
+> - Codex: `spawn_agent` mounting the skill, then `wait_agent`; `close_agent` afterwards to release the thread slot.
+>
+> **Inline self-review fallback (no sub-agents available).** Perform the review inline as the main agent: read `task-reviewer-chorus`, follow its procedure (fetch the task, its AC, comments, and the proposal `section: "documents"`; run the project's test/build/lint; verify each AC independently; classify BLOCKER vs NOTE), and post your own `VERDICT` comment via `chorus_add_comment`.
+
+**Verification loop, per task in the wave:**
+
+```
+for each task in wave_tasks:
+  t = chorus_get_task({ taskUuid: "<task-uuid>" })
+  if t.status != "to_verify":
+    continue   # worker did not submit; handle in a later wave or escalate
+
+  # Spawn the task reviewer (Independent Review pattern) with taskUuid + round.
+  # Fallback: inline self-review.
+
+  comments = chorus_get_comments({ targetType: "task", targetUuid: "<task-uuid>" })
+  # Find the most recent comment containing "VERDICT:".
+```
+
+Act on the verdict — three outcomes:
+
+1. **`VERDICT: PASS`** — all AC verified, no issues. Mark AC and verify:
+
+   ```
+   chorus_mark_acceptance_criteria({
+     taskUuid: "<task-uuid>",
+     criteria: [ { uuid: "<ac-uuid>", status: "passed", evidence: "<from reviewer>" } /* ... */ ]
+   })
+   chorus_admin_verify_task({ taskUuid: "<task-uuid>" })   # -> done, unblocks dependents
+   ```
+
+2. **`VERDICT: PASS WITH NOTES`** — minor, non-blocking notes only. Still mark AC and verify (same two calls as above).
+
+3. **`VERDICT: FAIL`** — BLOCKERs found. Do NOT verify. Reopen for rework; the task returns to `in_progress` (its AC reset to pending) and is picked up in the next wave:
+
+   ```
+   chorus_admin_reopen_task({ taskUuid: "<task-uuid>" })
+   chorus_add_comment({ targetType: "task", targetUuid: "<task-uuid>",
+                        content: "Reopened. BLOCKERs to fix: <list>" })
+   ```
+
+**Max rounds escalation.** Track review rounds per task via `maxTaskReviewRounds` (default **3**). If a task has been reopened 3 times and still FAILs, skip it and flag for human escalation — do **not** halt the whole pipeline for one stuck task:
+
+```
+ESCALATE: "Task '<title>' failed review after 3 rounds. Last BLOCKERs: <list>.
+           Manual intervention needed. Task UUID: <task-uuid>."
+```
+
+**No VERDICT comment after the reviewer returns?** It exhausted its turn budget. **Respawn it once** with a concise-budget hint: *"Stay within turn budget. Fetch the task/proposal/comments, run only the core tests, and post your VERDICT within the first ~12 turns."* If the second attempt still posts no VERDICT, treat as **PASS WITH NOTES** and proceed — do not loop indefinitely.
+
+After verifying every task in the wave, return to **Phase 3** and re-run `chorus_get_unblocked_tasks` for newly unblocked tasks. Repeat until no tasks remain.
+
+---
+
+### Phase 5: Report
+
+When all waves complete, output a markdown summary:
+
+```markdown
+## Yolo Complete
+
+**Project:** <project-name> (<project-uuid>)
+**Proposal:** <proposal-title> (<proposal-uuid>)
+**Idea:** <idea-title> (<idea-uuid>)
+
+### Tasks
+| Task | Status | Review Rounds |
+|------|--------|---------------|
+| <title> | done      | 1 |
+| <title> | done      | 2 |
+| <title> | ESCALATED | 3 (max) |
+
+### Summary
+- Total tasks: N
+- Completed: X / N
+- Escalated: Y (need human review)
+- Waves executed: W
+- Idea Completion Report: <document-uuid>   (from Phase 5b)
+```
+
+---
+
+### Phase 5b: Idea Completion Report (mandatory)
+
+A successful yolo run always finishes the Idea. Call `chorus_create_report` **exactly once**, with `proposalUuid` set to the **last verified proposal**. The tool's own description carries the section template — follow it. Surface the returned `documentUuid` in the Phase 5 summary table. Skipping this is a protocol violation.
+
+```
+result = chorus_create_report({
+  proposalUuid: "<last-verified-proposal-uuid>",
+  // ... follow the tool description's section template ...
+})
+# Surface result.documentUuid in the Phase 5 summary.
+```
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Missing permissions at startup | Abort, listing **every** missing `resource:action` pair (see Prerequisites). Recommend an Admin-preset API key. |
+| Project creation fails | Report the error; suggest the user create the project manually and rerun with an existing-project hint. |
+| Proposal review FAILs after `maxProposalReviewRounds` (3) | Stop the pipeline; report the persisting BLOCKERs; recommend manual review of the proposal. |
+| Task review FAILs after `maxTaskReviewRounds` (3) | Flag the task as escalation-needed; continue with the other tasks. |
+| Reviewer returns no VERDICT | Respawn the reviewer once with a concise-budget hint; if still none, treat as PASS WITH NOTES and proceed. |
+| Worker crashes / never submits | Log it, leave the task non-`to_verify`; re-pick it in a later wave or escalate if it stays stuck. |
+| No unblocked tasks but some not done | Stuck DAG (failed reviews or bad dependencies). Break with an escalation report; do not loop. |
+| Sub-agents unavailable | Use the inline self-review fallback (reviews) and the sequential main-agent fallback (execution). |
+| Interrupted mid-run | All entities persist in Chorus. Resume via `develop-chorus` or `review-chorus`. |
+
+---
+
+## Tips
+
+- **Keep the prompt detailed** — richer input yields a stronger proposal and fewer review rounds.
+- **The proposal reviewer is your quality gate** — repeated FAILs usually mean the prompt is too vague; tighten it and rerun.
+- **Watch the wave count** — if tasks keep getting reopened, interrupt and inspect the reviewer feedback before continuing.
+- **Prefer sub-agents when available** — a fresh read-only reviewer is more adversarial than reviewing your own output inline; use the inline fallback only when you must.
+- **Everything is audited** — elaboration Q&A, reviewer VERDICTs, work reports, and approvals all persist; inspect the Chorus UI for the full history.
+- **For small, single-step work**, prefer `quick-dev-chorus` (`<BASE_URL>/skill/quick-dev-chorus/SKILL.md`) — it skips the Idea -> Proposal overhead.
+- **Sub-agents share your API key** — confirm it carries the Prerequisites permissions before starting.
+
+---
+
+## Next
+
+- To create proposals manually: `proposal-chorus` skill (`<BASE_URL>/skill/proposal-chorus/SKILL.md`)
+- To develop tasks manually: `develop-chorus` skill (`<BASE_URL>/skill/develop-chorus/SKILL.md`)
+- To review proposals and verify tasks manually: `review-chorus` skill (`<BASE_URL>/skill/review-chorus/SKILL.md`)
+- For platform overview and shared tools: `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`)


### PR DESCRIPTION
## Summary

The standalone `public/skill/` distribution (curl-installable by any agent) lacked a yolo lifecycle skill and had **no reviewer skills**, while `develop-chorus` / `review-chorus` pointed at the `chorus:proposal-reviewer` / `chorus:task-reviewer` agent types — machinery that only exists in the Claude Code plugin, not for a pure-skill consumer. Learning from the Codex plugin's skill-based reviewers, this adds the missing skills and unifies all reviewer references to a framework-neutral pattern.

- **New:** `yolo-chorus`, `proposal-reviewer-chorus`, `task-reviewer-chorus` skills (`<stage>-chorus` naming).
- **Unified reviewer invocation:** one canonical "spawn a read-only sub-agent → load the reviewer skill → read its VERDICT comment" pattern, documented once in `chorus/SKILL.md` and referenced from `develop-chorus` (Step 8) and `review-chorus` (A3.5 rewritten + new B2.5). **Zero** `chorus:*-reviewer` agent-type references remain in `public/skill/`.
- **Closed pre-existing gaps:** registered the unregistered `quick-dev-chorus` + `brainstorm-chorus` in `package.json` / routing / install scripts; normalized `quick-dev-chorus` frontmatter; aligned the whole standalone surface to **0.9.3**.
- **Claude Code plugin bump:** `marketplace.json` + `plugin.json` + 9 skills `0.9.2` → `0.9.3` (matches the Codex plugin). OpenClaw intentionally left on its own sequence.

Docs/skills only — no backend, schema, or UI changes. Built end-to-end through the `/yolo` AI-DLC pipeline (idea → elaboration → proposal → adversarial review → wave execution → verification); the proposal reviewer caught two real BLOCKERs in round 1 (a non-existent `B2.5` and a false manifest baseline), both fixed before any file was written.

## Changed files

| File(s) | Change |
|---------|--------|
| `public/skill/yolo-chorus/SKILL.md` | **New** — full-auto AI-DLC lifecycle doc, framework-neutral reviewer invocation |
| `public/skill/proposal-reviewer-chorus/SKILL.md` | **New** — read-only adversarial proposal reviewer (VERDICT contract) |
| `public/skill/task-reviewer-chorus/SKILL.md` | **New** — read-only adversarial task reviewer (VERDICT contract) |
| `public/skill/chorus/SKILL.md` | New canonical "Independent Review" section; Skill Files table + both install scripts + Skill Routing now list all 10 skills; v0.9.3 |
| `public/skill/develop-chorus/SKILL.md` | Step 8 reviewer note → neutral pattern + `task-reviewer-chorus`; v0.9.3 |
| `public/skill/review-chorus/SKILL.md` | A3.5 → neutral pattern + `proposal-reviewer-chorus`; new B2.5 → `task-reviewer-chorus`; v0.9.3 |
| `public/skill/package.json` | Registers all 10 skills in both maps; new triggers; version 0.9.3 |
| `public/skill/{idea,proposal,brainstorm,quick-dev}-chorus/SKILL.md` | Frontmatter version → 0.9.3 (quick-dev normalized to standard shape) |
| `.claude-plugin/marketplace.json`, `public/chorus-plugin/.claude-plugin/plugin.json`, `public/chorus-plugin/skills/*/SKILL.md` | Claude Code plugin 0.9.2 → 0.9.3 |
| `openspec/specs/public-skill-yolo-reviewers/spec.md`, `openspec/changes/archive/2026-06-03-add-public-yolo-reviewer-skills/` | Archived OpenSpec change + emitted capability spec |

## Test plan

- [x] `grep -rn 'chorus:proposal-reviewer\|chorus:task-reviewer' public/skill/` → zero hits
- [x] `package.json` (both maps) exactly matches on-disk `public/skill/*/SKILL.md` (10/10, bidirectional)
- [x] All 10 standalone SKILL.md + Claude Code plugin files read `0.9.3`; all JSON valid
- [x] OpenSpec change validates and archives; emitted spec round-trips byte-equal with its Chorus Document
- [ ] No automated test suite applies (docs/skills only)

Generated with [Claude Code](https://claude.com/claude-code)