### PR TITLE
fix(idea): switch open panel when clicking lineage parent/child in Overview

### DIFF
--- a/src/app/(dashboard)/projects/[uuid]/dashboard/idea-tracker.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/idea-tracker.tsx
@@ -159,6 +159,7 @@ export function IdeaTracker({ projectUuid, currentUserUuid, initialTrackerData, 
           projectUuid={projectUuid}
           currentUserUuid={currentUserUuid}
           onClose={closePanel}
+          onNavigate={openPanel}
         />
       )}
     </div>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -134,6 +134,11 @@ interface IdeaDetailPanelProps {
   projectUuid: string;
   currentUserUuid: string;
   onClose: () => void;
+  // Switch the open panel to another idea (lineage parent/child, post-derive).
+  // Wired to the parent's usePanelUrl.openPanel so the panel actually re-renders
+  // for the new idea — a bare router.push of ?panel= changes the URL but not the
+  // hook's selectedId state, so the panel would never switch.
+  onNavigate?: (ideaUuid: string) => void;
 }
 
 export function IdeaDetailPanel({
@@ -141,6 +146,7 @@ export function IdeaDetailPanel({
   projectUuid,
   currentUserUuid,
   onClose,
+  onNavigate,
 }: IdeaDetailPanelProps) {
   const t = useTranslations();
   const tTracker = useTranslations("ideaTracker");
@@ -423,14 +429,14 @@ export function IdeaDetailPanel({
     setIsEditing(true);
   };
 
-  // After the derive dialog creates the child, open it in the panel.
+  // After the derive dialog creates the child, switch the panel to it.
+  // router.refresh() repaints the underlying tree/list with the new edge;
+  // onNavigate (the parent's openPanel) is what actually swaps the open panel —
+  // a bare router.push of ?panel= changes the URL but not the hook's state.
   const handleDerived = (childUuid: string) => {
     toast.success(tLineage("deriveIdea"));
     router.refresh();
-    const params = new URLSearchParams(window.location.search);
-    params.set("panel", childUuid);
-    params.set("tab", "overview");
-    router.push(`${window.location.pathname}?${params.toString()}`);
+    onNavigate?.(childUuid);
   };
 
   const handleCancelEdit = () => {
@@ -698,12 +704,7 @@ export function IdeaDetailPanel({
                         {idea.parent ? (
                           <button
                             type="button"
-                            onClick={() => {
-                              const params = new URLSearchParams(window.location.search);
-                              params.set("panel", idea.parent!.uuid);
-                              params.set("tab", "overview");
-                              router.push(`${window.location.pathname}?${params.toString()}`);
-                            }}
+                            onClick={() => onNavigate?.(idea.parent!.uuid)}
                             className="flex w-full items-center gap-2 rounded-lg bg-[#FAF8F4] px-3 py-2.5 text-left transition-colors hover:bg-[#F5F2EC]"
                           >
                             <CornerLeftUp className="h-3.5 w-3.5 shrink-0 text-[#888780]" />
@@ -727,12 +728,7 @@ export function IdeaDetailPanel({
                                   {idx > 0 && <div className="h-px bg-[#F0EEEA]" />}
                                   <button
                                     type="button"
-                                    onClick={() => {
-                                      const params = new URLSearchParams(window.location.search);
-                                      params.set("panel", child.uuid);
-                                      params.set("tab", "overview");
-                                      router.push(`${window.location.pathname}?${params.toString()}`);
-                                    }}
+                                    onClick={() => onNavigate?.(child.uuid)}
                                     className="flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-[#FAF8F4]"
                                   >
                                     <span className="flex min-w-0 items-center gap-2">


### PR DESCRIPTION
## Summary
- The Overview-tab **Lineage** section's parent breadcrumb, derived-child rows, and post-derive navigation were dead — clicking them changed the URL but never switched the open right-side panel.
- Root cause: those handlers did a query-only `router.push("?panel=<uuid>")`, but the open panel is bound to `selectedId` **state** owned by `usePanelUrl`, which only updates via `openPanel`/`closePanel` or a real `popstate`. A query-only `router.push` fires no `popstate`, so `selectedIdeaUuid` (the panel's `ideaUuid`) never changed.
- Fix: thread the parent's `usePanelUrl.openPanel` into `IdeaDetailPanel` as `onNavigate` and call it at the three sites — the exact path list/tree rows already use (`onIdeaClick={openPanel}`).

## Changed files
| File | Change |
|------|--------|
| `src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx` | Add optional `onNavigate(ideaUuid)` prop; parent breadcrumb, child rows, and `handleDerived` now call `onNavigate?.(uuid)` instead of building a URL + `router.push`. |
| `src/app/(dashboard)/projects/[uuid]/dashboard/idea-tracker.tsx` | Wire `onNavigate={openPanel}` (the live `usePanelUrl` state setter) into the panel. |

## Behavior note
The old code forced `&tab=overview` on navigation, but since the panel never switched, that was itself dead. Going through `openPanel` (no tab arg) lands the target idea on its most relevant tab via the panel's existing `getDefaultTab` auto-select — consistent with how list/tree rows open ideas.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` clean for changed files (one pre-existing unrelated warning)
- [x] Existing `idea-tracker.test.tsx` (6 tests) pass
- [x] Independent code-review agent: no blockers, no should-fix items
- [x] Manual e2e (Playwright, local default-auth): in "Derive UX Check", opened the child idea panel → clicked **"Derived from Parent idea for derive test"** → panel switched to the parent (heading + content "root"), URL updated to the parent's `?panel=`. User also verified manually.

## Optional follow-ups (non-blocking, from review)
- Make `onNavigate` required to guard a future second mount from silently re-breaking the clicks.
- Add a regression test asserting a parent/child click calls `openPanel` with the target uuid.

Generated with [Claude Code](https://claude.com/claude-code)