### PR TITLE
develop -> main: landing Cloudflare static assets fix

### DIFF
--- a/packages/landing/wrangler.jsonc
+++ b/packages/landing/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "chorus-landing",
+  "compatibility_date": "2026-06-09",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
## Summary
Promote `develop` to `main`. Single commit:

- `7a1c600` fix(landing): pin Cloudflare deploy as static assets to avoid SESSION KV auto-provision (#303)

## Why
Cloudflare's Astro framework preset was auto-injecting a `SESSION` KV binding into the landing site's deploy, breaking redeploys with `10014: namespace already exists`. Adding `packages/landing/wrangler.jsonc` overrides the preset and ships `dist/` as plain static assets.

## Merge instructions
**Do not squash.** Use a regular merge commit so the develop history is preserved on main and CI is triggered.

Generated with [Claude Code](https://claude.com/claude-code)