### PR TITLE
feat(tasks): align Task edit UI's AC editor with Task Draft

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -985,7 +985,8 @@
     "gateReady": "All required criteria passed",
     "addCriterion": "Add Criterion",
     "removeCriterion": "Remove",
-    "criterionPlaceholder": "Describe the acceptance criterion..."
+    "criterionPlaceholder": "Describe the acceptance criterion...",
+    "atLeastOneRequired": "At least one acceptance criterion with a non-empty description is required."
   },
   "onboarding": {
     "skip": "Skip for now",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -986,7 +986,8 @@
     "gateReady": "所有必需标准已通过",
     "addCriterion": "添加标准",
     "removeCriterion": "移除",
-    "criterionPlaceholder": "描述验收标准..."
+    "criterionPlaceholder": "描述验收标准...",
+    "atLeastOneRequired": "至少需要一条非空的验收标准。"
   },
   "onboarding": {
     "skip": "暂时跳过",

--- a/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/README.md
+++ b/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/README.md
@@ -1,0 +1,3 @@
+# align-task-edit-ui-with-draft
+
+Align the real Task edit UI's acceptance-criteria editor with the Task Draft panel (structured rows instead of legacy Markdown textarea)

--- a/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/design.md
+++ b/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/design.md
@@ -1,0 +1,148 @@
+# Design — Align Task Edit UI with Task Draft
+
+## Context
+
+Two panels edit a task's acceptance criteria, and they disagree:
+
+| Surface | File | AC editor today |
+|---|---|---|
+| Task Draft (proposal stage) | `proposals/[proposalUuid]/task-draft-detail-panel.tsx` | structured rows: `Input` + `Switch(required)` + add/delete (lines ~420–480) |
+| Real Task (post-materialize) | `tasks/task-detail-panel.tsx` | single legacy Markdown `<Textarea>` bound to `task.acceptanceCriteria` (lines 576–587) |
+
+The structured criteria (`acceptanceCriteriaItems`) already exist on a real task — they
+are displayed read-only in the panel (lines 983–1129) and gate verification — but the
+**edit form** can only touch the legacy string. The backend already supports replacing
+the structured set: `replaceAcceptanceCriteria(companyUuid, taskUuid, items)` in
+`task.service.ts` (used by `chorus_update_task`). It is atomic (delete + recreate in one
+transaction) and intentionally discards verification marks because the definition of done
+changed.
+
+## Goals / Non-Goals
+
+**Goals**
+- The real-task edit form edits acceptance criteria with the exact same structured UI as
+  the draft panel.
+- The two panels share one component (no copy-paste divergence).
+- Editing AC persists via the existing service; editing other fields never disturbs AC
+  verification marks.
+
+**Non-Goals**
+- Changing the dependency editor, status locks, or role gating.
+- Any backend/service/schema/API change beyond threading one optional field through the
+  existing server action.
+- Migrating or removing the legacy `acceptanceCriteria` string field from the model.
+
+## Decisions
+
+### D1. Extract a shared `AcceptanceCriteriaEditor` component
+
+Create `src/components/acceptance-criteria-editor.tsx`:
+
+```tsx
+export interface AcceptanceCriteriaItemDraft {
+  description: string;
+  required: boolean;
+}
+
+interface Props {
+  items: AcceptanceCriteriaItemDraft[];
+  onChange: (items: AcceptanceCriteriaItemDraft[]) => void;
+  disabled?: boolean;
+}
+```
+
+It renders exactly what the draft panel renders today: one row per item
+(`Input` for description, `Switch` for `required` with required/optional label, `Trash2`
+delete button) plus a bottom "Add Criterion" button. It is a controlled component — it
+owns no persistence and no validation beyond row add/remove. i18n keys reused:
+`acceptanceCriteria.criterionPlaceholder`, `acceptanceCriteria.required`,
+`acceptanceCriteria.optional`, `acceptanceCriteria.addCriterion`.
+
+Both panels then render `<AcceptanceCriteriaEditor items={...} onChange={...} />`. The
+draft panel's inline JSX is replaced by this component to guarantee alignment (this is the
+"aligned by construction" guarantee — they can't drift because they're the same code).
+
+### D2. Seed the editor from `task.acceptanceCriteriaItems`
+
+When entering edit mode on a real task, initialize editor state from the task's existing
+structured criteria, not the legacy string:
+
+```ts
+const initialAcItems = (task?.acceptanceCriteriaItems ?? [])
+  .map((it) => ({ description: it.description, required: it.required ?? true }));
+```
+
+State `editCriteriaItems` replaces the old `editAcceptanceCriteria` string in
+`task-detail-panel.tsx`. The legacy `<Textarea>` is removed. The legacy
+`task.acceptanceCriteria` string is left untouched in the model (not displayed, not
+edited) to avoid scope creep / a migration.
+
+### D3. Persist via `updateTaskFieldsAction` + change detection
+
+Extend the server action input:
+
+```ts
+interface UpdateTaskFieldsInput {
+  taskUuid: string;
+  projectUuid: string;
+  title: string;
+  description?: string | null;
+  priority?: string;
+  storyPoints?: number | null;
+  acceptanceCriteria?: string | null;              // kept; still passed through
+  acceptanceCriteriaItems?: AcceptanceCriteriaItemInput[]; // NEW, optional
+}
+```
+
+In `updateTaskFieldsAction`:
+1. Always call the existing `updateTask(...)` for title/description/priority/storyPoints.
+2. **Only if** `acceptanceCriteriaItems` is provided, call
+   `replaceAcceptanceCriteria(auth.companyUuid, taskUuid, items)`.
+
+The **change detection lives in the client** (the panel): the panel compares the edited
+rows against the task's original `acceptanceCriteriaItems` (by `description` + `required`
++ order) and includes `acceptanceCriteriaItems` in the action call **only when they
+differ**. When unchanged, the field is omitted → `replaceAcceptanceCriteria` is never
+called → verification marks survive. This keeps the destructive replace strictly opt-in
+and matches the elaboration decision (Q3a).
+
+Rationale for client-side detection: the panel already holds both the original task and
+the edited rows; comparing there avoids an extra DB round-trip and keeps the server action
+a thin pass-through. The service-level non-empty validation
+(`ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE`) still guards against saving an empty set.
+
+### D4. Empty-set guard in the UI
+
+`replaceAcceptanceCriteria` throws if the resulting set is empty. The panel must therefore
+block "Save" (or surface the error) when the user has deleted all criteria while AC
+changed. We mirror the draft panel: filter out blank-description rows before comparing /
+sending; if the filtered set is empty **and** differs from the original (i.e. user cleared
+all AC), show an inline validation error using the existing required-AC message rather than
+letting the server 500. Title-required validation is unchanged.
+
+## Data Safety
+
+The only destructive operation is `replaceAcceptanceCriteria`, which wipes dev/admin
+verification marks. It runs **only** when the criteria set changed. Concretely:
+
+- Edit title only → `acceptanceCriteriaItems` omitted → marks preserved. ✅
+- Add/remove/reword a criterion or flip required → field sent → marks reset (correct: the
+  definition of done changed). ✅
+- Re-open the form and Save with no AC change → field omitted → marks preserved. ✅
+
+## Risks / Trade-offs
+
+- **Risk:** false-negative change detection sends AC unnecessarily and wipes marks.
+  *Mitigation:* compare normalized rows (trimmed description + boolean required + index);
+  unit-test the comparison helper.
+- **Risk:** false-positive (misses a real change) leaves stale AC.
+  *Mitigation:* comparison is exact on the same fields the editor can change; covered by
+  tests.
+- **Trade-off:** keeping the legacy `acceptanceCriteria` string in the model is mild debt,
+  but removing it is out of scope and would require a migration + data backfill review.
+
+## Migration / Rollout
+
+Pure frontend + one server-action signature extension. No DB migration. No data backfill
+(consistent with the project's no-DML-in-migrations rule). Ships behind no flag — the new
+editor simply replaces the textarea.

--- a/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/proposal.md
+++ b/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/proposal.md
@@ -1,0 +1,62 @@
+# Align Task Edit UI with Task Draft
+
+## Why
+
+When a Proposal is approved, its Task Drafts materialize into real Tasks. The two
+editing surfaces have drifted apart:
+
+- **Task Draft panel** (`task-draft-detail-panel.tsx`) edits acceptance criteria as
+  **structured rows** — one `description` input + a `required` toggle per criterion,
+  with add / delete controls.
+- **Real Task panel** (`task-detail-panel.tsx`) edits acceptance criteria as a single
+  **legacy Markdown `<Textarea>`**. The structured `acceptanceCriteriaItems` (which the
+  task already carries and which gate verification) are read-only in this form.
+
+So a field that is first-class during proposal authoring becomes uneditable once the
+task is real — a PM can no longer add, reword, or re-flag a criterion as required/optional
+from the UI, even though the backend already supports it (`replaceAcceptanceCriteria`,
+used by the `chorus_update_task` MCP tool). The legacy textarea also does not map to the
+structured criteria at all, so editing it is misleading.
+
+Every other field on the task edit form — title, description, priority, storyPoints — is
+already aligned with the draft. Dependencies are already add/remove-able in the view with
+cycle detection. The **only** real gap is the acceptance-criteria editor.
+
+## What Changes
+
+- Replace the legacy Markdown acceptance-criteria `<Textarea>` in the Task edit form with
+  the **same structured-rows editor** used by the Task Draft panel (description input +
+  `required` switch + add / delete rows).
+- Extract that editor into a **shared component** so the draft panel and the task panel
+  render byte-identical UI and cannot drift again.
+- Persist edited structured criteria by extending the existing `updateTaskFieldsAction`
+  to accept an optional `acceptanceCriteriaItems[]` and route it through the existing
+  `replaceAcceptanceCriteria` service.
+- Apply **change detection**: only call `replaceAcceptanceCriteria` when the criteria set
+  actually changed (description + required + order), so editing an unrelated field (e.g.
+  title) never wipes existing dev/admin verification marks.
+
+### Out of scope (confirmed in elaboration)
+
+- No new state-based edit locks for `in_progress` / `to_verify` — existing edit behavior
+  is preserved.
+- No new role gate for AC editing — it rides the form's existing `canEdit` gate, same as
+  the draft panel.
+- No rework of the dependency editor — it already works in the task view.
+- No new backend service, REST endpoint, or schema migration — the persistence path
+  already exists.
+
+## Capabilities
+
+- `task-edit-ui` — the real-Task editing surface in the dashboard task panel.
+
+## Impact
+
+- **Affected code:**
+  - `src/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel.tsx` (swap textarea for shared editor; save logic)
+  - `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/task-draft-detail-panel.tsx` (consume shared editor)
+  - new shared component under `src/components/` (the structured AC editor)
+  - `src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts` (`updateTaskFieldsAction` accepts `acceptanceCriteriaItems`)
+  - `messages/en.json`, `messages/zh.json` (reuse existing `acceptanceCriteria.*` keys; add any missing)
+- **No DB changes.** `AcceptanceCriterion` model and `replaceAcceptanceCriteria` already exist.
+- **Data safety:** verification marks preserved unless criteria genuinely change.

--- a/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/specs/task-edit-ui/spec.md
+++ b/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/specs/task-edit-ui/spec.md
@@ -1,0 +1,68 @@
+# task-edit-ui — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Structured acceptance-criteria editing in the Task panel
+
+The real-Task edit form SHALL edit acceptance criteria as structured items — each with a
+text description and a `required` flag — using the same controls as the Task Draft panel
+(a description input, a required toggle, and per-row delete plus an add control). The form
+SHALL NOT present acceptance criteria as a single free-text / Markdown field.
+
+#### Scenario: Editor seeded from existing structured criteria
+
+- **WHEN** a user opens the edit form for a task that has structured acceptance criteria
+- **THEN** the editor shows one editable row per existing criterion, each pre-filled with
+  its description and its required/optional state
+
+#### Scenario: Add, reword, and remove criteria
+
+- **WHEN** the user adds a row, edits a description, toggles `required`, or deletes a row
+  and saves
+- **THEN** the task's structured acceptance criteria reflect exactly the edited set
+
+#### Scenario: Same editor component as the draft panel
+
+- **WHEN** acceptance criteria are edited in the Task panel and in the Task Draft panel
+- **THEN** both surfaces render the same editor component, so their controls and behavior
+  are identical
+
+### Requirement: Acceptance-criteria edits persist via the existing replace path
+
+Saving structured acceptance-criteria edits from the Task panel SHALL persist them by
+replacing the task's acceptance-criteria set through the existing service path
+(`replaceAcceptanceCriteria`), reached by extending the existing task-fields update action
+with an optional structured-criteria field. No new persistence service, REST endpoint, or
+database schema change SHALL be introduced.
+
+#### Scenario: Saving edited criteria replaces the set
+
+- **WHEN** the user changes the acceptance criteria and saves
+- **THEN** the task's stored acceptance-criteria items are replaced with the edited set
+  and the panel reflects the new items
+
+#### Scenario: Empty criteria set is rejected in the UI
+
+- **WHEN** the user removes all acceptance criteria (or leaves only blank rows) and the set
+  has changed, then attempts to save
+- **THEN** the form blocks the save and shows the existing "acceptance criteria required"
+  validation message instead of failing on the server
+
+### Requirement: Verification marks preserved when criteria are unchanged
+
+Editing the Task panel SHALL only trigger an acceptance-criteria replacement when the
+criteria set actually changed (by description, required flag, or order). Editing other
+fields SHALL NOT disturb existing dev or admin verification marks on the criteria.
+
+#### Scenario: Editing only the title preserves verification marks
+
+- **WHEN** a task has criteria with existing dev/admin pass-or-fail marks, and the user
+  edits only the title (or another non-AC field) and saves
+- **THEN** the acceptance-criteria replacement is not invoked and all existing verification
+  marks remain intact
+
+#### Scenario: Changing criteria resets verification marks
+
+- **WHEN** the user adds, removes, reorders, or modifies a criterion and saves
+- **THEN** the acceptance-criteria set is replaced and prior verification marks are reset,
+  reflecting that the definition of done changed

--- a/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/tasks.md
+++ b/openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/tasks.md
@@ -1,0 +1,18 @@
+# Tasks — Align Task Edit UI with Task Draft
+
+## 1. Shared acceptance-criteria editor component
+- [ ] 1.1 Create `src/components/acceptance-criteria-editor.tsx` (controlled: items + onChange + disabled), rendering the draft panel's row UI (Input + required Switch + Trash delete + Add Criterion). Reuse `acceptanceCriteria.*` i18n keys.
+- [ ] 1.2 Refactor `task-draft-detail-panel.tsx` to consume the shared editor (replace inline JSX), preserving behavior.
+- [ ] 1.3 Unit test the change-detection helper (normalized compare of description + required + order).
+
+## 2. Task panel edit form
+- [ ] 2.1 In `task-detail-panel.tsx`, replace the legacy `acceptanceCriteria` `<Textarea>` and `editAcceptanceCriteria` state with `editCriteriaItems` seeded from `task.acceptanceCriteriaItems`; render `<AcceptanceCriteriaEditor>`.
+- [ ] 2.2 In save handler, compute whether AC changed vs original; include `acceptanceCriteriaItems` in the action call only when changed; block save with the required-AC message if the changed set is empty.
+
+## 3. Persistence
+- [ ] 3.1 Extend `updateTaskFieldsAction` (`tasks/[taskUuid]/actions.ts`) with optional `acceptanceCriteriaItems`; when present, call `replaceAcceptanceCriteria` after `updateTask`.
+
+## 4. i18n + verification
+- [ ] 4.1 Ensure all strings use existing/added keys in both `en.json` and `zh.json`.
+- [ ] 4.2 `pnpm lint`, `npx tsc --noEmit`, and relevant `pnpm test` pass; manually verify: edit title preserves marks, edit AC resets marks.
+- [ ] 4.3 Update `docs/design.pen` for the changed Task edit panel.

--- a/openspec/specs/task-edit-ui/spec.md
+++ b/openspec/specs/task-edit-ui/spec.md
@@ -1,0 +1,70 @@
+# task-edit-ui Specification
+
+## Purpose
+TBD - created by archiving change align-task-edit-ui-with-draft. Update Purpose after archive.
+## Requirements
+### Requirement: Structured acceptance-criteria editing in the Task panel
+
+The real-Task edit form SHALL edit acceptance criteria as structured items — each with a
+text description and a `required` flag — using the same controls as the Task Draft panel
+(a description input, a required toggle, and per-row delete plus an add control). The form
+SHALL NOT present acceptance criteria as a single free-text / Markdown field.
+
+#### Scenario: Editor seeded from existing structured criteria
+
+- **WHEN** a user opens the edit form for a task that has structured acceptance criteria
+- **THEN** the editor shows one editable row per existing criterion, each pre-filled with
+  its description and its required/optional state
+
+#### Scenario: Add, reword, and remove criteria
+
+- **WHEN** the user adds a row, edits a description, toggles `required`, or deletes a row
+  and saves
+- **THEN** the task's structured acceptance criteria reflect exactly the edited set
+
+#### Scenario: Same editor component as the draft panel
+
+- **WHEN** acceptance criteria are edited in the Task panel and in the Task Draft panel
+- **THEN** both surfaces render the same editor component, so their controls and behavior
+  are identical
+
+### Requirement: Acceptance-criteria edits persist via the existing replace path
+
+Saving structured acceptance-criteria edits from the Task panel SHALL persist them by
+replacing the task's acceptance-criteria set through the existing service path
+(`replaceAcceptanceCriteria`), reached by extending the existing task-fields update action
+with an optional structured-criteria field. No new persistence service, REST endpoint, or
+database schema change SHALL be introduced.
+
+#### Scenario: Saving edited criteria replaces the set
+
+- **WHEN** the user changes the acceptance criteria and saves
+- **THEN** the task's stored acceptance-criteria items are replaced with the edited set
+  and the panel reflects the new items
+
+#### Scenario: Empty criteria set is rejected in the UI
+
+- **WHEN** the user removes all acceptance criteria (or leaves only blank rows) and the set
+  has changed, then attempts to save
+- **THEN** the form blocks the save and shows the existing "acceptance criteria required"
+  validation message instead of failing on the server
+
+### Requirement: Verification marks preserved when criteria are unchanged
+
+Editing the Task panel SHALL only trigger an acceptance-criteria replacement when the
+criteria set actually changed (by description, required flag, or order). Editing other
+fields SHALL NOT disturb existing dev or admin verification marks on the criteria.
+
+#### Scenario: Editing only the title preserves verification marks
+
+- **WHEN** a task has criteria with existing dev/admin pass-or-fail marks, and the user
+  edits only the title (or another non-AC field) and saves
+- **THEN** the acceptance-criteria replacement is not invoked and all existing verification
+  marks remain intact
+
+#### Scenario: Changing criteria resets verification marks
+
+- **WHEN** the user adds, removes, reorders, or modifies a criterion and saves
+- **THEN** the acceptance-criteria set is replaced and prior verification marks are reset,
+  reflecting that the definition of done changed
+

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/task-draft-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/task-draft-detail-panel.tsx
@@ -10,7 +10,10 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Switch } from "@/components/ui/switch";
+import {
+  AcceptanceCriteriaEditor,
+  type AcceptanceCriteriaItemDraft,
+} from "@/components/acceptance-criteria-editor";
 import {
   Select,
   SelectContent,
@@ -101,7 +104,7 @@ export function TaskDraftDetailPanel({
   const [editStoryPoints, setEditStoryPoints] = useState(
     taskDraft?.storyPoints?.toString() || ""
   );
-  const [editCriteriaItems, setEditCriteriaItems] = useState<AcceptanceCriteriaItem[]>(
+  const [editCriteriaItems, setEditCriteriaItems] = useState<AcceptanceCriteriaItemDraft[]>(
     taskDraft?.acceptanceCriteriaItems?.map((item) => ({ description: item.description, required: item.required ?? true })) || []
   );
   // Pending deps for create mode (stored locally until save)
@@ -422,61 +425,10 @@ export function TaskDraftDetailPanel({
           <ClipboardCheck className="h-3.5 w-3.5 text-[#C67A52]" />
           {t("acceptanceCriteria.title")}
         </Label>
-        {editCriteriaItems.length > 0 && (
-          <div className="space-y-2">
-            {editCriteriaItems.map((item, index) => (
-              <div key={index} className="flex items-start gap-2 rounded-lg border border-[#E5E2DC] bg-[#FAF8F4] p-2.5">
-                <div className="flex-1 min-w-0">
-                  <Input
-                    value={item.description}
-                    onChange={(e) => {
-                      const updated = [...editCriteriaItems];
-                      updated[index] = { ...updated[index], description: e.target.value };
-                      setEditCriteriaItems(updated);
-                    }}
-                    placeholder={t("acceptanceCriteria.criterionPlaceholder")}
-                    className="border-[#E5E2DC] text-sm focus-visible:ring-[#C67A52] h-8"
-                  />
-                </div>
-                <div className="flex items-center gap-2 shrink-0 pt-1">
-                  <Switch
-                    checked={item.required ?? true}
-                    onCheckedChange={(checked) => {
-                      const updated = [...editCriteriaItems];
-                      updated[index] = { ...updated[index], required: checked };
-                      setEditCriteriaItems(updated);
-                    }}
-                    className="data-[state=checked]:bg-[#C67A52]"
-                  />
-                  <span className="text-[10px] font-medium text-[#6B6B6B] min-w-[52px]">
-                    {(item.required ?? true) ? t("acceptanceCriteria.required") : t("acceptanceCriteria.optional")}
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-7 p-0 border-[#E5E2DC] text-[#9A9A9A] hover:text-[#D32F2F] hover:border-[#D32F2F] hover:bg-[#FFEBEE]"
-                    onClick={() => {
-                      setEditCriteriaItems(editCriteriaItems.filter((_, i) => i !== index));
-                    }}
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-8 gap-1.5 border-[#E5E2DC] text-xs text-[#6B6B6B] hover:text-[#C67A52] hover:border-[#C67A52]"
-          onClick={() => {
-            setEditCriteriaItems([...editCriteriaItems, { description: "", required: true }]);
-          }}
-        >
-          <Plus className="h-3 w-3" />
-          {t("acceptanceCriteria.addCriterion")}
-        </Button>
+        <AcceptanceCriteriaEditor
+          items={editCriteriaItems}
+          onChange={setEditCriteriaItems}
+        />
       </div>
 
       {/* Dependencies section in edit/create form */}

--- a/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts
@@ -2,9 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 import { getServerAuthContext } from "@/lib/auth-server";
-import { claimTask, getTaskByUuid, updateTask, releaseTask, createTask, deleteTask, checkAcceptanceCriteriaGate } from "@/services/task.service";
+import { claimTask, getTaskByUuid, updateTask, releaseTask, createTask, deleteTask, checkAcceptanceCriteriaGate, replaceAcceptanceCriteria } from "@/services/task.service";
 import { getAssignableAgents, getCompanyUsers } from "@/services/agent.service";
 import { createActivity } from "@/services/activity.service";
+import type { AcceptanceCriteriaItemInput } from "@/lib/acceptance-criteria";
 import logger from "@/lib/logger";
 
 export async function claimTaskAction(taskUuid: string) {
@@ -319,6 +320,7 @@ interface UpdateTaskFieldsInput {
   priority?: string;
   storyPoints?: number | null;
   acceptanceCriteria?: string | null;
+  acceptanceCriteriaItems?: AcceptanceCriteriaItemInput[];
 }
 
 export async function updateTaskFieldsAction(input: UpdateTaskFieldsInput) {
@@ -341,11 +343,18 @@ export async function updateTaskFieldsAction(input: UpdateTaskFieldsInput) {
       acceptanceCriteria: input.acceptanceCriteria,
     });
 
+    // Only replace structured acceptance criteria when the client explicitly
+    // sends them (i.e. they actually changed). Omitting the field leaves the
+    // existing criteria — and their dev/admin verification marks — untouched.
+    if (input.acceptanceCriteriaItems !== undefined) {
+      await replaceAcceptanceCriteria(auth.companyUuid, input.taskUuid, input.acceptanceCriteriaItems);
+    }
+
     revalidatePath(`/projects/${input.projectUuid}/tasks`);
     return { success: true };
   } catch (error) {
     logger.error({ err: error }, "Failed to update task");
-    return { success: false, error: "Failed to update task" };
+    return { success: false, error: error instanceof Error ? error.message : "Failed to update task" };
   }
 }
 

--- a/src/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel.tsx
@@ -42,6 +42,11 @@ import {
 } from "./[taskUuid]/source-actions";
 import { MarkdownContent } from "@/components/markdown-content";
 import { ContentWithMentions } from "@/components/mention-renderer";
+import {
+  AcceptanceCriteriaEditor,
+  acCriteriaChanged,
+  type AcceptanceCriteriaItemDraft,
+} from "@/components/acceptance-criteria-editor";
 import { AssignTaskModal } from "./assign-task-modal";
 import {
   getTaskDependenciesAction,
@@ -274,8 +279,11 @@ export function TaskDetailPanel({
   const [editStoryPoints, setEditStoryPoints] = useState<string>(
     task?.storyPoints != null ? String(task.storyPoints) : ""
   );
-  const [editAcceptanceCriteria, setEditAcceptanceCriteria] = useState(
-    task?.acceptanceCriteria || ""
+  const [editCriteriaItems, setEditCriteriaItems] = useState<AcceptanceCriteriaItemDraft[]>(
+    (task?.acceptanceCriteriaItems ?? []).map((item) => ({
+      description: item.description,
+      required: item.required ?? true,
+    }))
   );
   const [isSaving, setIsSaving] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
@@ -343,10 +351,15 @@ export function TaskDetailPanel({
       setEditDescription(task.description || "");
       setEditPriority(task.priority);
       setEditStoryPoints(task.storyPoints != null ? String(task.storyPoints) : "");
-      setEditAcceptanceCriteria(task.acceptanceCriteria || "");
+      setEditCriteriaItems(
+        (task.acceptanceCriteriaItems ?? []).map((item) => ({
+          description: item.description,
+          required: item.required ?? true,
+        }))
+      );
       setEditError(null);
     }
-  }, [task?.uuid, task?.title, task?.description, task?.priority, task?.storyPoints, task?.acceptanceCriteria]);
+  }, [task?.uuid, task?.title, task?.description, task?.priority, task?.storyPoints, task?.acceptanceCriteriaItems]);
 
   const handleStatusChange = async (newStatus: string) => {
     if (!task) return;
@@ -365,7 +378,12 @@ export function TaskDetailPanel({
     setEditDescription(task.description || "");
     setEditPriority(task.priority);
     setEditStoryPoints(task.storyPoints != null ? String(task.storyPoints) : "");
-    setEditAcceptanceCriteria(task.acceptanceCriteria || "");
+    setEditCriteriaItems(
+      (task.acceptanceCriteriaItems ?? []).map((item) => ({
+        description: item.description,
+        required: item.required ?? true,
+      }))
+    );
     setEditError(null);
     setIsEditing(true);
   };
@@ -381,7 +399,12 @@ export function TaskDetailPanel({
       setEditDescription(task.description || "");
       setEditPriority(task.priority);
       setEditStoryPoints(task.storyPoints != null ? String(task.storyPoints) : "");
-      setEditAcceptanceCriteria(task.acceptanceCriteria || "");
+      setEditCriteriaItems(
+        (task.acceptanceCriteriaItems ?? []).map((item) => ({
+          description: item.description,
+          required: item.required ?? true,
+        }))
+      );
     }
     setEditError(null);
   };
@@ -404,7 +427,7 @@ export function TaskDetailPanel({
         description: editDescription.trim() || undefined,
         priority: editPriority,
         storyPoints: storyPointsValue,
-        acceptanceCriteria: editAcceptanceCriteria.trim() || null,
+        acceptanceCriteria: null,
       });
 
       setIsSaving(false);
@@ -424,6 +447,27 @@ export function TaskDetailPanel({
         setEditError(result.error || t("tasks.createFailed"));
       }
     } else {
+      // Compute change-detection on structured AC: only send the new items
+      // when they actually differ from the task's current items, so unchanged
+      // saves preserve dev/admin verification marks. Filter blank rows first
+      // because the editor allows in-progress empty inputs.
+      const originalItems: AcceptanceCriteriaItemDraft[] = (task!.acceptanceCriteriaItems ?? []).map(
+        (item) => ({ description: item.description, required: item.required ?? true })
+      );
+      const filteredEdited = editCriteriaItems.filter(
+        (item) => item.description.trim().length > 0
+      );
+      const acChanged = acCriteriaChanged(originalItems, filteredEdited);
+
+      // Empty-set guard: if the user wiped all AC, surface the existing
+      // required-AC validation message inline rather than letting the server
+      // reject with a 500.
+      if (acChanged && filteredEdited.length === 0) {
+        setIsSaving(false);
+        setEditError(t("acceptanceCriteria.atLeastOneRequired"));
+        return;
+      }
+
       const result = await updateTaskFieldsAction({
         taskUuid: task!.uuid,
         projectUuid,
@@ -431,7 +475,14 @@ export function TaskDetailPanel({
         description: editDescription.trim() || null,
         priority: editPriority,
         storyPoints: storyPointsValue,
-        acceptanceCriteria: editAcceptanceCriteria.trim() || null,
+        ...(acChanged
+          ? {
+              acceptanceCriteriaItems: filteredEdited.map((item) => ({
+                description: item.description.trim(),
+                required: item.required,
+              })),
+            }
+          : {}),
       });
 
       setIsSaving(false);
@@ -574,15 +625,12 @@ export function TaskDetailPanel({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="edit-acceptance-criteria" className="text-[13px] font-medium text-[#2C2C2C]">
-          {t("tasks.acceptanceCriteriaLabel")}
+        <Label className="text-[13px] font-medium text-[#2C2C2C]">
+          {t("acceptanceCriteria.title")}
         </Label>
-        <Textarea
-          id="edit-acceptance-criteria"
-          value={editAcceptanceCriteria}
-          onChange={(e) => setEditAcceptanceCriteria(e.target.value)}
-          rows={4}
-          className="border-[#E5E0D8] text-sm resize-none focus-visible:ring-[#C67A52]"
+        <AcceptanceCriteriaEditor
+          items={editCriteriaItems}
+          onChange={setEditCriteriaItems}
         />
       </div>
 

--- a/src/components/__tests__/acceptance-criteria-editor.test.ts
+++ b/src/components/__tests__/acceptance-criteria-editor.test.ts
@@ -1,0 +1,95 @@
+/**
+ * acceptance-criteria-editor.test.ts
+ *
+ * Unit tests for the change-detection helper exported alongside
+ * AcceptanceCriteriaEditor. The component itself is rendered via React in the
+ * panels — vitest here runs in node (no jsdom), so we cover the pure helper
+ * that both panels consume to decide whether to call replaceAcceptanceCriteria
+ * on save.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  acCriteriaChanged,
+  type AcceptanceCriteriaItemDraft,
+} from "../acceptance-criteria-editor";
+
+const item = (
+  description: string,
+  required: boolean
+): AcceptanceCriteriaItemDraft => ({ description, required });
+
+describe("acCriteriaChanged", () => {
+  it("returns false for two empty arrays", () => {
+    expect(acCriteriaChanged([], [])).toBe(false);
+  });
+
+  it("returns false when rows are byte-identical", () => {
+    const original = [item("desc A", true), item("desc B", false)];
+    const edited = [item("desc A", true), item("desc B", false)];
+    expect(acCriteriaChanged(original, edited)).toBe(false);
+  });
+
+  it("ignores leading/trailing whitespace differences in description", () => {
+    const original = [item("desc A", true)];
+    const edited = [item("  desc A  ", true)];
+    expect(acCriteriaChanged(original, edited)).toBe(false);
+  });
+
+  it("returns true when a description text changes", () => {
+    const original = [item("desc A", true)];
+    const edited = [item("desc A!", true)];
+    expect(acCriteriaChanged(original, edited)).toBe(true);
+  });
+
+  it("returns true when the required flag flips", () => {
+    const original = [item("desc A", true)];
+    const edited = [item("desc A", false)];
+    expect(acCriteriaChanged(original, edited)).toBe(true);
+  });
+
+  it("returns true when a row is added", () => {
+    const original = [item("desc A", true)];
+    const edited = [item("desc A", true), item("desc B", true)];
+    expect(acCriteriaChanged(original, edited)).toBe(true);
+  });
+
+  it("returns true when a row is removed", () => {
+    const original = [item("desc A", true), item("desc B", true)];
+    const edited = [item("desc A", true)];
+    expect(acCriteriaChanged(original, edited)).toBe(true);
+  });
+
+  it("returns true when rows are reordered", () => {
+    const original = [item("desc A", true), item("desc B", false)];
+    const edited = [item("desc B", false), item("desc A", true)];
+    expect(acCriteriaChanged(original, edited)).toBe(true);
+  });
+
+  it("returns true when the only change is a required-flag flip mid-list", () => {
+    const original = [
+      item("desc A", true),
+      item("desc B", true),
+      item("desc C", false),
+    ];
+    const edited = [
+      item("desc A", true),
+      item("desc B", false), // flipped
+      item("desc C", false),
+    ];
+    expect(acCriteriaChanged(original, edited)).toBe(true);
+  });
+
+  it("treats whitespace-only edits across multiple rows as unchanged", () => {
+    const original = [item("desc A", true), item("desc B", false)];
+    const edited = [item("desc A   ", true), item("\tdesc B\n", false)];
+    expect(acCriteriaChanged(original, edited)).toBe(false);
+  });
+
+  it("returns true when comparing empty original to a populated edit", () => {
+    expect(acCriteriaChanged([], [item("desc A", true)])).toBe(true);
+  });
+
+  it("returns true when comparing populated original to empty edit", () => {
+    expect(acCriteriaChanged([item("desc A", true)], [])).toBe(true);
+  });
+});

--- a/src/components/acceptance-criteria-editor.tsx
+++ b/src/components/acceptance-criteria-editor.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+
+/**
+ * Draft shape for a single acceptance criterion row in the editor.
+ * Mirrors the minimum fields the UI needs to add / edit / persist a row.
+ * Both the Task Draft panel (proposal stage) and the Task Detail panel
+ * (post-materialize) consume this same shape.
+ */
+export interface AcceptanceCriteriaItemDraft {
+  description: string;
+  required: boolean;
+}
+
+interface AcceptanceCriteriaEditorProps {
+  items: AcceptanceCriteriaItemDraft[];
+  onChange: (items: AcceptanceCriteriaItemDraft[]) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Controlled editor for a list of acceptance criteria.
+ *
+ * Renders one row per item: a description Input, a `required` Switch with
+ * required/optional label, and a delete button. A bottom "Add Criterion"
+ * button appends a fresh row with `{ description: "", required: true }`.
+ *
+ * Owns no persistence and no validation: callers supply `items` and
+ * `onChange`, and decide when/how to save (e.g. filter empty rows on save,
+ * call change-detection via `acCriteriaChanged`).
+ */
+export function AcceptanceCriteriaEditor({
+  items,
+  onChange,
+  disabled,
+}: AcceptanceCriteriaEditorProps) {
+  const t = useTranslations();
+
+  const updateAt = (index: number, patch: Partial<AcceptanceCriteriaItemDraft>) => {
+    const next = items.slice();
+    next[index] = { ...next[index], ...patch };
+    onChange(next);
+  };
+
+  const removeAt = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  const append = () => {
+    onChange([...items, { description: "", required: true }]);
+  };
+
+  return (
+    <div className="space-y-3">
+      {items.length > 0 && (
+        <div className="space-y-2">
+          {items.map((item, index) => (
+            <div
+              key={index}
+              className="flex items-start gap-2 rounded-lg border border-[#E5E2DC] bg-[#FAF8F4] p-2.5"
+            >
+              <div className="flex-1 min-w-0">
+                <Input
+                  value={item.description}
+                  onChange={(e) => updateAt(index, { description: e.target.value })}
+                  placeholder={t("acceptanceCriteria.criterionPlaceholder")}
+                  className="border-[#E5E2DC] text-sm focus-visible:ring-[#C67A52] h-8"
+                  disabled={disabled}
+                />
+              </div>
+              <div className="flex items-center gap-2 shrink-0 pt-1">
+                <Switch
+                  checked={item.required}
+                  onCheckedChange={(checked) => updateAt(index, { required: checked })}
+                  className="data-[state=checked]:bg-[#C67A52]"
+                  disabled={disabled}
+                />
+                <span className="text-[10px] font-medium text-[#6B6B6B] min-w-[52px]">
+                  {item.required
+                    ? t("acceptanceCriteria.required")
+                    : t("acceptanceCriteria.optional")}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 w-7 p-0 border-[#E5E2DC] text-[#9A9A9A] hover:text-[#D32F2F] hover:border-[#D32F2F] hover:bg-[#FFEBEE]"
+                  onClick={() => removeAt(index)}
+                  disabled={disabled}
+                  type="button"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-8 gap-1.5 border-[#E5E2DC] text-xs text-[#6B6B6B] hover:text-[#C67A52] hover:border-[#C67A52]"
+        onClick={append}
+        disabled={disabled}
+        type="button"
+      >
+        <Plus className="h-3 w-3" />
+        {t("acceptanceCriteria.addCriterion")}
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Normalize a row for comparison: trim description, coerce required to a
+ * boolean. Order is preserved by the caller (we compare arrays index-wise).
+ */
+function normalizeRow(item: AcceptanceCriteriaItemDraft): {
+  description: string;
+  required: boolean;
+} {
+  return {
+    description: item.description.trim(),
+    required: Boolean(item.required),
+  };
+}
+
+/**
+ * Returns true if the edited acceptance-criteria rows differ from the
+ * original set in a way that requires a server-side replace. Compares:
+ *
+ *   - trimmed description
+ *   - boolean `required` flag
+ *   - row order (index-wise)
+ *
+ * Whitespace-only differences are ignored (`"foo "` and `"foo"` are equal).
+ *
+ * Used by both panels (Task Draft + Task Detail in Task 2) to decide whether
+ * to call `replaceAcceptanceCriteria` on save — skipping the call when the
+ * set is unchanged preserves dev/admin verification marks.
+ */
+export function acCriteriaChanged(
+  original: AcceptanceCriteriaItemDraft[],
+  edited: AcceptanceCriteriaItemDraft[]
+): boolean {
+  if (original.length !== edited.length) return true;
+  for (let i = 0; i < original.length; i++) {
+    const a = normalizeRow(original[i]);
+    const b = normalizeRow(edited[i]);
+    if (a.description !== b.description) return true;
+    if (a.required !== b.required) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

The real Task edit form rendered acceptance criteria as a legacy Markdown `<Textarea>`, while the Task Draft panel used a structured-rows editor (one row per item with a `required` toggle). Every other editable field on the form was already aligned with the draft panel — only the AC editor had drifted.

This PR closes that gap:

- Extracts the structured AC editor into a shared controlled component so the draft panel and the real-task panel render identical UI by construction (they can no longer drift).
- Persists real-task AC edits through the existing `replaceAcceptanceCriteria` service via a small extension to `updateTaskFieldsAction` — no new service, REST endpoint, or schema change.
- Uses client-side change detection so editing a non-AC field (title, description, priority, storyPoints) does **not** trigger the destructive replace — existing dev/admin verification marks survive.
- Empty-clear guard: if a user wipes all criteria, the form blocks Save with the existing required-AC i18n message rather than letting the server throw.

OpenSpec change `align-task-edit-ui-with-draft` is included and archived in this PR.

## Changed files

| File | Change |
|------|--------|
| `src/components/acceptance-criteria-editor.tsx` | **New.** Shared controlled `AcceptanceCriteriaEditor` + `AcceptanceCriteriaItemDraft` type + `acCriteriaChanged(original, edited)` change-detection helper. |
| `src/components/__tests__/acceptance-criteria-editor.test.ts` | **New.** 12 unit tests for `acCriteriaChanged`: identical, whitespace-only, length, description text, required flip, mid-list flip, reorder, add/remove, empty↔populated. |
| `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/task-draft-detail-panel.tsx` | Replaces ~60 lines of inline AC editor JSX with `<AcceptanceCriteriaEditor>`. Behavior preserved (empty-row filtering on save remains in `handleSave`). |
| `src/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel.tsx` | Removes legacy `<Textarea>` + `editAcceptanceCriteria` string state. Adds `editCriteriaItems` seeded from `task.acceptanceCriteriaItems`, mounts the shared editor, and conditionally spreads `acceptanceCriteriaItems` into `updateTaskFieldsAction` only when `acCriteriaChanged` is true. Empty-set guard short-circuits with the i18n required-AC message. |
| `src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts` | Extends `UpdateTaskFieldsInput` with optional `acceptanceCriteriaItems`. After `updateTask(...)`, when the field is provided (`!== undefined`) routes it to `replaceAcceptanceCriteria`. Auth/scoping/error-handling preserved; required-AC error surfaced verbatim. |
| `messages/en.json`, `messages/zh.json` | Adds `acceptanceCriteria.atLeastOneRequired` for the empty-clear inline error in both locales. |
| `openspec/changes/archive/2026-06-07-align-task-edit-ui-with-draft/` | OpenSpec change archive (proposal/design/spec/tasks). |
| `openspec/specs/task-edit-ui/spec.md` | New long-term spec for the `task-edit-ui` capability, emitted by `openspec archive`. |

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [x] `pnpm test -- src/components/__tests__/acceptance-criteria-editor.test.ts` → 12/12 pass
- [x] `npx eslint` on the touched files → exit 0 (warnings only, all pre-existing)
- [ ] Manual: open a task with passed-AC and edit the title — verify Save preserves the green AC marks
- [ ] Manual: open a task and add/edit/remove a criterion — verify Save replaces the set and resets verification marks
- [ ] Manual: open a task, delete every criterion in the editor, click Save — verify the inline "at least one acceptance criterion required" message appears and no server call is made
- [ ] Manual: confirm the draft panel's AC editor still works identically

## Out of scope / follow-ups

- `docs/design.pen` update for the new Task panel AC editor — Pencil MCP bridge to VS Code was unreachable during this work; will be picked up in a small follow-up once Pencil connectivity is restored.
- Removing the legacy `task.acceptanceCriteria` Markdown column — left in the model since it requires a migration; noted as future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)