### PR TITLE
fix(landing): pin Cloudflare deploy as static assets

### DIFF
--- a/packages/landing/wrangler.jsonc
+++ b/packages/landing/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "chorus-landing",
+  "compatibility_date": "2026-06-09",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `packages/landing/wrangler.jsonc` declaring an assets-only deploy so Cloudflare stops auto-injecting a `SESSION` KV binding for the static landing site.

## Why
Cloudflare's Workers Builds Astro framework preset silently pulls in `@astrojs/cloudflare`, which unconditionally writes `kv_namespaces: [{ binding: "SESSION" }]` into the generated `dist/server/wrangler.json` — even when `output: 'static'` (see [withastro/astro#15802](https://github.com/withastro/astro/issues/15802)). The auto-provisioning step then re-creates the namespace on every deploy and fails with `10014: a namespace with this account ID and title already exists` after the first run.

A repo-level `wrangler.jsonc` overrides the framework preset and tells wrangler to deploy `dist/` as plain static assets — no adapter, no KV.

## Changed files
| File | Change |
|------|--------|
| `packages/landing/wrangler.jsonc` | New: declares static-assets deployment, no bindings |

## Test plan
- [ ] After merge, trigger Cloudflare deploy and confirm log no longer contains `Provisioning SESSION (KV Namespace)...`
- [ ] Confirm landing page still serves `dist/` correctly at chorus-ai.dev

Generated with [Claude Code](https://claude.com/claude-code)