### PR TITLE
feat(elaboration): simplify flow — unified round generation, optional roundUuid, admin-gated validate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1144,14 +1144,14 @@ Gated tools are grouped below by the permission they require. An agent sees a to
 
 | Required Permission | Representative Tools |
 |-----|-----|
-| `idea:write` | `chorus_claim_idea`, `chorus_release_idea`, `chorus_move_idea`, `chorus_pm_create_idea`, `chorus_pm_start_elaboration`, `chorus_pm_validate_elaboration`, `chorus_pm_skip_elaboration` |
+| `idea:write` | `chorus_claim_idea`, `chorus_release_idea`, `chorus_move_idea`, `chorus_pm_create_idea`, `chorus_pm_start_elaboration`, `chorus_pm_skip_elaboration` |
 | `proposal:write` | `chorus_pm_create_proposal`, `chorus_pm_submit_proposal`, `chorus_pm_validate_proposal`, `chorus_pm_{add,update,remove}_document_draft`, `chorus_pm_{add,update,remove}_task_draft`, `chorus_pm_assign_task`, `chorus_pm_{reject,revoke}_proposal` |
 | `document:write` | `chorus_pm_create_document`, `chorus_pm_update_document` |
 | `task:write` | `chorus_claim_task`, `chorus_release_task`, `chorus_submit_for_verify`, `chorus_report_work`, `chorus_report_criteria_self_check` |
 | `project:write` | `chorus_admin_create_project`, `chorus_admin_{create,update,delete}_project_group`, `chorus_admin_move_project_to_group` |
 | `proposal:admin` | `chorus_admin_approve_proposal`, `chorus_admin_close_proposal` |
 | `task:admin` | `chorus_admin_verify_task`, `chorus_admin_reopen_task`, `chorus_admin_close_task`, `chorus_mark_acceptance_criteria`, `chorus_admin_delete_task` |
-| `idea:admin` | `chorus_admin_delete_idea` |
+| `idea:admin` | `chorus_pm_validate_elaboration`, `chorus_admin_delete_idea` |
 | `document:admin` | `chorus_admin_delete_document` |
 
 The `admin_agent` preset grants all `*:admin` bits and so exposes every tool in the table above. Any custom combination (e.g. Developer preset + `task:admin` to self-verify) produces the corresponding tool set automatically.

--- a/docs/ARCHITECTURE.zh.md
+++ b/docs/ARCHITECTURE.zh.md
@@ -1100,14 +1100,14 @@ Header: Authorization: Bearer {api_key}
 
 | 必需权限 | 代表性工具 |
 |-----|-----|
-| `idea:write` | `chorus_claim_idea`、`chorus_release_idea`、`chorus_move_idea`、`chorus_pm_create_idea`、`chorus_pm_start_elaboration`、`chorus_pm_validate_elaboration`、`chorus_pm_skip_elaboration` |
+| `idea:write` | `chorus_claim_idea`、`chorus_release_idea`、`chorus_move_idea`、`chorus_pm_create_idea`、`chorus_pm_start_elaboration`、`chorus_pm_skip_elaboration` |
 | `proposal:write` | `chorus_pm_create_proposal`、`chorus_pm_submit_proposal`、`chorus_pm_validate_proposal`、`chorus_pm_{add,update,remove}_document_draft`、`chorus_pm_{add,update,remove}_task_draft`、`chorus_pm_assign_task`、`chorus_pm_{reject,revoke}_proposal` |
 | `document:write` | `chorus_pm_create_document`、`chorus_pm_update_document` |
 | `task:write` | `chorus_claim_task`、`chorus_release_task`、`chorus_submit_for_verify`、`chorus_report_work`、`chorus_report_criteria_self_check` |
 | `project:write` | `chorus_admin_create_project`、`chorus_admin_{create,update,delete}_project_group`、`chorus_admin_move_project_to_group` |
 | `proposal:admin` | `chorus_admin_approve_proposal`、`chorus_admin_close_proposal` |
 | `task:admin` | `chorus_admin_verify_task`、`chorus_admin_reopen_task`、`chorus_admin_close_task`、`chorus_mark_acceptance_criteria`、`chorus_admin_delete_task` |
-| `idea:admin` | `chorus_admin_delete_idea` |
+| `idea:admin` | `chorus_pm_validate_elaboration`、`chorus_admin_delete_idea` |
 | `document:admin` | `chorus_admin_delete_document` |
 
 `admin_agent` 预设拥有所有 `*:admin` 位，因此会暴露上表全部工具。任意自定义组合（例如 Developer 预设 + `task:admin` 让 Agent 自行验收任务）会自动得到对应工具集。

--- a/docs/DESIGN_REQUIREMENTS_ELABORATION.md
+++ b/docs/DESIGN_REQUIREMENTS_ELABORATION.md
@@ -18,10 +18,12 @@ AI-DLC requires a **mandatory clarification loop** between receiving requirement
 
 ```
 Idea → PM analyzes → PM asks structured questions → Human answers →
-  PM validates (contradictions? gaps?) →
-    ├─ Issues found → PM asks follow-up questions → Human answers → ...
-    └─ All clear → PM creates Proposal (informed by validated answers)
+  PM reviews answers →
+    ├─ Gaps remain → PM opens another round (start_elaboration again) → Human answers → ...
+    └─ Clear      → PM resolves elaboration (human-confirmed) → creates Proposal
 ```
+
+> **Tool model.** Three tools drive the loop: `chorus_pm_start_elaboration` generates **any** round (first, follow-up, or a round appended after resolution); `chorus_answer_elaboration` records answers (its `roundUuid` is optional — it auto-locates the active round); and `chorus_pm_validate_elaboration` (gated `idea:admin`, human-confirmed except in YOLO) marks the whole elaboration complete. `chorus_pm_validate_elaboration` takes only `ideaUuid` and an optional `roundUuid`; opening a follow-up round is just another `start_elaboration` call. The round cap is **10**.
 
 ## Design Goals
 
@@ -94,13 +96,11 @@ interface ElaborationRound {
   questions: ElaborationQuestion[];
 
   // Round-level status
-  status: "pending_answers" | "answered" | "validated" | "needs_followup";
+  status: "pending_answers" | "answered" | "validated";
 
-  // Validation result (filled after PM validates)
-  validation?: {
-    validatedAt: string;
-    issues: ValidationIssue[];   // Empty if all clear
-  };
+  // True when the round was created after the Idea was first resolved
+  // (a pure supplement; keeps the Idea elaborated/resolved). See "Appended rounds".
+  isAppended: boolean;
 }
 
 interface ElaborationQuestion {
@@ -129,12 +129,9 @@ interface QuestionOption {
   description?: string; // Longer explanation
 }
 
-interface ValidationIssue {
-  questionId: string;
-  type: "contradiction" | "ambiguity" | "incomplete" | "out_of_scope";
-  description: string;
-  followUpQuestionIds?: string[];  // Questions in the next round addressing this
-}
+// NOTE: there is no per-question issue tagging — `ValidationIssue` / round
+// `validation` are not written. Opening a follow-up round is just another
+// `chorus_pm_start_elaboration` call.
 ```
 
 ### Example Data
@@ -184,6 +181,15 @@ interface ValidationIssue {
 }
 ```
 
+### Appended rounds
+
+Once an Idea's elaboration is resolved (`elaborationStatus = "resolved"`, Idea `elaborated`), a PM can still attach more clarification by calling `chorus_pm_start_elaboration` again. Such a round is flagged `isAppended = true` and is a **pure supplement**:
+
+- The Idea **stays** `elaborated` and `elaborationStatus` **stays** `resolved`. Creating or answering an appended round never regresses the Idea back to `elaborating`/`validating`.
+- Because the proposal-submission gate keys off `elaborationStatus === "resolved"`, an open appended round **never blocks** an in-flight Proposal.
+- Re-resolving (`chorus_pm_validate_elaboration`) after answering an appended round is optional — it simply re-validates that round; the Idea was already resolved.
+- The marker surfaces in `chorus_get_elaboration` (per-round `isAppended`) and in the elaboration UI as an "appended / follow-up" badge.
+
 ## Idea Status Flow (Simplified)
 
 ```
@@ -191,9 +197,9 @@ open → elaborating → proposal_created → completed
           │    ▲
           │    │ (follow-up round needed)
           ▼    │
-     [PM asks questions]
-     [Human answers]
-     [PM validates]
+     [PM asks questions — start_elaboration]
+     [Human answers — answer_elaboration]
+     [PM resolves — resolve_elaboration, human-confirmed]
           │
           ▼
     [All resolved] → PM creates Proposal → proposal_created
@@ -223,7 +229,7 @@ any → closed                 (admin closes)
 
 #### `chorus_pm_start_elaboration`
 
-PM Agent analyzes the Idea and determines the appropriate depth. Creates the first round of questions.
+PM Agent analyzes the Idea and determines the appropriate depth. This is the single entry point for **every** round — the first round, any follow-up round, and rounds appended after the elaboration was already resolved.
 
 ```typescript
 chorus_pm_start_elaboration({
@@ -245,41 +251,42 @@ chorus_pm_start_elaboration({
 ```
 
 **Behavior**:
-- Sets `elaborationDepth`, creates first `ElaborationRound` in `elaborationRounds`
-- Sets `elaborationStatus` to `"pending_answers"`
-- Transitions Idea status to `"elaborating"` (if currently `in_progress`)
+- Sets `elaborationDepth`, creates a new `ElaborationRound` in `elaborationRounds`
+- **Normal round** (Idea `elaborating`): sets `elaborationStatus` to `"pending_answers"`, `isAppended = false`
+- **Appended round** (Idea already `elaborated` / `elaborationStatus = "resolved"`): sets `isAppended = true`, leaves Idea status `"elaborated"` and `elaborationStatus = "resolved"` (a pure supplement — see "Appended rounds")
+- Transitions Idea status to `"elaborating"` (only when not already `elaborated`)
 - Creates Activity: `"elaboration_started"`
 - Returns the created round UUID
 
 **Validation**:
 - Idea must be assigned to calling agent
-- Idea must be in `in_progress` or `elaborating` status
+- Idea must be in `elaborating` **or** `elaborated` status (the `elaborated` case produces an appended round)
+- Round cap: at most **10** rounds per Idea
 - At least 1 question required
 - Each question must have 2-5 options
 
 #### `chorus_pm_validate_elaboration`
 
-PM Agent reviews answers and validates for contradictions/ambiguities.
+PM Agent marks the whole elaboration complete: validates the most recent `answered` round, moves the Idea to `elaborated`, and sets `elaborationStatus = resolved`. **Requires `idea:admin`** and **human confirmation before calling (except in YOLO mode).**
 
 ```typescript
 chorus_pm_validate_elaboration({
   ideaUuid: string,
-  roundUuid: string,
-  issues: [                    // Empty array if all clear
-    {
-      questionId: string,
-      type: "contradiction" | "ambiguity" | "incomplete",
-      description: string
-    }
-  ],
-  followUpQuestions?: [...]    // If issues found, create next round
+  roundUuid?: string           // Optional — defaults to the most recent `answered` round
 })
 ```
 
 **Behavior**:
-- If `issues` is empty: marks round as `"validated"`, sets `elaborationStatus` to `"resolved"`
-- If `issues` is non-empty AND `followUpQuestions` provided: marks round as `"needs_followup"`, creates new round, keeps `elaborationStatus` as `"pending_answers"`
-- Creates Activity: `"elaboration_validated"` or `"elaboration_followup_created"`
+- Validates the targeted (or latest `answered`) round → round status `"validated"`
+- Idea status → `"elaborated"`, `elaborationStatus` → `"resolved"`
+- Creates Activity: `"elaboration_resolved"`
+- Fails if there is no `answered` round to resolve
+
+**Permission / assignee notes**:
+- Gated `idea:admin`. The `pm_agent` preset only grants `idea:write`, so a PM-preset agent must hand off to an `admin_agent`-preset agent (or admin key) to resolve.
+- The resolving actor must also be the Idea's **assignee**. A separate human reviewer resolving a PM-owned Idea therefore needs **both** `idea:admin` and the Idea assignment.
+
+> **Opening a follow-up round** no longer goes through a dedicated tool — just call `chorus_pm_start_elaboration` again (works while `elaborating`, or appended after `resolved`).
 
 #### `chorus_pm_skip_elaboration`
 
@@ -306,7 +313,7 @@ Human (or Admin Agent) answers the pending questions.
 ```typescript
 chorus_answer_elaboration({
   ideaUuid: string,
-  roundUuid: string,
+  roundUuid?: string,                  // Optional — auto-locates the active `pending_answers` round
   answers: [
     {
       questionId: string,
@@ -318,8 +325,9 @@ chorus_answer_elaboration({
 ```
 
 **Behavior**:
+- `roundUuid` is **optional**: when omitted, the service auto-locates the Idea's single `pending_answers` round (errors if there are zero or more than one)
 - Fills in `answer` on each question in the round
-- If all required questions answered: marks round as `"answered"`, sets `elaborationStatus` to `"validating"`
+- If all required questions answered: marks round as `"answered"`; sets `elaborationStatus` to `"validating"` **unless** the Idea is already `resolved` (an appended round keeps `elaborationStatus = "resolved"` and never regresses the Idea — see "Appended rounds")
 - Creates Activity: `"elaboration_answered"`
 - Creates Notification to PM agent: "Elaboration answers received for Idea X"
 
@@ -327,6 +335,8 @@ chorus_answer_elaboration({
 - All required questions must have answers
 - `selectedOptionId` must match one of the question's option IDs (or null for custom)
 - If `selectedOptionId` is the "Other" option, `customText` is required
+
+> Each round object returned by `chorus_get_elaboration` includes an `isAppended` boolean so clients and the UI can render an "appended / follow-up" badge.
 
 #### `chorus_get_elaboration`
 
@@ -398,7 +408,7 @@ After analyzing the Idea, determine if clarification is needed:
 
   3. Wait for answers (human fills in via UI or chorus_answer_elaboration tool).
 
-  4. Validate the answers:
+  4. Review the answers:
      chorus_get_elaboration({ ideaUuid: "<idea-uuid>" })
 
      Check for:
@@ -406,24 +416,23 @@ After analyzing the Idea, determine if clarification is needed:
      - Ambiguities (e.g., "Other" without clear explanation)
      - Missing context (required question unanswered)
 
-  5. If issues found, create follow-up round:
-     chorus_pm_validate_elaboration({
+  5. If gaps remain, open a follow-up round — just call start_elaboration again:
+     chorus_pm_start_elaboration({
        ideaUuid: "<idea-uuid>",
-       roundUuid: "<round-uuid>",
-       issues: [{ questionId: "q3", type: "ambiguity", description: "..." }],
-       followUpQuestions: [...]
+       depth: "standard",
+       questions: [ /* the follow-up questions */ ]
      })
 
-  6. Repeat until all rounds validated.
+  6. Repeat until you're satisfied the requirements are clear.
 
-  7. If all clear:
+  7. When all clear — obtain human confirmation (skipped only in YOLO), then resolve:
      chorus_pm_validate_elaboration({
-       ideaUuid: "<idea-uuid>",
-       roundUuid: "<round-uuid>",
-       issues: []
+       ideaUuid: "<idea-uuid>"
+       // roundUuid optional — defaults to the latest answered round
      })
-     → elaborationStatus becomes "resolved"
+     → Idea status becomes "elaborated", elaborationStatus becomes "resolved"
      → Proceed to create Proposal (Step 5)
+     (Requires idea:admin — a pm_agent-preset key must hand off to an admin-preset agent.)
 ```
 
 ## Question Categories
@@ -492,9 +501,9 @@ Human answers in terminal
 PM Agent calls chorus_answer_elaboration()          ← persists answers
   │
   ▼
-PM Agent validates (check contradictions / gaps)
-  ├─ All clear → proceed to Proposal
-  └─ Issues → AskUserQuestion with follow-up → iterate
+PM Agent reviews answers (check contradictions / gaps)
+  ├─ All clear → resolve (human-confirmed) → proceed to Proposal
+  └─ Gaps → start_elaboration again with follow-up questions → iterate
 ```
 
 **No plugin hooks, no message relay, no proxy.** The PM skill doc simply instructs: "After calling `chorus_pm_start_elaboration`, immediately present the questions to the user via `AskUserQuestion`, then submit answers via `chorus_answer_elaboration`."
@@ -516,7 +525,7 @@ PM Agent creates questions → Chorus stores → Notification created
 SSE pushes to browser → NotificationBell badge → Human clicks
   → Idea detail page → Elaboration panel → Radio buttons
   → Human answers → Server action calls elaborationService
-  → Notification to PM Agent → PM validates on next session
+  → Notification to PM Agent → PM resolves on next session
 ```
 
 ### Session Resume Flow
@@ -530,7 +539,7 @@ SessionStart hook → chorus_checkin() → assignments include:
   ▼
 PM Agent calls chorus_get_elaboration({ ideaUuid })
   ├─ Unanswered questions → AskUserQuestion (resume where left off)
-  ├─ Answers exist, not validated → validate → proceed or follow-up
+  ├─ Answers exist, not resolved → resolve (human-confirmed) → proceed, or start_elaboration again for a follow-up
   └─ Elaboration resolved → proceed to Proposal creation
 ```
 
@@ -543,7 +552,7 @@ This requires no special hook logic — the PM skill doc instructs the agent to 
   CC Terminal       │  elaborationService      │      Web UI
   (AskUserQuestion) │  .startElaboration()     │  (Radio button form)
         │           │  .answerElaboration()     │        │
-        │           │  .validateElaboration()   │        │
+        │           │  .resolveElaboration()    │        │
         ▼           │  .getElaboration()        │        ▼
   MCP Tool call ───▶│                          │◀─── Server Action
                     └──────────────────────────┘
@@ -670,7 +679,7 @@ When a PM Agent's CC session restarts (crash, timeout, next day), the SessionSta
 PM Agent starts session → chorus_checkin() → sees assigned Ideas
   → For each Idea with elaborationStatus = "pending_answers":
       → chorus_get_elaboration() → check if human answered on UI while PM was offline
-        ├─ Answers present → validate → proceed
+        ├─ Answers present → resolve (human-confirmed) → proceed
         └─ No answers → AskUserQuestion again (resume in CC)
 ```
 
@@ -685,7 +694,7 @@ No plugin hook changes needed — this is purely skill doc instructions.
 4. PM Agent IMMEDIATELY uses AskUserQuestion → human sees questions in terminal
 5. Human answers in terminal
 6. PM Agent calls chorus_answer_elaboration (persists answers)
-7. PM Agent validates → all clear → creates Proposal
+7. PM Agent resolves (human-confirmed) → all clear → creates Proposal
 ```
 
 Total round-trip: seconds. No async wait, no channel switching.
@@ -701,7 +710,7 @@ Total round-trip: seconds. No async wait, no channel switching.
 4. NotificationListener → SSE push → Dashboard bell badge
 5. Human clicks notification → Idea detail page → answers in UI
 6. NotificationListener → notification to PM Agent
-7. PM Agent's next session: chorus_get_elaboration → sees answers → validates → Proposal
+7. PM Agent's next session: chorus_get_elaboration → sees answers → resolves (human-confirmed) → Proposal
 ```
 
 Both flows use the same service layer. The difference is whether human interaction is synchronous (CC) or asynchronous (UI).
@@ -712,9 +721,9 @@ Both flows use the same service layer. The difference is whether human interacti
 
 ```typescript
 // Core functions
-startElaboration(companyUuid, ideaUuid, actorUuid, depth, questions): ElaborationResponse
-answerElaboration(companyUuid, ideaUuid, roundUuid, actorUuid, actorType, answers): ElaborationResponse
-validateElaboration(companyUuid, ideaUuid, roundUuid, actorUuid, issues, followUpQuestions?): ElaborationResponse
+startElaboration(companyUuid, ideaUuid, actorUuid, depth, questions): ElaborationResponse  // any round; sets isAppended when Idea already resolved
+answerElaboration(companyUuid, ideaUuid, actorUuid, actorType, answers, roundUuid?): ElaborationResponse  // roundUuid optional — auto-locates active round
+resolveElaboration(companyUuid, ideaUuid, actorUuid, actorType, roundUuid?): ElaborationResponse  // idea:admin; validates latest answered round → resolved
 skipElaboration(companyUuid, ideaUuid, actorUuid, reason): ElaborationResponse
 getElaboration(companyUuid, ideaUuid): ElaborationResponse
 
@@ -727,9 +736,9 @@ buildElaborationSummary(rounds): Summary  // Aggregates stats across rounds
 ### MCP Tool Registration
 
 New tools registered in `src/mcp/tools/pm.ts` (PM-only):
-- `chorus_pm_start_elaboration`
-- `chorus_pm_validate_elaboration`
-- `chorus_pm_skip_elaboration`
+- `chorus_pm_start_elaboration` (gated `idea:write`)
+- `chorus_pm_validate_elaboration` (gated `idea:admin`; human-confirmed except in YOLO)
+- `chorus_pm_skip_elaboration` (gated `idea:write`)
 
 New tools registered in `src/mcp/tools/public.ts` (all roles):
 - `chorus_answer_elaboration`

--- a/docs/DESIGN_REQUIREMENTS_ELABORATION.md
+++ b/docs/DESIGN_REQUIREMENTS_ELABORATION.md
@@ -199,7 +199,7 @@ open → elaborating → proposal_created → completed
           ▼    │
      [PM asks questions — start_elaboration]
      [Human answers — answer_elaboration]
-     [PM resolves — resolve_elaboration, human-confirmed]
+     [PM resolves — validate_elaboration, human-confirmed]
           │
           ▼
     [All resolved] → PM creates Proposal → proposal_created

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -31,7 +31,7 @@ The following table summarizes every permission-gated MCP tool. Each tool has ex
 | `chorus_move_idea` | `idea:write` |
 | `chorus_pm_create_idea` | `idea:write` |
 | `chorus_pm_start_elaboration` | `idea:write` |
-| `chorus_pm_validate_elaboration` | `idea:write` |
+| `chorus_pm_validate_elaboration` | `idea:admin` |
 | `chorus_pm_skip_elaboration` | `idea:write` |
 | `chorus_pm_create_proposal` | `proposal:write` |
 | `chorus_pm_validate_proposal` | `proposal:write` |
@@ -471,13 +471,13 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 
 ### chorus_answer_elaboration
 
-**Description**: Answer elaboration questions for an Idea. Submits answers for a specific elaboration round. When all required questions are answered, the round moves to validation.
+**Description**: Answer elaboration questions for an Idea. Submits answers for an elaboration round. When all required questions are answered, the round moves to `answered`. `roundUuid` is optional — when omitted, the service auto-locates the Idea's single active (`pending_answers`) round.
 
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | ideaUuid | string | Yes | Idea UUID |
-| roundUuid | string | Yes | Elaboration round UUID |
+| roundUuid | string | No | Elaboration round UUID. **Optional** — when omitted, the active `pending_answers` round is auto-located. Pass explicitly to target a specific round. Fails if omitted and there is no active round, or more than one. |
 | answers | array | Yes | Answers to submit |
 
 **answers array item fields**:
@@ -509,6 +509,7 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
       "uuid": "...",
       "roundNumber": 1,
       "status": "validated",
+      "isAppended": false,
       "questions": [...],
       "createdAt": "ISO timestamp"
     }
@@ -1234,7 +1235,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 ### chorus_pm_start_elaboration
 
-**Description**: Start an elaboration round for an Idea. Creates structured questions for the Idea creator/stakeholder to answer, clarifying requirements before proposal creation. Recommended for every Idea. Structured elaboration improves Proposal quality and reduces rejection cycles.
+**Description**: Generate an elaboration round for an Idea — the single entry point for the first round, follow-up rounds, and rounds appended after resolution. Creates structured questions for the Idea creator/stakeholder to answer, clarifying requirements before proposal creation. Callable when the Idea is `elaborating` (normal/follow-up round) **and** when it is `elaborated`/`resolved`: in the resolved case it creates an **appended round** (`isAppended: true`) that keeps the Idea `elaborated` and `elaborationStatus = resolved`, so it never blocks an in-flight Proposal. The round cap is 10. Recommended for every Idea. Structured elaboration improves Proposal quality and reduces rejection cycles.
 
 **Required Permission**: `idea:write`
 
@@ -1265,28 +1266,19 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 ### chorus_pm_validate_elaboration
 
-**Description**: Validate answers from an elaboration round. If no issues are found, the elaboration is marked as resolved. If issues exist, optionally provide follow-up questions for a new round.
+**Description**: Mark an Idea's elaboration complete. Validates the most recent `answered` round, moves the Idea to `elaborated`, and sets `elaborationStatus = resolved` (the gating signal that lets a downstream Proposal be submitted). **Requires human confirmation before calling (except in YOLO mode).** To open a follow-up round instead, call `chorus_pm_start_elaboration` again.
 
-**Required Permission**: `idea:write`
+**Required Permission**: `idea:admin`
+
+> **Permission handoff:** the `pm_agent` preset grants only `idea:write`, so a PM-preset agent cannot resolve — resolving requires an `admin_agent`-preset agent (or an admin-preset key). **Assignee precondition:** the resolving actor must also be the Idea's assignee, so a separate human reviewer resolving a PM-owned Idea needs both `idea:admin` and the Idea assignment (claim/reassign first).
 
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | ideaUuid | string | Yes | Idea UUID |
-| roundUuid | string | Yes | Elaboration round UUID |
-| issues | array | Yes | List of issues found (empty array = all valid) |
-| followUpQuestions | array | No | Follow-up questions for a new round (only if issues found) |
+| roundUuid | string | No | Round to validate. **Optional** — defaults to the most recent `answered` round. |
 
-**issues array item fields**:
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| questionId | string | Yes | Question ID with the issue |
-| type | enum | Yes | Issue type: contradiction, ambiguity, incomplete |
-| description | string | Yes | Issue description |
-
-**followUpQuestions array item fields**: Same as `questions` in `chorus_pm_start_elaboration`.
-
-**Output**: Validation result JSON. If issues are empty, elaboration status changes to `resolved`. If follow-up questions are provided, a new round is created with status `pending_answers`.
+**Output**: Resolution result JSON. The targeted round becomes `validated`, the Idea status becomes `elaborated`, and `elaborationStatus` becomes `resolved`. Fails if there is no `answered` round to resolve.
 
 ### chorus_pm_skip_elaboration
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -869,6 +869,7 @@
     "validated": "Validated",
     "pendingAnswers": "Pending answers",
     "statusAnswered": "Answered",
+    "appendedBadge": "Follow-up",
     "noAnswer": "No answer",
     "otherOption": "Other",
     "otherPlaceholder": "Please specify...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -870,6 +870,7 @@
     "validated": "已验证",
     "pendingAnswers": "待回答",
     "statusAnswered": "已回答",
+    "appendedBadge": "后续补充",
     "noAnswer": "未回答",
     "otherOption": "其他",
     "otherPlaceholder": "请说明...",

--- a/openspec/changes/simplify-elaboration-flow/.openspec.yaml
+++ b/openspec/changes/simplify-elaboration-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/simplify-elaboration-flow/README.md
+++ b/openspec/changes/simplify-elaboration-flow/README.md
@@ -1,0 +1,3 @@
+# simplify-elaboration-flow
+
+Simplify elaboration: unified round generation, optional roundUuid, admin-gated resolve, appended-round marking

--- a/openspec/changes/simplify-elaboration-flow/design.md
+++ b/openspec/changes/simplify-elaboration-flow/design.md
@@ -1,0 +1,96 @@
+# Design: Simplify Elaboration Flow
+
+## Context
+
+Elaboration (AI-DLC Stage 3) clarifies an Idea's requirements through structured Q&A rounds before a Proposal is authored. Today it is modeled by two Prisma models — `ElaborationRound` and `ElaborationQuestion` — and driven by five MCP tools. See `src/services/elaboration.service.ts` for the current lifecycle.
+
+This change keeps the round/question data model and the human-in-the-loop verification gate, but redistributes the tool responsibilities so the common flows take fewer calls and less UUID bookkeeping, and so rounds can be appended after resolution.
+
+## Current vs. target tool surface
+
+| Concern | Today | Target |
+|---|---|---|
+| Generate a round (first / follow-up / appended) | `start_elaboration` (first) + `validate(followUpQuestions)` (follow-up); no appended path | `start_elaboration` for **all** cases |
+| Answer a round | `answer_elaboration(roundUuid required)` | `answer_elaboration(roundUuid optional)` |
+| Resolve the elaboration | `validate(issues=[])` (idea:write) | `chorus_pm_validate_elaboration` — pure resolve (idea:admin, human-confirmed) |
+| Tag per-question issues | `validate(issues=[...])` | not supported |
+| Skip | `skip_elaboration` | unchanged |
+
+## State machine (unchanged statuses, new transitions)
+
+`Idea.status`: `open → elaborating → elaborated`. `Idea.elaborationStatus`: `null → pending_answers → validating → resolved`. `Round.status`: `pending_answers → answered → validated`.
+
+New transitions introduced by this change:
+
+- **Appended round from a resolved Idea.** `start_elaboration` is now allowed when `Idea.status === "elaborated"`. It creates a new `pending_answers` round with `isAppended = true`, and does **not** change `Idea.status` (stays `elaborated`). It MAY set `elaborationStatus` back to `pending_answers` so the UI shows there is an open round, but `Idea.status` stays `elaborated` (the gating signal for proposal submission is `elaborationStatus === "resolved"`, so an open appended round will re-block submission until re-resolved — see Risk R2).
+
+> **Decision (R2):** appended rounds are a *pure supplement*. To honor "never blocks downstream proposals", `start_elaboration` on a resolved Idea leaves `elaborationStatus = "resolved"` and only the new round sits at `pending_answers`. The "answered → validating" auto-transition in `answerElaboration` must therefore be guarded so it does not flip a resolved Idea back to `validating`. Net effect: an appended round can be answered and (optionally) re-resolved without ever un-resolving the Idea or blocking proposal submission. This is the behavior the owner asked for.
+
+- **`chorus_pm_validate_elaboration`**: round → `validated`, Idea → `elaborated`, `elaborationStatus → resolved`. Takes `ideaUuid` + optional `roundUuid`, gated `idea:admin`; the backing service fn is `resolveElaboration`. Idempotent-friendly: resolving an already-resolved Idea with a freshly answered appended round simply re-validates that round.
+
+- **Follow-up while still `elaborating`** (the old `validate(followUpQuestions)` path): the PM just calls `start_elaboration` again. The prior answered round stays `answered` (no `needs_followup` status needed — that status existed only to record validate's issue path, which is gone). `getElaboration` treats any non-`pending_answers` round as "done" for display, exactly as the UI already does.
+
+## Data model
+
+```prisma
+model ElaborationRound {
+  // ... existing fields ...
+  isAppended Boolean @default(false) // true when created after the Idea was first resolved
+}
+```
+
+- Default `false` → all existing rows are non-appended, no backfill needed (DDL-only migration, per project rule "no DML in migrations").
+- `isAppended` is set at creation time in `startElaboration`, computed from whether the Idea was already `elaborated` (equivalently `elaborationStatus === "resolved"`) at the moment of the call.
+
+`ElaborationQuestion.issueType` / `issueDescription` columns are **retained** (no destructive migration) but become write-dead once `validate` is removed. Removing the columns is out of scope to keep the migration DDL-additive only.
+
+## Service contracts
+
+### `startElaboration` (modified)
+
+- Precondition relaxed: allow `idea.status` ∈ `{ elaborating, elaborated }` (previously `elaborating` only).
+- `isAppended = (idea.status === "elaborated")` at call time.
+- When `isAppended`: do NOT downgrade `idea.status`; set `elaborationStatus` only if it is currently `resolved` → leave as `resolved` (R2 decision) — i.e. do not write `pending_answers` over `resolved`. The new round itself is `pending_answers`.
+- When not appended (normal `elaborating` flow): behavior unchanged.
+- Round cap: keep the max-rounds guard but raise/relax it so appended rounds aren't blocked by the old "max 5" — count is fine but appended rounds should not be permanently capped. **Decision:** keep a generous cap (e.g. 10) rather than 5, since appended rounds extend the lifetime. Document the number in the spec.
+
+### `answerElaboration` (modified)
+
+- `roundUuid` optional. When omitted: find the Idea's unique round with `status === "pending_answers"`. If zero → error "no active round". If more than one → error "multiple active rounds; specify roundUuid" (defensive; normally impossible).
+- Guard the "all required answered → elaborationStatus = validating" write: only apply when `idea.elaborationStatus !== "resolved"` (R2). For an appended round on a resolved Idea, mark the round `answered` but keep `elaborationStatus = resolved`.
+
+### `resolveElaboration` (new)
+
+- Inputs: `companyUuid, ideaUuid, actorUuid, actorType` (no `roundUuid` required — resolve operates on the Idea; it validates the latest answered round).
+- Optional `roundUuid` to target a specific answered round; default = most recent `answered` round.
+- Preconditions: actor is the Idea assignee; there is an `answered` round to validate.
+- Effect: round → `validated`; Idea → `elaborated`; `elaborationStatus → resolved`; activity `elaboration_resolved`.
+- Permission: `idea:admin` (see permission-map).
+
+### `chorus_pm_validate_elaboration` wiring
+
+- The `chorus_pm_validate_elaboration` tool routes to `resolveElaboration`. It does not carry issue-tagging or follow-up-creation logic. Update all tests/skills accordingly.
+
+## MCP & permissions
+
+- `chorus_pm_validate_elaboration` → `permission-map.ts`: `idea:admin`. The tool calls `resolveElaboration` and takes `ideaUuid` + optional `roundUuid`.
+- `chorus_answer_elaboration` stays public; `roundUuid` becomes optional in its zod schema.
+- `chorus_pm_start_elaboration` stays `idea:write`.
+- The `chorus_pm_validate_elaboration` tool description MUST include: *"Requires human confirmation before calling (except in YOLO mode). Marks the elaboration complete."*
+
+## Frontend
+
+- `ElaborationResponse.rounds[].isAppended` flows through `formatRoundResponse`.
+- `elaboration-panel.tsx` `RoundCard` header renders an "appended / follow-up" badge when `round.isAppended` (i18n keys `elaboration.appendedBadge`). Distinct color from the round-number badge.
+- No change to the carousel answer UX itself.
+
+## Risks / trade-offs
+
+- **R1 — Removing a public-ish MCP tool.** `validate_elaboration` is `idea:write`-gated and used by our own skills only. Mitigation: update all four skill surfaces + docs in the same change; reviewer checks no live references remain.
+- **R2 — Appended round re-blocking proposal submission.** `submit_proposal` requires every input Idea's `elaborationStatus === "resolved"`. If appending a round flipped it to `pending_answers`, an in-flight proposal could be blocked. Decision above keeps `elaborationStatus = resolved` for appended rounds, so submission is never blocked; re-resolving is optional and only re-validates the appended round. This exactly matches the owner's "pure supplement, doesn't block proposal" requirement.
+- **R3 — Round cap.** Appended rounds extend lifetime; bumping the cap from 5 → 10 avoids surprising lockouts while still bounding abuse.
+- **R4 — i18n.** New badge strings must land in both `en` and `zh` (project rule).
+
+## Migration
+
+DDL-only, via `pnpm db:migrate:dev` after editing `schema.prisma`. One additive nullable-with-default column. No data backfill (project rule: no DML in migrations).

--- a/openspec/changes/simplify-elaboration-flow/proposal.md
+++ b/openspec/changes/simplify-elaboration-flow/proposal.md
@@ -1,0 +1,41 @@
+# Simplify Elaboration Flow
+
+## Why
+
+The current elaboration workflow is cumbersome for agents and PMs:
+
+1. **Too many MCP calls with manual UUID bookkeeping.** A full two-round elaboration takes 5+ calls (`start → answer → validate → start → answer → validate`), and `answer` / `validate` each require the caller to extract and pass `roundUuid` from a prior response. Agents routinely lose track of which round is active.
+2. **`validate` conflates three unrelated jobs** — resolving the whole elaboration, opening a follow-up round, and tagging per-question issues. The issue-tagging job (`contradiction` / `ambiguity` / `incomplete`) is **never rendered in the UI** (`elaboration-panel.tsx` only shows Q/A text and a binary answered/pending badge), so it carries no user value.
+3. **No first-class way to add a round after elaboration is resolved.** Once an Idea reaches `elaborated`, the only "add a round" path is `validate(followUpQuestions)`, which is unavailable from the resolved state. PMs who want to append a clarification after the fact have no clean entry point.
+
+The original Idea title mentioned "appendConversation", but elaboration confirmed this was a misnomer: the real need is **making it easy to append elaboration rounds**, not introducing a free-form chat model.
+
+## What Changes
+
+- **`chorus_pm_start_elaboration` becomes the single "generate a round" entry point.** It already creates a round; we extend it so it is callable both while `elaborating` and after `elaborated`. When invoked on a resolved Idea it creates an **appended round** and keeps the Idea in `elaborated` (a pure supplement — never reverts to `elaborating`, never blocks downstream proposals).
+- **`chorus_answer_elaboration` makes `roundUuid` optional.** When omitted, the service auto-locates the Idea's single active (`pending_answers`) round. Passing `roundUuid` still works (backward compatible).
+- **`chorus_pm_validate_elaboration` marks the elaboration complete (requires `idea:admin`).** It validates the most recent answered round (Idea → `elaborated`, `elaborationStatus` → `resolved`) and takes only `ideaUuid` + optional `roundUuid`. It does not tag per-question issues or create follow-up rounds — opening a follow-up round is just another `chorus_pm_start_elaboration` call. The tool description and every skill that calls it MUST state that **human confirmation is required before calling it (except in YOLO mode)**.
+- **Round-level `isAppended` marker.** Rounds created after the Idea was first resolved are flagged. Both the UI (an "appended / follow-up" badge) and MCP responses (`chorus_get_elaboration`, and the Idea's elaboration payload) surface the marker.
+- **`chorus_pm_skip_elaboration` is unchanged.**
+
+## Capabilities
+
+- **elaboration-round-generation** — unified round creation across `elaborating` and `elaborated` states, including appended rounds and their marker.
+- **elaboration-resolution** — the admin-gated, human-confirmed resolution action exposed via `chorus_pm_validate_elaboration`.
+- **elaboration-answer-autolocate** — optional `roundUuid` on answering, with auto-location of the active round.
+
+## Impact
+
+- **Affected specs:** new capabilities `elaboration-round-generation`, `elaboration-resolution`, `elaboration-answer-autolocate`.
+- **Affected code:**
+  - `prisma/schema.prisma` — add `ElaborationRound.isAppended Boolean @default(false)` (migration via CLI).
+  - `src/types/elaboration.ts` — add `isAppended` to round response; remove `ValidationIssueInput` / `ValidationIssueType` usage tied to the dropped issue-tagging job (kept only if referenced elsewhere).
+  - `src/services/elaboration.service.ts` — `startElaboration` accepts resolved-state entry + sets `isAppended`; `answerElaboration` auto-locates round; new `resolveElaboration` service fn (backs the re-scoped tool); delete old `validateElaboration` issue/follow-up logic.
+  - `src/mcp/tools/pm.ts` — re-scope the `chorus_pm_validate_elaboration` tool to call `resolveElaboration` (drop the `issues[]` / `followUpQuestions` params); make `roundUuid` optional on answer.
+  - `src/mcp/tools/permission-map.ts` — re-gate `chorus_pm_validate_elaboration` from `idea:write` → `idea:admin`.
+  - `src/components/elaboration-panel.tsx` — render the appended-round badge.
+  - `messages/en.json`, `messages/zh.json` — i18n for the new badge.
+  - `docs/MCP_TOOLS.md`, `docs/DESIGN_REQUIREMENTS_ELABORATION.md` — reference updates.
+  - Skill surfaces (4 roots): `idea`, `yolo`, `brainstorm` SKILL.md — update `chorus_pm_validate_elaboration` guidance to the new resolve semantics + the human-confirmation note + the `idea:admin` handoff.
+- **Backward compatibility:** `start` / `answer` / `skip` signatures preserved (`roundUuid` only relaxed to optional). The `chorus_pm_validate_elaboration` **name is kept** (reused), so callers don't hit "tool not found"; but its signature changed (dropped `issues[]` / `followUpQuestions`) and its permission rose to `idea:admin` — an accepted breaking change for that one tool (it has no production-critical external consumers, and its only meaningful output, resolve, is preserved).
+- **Tests:** `src/services/__tests__/elaboration.service.test.ts`, `src/mcp/__tests__/server.test.ts`, `src/__tests__/integration/permissions.test.ts` updated for the new tool surface and behavior.

--- a/openspec/changes/simplify-elaboration-flow/specs/elaboration-answer-autolocate/spec.md
+++ b/openspec/changes/simplify-elaboration-flow/specs/elaboration-answer-autolocate/spec.md
@@ -1,0 +1,39 @@
+# elaboration-answer-autolocate
+
+## ADDED Requirements
+
+### Requirement: Optional roundUuid with active-round auto-location
+
+The `chorus_answer_elaboration` tool SHALL accept `roundUuid` as an optional parameter. When `roundUuid` is omitted, the system SHALL automatically locate the Idea's single round in status `pending_answers` and apply the answers to it. When `roundUuid` is provided, the existing behavior SHALL be preserved (backward compatible).
+
+#### Scenario: Answer without specifying roundUuid
+
+- **WHEN** a client calls `chorus_answer_elaboration` with `ideaUuid` and `answers` but no `roundUuid`, and the Idea has exactly one `pending_answers` round
+- **THEN** the answers are applied to that active round
+- **AND** the call succeeds without the client needing to know the round UUID
+
+#### Scenario: Answer with explicit roundUuid still works
+
+- **WHEN** a client calls `chorus_answer_elaboration` with an explicit `roundUuid`
+- **THEN** the answers are applied to that specific round, exactly as before this change
+
+#### Scenario: No active round to auto-locate
+
+- **WHEN** `chorus_answer_elaboration` is called without `roundUuid` and the Idea has no round in `pending_answers`
+- **THEN** the call fails with an error indicating there is no active round to answer
+
+#### Scenario: Ambiguous active round
+
+- **WHEN** `chorus_answer_elaboration` is called without `roundUuid` and the Idea has more than one round in `pending_answers`
+- **THEN** the call fails with an error instructing the caller to specify `roundUuid`
+
+### Requirement: Answering an appended round does not regress a resolved Idea
+
+When all required questions of a round are answered, the system SHALL move the round to `answered`. For an appended round on an Idea whose `elaborationStatus` is `resolved`, the system SHALL NOT change `elaborationStatus` away from `resolved`.
+
+#### Scenario: Answering an appended round keeps the Idea resolved
+
+- **WHEN** all required questions of an appended round (on an Idea with `elaborationStatus = resolved`) are answered
+- **THEN** the round status becomes `answered`
+- **AND** the Idea `elaborationStatus` remains `resolved`
+- **AND** the Idea status remains `elaborated`

--- a/openspec/changes/simplify-elaboration-flow/specs/elaboration-resolution/spec.md
+++ b/openspec/changes/simplify-elaboration-flow/specs/elaboration-resolution/spec.md
@@ -1,0 +1,49 @@
+# elaboration-resolution
+
+## ADDED Requirements
+
+### Requirement: Dedicated admin-gated resolution action
+
+The system SHALL provide a `chorus_pm_validate_elaboration` MCP tool that marks an Idea's elaboration as complete. This tool SHALL require the `idea:admin` permission. It SHALL accept only `ideaUuid` and an optional `roundUuid`.
+
+#### Scenario: Resolve elaboration with admin permission
+
+- **WHEN** an agent holding `idea:admin` calls `chorus_pm_validate_elaboration` on an Idea that has an `answered` round and is the agent's assigned Idea
+- **THEN** the most recent answered round becomes `validated`
+- **AND** the Idea status becomes `elaborated`
+- **AND** the Idea `elaborationStatus` becomes `resolved`
+- **AND** an `elaboration_resolved` activity is logged
+
+#### Scenario: Resolution rejected without admin permission
+
+- **WHEN** an agent that holds `idea:write` but not `idea:admin` calls `chorus_pm_validate_elaboration`
+- **THEN** the call is rejected because the tool requires `idea:admin`
+
+#### Scenario: Resolution requires an answered round
+
+- **WHEN** `chorus_pm_validate_elaboration` is called on an Idea whose latest round is still `pending_answers`
+- **THEN** the call fails with an error indicating there is no answered round to resolve
+
+### Requirement: Human confirmation is required before resolving
+
+The `chorus_pm_validate_elaboration` tool description and every Chorus skill that invokes it (idea, yolo, brainstorm) SHALL state that human confirmation is required before calling it, except in YOLO mode where the agent may resolve autonomously.
+
+#### Scenario: Tool description states the confirmation requirement
+
+- **WHEN** a client inspects the `chorus_pm_validate_elaboration` tool description
+- **THEN** the description states that human confirmation is required before calling it (except in YOLO mode)
+
+#### Scenario: Skill docs carry the confirmation note
+
+- **WHEN** the idea, yolo, and brainstorm skill documents reference resolution
+- **THEN** each instructs the agent to obtain human confirmation before resolving, except under YOLO automation
+
+### Requirement: Validate performs only resolution
+
+The `chorus_pm_validate_elaboration` tool SHALL perform only the resolution action. It SHALL NOT tag per-question issues and SHALL NOT create follow-up rounds. Opening a follow-up round SHALL be achieved by calling `chorus_pm_start_elaboration` again.
+
+#### Scenario: Validate tool only resolves
+
+- **WHEN** an agent holding `idea:admin` calls `chorus_pm_validate_elaboration`
+- **THEN** the tool marks the elaboration complete and accepts only `ideaUuid` and an optional `roundUuid`
+- **AND** opening a follow-up round is achieved by calling `chorus_pm_start_elaboration` again

--- a/openspec/changes/simplify-elaboration-flow/specs/elaboration-round-generation/spec.md
+++ b/openspec/changes/simplify-elaboration-flow/specs/elaboration-round-generation/spec.md
@@ -1,0 +1,51 @@
+# elaboration-round-generation
+
+## ADDED Requirements
+
+### Requirement: Unified round generation across elaboration states
+
+The system SHALL provide a single round-generation operation (`chorus_pm_start_elaboration`) that creates an elaboration round when the source Idea is in either the `elaborating` or the `elaborated` state. Creating a round MUST NOT require the caller to manage the previous round's UUID.
+
+#### Scenario: Generate the first round on a newly claimed Idea
+
+- **WHEN** an agent with `idea:write` calls `chorus_pm_start_elaboration` on an Idea in status `elaborating`
+- **THEN** a new round is created with status `pending_answers` and `isAppended = false`
+- **AND** the Idea's `elaborationStatus` becomes `pending_answers`
+
+#### Scenario: Generate a follow-up round while still elaborating
+
+- **WHEN** an agent calls `chorus_pm_start_elaboration` again on an Idea still in status `elaborating` whose prior round is already `answered`
+- **THEN** a new `pending_answers` round is created with `isAppended = false`
+- **AND** no per-question issue tagging and no `validate` call is required to open the new round
+
+### Requirement: Appended rounds after resolution
+
+The system SHALL allow `chorus_pm_start_elaboration` to be called on an Idea whose elaboration has already been resolved (Idea status `elaborated`). Such a round SHALL be marked as appended and MUST be a pure supplement that does not regress the Idea's lifecycle.
+
+#### Scenario: Append a round to a resolved Idea
+
+- **WHEN** an agent calls `chorus_pm_start_elaboration` on an Idea in status `elaborated` (`elaborationStatus = resolved`)
+- **THEN** a new `pending_answers` round is created with `isAppended = true`
+- **AND** the Idea's status remains `elaborated`
+- **AND** the Idea's `elaborationStatus` remains `resolved`
+
+#### Scenario: Appended round never blocks proposal submission
+
+- **WHEN** an Idea with `elaborationStatus = resolved` is an input to an in-flight proposal and an appended round is created
+- **THEN** `chorus_pm_submit_proposal` for that proposal still succeeds because the Idea's `elaborationStatus` is unchanged at `resolved`
+
+### Requirement: Appended marker is surfaced everywhere
+
+The system SHALL expose the appended marker (`isAppended`) on every round in MCP responses and SHALL display a distinct visual badge for appended rounds in the elaboration UI.
+
+#### Scenario: MCP elaboration payload includes the marker
+
+- **WHEN** a client calls `chorus_get_elaboration` for an Idea that has at least one appended round
+- **THEN** each round object in the response includes an `isAppended` boolean
+- **AND** the appended round reports `isAppended = true`
+
+#### Scenario: UI shows an appended badge
+
+- **WHEN** the elaboration panel renders a round whose `isAppended` is true
+- **THEN** the round card displays a localized "appended / follow-up" badge distinct from the normal round-number badge
+- **AND** the badge label is available in both `en` and `zh` locales

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus-openclaw-plugin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "OpenClaw plugin for Chorus AI-DLC collaboration platform — native MCP + SSE real-time events",
   "license": "MIT",
   "type": "module",

--- a/packages/openclaw-plugin/skills/brainstorm/SKILL.md
+++ b/packages/openclaw-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -36,7 +36,7 @@ Only as a sub-step of the idea skill, only after the user has explicitly opted i
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -123,8 +123,8 @@ chorus_answer_elaboration({
 
 Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
 
-- If the synthesized round answers cover everything → caller validates with `issues: []`.
-- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+- If the synthesized round answers cover everything → caller obtains human confirmation, then resolves with `chorus_pm_validate_elaboration`.
+- If gaps remain → caller opens a structured Round 2 with `chorus_pm_start_elaboration`.
 
 The depth of any follow-up round is the caller's call, not yours.
 
@@ -157,7 +157,7 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
 - **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
 - **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence.
-- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling it here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
 - **Asking multiple questions in one prompt.** The cadence is one question per turn during divergence, then one final convergence prompt with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/develop/SKILL.md
+++ b/packages/openclaw-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/idea/SKILL.md
+++ b/packages/openclaw-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -46,10 +46,10 @@ All post-elaboration progress (planning, building, verifying, done) is **derived
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_pm_start_elaboration` | Start an elaboration round with structured questions |
-| `chorus_pm_validate_elaboration` | Validate answers (resolve or create follow-up round) |
+| `chorus_pm_start_elaboration` | Generate an elaboration round (first, follow-up, or appended-after-resolution) |
+| `chorus_pm_validate_elaboration` | Mark the whole elaboration complete (requires `idea:admin`; requires human confirmation first) |
 | `chorus_pm_skip_elaboration` | Skip elaboration for trivially clear Ideas |
-| `chorus_answer_elaboration` | Submit answers for an elaboration round |
+| `chorus_answer_elaboration` | Submit answers for an elaboration round (`roundUuid` optional — auto-locates the active round) |
 | `chorus_get_elaboration` | Get full elaboration state (rounds, questions, answers) |
 
 **Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
@@ -129,8 +129,8 @@ If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice quest
 
 When `/brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
 
-- If the synthesized round answers cover everything → call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration.
-- If gaps remain → call `chorus_pm_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+- If the synthesized round answers cover everything → obtain human confirmation, then call `chorus_pm_validate_elaboration` to mark the elaboration complete. (Requires `idea:admin` — see Step 5.6 if your key is `pm_agent`-preset.)
+- If gaps remain → call `chorus_pm_start_elaboration` again to open a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
 
 Either outcome ends Step 4.5; skip Step 5.
 
@@ -211,6 +211,8 @@ chorus_pm_skip_elaboration({
    - **Select an option + add a note**: `selectedOptionId: "a", customText: "additional context"`
    - **Free text (no option matched)**: `selectedOptionId: null, customText: "your answer"` — customText is required when no option is selected
 
+   > `roundUuid` is **optional** on `chorus_answer_elaboration`. Omit it and the service auto-locates the Idea's single active (`pending_answers`) round. Pass it explicitly only when you need to target a specific round.
+
 5. **Review answers and confirm with the owner (@mention flow):**
 
    After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you validate.
@@ -232,37 +234,28 @@ chorus_pm_skip_elaboration({
    c. **Wait for confirmation** via comments.
 
    d. **Based on the response:**
-      - **Confirmed** — Proceed to validate with empty issues
-      - **Additions/corrections** — Incorporate feedback, optionally start a follow-up round
+      - **Confirmed** — Treat this as the human confirmation required to resolve; proceed to Step 5.6 and call `chorus_pm_validate_elaboration`
+      - **Additions/corrections** — Incorporate feedback, optionally open a follow-up round with `chorus_pm_start_elaboration`
       - **Unclear** — Ask clarifying questions via another comment
 
-6. **Validate the elaboration:**
+6. **Resolve the elaboration (the single commit gate):**
 
-   `chorus_pm_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
+   Resolving marks the **whole elaboration phase** complete — it sets `idea.elaborationStatus = "resolved"` (Idea → `elaborated`), which is the gating signal that lets a downstream Proposal be submitted. It is NOT a per-round close. Resolve once, when you believe elaboration is done.
 
-   ```
-   chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [],
-     followUpQuestions: []
-   })
-   ```
+   > **⚠️ Human confirmation required.** Outside YOLO automation you MUST obtain explicit human confirmation before resolving (a plain-text yes/no prompt is fine on OpenClaw). The "Confirmed" reply in step 5d above counts as that confirmation. Never resolve on your own judgment alone.
 
-   If issues are found (contradictions, ambiguities, incomplete answers), include them in `issues` and provide `followUpQuestions` for a new round:
+   > **Permission (N1): `chorus_pm_validate_elaboration` requires `idea:admin`.** The `pm_agent` preset only grants `idea:write`, so a PM-preset agent **cannot** resolve — it must hand off to an `admin_agent`-preset agent (or an admin-preset API key) to perform the resolve. If your key lacks `idea:admin`, surface this to the human and request the handoff instead of failing silently.
+
+   > **Assignee precondition (N2):** the resolving actor must be the Idea's **assignee**. A separate human reviewer resolving a PM-owned Idea therefore needs **both** `idea:admin` **and** to be assigned the Idea (claim/reassign it first). Admin permission alone is not enough.
 
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [
-       { questionId: "q1", type: "ambiguity", description: "Role-based access selected but no roles defined" }
-     ],
-     followUpQuestions: [
-       { id: "fq1", text: "Which specific roles should have access?", category: "functional", options: [...] }
-     ]
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   **Want a follow-up round instead of resolving?** Just call `chorus_pm_start_elaboration` again — there is no separate "open a round" flag. It works while still `elaborating` (a normal follow-up round) and, after you've already resolved, as an **appended round** (`isAppended: true`) that keeps the Idea `elaborated` and never blocks an in-flight Proposal. Per-question issue tagging no longer exists.
 
 7. **Check elaboration status** at any time:
    ```
@@ -273,8 +266,6 @@ chorus_pm_skip_elaboration({
 
 **Question categories:** `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, `scope`
 
-**Validation issue types:** `contradiction`, `ambiguity`, `incomplete`
-
 ---
 
 ## Tips
@@ -283,7 +274,7 @@ chorus_pm_skip_elaboration({
 - Elaboration improves Proposal quality — don't skip it unless the requirements are trivially clear
 - Present interactive questions as plain text and collect free-text replies — OpenClaw has no `AskUserQuestion` primitive
 - Record decisions made in conversation as elaboration rounds for auditability
-- Always @mention the owner to confirm understanding before validating
+- Always @mention the owner to confirm understanding before resolving
 
 ---
 

--- a/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
+++ b/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows on OpenClaw.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial read-only review of a submitted Chorus proposal — doc
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/quick-dev/SKILL.md
+++ b/packages/openclaw-plugin/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/review/SKILL.md
+++ b/packages/openclaw-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial verification of a submitted Chorus task against its AC 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/yolo/SKILL.md
+++ b/packages/openclaw-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.2"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -174,14 +174,16 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-3. **Validate** (no issues in self-mode):
+3. **Resolve** — in YOLO mode the agent resolves elaboration **autonomously, with no human-confirmation gate** (the human-confirmation requirement that applies to the interactive `/idea` flow is explicitly waived under `/yolo` automation):
+
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: []
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   > `chorus_pm_validate_elaboration` requires `idea:admin`. `/yolo` already mandates an Admin-preset key in Prerequisites, so this is satisfied. To open another self-elaboration round instead of resolving, just call `chorus_pm_start_elaboration` again.
 
 #### Step 1.4: Create Proposal
 

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -54,7 +54,7 @@ ACCEPT="Accept: application/json, text/event-stream"
 CT="Content-Type: application/json"
 
 INIT=$(cat <<JSON
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.9.3"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.9.4"}}}
 JSON
 )
 

--- a/plugins/chorus/skills/brainstorm/SKILL.md
+++ b/plugins/chorus/skills/brainstorm/SKILL.md
@@ -32,7 +32,7 @@ Only as a sub-step of the idea skill, only after the user has explicitly opted i
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `resolve_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -160,7 +160,7 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
 - **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
 - **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
-- **`resolve_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling resolve here strips the caller of its scheduler role.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling it here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
 - **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/plugins/chorus/skills/brainstorm/SKILL.md
+++ b/plugins/chorus/skills/brainstorm/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: brainstorm
-description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never validates elaboration.
+description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never resolves elaboration.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -13,7 +13,7 @@ metadata:
 
 A divergent-then-convergent dialogue cadence for ideas whose direction is still being formed. Compresses the conversation into one `ElaborationRound` of decision-point Q&A — same shape as a structured elaboration round, but the questions, options and answers are synthesized at the end of the conversation rather than asked up front.
 
-This skill is a **producer** of one elaboration round; the **scheduler** decision (validate vs. follow-up) belongs to the calling idea skill.
+This skill is a **producer** of one elaboration round; the **scheduler** decision (resolve vs. follow-up) belongs to the calling idea skill.
 
 ---
 
@@ -32,7 +32,7 @@ Only as a sub-step of the idea skill, only after the user has explicitly opted i
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+8. **No `resolve_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -126,8 +126,8 @@ chorus_answer_elaboration({
 
 Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
 
-- If the synthesized round answers cover everything → caller validates with `issues: []`.
-- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+- If the synthesized round answers cover everything → caller obtains human confirmation, then resolves with `chorus_pm_validate_elaboration`.
+- If gaps remain → caller opens a structured Round 2 by calling `chorus_pm_start_elaboration` again.
 
 The depth of any follow-up round is the caller's call, not yours.
 
@@ -160,7 +160,7 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
 - **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
 - **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
-- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`resolve_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling resolve here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
 - **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, au
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus proposal reviewer

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus task reviewer

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, and spawn
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -44,10 +44,10 @@ All post-elaboration progress (planning, building, verifying, done) is **derived
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_pm_start_elaboration` | Start an elaboration round with structured questions |
-| `chorus_pm_validate_elaboration` | Validate answers (resolve or create follow-up round) |
+| `chorus_pm_start_elaboration` | Generate an elaboration round (first, follow-up, or appended-after-resolution) |
+| `chorus_pm_validate_elaboration` | Mark the whole elaboration complete (requires `idea:admin`; requires human confirmation first) |
 | `chorus_pm_skip_elaboration` | Skip elaboration for trivially clear Ideas |
-| `chorus_answer_elaboration` | Submit answers for an elaboration round |
+| `chorus_answer_elaboration` | Submit answers for an elaboration round (`roundUuid` optional — auto-locates the active round) |
 | `chorus_get_elaboration` | Get full elaboration state (rounds, questions, answers) |
 
 **Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
@@ -123,8 +123,8 @@ If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice quest
 
 When `/brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
 
-- If the synthesized round answers cover everything → call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration.
-- If gaps remain → call `chorus_pm_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+- If the synthesized round answers cover everything → obtain human confirmation, then call `chorus_pm_validate_elaboration` to resolve the elaboration. (Resolve needs `idea:admin` — see Step 5.6 if your key is `pm_agent`-preset.)
+- If gaps remain → call `chorus_pm_start_elaboration` again to open a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
 
 Either outcome ends Step 4.5; skip Step 5.
 
@@ -210,9 +210,11 @@ chorus_pm_skip_elaboration({
    - **Select an option + add a note**: `selectedOptionId: "a", customText: "additional context"`
    - **Choose "Other" (free text)**: `selectedOptionId: null, customText: "your answer"` — customText is required when no option is selected
 
+   > `roundUuid` is **optional** on `chorus_answer_elaboration`. Omit it and the service auto-locates the Idea's single active (`pending_answers`) round. Pass it explicitly only when you need to target a specific round.
+
 5. **Review answers and confirm with the owner (@mention flow):**
 
-   After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you validate.
+   After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you resolve.
 
    a. **Get owner info** from checkin response (`agent.owner`) or search:
       ```
@@ -231,37 +233,28 @@ chorus_pm_skip_elaboration({
    c. **Wait for confirmation** via comments.
 
    d. **Based on the response:**
-      - **Confirmed** — Proceed to validate with empty issues
-      - **Additions/corrections** — Incorporate feedback, optionally start a follow-up round
+      - **Confirmed** — Treat this as the human confirmation required to resolve; proceed to Step 5.6 and call `chorus_pm_validate_elaboration`
+      - **Additions/corrections** — Incorporate feedback, optionally open a follow-up round with `chorus_pm_start_elaboration`
       - **Unclear** — Ask clarifying questions via another comment
 
-6. **Validate the elaboration:**
+6. **Resolve the elaboration (the single commit gate):**
 
-   `chorus_pm_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
+   Resolving marks the **whole elaboration phase** complete — it sets `idea.elaborationStatus = "resolved"` (Idea → `elaborated`), which is the gating signal that lets a downstream Proposal be submitted. It is NOT a per-round close. Resolve once, when you believe elaboration is done.
 
-   ```
-   chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [],
-     followUpQuestions: []
-   })
-   ```
+   > **⚠️ Human confirmation required.** Outside YOLO automation you MUST obtain explicit human confirmation before resolving. The "Confirmed" reply in step 5d above counts as that confirmation. Never resolve on your own judgment alone.
 
-   If issues are found (contradictions, ambiguities, incomplete answers), include them in `issues` and provide `followUpQuestions` for a new round:
+   > **Permission (N1): `chorus_pm_validate_elaboration` requires `idea:admin`.** The `pm_agent` preset only grants `idea:write`, so a PM-preset agent **cannot** resolve — it must hand off to an `admin_agent`-preset agent (or an admin-preset API key) to perform the resolve. If your key lacks `idea:admin`, surface this to the human and request the handoff instead of failing silently.
+
+   > **Assignee precondition (N2):** the resolving actor must be the Idea's **assignee**. A separate human reviewer resolving a PM-owned Idea therefore needs **both** `idea:admin` **and** to be assigned the Idea (claim/reassign it first). Admin permission alone is not enough.
 
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [
-       { questionId: "q1", type: "ambiguity", description: "Role-based access selected but no roles defined" }
-     ],
-     followUpQuestions: [
-       { id: "fq1", text: "Which specific roles should have access?", category: "functional", options: [...] }
-     ]
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   **Want a follow-up round instead of resolving?** Just call `chorus_pm_start_elaboration` again — there is no separate "open a round" flag. It works while still `elaborating` (a normal follow-up round) and, after you've already resolved, as an **appended round** (`isAppended: true`) that keeps the Idea `elaborated` and never blocks an in-flight Proposal. Per-question issue tagging no longer exists.
 
 7. **Check elaboration status** at any time:
    ```
@@ -272,8 +265,6 @@ chorus_pm_skip_elaboration({
 
 **Question categories:** `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, `scope`
 
-**Validation issue types:** `contradiction`, `ambiguity`, `incomplete`
-
 ---
 
 ## Tips
@@ -282,7 +273,7 @@ chorus_pm_skip_elaboration({
 - Elaboration improves Proposal quality — don't skip it unless the requirements are trivially clear
 - Use `AskUserQuestion` for all interactive questions — never plain text
 - Record decisions made in conversation as elaboration rounds for auditability
-- Always @mention the owner to confirm understanding before validating
+- Always @mention the owner to confirm understanding before resolving
 
 ---
 

--- a/plugins/chorus/skills/openspec-aware/SKILL.md
+++ b/plugins/chorus/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Codex. De
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -170,14 +170,16 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-3. **Validate** (no issues in self-mode):
+3. **Resolve** — in YOLO mode the agent resolves elaboration **autonomously, with no human-confirmation gate** (the human-confirmation requirement that applies to the interactive `/idea` flow is explicitly waived under `/yolo` automation):
+
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: []
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   > `chorus_pm_validate_elaboration` requires `idea:admin`. `/yolo` already mandates an Admin-preset key in Prerequisites, so this is satisfied. To open another self-elaboration round instead of resolving, just call `chorus_pm_start_elaboration` again.
 
 #### Step 1.4: Create Proposal
 

--- a/prisma/migrations/20260604130604_add_elaboration_round_is_appended/migration.sql
+++ b/prisma/migrations/20260604130604_add_elaboration_round_is_appended/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ElaborationRound" ADD COLUMN     "isAppended" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -468,7 +468,7 @@ model ElaborationRound {
   companyUuid   String
   ideaUuid      String
   roundNumber   Int
-  status        String    @default("pending_answers") // pending_answers | answered | validated | needs_followup
+  status        String    @default("pending_answers") // pending_answers | answered | validated (needs_followup retained for legacy rows only — no longer written)
   isAppended    Boolean   @default(false) // true when created after the Idea was first resolved
   createdByType String    // agent | user
   createdByUuid String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -469,6 +469,7 @@ model ElaborationRound {
   ideaUuid      String
   roundNumber   Int
   status        String    @default("pending_answers") // pending_answers | answered | validated | needs_followup
+  isAppended    Boolean   @default(false) // true when created after the Idea was first resolved
   createdByType String    // agent | user
   createdByUuid String
   validatedAt   DateTime?

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/skills/brainstorm/SKILL.md
+++ b/public/chorus-plugin/skills/brainstorm/SKILL.md
@@ -32,7 +32,7 @@ Only as a sub-step of the idea skill, only after the user has explicitly opted i
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `resolve_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -160,7 +160,7 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
 - **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
 - **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
-- **`resolve_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling resolve here strips the caller of its scheduler role.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling it here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
 - **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/public/chorus-plugin/skills/brainstorm/SKILL.md
+++ b/public/chorus-plugin/skills/brainstorm/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: brainstorm
-description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never validates elaboration.
+description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never resolves elaboration.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -13,7 +13,7 @@ metadata:
 
 A divergent-then-convergent dialogue cadence for ideas whose direction is still being formed. Compresses the conversation into one `ElaborationRound` of decision-point Q&A — same shape as a structured elaboration round, but the questions, options and answers are synthesized at the end of the conversation rather than asked up front.
 
-This skill is a **producer** of one elaboration round; the **scheduler** decision (validate vs. follow-up) belongs to the calling idea skill.
+This skill is a **producer** of one elaboration round; the **scheduler** decision (resolve vs. follow-up) belongs to the calling idea skill.
 
 ---
 
@@ -32,7 +32,7 @@ Only as a sub-step of the idea skill, only after the user has explicitly opted i
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+8. **No `resolve_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -126,8 +126,8 @@ chorus_answer_elaboration({
 
 Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
 
-- If the synthesized round answers cover everything → caller validates with `issues: []`.
-- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+- If the synthesized round answers cover everything → caller obtains human confirmation, then resolves with `chorus_pm_validate_elaboration`.
+- If gaps remain → caller opens a structured Round 2 by calling `chorus_pm_start_elaboration` again.
 
 The depth of any follow-up round is the caller's call, not yours.
 
@@ -160,7 +160,7 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
 - **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
 - **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
-- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`resolve_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling resolve here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
 - **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -44,10 +44,10 @@ All post-elaboration progress (planning, building, verifying, done) is **derived
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_pm_start_elaboration` | Start an elaboration round with structured questions |
-| `chorus_pm_validate_elaboration` | Validate answers (resolve or create follow-up round) |
+| `chorus_pm_start_elaboration` | Generate an elaboration round (first, follow-up, or appended-after-resolution) |
+| `chorus_pm_validate_elaboration` | Mark the whole elaboration complete (requires `idea:admin`; requires human confirmation first) |
 | `chorus_pm_skip_elaboration` | Skip elaboration for trivially clear Ideas |
-| `chorus_answer_elaboration` | Submit answers for an elaboration round |
+| `chorus_answer_elaboration` | Submit answers for an elaboration round (`roundUuid` optional — auto-locates the active round) |
 | `chorus_get_elaboration` | Get full elaboration state (rounds, questions, answers) |
 
 **Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
@@ -123,8 +123,8 @@ If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice quest
 
 When `/brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
 
-- If the synthesized round answers cover everything → call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration.
-- If gaps remain → call `chorus_pm_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+- If the synthesized round answers cover everything → obtain human confirmation, then call `chorus_pm_validate_elaboration` to resolve the elaboration. (Resolve needs `idea:admin` — see Step 5.6 if your key is `pm_agent`-preset.)
+- If gaps remain → call `chorus_pm_start_elaboration` again to open a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
 
 Either outcome ends Step 4.5; skip Step 5.
 
@@ -210,9 +210,11 @@ chorus_pm_skip_elaboration({
    - **Select an option + add a note**: `selectedOptionId: "a", customText: "additional context"`
    - **Choose "Other" (free text)**: `selectedOptionId: null, customText: "your answer"` — customText is required when no option is selected
 
+   > `roundUuid` is **optional** on `chorus_answer_elaboration`. Omit it and the service auto-locates the Idea's single active (`pending_answers`) round. Pass it explicitly only when you need to target a specific round.
+
 5. **Review answers and confirm with the owner (@mention flow):**
 
-   After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you validate.
+   After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you resolve.
 
    a. **Get owner info** from checkin response (`agent.owner`) or search:
       ```
@@ -231,37 +233,28 @@ chorus_pm_skip_elaboration({
    c. **Wait for confirmation** via comments.
 
    d. **Based on the response:**
-      - **Confirmed** — Proceed to validate with empty issues
-      - **Additions/corrections** — Incorporate feedback, optionally start a follow-up round
+      - **Confirmed** — Treat this as the human confirmation required to resolve; proceed to Step 5.6 and call `chorus_pm_validate_elaboration`
+      - **Additions/corrections** — Incorporate feedback, optionally open a follow-up round with `chorus_pm_start_elaboration`
       - **Unclear** — Ask clarifying questions via another comment
 
-6. **Validate the elaboration:**
+6. **Resolve the elaboration (the single commit gate):**
 
-   `chorus_pm_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
+   Resolving marks the **whole elaboration phase** complete — it sets `idea.elaborationStatus = "resolved"` (Idea → `elaborated`), which is the gating signal that lets a downstream Proposal be submitted. It is NOT a per-round close. Resolve once, when you believe elaboration is done.
 
-   ```
-   chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [],
-     followUpQuestions: []
-   })
-   ```
+   > **⚠️ Human confirmation required.** Outside YOLO automation you MUST obtain explicit human confirmation before resolving. The "Confirmed" reply in step 5d above counts as that confirmation. Never resolve on your own judgment alone.
 
-   If issues are found (contradictions, ambiguities, incomplete answers), include them in `issues` and provide `followUpQuestions` for a new round:
+   > **Permission (N1): `chorus_pm_validate_elaboration` requires `idea:admin`.** The `pm_agent` preset only grants `idea:write`, so a PM-preset agent **cannot** resolve — it must hand off to an `admin_agent`-preset agent (or an admin-preset API key) to perform the resolve. If your key lacks `idea:admin`, surface this to the human and request the handoff instead of failing silently.
+
+   > **Assignee precondition (N2):** the resolving actor must be the Idea's **assignee**. A separate human reviewer resolving a PM-owned Idea therefore needs **both** `idea:admin` **and** to be assigned the Idea (claim/reassign it first). Admin permission alone is not enough.
 
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [
-       { questionId: "q1", type: "ambiguity", description: "Role-based access selected but no roles defined" }
-     ],
-     followUpQuestions: [
-       { id: "fq1", text: "Which specific roles should have access?", category: "functional", options: [...] }
-     ]
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   **Want a follow-up round instead of resolving?** Just call `chorus_pm_start_elaboration` again — there is no separate "open a round" flag. It works while still `elaborating` (a normal follow-up round) and, after you've already resolved, as an **appended round** (`isAppended: true`) that keeps the Idea `elaborated` and never blocks an in-flight Proposal. Per-question issue tagging no longer exists.
 
 7. **Check elaboration status** at any time:
    ```
@@ -272,8 +265,6 @@ chorus_pm_skip_elaboration({
 
 **Question categories:** `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, `scope`
 
-**Validation issue types:** `contradiction`, `ambiguity`, `incomplete`
-
 ---
 
 ## Tips
@@ -282,7 +273,7 @@ chorus_pm_skip_elaboration({
 - Elaboration improves Proposal quality — don't skip it unless the requirements are trivially clear
 - Use `AskUserQuestion` for all interactive questions — never plain text
 - Record decisions made in conversation as elaboration rounds for auditability
-- Always @mention the owner to confirm understanding before validating
+- Always @mention the owner to confirm understanding before resolving
 
 ---
 

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Co
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -170,14 +170,16 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-3. **Validate** (no issues in self-mode):
+3. **Resolve** — in YOLO mode the agent resolves elaboration **autonomously, with no human-confirmation gate** (the human-confirmation requirement that applies to the interactive `/idea` flow is explicitly waived under `/yolo` automation):
+
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: []
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   > `chorus_pm_validate_elaboration` requires `idea:admin`. `/yolo` already mandates an Admin-preset key in Prerequisites, so this is satisfied. To open another self-elaboration round instead of resolving, just call `chorus_pm_start_elaboration` again.
 
 #### Step 1.4: Create Proposal
 

--- a/public/skill/brainstorm-chorus/SKILL.md
+++ b/public/skill/brainstorm-chorus/SKILL.md
@@ -32,7 +32,7 @@ Only as a sub-step of the idea skill, only after the user has explicitly opted i
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `resolve_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
+8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -160,7 +160,7 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
 - **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
 - **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
-- **`resolve_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling resolve here strips the caller of its scheduler role.
+- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling it here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
 - **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/public/skill/brainstorm-chorus/SKILL.md
+++ b/public/skill/brainstorm-chorus/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: brainstorm-chorus
-description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never validates elaboration.
+description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoked from the idea skill as a prelude to structured elaboration; produces one ElaborationRound of decision-point Q&A and returns control. Never writes files, never posts comments, never resolves elaboration.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -13,7 +13,7 @@ metadata:
 
 A divergent-then-convergent dialogue cadence for ideas whose direction is still being formed. Compresses the conversation into one `ElaborationRound` of decision-point Q&A — same shape as a structured elaboration round, but the questions, options and answers are synthesized at the end of the conversation rather than asked up front.
 
-This skill is a **producer** of one elaboration round; the **scheduler** decision (validate vs. follow-up) belongs to the calling idea skill.
+This skill is a **producer** of one elaboration round; the **scheduler** decision (resolve vs. follow-up) belongs to the calling idea skill.
 
 ---
 
@@ -32,7 +32,7 @@ Only as a sub-step of the idea skill, only after the user has explicitly opted i
 5. **No files written.** Do NOT write any markdown, design doc, scratch file, or any other file to disk. The conversation produces an `ElaborationRound` and nothing else on disk.
 6. **No comments posted.** Do NOT call `chorus_add_comment` from this skill. Comments belong to the idea skill or the user, not to the brainstorm step.
 7. **No design-doc handoff.** Do NOT invoke `writing-plans`, `writing-skills`, or any skill whose purpose is to produce a design document. The brainstorm output is the synthesized round — there is no separate doc.
-8. **No `validate_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to validate (resolve elaboration) or follow up (issues + followUpQuestions) is the calling idea skill's decision, not this skill's.
+8. **No `resolve_elaboration` call.** Do NOT call `chorus_pm_validate_elaboration` from this skill. Whether to resolve the elaboration or open a follow-up round (`chorus_pm_start_elaboration` again) is the calling idea skill's decision, not this skill's.
 
 ---
 
@@ -126,8 +126,8 @@ chorus_answer_elaboration({
 
 Stop here. Do **NOT** call `chorus_pm_validate_elaboration`. The idea skill's caller now decides:
 
-- If the synthesized round answers cover everything → caller validates with `issues: []`.
-- If gaps remain → caller validates with `issues + followUpQuestions` to start a structured Round 2.
+- If the synthesized round answers cover everything → caller obtains human confirmation, then resolves with `chorus_pm_validate_elaboration`.
+- If gaps remain → caller opens a structured Round 2 by calling `chorus_pm_start_elaboration` again.
 
 The depth of any follow-up round is the caller's call, not yours.
 
@@ -160,7 +160,7 @@ Do not do any of the following. Each has a specific failure mode that this skill
 - **Single-summary `customText` blob.** Compressing the entire conversation into one ElaborationQuestion with a long markdown summary in `customText`. The schema is multi-question for a reason — preserve the decision granularity.
 - **Transcript-as-comment.** Posting the raw conversation log as a comment on the idea (or anywhere). The synthesized round IS the artifact. Raw transcripts pollute the audit trail with noise.
 - **File writes.** Writing any markdown, design doc, plan, or scratch file to disk. There is no design doc in this flow. This is a deliberate divergence from the upstream `superpowers/brainstorming` cadence — read the design.md if confused.
-- **`validate_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling validate here strips the caller of its scheduler role.
+- **`resolve_elaboration` calls.** Closing the elaboration phase from this skill. The lifecycle decision belongs to the idea skill. Calling resolve here strips the caller of its scheduler role.
 - **`writing-plans` / design-doc handoff.** Invoking any skill that produces an implementation plan or design document. The Chorus pipeline already has Proposal → Document Drafts → Task Drafts for that — the brainstorm output feeds them through ElaborationRound, not through external doc skills.
 - **Length-2 binary "yes / no" framings.** Reducing every decision to "do this thing — yes / no". Almost always the genuine alternatives are 3+ approaches with meaningfully different tradeoffs. Length-2 framings often mean the divergent phase ended too early.
 - **Asking multiple questions in one `AskUserQuestion`.** The cadence is one question per turn during divergence, then one final convergence question with 2-3 options. Combining unrelated questions is a sign you are rushing.

--- a/public/skill/idea-chorus/SKILL.md
+++ b/public/skill/idea-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -44,10 +44,10 @@ All post-elaboration progress (planning, building, verifying, done) is **derived
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_pm_start_elaboration` | Start an elaboration round with structured questions |
-| `chorus_pm_validate_elaboration` | Validate answers (resolve or create follow-up round) |
+| `chorus_pm_start_elaboration` | Generate an elaboration round (first, follow-up, or appended-after-resolution) |
+| `chorus_pm_validate_elaboration` | Mark the whole elaboration complete (requires `idea:admin`; requires human confirmation first) |
 | `chorus_pm_skip_elaboration` | Skip elaboration for trivially clear Ideas |
-| `chorus_answer_elaboration` | Submit answers for an elaboration round |
+| `chorus_answer_elaboration` | Submit answers for an elaboration round (`roundUuid` optional — auto-locates the active round) |
 | `chorus_get_elaboration` | Get full elaboration state (rounds, questions, answers) |
 
 **Shared tools** (checkin, query, comment, search, notifications): see `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`)
@@ -123,8 +123,8 @@ If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice quest
 
 When the brainstorm skill returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
 
-- If the synthesized round answers cover everything → call `chorus_pm_validate_elaboration` with `issues: []` to resolve elaboration.
-- If gaps remain → call `chorus_pm_validate_elaboration` with `issues + followUpQuestions` to start a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
+- If the synthesized round answers cover everything → obtain human confirmation, then call `chorus_pm_validate_elaboration` to resolve the elaboration. (Resolve needs `idea:admin` — see Step 5.6 if your key is `pm_agent`-preset.)
+- If gaps remain → call `chorus_pm_start_elaboration` again to open a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
 
 Either outcome ends Step 4.5; skip Step 5.
 
@@ -205,9 +205,11 @@ chorus_pm_skip_elaboration({
    - **Select an option + add a note**: `selectedOptionId: "a", customText: "additional context"`
    - **Choose "Other" (free text)**: `selectedOptionId: null, customText: "your answer"` — customText is required when no option is selected
 
+   > `roundUuid` is **optional** on `chorus_answer_elaboration`. Omit it and the service auto-locates the Idea's single active (`pending_answers`) round. Pass it explicitly only when you need to target a specific round.
+
 5. **Review answers and confirm with the owner (@mention flow):**
 
-   After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you validate.
+   After answers are submitted, **@mention the answerer** (typically the agent's owner) with a summary of your understanding. This prevents misinterpretation before you resolve.
 
    a. **Get owner info** from checkin response (`agent.owner`) or search:
       ```
@@ -226,37 +228,28 @@ chorus_pm_skip_elaboration({
    c. **Wait for confirmation** via comments.
 
    d. **Based on the response:**
-      - **Confirmed** — Proceed to validate with empty issues
-      - **Additions/corrections** — Incorporate feedback, optionally start a follow-up round
+      - **Confirmed** — Treat this as the human confirmation required to resolve; proceed to Step 5.6 and call `chorus_pm_validate_elaboration`
+      - **Additions/corrections** — Incorporate feedback, optionally open a follow-up round with `chorus_pm_start_elaboration`
       - **Unclear** — Ask clarifying questions via another comment
 
-6. **Validate the elaboration:**
+6. **Resolve the elaboration (the single commit gate):**
 
-   `chorus_pm_validate_elaboration` is the **single commit gate for the entire elaboration phase**, NOT a per-round close. Calling it with `issues: []` resolves the whole elaboration (sets `idea.elaborationStatus = "resolved"`); calling it with `issues + followUpQuestions` opens a new round while keeping elaboration in progress. Do not call validate after every round — call it once when you believe elaboration is done, or when you want to start a follow-up round.
+   Resolving marks the **whole elaboration phase** complete — it sets `idea.elaborationStatus = "resolved"` (Idea → `elaborated`), which is the gating signal that lets a downstream Proposal be submitted. It is NOT a per-round close. Resolve once, when you believe elaboration is done.
 
-   ```
-   chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [],
-     followUpQuestions: []
-   })
-   ```
+   > **⚠️ Human confirmation required.** Outside YOLO automation you MUST obtain explicit human confirmation before resolving. The "Confirmed" reply in step 5d above counts as that confirmation. Never resolve on your own judgment alone.
 
-   If issues are found (contradictions, ambiguities, incomplete answers), include them in `issues` and provide `followUpQuestions` for a new round:
+   > **Permission (N1): `chorus_pm_validate_elaboration` requires `idea:admin`.** The `pm_agent` preset only grants `idea:write`, so a PM-preset agent **cannot** resolve — it must hand off to an `admin_agent`-preset agent (or an admin-preset API key) to perform the resolve. If your key lacks `idea:admin`, surface this to the human and request the handoff instead of failing silently.
+
+   > **Assignee precondition (N2):** the resolving actor must be the Idea's **assignee**. A separate human reviewer resolving a PM-owned Idea therefore needs **both** `idea:admin` **and** to be assigned the Idea (claim/reassign it first). Admin permission alone is not enough.
 
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: [
-       { questionId: "q1", type: "ambiguity", description: "Role-based access selected but no roles defined" }
-     ],
-     followUpQuestions: [
-       { id: "fq1", text: "Which specific roles should have access?", category: "functional", options: [...] }
-     ]
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   **Want a follow-up round instead of resolving?** Just call `chorus_pm_start_elaboration` again — there is no separate "open a round" flag. It works while still `elaborating` (a normal follow-up round) and, after you've already resolved, as an **appended round** (`isAppended: true`) that keeps the Idea `elaborated` and never blocks an in-flight Proposal. Per-question issue tagging no longer exists.
 
 7. **Check elaboration status** at any time:
    ```
@@ -267,8 +260,6 @@ chorus_pm_skip_elaboration({
 
 **Question categories:** `functional`, `non_functional`, `business_context`, `technical_context`, `user_scenario`, `scope`
 
-**Validation issue types:** `contradiction`, `ambiguity`, `incomplete`
-
 ---
 
 ## Tips
@@ -277,7 +268,7 @@ chorus_pm_skip_elaboration({
 - Elaboration improves Proposal quality — prefer not to skip it unless the requirements are trivially clear
 - Use your IDE's interactive prompt mechanism if available for user-facing questions; otherwise present options as text
 - Record decisions made in conversation as elaboration rounds for auditability
-- Consider @mentioning the owner to confirm understanding before validating
+- Consider @mentioning the owner to confirm understanding before resolving
 
 ---
 

--- a/public/skill/yolo-chorus/SKILL.md
+++ b/public/skill/yolo-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — drive a single prompt from Idea throu
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.9.3"
+  version: "0.9.4"
   category: project-management
   mcp_server: chorus
 ---
@@ -192,15 +192,16 @@ In yolo mode you generate the elaboration questions AND answer them yourself —
    })
    ```
 
-3. **Validate** — in self-mode there are no outstanding human issues, so close the round clean:
+3. **Resolve** — in YOLO mode the agent resolves elaboration **autonomously, with no human-confirmation gate** (the human-confirmation requirement that applies to the interactive idea flow is explicitly waived under `/yolo` automation):
 
    ```
    chorus_pm_validate_elaboration({
-     ideaUuid: "<idea-uuid>",
-     roundUuid: "<round-uuid>",
-     issues: []
+     ideaUuid: "<idea-uuid>"
+     // roundUuid optional — defaults to the most recent answered round
    })
    ```
+
+   > `chorus_pm_validate_elaboration` requires `idea:admin`. `/yolo` already mandates an Admin-preset key in Prerequisites, so this is satisfied. To open another self-elaboration round instead of resolving, just call `chorus_pm_start_elaboration` again.
 
 #### Step 1.4: Create the Proposal
 

--- a/src/__tests__/integration/permissions.test.ts
+++ b/src/__tests__/integration/permissions.test.ts
@@ -211,6 +211,10 @@ function enumerateGatedMcpTools(auth: AgentAuthContext): Set<string> {
 // (covered by the update-task tool's incremental dependency arrays). See
 // permission-map.ts and pm.ts; the names are intentionally not spelled here so
 // downstream grep checks stay clean.
+//
+// Note: chorus_pm_validate_elaboration is gated on idea:admin, so it is
+// admin-only and not part of this idea:write baseline. See the admin_agent
+// expectation and the dedicated gating assertions below.
 const OLD_PM_TOOLS = [
   "chorus_claim_idea",
   "chorus_release_idea",
@@ -227,7 +231,6 @@ const OLD_PM_TOOLS = [
   "chorus_pm_remove_task_draft",
   "chorus_pm_assign_task",
   "chorus_pm_start_elaboration",
-  "chorus_pm_validate_elaboration",
   "chorus_pm_skip_elaboration",
   "chorus_move_idea",
   "chorus_pm_reject_proposal",
@@ -444,7 +447,7 @@ describe("Scenario 2: preset parity with 0.6.x baseline (AC2)", () => {
     expect(tools).toEqual(new Set(OLD_DEVELOPER_TOOLS));
   });
 
-  it("admin_agent preset registers exactly the 0.6.x admin ∪ pm ∪ developer tool set plus 0.9.0 chorus_create_report", () => {
+  it("admin_agent preset registers exactly the 0.6.x admin ∪ pm ∪ developer tool set plus 0.9.0 chorus_create_report and 0.9.4 chorus_pm_validate_elaboration", () => {
     const auth = makeAgentAuth([...ROLE_PRESETS.admin_agent], ["admin_agent"]);
     const tools = enumerateGatedMcpTools(auth);
     const expected = new Set([
@@ -453,6 +456,9 @@ describe("Scenario 2: preset parity with 0.6.x baseline (AC2)", () => {
       ...OLD_DEVELOPER_TOOLS,
       // 0.9.0 addition (document:write-gated, public-namespaced).
       "chorus_create_report",
+      // 0.9.4 (simplify-elaboration-flow): chorus_pm_validate_elaboration is
+      // re-gated to idea:admin. admin_agent carries idea:admin.
+      "chorus_pm_validate_elaboration",
     ]);
     expect(tools).toEqual(expected);
   });
@@ -492,9 +498,37 @@ describe("Scenario 2: preset parity with 0.6.x baseline (AC2)", () => {
       "chorus_admin_delete_task",
       "chorus_admin_delete_idea",
       "chorus_admin_delete_document",
+      // 0.9.4: chorus_pm_validate_elaboration is now idea:admin-gated; pm_agent
+      // (idea:write only) must not see it.
+      "chorus_pm_validate_elaboration",
     ]) {
       expect(tools.has(adminOnly)).toBe(false);
     }
+  });
+});
+
+// ============================================================
+// Scenario 2b — elaboration validate gating: chorus_pm_validate_elaboration is
+// gated on idea:admin.
+// ============================================================
+
+describe("Scenario 2b: elaboration validate gating", () => {
+  it("chorus_pm_validate_elaboration is gated on idea:admin in the permission map", () => {
+    expect(
+      (TOOL_PERMISSIONS as Record<string, string>).chorus_pm_validate_elaboration
+    ).toBe("idea:admin");
+  });
+
+  it("an idea:admin agent sees chorus_pm_validate_elaboration", () => {
+    const auth = makeAgentAuth(["idea:admin"]);
+    const tools = enumerateGatedMcpTools(auth);
+    expect(tools.has("chorus_pm_validate_elaboration")).toBe(true);
+  });
+
+  it("an idea:write-only agent does NOT see chorus_pm_validate_elaboration", () => {
+    const auth = makeAgentAuth(["idea:write"]);
+    const tools = enumerateGatedMcpTools(auth);
+    expect(tools.has("chorus_pm_validate_elaboration")).toBe(false);
   });
 });
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/activity-timeline.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/activity-timeline.tsx
@@ -35,6 +35,7 @@ function formatActivityMessage(activity: ActivityResponse, t: TranslateFn): stri
       return t("activity.elaborationSkipped", { actor: actorName });
     case "elaboration_resolved":
       return t("activity.elaborationResolved", { actor: actorName });
+    // elaboration_followup is no longer emitted; retained for legacy rows.
     case "elaboration_followup":
       return t("activity.elaborationFollowup", { actor: actorName });
     default:

--- a/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
@@ -121,6 +121,7 @@ function formatActivityMessage(activity: ActivityResponse, t: any): string {
       return t("activity.elaborationSkipped", { actor: actorName });
     case "elaboration_resolved":
       return t("activity.elaborationResolved", { actor: actorName });
+    // elaboration_followup is no longer emitted; retained for legacy rows.
     case "elaboration_followup":
       return t("activity.elaborationFollowup", { actor: actorName });
     default:

--- a/src/components/elaboration-panel.tsx
+++ b/src/components/elaboration-panel.tsx
@@ -104,9 +104,9 @@ interface RoundCardProps {
 
 function RoundCard({ round, ideaUuid, onAnswered }: RoundCardProps) {
   const t = useTranslations("elaboration");
-  // `needs_followup` means all questions in this round were answered, but
-  // validation flagged issues — a new follow-up round handles those.
-  // So this round should display as "done" (read-only Q&A view).
+  // `needs_followup` is a legacy round status no longer written by the service
+  // (the per-question issue / follow-up mechanism was removed). Kept here only
+  // so any historical rows still render as "done" (read-only Q&A view).
   const isPending = round.status === "pending_answers";
   const isDone =
     round.status === "answered" ||

--- a/src/components/elaboration-panel.tsx
+++ b/src/components/elaboration-panel.tsx
@@ -149,6 +149,14 @@ function RoundCard({ round, ideaUuid, onAnswered }: RoundCardProps) {
                 {t("roundLabel", { number: round.roundNumber })}
               </span>
 
+              {/* Appended (follow-up) badge — muted accent, distinct from
+                  the round-number badge and the status badge */}
+              {round.isAppended && (
+                <span className="rounded bg-[#EDE7F6] px-2 py-0.5 text-[10px] font-medium text-[#6A4FB6]">
+                  {t("appendedBadge")}
+                </span>
+              )}
+
               {/* Question count (shown when collapsed) */}
               {!isOpen && (
                 <span className="text-xs text-[#9A9A9A]">

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -87,6 +87,11 @@ function registeredFor(permissions: Permission[]): Set<string> {
 // (covered by the update-task tool's incremental dependency arrays). See
 // permission-map.ts and pm.ts; the names are intentionally not spelled here so
 // downstream grep checks stay clean.
+//
+// Note: chorus_pm_validate_elaboration is gated on idea:admin, so it is NOT a
+// pm-surface (idea:write) tool and intentionally does not appear in this
+// idea:write baseline. It surfaces only for admin_agent; see the admin_agent
+// expectation and the dedicated validate assertions below.
 const OLD_PM_TOOLS = [
   "chorus_claim_idea",
   "chorus_release_idea",
@@ -103,7 +108,6 @@ const OLD_PM_TOOLS = [
   "chorus_pm_remove_task_draft",
   "chorus_pm_assign_task",
   "chorus_pm_start_elaboration",
-  "chorus_pm_validate_elaboration",
   "chorus_pm_skip_elaboration",
   "chorus_move_idea",
   "chorus_pm_reject_proposal",
@@ -198,7 +202,7 @@ describe("MCP tool permission wiring", () => {
   });
 
   describe("backward-compat: admin_agent preset (AC6)", () => {
-    it("admin_agent sees exactly the union of 0.6.x admin + pm + developer tool sets plus 0.9.0 chorus_create_report", () => {
+    it("admin_agent sees exactly the union of 0.6.x admin + pm + developer tool sets plus 0.9.0 chorus_create_report and 0.9.4 chorus_pm_validate_elaboration", () => {
       const registered = registeredFor([...ROLE_PRESETS.admin_agent]);
       const expected = new Set([
         ...OLD_ADMIN_TOOLS,
@@ -207,6 +211,10 @@ describe("MCP tool permission wiring", () => {
         // 0.9.0: public-namespaced, document:write-gated. admin_agent carries
         // document:write so the tool is visible to admin presets.
         "chorus_create_report",
+        // 0.9.4 (simplify-elaboration-flow): chorus_pm_validate_elaboration is
+        // now idea:admin-gated (the simplified resolve action). admin_agent
+        // carries idea:admin; pm_agent (idea:write only) does not.
+        "chorus_pm_validate_elaboration",
       ]);
       expect(registered).toEqual(expected);
     });
@@ -256,6 +264,26 @@ describe("MCP tool permission wiring", () => {
 
     it("chorus_create_report is gated on document:write (AC2 of add-idea-completion-report)", () => {
       expect(TOOL_PERMISSIONS.chorus_create_report).toBe("document:write");
+    });
+  });
+
+  // chorus_pm_validate_elaboration marks an Idea's elaboration complete and is
+  // gated on idea:admin (admin-only).
+  describe("elaboration validate tool wiring", () => {
+    it("chorus_pm_validate_elaboration is registered for an idea:admin agent", () => {
+      const registered = registeredFor(["idea:admin"]);
+      expect(registered.has("chorus_pm_validate_elaboration")).toBe(true);
+    });
+
+    it("chorus_pm_validate_elaboration is NOT registered for an idea:write-only agent", () => {
+      const registered = registeredFor(["idea:write"]);
+      expect(registered.has("chorus_pm_validate_elaboration")).toBe(false);
+    });
+
+    it("chorus_pm_validate_elaboration is mapped to idea:admin in the permission map", () => {
+      expect(
+        (TOOL_PERMISSIONS as Record<string, string>).chorus_pm_validate_elaboration
+      ).toBe("idea:admin");
     });
   });
 });

--- a/src/mcp/tools/permission-map.ts
+++ b/src/mcp/tools/permission-map.ts
@@ -29,8 +29,12 @@ export const TOOL_PERMISSIONS = {
   chorus_pm_create_idea: "idea:write",
   // Elaboration (idea:write per §5.3)
   chorus_pm_start_elaboration: "idea:write",
-  chorus_pm_validate_elaboration: "idea:write",
   chorus_pm_skip_elaboration: "idea:write",
+  // Resolution is admin-gated (idea:admin) per simplify-elaboration-flow Tech
+  // Design §MCP & permissions: only admin_agent can resolve; pm_agent's preset
+  // (idea:write) cannot, by design. Exposed under the legacy name
+  // `chorus_pm_validate_elaboration` (reused, not a new tool).
+  chorus_pm_validate_elaboration: "idea:admin",
   // Proposal writes
   chorus_pm_create_proposal: "proposal:write",
   chorus_pm_validate_proposal: "proposal:write",

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -733,45 +733,31 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     }
   );
 
-  // chorus_pm_validate_elaboration - Validate answers from an elaboration round
+  // chorus_pm_validate_elaboration - Mark an Idea's elaboration as complete.
+  // The tool is exposed under the legacy name `chorus_pm_validate_elaboration`,
+  // but its behavior is the simplified "resolve" action (no issues[] /
+  // followUpQuestions — opening a follow-up round is just another
+  // chorus_pm_start_elaboration call). The backing service fn is resolveElaboration.
   registerPermissionedTool(
     server,
     auth,
-    "idea:write",
+    "idea:admin",
     "chorus_pm_validate_elaboration",
     {
-      description: "Validate answers from an elaboration round. If no issues are found, the elaboration is marked as resolved. If issues exist, optionally provide follow-up questions for a new round. IMPORTANT: Before resolving (empty issues), always confirm with the user that they have no remaining concerns or topics to discuss.",
+      description: "Resolve an Idea's elaboration (round -> validated, Idea -> elaborated, elaborationStatus -> resolved). Resolves the most recent answered round by default, or a specific round when roundUuid is provided. Requires human confirmation before calling (except in YOLO mode). Marks the elaboration complete.",
       inputSchema: z.object({
         ideaUuid: z.string().describe("Idea UUID"),
-        roundUuid: z.string().describe("Elaboration round UUID"),
-        issues: zArray(z.object({
-          questionId: z.string().describe("Question ID with the issue"),
-          type: z.enum(["contradiction", "ambiguity", "incomplete"]).describe("Issue type"),
-          description: z.string().describe("Issue description"),
-        })).describe("List of issues found (empty array = all valid)"),
-        followUpQuestions: zArray(z.object({
-          id: z.string().describe("Unique question identifier"),
-          text: z.string().describe("Question text"),
-          category: z.enum(["functional", "non_functional", "business_context", "technical_context", "user_scenario", "scope"]).describe("Question category"),
-          options: zArray(z.object({
-            id: z.string().describe("Option identifier"),
-            label: z.string().describe("Option label"),
-            description: z.string().optional().describe("Option description"),
-          })).describe("Answer options (2-5). Do NOT include 'Other' — the UI adds it automatically."),
-          required: z.boolean().optional().describe("Whether the question is required (default: true)"),
-        })).optional().describe("Follow-up questions for next round (only when issues exist)"),
+        roundUuid: z.string().optional().describe("Elaboration round UUID (optional; defaults to the most recent answered round)"),
       }),
     },
-    async ({ ideaUuid, roundUuid, issues, followUpQuestions }) => {
+    async ({ ideaUuid, roundUuid }) => {
       try {
-        const result = await elaborationService.validateElaboration({
+        const result = await elaborationService.resolveElaboration({
           companyUuid: auth.companyUuid,
           ideaUuid,
-          roundUuid,
           actorUuid: auth.actorUuid,
           actorType: "agent",
-          issues,
-          followUpQuestions,
+          roundUuid,
         });
 
         return {
@@ -779,7 +765,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         };
       } catch (error) {
         return {
-          content: [{ type: "text", text: `Failed to validate elaboration: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          content: [{ type: "text", text: `Failed to resolve elaboration: ${error instanceof Error ? error.message : "Unknown error"}` }],
           isError: true,
         };
       }

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -611,10 +611,10 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_answer_elaboration",
     {
-      description: "Answer elaboration questions for an Idea. Submits answers for a specific elaboration round. When all required questions are answered, the round moves to validation. Also use this to record decisions made outside the formal elaboration flow — if the user clarified requirements in conversation, capture those decisions here as answers so they are persisted to the Idea as an audit trail.",
+      description: "Answer elaboration questions for an Idea. Submits answers for an elaboration round. When roundUuid is omitted, the Idea's single active (pending_answers) round is located automatically. When all required questions are answered, the round moves to validation. Also use this to record decisions made outside the formal elaboration flow — if the user clarified requirements in conversation, capture those decisions here as answers so they are persisted to the Idea as an audit trail.",
       inputSchema: z.object({
         ideaUuid: z.string().describe("Idea UUID"),
-        roundUuid: z.string().describe("Elaboration round UUID"),
+        roundUuid: z.string().optional().describe("Elaboration round UUID (optional; when omitted, the active round is located automatically)"),
         answers: zArray(z.object({
           questionId: z.string().describe("Question ID to answer"),
           selectedOptionId: z.string().nullable().describe("Selected option ID. Set to null for free-text 'Other' answers."),

--- a/src/services/__tests__/elaboration.service.pure.test.ts
+++ b/src/services/__tests__/elaboration.service.pure.test.ts
@@ -110,6 +110,7 @@ describe("formatRoundResponse", () => {
     uuid: "round-uuid",
     roundNumber: 1,
     status: "pending_answers",
+    isAppended: false,
     createdByType: "agent",
     createdByUuid: "agent-uuid",
     validatedAt: null as Date | null,
@@ -122,10 +123,17 @@ describe("formatRoundResponse", () => {
     expect(result.uuid).toBe("round-uuid");
     expect(result.roundNumber).toBe(1);
     expect(result.status).toBe("pending_answers");
+    expect(result.isAppended).toBe(false);
     expect(result.createdBy).toEqual({ type: "agent", uuid: "agent-uuid" });
     expect(result.validatedAt).toBeNull();
     expect(result.createdAt).toBe("2026-01-01T00:00:00.000Z");
     expect(result.questions).toEqual([]);
+  });
+
+  it("should pass through isAppended when true", () => {
+    const round = { ...baseRound, isAppended: true };
+    const result = formatRoundResponse(round);
+    expect(result.isAppended).toBe(true);
   });
 
   it("should format validatedAt as ISO string when present", () => {

--- a/src/services/__tests__/elaboration.service.test.ts
+++ b/src/services/__tests__/elaboration.service.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/services", () => ({
 import {
   startElaboration,
   answerElaboration,
-  validateElaboration,
+  resolveElaboration,
   skipElaboration,
   getElaboration,
 } from "@/services/elaboration.service";
@@ -96,6 +96,7 @@ function makeRound(overrides: Record<string, unknown> = {}) {
     ideaUuid: IDEA_UUID,
     roundNumber: 1,
     status: "pending_answers",
+    isAppended: false,
     createdByType: "agent",
     createdByUuid: ACTOR_UUID,
     validatedAt: null,
@@ -250,9 +251,39 @@ describe("startElaboration", () => {
     ).rejects.toThrow("Cannot start elaboration from status");
   });
 
-  it("should throw if max 5 rounds exceeded", async () => {
+  it("should allow starting a 10th round (cap is 10, not 5)", async () => {
+    const idea = makeIdea();
+    const created = { uuid: ROUND_UUID };
+    const round = makeRound({ roundNumber: 10 });
+
+    mockPrisma.idea.findFirst.mockResolvedValue(idea);
+    // 9 existing rounds → this is round 10, which is allowed.
+    mockPrisma.elaborationRound.count.mockResolvedValue(9);
+    mockPrisma.elaborationRound.create.mockResolvedValue(created);
+    mockPrisma.elaborationRound.findUniqueOrThrow.mockResolvedValue(round);
+    mockPrisma.idea.update.mockResolvedValue(idea);
+
+    const result = await startElaboration({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      actorUuid: ACTOR_UUID,
+      actorType: "agent",
+      depth: "standard",
+      questions: validQuestions,
+    });
+
+    expect(mockPrisma.elaborationRound.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ roundNumber: 10 }),
+      })
+    );
+    expect(result.roundNumber).toBe(10);
+  });
+
+  it("should throw if max 10 rounds exceeded (round 11)", async () => {
     mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
-    mockPrisma.elaborationRound.count.mockResolvedValue(5);
+    // 10 existing rounds → this would be round 11, which exceeds the cap.
+    mockPrisma.elaborationRound.count.mockResolvedValue(10);
 
     await expect(
       startElaboration({
@@ -263,7 +294,95 @@ describe("startElaboration", () => {
         depth: "standard",
         questions: validQuestions,
       })
-    ).rejects.toThrow("Maximum 5 elaboration rounds per Idea");
+    ).rejects.toThrow("Maximum 10 elaboration rounds per Idea");
+  });
+
+  it("should create an appended round (isAppended=true) on a resolved Idea, keeping it elaborated/resolved", async () => {
+    // Idea already elaborated + resolved → appended round.
+    const idea = makeIdea({ status: "elaborated", elaborationStatus: "resolved" });
+    const created = { uuid: ROUND_UUID };
+    const appendedRound = makeRound({
+      roundNumber: 2,
+      isAppended: true,
+    });
+
+    mockPrisma.idea.findFirst.mockResolvedValue(idea);
+    mockPrisma.elaborationRound.count.mockResolvedValue(1);
+    mockPrisma.elaborationRound.create.mockResolvedValue(created);
+    mockPrisma.elaborationRound.findUniqueOrThrow.mockResolvedValue(appendedRound);
+    mockPrisma.idea.update.mockResolvedValue(idea);
+
+    const result = await startElaboration({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      actorUuid: ACTOR_UUID,
+      actorType: "agent",
+      depth: "standard",
+      questions: validQuestions,
+    });
+
+    // Round is created with isAppended=true and status pending_answers.
+    expect(mockPrisma.elaborationRound.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          isAppended: true,
+          status: "pending_answers",
+        }),
+      })
+    );
+
+    // R2 decision: the Idea is NOT regressed — its status/elaborationStatus are
+    // left untouched. The update only persists the elaboration depth; it must
+    // NOT write status or elaborationStatus.
+    expect(mockPrisma.idea.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: IDEA_UUID },
+        data: { elaborationDepth: "standard" },
+      })
+    );
+    const ideaUpdateData = mockPrisma.idea.update.mock.calls[0][0].data;
+    expect(ideaUpdateData).not.toHaveProperty("status");
+    expect(ideaUpdateData).not.toHaveProperty("elaborationStatus");
+
+    expect(result.isAppended).toBe(true);
+  });
+
+  it("should create a non-appended round (isAppended=false) on an elaborating Idea and set elaborationStatus=pending_answers", async () => {
+    const idea = makeIdea({ status: "elaborating", elaborationStatus: "pending_answers" });
+    const created = { uuid: ROUND_UUID };
+    const round = makeRound({ isAppended: false });
+
+    mockPrisma.idea.findFirst.mockResolvedValue(idea);
+    mockPrisma.elaborationRound.count.mockResolvedValue(0);
+    mockPrisma.elaborationRound.create.mockResolvedValue(created);
+    mockPrisma.elaborationRound.findUniqueOrThrow.mockResolvedValue(round);
+    mockPrisma.idea.update.mockResolvedValue(idea);
+
+    const result = await startElaboration({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      actorUuid: ACTOR_UUID,
+      actorType: "agent",
+      depth: "standard",
+      questions: validQuestions,
+    });
+
+    expect(mockPrisma.elaborationRound.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ isAppended: false }),
+      })
+    );
+    // Normal flow: the Idea is moved to elaborating/pending_answers.
+    expect(mockPrisma.idea.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: IDEA_UUID },
+        data: expect.objectContaining({
+          status: "elaborating",
+          elaborationStatus: "pending_answers",
+        }),
+      })
+    );
+    expect(result.isAppended).toBe(false);
   });
 });
 
@@ -321,6 +440,136 @@ describe("answerElaboration", () => {
     );
 
     expect(result.uuid).toBe(ROUND_UUID);
+  });
+
+  it("should auto-locate the single active round when roundUuid is omitted", async () => {
+    const round = makeRound({ status: "pending_answers" });
+    const answeredQuestions = round.questions.map((q: Record<string, unknown>) => ({
+      ...q,
+      answeredAt: now,
+      selectedOptionId: "o1",
+    }));
+
+    // Auto-location: exactly one pending_answers round.
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([{ uuid: ROUND_UUID }]);
+    mockPrisma.elaborationRound.findFirst.mockResolvedValue(round);
+    mockPrisma.elaborationQuestion.update.mockResolvedValue({});
+    mockPrisma.elaborationQuestion.findMany.mockResolvedValue(answeredQuestions);
+    mockPrisma.elaborationRound.update.mockResolvedValue({});
+    mockPrisma.idea.update.mockResolvedValue({});
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findUnique.mockResolvedValue(
+      makeRound({ status: "answered", questions: answeredQuestions })
+    );
+
+    const result = await answerElaboration({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      // no roundUuid
+      actorUuid: ACTOR_UUID,
+      actorType: "user",
+      answers: [
+        { questionId: "q1", selectedOptionId: "o1", customText: null },
+      ],
+    });
+
+    // It must have looked up the active round by status.
+    expect(mockPrisma.elaborationRound.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "pending_answers" }),
+      })
+    );
+    // And applied answers to that auto-located round.
+    expect(mockPrisma.elaborationRound.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ uuid: ROUND_UUID }),
+      })
+    );
+    expect(result.uuid).toBe(ROUND_UUID);
+  });
+
+  it("should throw 'no active round' when roundUuid omitted and zero active rounds", async () => {
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([]);
+
+    await expect(
+      answerElaboration({
+        companyUuid: COMPANY_UUID,
+        ideaUuid: IDEA_UUID,
+        actorUuid: ACTOR_UUID,
+        actorType: "user",
+        answers: [{ questionId: "q1", selectedOptionId: "o1", customText: null }],
+      })
+    ).rejects.toThrow("no active round to answer");
+  });
+
+  it("should throw 'specify roundUuid' when roundUuid omitted and multiple active rounds", async () => {
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([
+      { uuid: "round-a" },
+      { uuid: "round-b" },
+    ]);
+
+    await expect(
+      answerElaboration({
+        companyUuid: COMPANY_UUID,
+        ideaUuid: IDEA_UUID,
+        actorUuid: ACTOR_UUID,
+        actorType: "user",
+        answers: [{ questionId: "q1", selectedOptionId: "o1", customText: null }],
+      })
+    ).rejects.toThrow("multiple active rounds; specify roundUuid");
+  });
+
+  it("should mark an appended round answered but keep the Idea's elaborationStatus=resolved", async () => {
+    // Appended round on an already-resolved Idea.
+    const appendedRound = makeRound({ status: "pending_answers", isAppended: true });
+    const answeredQuestions = appendedRound.questions.map(
+      (q: Record<string, unknown>) => ({
+        ...q,
+        answeredAt: now,
+        selectedOptionId: "o1",
+      })
+    );
+
+    mockPrisma.elaborationRound.findFirst.mockResolvedValue(appendedRound);
+    mockPrisma.elaborationQuestion.update.mockResolvedValue({});
+    mockPrisma.elaborationQuestion.findMany.mockResolvedValue(answeredQuestions);
+    mockPrisma.elaborationRound.update.mockResolvedValue({});
+    mockPrisma.idea.update.mockResolvedValue({});
+    // The Idea is resolved — the R2 guard must prevent flipping to validating.
+    mockPrisma.idea.findFirst.mockResolvedValue(
+      makeIdea({ status: "elaborated", elaborationStatus: "resolved" })
+    );
+    mockPrisma.elaborationRound.findUnique.mockResolvedValue(
+      makeRound({ status: "answered", isAppended: true, questions: answeredQuestions })
+    );
+
+    const result = await answerElaboration({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      roundUuid: ROUND_UUID,
+      actorUuid: ACTOR_UUID,
+      actorType: "user",
+      answers: [
+        { questionId: "q1", selectedOptionId: "o1", customText: null },
+      ],
+    });
+
+    // Round advances to answered.
+    expect(mockPrisma.elaborationRound.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: ROUND_UUID },
+        data: { status: "answered" },
+      })
+    );
+
+    // R2 guard: the Idea's elaborationStatus must NOT be downgraded to validating.
+    // The only idea.update calls (if any) must not write elaborationStatus.
+    const wroteValidating = mockPrisma.idea.update.mock.calls.some(
+      (call) => call[0]?.data?.elaborationStatus === "validating"
+    );
+    expect(wroteValidating).toBe(false);
+
+    expect(result.status).toBe("answered");
   });
 
   it("should throw if round not found", async () => {
@@ -401,25 +650,32 @@ describe("answerElaboration", () => {
   });
 });
 
-describe("validateElaboration", () => {
-  it("should mark round as validated when no issues", async () => {
-    const round = makeRound({ status: "answered" });
+describe("resolveElaboration", () => {
+  it("should mark the most recent answered round validated and resolve the Idea (no roundUuid)", async () => {
+    const answeredRound = makeRound({ status: "answered", roundNumber: 2 });
     const validatedRound = makeRound({ status: "validated", validatedAt: now });
 
-    mockPrisma.elaborationRound.findFirst.mockResolvedValue(round);
+    // 1) assignee check, 2) most-recent answered round, ... 3) final reload
     mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findFirst.mockResolvedValue(answeredRound);
     mockPrisma.elaborationRound.update.mockResolvedValue({});
     mockPrisma.idea.update.mockResolvedValue({});
     mockPrisma.elaborationRound.findUnique.mockResolvedValue(validatedRound);
 
-    const result = await validateElaboration({
+    const result = await resolveElaboration({
       companyUuid: COMPANY_UUID,
       ideaUuid: IDEA_UUID,
-      roundUuid: ROUND_UUID,
       actorUuid: ACTOR_UUID,
       actorType: "agent",
-      issues: [],
     });
+
+    // Defaulted to the most recent answered round via desc ordering.
+    expect(mockPrisma.elaborationRound.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { ideaUuid: IDEA_UUID, companyUuid: COMPANY_UUID, status: "answered" },
+        orderBy: { roundNumber: "desc" },
+      })
+    );
 
     expect(mockPrisma.elaborationRound.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -438,104 +694,99 @@ describe("validateElaboration", () => {
     expect(mockCreateActivity).toHaveBeenCalledWith(
       expect.objectContaining({ action: "elaboration_resolved" })
     );
-
-    expect(result.validatedRound).toBeDefined();
-    expect(result.followUpRound).toBeUndefined();
+    expect(mockEventBus.emitChange).toHaveBeenCalled();
+    expect(result).toBeDefined();
   });
 
-  it("should create follow-up round when issues with follow-up questions", async () => {
-    const round = makeRound({ status: "answered" });
-    const idea = makeIdea({ elaborationDepth: "standard" });
+  it("should resolve a specific answered round when roundUuid is provided", async () => {
+    const answeredRound = makeRound({ status: "answered" });
 
-    mockPrisma.elaborationRound.findFirst.mockResolvedValue(round);
-    mockPrisma.idea.findFirst
-      .mockResolvedValueOnce(idea) // validateElaboration call
-      .mockResolvedValueOnce(idea); // startElaboration inner call
-    mockPrisma.elaborationQuestion.update.mockResolvedValue({});
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findFirst.mockResolvedValue(answeredRound);
     mockPrisma.elaborationRound.update.mockResolvedValue({});
-
-    // For startElaboration (follow-up round creation)
-    mockPrisma.elaborationRound.count.mockResolvedValue(1);
-    const followUpRound = makeRound({
-      uuid: "follow-up-round-uuid",
-      roundNumber: 2,
-    });
-    mockPrisma.elaborationRound.create.mockResolvedValue({ uuid: "follow-up-round-uuid" });
-    mockPrisma.elaborationRound.findUniqueOrThrow.mockResolvedValue(followUpRound);
     mockPrisma.idea.update.mockResolvedValue({});
-
-    // Final findUnique for validated round
     mockPrisma.elaborationRound.findUnique.mockResolvedValue(
-      makeRound({ status: "needs_followup", validatedAt: now })
+      makeRound({ status: "validated", validatedAt: now })
     );
 
-    const result = await validateElaboration({
+    await resolveElaboration({
       companyUuid: COMPANY_UUID,
       ideaUuid: IDEA_UUID,
       roundUuid: ROUND_UUID,
       actorUuid: ACTOR_UUID,
       actorType: "agent",
-      issues: [
-        { questionId: "q1", type: "ambiguity", description: "Unclear answer" },
-      ],
-      followUpQuestions: validQuestions,
     });
 
-    expect(mockPrisma.elaborationRound.update).toHaveBeenCalledWith(
+    // Looked up the explicit round, not the desc-ordered default.
+    expect(mockPrisma.elaborationRound.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { uuid: ROUND_UUID },
-        data: expect.objectContaining({ status: "needs_followup" }),
+        where: { uuid: ROUND_UUID, ideaUuid: IDEA_UUID, companyUuid: COMPANY_UUID },
       })
     );
-
-    expect(mockPrisma.elaborationQuestion.update).toHaveBeenCalledWith(
+    expect(mockPrisma.idea.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
-          issueType: "ambiguity",
-          issueDescription: "Unclear answer",
-        }),
+        data: { status: "elaborated", elaborationStatus: "resolved" },
       })
     );
-
-    expect(result.validatedRound).toBeDefined();
-    expect(result.followUpRound).toBeDefined();
   });
 
-  it("should throw if round not in answered status", async () => {
+  it("should throw when there is no answered round to resolve", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findFirst.mockResolvedValue(null);
+
+    await expect(
+      resolveElaboration({
+        companyUuid: COMPANY_UUID,
+        ideaUuid: IDEA_UUID,
+        actorUuid: ACTOR_UUID,
+        actorType: "agent",
+      })
+    ).rejects.toThrow("no answered round to resolve");
+  });
+
+  it("should throw if an explicit round is not in answered status", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
     mockPrisma.elaborationRound.findFirst.mockResolvedValue(
       makeRound({ status: "pending_answers" })
     );
 
     await expect(
-      validateElaboration({
+      resolveElaboration({
         companyUuid: COMPANY_UUID,
         ideaUuid: IDEA_UUID,
         roundUuid: ROUND_UUID,
         actorUuid: ACTOR_UUID,
         actorType: "agent",
-        issues: [],
       })
     ).rejects.toThrow("expected 'answered'");
   });
 
   it("should throw if actor is not the idea assignee", async () => {
-    mockPrisma.elaborationRound.findFirst.mockResolvedValue(
-      makeRound({ status: "answered" })
-    );
     mockPrisma.idea.findFirst.mockResolvedValue(
       makeIdea({ assigneeUuid: "other-agent" })
     );
 
     await expect(
-      validateElaboration({
+      resolveElaboration({
         companyUuid: COMPANY_UUID,
         ideaUuid: IDEA_UUID,
-        roundUuid: ROUND_UUID,
         actorUuid: ACTOR_UUID,
         actorType: "agent",
-        issues: [],
       })
-    ).rejects.toThrow("Only the assigned agent can validate elaboration");
+    ).rejects.toThrow("Only the assigned agent can resolve elaboration");
+  });
+
+  it("should throw if the Idea is not found", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(null);
+
+    await expect(
+      resolveElaboration({
+        companyUuid: COMPANY_UUID,
+        ideaUuid: IDEA_UUID,
+        actorUuid: ACTOR_UUID,
+        actorType: "agent",
+      })
+    ).rejects.toThrow("Idea not found");
   });
 });
 

--- a/src/services/elaboration.service.ts
+++ b/src/services/elaboration.service.ts
@@ -7,7 +7,6 @@ import { activityService } from "@/services";
 import {
   type QuestionInput,
   type AnswerInput,
-  type ValidationIssueInput,
   type ElaborationDepth,
   type ElaborationResponse,
   type ElaborationRoundResponse,
@@ -45,11 +44,17 @@ export async function startElaboration({
   if (idea.assigneeUuid !== actorUuid) {
     throw new Error("Only the assigned agent can start elaboration");
   }
-  if (idea.status !== "elaborating") {
+  if (idea.status !== "elaborating" && idea.status !== "elaborated") {
     throw new Error(
-      `Cannot start elaboration from status '${idea.status}'. Idea must be in 'elaborating' status (claim it first).`
+      `Cannot start elaboration from status '${idea.status}'. Idea must be in 'elaborating' or 'elaborated' status (claim it first).`
     );
   }
+
+  // Appended round: the Idea's elaboration was already resolved at call time.
+  // Appended rounds are a pure supplement — they must NOT regress the Idea
+  // lifecycle (R2 decision): keep status `elaborated` and elaborationStatus
+  // `resolved` so an in-flight proposal is never re-blocked.
+  const isAppended = idea.status === "elaborated";
 
   // Determine round number
   const existingRounds = await prisma.elaborationRound.count({
@@ -57,8 +62,8 @@ export async function startElaboration({
   });
   const roundNumber = existingRounds + 1;
 
-  if (roundNumber > 5) {
-    throw new Error("Maximum 5 elaboration rounds per Idea");
+  if (roundNumber > 10) {
+    throw new Error("Maximum 10 elaboration rounds per Idea");
   }
 
   // Create round + questions
@@ -68,6 +73,7 @@ export async function startElaboration({
       ideaUuid,
       roundNumber,
       status: "pending_answers",
+      isAppended,
       createdByType: actorType,
       createdByUuid: actorUuid,
       questions: {
@@ -88,15 +94,24 @@ export async function startElaboration({
     include: { questions: true },
   });
 
-  // Update idea status + elaboration fields
-  await prisma.idea.update({
-    where: { uuid: ideaUuid },
-    data: {
-      status: "elaborating",
-      elaborationDepth: depth,
-      elaborationStatus: "pending_answers",
-    },
-  });
+  // Update idea status + elaboration fields.
+  // For appended rounds, do NOT downgrade idea.status and do NOT overwrite a
+  // `resolved` elaborationStatus — only the new round sits at pending_answers.
+  if (isAppended) {
+    await prisma.idea.update({
+      where: { uuid: ideaUuid },
+      data: { elaborationDepth: depth },
+    });
+  } else {
+    await prisma.idea.update({
+      where: { uuid: ideaUuid },
+      data: {
+        status: "elaborating",
+        elaborationDepth: depth,
+        elaborationStatus: "pending_answers",
+      },
+    });
+  }
 
   // Log activity
   const resolvedProjectUuid = projectUuid || idea.projectUuid;
@@ -128,14 +143,31 @@ export async function answerElaboration({
 }: {
   companyUuid: string;
   ideaUuid: string;
-  roundUuid: string;
+  roundUuid?: string;
   actorUuid: string;
   actorType: string;
   answers: AnswerInput[];
 }): Promise<ElaborationRoundResponse> {
+  // Resolve the target round. When roundUuid is omitted, auto-locate the
+  // Idea's single active (pending_answers) round.
+  let resolvedRoundUuid = roundUuid;
+  if (!resolvedRoundUuid) {
+    const activeRounds = await prisma.elaborationRound.findMany({
+      where: { ideaUuid, companyUuid, status: "pending_answers" },
+      select: { uuid: true },
+    });
+    if (activeRounds.length === 0) {
+      throw new Error("no active round to answer");
+    }
+    if (activeRounds.length > 1) {
+      throw new Error("multiple active rounds; specify roundUuid");
+    }
+    resolvedRoundUuid = activeRounds[0].uuid;
+  }
+
   // Load round with questions
   const round = await prisma.elaborationRound.findFirst({
-    where: { uuid: roundUuid, ideaUuid, companyUuid },
+    where: { uuid: resolvedRoundUuid, ideaUuid, companyUuid },
     include: { questions: true },
   });
   if (!round) throw new Error("Elaboration round not found");
@@ -185,28 +217,33 @@ export async function answerElaboration({
 
   // Check if all required questions are answered
   const updatedQuestions = await prisma.elaborationQuestion.findMany({
-    where: { roundUuid },
+    where: { roundUuid: resolvedRoundUuid },
   });
   const allRequiredAnswered = updatedQuestions
     .filter((q) => q.required)
     .every((q) => q.answeredAt !== null);
 
-  // Update round status if all answered
-  if (allRequiredAnswered) {
-    await prisma.elaborationRound.update({
-      where: { uuid: roundUuid },
-      data: { status: "answered" },
-    });
-    await prisma.idea.update({
-      where: { uuid: ideaUuid },
-      data: { elaborationStatus: "validating" },
-    });
-  }
-
-  // Load idea for project UUID
+  // Load idea (needed for project UUID and the resolved-state guard below)
   const idea = await prisma.idea.findFirst({
     where: { uuid: ideaUuid, companyUuid },
   });
+
+  // Update round status if all answered
+  if (allRequiredAnswered) {
+    await prisma.elaborationRound.update({
+      where: { uuid: resolvedRoundUuid },
+      data: { status: "answered" },
+    });
+    // R2 guard: never flip a resolved Idea back to `validating`. Appended
+    // rounds keep the Idea at `resolved` so an in-flight proposal is not
+    // re-blocked — the round still moves to `answered` above.
+    if (idea?.elaborationStatus !== "resolved") {
+      await prisma.idea.update({
+        where: { uuid: ideaUuid },
+        data: { elaborationStatus: "validating" },
+      });
+    }
+  }
 
   // Log activity
   await activityService.createActivity({
@@ -227,129 +264,68 @@ export async function answerElaboration({
 
   // Return updated round
   const updatedRound = await prisma.elaborationRound.findUnique({
-    where: { uuid: roundUuid },
+    where: { uuid: resolvedRoundUuid },
     include: { questions: true },
   });
   return formatRoundResponse(updatedRound!);
 }
 
-// ===== Validate Elaboration =====
+// ===== Resolve Elaboration =====
 
-export async function validateElaboration({
+export async function resolveElaboration({
   companyUuid,
   ideaUuid,
-  roundUuid,
   actorUuid,
   actorType,
-  issues,
-  followUpQuestions,
+  roundUuid,
 }: {
   companyUuid: string;
   ideaUuid: string;
-  roundUuid: string;
   actorUuid: string;
   actorType: string;
-  issues: ValidationIssueInput[];
-  followUpQuestions?: QuestionInput[];
-}): Promise<{
-  validatedRound: ElaborationRoundResponse;
-  followUpRound?: ElaborationRoundResponse;
-}> {
-  // Load round
-  const round = await prisma.elaborationRound.findFirst({
-    where: { uuid: roundUuid, ideaUuid, companyUuid },
-    include: { questions: true },
-  });
-  if (!round) throw new Error("Elaboration round not found");
-  if (round.status !== "answered") {
-    throw new Error(`Round is '${round.status}', expected 'answered'`);
-  }
-
-  // Verify actor is the idea assignee
+  roundUuid?: string;
+}): Promise<ElaborationRoundResponse> {
+  // Verify the Idea exists and the actor is its assignee
   const idea = await prisma.idea.findFirst({
     where: { uuid: ideaUuid, companyUuid },
   });
   if (!idea) throw new Error("Idea not found");
   if (idea.assigneeUuid !== actorUuid) {
-    throw new Error("Only the assigned agent can validate elaboration");
+    throw new Error("Only the assigned agent can resolve elaboration");
   }
 
-  const noIssues = issues.length === 0;
-
-  if (noIssues) {
-    // All clear — mark round as validated, elaboration as resolved
-    await prisma.elaborationRound.update({
-      where: { uuid: roundUuid },
-      data: { status: "validated", validatedAt: new Date() },
-    });
-    await prisma.idea.update({
-      where: { uuid: ideaUuid },
-      data: { status: "elaborated", elaborationStatus: "resolved" },
-    });
-
-    await activityService.createActivity({
-      companyUuid,
-      projectUuid: idea.projectUuid,
-      targetType: "idea",
-      targetUuid: ideaUuid,
-      actorType,
-      actorUuid,
-      action: "elaboration_resolved",
-      value: {
-        totalRounds: round.roundNumber,
-        totalQuestions: round.questions.length,
-      },
-    });
-
-    eventBus.emitChange({ companyUuid, projectUuid: idea.projectUuid, entityType: "idea", entityUuid: ideaUuid, action: "updated" });
-
-    const updated = await prisma.elaborationRound.findUnique({
-      where: { uuid: roundUuid },
+  // Resolve the target round: an explicit roundUuid, otherwise the most recent
+  // `answered` round.
+  let round;
+  if (roundUuid) {
+    round = await prisma.elaborationRound.findFirst({
+      where: { uuid: roundUuid, ideaUuid, companyUuid },
       include: { questions: true },
     });
-    return { validatedRound: formatRoundResponse(updated!) };
-  }
-
-  // Issues found — mark issues on questions, create follow-up round
-  for (const issue of issues) {
-    const question = round.questions.find(
-      (q) => q.questionId === issue.questionId
-    );
-    if (question) {
-      await prisma.elaborationQuestion.update({
-        where: { uuid: question.uuid },
-        data: {
-          issueType: issue.type,
-          issueDescription: issue.description,
-        },
-      });
+    if (!round) throw new Error("Elaboration round not found");
+    if (round.status !== "answered") {
+      throw new Error(`Round is '${round.status}', expected 'answered'`);
+    }
+  } else {
+    round = await prisma.elaborationRound.findFirst({
+      where: { ideaUuid, companyUuid, status: "answered" },
+      include: { questions: true },
+      orderBy: { roundNumber: "desc" },
+    });
+    if (!round) {
+      throw new Error("no answered round to resolve");
     }
   }
 
+  // Mark round as validated, elaboration as resolved
   await prisma.elaborationRound.update({
-    where: { uuid: roundUuid },
-    data: { status: "needs_followup", validatedAt: new Date() },
+    where: { uuid: round.uuid },
+    data: { status: "validated", validatedAt: new Date() },
   });
-
-  let followUpRound: ElaborationRoundResponse | undefined;
-
-  if (followUpQuestions && followUpQuestions.length > 0) {
-    followUpRound = await startElaboration({
-      companyUuid,
-      ideaUuid,
-      actorUuid,
-      actorType,
-      depth: (idea.elaborationDepth as ElaborationDepth) || "standard",
-      questions: followUpQuestions,
-      projectUuid: idea.projectUuid,
-    });
-  } else {
-    // Just mark as needs_followup, keep elaboration pending
-    await prisma.idea.update({
-      where: { uuid: ideaUuid },
-      data: { elaborationStatus: "pending_answers" },
-    });
-  }
+  await prisma.idea.update({
+    where: { uuid: ideaUuid },
+    data: { status: "elaborated", elaborationStatus: "resolved" },
+  });
 
   await activityService.createActivity({
     companyUuid,
@@ -358,21 +334,20 @@ export async function validateElaboration({
     targetUuid: ideaUuid,
     actorType,
     actorUuid,
-    action: "elaboration_followup",
+    action: "elaboration_resolved",
     value: {
-      roundNumber: round.roundNumber,
-      issueCount: issues.length,
-      followUpQuestionCount: followUpQuestions?.length || 0,
+      totalRounds: round.roundNumber,
+      totalQuestions: round.questions.length,
     },
   });
 
   eventBus.emitChange({ companyUuid, projectUuid: idea.projectUuid, entityType: "idea", entityUuid: ideaUuid, action: "updated" });
 
-  const updatedRound = await prisma.elaborationRound.findUnique({
-    where: { uuid: roundUuid },
+  const updated = await prisma.elaborationRound.findUnique({
+    where: { uuid: round.uuid },
     include: { questions: true },
   });
-  return { validatedRound: formatRoundResponse(updatedRound!), followUpRound };
+  return formatRoundResponse(updated!);
 }
 
 // ===== Skip Elaboration =====
@@ -498,6 +473,7 @@ export function formatRoundResponse(
     uuid: string;
     roundNumber: number;
     status: string;
+    isAppended: boolean;
     createdByType: string;
     createdByUuid: string;
     validatedAt: Date | null;
@@ -523,6 +499,7 @@ export function formatRoundResponse(
     uuid: round.uuid,
     roundNumber: round.roundNumber,
     status: round.status,
+    isAppended: round.isAppended,
     createdBy: {
       type: round.createdByType,
       uuid: round.createdByUuid,

--- a/src/services/notification-listener.ts
+++ b/src/services/notification-listener.ts
@@ -32,6 +32,8 @@ function resolveNotificationType(action: string, targetType: string): string | n
     // elaboration events (target type is always "idea")
     "idea:elaboration_started": "elaboration_requested",
     "idea:elaboration_answered": "elaboration_answered",
+    // elaboration_followup is no longer emitted (the validate/follow-up
+    // mechanism was removed); mapping retained for legacy activity rows.
     "idea:elaboration_followup": "elaboration_requested",
     "idea:elaboration_resolved": "elaboration_answered",
     "idea:elaboration_skipped": "elaboration_answered",

--- a/src/types/elaboration.ts
+++ b/src/types/elaboration.ts
@@ -5,6 +5,9 @@ export type ElaborationDepth = "minimal" | "standard" | "comprehensive";
 
 export type ElaborationStatus = "pending_answers" | "validating" | "resolved";
 
+// "needs_followup" is retained for legacy data only — the service no longer
+// writes it (the per-question issue / follow-up mechanism was removed). New
+// rounds only ever reach "answered" or "validated".
 export type RoundStatus = "pending_answers" | "answered" | "validated" | "needs_followup";
 
 export type QuestionCategory =
@@ -14,8 +17,6 @@ export type QuestionCategory =
   | "technical_context"
   | "user_scenario"
   | "scope";
-
-export type ValidationIssueType = "contradiction" | "ambiguity" | "incomplete";
 
 export interface QuestionOption {
   id: string;
@@ -35,12 +36,6 @@ export interface AnswerInput {
   questionId: string;
   selectedOptionId: string | null;
   customText: string | null;
-}
-
-export interface ValidationIssueInput {
-  questionId: string;
-  type: ValidationIssueType;
-  description: string;
 }
 
 // Response types

--- a/src/types/elaboration.ts
+++ b/src/types/elaboration.ts
@@ -68,6 +68,7 @@ export interface ElaborationRoundResponse {
   uuid: string;
   roundNumber: number;
   status: string;
+  isAppended: boolean;
   createdBy: { type: string; uuid: string };
   validatedAt: string | null;
   questions: ElaborationQuestionResponse[];


### PR DESCRIPTION
## Summary
Reworks the elaboration tool surface so common flows take fewer calls, and lets rounds be appended after an idea is resolved.

- **`chorus_pm_start_elaboration`** generates *any* round — first, follow-up, or appended-after-resolution. Callable both while `elaborating` and after `elaborated`. Appended rounds set `isAppended=true` and **keep the Idea `resolved`** (R2 guard) so an in-flight proposal is never re-blocked.
- **`chorus_answer_elaboration`**: `roundUuid` is now **optional** — auto-locates the single active (`pending_answers`) round.
- **`chorus_pm_validate_elaboration`**: re-scoped to a pure resolve action, gated **`idea:admin`**, requires human confirmation (except in YOLO). No `issues[]` / `followUpQuestions`; opening a follow-up round is just another `start` call.
- **`ElaborationRound.isAppended`** column (DDL-only migration); surfaced via `chorus_get_elaboration` and a UI "Follow-up" badge on appended round cards.

## Changed files
| Area | Files |
|------|-------|
| Schema/migration | `prisma/schema.prisma`, `prisma/migrations/20260604130604_add_elaboration_round_is_appended/` |
| Service + types | `src/services/elaboration.service.ts`, `src/types/elaboration.ts` |
| MCP tools | `src/mcp/tools/pm.ts`, `public.ts`, `permission-map.ts` |
| Frontend + i18n | `src/components/elaboration-panel.tsx`, `messages/en.json`, `messages/zh.json` |
| Tests | `elaboration.service*.test.ts`, `server.test.ts`, `permissions.test.ts` |
| Docs | `docs/MCP_TOOLS.md`, `DESIGN_REQUIREMENTS_ELABORATION.md`, `ARCHITECTURE{,.zh}.md` |
| Skills (4 surfaces) | `public/chorus-plugin/`, `plugins/chorus/`, `packages/openclaw-plugin/`, `public/skill/` |
| OpenSpec change | `openspec/changes/simplify-elaboration-flow/` |
| Version bumps | CC/Codex 0.9.4, OpenClaw pkg 0.5.3 + skills 0.9.4, standalone changed skills 0.9.4 |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full suite green — 1764 passed / 1 skipped (98 files)
- [x] Coverage thresholds met — 97.41% lines / 89.34% branches
- [x] `openspec validate simplify-elaboration-flow` valid
- [x] End-to-end verified against a live local MCP server (auto-locate answer → validate → appended round → R2 guard), incl. the renamed-tool path through the IDE MCP client

## Notes
- **`docs/design.pen` badge update deferred.** The file was emptied by a Pencil app disconnect mid-edit; restored from HEAD and intentionally excluded from this PR. The "Follow-up" badge will be added to the design once the Pencil environment is stable.

Generated with [Claude Code](https://claude.com/claude-code)