### PR TITLE
feat(dashboard): show project name & description on Idea Tracker header

### DIFF
--- a/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
@@ -16,12 +16,15 @@ export async function DashboardContent({ projectUuid, initialSelectedIdeaUuid }:
 
   return (
     <div className="flex h-full flex-col gap-5 p-5 md:p-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-medium text-[#2C2C2A]">{t("ideaTracker.overview")}</h1>
-          <p className="mt-1 text-[13px] text-[#5F5E5A]">{t("ideaTracker.overviewSubtitle")}</p>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-[#A8A39B]">{t("ideaTracker.overview")}</p>
+          <h1 className="mt-1 truncate text-2xl font-semibold tracking-tight text-[#2C2C2A]">{project.name}</h1>
+          <p className="mt-1 text-[13px] text-[#5F5E5A]">
+            {project.description?.trim() ? project.description : t("ideaTracker.overviewSubtitle")}
+          </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex shrink-0 items-center gap-3">
           <ProjectSettingsModal projectUuid={projectUuid} projectName={project.name} projectDescription={project.description ?? null} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The project dashboard (Idea Tracker) header showed a generic "Overview" title + static subtitle, never identifying the current project.
- Promote the **project name** to the H1 heading and surface the **project description** as the subtitle.
- Keep "Overview" as a small uppercase eyebrow label so the existing `ideaTracker.overview` key stays meaningful.
- Description falls back to the generic `ideaTracker.overviewSubtitle` when empty/null, so the header never renders an empty element.

## Changed files
| File | Change |
|------|--------|
| `src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx` | Header now renders `project.name` (H1) + `project.description` (subtitle, with fallback); "Overview" demoted to eyebrow label. Long names truncate; Settings action stays right-aligned with `shrink-0`. |

## Notes
- No new i18n keys needed — reuses existing `ideaTracker.overview` / `ideaTracker.overviewSubtitle`; name/description are data values.
- `project` (with `name`/`description`) was already in scope from `getDashboardData()`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `pnpm lint` (eslint on changed file) passes
- [x] Manual e2e (Playwright): header shows project name + description with description present; 0 console errors. User verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)