### PR TITLE
feat(idea): expose parentUuid on lightweight idea-read MCP surfaces

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -202,7 +202,7 @@ Tools available to all Agents.
     "<project-uuid>": {
       "name": "Project name",
       "ideas": [
-        { "uuid": "...", "title": "...", "status": "in_progress", "proposals": 1, "tasks": 3 }
+        { "uuid": "...", "title": "...", "status": "in_progress", "proposals": 1, "tasks": 3, "parentUuid": null }
       ]
     }
   },
@@ -212,6 +212,8 @@ Tools available to all Agents.
   }
 }
 ```
+
+Each idea entry carries the stored single-parent lineage edge as `parentUuid` (or `null` for top-level ideas) — this lightweight surface exposes `parentUuid` ONLY, not `childCount` (which stays exclusive to `chorus_get_ideas` / `chorus_get_idea`).
 
 > The legacy 0.6.x shape (`roles: ["developer"]`, `assignments`, `pending`) was replaced in 0.6.6 by the project-grouped `ideaTracker` and in 0.7.0 by the resource-aggregated `permissions` object. The old fields are no longer returned.
 
@@ -398,7 +400,8 @@ Tools available to all Agents.
           "title": "...",
           "status": "in_progress",
           "proposals": 1,
-          "tasks": 3
+          "tasks": 3,
+          "parentUuid": null
         }
       ]
     }
@@ -421,7 +424,7 @@ Tools available to all Agents.
 }
 ```
 
-Each idea entry's `status` is the derived status (`todo` / `in_progress` / `human_conduct_required`); each task entry's `ac` reports admin-verified acceptance-criteria progress.
+Each idea entry's `status` is the derived status (`todo` / `in_progress` / `human_conduct_required`); each task entry's `ac` reports admin-verified acceptance-criteria progress. Each idea entry also carries the stored single-parent lineage edge as `parentUuid` (or `null` for top-level ideas) — this lightweight surface exposes `parentUuid` ONLY, not `childCount` (which stays exclusive to `chorus_get_ideas` / `chorus_get_idea`).
 
 > **BREAKING (0.7.2)**: prior to 0.7.2 this tool returned a flat `{ ideas: [], tasks: [] }`. The new shape aligns 1:1 with `chorus_checkin.ideaTracker`.
 
@@ -434,7 +437,7 @@ Each idea entry's `status` is the derived status (`todo` / `in_progress` / `huma
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
 
-**Output**: List of claimable Ideas
+**Output**: List of claimable Ideas. Each entry carries the stored single-parent lineage edge as `parentUuid` (or `null` for top-level ideas) — this lightweight surface exposes `parentUuid` ONLY, not `childCount` (which stays exclusive to `chorus_get_ideas` / `chorus_get_idea`).
 
 ### chorus_get_available_tasks
 

--- a/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/README.md
+++ b/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/README.md
@@ -1,0 +1,3 @@
+# lineage-parentuuid-lightweight-surfaces
+
+Propagate the stored Idea.parentUuid lineage edge onto the lightweight idea-read MCP surfaces (get_available_ideas + idea tracker)

--- a/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/design.md
+++ b/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/design.md
@@ -1,0 +1,46 @@
+# Design: `parentUuid` on lightweight idea-read surfaces
+
+## Context
+
+`add-idea-lineage` stored the edge as `Idea.parentUuid` (nullable self-relation) and surfaced it on the rich reads. The two lightweight surfaces have independent select-projections that pre-date lineage, so they silently drop the field. This change is a pure projection-widening: add one column to two `select`s and thread it through two response mappers. No new queries, no rollup, no N+1 concern.
+
+## Surfaces and their backing code
+
+### 1. `chorus_get_available_ideas` → `assignment.service.getAvailableItems`
+
+Today the idea branch selects `{ uuid, title, content, status, createdByUuid, createdAt }` and `formatAvailableIdea` maps to `AvailableIdeaResponse`. The change:
+
+- `AvailableIdeaResponse` gains `parentUuid: string | null`.
+- The `prisma.idea.findMany` `select` gains `parentUuid: true`.
+- `formatAvailableIdea`'s input type gains `parentUuid: string | null` and the return object sets `parentUuid: idea.parentUuid ?? null`.
+
+`formatAvailableIdea` is `async` (it resolves `createdBy`); adding a synchronous field does not change its shape.
+
+### 2 & 3. `chorus_get_my_assignments` + `chorus_checkin` → `idea-tracker.service.buildIdeaTracker`
+
+Both surfaces render the idea tracker through the single `buildIdeaTracker` function, so one edit covers both (this shared-shape invariant is the whole reason `idea-tracker.service` exists — see its header comment). The change:
+
+- `IdeaTrackerEntry` gains `parentUuid: string | null`.
+- The `prisma.idea.findMany` `select` (Q1 in `buildIdeaTracker`) gains `parentUuid: true`.
+- The `tracker[projectUuid].ideas.push({...})` object sets `parentUuid: idea.parentUuid ?? null`.
+
+`checkin.service.ts` declares its own `CheckinIdea` interface that is structurally parallel to `IdeaTrackerEntry` but is a **separate type** (it is the static type of `CheckinResponse.ideaTracker`). The runtime value already comes from `buildIdeaTracker`, so the value is correct regardless; but to keep the declared `chorus_checkin` response type accurate, `CheckinIdea` also gains `parentUuid: string | null`. This is a type-only edit — no runtime behavior change in `checkin.service`.
+
+## Field semantics
+
+- `parentUuid` is the **stored** edge, surfaced verbatim. `null` for a top-level idea.
+- No `childCount`, no `parent` title — those remain exclusive to `chorus_get_ideas` / `chorus_get_idea` (elaboration q2 = a). An agent that needs the rollup or parent title makes one `chorus_get_idea` call.
+- Normalization: emit `idea.parentUuid ?? null` so the field is always present (never `undefined`) in the JSON payload, matching how `listIdeas` does it (`ideas[i].parentUuid = raw.parentUuid ?? null`).
+
+## Query budget
+
+Zero new queries. `parentUuid` is an already-indexed scalar column on rows both surfaces already fetch; it rides along in the existing `select`. The tracker's documented "4 prisma calls" budget is unchanged, and `getAvailableItems` stays at its single idea fetch.
+
+## Testing
+
+- `assignment.service.test.ts` — the existing `getAvailableItems` fixtures return raw idea rows; extend a fixture row with `parentUuid` and assert the formatted response carries it (and that a row without a parent yields `null`).
+- `idea-tracker.service.test.ts` — extend a `buildIdeaTracker` fixture idea with `parentUuid` and assert the tracker entry carries it through; assert a parentless idea yields `null`. Because `checkin` and `my_assignments` both call `buildIdeaTracker`, the single tracker test covers both surfaces' runtime behavior.
+
+## Risks
+
+- **Low.** Additive field only; no consumer removes or renames anything. Existing clients ignoring unknown fields are unaffected. The only failure mode is forgetting to update one of the two parallel interfaces (`IdeaTrackerEntry` vs `CheckinIdea`), which `tsc --noEmit` catches.

--- a/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/proposal.md
+++ b/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/proposal.md
@@ -1,0 +1,56 @@
+# Proposal: Propagate `parentUuid` to the lightweight idea-read MCP surfaces
+
+## Why
+
+The `add-idea-lineage` change (0.10.0) added a single-parent `Idea.parentUuid` self-relation and exposed it on the two "rich" idea-read surfaces — `chorus_get_idea` (full `parent` / `children[]` / `descendantUuids`) and `chorus_get_ideas` (`parentUuid` + `childCount` rollup). The remaining idea-returning surfaces were left on their pre-lineage shapes, so an agent's view of "does this idea have a parent" is inconsistent across tools:
+
+| MCP surface | Returns `parentUuid` today? | Backing |
+|---|---|---|
+| `chorus_get_idea` | ✅ yes (+ `parent`, `children[]`, `descendantUuids`) | `idea.service` |
+| `chorus_get_ideas` | ✅ yes (+ `childCount`) | `idea.service` `listIdeas` |
+| `chorus_get_available_ideas` | ❌ no | `assignment.service` `getAvailableItems` |
+| `chorus_get_my_assignments` | ❌ no | `idea-tracker.service` `buildIdeaTracker` |
+| `chorus_checkin` (`ideaTracker`) | ❌ no | same `idea-tracker.service` shape |
+| `chorus_search` (idea hits) | ❌ no | `search.service` generic result |
+
+Concrete pain:
+
+1. An agent discovering claimable work via `chorus_get_available_ideas` cannot tell that an open idea is the child of another idea without a second `chorus_get_idea` round-trip.
+2. The `checkin` / `get_my_assignments` tracker views show no lineage, so an agent cannot reason about its assigned ideas' hierarchy at a glance.
+3. The lineage forest is currently only buildable from `chorus_get_ideas`; the lightweight discovery/tracker surfaces are blind to it.
+
+## What Changes
+
+Confirmed scope from elaboration (Round 1, all answered):
+
+- **q1 = b** — enrich `chorus_get_available_ideas` **and** the shared idea-tracker shape (`chorus_get_my_assignments` + `chorus_checkin`). Leave `chorus_search` alone (its result type is generic across task/idea/proposal/document/project, so an idea-only field is a poor fit there).
+- **q2 = a** — add **only** `parentUuid`. No `childCount` rollup, no parent title. Agents needing more fall back to `chorus_get_idea`.
+- **q3 = a** — pure agent-facing payload enrichment. **No** frontend tracker UI changes.
+
+Resulting edits:
+
+- **`assignment.service.ts`** — add `parentUuid` to the `AvailableIdeaResponse` type, the `idea.findMany` `select` in `getAvailableItems`, and the `formatAvailableIdea` mapper. Surfaces on `chorus_get_available_ideas`.
+- **`idea-tracker.service.ts`** — add `parentUuid` to the `IdeaTrackerEntry` type, the `idea.findMany` `select` in `buildIdeaTracker`, and the pushed entry. Surfaces on **both** `chorus_get_my_assignments` and `chorus_checkin` in one edit (they share `buildIdeaTracker`).
+- **`checkin.service.ts`** — add `parentUuid` to the structurally-parallel `CheckinIdea` interface so the `chorus_checkin` response type stays accurate (the runtime value already flows through `buildIdeaTracker`).
+- **`docs/MCP_TOOLS.md`** — update the example payloads / field notes for the three tools to show `parentUuid`.
+
+### Explicitly out of scope
+
+- No `childCount` / parent-title rollup on these lightweight surfaces (q2 = a).
+- No `chorus_search` change (q1 = b).
+- No frontend / tracker UI change (q3 = a).
+- No schema change — `parentUuid` already exists on `Idea`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `idea-lineage`: extend the "Read-Only Direct-Child Rollup" surface contract so the lightweight discovery and tracker reads also carry the stored `parentUuid` edge (the field only, not the `childCount` rollup).
+
+## Impact
+
+- **Schema**: zero migrations. `Idea.parentUuid` already exists from `add-idea-lineage`.
+- **Backend code**: `src/services/assignment.service.ts`, `src/services/idea-tracker.service.ts`, `src/services/checkin.service.ts`.
+- **Tests**: `src/services/__tests__/assignment.service.test.ts`, `src/services/__tests__/idea-tracker.service.test.ts` — extend the existing fixtures to assert `parentUuid` is carried through.
+- **Docs**: `docs/MCP_TOOLS.md` example payloads for `chorus_checkin`, `chorus_get_my_assignments`, `chorus_get_available_ideas`.
+- **No MCP tool added or removed**; no permission-map change; no i18n; no `design.pen` (no UI surface touched).

--- a/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/specs/idea-lineage/spec.md
+++ b/openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/specs/idea-lineage/spec.md
@@ -1,0 +1,46 @@
+# idea-lineage delta — propagate `parentUuid` to lightweight idea-read surfaces
+
+## MODIFIED Requirements
+
+### Requirement: Read-Only Direct-Child Rollup
+
+The system SHALL expose a read-only rollup of an idea's **direct** children only (not the recursive subtree). `chorus_get_idea` SHALL return the idea's `parent` and `children[]`. `chorus_get_ideas` SHALL return `parentUuid` and a `childCount` of direct children for each idea. The rollup SHALL be computed without per-idea N+1 queries.
+
+The system MAY additionally provide an on-demand transitive-descendant lookup for a **single** idea, used only to support cycle-aware UI affordances (see "Idea Detail Lineage Section"). This single-idea lookup is distinct from the direct-child list rollup and does not change the rollup's direct-children-only semantics.
+
+The stored single-parent edge SHALL additionally be carried on the lightweight idea-read surfaces so an agent's view of lineage is consistent across discovery and tracker tools without a follow-up `chorus_get_idea` round-trip. Specifically, `chorus_get_available_ideas`, `chorus_get_my_assignments`, and the `ideaTracker` of `chorus_checkin` SHALL each include `parentUuid` (the stored edge, or `null` for a top-level idea) on every idea entry. These lightweight surfaces SHALL carry the `parentUuid` field **only** — they SHALL NOT include the `childCount` rollup or the parent title, which remain exclusive to `chorus_get_ideas` / `chorus_get_idea`. Adding `parentUuid` to these surfaces SHALL NOT introduce additional database queries — it rides along in the existing idea `select` projection. `chorus_search` idea hits SHALL NOT be modified, because the search result type is generic across all entity types.
+
+#### Scenario: Detail view returns parent and children
+
+- **WHEN** `chorus_get_idea` is called for an idea with a parent and two children
+- **THEN** the response includes the parent reference and a `children[]` array of length 2
+
+#### Scenario: List view returns child counts
+
+- **WHEN** `chorus_get_ideas` is called for a project
+- **THEN** each idea includes its `parentUuid` and a `childCount` equal to its number of direct children
+
+#### Scenario: Available-ideas discovery surface carries the parent edge
+
+- **WHEN** `chorus_get_available_ideas` is called for a project that has a claimable idea whose `parentUuid` points at another idea
+- **THEN** that idea's entry includes `parentUuid` equal to the stored parent edge
+- **AND** a claimable top-level idea's entry includes `parentUuid` equal to `null`
+- **AND** no entry includes a `childCount` field
+
+#### Scenario: Tracker surfaces carry the parent edge
+
+- **WHEN** `chorus_get_my_assignments` or `chorus_checkin` is called and the agent's tracker includes an idea whose `parentUuid` points at another idea
+- **THEN** that idea's tracker entry includes `parentUuid` equal to the stored parent edge
+- **AND** a tracked top-level idea's entry includes `parentUuid` equal to `null`
+- **AND** the entry does not include a `childCount` field
+
+#### Scenario: Lightweight surfaces add no extra queries and no rollup
+
+- **WHEN** `chorus_get_available_ideas`, `chorus_get_my_assignments`, or `chorus_checkin` builds its idea payload
+- **THEN** `parentUuid` is sourced from the existing idea `select` projection with no additional per-idea query
+- **AND** neither `childCount` nor a parent title is computed for these surfaces
+
+#### Scenario: Search results are left unchanged
+
+- **WHEN** `chorus_search` returns idea hits
+- **THEN** the idea hit shape is unchanged and does not gain a `parentUuid` field

--- a/openspec/specs/idea-lineage/spec.md
+++ b/openspec/specs/idea-lineage/spec.md
@@ -70,6 +70,8 @@ The system SHALL expose a read-only rollup of an idea's **direct** children only
 
 The system MAY additionally provide an on-demand transitive-descendant lookup for a **single** idea, used only to support cycle-aware UI affordances (see "Idea Detail Lineage Section"). This single-idea lookup is distinct from the direct-child list rollup and does not change the rollup's direct-children-only semantics.
 
+The stored single-parent edge SHALL additionally be carried on the lightweight idea-read surfaces so an agent's view of lineage is consistent across discovery and tracker tools without a follow-up `chorus_get_idea` round-trip. Specifically, `chorus_get_available_ideas`, `chorus_get_my_assignments`, and the `ideaTracker` of `chorus_checkin` SHALL each include `parentUuid` (the stored edge, or `null` for a top-level idea) on every idea entry. These lightweight surfaces SHALL carry the `parentUuid` field **only** — they SHALL NOT include the `childCount` rollup or the parent title, which remain exclusive to `chorus_get_ideas` / `chorus_get_idea`. Adding `parentUuid` to these surfaces SHALL NOT introduce additional database queries — it rides along in the existing idea `select` projection. `chorus_search` idea hits SHALL NOT be modified, because the search result type is generic across all entity types.
+
 #### Scenario: Detail view returns parent and children
 
 - **WHEN** `chorus_get_idea` is called for an idea with a parent and two children
@@ -79,6 +81,31 @@ The system MAY additionally provide an on-demand transitive-descendant lookup fo
 
 - **WHEN** `chorus_get_ideas` is called for a project
 - **THEN** each idea includes its `parentUuid` and a `childCount` equal to its number of direct children
+
+#### Scenario: Available-ideas discovery surface carries the parent edge
+
+- **WHEN** `chorus_get_available_ideas` is called for a project that has a claimable idea whose `parentUuid` points at another idea
+- **THEN** that idea's entry includes `parentUuid` equal to the stored parent edge
+- **AND** a claimable top-level idea's entry includes `parentUuid` equal to `null`
+- **AND** no entry includes a `childCount` field
+
+#### Scenario: Tracker surfaces carry the parent edge
+
+- **WHEN** `chorus_get_my_assignments` or `chorus_checkin` is called and the agent's tracker includes an idea whose `parentUuid` points at another idea
+- **THEN** that idea's tracker entry includes `parentUuid` equal to the stored parent edge
+- **AND** a tracked top-level idea's entry includes `parentUuid` equal to `null`
+- **AND** the entry does not include a `childCount` field
+
+#### Scenario: Lightweight surfaces add no extra queries and no rollup
+
+- **WHEN** `chorus_get_available_ideas`, `chorus_get_my_assignments`, or `chorus_checkin` builds its idea payload
+- **THEN** `parentUuid` is sourced from the existing idea `select` projection with no additional per-idea query
+- **AND** neither `childCount` nor a parent title is computed for these surfaces
+
+#### Scenario: Search results are left unchanged
+
+- **WHEN** `chorus_search` returns idea hits
+- **THEN** the idea hit shape is unchanged and does not gain a `parentUuid` field
 
 ### Requirement: Delete Orphans Children To Top-Level
 

--- a/src/services/__tests__/assignment.service.test.ts
+++ b/src/services/__tests__/assignment.service.test.ts
@@ -41,6 +41,7 @@ function makeIdea(overrides: Record<string, unknown> = {}) {
     title: "Test Idea",
     content: "Idea content",
     status: "open",
+    parentUuid: null,
     createdByUuid: userUuid,
     createdAt: now,
     ...overrides,
@@ -329,6 +330,40 @@ describe("getAvailableItems", () => {
     expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         orderBy: { createdAt: "desc" },
+      })
+    );
+  });
+
+  it("should carry parentUuid through to the formatted idea response (set parent)", async () => {
+    const parentIdeaUuid = "idea-0000-0000-0000-0000000000aa";
+    const idea = makeIdea({ parentUuid: parentIdeaUuid });
+    mockPrisma.idea.findMany.mockResolvedValue([idea]);
+    mockPrisma.task.findMany.mockResolvedValue([]);
+
+    const result = await getAvailableItems(companyUuid, projectUuid, true, true);
+
+    expect(result.ideas[0].parentUuid).toBe(parentIdeaUuid);
+  });
+
+  it("should normalize a missing/null parentUuid to null", async () => {
+    const idea = makeIdea({ parentUuid: null });
+    mockPrisma.idea.findMany.mockResolvedValue([idea]);
+    mockPrisma.task.findMany.mockResolvedValue([]);
+
+    const result = await getAvailableItems(companyUuid, projectUuid, true, true);
+
+    expect(result.ideas[0].parentUuid).toBeNull();
+  });
+
+  it("should request parentUuid in the idea select projection (no extra query)", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([]);
+    mockPrisma.task.findMany.mockResolvedValue([]);
+
+    await getAvailableItems(companyUuid, projectUuid, true, true);
+
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ parentUuid: true }),
       })
     );
   });

--- a/src/services/__tests__/idea-tracker.service.test.ts
+++ b/src/services/__tests__/idea-tracker.service.test.ts
@@ -49,6 +49,7 @@ function makeIdea(
     title: `Idea ${uuid}`,
     status,
     elaborationStatus: null,
+    parentUuid: null,
     projectUuid,
     createdAt: now,
     updatedAt: now,
@@ -316,6 +317,38 @@ describe("buildIdeaTracker — proposal/task counts", () => {
 
     const tracker = await buildIdeaTracker(agentAuth);
     expect(tracker[PROJECT_A].ideas[0].proposals).toBe(0);
+  });
+});
+
+describe("buildIdeaTracker — parentUuid pass-through", () => {
+  it("requests parentUuid in the idea select projection (no extra query)", async () => {
+    await buildIdeaTracker(agentAuth);
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ parentUuid: true }),
+      }),
+    );
+  });
+
+  it("carries the stored parentUuid onto the tracker entry when set", async () => {
+    const parentIdeaUuid = "idea-pppp-pppp-pppp-pppppppppppp";
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i_child", PROJECT_A, "open", { parentUuid: parentIdeaUuid }),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].parentUuid).toBe(parentIdeaUuid);
+  });
+
+  it("normalizes a parentless idea to parentUuid: null", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i_top", PROJECT_A, "open", { parentUuid: null }),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas[0].parentUuid).toBeNull();
   });
 });
 

--- a/src/services/assignment.service.ts
+++ b/src/services/assignment.service.ts
@@ -20,6 +20,7 @@ export interface AvailableIdeaResponse {
   title: string;
   content: string | null;
   status: string;
+  parentUuid: string | null;
   createdBy: { type: string; uuid: string; name: string } | null;
   createdAt: string;
 }
@@ -57,6 +58,7 @@ async function formatAvailableIdea(idea: {
   title: string;
   content: string | null;
   status: string;
+  parentUuid: string | null;
   createdByUuid: string;
   createdAt: Date;
 }): Promise<AvailableIdeaResponse> {
@@ -67,6 +69,7 @@ async function formatAvailableIdea(idea: {
     title: idea.title,
     content: idea.content,
     status: idea.status,
+    parentUuid: idea.parentUuid ?? null,
     createdBy,
     createdAt: idea.createdAt.toISOString(),
   };
@@ -140,6 +143,7 @@ export async function getAvailableItems(
             title: true,
             content: true,
             status: true,
+            parentUuid: true,
             createdByUuid: true,
             createdAt: true,
           },

--- a/src/services/checkin.service.ts
+++ b/src/services/checkin.service.ts
@@ -33,6 +33,7 @@ export interface CheckinIdea {
   uuid: string;
   title: string;
   status: DerivedIdeaStatus;
+  parentUuid: string | null;
   proposals: number;
   tasks: number;
 }

--- a/src/services/idea-tracker.service.ts
+++ b/src/services/idea-tracker.service.ts
@@ -16,6 +16,7 @@ export interface IdeaTrackerEntry {
   uuid: string;
   title: string;
   status: DerivedIdeaStatus;
+  parentUuid: string | null;
   proposals: number;
   tasks: number;
 }
@@ -116,6 +117,7 @@ export async function buildIdeaTracker(
       title: true,
       status: true,
       elaborationStatus: true,
+      parentUuid: true,
       projectUuid: true,
       createdAt: true,
       updatedAt: true,
@@ -233,6 +235,7 @@ export async function buildIdeaTracker(
       uuid: idea.uuid,
       title: idea.title,
       status: derivedStatus,
+      parentUuid: idea.parentUuid ?? null,
       proposals: ideaProposalCount.get(idea.uuid) ?? 0,
       tasks: taskStatuses.length,
     });


### PR DESCRIPTION
## Summary
Follow-up to `add-idea-lineage` (#307). That change surfaced `parentUuid` only on the rich reads (`chorus_get_idea`, `chorus_get_ideas`), leaving the lightweight discovery and tracker reads blind to the edge — so an agent had to make a second `chorus_get_idea` round-trip just to learn whether an open idea has a parent.

This carries the stored `Idea.parentUuid` edge through the two lightweight service paths:
- `assignment.service.getAvailableItems` → `chorus_get_available_ideas`
- `idea-tracker.service.buildIdeaTracker` → `chorus_get_my_assignments` **and** `chorus_checkin` (shared shape — one edit covers both)

Field-only by design, per the resolved elaboration (q1=b, q2=a, q3=a): **no** `childCount` rollup, **no** parent title, **no** `chorus_search` change, **no** UI change. `parentUuid` rides the existing `select` projections, so **no new DB query** is added and the tracker keeps its 4-query budget. Null-normalized (`?? null`) to match the existing `listIdeas` pattern.

## Changed files
| File | Change |
|------|--------|
| `src/services/assignment.service.ts` | `parentUuid` on `AvailableIdeaResponse`, the `getAvailableItems` select, and `formatAvailableIdea` |
| `src/services/idea-tracker.service.ts` | `parentUuid` on `IdeaTrackerEntry`, the Q1 select, and the pushed entry (covers both tracker surfaces) |
| `src/services/checkin.service.ts` | `parentUuid` on the parallel `CheckinIdea` type (type accuracy; value already flows via `buildIdeaTracker`) |
| `src/services/__tests__/assignment.service.test.ts` | pass-through tests (set-parent, null, projection shape) |
| `src/services/__tests__/idea-tracker.service.test.ts` | pass-through tests (set-parent, null, projection shape) |
| `docs/MCP_TOOLS.md` | example payloads + parentUuid-only (no childCount) notes for the 3 tools |
| `openspec/specs/idea-lineage/spec.md` | archived spec merge — extends "Read-Only Direct-Child Rollup" |
| `openspec/changes/archive/2026-06-13-lineage-parentuuid-lightweight-surfaces/` | archived OpenSpec change (proposal/design/spec delta) |

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm test` — 1828 passed / 1 skipped / 0 failed (incl. 6 new pass-through tests)
- [x] `eslint` on the 3 modified service files — 0 errors / 0 warnings
- [x] Independent code review — APPROVE, no blockers
- [x] Live MCP test against local dev server: `chorus_get_available_ideas`, `chorus_get_my_assignments`, `chorus_checkin` all return correct `parentUuid` (children → parent edge, top-level → null) with no `childCount`; `chorus_search` correctly unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)