### PR TITLE
feat(cli): chorus daemon — wake local Claude Code on remote task dispatch

### DIFF
--- a/chorus.mjs
+++ b/chorus.mjs
@@ -17,6 +17,59 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
+// Subcommand router (client-mode commands)
+// ---------------------------------------------------------------------------
+// `chorus` with no subcommand (or the existing server flags) launches the
+// Next.js server exactly as before. `chorus daemon` and `chorus login` are
+// client commands that connect OUT to a remote Chorus server. Their modules are
+// lazy-imported so the server-launch path pays no startup cost.
+
+const SUBCOMMANDS = new Set(["daemon", "login"]);
+
+/** Parse `--url` / `--api-key` (and `=` forms) + boolean `--yolo` out of an arg list. */
+function parseClientFlags(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--url") out.url = argv[i + 1];
+    else if (a.startsWith("--url=")) out.url = a.slice("--url=".length);
+    else if (a === "--api-key") out.apiKey = argv[i + 1];
+    else if (a.startsWith("--api-key=")) out.apiKey = a.slice("--api-key=".length);
+    else if (a === "--yolo") out.yolo = true;
+  }
+  return out;
+}
+
+async function runSubcommand(name, rest) {
+  const flags = parseClientFlags(rest);
+  if (name === "login") {
+    const { runLogin } = await import("./cli/login.mjs");
+    return runLogin(flags);
+  }
+  if (name === "daemon") {
+    const { runDaemon } = await import("./cli/daemon.mjs");
+    return runDaemon(flags);
+  }
+  return 1;
+}
+
+{
+  const sub = process.argv[2];
+  if (sub && SUBCOMMANDS.has(sub)) {
+    runSubcommand(sub, process.argv.slice(3))
+      .then((code) => process.exit(typeof code === "number" ? code : 0))
+      .catch((err) => {
+        console.error(`Fatal error in 'chorus ${sub}':`, err);
+        process.exit(1);
+      });
+    // Stop the server-launch module body from executing in this process tick.
+    // The promise above owns process lifetime from here.
+  }
+}
+
+const isSubcommand = SUBCOMMANDS.has(process.argv[2]);
+
+// ---------------------------------------------------------------------------
 // Dependency resolution (hoist-safe — see issue #214)
 // ---------------------------------------------------------------------------
 // Use import.meta.resolve so the correct copy of each dependency is found
@@ -57,16 +110,21 @@ function hasFlag(long, short) {
   return args.includes(long) || args.includes(short);
 }
 
-// --help / --version fast paths
-if (hasFlag("--help", "-h")) {
+// --help / --version fast paths (skipped when a client subcommand was dispatched —
+// e.g. `chorus login --help` belongs to the subcommand, not the server)
+if (!isSubcommand && hasFlag("--help", "-h")) {
   const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
   process.stdout.write(`
 Chorus v${pkg.version} — AI Agent & Human collaboration platform
 
 USAGE
-  chorus [options]
+  chorus [options]                 Start the Chorus server (default)
+  chorus login [--url --api-key]   Authenticate as an agent; saves ~/.chorus/daemon.json
+  chorus daemon [--url --api-key]  Connect to a remote Chorus server, subscribe to the
+                                   agent notification stream, and wake a local headless
+                                   Claude Code on task dispatch
 
-OPTIONS
+SERVER OPTIONS
   -p, --port <port>        HTTP server port             (default: 8637, env: PORT)
   -d, --data-dir <path>    Data directory for PGlite    (default: ~/.chorus-data, env: CHORUS_DATA_DIR)
       --hostname <host>    Bind address                 (default: 0.0.0.0)
@@ -84,16 +142,35 @@ ENVIRONMENT VARIABLES
   NEXTAUTH_SECRET          Session signing secret (auto-generated if unset)
   COOKIE_SECURE            Set to "true" for HTTPS deployments
 
+DAEMON / LOGIN (client mode)
+  --url <url>              Remote Chorus server URL      (env: CHORUS_URL)
+  --api-key <cho_...>      Agent API key                 (env: CHORUS_API_KEY)
+  --yolo                   Give the woken Claude FULL permissions             (env: CHORUS_YOLO=1)
+                           (--dangerously-skip-permissions: Bash, file writes,
+                           any command). Default is Chorus-MCP-tools-only.
+
+  Credential resolution order: flags > CHORUS_URL/CHORUS_API_KEY env >
+  ~/.chorus/daemon.json (from 'chorus login') > Claude Code plugin config.
+
+  The daemon spawns the local 'claude' CLI headlessly per task dispatch; it must
+  be on PATH. Override with CHORUS_CLAUDE_PATH. By default the woken Claude may
+  use only Chorus MCP tools (comment/claim/report/status) — pass --yolo for full
+  autonomy (real code-writing AI-DLC), which is dangerous: run it sandboxed.
+
 EXAMPLES
   chorus                                     # Embedded PGlite (default)
   chorus --port 3000                         # Custom port
   chorus --data-dir /var/lib/chorus          # Custom data directory
   DATABASE_URL=postgres://... chorus --use-pglite=false   # External PostgreSQL
+  chorus login                               # Interactive: validate key, save credentials
+  chorus daemon                              # Connect & wake local Claude Code (Chorus tools only)
+  chorus daemon --yolo                       # Full autonomy: woken Claude can run Bash / edit files
+  CHORUS_URL=https://... CHORUS_API_KEY=cho_... chorus daemon
 `);
   process.exit(0);
 }
 
-if (hasFlag("--version", "-v")) {
+if (!isSubcommand && hasFlag("--version", "-v")) {
   const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
   process.stdout.write(`${pkg.version}\n`);
   process.exit(0);
@@ -362,8 +439,11 @@ process.on("exit", () => {
 // Run
 // ---------------------------------------------------------------------------
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  if (pgliteProcess && !pgliteProcess.killed) pgliteProcess.kill("SIGTERM");
-  process.exit(1);
-});
+// Only launch the server when no client subcommand was dispatched above.
+if (!isSubcommand) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    if (pgliteProcess && !pgliteProcess.killed) pgliteProcess.kill("SIGTERM");
+    process.exit(1);
+  });
+}

--- a/cli/__tests__/backfill.test.mjs
+++ b/cli/__tests__/backfill.test.mjs
@@ -1,0 +1,68 @@
+// cli/__tests__/backfill.test.mjs
+// Covers cli-daemon spec "Reconnect with backfill" — missed dispatch recovered.
+import { describe, it, expect, vi } from "vitest";
+import { createBackfill } from "../backfill.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+describe("createBackfill", () => {
+  it("re-dispatches unread notifications missed during the gap", async () => {
+    const dispatched = [];
+    const mcpClient = {
+      callTool: vi.fn(async () => ({
+        notifications: [{ uuid: "n1" }, { uuid: "n2" }],
+      })),
+    };
+    const backfill = createBackfill({
+      mcpClient,
+      dispatch: (e) => dispatched.push(e),
+      logger: silent,
+    });
+
+    await backfill();
+
+    expect(mcpClient.callTool).toHaveBeenCalledWith("chorus_get_notifications", {
+      status: "unread",
+      limit: 50,
+      autoMarkRead: false,
+    });
+    expect(dispatched).toEqual([
+      { type: "new_notification", notificationUuid: "n1" },
+      { type: "new_notification", notificationUuid: "n2" },
+    ]);
+  });
+
+  it("de-dupes against already-seen notifications across reconnects", async () => {
+    const dispatched = [];
+    const seen = new Set();
+    const mcpClient = {
+      callTool: vi.fn(async () => ({ notifications: [{ uuid: "n1" }, { uuid: "n2" }] })),
+    };
+    const backfill = createBackfill({ mcpClient, dispatch: (e) => dispatched.push(e), seen, logger: silent });
+
+    await backfill(); // first reconnect: n1, n2
+    await backfill(); // second reconnect: same two, already seen → nothing new
+
+    expect(dispatched).toHaveLength(2);
+  });
+
+  it("does not throw if the fetch fails", async () => {
+    const mcpClient = { callTool: vi.fn(async () => { throw new Error("boom"); }) };
+    const warns = [];
+    const backfill = createBackfill({
+      mcpClient,
+      dispatch: () => { throw new Error("should not dispatch"); },
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+    await expect(backfill()).resolves.toBeUndefined();
+    expect(warns.join("")).toMatch(/backfill fetch failed/);
+  });
+
+  it("handles a response with no notifications array", async () => {
+    const mcpClient = { callTool: vi.fn(async () => ({})) };
+    const dispatched = [];
+    const backfill = createBackfill({ mcpClient, dispatch: (e) => dispatched.push(e), logger: silent });
+    await backfill();
+    expect(dispatched).toEqual([]);
+  });
+});

--- a/cli/__tests__/backfill.test.mjs
+++ b/cli/__tests__/backfill.test.mjs
@@ -2,6 +2,8 @@
 // Covers cli-daemon spec "Reconnect with backfill" — missed dispatch recovered.
 import { describe, it, expect, vi } from "vitest";
 import { createBackfill } from "../backfill.mjs";
+import { EventRouter } from "../event-router.mjs";
+import { WAKE_ACTIONS } from "../prompts.mjs";
 
 const silent = { info() {}, warn() {}, error() {} };
 
@@ -32,18 +34,21 @@ describe("createBackfill", () => {
     ]);
   });
 
-  it("de-dupes against already-seen notifications across reconnects", async () => {
+  it("skips uuids already in the shared seen set, dispatches the rest (pre-check only, does NOT mark)", async () => {
     const dispatched = [];
-    const seen = new Set();
+    const seen = new Set(["n1"]); // n1 already handled by the live path
     const mcpClient = {
       callTool: vi.fn(async () => ({ notifications: [{ uuid: "n1" }, { uuid: "n2" }] })),
     };
     const backfill = createBackfill({ mcpClient, dispatch: (e) => dispatched.push(e), seen, logger: silent });
 
-    await backfill(); // first reconnect: n1, n2
-    await backfill(); // second reconnect: same two, already seen → nothing new
+    await backfill();
 
-    expect(dispatched).toHaveLength(2);
+    // n1 skipped (already seen), n2 dispatched.
+    expect(dispatched).toEqual([{ type: "new_notification", notificationUuid: "n2" }]);
+    // backfill MUST NOT mark seen itself — that's the router's job. If it did,
+    // the router's dispatch would early-return and the wake would be lost.
+    expect(seen.has("n2")).toBe(false);
   });
 
   it("does not throw if the fetch fails", async () => {
@@ -64,5 +69,53 @@ describe("createBackfill", () => {
     const backfill = createBackfill({ mcpClient, dispatch: (e) => dispatched.push(e), logger: silent });
     await backfill();
     expect(dispatched).toEqual([]);
+  });
+});
+
+// Integration: real createBackfill → real EventRouter with a SHARED seen set —
+// exactly the wiring the daemon uses (daemon.mjs). A prior regression where
+// backfill marked `seen` before dispatch caused the router's dedup to early-
+// return and drop EVERY backfilled wake; no test wired these two together with
+// a shared set, so it slipped through. This is that test.
+describe("backfill → router integration (shared seen set)", () => {
+  const TASK_NOTIF = {
+    uuid: "n1",
+    projectUuid: "p1",
+    entityType: "task",
+    entityUuid: "task-1",
+    entityTitle: "t",
+    action: "task_assigned",
+    message: "",
+    actorType: "user",
+    actorUuid: "u1",
+    actorName: "Alice",
+  };
+
+  function wire(notifications) {
+    const seen = new Set();
+    const enqueued = [];
+    const mcpClient = { callTool: vi.fn(async () => ({ notifications })) };
+    const waker = { keyFor: vi.fn(async () => "idea:root-1"), wake: vi.fn(async () => {}) };
+    const queue = { enqueue: (key, task) => enqueued.push({ key, task }) };
+    const router = new EventRouter({ mcpClient, waker, queue, wakeActions: WAKE_ACTIONS, seen, logger: silent });
+    const backfill = createBackfill({ mcpClient, dispatch: (e) => router.dispatch(e), seen, logger: silent });
+    return { seen, enqueued, router, backfill };
+  }
+
+  it("backfill alone DOES wake (the regression: it was dropping everything)", async () => {
+    const { enqueued, backfill } = wire([TASK_NOTIF]);
+    await backfill();
+    await new Promise((r) => setTimeout(r, 0)); // let router's async fetchAndRoute settle
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].key).toBe("idea:root-1");
+  });
+
+  it("live dispatch then backfill of the same uuid wakes exactly once (dedup still holds)", async () => {
+    const { enqueued, router, backfill } = wire([TASK_NOTIF]);
+    router.dispatch({ type: "new_notification", notificationUuid: "n1" }); // live
+    await new Promise((r) => setTimeout(r, 0));
+    await backfill(); // reconnect backfill sees n1 already handled → skip
+    await new Promise((r) => setTimeout(r, 0));
+    expect(enqueued).toHaveLength(1);
   });
 });

--- a/cli/__tests__/chorus-client.test.mjs
+++ b/cli/__tests__/chorus-client.test.mjs
@@ -1,0 +1,56 @@
+// cli/__tests__/chorus-client.test.mjs
+// Covers the MCP client contract used across the daemon: callTool returns
+// parsed JSON, and validateAndFetchIdentity extracts the agent identity.
+// (cli-daemon AC "ChorusMcpClient ... returns parsed JSON" + login validation.)
+import { describe, it, expect, vi } from "vitest";
+import { validateAndFetchIdentity } from "../chorus-client.mjs";
+
+describe("validateAndFetchIdentity", () => {
+  it("calls chorus_checkin and returns {uuid,name} on success", async () => {
+    const callTool = vi.fn(async () => ({ agent: { uuid: "a-1", name: "Bot" } }));
+    const disconnect = vi.fn(async () => {});
+    const makeClient = vi.fn((o) => ({ url: o.url, apiKey: o.apiKey, callTool, disconnect }));
+
+    const identity = await validateAndFetchIdentity(
+      { url: "https://c", apiKey: "cho_x" },
+      { makeClient }
+    );
+
+    expect(makeClient).toHaveBeenCalledWith({ url: "https://c", apiKey: "cho_x" });
+    expect(callTool).toHaveBeenCalledWith("chorus_checkin", {});
+    expect(identity).toEqual({ uuid: "a-1", name: "Bot" });
+    expect(disconnect).toHaveBeenCalled(); // always disconnects (finally)
+  });
+
+  it("falls back to uuid when name is missing", async () => {
+    const makeClient = () => ({
+      callTool: async () => ({ agent: { uuid: "only-uuid" } }),
+      disconnect: async () => {},
+    });
+    const identity = await validateAndFetchIdentity({ url: "u", apiKey: "k" }, { makeClient });
+    expect(identity).toEqual({ uuid: "only-uuid", name: "only-uuid" });
+  });
+
+  it("throws on an unexpected response shape and still disconnects", async () => {
+    const disconnect = vi.fn(async () => {});
+    const makeClient = () => ({ callTool: async () => ({ notAgent: true }), disconnect });
+    await expect(
+      validateAndFetchIdentity({ url: "u", apiKey: "k" }, { makeClient })
+    ).rejects.toThrow(/no agent identity/i);
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it("propagates a transport/auth error from callTool", async () => {
+    const disconnect = vi.fn(async () => {});
+    const makeClient = () => ({
+      callTool: async () => {
+        throw new Error("401 Unauthorized");
+      },
+      disconnect,
+    });
+    await expect(
+      validateAndFetchIdentity({ url: "u", apiKey: "bad" }, { makeClient })
+    ).rejects.toThrow(/401/);
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/cli/__tests__/chorus-client.test.mjs
+++ b/cli/__tests__/chorus-client.test.mjs
@@ -3,7 +3,22 @@
 // parsed JSON, and validateAndFetchIdentity extracts the agent identity.
 // (cli-daemon AC "ChorusMcpClient ... returns parsed JSON" + login validation.)
 import { describe, it, expect, vi } from "vitest";
-import { validateAndFetchIdentity } from "../chorus-client.mjs";
+import { ChorusClient, validateAndFetchIdentity } from "../chorus-client.mjs";
+
+/** Build a ChorusClient with its internal MCP client + connect() stubbed. */
+function clientWith(callToolImpl) {
+  const c = new ChorusClient({ url: "https://c", apiKey: "cho_x" });
+  c.status = "connected";
+  c.client = { callTool: callToolImpl };
+  let connects = 0;
+  // Stub (re)connect so we can detect whether a reconnect was attempted.
+  c.connect = async () => {
+    connects++;
+    c.status = "connected";
+    c.client = { callTool: callToolImpl };
+  };
+  return { c, connects: () => connects };
+}
 
 describe("validateAndFetchIdentity", () => {
   it("calls chorus_checkin and returns {uuid,name} on success", async () => {
@@ -52,5 +67,36 @@ describe("validateAndFetchIdentity", () => {
       validateAndFetchIdentity({ url: "u", apiKey: "bad" }, { makeClient })
     ).rejects.toThrow(/401/);
     expect(disconnect).toHaveBeenCalled();
+  });
+});
+
+describe("ChorusClient.callTool tool-error vs session-expiry", () => {
+  it("does NOT reconnect on a tool-level error whose text contains 'not found'", async () => {
+    // Server ran the tool and returned an error result — NOT a session issue.
+    const callTool = vi.fn(async () => ({
+      isError: true,
+      content: [{ type: "text", text: "Task not found" }],
+    }));
+    const { c, connects } = clientWith(callTool);
+
+    await expect(c.callTool("chorus_get_task", { taskUuid: "x" })).rejects.toThrow(/Task not found/);
+    // Called exactly once — no reconnect+retry triggered by the "not found" text.
+    expect(callTool).toHaveBeenCalledTimes(1);
+    expect(connects()).toBe(0);
+  });
+
+  it("DOES reconnect+retry once on a real stateless-404 transport error", async () => {
+    let n = 0;
+    const callTool = vi.fn(async () => {
+      n++;
+      if (n === 1) throw new Error("HTTP 404: session not found"); // transport-level
+      return { isError: false, content: [{ type: "text", text: '{"ok":true}' }] };
+    });
+    const { c, connects } = clientWith(callTool);
+
+    const out = await c.callTool("chorus_checkin", {});
+    expect(out).toEqual({ ok: true });
+    expect(callTool).toHaveBeenCalledTimes(2); // first failed, retried after reconnect
+    expect(connects()).toBe(1);
   });
 });

--- a/cli/__tests__/claude-spawner.test.mjs
+++ b/cli/__tests__/claude-spawner.test.mjs
@@ -1,0 +1,319 @@
+// cli/__tests__/claude-spawner.test.mjs
+// Covers cli-daemon spec "Cross-platform headless spawn" (both scenarios) and
+// the spawner AC: stdin prompt, path resolution incl. Windows .cmd, NDJSON
+// parse with CRLF + session_id extraction, fire-and-forget failure handling.
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import {
+  ClaudeSpawner,
+  resolveClaudePath,
+  buildArgs,
+  parseNdjsonChunk,
+  resolveSpawnCommand,
+} from "../claude-spawner.mjs";
+import { writeMcpConfig, buildMcpConfig } from "../mcp-config.mjs";
+
+/** A fake child process: stdin captures writes; stdout/stderr are emitters. */
+function makeFakeChild() {
+  const child = new EventEmitter();
+  const stdinChunks = [];
+  const stdin = new EventEmitter(); // real emitter so .on("error") works
+  stdin.writes = stdinChunks;
+  stdin.write = (c) => stdinChunks.push(String(c));
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+  child.stdout = new EventEmitter();
+  child.stdout.setEncoding = () => {};
+  child.stderr = new EventEmitter();
+  child.stderr.setEncoding = () => {};
+  return child;
+}
+
+const silent = { info() {}, warn() {}, error() {} };
+
+describe("buildArgs", () => {
+  it("uses --session-id for a new session, never puts prompt in argv", () => {
+    const args = buildArgs({ sessionId: "sid-1", isNew: true, mcpConfigPath: "/tmp/m.json" });
+    expect(args).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--session-id",
+      "sid-1",
+      "--mcp-config",
+      "/tmp/m.json",
+      // default permission mode: allow only Chorus MCP tools through
+      "--allowedTools",
+      "mcp__chorus__*",
+    ]);
+    expect(args.join(" ")).not.toMatch(/prompt/i);
+  });
+
+  it("uses --resume for an existing session", () => {
+    const args = buildArgs({ sessionId: "sid-2", isNew: false });
+    expect(args).toContain("--resume");
+    expect(args).toContain("sid-2");
+    expect(args).not.toContain("--session-id");
+  });
+
+  it("default permission mode allowlists Chorus MCP tools and does NOT skip permissions", () => {
+    const args = buildArgs({ sessionId: "s", isNew: true });
+    const i = args.indexOf("--allowedTools");
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe("mcp__chorus__*");
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("yolo permission mode skips all permissions and drops the allowlist", () => {
+    const args = buildArgs({ sessionId: "s", isNew: true, permissionMode: "yolo" });
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).not.toContain("--allowedTools");
+  });
+});
+
+describe("resolveClaudePath", () => {
+  it("finds plain `claude` on a unix PATH", () => {
+    const path = resolveClaudePath({
+      platform: "linux",
+      env: { PATH: "/usr/bin:/home/u/.local/bin" },
+      isFile: (p) => p === "/home/u/.local/bin/claude",
+    });
+    expect(path).toBe("/home/u/.local/bin/claude");
+  });
+
+  it("finds claude.cmd on Windows (shim) and prefers it over bare name", () => {
+    const path = resolveClaudePath({
+      platform: "win32",
+      env: { Path: "C:\\bin;C:\\npm" },
+      isFile: (p) => p === "C:\\npm\\claude.cmd",
+    });
+    expect(path).toBe("C:\\npm\\claude.cmd");
+  });
+
+  it("honors CHORUS_CLAUDE_PATH override", () => {
+    const path = resolveClaudePath({
+      env: { CHORUS_CLAUDE_PATH: "/opt/claude", PATH: "/usr/bin" },
+      isFile: (p) => p === "/opt/claude",
+    });
+    expect(path).toBe("/opt/claude");
+  });
+
+  it("returns null when not found", () => {
+    expect(resolveClaudePath({ platform: "linux", env: { PATH: "/usr/bin" }, isFile: () => false })).toBeNull();
+  });
+});
+
+describe("parseNdjsonChunk", () => {
+  it("parses whole lines, strips CR, buffers partials, skips blanks", () => {
+    const got = [];
+    let buf = "";
+    buf = parseNdjsonChunk(buf, '{"a":1}\r\n{"b":2}\n{"c":', (o) => got.push(o));
+    expect(got).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(buf).toBe('{"c":'); // partial retained
+    buf = parseNdjsonChunk(buf, '3}\n\n', (o) => got.push(o));
+    expect(got).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it("warns and skips malformed lines without throwing", () => {
+    const got = [];
+    const warns = [];
+    parseNdjsonChunk("", "not json\n{\"ok\":1}\n", (o) => got.push(o), (m) => warns.push(m));
+    expect(got).toEqual([{ ok: 1 }]);
+    expect(warns.join("")).toMatch(/parse error/);
+  });
+});
+
+describe("ClaudeSpawner.wake", () => {
+  it("feeds prompt over stdin (not argv) and resolves with the generated session id", async () => {
+    const child = makeFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const spawner = new ClaudeSpawner({
+      claudePath: "/usr/bin/claude",
+      spawnImpl,
+      logger: silent,
+      genId: () => "fixed-sid",
+    });
+
+    const longPrompt = "X".repeat(50_000); // would blow the Windows cmdline if argv
+    const p = spawner.wake({ prompt: longPrompt, mcpConfigPath: "/tmp/m.json" });
+
+    // Emit a stream-json line carrying a session_id, then close cleanly.
+    child.stdout.emit("data", '{"type":"system","session_id":"fixed-sid"}\n');
+    child.emit("close", 0);
+
+    const result = await p;
+    expect(result).toEqual({ sessionId: "fixed-sid", exitCode: 0, isNew: true });
+
+    // argv: no prompt; spawned without shell
+    const [path, args, opts] = spawnImpl.mock.calls[0];
+    expect(path).toBe("/usr/bin/claude");
+    expect(args).toContain("--session-id");
+    expect(args.join(" ")).not.toContain("X".repeat(50_000));
+    expect(opts.shell).toBe(false);
+    // prompt arrived via stdin
+    expect(child.stdin.writes.join("")).toBe(longPrompt);
+    expect(child.stdin.end).toHaveBeenCalled();
+  });
+
+  it("passes --resume for an existing session and captures observed session_id", async () => {
+    const child = makeFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const spawner = new ClaudeSpawner({ claudePath: "/c", spawnImpl, logger: silent });
+    const onMessage = vi.fn();
+
+    const p = spawner.wake({ prompt: "go", sessionId: "root-sid", onMessage });
+    child.stdout.emit("data", '{"type":"assistant","session_id":"root-sid"}\n');
+    child.emit("close", 0);
+    const result = await p;
+
+    expect(spawnImpl.mock.calls[0][1]).toContain("--resume");
+    expect(result.isNew).toBe(false);
+    expect(result.sessionId).toBe("root-sid");
+    expect(onMessage).toHaveBeenCalledWith({ type: "assistant", session_id: "root-sid" });
+  });
+
+  it("does NOT throw and resolves with exitCode null when claude is missing", async () => {
+    const spawner = new ClaudeSpawner({ claudePath: null, spawnImpl: () => { throw new Error("should not spawn"); }, logger: silent });
+    // claudePath null + resolveClaudePath finds nothing → returns without spawning
+    const result = await spawner.wake({ prompt: "x" });
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("does NOT crash on a non-zero exit; reports it", async () => {
+    const child = makeFakeChild();
+    const warns = [];
+    const spawner = new ClaudeSpawner({
+      claudePath: "/c",
+      spawnImpl: () => child,
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      genId: () => "s",
+    });
+    const p = spawner.wake({ prompt: "x" });
+    child.emit("close", 2);
+    const result = await p;
+    expect(result.exitCode).toBe(2);
+    expect(warns.join("")).toMatch(/exited with code 2/);
+  });
+
+  it("does NOT crash on a spawn 'error' event", async () => {
+    const child = makeFakeChild();
+    const errs = [];
+    const spawner = new ClaudeSpawner({
+      claudePath: "/c",
+      spawnImpl: () => child,
+      logger: { ...silent, error: (m) => errs.push(m) },
+      genId: () => "s",
+    });
+    const p = spawner.wake({ prompt: "x" });
+    child.emit("error", new Error("ENOENT"));
+    const result = await p;
+    expect(result.exitCode).toBeNull();
+    expect(errs.join("")).toMatch(/process error/);
+  });
+});
+
+describe("mcp-config", () => {
+  it("buildMcpConfig wires the chorus http server with Bearer auth", () => {
+    const cfg = buildMcpConfig({ url: "https://chorus.example/", apiKey: "cho_x" });
+    expect(cfg.mcpServers.chorus.url).toBe("https://chorus.example/api/mcp");
+    expect(cfg.mcpServers.chorus.headers.Authorization).toBe("Bearer cho_x");
+  });
+
+  it("writeMcpConfig writes under the temp dir and cleanup removes it", () => {
+    const writes = [];
+    const rms = [];
+    const { path, cleanup } = writeMcpConfig(
+      { url: "u", apiKey: "k" },
+      {
+        tmp: "/TMP",
+        mkdtemp: (prefix) => prefix + "ABC",
+        write: (p, c, o) => writes.push([p, c, o]),
+        rm: (d, o) => rms.push([d, o]),
+      }
+    );
+    expect(path.replace(/\\/g, "/")).toBe("/TMP/chorus-mcp-ABC/mcp.json");
+    expect(writes[0][2]).toEqual({ mode: 0o600 });
+    cleanup();
+    cleanup(); // idempotent
+    expect(rms).toHaveLength(1);
+    expect(rms[0][1]).toEqual({ recursive: true, force: true });
+  });
+});
+
+describe("resolveSpawnCommand (Windows .cmd routing)", () => {
+  const ARGS = ["-p", "--output-format", "stream-json"];
+
+  it("routes a Windows .cmd shim through cmd.exe /d /s /c", () => {
+    const { command, argv } = resolveSpawnCommand("C:\\npm\\claude.cmd", ARGS, "win32", {
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+    });
+    expect(command).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(argv).toEqual(["/d", "/s", "/c", "C:\\npm\\claude.cmd", ...ARGS]);
+  });
+
+  it("routes a Windows .bat shim through cmd.exe and falls back to cmd.exe when ComSpec unset", () => {
+    const { command, argv } = resolveSpawnCommand("C:\\x\\claude.bat", ARGS, "win32", {});
+    expect(command).toBe("cmd.exe");
+    expect(argv[0]).toBe("/d");
+    expect(argv).toContain("C:\\x\\claude.bat");
+  });
+
+  it("spawns a real .exe directly on Windows (no cmd.exe wrapper)", () => {
+    const { command, argv } = resolveSpawnCommand("C:\\x\\claude.exe", ARGS, "win32", {});
+    expect(command).toBe("C:\\x\\claude.exe");
+    expect(argv).toEqual(ARGS);
+  });
+
+  it("spawns the path directly on POSIX", () => {
+    const { command, argv } = resolveSpawnCommand("/usr/bin/claude", ARGS, "linux", {});
+    expect(command).toBe("/usr/bin/claude");
+    expect(argv).toEqual(ARGS);
+  });
+});
+
+describe("ClaudeSpawner Windows .cmd integration", () => {
+  it("wake() on Windows spawns cmd.exe with the .cmd as an argv element (prompt still via stdin)", async () => {
+    const child = makeFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    // Force the spawner to treat the resolved path as a .cmd by giving it one.
+    const spawner = new ClaudeSpawner({
+      claudePath: "C:\\npm\\claude.cmd",
+      spawnImpl,
+      logger: { info() {}, warn() {}, error() {} },
+      genId: () => "sid",
+    });
+    // Override platform detection used by resolveSpawnCommand via env: the
+    // spawner calls resolveSpawnCommand(path, args) with process.platform, so on
+    // this Linux host the .cmd is NOT rewritten. Assert the POSIX path instead:
+    // command === the .cmd path, argv === args (documents host behavior). The
+    // pure resolveSpawnCommand tests above cover the win32 rewrite deterministically.
+    const p = spawner.wake({ prompt: "hi", mcpConfigPath: "/m.json" });
+    child.emit("close", 0);
+    await p;
+    const [command, argv] = spawnImpl.mock.calls[0];
+    expect(command).toBe("C:\\npm\\claude.cmd"); // unchanged on a POSIX test host
+    expect(argv).toContain("--session-id");
+    expect(child.stdin.writes.join("")).toBe("hi");
+  });
+});
+
+describe("ClaudeSpawner stdin EPIPE resilience", () => {
+  it("does NOT crash when child.stdin emits an async 'error' (EPIPE)", async () => {
+    const child = makeFakeChild();
+    const warns = [];
+    const spawner = new ClaudeSpawner({
+      claudePath: "/usr/bin/claude",
+      spawnImpl: () => child,
+      logger: { info() {}, warn: (m) => warns.push(m), error() {} },
+      genId: () => "sid",
+    });
+    const p = spawner.wake({ prompt: "x" });
+    // Simulate claude exiting before reading stdin → writable emits EPIPE.
+    child.stdin.emit("error", Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+    child.emit("close", 1);
+    const result = await p;
+    expect(result.exitCode).toBe(1); // resolved cleanly, no throw
+    expect(warns.join("")).toMatch(/stdin error/i);
+  });
+});

--- a/cli/__tests__/credentials.test.mjs
+++ b/cli/__tests__/credentials.test.mjs
@@ -1,0 +1,128 @@
+// cli/__tests__/credentials.test.mjs
+// Covers cli-auth spec "Layered credential and address resolution".
+import { describe, it, expect } from "vitest";
+import { resolveCredentials, loginFilePath, claudeSettingsPath } from "../credentials.mjs";
+
+const LOGIN_PATH = "/home/u/.chorus/daemon.json";
+const SETTINGS_PATH = "/home/u/.claude/settings.json";
+
+/** Build deps with a fake filesystem keyed by path. */
+function deps({ env = {}, files = {} } = {}) {
+  return {
+    env,
+    loginPath: LOGIN_PATH,
+    settingsPath: SETTINGS_PATH,
+    readJson: (p) => (p in files ? files[p] : null),
+  };
+}
+
+describe("resolveCredentials precedence", () => {
+  it("flags win over all other sources", () => {
+    const r = resolveCredentials(
+      { url: "https://flag", apiKey: "cho_flag" },
+      deps({
+        env: { CHORUS_URL: "https://env", CHORUS_API_KEY: "cho_env" },
+        files: {
+          [LOGIN_PATH]: { url: "https://file", apiKey: "cho_file" },
+          [SETTINGS_PATH]: { env: { CHORUS_URL: "https://plug", CHORUS_API_KEY: "cho_plug" } },
+        },
+      })
+    );
+    expect(r).toEqual({ url: "https://flag", apiKey: "cho_flag", source: "flag" });
+  });
+
+  it("env used when no flags", () => {
+    const r = resolveCredentials(
+      {},
+      deps({
+        env: { CHORUS_URL: "https://env", CHORUS_API_KEY: "cho_env" },
+        files: { [LOGIN_PATH]: { url: "https://file", apiKey: "cho_file" } },
+      })
+    );
+    expect(r).toEqual({ url: "https://env", apiKey: "cho_env", source: "env" });
+  });
+
+  it("login file used when no flags or env", () => {
+    const r = resolveCredentials(
+      {},
+      deps({ files: { [LOGIN_PATH]: { url: "https://file", apiKey: "cho_file" } } })
+    );
+    expect(r).toEqual({ url: "https://file", apiKey: "cho_file", source: "login-file" });
+  });
+
+  it("plugin settings env block used as last resort", () => {
+    const r = resolveCredentials(
+      {},
+      deps({
+        files: { [SETTINGS_PATH]: { env: { CHORUS_URL: "https://plug", CHORUS_API_KEY: "cho_plug" } } },
+      })
+    );
+    expect(r).toEqual({ url: "https://plug", apiKey: "cho_plug", source: "plugin-fallback" });
+  });
+
+  it("partial pair at a higher tier falls through to the next complete source", () => {
+    // env has only a URL; login file is complete → login file wins.
+    const r = resolveCredentials(
+      {},
+      deps({
+        env: { CHORUS_URL: "https://env-only" },
+        files: { [LOGIN_PATH]: { url: "https://file", apiKey: "cho_file" } },
+      })
+    );
+    expect(r.source).toBe("login-file");
+  });
+
+  it("blank/whitespace values are treated as absent", () => {
+    const r = resolveCredentials(
+      { url: "  ", apiKey: "" },
+      deps({ env: { CHORUS_URL: "https://env", CHORUS_API_KEY: "cho_env" } })
+    );
+    expect(r.source).toBe("env");
+  });
+
+  it("malformed login file does not throw and falls through", () => {
+    // login file path returns null (as if JSON.parse failed); settings has the pair.
+    const r = resolveCredentials(
+      {},
+      {
+        env: {},
+        loginPath: LOGIN_PATH,
+        settingsPath: SETTINGS_PATH,
+        readJson: (p) =>
+          p === SETTINGS_PATH
+            ? { env: { CHORUS_URL: "https://plug", CHORUS_API_KEY: "cho_plug" } }
+            : null,
+      }
+    );
+    expect(r.source).toBe("plugin-fallback");
+  });
+});
+
+describe("resolveCredentials failure", () => {
+  it("throws a single actionable error listing every source tried", () => {
+    let err;
+    try {
+      resolveCredentials({}, deps({ env: {}, files: {} }));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const msg = err.message;
+    // Lists all four sources in order
+    expect(msg).toContain("--url/--api-key flags");
+    expect(msg).toContain("CHORUS_URL / CHORUS_API_KEY environment variables");
+    expect(msg).toContain("login file");
+    expect(msg).toContain("Claude Code plugin config");
+    // And tells the user how to supply credentials
+    expect(msg).toContain("chorus login");
+  });
+});
+
+describe("path helpers", () => {
+  it("loginFilePath ends with .chorus/daemon.json", () => {
+    expect(loginFilePath().replace(/\\/g, "/")).toMatch(/\.chorus\/daemon\.json$/);
+  });
+  it("claudeSettingsPath ends with .claude/settings.json", () => {
+    expect(claudeSettingsPath().replace(/\\/g, "/")).toMatch(/\.claude\/settings\.json$/);
+  });
+});

--- a/cli/__tests__/daemon-integration.test.mjs
+++ b/cli/__tests__/daemon-integration.test.mjs
@@ -1,0 +1,186 @@
+// cli/__tests__/daemon-integration.test.mjs
+// Full-chain integration: a task_assigned SSE event flows through the assembled
+// daemon (mock MCP + mock SSE + mock claude subprocess) all the way to the
+// spawn args. Covers the integration AC and "task-dispatch wakes Claude Code".
+import { describe, it, expect, vi } from "vitest";
+import { buildDaemon, runDaemon } from "../daemon.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+const TASK_NOTIF = {
+  uuid: "notif-1",
+  projectUuid: "proj-1",
+  entityType: "task",
+  entityUuid: "task-1",
+  entityTitle: "Build the thing",
+  action: "task_assigned",
+  message: "",
+  actorType: "user",
+  actorUuid: "user-1",
+  actorName: "Alice",
+};
+
+/** A mock MCP client answering the lineage walk + notification fetch. */
+function mockMcp() {
+  return {
+    disconnected: false,
+    async callTool(name) {
+      switch (name) {
+        case "chorus_get_notifications":
+          return { notifications: [TASK_NOTIF] };
+        case "chorus_get_task":
+          return { proposalUuid: "prop-1" };
+        case "chorus_get_proposal":
+          return { inputType: "idea", inputUuids: ["root-idea"] };
+        case "chorus_get_idea":
+          return { parentUuid: null }; // root-idea is its own root
+        default:
+          return null;
+      }
+    },
+    async disconnect() {
+      this.disconnected = true;
+    },
+  };
+}
+
+/** A mock SSE listener we can manually drive. */
+class MockSse {
+  constructor(opts) {
+    this.opts = opts;
+    this.connected = false;
+  }
+  async connect() {
+    this.connected = true;
+  }
+  disconnect() {
+    this.connected = false;
+  }
+  /** test helper: deliver an event as if it came off the wire */
+  deliver(event) {
+    this.opts.onEvent(event);
+  }
+}
+
+describe("daemon integration: notification → spawn", () => {
+  it("a task_assigned event drives a headless claude spawn with the right prompt + mcp-config", async () => {
+    const spawnCalls = [];
+    const spawner = {
+      wake: vi.fn(async (params) => {
+        spawnCalls.push(params);
+        params.onMessage?.({ type: "system", session_id: "sid-new" });
+        return { sessionId: "sid-new", exitCode: 0, isNew: true };
+      }),
+    };
+    const sessionMap = {
+      resolve: vi.fn(() => ({ sessionId: null, isNew: true })),
+      record: vi.fn(),
+    };
+    let captured;
+    const daemon = buildDaemon(
+      { url: "https://chorus.example", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mockMcp(),
+        spawner,
+        sessionMap,
+        makeSseListener: (o) => {
+          captured = new MockSse(o);
+          return captured;
+        },
+      }
+    );
+
+    await daemon.start();
+    expect(captured.connected).toBe(true);
+
+    // Deliver a task_assigned notification.
+    captured.deliver({ type: "new_notification", notificationUuid: "notif-1" });
+    // Let the async fetch/route/queue/spawn chain settle.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(spawner.wake).toHaveBeenCalledTimes(1);
+    const params = spawnCalls[0];
+    expect(params.prompt).toContain("task-1"); // task UUID in prompt
+    expect(params.prompt).toContain("chorus_claim_task");
+    expect(params.sessionId).toBeNull(); // new session for this root idea
+    expect(params.mcpConfigPath).toMatch(/mcp\.json$/); // wrote a temp mcp config
+    // session id persisted under the root-idea key
+    expect(sessionMap.record).toHaveBeenCalledWith("idea:root-idea", "sid-new");
+
+    await daemon.stop();
+    expect(captured.connected).toBe(false);
+  });
+
+  it("ignores a non-wake notification (no spawn)", async () => {
+    const spawner = { wake: vi.fn() };
+    const mcp = mockMcp();
+    mcp.callTool = async (name) =>
+      name === "chorus_get_notifications"
+        ? { notifications: [{ ...TASK_NOTIF, action: "count_update" }] }
+        : null;
+    let captured;
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "k" },
+      { logger: silent, mcpClient: mcp, spawner, makeSseListener: (o) => (captured = new MockSse(o)) }
+    );
+    await daemon.start();
+    captured.deliver({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(spawner.wake).not.toHaveBeenCalled();
+  });
+});
+
+describe("runDaemon entry", () => {
+  it("aborts with code 1 when credentials don't resolve", async () => {
+    const errs = [];
+    const code = await runDaemon(
+      {},
+      {
+        resolve: () => {
+          throw new Error("no creds");
+        },
+        errLog: (m) => errs.push(m),
+        log: () => {},
+      }
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toContain("no creds");
+  });
+
+  it("aborts with code 1 when validation fails (bad key)", async () => {
+    const errs = [];
+    const code = await runDaemon(
+      { url: "u", apiKey: "bad" },
+      {
+        resolve: () => ({ url: "u", apiKey: "bad", source: "flag" }),
+        validate: async () => {
+          throw new Error("401 Unauthorized");
+        },
+        errLog: (m) => errs.push(m),
+        log: () => {},
+      }
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toMatch(/validation failed/);
+  });
+
+  it("validates, starts the daemon, and waits (happy path)", async () => {
+    const logs = [];
+    const started = vi.fn();
+    const code = await runDaemon(
+      { url: "u", apiKey: "cho_x" },
+      {
+        resolve: () => ({ url: "u", apiKey: "cho_x", source: "env" }),
+        validate: async () => ({ uuid: "agent-1", name: "Daemon Bot" }),
+        build: () => ({ async start() { started(); }, async stop() {} }),
+        log: (m) => logs.push(m),
+        errLog: (m) => logs.push("ERR:" + m),
+        waitForever: async () => {}, // return immediately for the test
+      }
+    );
+    expect(code).toBe(0);
+    expect(started).toHaveBeenCalled();
+    expect(logs.join("\n")).toContain("authenticated as Daemon Bot (agent-1)");
+  });
+});

--- a/cli/__tests__/lineage.test.mjs
+++ b/cli/__tests__/lineage.test.mjs
@@ -1,0 +1,104 @@
+// cli/__tests__/lineage.test.mjs
+// Covers cli-daemon spec "Lineage-anchored session continuity" (resolution half).
+import { describe, it, expect } from "vitest";
+import { LineageResolver } from "../lineage.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+/** Build a fake MCP client from fixture maps. */
+function fakeMcp({ tasks = {}, proposals = {}, ideas = {} } = {}) {
+  return {
+    calls: [],
+    async callTool(name, args) {
+      this.calls.push([name, args]);
+      if (name === "chorus_get_task") return tasks[args.taskUuid] ?? null;
+      if (name === "chorus_get_proposal") return proposals[args.proposalUuid] ?? null;
+      if (name === "chorus_get_idea") return ideas[args.ideaUuid] ?? null;
+      return null;
+    },
+  };
+}
+
+describe("LineageResolver.rootIdeaFor", () => {
+  it("resolves a task → proposal → idea → root", async () => {
+    const mcp = fakeMcp({
+      tasks: { t1: { proposalUuid: "p1" } },
+      proposals: { p1: { inputType: "idea", inputUuids: ["child-idea"] } },
+      ideas: {
+        "child-idea": { parentUuid: "root-idea" },
+        "root-idea": { parentUuid: null },
+      },
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
+    expect(root).toBe("root-idea");
+  });
+
+  it("resolves an idea event by walking parentUuid to the top", async () => {
+    const mcp = fakeMcp({
+      ideas: {
+        a: { parentUuid: "b" },
+        b: { parentUuid: "c" },
+        c: { parentUuid: null },
+      },
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    expect(await r.rootIdeaFor({ entityType: "idea", entityUuid: "a" })).toBe("c");
+  });
+
+  it("a top-level idea is its own root", async () => {
+    const mcp = fakeMcp({ ideas: { solo: { parentUuid: null } } });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    expect(await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" })).toBe("solo");
+  });
+
+  it("returns null for a quick task with no proposal (no idea ancestor)", async () => {
+    const mcp = fakeMcp({ tasks: { t: { proposalUuid: null } } });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
+  });
+
+  it("returns null when proposal is document-typed (no idea input)", async () => {
+    const mcp = fakeMcp({
+      tasks: { t: { proposalUuid: "p" } },
+      proposals: { p: { inputType: "document", inputUuids: ["doc"] } },
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
+  });
+
+  it("stops on a parent cycle without infinite-looping", async () => {
+    const warns = [];
+    const mcp = fakeMcp({
+      ideas: { a: { parentUuid: "b" }, b: { parentUuid: "a" } },
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: { ...silent, warn: (m) => warns.push(m) } });
+    const root = await r.rootIdeaFor({ entityType: "idea", entityUuid: "a" });
+    expect(["a", "b"]).toContain(root); // returns last-good, doesn't hang
+    expect(warns.join("")).toMatch(/cycle/i);
+  });
+
+  it("caches resolution within a run (no duplicate MCP calls)", async () => {
+    const mcp = fakeMcp({ ideas: { solo: { parentUuid: null } } });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
+    expect(mcp.calls.filter((c) => c[0] === "chorus_get_idea")).toHaveLength(1);
+  });
+
+  it("returns null (not throw) on a missing entityUuid", async () => {
+    const mcp = fakeMcp({});
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    expect(await r.rootIdeaFor({ entityType: "task" })).toBeNull();
+  });
+
+  it("returns null (not throw) when an MCP call errors", async () => {
+    const mcp = {
+      async callTool() {
+        throw new Error("network down");
+      },
+    };
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
+  });
+});

--- a/cli/__tests__/login.test.mjs
+++ b/cli/__tests__/login.test.mjs
@@ -1,0 +1,129 @@
+// cli/__tests__/login.test.mjs
+// Covers cli-auth spec "Interactive login command".
+import { describe, it, expect, vi } from "vitest";
+import { runLogin, writeLoginFile, prompt } from "../login.mjs";
+
+describe("runLogin success path", () => {
+  it("validates, persists with identity, echoes name+uuid, returns 0", async () => {
+    const written = [];
+    const logs = [];
+    const validate = vi.fn(async () => ({ uuid: "agent-123", name: "Daemon Bot" }));
+    const write = vi.fn((data) => {
+      written.push(data);
+      return "/home/u/.chorus/daemon.json";
+    });
+
+    const code = await runLogin(
+      { url: "https://chorus.example", apiKey: "cho_valid" },
+      { validate, write, log: (m) => logs.push(m), errLog: (m) => logs.push("ERR:" + m) }
+    );
+
+    expect(code).toBe(0);
+    expect(validate).toHaveBeenCalledWith({ url: "https://chorus.example", apiKey: "cho_valid" });
+    expect(written).toEqual([
+      { url: "https://chorus.example", apiKey: "cho_valid", agentUuid: "agent-123", agentName: "Daemon Bot" },
+    ]);
+    expect(logs.join("\n")).toContain("Daemon Bot");
+    expect(logs.join("\n")).toContain("agent-123");
+  });
+});
+
+describe("runLogin failure path", () => {
+  it("does NOT write the file when validation fails, returns non-zero", async () => {
+    const validate = vi.fn(async () => {
+      throw new Error("Invalid API key");
+    });
+    const write = vi.fn();
+    const errs = [];
+
+    const code = await runLogin(
+      { url: "https://chorus.example", apiKey: "cho_bad" },
+      { validate, write, log: () => {}, errLog: (m) => errs.push(m) }
+    );
+
+    expect(code).toBe(1);
+    expect(write).not.toHaveBeenCalled();
+    expect(errs.join("\n")).toContain("Invalid API key");
+    expect(errs.join("\n")).toMatch(/NOT saved/i);
+  });
+
+  it("aborts (no validate, no write) when url or key missing after prompting", async () => {
+    const validate = vi.fn();
+    const write = vi.fn();
+    const code = await runLogin(
+      {},
+      {
+        validate,
+        write,
+        prompt: vi.fn(async () => ""), // user enters nothing
+        log: () => {},
+        errLog: () => {},
+      }
+    );
+    expect(code).toBe(1);
+    expect(validate).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+});
+
+describe("runLogin interactive prompting", () => {
+  it("prompts for url then masked api key when flags absent", async () => {
+    const asks = [];
+    const ask = vi.fn(async (q, opts) => {
+      asks.push({ q, mask: opts?.mask ?? false });
+      return q.startsWith("Chorus URL") ? "https://typed" : "cho_typed";
+    });
+    const validate = vi.fn(async () => ({ uuid: "u", name: "n" }));
+    const write = vi.fn(() => "/p");
+
+    const code = await runLogin({}, { validate, write, prompt: ask, log: () => {}, errLog: () => {} });
+
+    expect(code).toBe(0);
+    // URL prompt is not masked; API-key prompt IS masked
+    expect(asks).toEqual([
+      { q: "Chorus URL: ", mask: false },
+      { q: "Chorus API key (cho_...): ", mask: true },
+    ]);
+    expect(validate).toHaveBeenCalledWith({ url: "https://typed", apiKey: "cho_typed" });
+  });
+});
+
+describe("writeLoginFile", () => {
+  it("creates the dir and writes JSON with 0600 mode", () => {
+    const mkdirCalls = [];
+    const writeCalls = [];
+    const path = writeLoginFile(
+      { url: "u", apiKey: "k", agentUuid: "a", agentName: "n" },
+      {
+        path: "/home/u/.chorus/daemon.json",
+        mkdir: (p, o) => mkdirCalls.push([p, o]),
+        write: (p, c, o) => writeCalls.push([p, c, o]),
+      }
+    );
+    expect(path).toBe("/home/u/.chorus/daemon.json");
+    expect(mkdirCalls[0][1]).toEqual({ recursive: true });
+    expect(writeCalls[0][2]).toEqual({ mode: 0o600 });
+    expect(JSON.parse(writeCalls[0][1])).toEqual({ url: "u", apiKey: "k", agentUuid: "a", agentName: "n" });
+  });
+});
+
+describe("prompt masking", () => {
+  it("masked prompt does not echo typed secret characters to output", async () => {
+    // Simulate a readline-style input: feed the query, type chars, press enter.
+    const { Readable, Writable } = await import("node:stream");
+    const outChunks = [];
+    const output = new Writable({
+      write(chunk, _enc, cb) {
+        outChunks.push(chunk.toString());
+        cb();
+      },
+    });
+    // Readable that emits the secret + newline
+    const input = Readable.from(["cho_secret123\n"]);
+    // node's readline needs a TTY-ish input; Readable.from works for line input.
+    const answer = await prompt("Key: ", { mask: true, input, output });
+    expect(answer).toBe("cho_secret123");
+    // The secret must not appear verbatim in echoed output.
+    expect(outChunks.join("")).not.toContain("cho_secret123");
+  });
+});

--- a/cli/__tests__/session-map.test.mjs
+++ b/cli/__tests__/session-map.test.mjs
@@ -1,0 +1,138 @@
+// cli/__tests__/session-map.test.mjs
+// Covers cli-daemon spec "Lineage-anchored session continuity" (mapping half):
+// same root resumes, new root is fresh, persistence, corrupt/missing tolerance.
+import { describe, it, expect } from "vitest";
+import { SessionMap, sessionMapPath } from "../session-map.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+/** In-memory fake fs for the map file. */
+function fakeFs(initialContent) {
+  const store = { content: initialContent };
+  return {
+    store,
+    read: () => {
+      if (store.content === undefined) {
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      }
+      return store.content;
+    },
+    write: (_p, c) => {
+      store.content = c;
+    },
+    mkdir: () => {},
+  };
+}
+
+describe("SessionMap resolve/record", () => {
+  it("new root → isNew:true, sessionId null; after record → isNew:false, resume id", () => {
+    const fs = fakeFs(undefined);
+    const map = new SessionMap({ path: "/m.json", logger: silent, now: () => "T0", ...fs });
+
+    expect(map.resolve("root-1")).toEqual({ sessionId: null, isNew: true });
+
+    map.record("root-1", "claude-sid-1");
+    expect(map.resolve("root-1")).toEqual({ sessionId: "claude-sid-1", isNew: false });
+
+    // Different root is still new
+    expect(map.resolve("root-2")).toEqual({ sessionId: null, isNew: true });
+  });
+
+  it("persists to disk and reloads in a fresh instance", () => {
+    const fs = fakeFs(undefined);
+    const a = new SessionMap({ path: "/m.json", logger: silent, now: () => "T1", ...fs });
+    a.record("root-1", "sid-1");
+
+    // New instance reading the same backing store
+    const b = new SessionMap({ path: "/m.json", logger: silent, ...fs });
+    expect(b.resolve("root-1")).toEqual({ sessionId: "sid-1", isNew: false });
+
+    // Persisted JSON shape
+    expect(JSON.parse(fs.store.content)["root-1"]).toEqual({ sessionId: "sid-1", updatedAt: "T1" });
+  });
+
+  it("record() writes 0600 and includes updatedAt", () => {
+    const writes = [];
+    const map = new SessionMap({
+      path: "/m.json",
+      logger: silent,
+      now: () => "STAMP",
+      read: () => {
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+      write: (p, c, o) => writes.push([p, c, o]),
+      mkdir: () => {},
+    });
+    map.record("k", "s");
+    expect(writes[0][2]).toEqual({ mode: 0o600 });
+    expect(JSON.parse(writes[0][1]).k).toEqual({ sessionId: "s", updatedAt: "STAMP" });
+  });
+});
+
+describe("SessionMap fault tolerance", () => {
+  it("missing file → starts empty (no crash, no warn)", () => {
+    const warns = [];
+    const map = new SessionMap({
+      path: "/nope.json",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      read: () => {
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+      write: () => {},
+      mkdir: () => {},
+    });
+    expect(map.resolve("anything")).toEqual({ sessionId: null, isNew: true });
+    expect(warns).toEqual([]); // missing file is normal, not a warning
+  });
+
+  it("corrupt JSON → starts empty + logs a warning (no crash)", () => {
+    const warns = [];
+    const map = new SessionMap({
+      path: "/m.json",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      read: () => "{ this is not valid json ",
+      write: () => {},
+      mkdir: () => {},
+    });
+    expect(map.resolve("k")).toEqual({ sessionId: null, isNew: true });
+    expect(warns.join("")).toMatch(/corrupt/i);
+  });
+
+  it("ignores entries without a string sessionId", () => {
+    const map = new SessionMap({
+      path: "/m.json",
+      logger: silent,
+      read: () => JSON.stringify({ good: { sessionId: "s" }, bad: { nope: 1 } }),
+      write: () => {},
+      mkdir: () => {},
+    });
+    expect(map.resolve("good").isNew).toBe(false);
+    expect(map.resolve("bad").isNew).toBe(true);
+  });
+
+  it("a failed persist write is swallowed with a warning", () => {
+    const warns = [];
+    const map = new SessionMap({
+      path: "/ro.json",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      read: () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+      write: () => { throw new Error("EACCES"); },
+      mkdir: () => {},
+      now: () => "T",
+    });
+    expect(() => map.record("k", "s")).not.toThrow();
+    expect(warns.join("")).toMatch(/failed to persist/i);
+  });
+});
+
+describe("sessionMapPath", () => {
+  it("ends with .chorus/sessions.json", () => {
+    expect(sessionMapPath().replace(/\\/g, "/")).toMatch(/\.chorus\/sessions\.json$/);
+  });
+});

--- a/cli/__tests__/sse-listener.test.mjs
+++ b/cli/__tests__/sse-listener.test.mjs
@@ -1,0 +1,174 @@
+// cli/__tests__/sse-listener.test.mjs
+// Covers cli-daemon spec "Daemon subcommand and notification subscription"
+// (SSE parsing) and the backoff/reconnect behavior.
+import { describe, it, expect, vi } from "vitest";
+import { SseListener } from "../sse-listener.mjs";
+
+/** Build a fetch Response whose body streams the given chunks then ends. */
+function streamingResponse(chunks, { ok = true, status = 200 } = {}) {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    },
+  });
+  return { ok, status, body };
+}
+
+const silentLogger = { info() {}, warn() {}, error() {} };
+
+describe("SseListener parsing", () => {
+  it("parses data: lines as JSON and ignores heartbeats", async () => {
+    const events = [];
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse([
+        ": connected\n\n",
+        'data: {"type":"new_notification","notificationUuid":"n1"}\n\n',
+        ": heartbeat\n\n",
+        'data: {"type":"count_update","unreadCount":3}\n\n',
+      ])
+    );
+    const listener = new SseListener({
+      url: "https://chorus.example/",
+      apiKey: "cho_x",
+      onEvent: (e) => events.push(e),
+      logger: silentLogger,
+      fetchImpl,
+    });
+
+    await listener.connect();
+    // Give the stream consumer a tick to drain.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(events).toEqual([
+      { type: "new_notification", notificationUuid: "n1" },
+      { type: "count_update", unreadCount: 3 },
+    ]);
+    // Sent Bearer auth to the right endpoint
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://chorus.example/api/events/notifications",
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer cho_x" }) })
+    );
+  });
+
+  it("strips trailing CR so CRLF transports parse", async () => {
+    const events = [];
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse(['data: {"type":"x","v":1}\r\n\r\n'])
+    );
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (e) => events.push(e),
+      logger: silentLogger,
+      fetchImpl,
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(events).toEqual([{ type: "x", v: 1 }]);
+  });
+
+  it("tolerates malformed data line without throwing", async () => {
+    const events = [];
+    const warns = [];
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse(["data: {not json}\n\n", 'data: {"ok":true}\n\n'])
+    );
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (e) => events.push(e),
+      logger: { ...silentLogger, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(events).toEqual([{ ok: true }]);
+    expect(warns.join("")).toMatch(/parse error/i);
+  });
+});
+
+describe("SseListener reconnect", () => {
+  it("schedules a backoff reconnect on non-ok response without crashing", async () => {
+    vi.useFakeTimers();
+    let call = 0;
+    const events = [];
+    const fetchImpl = vi.fn(async () => {
+      call++;
+      if (call === 1) return { ok: false, status: 503, body: null };
+      return streamingResponse(['data: {"type":"after_reconnect"}\n\n']);
+    });
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (e) => events.push(e),
+      logger: silentLogger,
+      fetchImpl,
+      initialDelayMs: 1000,
+    });
+
+    await listener.connect();
+    expect(listener.status).toBe("reconnecting");
+    expect(call).toBe(1);
+
+    // Advance past the 1s backoff → second connect fires.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(call).toBe(2);
+
+    vi.useRealTimers();
+    listener.disconnect();
+  });
+
+  it("fires onReconnect after a successful reconnect", async () => {
+    vi.useFakeTimers();
+    let call = 0;
+    const onReconnect = vi.fn(async () => {});
+    const fetchImpl = vi.fn(async () => {
+      call++;
+      if (call === 1) return { ok: false, status: 500, body: null };
+      return streamingResponse([": hb\n\n"]);
+    });
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: () => {},
+      onReconnect,
+      logger: silentLogger,
+      fetchImpl,
+      initialDelayMs: 500,
+    });
+
+    await listener.connect(); // fails → reconnecting
+    await vi.advanceTimersByTimeAsync(500); // reconnect succeeds
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+    listener.disconnect();
+  });
+
+  it("disconnect() aborts and does not reconnect", async () => {
+    const fetchImpl = vi.fn(
+      (url, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => {
+            const e = new Error("aborted");
+            e.name = "AbortError";
+            reject(e);
+          });
+        })
+    );
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: () => {},
+      logger: silentLogger,
+      fetchImpl,
+    });
+    const p = listener.connect();
+    listener.disconnect();
+    await p;
+    expect(listener.status).toBe("disconnected");
+  });
+});

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -1,0 +1,280 @@
+// cli/__tests__/wake-orchestration.test.mjs
+// Covers the EventRouter → Waker → ClaudeSpawner wake loop, prompt builders,
+// failure isolation, and the no-op upload hooks (cli-daemon spec
+// "Task-dispatch wake" + "Reserved upload hooks").
+import { describe, it, expect, vi } from "vitest";
+import { buildPrompt, WAKE_ACTIONS } from "../prompts.mjs";
+import { createNoopUploadHooks } from "../upload-hooks.mjs";
+import { Waker } from "../waker.mjs";
+import { EventRouter } from "../event-router.mjs";
+import { WakeQueue } from "../wake-queue.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+const TASK_NOTIF = {
+  uuid: "notif-1",
+  projectUuid: "proj-1",
+  entityType: "task",
+  entityUuid: "task-1",
+  entityTitle: "Build the thing",
+  action: "task_assigned",
+  message: "",
+  actorType: "user",
+  actorUuid: "user-1",
+  actorName: "Alice",
+};
+
+describe("buildPrompt", () => {
+  it("task_assigned prompt contains the task + project UUIDs and the claim tool", () => {
+    const p = buildPrompt(TASK_NOTIF);
+    expect(p).toContain("task-1");
+    expect(p).toContain("proj-1");
+    expect(p).toContain("chorus_get_task");
+    expect(p).toContain("chorus_claim_task");
+    expect(p).toContain("@[Alice](user:user-1)"); // mention guidance
+  });
+
+  it("returns null for non-wake actions", () => {
+    expect(buildPrompt({ ...TASK_NOTIF, action: "count_update" })).toBeNull();
+    // Deliberately-ignored real actions also return null.
+    expect(buildPrompt({ ...TASK_NOTIF, action: "task_status_changed" })).toBeNull();
+    expect(buildPrompt({ ...TASK_NOTIF, action: "report_created" })).toBeNull();
+  });
+
+  it("comment_added does NOT wake (too noisy); only an explicit @mention does", () => {
+    // A plain comment to the task's assignee/creator should be ignored...
+    expect(buildPrompt({ ...TASK_NOTIF, action: "comment_added", message: "please rebase" })).toBeNull();
+    // ...but an @mention (delivered as action "mentioned") wakes.
+    const m = buildPrompt({ ...TASK_NOTIF, action: "mentioned", message: "@agent please rebase" });
+    expect(m).not.toBeNull();
+    expect(m).toContain("chorus_get_comments");
+  });
+
+  it("builds a non-null prompt for every action in WAKE_ACTIONS (no dead/missing entries)", () => {
+    for (const action of WAKE_ACTIONS) {
+      const p = buildPrompt({ ...TASK_NOTIF, action });
+      expect(p, `WAKE_ACTIONS has "${action}" but buildPrompt returns null for it`).not.toBeNull();
+    }
+  });
+
+  it("WAKE_ACTIONS covers the agent-relevant server notifications and excludes the noisy ones", () => {
+    for (const a of [
+      "task_assigned",
+      "mentioned",
+      "elaboration_requested",
+      "elaboration_answered",
+      "proposal_rejected",
+      "proposal_approved",
+      "idea_claimed",
+      "task_reopened",
+      "task_verified",
+    ]) {
+      expect(WAKE_ACTIONS.has(a), `expected ${a} to wake`).toBe(true);
+    }
+    for (const a of [
+      "comment_added",
+      "task_status_changed",
+      "task_submitted_for_verify",
+      "report_created",
+      "count_update",
+    ]) {
+      expect(WAKE_ACTIONS.has(a), `expected ${a} NOT to wake`).toBe(false);
+    }
+  });
+});
+
+function makeWaker(overrides = {}) {
+  const spawner = overrides.spawner ?? {
+    wake: vi.fn(async ({ onMessage }) => {
+      onMessage?.({ type: "system", session_id: "new-sid" });
+      return { sessionId: "new-sid", exitCode: 0, isNew: true };
+    }),
+  };
+  const sessionMap =
+    overrides.sessionMap ??
+    {
+      resolve: vi.fn(() => ({ sessionId: null, isNew: true })),
+      record: vi.fn(),
+    };
+  const lineage = overrides.lineage ?? { rootIdeaFor: vi.fn(async () => "root-1") };
+  const hooks = overrides.hooks ?? createNoopUploadHooks();
+  const writeMcpConfigFn =
+    overrides.writeMcpConfigFn ?? vi.fn(() => ({ path: "/tmp/m.json", cleanup: vi.fn() }));
+  const waker = new Waker({
+    creds: { url: "https://c", apiKey: "cho_x" },
+    lineage,
+    sessionMap,
+    spawner,
+    hooks,
+    logger: silent,
+    writeMcpConfigFn,
+  });
+  return { waker, spawner, sessionMap, lineage, hooks, writeMcpConfigFn };
+}
+
+describe("Waker.wake full loop", () => {
+  it("resolves key, builds mcp-config, spawns, records session, cleans up", async () => {
+    const { waker, spawner, sessionMap, writeMcpConfigFn } = makeWaker();
+    const cfg = { path: "/tmp/m.json", cleanup: vi.fn() };
+    writeMcpConfigFn.mockReturnValue(cfg);
+
+    const key = await waker.keyFor(TASK_NOTIF);
+    expect(key).toBe("idea:root-1");
+
+    await waker.wake(TASK_NOTIF, key);
+
+    // spawner got the prompt + null sessionId (new) + mcp config path
+    const spawnArgs = spawner.wake.mock.calls[0][0];
+    expect(spawnArgs.prompt).toContain("task-1");
+    expect(spawnArgs.sessionId).toBeNull();
+    expect(spawnArgs.mcpConfigPath).toBe("/tmp/m.json");
+    // new session id recorded for the key
+    expect(sessionMap.record).toHaveBeenCalledWith("idea:root-1", "new-sid");
+    // temp config cleaned up
+    expect(cfg.cleanup).toHaveBeenCalled();
+  });
+
+  it("passes --resume sessionId for an existing root", async () => {
+    const { waker, spawner } = makeWaker({
+      sessionMap: { resolve: () => ({ sessionId: "existing-sid", isNew: false }), record: vi.fn() },
+    });
+    await waker.wake(TASK_NOTIF, "idea:root-1");
+    expect(spawner.wake.mock.calls[0][0].sessionId).toBe("existing-sid");
+  });
+
+  it("falls back to a per-entity key when there's no idea ancestor", async () => {
+    const { waker } = makeWaker({ lineage: { rootIdeaFor: async () => null } });
+    const key = await waker.keyFor(TASK_NOTIF);
+    expect(key).toBe("entity:task:task-1");
+  });
+
+  it("a spawn failure is logged and does NOT throw", async () => {
+    const warns = [];
+    const { waker } = makeWaker({
+      spawner: { wake: vi.fn(async () => { throw new Error("spawn exploded"); }) },
+    });
+    waker.logger = { ...silent, warn: (m) => warns.push(m) };
+    await expect(waker.wake(TASK_NOTIF, "idea:root-1")).resolves.toBeUndefined();
+    expect(warns.join("")).toMatch(/wake failed/);
+  });
+
+  it("invokes the onSessionStart upload hook (no-op here)", async () => {
+    const onSessionStart = vi.fn(async () => {});
+    const { waker } = makeWaker({
+      hooks: { onSessionStart, onConnect: async () => {}, onTranscriptMessage: async () => {} },
+    });
+    await waker.wake(TASK_NOTIF, "idea:root-1");
+    expect(onSessionStart).toHaveBeenCalledWith(
+      expect.objectContaining({ rootIdeaKey: "idea:root-1", isNew: true })
+    );
+  });
+
+  it("does NOT record a session id when the wake exits non-zero (no phantom --resume)", async () => {
+    const record = vi.fn();
+    const { waker } = makeWaker({
+      sessionMap: { resolve: () => ({ sessionId: null, isNew: true }), record },
+      // exitCode null (e.g. claude missing) — must not be recorded
+      spawner: { wake: vi.fn(async () => ({ sessionId: "phantom", exitCode: null, isNew: true })) },
+    });
+    await waker.wake(TASK_NOTIF, "idea:root-1");
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it("records the session id only on a clean (exit 0) wake", async () => {
+    const record = vi.fn();
+    const { waker } = makeWaker({
+      sessionMap: { resolve: () => ({ sessionId: null, isNew: true }), record },
+      spawner: { wake: vi.fn(async () => ({ sessionId: "real-sid", exitCode: 0, isNew: true })) },
+    });
+    await waker.wake(TASK_NOTIF, "idea:root-1");
+    expect(record).toHaveBeenCalledWith("idea:root-1", "real-sid");
+  });
+});
+
+describe("EventRouter dispatch", () => {
+  function makeRouter(notifications, waker, queue, seen) {
+    const mcpClient = { callTool: vi.fn(async () => ({ notifications })) };
+    const router = new EventRouter({
+      mcpClient,
+      waker,
+      queue,
+      wakeActions: WAKE_ACTIONS,
+      seen,
+      logger: silent,
+    });
+    return { router, mcpClient };
+  }
+
+  it("routes a task_assigned notification onto the queue under its root-idea key", async () => {
+    const enqueued = [];
+    const queue = { enqueue: (key, task) => enqueued.push({ key, task }) };
+    const waker = {
+      keyFor: vi.fn(async () => "idea:root-1"),
+      wake: vi.fn(async () => {}),
+    };
+    const { router } = makeRouter([TASK_NOTIF], waker, queue);
+
+    router.dispatch({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].key).toBe("idea:root-1");
+    // running the enqueued task calls waker.wake with the notification + key
+    await enqueued[0].task();
+    expect(waker.wake).toHaveBeenCalledWith(TASK_NOTIF, "idea:root-1");
+  });
+
+  it("ignores non-new_notification events and non-wake actions", async () => {
+    const queue = { enqueue: vi.fn() };
+    const waker = { keyFor: vi.fn(), wake: vi.fn() };
+    const { router } = makeRouter([{ ...TASK_NOTIF, action: "count_update" }], waker, queue);
+
+    router.dispatch({ type: "count_update" });
+    router.dispatch({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(queue.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("de-dupes a notification already handled (shared seen set) — no double wake on reconnect", async () => {
+    const enqueued = [];
+    const queue = { enqueue: (key, task) => enqueued.push({ key, task }) };
+    const waker = { keyFor: vi.fn(async () => "idea:root-1"), wake: vi.fn(async () => {}) };
+    const seen = new Set();
+    const { router } = makeRouter([TASK_NOTIF], waker, queue, seen);
+
+    // Live delivery, then a reconnect-backfill re-dispatch of the SAME uuid.
+    router.dispatch({ type: "new_notification", notificationUuid: "notif-1" });
+    router.dispatch({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(enqueued).toHaveLength(1); // only one wake despite two dispatches
+    expect(seen.has("notif-1")).toBe(true);
+  });
+
+  it("two same-root notifications do not spawn concurrently (serialized via the real queue)", async () => {
+    const queue = new WakeQueue({ logger: silent });
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    const spawner = {
+      wake: vi.fn(async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((r) => setTimeout(r, 5));
+        concurrent--;
+        return { sessionId: "sid", exitCode: 0, isNew: true };
+      }),
+    };
+    const { waker } = makeWaker({ spawner, lineage: { rootIdeaFor: async () => "root-1" } });
+    const notifA = { ...TASK_NOTIF, uuid: "a" };
+    const notifB = { ...TASK_NOTIF, uuid: "b" };
+    const { router } = makeRouter([notifA, notifB], waker, queue);
+
+    router.dispatch({ type: "new_notification", notificationUuid: "a" });
+    router.dispatch({ type: "new_notification", notificationUuid: "b" });
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(spawner.wake).toHaveBeenCalledTimes(2);
+    expect(maxConcurrent).toBe(1); // same root → never concurrent
+  });
+});

--- a/cli/__tests__/wake-queue.test.mjs
+++ b/cli/__tests__/wake-queue.test.mjs
@@ -1,0 +1,129 @@
+// cli/__tests__/wake-queue.test.mjs
+// Covers cli-daemon spec "Per-root-idea wake serialization" — the BLOCKER fix
+// from proposal review. Three scenarios: same-key serial, cross-key concurrent,
+// failed task doesn't wedge the key.
+import { describe, it, expect } from "vitest";
+import { WakeQueue } from "../wake-queue.mjs";
+
+/** A controllable async task: resolves only when release() is called. */
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, release: () => resolve() };
+}
+
+const silent = { info() {}, warn() {}, error() {} };
+
+describe("WakeQueue same-key serialization", () => {
+  it("runs two same-key tasks strictly sequentially (2nd waits for 1st)", async () => {
+    const q = new WakeQueue({ logger: silent });
+    const order = [];
+    const d1 = deferred();
+    const d2 = deferred();
+
+    q.enqueue("root-1", async () => {
+      order.push("start-1");
+      await d1.promise;
+      order.push("end-1");
+    });
+    q.enqueue("root-1", async () => {
+      order.push("start-2");
+      await d2.promise;
+      order.push("end-2");
+    });
+
+    // Let microtasks flush: only task 1 should have started.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(["start-1"]);
+
+    // Finish task 1 → task 2 starts only now.
+    d1.release();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(order).toEqual(["start-1", "end-1", "start-2"]);
+
+    d2.release();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(order).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+  });
+});
+
+describe("WakeQueue cross-key concurrency", () => {
+  it("runs tasks for different keys concurrently", async () => {
+    const q = new WakeQueue({ maxConcurrency: 4, logger: silent });
+    const started = [];
+    const dA = deferred();
+    const dB = deferred();
+
+    q.enqueue("root-A", async () => {
+      started.push("A");
+      await dA.promise;
+    });
+    q.enqueue("root-B", async () => {
+      started.push("B");
+      await dB.promise;
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    // Both started without either finishing → genuinely concurrent.
+    expect(started.sort()).toEqual(["A", "B"]);
+    dA.release();
+    dB.release();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it("respects the global concurrency cap", async () => {
+    const q = new WakeQueue({ maxConcurrency: 2, logger: silent });
+    let active = 0;
+    let maxActive = 0;
+    const defs = [];
+    for (let i = 0; i < 5; i++) {
+      const d = deferred();
+      defs.push(d);
+      q.enqueue(`key-${i}`, async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await d.promise;
+        active--;
+      });
+    }
+    await new Promise((r) => setTimeout(r, 0));
+    expect(maxActive).toBe(2); // never more than the cap at once
+    defs.forEach((d) => d.release());
+    await new Promise((r) => setTimeout(r, 0));
+  });
+});
+
+describe("WakeQueue failure isolation", () => {
+  it("a throwing task is logged and the next same-key task still runs", async () => {
+    const warns = [];
+    const q = new WakeQueue({ logger: { ...silent, warn: (m) => warns.push(m) } });
+    const ran = [];
+
+    q.enqueue("root-1", async () => {
+      ran.push("first");
+      throw new Error("boom");
+    });
+    q.enqueue("root-1", async () => {
+      ran.push("second");
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(ran).toEqual(["first", "second"]); // poisoned task didn't wedge the key
+    expect(warns.join("")).toMatch(/wake task for root-1 failed/);
+  });
+});
+
+describe("WakeQueue enqueue is non-blocking", () => {
+  it("enqueue returns synchronously before the task runs", async () => {
+    const q = new WakeQueue({ logger: silent });
+    let ran = false;
+    q.enqueue("k", async () => {
+      ran = true;
+    });
+    // Synchronously after enqueue, the task has not run yet.
+    expect(ran).toBe(false);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(ran).toBe(true);
+  });
+});

--- a/cli/backfill.mjs
+++ b/cli/backfill.mjs
@@ -1,0 +1,64 @@
+// cli/backfill.mjs
+// Reconnect backfill: after the SSE stream reconnects, pull notifications that
+// arrived during the gap and hand each to the dispatch callback, so a dispatch
+// that occurred while the daemon was briefly disconnected is not lost
+// (cli-daemon spec "Reconnect with backfill"). Ported from the OpenClaw
+// plugin's onReconnect logic.
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/**
+ * Build an onReconnect handler that fetches unread notifications via MCP and
+ * re-emits each as a synthetic `new_notification` event into `dispatch`.
+ * De-dupes against notifications already seen this run so a reconnect storm
+ * doesn't double-wake.
+ *
+ * @param {{
+ *   mcpClient: { callTool: (name: string, args?: Record<string, unknown>) => Promise<unknown> },
+ *   dispatch: (event: { type: string, notificationUuid: string }) => void,
+ *   seen?: Set<string>,
+ *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+ *   limit?: number,
+ * }} opts
+ * @returns {() => Promise<void>}
+ */
+export function createBackfill(opts) {
+  const { mcpClient, dispatch } = opts;
+  const seen = opts.seen ?? new Set();
+  const logger = opts.logger ?? NOOP_LOGGER;
+  const limit = opts.limit ?? 50;
+
+  return async function backfill() {
+    let result;
+    try {
+      result = /** @type {{ notifications?: Array<{ uuid: string }> }} */ (
+        await mcpClient.callTool("chorus_get_notifications", {
+          status: "unread",
+          limit,
+          autoMarkRead: false,
+        })
+      );
+    } catch (err) {
+      logger.warn(`[Chorus] backfill fetch failed: ${err}`);
+      return;
+    }
+
+    const notifications = result?.notifications;
+    if (!Array.isArray(notifications)) {
+      logger.warn("[Chorus] backfill: no notifications array in response");
+      return;
+    }
+
+    let redispatched = 0;
+    for (const n of notifications) {
+      if (!n || typeof n.uuid !== "string") continue;
+      if (seen.has(n.uuid)) continue;
+      seen.add(n.uuid);
+      redispatched++;
+      dispatch({ type: "new_notification", notificationUuid: n.uuid });
+    }
+    if (redispatched > 0) {
+      logger.info(`[Chorus] backfill re-dispatched ${redispatched} missed notification(s)`);
+    }
+  };
+}

--- a/cli/backfill.mjs
+++ b/cli/backfill.mjs
@@ -52,8 +52,12 @@ export function createBackfill(opts) {
     let redispatched = 0;
     for (const n of notifications) {
       if (!n || typeof n.uuid !== "string") continue;
+      // Pre-check only — do NOT mark seen here. The router (dispatch) is the
+      // single owner of marking-at-dispatch; if backfill marked first, the
+      // router's own `seen.has(...)` early-return would fire and the wake would
+      // never enqueue (every backfilled dispatch silently dropped). This
+      // pre-check is just a cheap early-out for notifications already handled.
       if (seen.has(n.uuid)) continue;
-      seen.add(n.uuid);
       redispatched++;
       dispatch({ type: "new_notification", notificationUuid: n.uuid });
     }

--- a/cli/chorus-client.mjs
+++ b/cli/chorus-client.mjs
@@ -1,0 +1,144 @@
+// cli/chorus-client.mjs
+// Minimal MCP client for the Chorus CLI daemon's OWN calls into the server
+// (login validation, notification backfill, lineage resolution). Reuses
+// @modelcontextprotocol/sdk, already a top-level dependency — adds no new dep
+// (CLAUDE.md pitfall #9). Plain ESM port of packages/openclaw-plugin/src/mcp-client.ts.
+//
+// This is the daemon's client to Chorus; it is NOT how the spawned Claude Code
+// gets its chorus_* tools (that's wired via --mcp-config in the spawner task).
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/**
+ * @typedef {Object} ChorusClientOptions
+ * @property {string} url      Chorus base URL.
+ * @property {string} apiKey   `cho_` API key.
+ * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
+ */
+
+export class ChorusClient {
+  /** @param {ChorusClientOptions} opts */
+  constructor(opts) {
+    this.url = opts.url;
+    this.apiKey = opts.apiKey;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    /** @type {Client | null} */
+    this.client = null;
+    /** @type {StreamableHTTPClientTransport | null} */
+    this.transport = null;
+    this.status = "disconnected";
+  }
+
+  /** Lazily establish the MCP connection. */
+  async connect() {
+    if (this.status === "connected" && this.client) return;
+    this.status = "connecting";
+    try {
+      this.transport = new StreamableHTTPClientTransport(new URL("/api/mcp", this.url), {
+        requestInit: { headers: { Authorization: `Bearer ${this.apiKey}` } },
+      });
+      this.client = new Client({ name: "chorus-cli-daemon", version: "0.1.0" });
+      await this.client.connect(this.transport);
+      this.status = "connected";
+    } catch (err) {
+      this.status = "disconnected";
+      this.client = null;
+      this.transport = null;
+      throw err;
+    }
+  }
+
+  /**
+   * Call an MCP tool, returning the first text content block parsed as JSON
+   * (or the raw text if not JSON). Lazy-connects; retries once on a stateless
+   * 404 / session-expired error.
+   * @param {string} name
+   * @param {Record<string, unknown>} [args]
+   * @returns {Promise<unknown>}
+   */
+  async callTool(name, args = {}) {
+    if (!this.client || this.status !== "connected") await this.connect();
+    try {
+      return await this.#doCallTool(name, args);
+    } catch (err) {
+      if (this.#isSessionExpired(err)) {
+        this.logger.warn("MCP session expired, reconnecting...");
+        this.status = "reconnecting";
+        this.client = null;
+        this.transport = null;
+        await this.connect();
+        return await this.#doCallTool(name, args);
+      }
+      throw err;
+    }
+  }
+
+  async disconnect() {
+    if (this.client) {
+      try {
+        await this.client.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.client = null;
+    this.transport = null;
+    this.status = "disconnected";
+  }
+
+  /** @param {string} name @param {Record<string, unknown>} args */
+  async #doCallTool(name, args) {
+    if (!this.client) throw new Error("MCP client not connected");
+    const result = await this.client.callTool({ name, arguments: args });
+    const blocks = /** @type {Array<{type:string,text?:string}>} */ (result.content ?? []);
+    if (result.isError) {
+      const text = blocks.filter((c) => c.type === "text").map((c) => c.text).join("\n");
+      throw new Error(`Chorus MCP tool error (${name}): ${text}`);
+    }
+    const textBlock = blocks.find((c) => c.type === "text");
+    if (!textBlock?.text) return null;
+    try {
+      return JSON.parse(textBlock.text);
+    } catch {
+      return textBlock.text;
+    }
+  }
+
+  /** @param {unknown} err */
+  #isSessionExpired(err) {
+    if (err instanceof Error) {
+      const m = err.message.toLowerCase();
+      return m.includes("404") || m.includes("session") || m.includes("not found");
+    }
+    return false;
+  }
+}
+
+/**
+ * Validate a url + apiKey pair by calling `chorus_checkin` and reading the
+ * authenticated agent identity. Returns the identity on success; throws on
+ * failure (bad key, unreachable server, unexpected shape).
+ *
+ * @param {{ url: string, apiKey: string }} creds
+ * @param {{ makeClient?: (o: ChorusClientOptions) => ChorusClient }} [deps]
+ * @returns {Promise<{ uuid: string, name: string }>}
+ */
+export async function validateAndFetchIdentity(creds, deps = {}) {
+  const makeClient = deps.makeClient ?? ((o) => new ChorusClient(o));
+  const client = makeClient({ url: creds.url, apiKey: creds.apiKey });
+  try {
+    const result = /** @type {{ agent?: { uuid?: string, name?: string } }} */ (
+      await client.callTool("chorus_checkin", {})
+    );
+    const agent = result?.agent;
+    if (!agent || typeof agent.uuid !== "string") {
+      throw new Error("Unexpected chorus_checkin response — no agent identity returned");
+    }
+    return { uuid: agent.uuid, name: typeof agent.name === "string" ? agent.name : agent.uuid };
+  } finally {
+    await client.disconnect();
+  }
+}

--- a/cli/chorus-client.mjs
+++ b/cli/chorus-client.mjs
@@ -96,7 +96,13 @@ export class ChorusClient {
     const blocks = /** @type {Array<{type:string,text?:string}>} */ (result.content ?? []);
     if (result.isError) {
       const text = blocks.filter((c) => c.type === "text").map((c) => c.text).join("\n");
-      throw new Error(`Chorus MCP tool error (${name}): ${text}`);
+      // Tool-LEVEL error (e.g. "Task not found"): the call reached the server
+      // and the tool ran — this is NOT a transport/session failure. Tag it so
+      // #isSessionExpired won't mistake its text (which may contain "not found")
+      // for a stateless-404 and trigger a pointless reconnect + retry.
+      const err = new Error(`Chorus MCP tool error (${name}): ${text}`);
+      /** @type {any} */ (err).isToolError = true;
+      throw err;
     }
     const textBlock = blocks.find((c) => c.type === "text");
     if (!textBlock?.text) return null;
@@ -109,11 +115,15 @@ export class ChorusClient {
 
   /** @param {unknown} err */
   #isSessionExpired(err) {
-    if (err instanceof Error) {
-      const m = err.message.toLowerCase();
-      return m.includes("404") || m.includes("session") || m.includes("not found");
-    }
-    return false;
+    if (!(err instanceof Error)) return false;
+    // A tool-level error reached the server and ran — never a session/transport
+    // issue, so don't reconnect+retry on it (it'd fail identically).
+    if (/** @type {any} */ (err).isToolError) return false;
+    const m = err.message.toLowerCase();
+    // Stateless-404 / lost-transport signals only. "not found" is intentionally
+    // NOT matched on its own (too broad — collides with entity-not-found tool
+    // text); a transport 404 still contains "404".
+    return m.includes("404") || m.includes("session");
   }
 }
 

--- a/cli/claude-spawner.mjs
+++ b/cli/claude-spawner.mjs
@@ -1,0 +1,290 @@
+// cli/claude-spawner.mjs
+// Cross-platform headless Claude Code spawner. This is the load-bearing
+// engineering point of the daemon: parsing stream-json is plain JS and
+// platform-neutral; the real work is spawning, and it is all Windows.
+//
+// Verified against Claude Code CLI 2.1.177:
+//   • `-p/--print` + `--output-format stream-json` emits NDJSON (one JSON object
+//     per line); every line carries `session_id`.
+//   • `--session-id <uuid>` sets the session id for a fresh run, and
+//     `--resume <uuid>` continues it. So we GENERATE the session id client-side
+//     and pass it in, rather than scraping it from the init event — the id is
+//     authoritative on our side. We still read `session_id` from the stream as
+//     confirmation.
+//   • `--mcp-config <file>` loads MCP servers from a JSON file.
+//
+// The flag list lives in ONE place (buildArgs) so a CLI flag change is a
+// single-line edit.
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { statSync } from "node:fs";
+import { win32 as pathWin32, posix as pathPosix } from "node:path";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/**
+ * Resolve the real `claude` executable path WITHOUT a shell. On Windows the bin
+ * is `claude.cmd` (npm shim); `spawn("claude")` without `shell:true` throws
+ * ENOENT because it won't resolve `.cmd`. We walk PATH for the platform's
+ * candidate names and return the first that exists. `shell:true` is avoided
+ * deliberately — it re-introduces the escaping/injection surface.
+ *
+ * @param {{ env?: NodeJS.ProcessEnv, platform?: NodeJS.Platform, isFile?: (p: string) => boolean }} [deps]
+ * @returns {string | null}
+ */
+export function resolveClaudePath(deps = {}) {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const isFile =
+    deps.isFile ??
+    ((p) => {
+      // isFile (not just exists): a directory named `claude` on PATH would
+      // otherwise be "found" and then fail at spawn time.
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+  // An explicit override always wins (set by the daemon if the user configured it).
+  if (env.CHORUS_CLAUDE_PATH && isFile(env.CHORUS_CLAUDE_PATH)) {
+    return env.CHORUS_CLAUDE_PATH;
+  }
+
+  // Use platform-correct path semantics so the resolver is testable for
+  // Windows from a POSIX host (`;` delimiter + `\` join vs `:` + `/`).
+  const isWin = platform === "win32";
+  const p = isWin ? pathWin32 : pathPosix;
+  const names = isWin ? ["claude.cmd", "claude.exe", "claude"] : ["claude"];
+  const pathVar = env.PATH || env.Path || "";
+  const dirs = pathVar.split(p.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = p.join(dir, name);
+      if (isFile(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * The MCP server name the daemon writes into --mcp-config (see mcp-config.mjs).
+ * Claude namespaces its tools as `mcp__<serverName>__<tool>`, so this drives the
+ * default allowlist below. Keep in sync with mcp-config.mjs's `mcpServers` key.
+ */
+export const CHORUS_MCP_SERVER_NAME = "chorus";
+
+/**
+ * Permission posture for the spawned headless Claude. Headless `claude -p`
+ * auto-DENIES any tool that isn't pre-approved (there's no interactive prompt to
+ * answer), so without one of these the woken agent can't call a single chorus_*
+ * tool and exits having done nothing. Verified against Claude Code 2.1.177.
+ *
+ * - "chorus" (default): `--allowedTools "mcp__chorus__*"` — the woken agent may
+ *   use Chorus MCP tools (comment, claim, report, status) but NOT Bash / file
+ *   edits. Safe default: covers comment/assign/elaboration wakes out of the box,
+ *   minimal blast radius.
+ * - "yolo": `--dangerously-skip-permissions` — full autonomy (Bash, file writes,
+ *   everything). Needed for real code-writing AI-DLC work. Dangerous: the woken
+ *   agent gets a full shell under the daemon's key, with a prompt that embeds
+ *   server-supplied strings. Use only in a trusted/sandboxed environment.
+ * @typedef {"chorus"|"yolo"} PermissionMode
+ */
+
+/**
+ * Build the argv for a headless run. Prompt is NEVER here — it goes over stdin.
+ * @param {{ sessionId: string, isNew: boolean, mcpConfigPath?: string, permissionMode?: PermissionMode }} o
+ * @returns {string[]}
+ */
+export function buildArgs({ sessionId, isNew, mcpConfigPath, permissionMode = "chorus" }) {
+  const args = ["-p", "--output-format", "stream-json", "--verbose"];
+  if (isNew) args.push("--session-id", sessionId);
+  else args.push("--resume", sessionId);
+  if (mcpConfigPath) args.push("--mcp-config", mcpConfigPath);
+  if (permissionMode === "yolo") {
+    args.push("--dangerously-skip-permissions");
+  } else {
+    // Default: allow only this daemon's Chorus MCP tools through, nothing else.
+    args.push("--allowedTools", `mcp__${CHORUS_MCP_SERVER_NAME}__*`);
+  }
+  return args;
+}
+
+/**
+ * Resolve the actual command + argv to spawn, given the resolved claude path
+ * and the headless args. On Windows a `.cmd`/`.bat` shim is NOT a PE executable,
+ * so `CreateProcess` (i.e. spawn with shell:false) cannot run it directly — it
+ * must be invoked through `cmd.exe /d /s /c <path> ...args`. We keep shell:false
+ * and pass argv as an array (no string concatenation), so there is no shell
+ * word-splitting / injection surface. On POSIX, and for a real `.exe`, we spawn
+ * the path directly.
+ *
+ * @param {string} claudePath
+ * @param {string[]} args
+ * @param {NodeJS.Platform} [platform]
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ command: string, argv: string[] }}
+ */
+export function resolveSpawnCommand(claudePath, args, platform = process.platform, env = process.env) {
+  const isWin = platform === "win32";
+  const lower = claudePath.toLowerCase();
+  if (isWin && (lower.endsWith(".cmd") || lower.endsWith(".bat"))) {
+    const comspec = env.ComSpec || env.COMSPEC || "cmd.exe";
+    // /d skip AutoRun, /s treat everything after /c literally, /c run then exit.
+    return { command: comspec, argv: ["/d", "/s", "/c", claudePath, ...args] };
+  }
+  return { command: claudePath, argv: args };
+}
+
+/**
+ * Parse a chunk of NDJSON, appending to a line buffer. Strips trailing CR
+ * (Windows \r\n) and ignores blank lines. Returns parsed objects; malformed
+ * lines are reported to `onWarn` and skipped (never throw).
+ *
+ * @param {string} buffer  Carry-over from previous chunk.
+ * @param {string} chunk
+ * @param {(obj: any) => void} onObject
+ * @param {(msg: string) => void} [onWarn]
+ * @returns {string}  New carry-over buffer (incomplete trailing line).
+ */
+export function parseNdjsonChunk(buffer, chunk, onObject, onWarn = () => {}) {
+  buffer += chunk;
+  let nl;
+  while ((nl = buffer.indexOf("\n")) !== -1) {
+    const line = buffer.slice(0, nl).replace(/\r$/, "");
+    buffer = buffer.slice(nl + 1);
+    if (!line.trim()) continue;
+    try {
+      onObject(JSON.parse(line));
+    } catch (err) {
+      onWarn(`stream-json parse error: ${err} — line: ${line}`);
+    }
+  }
+  return buffer;
+}
+
+/**
+ * @typedef {Object} ClaudeSpawnerOptions
+ * @property {string} [claudePath]   Resolved claude path (resolved lazily if omitted).
+ * @property {(o: object) => { stdin: any, stdout: any, stderr: any, on: Function, kill?: Function }} [spawnImpl]
+ * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
+ * @property {() => string} [genId]  Session-id generator (override in tests).
+ * @property {PermissionMode} [permissionMode]  How much the woken Claude may do (default "chorus").
+ */
+
+export class ClaudeSpawner {
+  /** @param {ClaudeSpawnerOptions} [opts] */
+  constructor(opts = {}) {
+    this.claudePath = opts.claudePath ?? null;
+    this.spawnImpl = opts.spawnImpl ?? spawn;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    this.genId = opts.genId ?? randomUUID;
+    this.permissionMode = opts.permissionMode ?? "chorus";
+  }
+
+  /**
+   * Spawn a headless Claude run. Resolves when the subprocess exits. The prompt
+   * is written to stdin (never argv) — this is what keeps long prompts off the
+   * Windows command line and out of shell escaping/injection.
+   *
+   * @param {{ prompt: string, sessionId?: string|null, mcpConfigPath?: string,
+   *           cwd?: string, onMessage?: (obj: any) => void }} params
+   * @returns {Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }>}
+   */
+  async wake({ prompt, sessionId = null, mcpConfigPath, cwd, onMessage }) {
+    const isNew = !sessionId;
+    const id = sessionId ?? this.genId();
+
+    const claudePath = this.claudePath ?? resolveClaudePath();
+    if (!claudePath) {
+      // No crash — surface visibly and resolve with a failure result.
+      this.logger.error("[Chorus] cannot locate the `claude` executable on PATH; skipping wake");
+      return { sessionId: id, exitCode: null, isNew };
+    }
+
+    const args = buildArgs({ sessionId: id, isNew, mcpConfigPath, permissionMode: this.permissionMode });
+    // On Windows, a .cmd/.bat shim must be run via cmd.exe /c (CreateProcess
+    // can't exec a script directly). resolveSpawnCommand keeps shell:false and
+    // passes argv as an array — no shell injection surface either way.
+    const { command, argv } = resolveSpawnCommand(claudePath, args);
+
+    return new Promise((resolve) => {
+      let child;
+      try {
+        child = this.spawnImpl(command, argv, {
+          cwd: cwd ?? process.cwd(),
+          stdio: ["pipe", "pipe", "pipe"],
+          // No shell:true — command is either the real executable or cmd.exe
+          // with the script as an argv element. Avoids shell word-splitting /
+          // injection; .cmd is handled explicitly via cmd.exe above.
+          shell: false,
+          windowsHide: true,
+        });
+      } catch (err) {
+        this.logger.error(`[Chorus] failed to spawn claude: ${err}`);
+        resolve({ sessionId: id, exitCode: null, isNew });
+        return;
+      }
+
+      let stdoutBuf = "";
+      let observedSessionId = id;
+
+      child.stdout?.setEncoding?.("utf8");
+      child.stdout?.on("data", (chunk) => {
+        stdoutBuf = parseNdjsonChunk(
+          stdoutBuf,
+          String(chunk),
+          (obj) => {
+            if (obj && typeof obj.session_id === "string") observedSessionId = obj.session_id;
+            if (onMessage) {
+              try {
+                onMessage(obj);
+              } catch (err) {
+                this.logger.warn(`[Chorus] onMessage handler threw: ${err}`);
+              }
+            }
+          },
+          (msg) => this.logger.warn(`[Chorus] ${msg}`)
+        );
+      });
+
+      child.stderr?.setEncoding?.("utf8");
+      child.stderr?.on("data", (chunk) => {
+        const text = String(chunk).trim();
+        if (text) this.logger.warn(`[Chorus] claude stderr: ${text}`);
+      });
+
+      child.on("error", (err) => {
+        // e.g. ENOENT if the resolved path vanished — log, don't throw.
+        this.logger.error(`[Chorus] claude process error: ${err}`);
+        resolve({ sessionId: observedSessionId, exitCode: null, isNew });
+      });
+
+      child.on("close", (code) => {
+        if (code !== 0) {
+          this.logger.warn(`[Chorus] claude exited with code ${code}`);
+        }
+        resolve({ sessionId: observedSessionId, exitCode: code, isNew });
+      });
+
+      // Guard against an ASYNC stdin error (EPIPE): if claude exits/closes
+      // stdin before the prompt finishes flushing, the writable emits an
+      // 'error' event. Without this listener it becomes an uncaughtException
+      // and crashes the daemon — violating "one failed wake does not kill the
+      // daemon". The try/catch below only catches a synchronous throw.
+      child.stdin?.on?.("error", (err) => {
+        this.logger.warn(`[Chorus] claude stdin error (ignored): ${err}`);
+      });
+
+      // Feed the prompt over stdin, then close it so the model runs.
+      try {
+        child.stdin?.write(prompt);
+        child.stdin?.end();
+      } catch (err) {
+        this.logger.warn(`[Chorus] failed writing prompt to claude stdin: ${err}`);
+      }
+    });
+  }
+}

--- a/cli/credentials.mjs
+++ b/cli/credentials.mjs
@@ -1,0 +1,138 @@
+// cli/credentials.mjs
+// Layered resolution of the Chorus server URL + `cho_` API key for the daemon
+// and login subcommands. Plain ESM, zero dependencies — ships verbatim in the
+// npm package alongside chorus.mjs (see package.json `files`).
+//
+// Precedence (first complete pair wins):
+//   1. explicit flags        --url / --api-key
+//   2. environment           CHORUS_URL / CHORUS_API_KEY
+//   3. login file            ~/.chorus/daemon.json   (written by `chorus login`)
+//   4. plugin fallback       ~/.claude/settings.json  → .env.CHORUS_URL / .env.CHORUS_API_KEY
+//
+// The CC chorus plugin does NOT persist credentials to a file — it reads
+// CHORUS_URL / CHORUS_API_KEY from the environment, which users configure in
+// the `env` block of ~/.claude/settings.json. Tier 4 reads that block as a
+// best-effort last resort (file may be absent or differently shaped — read
+// defensively). Verified against the 0.10.0 plugin: bin/*.sh all read the two
+// env vars; .chorus/state.json holds session state, never credentials.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Absolute path to the login file written by `chorus login`. */
+export function loginFilePath() {
+  return join(homedir(), ".chorus", "daemon.json");
+}
+
+/** Absolute path to the Claude Code user settings file (plugin fallback source). */
+export function claudeSettingsPath() {
+  return join(homedir(), ".claude", "settings.json");
+}
+
+/**
+ * Read a JSON file, returning `null` on any error (missing / unreadable /
+ * malformed). Never throws — callers treat a null as "source absent".
+ * @param {string} path
+ * @returns {Record<string, unknown> | null}
+ */
+function readJsonSafe(path) {
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A non-empty string, or undefined. Trims; empty/whitespace → undefined. */
+function nonEmpty(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * @typedef {Object} ResolvedCredentials
+ * @property {string} url
+ * @property {string} apiKey
+ * @property {"flag"|"env"|"login-file"|"plugin-fallback"} source
+ */
+
+/**
+ * @typedef {Object} ResolveDeps  Injectable IO for tests (no real disk/env).
+ * @property {Record<string, string|undefined>} [env]
+ * @property {(path: string) => (Record<string, unknown>|null)} [readJson]
+ * @property {string} [loginPath]
+ * @property {string} [settingsPath]
+ */
+
+/**
+ * Resolve credentials from the four layered sources, in fixed precedence.
+ *
+ * @param {{ url?: string, apiKey?: string }} flags  Explicit --url / --api-key.
+ * @param {ResolveDeps} [deps]
+ * @returns {ResolvedCredentials}
+ * @throws {Error} when no source yields a complete url+apiKey pair. The message
+ *   lists every source that was tried and how to supply credentials.
+ */
+export function resolveCredentials(flags = {}, deps = {}) {
+  const env = deps.env ?? process.env;
+  const readJson = deps.readJson ?? readJsonSafe;
+  const loginPath = deps.loginPath ?? loginFilePath();
+  const settingsPath = deps.settingsPath ?? claudeSettingsPath();
+
+  const tried = [];
+
+  // 1. Explicit flags
+  tried.push("--url/--api-key flags");
+  {
+    const url = nonEmpty(flags.url);
+    const apiKey = nonEmpty(flags.apiKey);
+    if (url && apiKey) return { url, apiKey, source: "flag" };
+  }
+
+  // 2. Environment variables
+  tried.push("CHORUS_URL / CHORUS_API_KEY environment variables");
+  {
+    const url = nonEmpty(env.CHORUS_URL);
+    const apiKey = nonEmpty(env.CHORUS_API_KEY);
+    if (url && apiKey) return { url, apiKey, source: "env" };
+  }
+
+  // 3. Login file (~/.chorus/daemon.json)
+  tried.push(`login file (${loginPath}, run \`chorus login\`)`);
+  {
+    const file = readJson(loginPath);
+    if (file) {
+      const url = nonEmpty(file.url);
+      const apiKey = nonEmpty(file.apiKey);
+      if (url && apiKey) return { url, apiKey, source: "login-file" };
+    }
+  }
+
+  // 4. Plugin fallback (~/.claude/settings.json → env block)
+  tried.push(`Claude Code plugin config (${settingsPath} → env.CHORUS_URL/CHORUS_API_KEY)`);
+  {
+    const settings = readJson(settingsPath);
+    const envBlock =
+      settings && typeof settings.env === "object" && settings.env !== null
+        ? /** @type {Record<string, unknown>} */ (settings.env)
+        : null;
+    if (envBlock) {
+      const url = nonEmpty(envBlock.CHORUS_URL);
+      const apiKey = nonEmpty(envBlock.CHORUS_API_KEY);
+      if (url && apiKey) return { url, apiKey, source: "plugin-fallback" };
+    }
+  }
+
+  throw new Error(
+    "Could not resolve Chorus credentials (url + cho_ API key). Tried, in order:\n" +
+      tried.map((t, i) => `  ${i + 1}. ${t}`).join("\n") +
+      "\n\nSupply credentials with one of:\n" +
+      "  • flags:   chorus daemon --url <https://...> --api-key <cho_...>\n" +
+      "  • env:     CHORUS_URL=<https://...> CHORUS_API_KEY=<cho_...> chorus daemon\n" +
+      "  • login:   chorus login   (persists to ~/.chorus/daemon.json)\n"
+  );
+}

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -1,0 +1,193 @@
+// cli/daemon.mjs
+// `chorus daemon` — the assembled client daemon. Wires together:
+//   CredentialResolver → ChorusClient (MCP) + SseListener (+ reconnect backfill)
+//     → EventRouter → WakeQueue → Waker (LineageResolver + SessionMap + ClaudeSpawner)
+// On a task_assigned (and other wake actions) it spawns a local headless Claude
+// Code, serialized per root idea, that acts via the chorus_* MCP tools.
+//
+// Connection / session / transcript reporting to the server is intentionally
+// NOT done here — the no-op UploadHooks reserve those seams for the derived
+// observability idea.
+
+import { resolveCredentials } from "./credentials.mjs";
+import { ChorusClient, validateAndFetchIdentity } from "./chorus-client.mjs";
+import { SseListener } from "./sse-listener.mjs";
+import { createBackfill } from "./backfill.mjs";
+import { EventRouter } from "./event-router.mjs";
+import { WakeQueue } from "./wake-queue.mjs";
+import { Waker } from "./waker.mjs";
+import { LineageResolver } from "./lineage.mjs";
+import { SessionMap } from "./session-map.mjs";
+import { ClaudeSpawner, resolveClaudePath } from "./claude-spawner.mjs";
+import { createNoopUploadHooks } from "./upload-hooks.mjs";
+import { WAKE_ACTIONS } from "./prompts.mjs";
+
+function defaultLogger() {
+  return {
+    info: (m) => process.stdout.write(`${m}\n`),
+    warn: (m) => process.stderr.write(`${m}\n`),
+    error: (m) => process.stderr.write(`${m}\n`),
+  };
+}
+
+/**
+ * Build the fully-wired daemon without starting it. Returned object exposes
+ * `start()` / `stop()` and the internal pieces (for integration tests).
+ *
+ * @param {{ url: string, apiKey: string }} creds
+ * @param {{
+ *   logger?: any,
+ *   mcpClient?: any,
+ *   sseListener?: any,
+ *   spawner?: any,
+ *   sessionMap?: any,
+ *   hooks?: any,
+ *   makeSseListener?: (opts: any) => any,
+ *   maxConcurrency?: number,
+ *   permissionMode?: "chorus"|"yolo",
+ * }} [deps]
+ */
+export function buildDaemon(creds, deps = {}) {
+  const logger = deps.logger ?? defaultLogger();
+  const hooks = deps.hooks ?? createNoopUploadHooks();
+  const permissionMode = deps.permissionMode ?? "chorus";
+
+  const mcpClient =
+    deps.mcpClient ?? new ChorusClient({ url: creds.url, apiKey: creds.apiKey, logger });
+  const lineage = new LineageResolver({ mcpClient, logger });
+  const sessionMap = deps.sessionMap ?? new SessionMap({ logger });
+  const spawner = deps.spawner ?? new ClaudeSpawner({ logger, permissionMode });
+  const queue = new WakeQueue({ maxConcurrency: deps.maxConcurrency ?? 4, logger });
+
+  // One dedup set shared by the router (live SSE path) and the reconnect
+  // backfill, so a notification handled live is never re-woken on reconnect.
+  const seen = new Set();
+  const waker = new Waker({ creds, lineage, sessionMap, spawner, hooks, logger });
+  const router = new EventRouter({ mcpClient, waker, queue, wakeActions: WAKE_ACTIONS, seen, logger });
+
+  // Reconnect backfill re-dispatches notifications missed during a gap, through
+  // the SAME router/queue (so serialization holds) and the SAME seen set (so
+  // already-handled notifications are skipped). The router marks seen at
+  // dispatch; backfill's own pre-check is a cheap early-out.
+  const backfill = createBackfill({
+    mcpClient,
+    dispatch: (event) => router.dispatch(event),
+    seen,
+    logger,
+  });
+
+  const sseListener =
+    deps.sseListener ??
+    (deps.makeSseListener ?? ((o) => new SseListener(o)))({
+      url: creds.url,
+      apiKey: creds.apiKey,
+      onEvent: (event) => router.dispatch(event),
+      onReconnect: backfill,
+      logger,
+    });
+
+  return {
+    mcpClient,
+    lineage,
+    sessionMap,
+    spawner,
+    queue,
+    waker,
+    router,
+    sseListener,
+    async start() {
+      await hooks.onConnect?.({ host: creds.url });
+      await sseListener.connect();
+    },
+    async stop() {
+      sseListener.disconnect?.();
+      await mcpClient.disconnect?.();
+    },
+  };
+}
+
+/**
+ * Entry point for `chorus daemon`. Resolves credentials, validates them
+ * (echoing the agent identity), and runs the daemon until terminated.
+ *
+ * @param {{ url?: string, apiKey?: string, yolo?: boolean }} flags
+ * @param {{
+ *   resolve?: typeof resolveCredentials,
+ *   validate?: typeof validateAndFetchIdentity,
+ *   build?: typeof buildDaemon,
+ *   log?: (m: string) => void,
+ *   errLog?: (m: string) => void,
+ *   waitForever?: () => Promise<void>,
+ *   env?: Record<string, string|undefined>,
+ * }} [deps]
+ * @returns {Promise<number>}
+ */
+export async function runDaemon(flags = {}, deps = {}) {
+  const resolve = deps.resolve ?? resolveCredentials;
+  const validate = deps.validate ?? validateAndFetchIdentity;
+  const build = deps.build ?? buildDaemon;
+  const log = deps.log ?? ((m) => process.stdout.write(`${m}\n`));
+  const errLog = deps.errLog ?? ((m) => process.stderr.write(`${m}\n`));
+  const env = deps.env ?? process.env;
+
+  // --yolo flag or CHORUS_YOLO env → full autonomy; default → chorus-only.
+  const yolo = flags.yolo === true || env.CHORUS_YOLO === "1" || env.CHORUS_YOLO === "true";
+  const permissionMode = yolo ? "yolo" : "chorus";
+
+  let creds;
+  try {
+    creds = resolve(flags);
+  } catch (err) {
+    errLog(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  log(`[Chorus] credentials resolved from: ${creds.source}`);
+
+  // Validate + echo identity before opening the long-lived connection.
+  let identity;
+  try {
+    identity = await validate({ url: creds.url, apiKey: creds.apiKey });
+  } catch (err) {
+    errLog(`[Chorus] credential validation failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+  log(`[Chorus] authenticated as ${identity.name} (${identity.uuid})`);
+
+  // Make the permission posture loud — it determines what a woken Claude can do.
+  if (permissionMode === "yolo") {
+    errLog(
+      "[Chorus] ⚠ PERMISSION MODE: YOLO (--dangerously-skip-permissions) — woken Claude has FULL " +
+        "autonomy: Bash, file writes, any command, under this daemon's API key. Run only in a " +
+        "trusted/sandboxed environment with people you trust to dispatch to it."
+    );
+  } else {
+    log(
+      "[Chorus] permission mode: chorus (default) — woken Claude may use Chorus MCP tools only " +
+        "(comment/claim/report/status), NOT Bash or file edits. Pass --yolo for full autonomy."
+    );
+  }
+
+  // Warn (don't fail) if claude isn't found — the daemon still subscribes; a
+  // wake will surface the missing-binary error visibly when one arrives.
+  if (!resolveClaudePath()) {
+    errLog("[Chorus] WARNING: `claude` not found on PATH — wakes will fail until it is installed.");
+  }
+
+  const daemon = build(creds, { logger: { info: log, warn: errLog, error: errLog }, permissionMode });
+
+  // Graceful shutdown on signals.
+  const shutdown = () => {
+    log("[Chorus] shutting down daemon...");
+    Promise.resolve(daemon.stop()).finally(() => process.exit(0));
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  log(`[Chorus] daemon starting — subscribing to ${creds.url}/api/events/notifications`);
+  await daemon.start();
+  log("[Chorus] daemon running. Waiting for task dispatches (Ctrl+C to stop).");
+
+  // Keep the process alive for the long-lived SSE subscription.
+  await (deps.waitForever ?? (() => new Promise(() => {})))();
+  return 0;
+}

--- a/cli/event-router.mjs
+++ b/cli/event-router.mjs
@@ -1,0 +1,92 @@
+// cli/event-router.mjs
+// Routes incoming SSE notification events to wakes. Plain ESM adaptation of
+// packages/openclaw-plugin/src/event-router.ts — but instead of OpenClaw's
+// runEmbeddedAgent, it enqueues onto the per-root-idea WakeQueue so the daemon
+// spawns headless Claude with correct serialization.
+//
+// Flow: SSE `new_notification` → fetch full detail via MCP → if it's a wake
+// action, resolve the root-idea key and enqueue the wake. Never throws into the
+// SSE loop.
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+export class EventRouter {
+  /**
+   * @param {{
+   *   mcpClient: { callTool: (name: string, args?: Record<string, unknown>) => Promise<any> },
+   *   waker: { keyFor: (n: any) => Promise<string>, wake: (n: any, key: string) => Promise<void> },
+   *   queue: { enqueue: (key: string, task: () => Promise<void>) => void },
+   *   wakeActions: Set<string>,
+   *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+   * }} opts
+   */
+  constructor(opts) {
+    this.mcp = opts.mcpClient;
+    this.waker = opts.waker;
+    this.queue = opts.queue;
+    this.wakeActions = opts.wakeActions;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    // Shared dedup set: the daemon passes the SAME Set to the reconnect backfill
+    // so a notification handled live is never re-woken on reconnect, and a
+    // duplicate live delivery is dropped. Keyed by notificationUuid, marked at
+    // dispatch time (before any async work) so concurrent dispatches for the
+    // same uuid collapse to one wake.
+    this.seen = opts.seen ?? new Set();
+  }
+
+  /**
+   * Handle one SSE event. Synchronous + non-throwing: it kicks off async
+   * fetch/route work and returns immediately so the SSE consumer never blocks.
+   * @param {{ type?: string, notificationUuid?: string }} event
+   */
+  dispatch(event) {
+    if (event?.type !== "new_notification") {
+      return; // count_update etc. — ignore quietly
+    }
+    if (!event.notificationUuid) {
+      this.logger.warn("[Chorus] new_notification missing notificationUuid, skipping");
+      return;
+    }
+    if (this.seen.has(event.notificationUuid)) {
+      return; // already handled (e.g. live delivery then reconnect backfill)
+    }
+    this.seen.add(event.notificationUuid);
+    this.#fetchAndRoute(event.notificationUuid).catch((err) => {
+      this.logger.error(`[Chorus] failed to route notification ${event.notificationUuid}: ${err}`);
+    });
+  }
+
+  /** @param {string} notificationUuid */
+  async #fetchAndRoute(notificationUuid) {
+    const result = await this.mcp.callTool("chorus_get_notifications", {
+      status: "unread",
+      limit: 50,
+      autoMarkRead: false,
+    });
+    const notifications = result?.notifications;
+    if (!Array.isArray(notifications)) {
+      this.logger.warn("[Chorus] could not fetch notifications list");
+      return;
+    }
+    const n = notifications.find((x) => x?.uuid === notificationUuid);
+    if (!n) {
+      this.logger.warn(`[Chorus] notification ${notificationUuid} not in unread list`);
+      return;
+    }
+    if (!this.wakeActions.has(n.action)) {
+      this.logger.info(`[Chorus] action "${n.action}" is not a wake action — ignoring`);
+      return;
+    }
+
+    // Resolve the serialization key, then enqueue. keyFor may hit the network
+    // (lineage), so do it before enqueue; the wake itself runs on the queue.
+    let key;
+    try {
+      key = await this.waker.keyFor(n);
+    } catch (err) {
+      this.logger.warn(`[Chorus] could not resolve wake key for ${notificationUuid}: ${err}`);
+      return;
+    }
+    this.queue.enqueue(key, () => this.waker.wake(n, key));
+  }
+}

--- a/cli/lineage.mjs
+++ b/cli/lineage.mjs
@@ -1,0 +1,116 @@
+// cli/lineage.mjs
+// Resolves any inbound Chorus notification to its ROOT idea, so the daemon can
+// key one Claude session per root idea (the idea_root anchor). Verified field
+// chains against the repo:
+//   • get_task → { proposalUuid: string | null }            (task.service.ts)
+//   • get_proposal → { inputType, inputUuids: string[] }     (proposal.service.ts)
+//       an idea-derived proposal has inputType "idea" and inputUuids[0] = idea
+//   • get_idea → { parentUuid: string | null }               (idea.service.ts)
+//       walk parentUuid to the top of the single-parent lineage forest
+//
+// All Chorus reads go through the injected ChorusMcpClient.callTool (contract:
+// never hand-roll fetch). Returns null when there is no idea ancestor (e.g. a
+// quick task with no proposal/idea) so the caller can fall back to a per-entity
+// session key.
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+const MAX_PARENT_HOPS = 50; // cycle/runaway guard
+
+export class LineageResolver {
+  /**
+   * @param {{
+   *   mcpClient: { callTool: (name: string, args?: Record<string, unknown>) => Promise<any> },
+   *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+   * }} opts
+   */
+  constructor(opts) {
+    this.mcp = opts.mcpClient;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    /** @type {Map<string, string|null>} per-run cache keyed by `${type}:${uuid}`. */
+    this.cache = new Map();
+  }
+
+  /**
+   * Resolve an event to its root idea uuid, or null if none.
+   * @param {{ entityType?: string, entityUuid?: string }} event
+   * @returns {Promise<string|null>}
+   */
+  async rootIdeaFor(event) {
+    const entityType = event?.entityType;
+    const entityUuid = event?.entityUuid;
+    if (!entityType || !entityUuid) {
+      this.logger.warn("[Chorus] lineage: event missing entityType/entityUuid");
+      return null;
+    }
+    const cacheKey = `${entityType}:${entityUuid}`;
+    if (this.cache.has(cacheKey)) return this.cache.get(cacheKey);
+
+    let root = null;
+    try {
+      const startIdeaUuid = await this.#toIdeaUuid(entityType, entityUuid);
+      root = startIdeaUuid ? await this.#walkToRoot(startIdeaUuid) : null;
+    } catch (err) {
+      this.logger.warn(`[Chorus] lineage resolution failed for ${cacheKey}: ${err}`);
+      root = null;
+    }
+    this.cache.set(cacheKey, root);
+    return root;
+  }
+
+  /**
+   * Map an entity to the idea uuid it belongs to (not yet walked to root).
+   * @param {string} entityType @param {string} entityUuid
+   * @returns {Promise<string|null>}
+   */
+  async #toIdeaUuid(entityType, entityUuid) {
+    switch (entityType) {
+      case "idea":
+        return entityUuid;
+      case "proposal":
+        return this.#ideaFromProposal(entityUuid);
+      case "task": {
+        const task = await this.mcp.callTool("chorus_get_task", { taskUuid: entityUuid });
+        const proposalUuid = task?.proposalUuid;
+        if (!proposalUuid) return null; // quick task, no proposal/idea ancestor
+        return this.#ideaFromProposal(proposalUuid);
+      }
+      case "document": {
+        // Documents materialize from a proposal; reuse the proposal path if the
+        // event carries one, else no idea ancestor.
+        return null;
+      }
+      default:
+        return null;
+    }
+  }
+
+  /** @param {string} proposalUuid @returns {Promise<string|null>} */
+  async #ideaFromProposal(proposalUuid) {
+    const proposal = await this.mcp.callTool("chorus_get_proposal", { proposalUuid });
+    if (proposal?.inputType !== "idea") return null;
+    const inputUuids = Array.isArray(proposal.inputUuids) ? proposal.inputUuids : [];
+    return inputUuids.length > 0 ? inputUuids[0] : null;
+  }
+
+  /**
+   * Walk parentUuid to the top of the lineage forest.
+   * @param {string} ideaUuid @returns {Promise<string>}
+   */
+  async #walkToRoot(ideaUuid) {
+    let current = ideaUuid;
+    const visited = new Set([current]);
+    for (let hop = 0; hop < MAX_PARENT_HOPS; hop++) {
+      const idea = await this.mcp.callTool("chorus_get_idea", { ideaUuid: current });
+      const parent = idea?.parentUuid;
+      if (!parent) return current; // reached a root
+      if (visited.has(parent)) {
+        this.logger.warn(`[Chorus] lineage: parent cycle detected at ${parent}, stopping`);
+        return current;
+      }
+      visited.add(parent);
+      current = parent;
+    }
+    this.logger.warn(`[Chorus] lineage: exceeded ${MAX_PARENT_HOPS} parent hops, stopping at ${current}`);
+    return current;
+  }
+}

--- a/cli/login.mjs
+++ b/cli/login.mjs
@@ -1,0 +1,112 @@
+// cli/login.mjs
+// `chorus login` — validate a Chorus url + cho_ API key and persist them to
+// ~/.chorus/daemon.json (0600). On validation failure, nothing is written.
+// Plain ESM; the only dependency is the in-repo MCP SDK (via chorus-client).
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { createInterface } from "node:readline";
+
+import { loginFilePath } from "./credentials.mjs";
+import { validateAndFetchIdentity } from "./chorus-client.mjs";
+
+/**
+ * Prompt for a line of input. When `mask` is true, typed characters are not
+ * echoed (used for the secret API key — cli-auth spec "interactive key entry
+ * is masked").
+ *
+ * @param {string} query
+ * @param {{ mask?: boolean, input?: NodeJS.ReadableStream, output?: NodeJS.WritableStream }} [opts]
+ * @returns {Promise<string>}
+ */
+export function prompt(query, opts = {}) {
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const mask = opts.mask ?? false;
+
+  return new Promise((resolve) => {
+    const rl = createInterface({ input, output, terminal: true });
+    if (mask) {
+      // Suppress echo: intercept the readline-internal write so typed chars
+      // (and the key itself) never render. The prompt string still shows.
+      const writeToOutput = /** @type {(s: string) => void} */ (
+        rl._writeToOutput?.bind(rl)
+      );
+      rl._writeToOutput = (str) => {
+        if (str === query || str.includes("\n") || str.includes("\r")) {
+          if (writeToOutput) writeToOutput(str);
+          else output.write(str);
+        }
+        // otherwise swallow — no echo of secret characters
+      };
+    }
+    rl.question(query, (answer) => {
+      rl.close();
+      if (mask) output.write("\n");
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * Persist credentials + identity to the login file with owner-only perms.
+ * @param {{ url: string, apiKey: string, agentUuid: string, agentName: string }} data
+ * @param {{ path?: string, write?: (p: string, c: string, o: object) => void, mkdir?: (p: string, o: object) => void }} [deps]
+ */
+export function writeLoginFile(data, deps = {}) {
+  const path = deps.path ?? loginFilePath();
+  const write = deps.write ?? writeFileSync;
+  const mkdir = deps.mkdir ?? mkdirSync;
+  mkdir(dirname(path), { recursive: true });
+  write(path, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
+  return path;
+}
+
+/**
+ * Run the login flow: collect url + key (flags or interactive), validate
+ * against the server, and on success persist + echo identity. Returns an exit
+ * code (0 success, non-zero failure). Never throws.
+ *
+ * @param {{ url?: string, apiKey?: string }} flags
+ * @param {{
+ *   validate?: typeof validateAndFetchIdentity,
+ *   write?: typeof writeLoginFile,
+ *   prompt?: typeof prompt,
+ *   log?: (m: string) => void,
+ *   errLog?: (m: string) => void,
+ * }} [deps]
+ * @returns {Promise<number>}
+ */
+export async function runLogin(flags = {}, deps = {}) {
+  const validate = deps.validate ?? validateAndFetchIdentity;
+  const write = deps.write ?? writeLoginFile;
+  const ask = deps.prompt ?? prompt;
+  const log = deps.log ?? ((m) => process.stdout.write(m + "\n"));
+  const errLog = deps.errLog ?? ((m) => process.stderr.write(m + "\n"));
+
+  let url = typeof flags.url === "string" && flags.url.trim() ? flags.url.trim() : "";
+  let apiKey = typeof flags.apiKey === "string" && flags.apiKey.trim() ? flags.apiKey.trim() : "";
+
+  if (!url) url = await ask("Chorus URL: ");
+  if (!apiKey) apiKey = await ask("Chorus API key (cho_...): ", { mask: true });
+
+  if (!url || !apiKey) {
+    errLog("Login aborted: both a URL and an API key are required.");
+    return 1;
+  }
+
+  let identity;
+  try {
+    identity = await validate({ url, apiKey });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errLog(`Login failed: ${msg}`);
+    errLog("Credentials were NOT saved.");
+    return 1;
+  }
+
+  const path = write({ url, apiKey, agentUuid: identity.uuid, agentName: identity.name });
+  log(`Logged in as ${identity.name} (${identity.uuid}).`);
+  log(`Credentials saved to ${path}.`);
+  return 0;
+}

--- a/cli/mcp-config.mjs
+++ b/cli/mcp-config.mjs
@@ -1,0 +1,58 @@
+// cli/mcp-config.mjs
+// Writes the --mcp-config JSON that wires the spawned headless Claude to THIS
+// daemon's Chorus server (url + cho_ key), into the OS temp dir (never a
+// hardcoded /tmp), and cleans it up. Plain ESM, zero deps.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Build the MCP config object that exposes the Chorus server to the spawned
+ * Claude as a `chorus` MCP server over Streamable HTTP (mirrors the entry the
+ * OpenClaw plugin writes — see mcp-registration.ts).
+ * @param {{ url: string, apiKey: string }} creds
+ */
+export function buildMcpConfig({ url, apiKey }) {
+  return {
+    mcpServers: {
+      chorus: {
+        type: "http",
+        url: `${url.replace(/\/$/, "")}/api/mcp`,
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+    },
+  };
+}
+
+/**
+ * Write the MCP config to a fresh temp file under os.tmpdir() and return its
+ * path plus a cleanup function. The caller MUST call cleanup() when the wake
+ * completes (or register it for process exit).
+ *
+ * @param {{ url: string, apiKey: string }} creds
+ * @param {{ tmp?: string, mkdtemp?: typeof mkdtempSync, write?: typeof writeFileSync, rm?: typeof rmSync }} [deps]
+ * @returns {{ path: string, cleanup: () => void }}
+ */
+export function writeMcpConfig(creds, deps = {}) {
+  const tmp = deps.tmp ?? tmpdir();
+  const mkdtemp = deps.mkdtemp ?? mkdtempSync;
+  const write = deps.write ?? writeFileSync;
+  const rm = deps.rm ?? rmSync;
+
+  const dir = mkdtemp(join(tmp, "chorus-mcp-"));
+  const path = join(dir, "mcp.json");
+  write(path, JSON.stringify(buildMcpConfig(creds), null, 2), { mode: 0o600 });
+
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    try {
+      rm(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort; temp dir is reclaimed by the OS regardless
+    }
+  };
+  return { path, cleanup };
+}

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -1,0 +1,125 @@
+// cli/prompts.mjs
+// Per-notification-action prompt builders. Ported from the OpenClaw plugin's
+// event-router wake messages. The spawned Claude is headless and acts only
+// through the chorus_* MCP tools — these prompts tell it what happened and
+// which tools to use.
+
+/**
+ * @typedef {Object} NotificationDetail
+ * @property {string} uuid
+ * @property {string} projectUuid
+ * @property {string} entityType
+ * @property {string} entityUuid
+ * @property {string} entityTitle
+ * @property {string} action
+ * @property {string} message
+ * @property {string} actorType
+ * @property {string} actorUuid
+ * @property {string} actorName
+ */
+
+/** @param {NotificationDetail} n @param {string} entityType */
+function mentionGuidance(n, entityType) {
+  return (
+    `After completing your work, post a comment on this ${entityType} using ` +
+    `chorus_add_comment with @mention: @[${n.actorName}](${n.actorType}:${n.actorUuid})`
+  );
+}
+
+/**
+ * Build the wake prompt for a notification, or null if the action has no
+ * wake (caller ignores those). Mirrors the OpenClaw event-router handlers.
+ * @param {NotificationDetail} n
+ * @returns {string | null}
+ */
+export function buildPrompt(n) {
+  switch (n.action) {
+    case "task_assigned":
+      return (
+        `[Chorus] Task assigned: ${n.entityTitle}. Task UUID: ${n.entityUuid}, ` +
+        `Project UUID: ${n.projectUuid}. Use chorus_get_task to review the task, ` +
+        `then chorus_claim_task to start work.\n${mentionGuidance(n, "task")}`
+      );
+    case "mentioned":
+      return (
+        `[Chorus] You were @mentioned in ${n.entityType} '${n.entityTitle}' ` +
+        `(entityType: ${n.entityType}, entityUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}): ${n.message}\n` +
+        `Review the ${n.entityType} and use chorus_get_comments (targetType: "${n.entityType}", ` +
+        `targetUuid: "${n.entityUuid}") to see the conversation, then respond.\n${mentionGuidance(n, n.entityType)}`
+      );
+    case "elaboration_requested":
+      return (
+        `[Chorus] Elaboration requested for idea '${n.entityTitle}' ` +
+        `(ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). ` +
+        `Use chorus_get_elaboration to review the questions.`
+      );
+    case "elaboration_answered":
+      return (
+        `[Chorus] Elaboration answers were submitted for idea '${n.entityTitle}' ` +
+        `(ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). Use chorus_get_elaboration to review the ` +
+        `answers, then either resolve the elaboration (chorus_pm_validate_elaboration) and proceed to a proposal, ` +
+        `or open another round (chorus_pm_start_elaboration) if gaps remain.\n${mentionGuidance(n, "idea")}`
+      );
+    case "proposal_rejected":
+      return (
+        `[Chorus] Proposal '${n.entityTitle}' was REJECTED (proposalUuid: ${n.entityUuid}, ` +
+        `projectUuid: ${n.projectUuid}). Review note: "${n.message}". Use chorus_get_proposal to review, ` +
+        `fix issues with chorus_pm_update_task_draft / chorus_pm_update_document_draft, then ` +
+        `chorus_pm_validate_proposal and chorus_pm_submit_proposal to resubmit.\n${mentionGuidance(n, "proposal")}`
+      );
+    case "proposal_approved":
+      return (
+        `[Chorus] Proposal '${n.entityTitle}' was APPROVED (proposalUuid: ${n.entityUuid}, ` +
+        `projectUuid: ${n.projectUuid}). Its documents and tasks have been created. Use ` +
+        `chorus_get_unblocked_tasks (projectUuid: "${n.projectUuid}") to find tasks ready to start.\n${mentionGuidance(n, "proposal")}`
+      );
+    case "idea_claimed":
+      return (
+        `[Chorus] Idea '${n.entityTitle}' was assigned to you (ideaUuid: ${n.entityUuid}, ` +
+        `projectUuid: ${n.projectUuid}). Use chorus_get_idea to review it, then claim it ` +
+        `(chorus_claim_idea) to begin elaboration.\n${mentionGuidance(n, "idea")}`
+      );
+    case "task_reopened":
+      return (
+        `[Chorus] Task '${n.entityTitle}' was reopened and needs rework (taskUuid: ${n.entityUuid}, ` +
+        `projectUuid: ${n.projectUuid}). Use chorus_get_task and chorus_get_comments to see the ` +
+        `verification feedback, then fix the issues.\n${mentionGuidance(n, "task")}`
+      );
+    case "task_verified":
+      return (
+        `[Chorus] Task '${n.entityTitle}' was verified and is now done (taskUuid: ${n.entityUuid}, ` +
+        `projectUuid: ${n.projectUuid}). Use chorus_get_unblocked_tasks (projectUuid: "${n.projectUuid}") ` +
+        `to see whether this unblocked any tasks that are now ready to start.`
+      );
+    default:
+      return null;
+  }
+}
+
+/**
+ * Actions that produce a wake. Used by the router to decide whether to enqueue.
+ *
+ * Covers the notifications that imply the agent should act — an explicit
+ * @mention, assignment, lifecycle transitions it owns, and unblock signals.
+ * Deliberately NOT woken:
+ *   - comment_added             (fires for EVERY comment to the task's
+ *                                assignee+creator, not just ones directed at the
+ *                                agent — too noisy; an @mention is the real
+ *                                "I need you" signal and arrives as `mentioned`)
+ *   - task_status_changed       (high-frequency, usually a side effect of own work)
+ *   - task_submitted_for_verify (reviewer/owner channel; verification is its own flow)
+ *   - report_created            (informational summary)
+ * The switch in buildPrompt is the source of truth — keep them in sync (a test
+ * asserts every WAKE_ACTIONS entry yields a non-null prompt).
+ */
+export const WAKE_ACTIONS = new Set([
+  "task_assigned",
+  "mentioned",
+  "elaboration_requested",
+  "elaboration_answered",
+  "proposal_rejected",
+  "proposal_approved",
+  "idea_claimed",
+  "task_reopened",
+  "task_verified",
+]);

--- a/cli/session-map.mjs
+++ b/cli/session-map.mjs
@@ -1,0 +1,105 @@
+// cli/session-map.mjs
+// Persistent map from a session key (root idea uuid, or a per-entity fallback
+// key when there's no idea ancestor) to the Claude session id, so the daemon
+// can --resume the same session across wakes for the same root idea.
+//
+// File: ~/.chorus/sessions.json  →  { "<key>": { sessionId, updatedAt } }
+// Corruption/absence is tolerated: load() logs and starts from an empty map
+// (no-silent-errors, but no crash).
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/** Default path: ~/.chorus/sessions.json */
+export function sessionMapPath() {
+  return join(homedir(), ".chorus", "sessions.json");
+}
+
+export class SessionMap {
+  /**
+   * @param {{
+   *   path?: string,
+   *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+   *   read?: (p: string) => string,
+   *   write?: (p: string, c: string, o: object) => void,
+   *   mkdir?: (p: string, o: object) => void,
+   *   now?: () => string,
+   * }} [opts]
+   */
+  constructor(opts = {}) {
+    this.path = opts.path ?? sessionMapPath();
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    this.read = opts.read ?? ((p) => readFileSync(p, "utf8"));
+    this.write = opts.write ?? writeFileSync;
+    this.mkdir = opts.mkdir ?? mkdirSync;
+    // now() is injectable because Date.now/new Date are unavailable in some
+    // sandboxes and to keep tests deterministic.
+    this.now = opts.now ?? (() => new Date().toISOString());
+    /** @type {Map<string, { sessionId: string, updatedAt: string }>} */
+    this.map = new Map();
+    this.#load();
+  }
+
+  /** Load the map from disk; tolerate missing/corrupt files. */
+  #load() {
+    let raw;
+    try {
+      raw = this.read(this.path);
+    } catch {
+      // Missing file is normal on first run — start empty, no warning noise.
+      this.map = new Map();
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        for (const [key, val] of Object.entries(parsed)) {
+          if (val && typeof val.sessionId === "string") {
+            this.map.set(key, { sessionId: val.sessionId, updatedAt: val.updatedAt ?? "" });
+          }
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        `[Chorus] session map at ${this.path} is corrupt — starting from empty map: ${err}`
+      );
+      this.map = new Map();
+    }
+  }
+
+  /**
+   * Look up the session for a key.
+   * @param {string} key  Root idea uuid (or per-entity fallback key).
+   * @returns {{ sessionId: string|null, isNew: boolean }}
+   *   isNew=false → caller passes --resume sessionId; isNew=true → fresh session.
+   */
+  resolve(key) {
+    const entry = this.map.get(key);
+    if (entry) return { sessionId: entry.sessionId, isNew: false };
+    return { sessionId: null, isNew: true };
+  }
+
+  /**
+   * Persist the session id for a key (called after a wake establishes/continues
+   * a session). Writes the whole map back to disk.
+   * @param {string} key @param {string} sessionId
+   */
+  record(key, sessionId) {
+    this.map.set(key, { sessionId, updatedAt: this.now() });
+    this.#persist();
+  }
+
+  #persist() {
+    const obj = {};
+    for (const [key, val] of this.map.entries()) obj[key] = val;
+    try {
+      this.mkdir(dirname(this.path), { recursive: true });
+      this.write(this.path, JSON.stringify(obj, null, 2) + "\n", { mode: 0o600 });
+    } catch (err) {
+      this.logger.warn(`[Chorus] failed to persist session map to ${this.path}: ${err}`);
+    }
+  }
+}

--- a/cli/sse-listener.mjs
+++ b/cli/sse-listener.mjs
@@ -1,0 +1,174 @@
+// cli/sse-listener.mjs
+// Subscribes to the Chorus notification SSE stream and feeds parsed events to a
+// callback. Plain ESM port of packages/openclaw-plugin/src/sse-listener.ts —
+// uses global fetch (Node 18+) so it adds no dependency.
+//
+// Endpoint: GET /api/events/notifications, Bearer <cho_ key>. Verified against
+// src/app/api/events/notifications/route.ts: getAuthContext accepts the Bearer
+// API key; data lines are `data: <json>\n\n`, heartbeats are `: ...` comments.
+
+const INITIAL_DELAY_MS = 1_000;
+const MAX_DELAY_MS = 30_000;
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/**
+ * @typedef {Object} SseListenerOptions
+ * @property {string} url       Chorus base URL.
+ * @property {string} apiKey    `cho_` API key.
+ * @property {(event: Record<string, unknown>) => void} onEvent
+ * @property {() => Promise<void>} [onReconnect]  Called after a reconnect so the
+ *   caller can back-fill notifications missed during the gap.
+ * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
+ * @property {typeof fetch} [fetchImpl]  Injectable for tests.
+ * @property {number} [initialDelayMs]
+ * @property {number} [maxDelayMs]
+ */
+
+export class SseListener {
+  /** @param {SseListenerOptions} opts */
+  constructor(opts) {
+    this.url = opts.url.replace(/\/$/, "");
+    this.apiKey = opts.apiKey;
+    this.onEvent = opts.onEvent;
+    this.onReconnect = opts.onReconnect ?? (async () => {});
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.initialDelayMs = opts.initialDelayMs ?? INITIAL_DELAY_MS;
+    this.maxDelayMs = opts.maxDelayMs ?? MAX_DELAY_MS;
+
+    this.status = "disconnected";
+    /** @type {AbortController | null} */
+    this.abortController = null;
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    this.reconnectTimer = null;
+    this.reconnectDelay = this.initialDelayMs;
+  }
+
+  /** Open the SSE connection. On failure, schedules a backoff reconnect. */
+  async connect() {
+    this.#clearReconnectTimer();
+    const abortController = new AbortController();
+    this.abortController = abortController;
+
+    const endpoint = `${this.url}/api/events/notifications`;
+    let response;
+    try {
+      response = await this.fetchImpl(endpoint, {
+        headers: { Authorization: `Bearer ${this.apiKey}`, Accept: "text/event-stream" },
+        signal: abortController.signal,
+      });
+    } catch (err) {
+      if (abortController.signal.aborted) return;
+      this.logger.error(`[Chorus] SSE connection failed: ${err}`);
+      this.#scheduleReconnect();
+      return;
+    }
+
+    if (!response.ok) {
+      this.logger.error(`[Chorus] SSE endpoint returned ${response.status}`);
+      this.#scheduleReconnect();
+      return;
+    }
+    if (!response.body) {
+      this.logger.error("[Chorus] SSE response has no body");
+      this.#scheduleReconnect();
+      return;
+    }
+
+    const wasReconnect = this.status === "reconnecting";
+    this.status = "connected";
+    this.reconnectDelay = this.initialDelayMs;
+    this.logger.info("[Chorus] SSE connection established");
+
+    if (wasReconnect) {
+      try {
+        await this.onReconnect();
+      } catch (err) {
+        this.logger.warn(`[Chorus] onReconnect callback error: ${err}`);
+      }
+    }
+
+    this.#consumeStream(response.body, abortController.signal);
+  }
+
+  /** Gracefully close the connection (no reconnect). */
+  disconnect() {
+    this.#clearReconnectTimer();
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+    this.status = "disconnected";
+    this.logger.info("[Chorus] SSE connection closed");
+  }
+
+  /** @param {ReadableStream<Uint8Array>} body @param {AbortSignal} signal */
+  async #consumeStream(body, signal) {
+    const decoder = new TextDecoder();
+    const reader = body.getReader();
+    let buffer = "";
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done || signal.aborted) break;
+        // Strip CR on ingest so CRLF transports (`\r\n\r\n` boundaries) parse the
+        // same as LF — the `\n\n` boundary scan below would otherwise never match.
+        buffer += decoder.decode(value, { stream: true }).replace(/\r/g, "");
+        let boundary;
+        while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+          const raw = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+          this.#processMessage(raw);
+        }
+      }
+    } catch (err) {
+      if (signal.aborted) return;
+      this.logger.warn(`[Chorus] SSE stream error: ${err}`);
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        // already released
+      }
+    }
+    if (!signal.aborted) {
+      this.logger.warn("[Chorus] SSE stream ended, scheduling reconnect");
+      this.#scheduleReconnect();
+    }
+  }
+
+  /** @param {string} raw */
+  #processMessage(raw) {
+    for (const line of raw.split("\n")) {
+      // CR already stripped on ingest. Heartbeat / comment lines start with ":".
+      if (line.startsWith(":")) continue;
+      if (line.startsWith("data: ")) {
+        const jsonStr = line.slice(6);
+        try {
+          this.onEvent(JSON.parse(jsonStr));
+        } catch (err) {
+          this.logger.warn(`[Chorus] SSE JSON parse error: ${err} — raw: ${jsonStr}`);
+        }
+      }
+    }
+  }
+
+  #scheduleReconnect() {
+    this.#clearReconnectTimer();
+    this.status = "reconnecting";
+    this.logger.info(`[Chorus] SSE reconnecting in ${this.reconnectDelay}ms`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.reconnectDelay);
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxDelayMs);
+  }
+
+  #clearReconnectTimer() {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}

--- a/cli/upload-hooks.mjs
+++ b/cli/upload-hooks.mjs
@@ -1,0 +1,28 @@
+// cli/upload-hooks.mjs
+// Reserved upload-hook points for the future observability layer (derived idea
+// "Daemon 连接可观测与管理"). This change ships them as no-op async stubs so the
+// observability work can report connection / session / transcript data to the
+// server WITHOUT touching the wake path. This change itself uploads NOTHING.
+//
+// cli-daemon spec "Reserved upload hooks for observability".
+
+/**
+ * @typedef {Object} UploadHooks
+ * @property {(info: { host: string, agentUuid?: string }) => Promise<void>} onConnect
+ * @property {(info: { rootIdeaKey: string, sessionId: string, isNew: boolean }) => Promise<void>} onSessionStart
+ * @property {(info: { rootIdeaKey: string, sessionId: string, message: any }) => Promise<void>} onTranscriptMessage
+ */
+
+/**
+ * The default no-op hooks. Each resolves immediately and does nothing — no
+ * network, no disk. The observability idea will provide a real implementation
+ * with the same shape and the daemon will accept it via dependency injection.
+ * @returns {UploadHooks}
+ */
+export function createNoopUploadHooks() {
+  return {
+    async onConnect() {},
+    async onSessionStart() {},
+    async onTranscriptMessage() {},
+  };
+}

--- a/cli/wake-queue.mjs
+++ b/cli/wake-queue.mjs
@@ -1,0 +1,101 @@
+// cli/wake-queue.mjs
+// Per-key FIFO scheduler with a global concurrency cap. This is what makes the
+// idea_root session anchor safe (cli-daemon spec "Per-root-idea wake
+// serialization", design.md "Concurrency model"):
+//   • within one key (root idea) → strictly serial, FIFO. The 2nd wake waits
+//     for the 1st subprocess to exit, so we never run two
+//     `claude --resume <sameSessionId>` against one session.
+//   • across keys → concurrent, bounded by maxConcurrency.
+//   • enqueue() returns immediately — never blocks the SSE loop.
+//   • a task that throws is logged and the next task for that key proceeds (a
+//     poisoned wake must not wedge the key's queue forever).
+// Plain ESM, zero deps, in-memory.
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+export class WakeQueue {
+  /**
+   * @param {{
+   *   maxConcurrency?: number,
+   *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+   * }} [opts]
+   */
+  constructor(opts = {}) {
+    this.maxConcurrency = opts.maxConcurrency ?? 4;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    /** @type {Map<string, Array<() => Promise<void>>>} pending tasks per key. */
+    this.pending = new Map();
+    /** @type {Set<string>} keys with a task currently running. */
+    this.running = new Set();
+    /** @type {string[]} keys waiting for a global concurrency slot. */
+    this.readyKeys = [];
+    this.activeCount = 0;
+  }
+
+  /**
+   * Enqueue a wake task under a key. Returns immediately. The task is a thunk
+   * returning a promise (the actual wake). Same key → serialized; different
+   * keys → concurrent up to maxConcurrency.
+   * @param {string} key
+   * @param {() => Promise<void>} task
+   */
+  enqueue(key, task) {
+    if (!this.pending.has(key)) this.pending.set(key, []);
+    this.pending.get(key).push(task);
+    // A key becomes "ready" to claim a global slot only when it's not already
+    // running (serial-per-key) and not already queued for a slot.
+    if (!this.running.has(key) && !this.readyKeys.includes(key)) {
+      this.readyKeys.push(key);
+    }
+    this.#pump();
+  }
+
+  /** Number of keys with pending work (for tests/observability). */
+  get pendingKeyCount() {
+    return [...this.pending.values()].filter((q) => q.length > 0).length;
+  }
+
+  /** Try to start as many ready keys as the concurrency cap allows. */
+  #pump() {
+    while (this.activeCount < this.maxConcurrency && this.readyKeys.length > 0) {
+      const key = this.readyKeys.shift();
+      if (this.running.has(key)) continue; // already running under another slot
+      const queue = this.pending.get(key);
+      if (!queue || queue.length === 0) continue;
+      this.#runNext(key);
+    }
+  }
+
+  /** Run the next task for a key, then chain to the following one. */
+  #runNext(key) {
+    const queue = this.pending.get(key);
+    if (!queue || queue.length === 0) {
+      this.running.delete(key);
+      return;
+    }
+    const task = queue.shift();
+    this.running.add(key);
+    this.activeCount++;
+
+    Promise.resolve()
+      .then(task)
+      .catch((err) => {
+        // Poisoned wake: log, do NOT let it wedge the key's queue.
+        this.logger.warn(`[Chorus] wake task for ${key} failed: ${err}`);
+      })
+      .finally(() => {
+        this.activeCount--;
+        const remaining = this.pending.get(key);
+        if (remaining && remaining.length > 0) {
+          // Same key still has work → it must run serially. Re-mark ready;
+          // #pump will pick it up (respecting the global cap).
+          if (!this.readyKeys.includes(key)) this.readyKeys.push(key);
+          this.running.delete(key); // free the key so #pump can re-claim it
+        } else {
+          this.running.delete(key);
+          this.pending.delete(key);
+        }
+        this.#pump();
+      });
+  }
+}

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -1,0 +1,118 @@
+// cli/waker.mjs
+// Executes a single wake: resolve the event to its root idea, look up / create
+// the session, build the --mcp-config, spawn headless Claude, persist the
+// session id, and fire the (no-op) upload hooks. The WakeQueue schedules these
+// per root idea so two wakes for the same idea never run concurrently.
+//
+// Module contract (design.md): Waker.wake(notification) → Promise<void>. A
+// failure is logged and swallowed — it must never crash the daemon (no-silent-
+// errors: visible log, no throw).
+
+import { buildPrompt } from "./prompts.mjs";
+import { writeMcpConfig } from "./mcp-config.mjs";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+export class Waker {
+  /**
+   * @param {{
+   *   creds: { url: string, apiKey: string },
+   *   lineage: { rootIdeaFor: (event: any) => Promise<string|null> },
+   *   sessionMap: { resolve: (key: string) => { sessionId: string|null, isNew: boolean }, record: (key: string, id: string) => void },
+   *   spawner: { wake: (params: any) => Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }> },
+   *   hooks?: import("./upload-hooks.mjs").UploadHooks,
+   *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+   *   writeMcpConfigFn?: typeof writeMcpConfig,
+   * }} opts
+   */
+  constructor(opts) {
+    this.creds = opts.creds;
+    this.lineage = opts.lineage;
+    this.sessionMap = opts.sessionMap;
+    this.spawner = opts.spawner;
+    this.hooks = opts.hooks;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    this.writeMcpConfigFn = opts.writeMcpConfigFn ?? writeMcpConfig;
+  }
+
+  /**
+   * Compute the queue key for an event WITHOUT running the wake. Used by the
+   * router to enqueue under the right serialization key. Falls back to a
+   * per-entity key when there's no idea ancestor (so unrelated entities still
+   * get their own serial lane).
+   * @param {any} notification
+   * @returns {Promise<string>}
+   */
+  async keyFor(notification) {
+    const root = await this.lineage.rootIdeaFor(notification);
+    if (root) return `idea:${root}`;
+    return `entity:${notification.entityType}:${notification.entityUuid}`;
+  }
+
+  /**
+   * Run one wake. Never throws.
+   * @param {import("./prompts.mjs").NotificationDetail} notification
+   * @param {string} key  The serialization key (from keyFor).
+   */
+  async wake(notification, key) {
+    let cfg;
+    try {
+      const prompt = buildPrompt(notification);
+      if (!prompt) {
+        this.logger.info(`[Chorus] no wake prompt for action "${notification.action}" — skipping`);
+        return;
+      }
+
+      const { sessionId, isNew } = this.sessionMap.resolve(key);
+      cfg = this.writeMcpConfigFn(this.creds);
+
+      await this.hooks?.onSessionStart?.({ rootIdeaKey: key, sessionId: sessionId ?? "", isNew });
+
+      // Track the session id the stream reports so the transcript hook can use
+      // it even before spawner.wake() returns. (Do NOT reference the awaited
+      // `result` inside onMessage — it's in the temporal dead zone there.)
+      let observedSessionId = sessionId ?? "";
+      const result = await this.spawner.wake({
+        prompt,
+        sessionId,
+        mcpConfigPath: cfg.path,
+        onMessage: (message) => {
+          if (message && typeof message.session_id === "string") observedSessionId = message.session_id;
+          // Fire-and-forget transcript hook (no-op in this change).
+          this.hooks
+            ?.onTranscriptMessage?.({ rootIdeaKey: key, sessionId: observedSessionId, message })
+            .catch(() => {});
+        },
+      });
+
+      // Persist the (possibly newly-created) session id so the next wake for
+      // this key resumes it — but ONLY on a clean exit. Recording the id after
+      // a failed first wake (e.g. claude missing → exitCode null) would make
+      // every later wake `--resume` a session that was never created, failing
+      // identically forever. On failure we leave the map untouched so the next
+      // wake retries as a fresh session. For an already-existing session
+      // (isNew=false) the id is already recorded, so re-recording is harmless
+      // but we still gate on a clean exit for consistency.
+      if (result?.sessionId && result.exitCode === 0) {
+        this.sessionMap.record(key, result.sessionId);
+      } else if (result && result.exitCode !== 0) {
+        this.logger.warn(
+          `[Chorus] wake for ${key} exited non-zero (${result.exitCode}); not recording session id`
+        );
+      }
+
+      this.logger.info(
+        `[Chorus] wake complete for ${key} (action=${notification.action}, ` +
+          `session=${result?.sessionId}, exit=${result?.exitCode})`
+      );
+    } catch (err) {
+      this.logger.warn(`[Chorus] wake failed for ${key}: ${err}`);
+    } finally {
+      try {
+        cfg?.cleanup?.();
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}

--- a/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/README.md
+++ b/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/README.md
@@ -1,0 +1,3 @@
+# add-chorus-cli-daemon
+
+Add a daemon client mode to the chorus npm CLI that connects to a remote Chorus server, subscribes to the agent notification stream, and wakes a local headless Claude Code on task dispatch

--- a/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/design.md
+++ b/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/design.md
@@ -1,0 +1,102 @@
+# Technical Design: Chorus CLI daemon core
+
+## Overview
+
+Add a client/daemon mode to the existing `chorus` npm CLI. Today `chorus.mjs` parses flags and boots the Next.js standalone server. We introduce a subcommand layer: a bare `chorus` (or `chorus serve`) keeps launching the server; `chorus daemon` and `chorus login` are new client-side commands that connect *out* to a remote Chorus server.
+
+The daemon is a long-lived process that:
+1. resolves connection credentials (url + `cho_` API key),
+2. opens an SSE subscription to the agent's notification stream,
+3. on a relevant notification, resolves the event up the Chorus lineage to its **root idea**,
+4. spawns a **headless `claude -p`** subprocess keyed (via `--resume`) to that root idea's session, with the Chorus MCP server wired in,
+5. lets Claude act through the existing `chorus_*` MCP tools (comment, report_work, claim, status changes),
+6. on reconnect, backfills unhandled notifications.
+
+The portable spine (SSE listener, event-router, MCP client, reconnect/backfill) is lifted from `packages/openclaw-plugin/src/{sse-listener,event-router,mcp-client}.ts`. The single replaced piece is the wake call: OpenClaw's in-process `runEmbeddedAgent` becomes a subprocess spawn.
+
+## Architecture
+
+```
+chorus.mjs (subcommand router)
+ ├─ (default / serve) → existing Next.js standalone launch  [unchanged]
+ ├─ login   → CredentialResolver.interactiveLogin()         [cli-auth]
+ └─ daemon  → Daemon.run()                                  [cli-daemon]
+                ├─ CredentialResolver.resolve()             [cli-auth]
+                ├─ ChorusMcpClient   (POST /api/mcp, Bearer cho_)   ← ported
+                ├─ SseListener       (GET /api/events/notifications) ← ported
+                │     └─ onReconnect → backfillUnhandled()
+                ├─ EventRouter       (route by notification.action) ← ported
+                │     └─ on task_assigned/mentioned/... → Waker.wake(event)
+                ├─ LineageResolver   (event → rootIdeaUuid)         ← new
+                ├─ SessionMap        (rootIdeaUuid ↔ claudeSessionId, persisted) ← new
+                ├─ ClaudeSpawner     (headless claude -p, stream-json)  ← new
+                └─ UploadHooks       (no-op stubs; reserved for derived idea) ← new
+```
+
+### Subcommand routing
+
+`chorus.mjs` inspects `process.argv[2]`. If it is `daemon` or `login`, route to the new modules; otherwise fall through to today's flag parsing + server launch (so `chorus -p 9000` etc. are untouched). Keep the daemon/login code lazy-imported so the server-launch path pays no startup cost.
+
+## Data Model
+
+**No database changes in this change.** All daemon state is local to the host:
+
+- `~/.chorus/daemon.json` — written by `chorus login`: `{ url, apiKey, agentUuid, agentName }`. `0600` perms.
+- `~/.chorus/sessions.json` (or under a data dir) — the `rootIdeaUuid → { claudeSessionId, updatedAt }` map. Read on wake, written after each spawn that establishes/continues a session.
+
+The `DaemonConnection` model and `AgentSession.connectionUuid` belong to the derived observability idea, not here.
+
+## Module Contracts
+
+Shared conventions every task must honor:
+
+- **Credential shape**: `ResolvedCredentials = { url: string, apiKey: string, source: "flag"|"env"|"login-file"|"plugin-fallback" }`. `CredentialResolver.resolve(flags)` returns this or throws a single typed error with a human-actionable message (which sources were tried). The daemon and `login` both call the same resolver.
+- **MCP call**: all server reads/writes go through the ported `ChorusMcpClient.callTool(name, args)` returning parsed JSON; never hand-roll fetch against `/api/mcp`. Auth header is `Authorization: Bearer <apiKey>`.
+- **Lineage result**: `LineageResolver.rootIdeaFor(event) → Promise<string|null>`. For a task event: `chorus_get_task` → proposal → idea; for an idea event: `chorus_get_idea` then walk `parentUuid` to the top. Returns `null` if no idea ancestor exists (e.g. a quick-task with no idea) — caller then falls back to a per-entity session key. Cache within a daemon run.
+- **Session key**: `SessionMap.resolve(rootIdeaUuid) → { sessionId, isNew }`. `isNew=false` means pass `--resume <sessionId>`; `isNew=true` means start fresh and capture the new session id from the first stream-json `system`/`init` message, then persist it.
+- **Spawn result**: `ClaudeSpawner.wake({ prompt, sessionId|null, mcpConfigPath }) → Promise<{ sessionId, exitCode }>`. Non-blocking with respect to the SSE loop (the listener must keep reading while a subprocess runs); failures are logged, never thrown into the listener (no-silent-errors: log visibly, keep the daemon alive — see project memory `feedback_no_silent_errors`). **Not** unconditionally fire-and-forget — wakes are scheduled through the per-root-idea serial queue below.
+- **Per-root-idea serialization**: `WakeQueue.enqueue(rootIdeaKey, () => Waker.wake(event))` runs at most **one** wake at a time **per root idea key** (the `rootIdeaUuid`, or the per-entity fallback key when there is no idea ancestor). Wakes for *different* root ideas run concurrently; wakes for the *same* root idea run strictly sequentially (FIFO). This is what makes the `idea_root` session anchor safe: a single root-idea session is one serial conversation, so two notifications under the same idea never spawn concurrent `claude --resume <sameSessionId>` against one session. The SSE loop enqueues and returns immediately; it never blocks on a running wake.
+- **Upload hooks**: `UploadHooks.onConnect()/onSessionStart()/onTranscriptMessage()` are defined as no-op async stubs in this change so the derived observability idea can implement them without re-touching the wake path.
+
+## Cross-platform spawn (the load-bearing engineering point)
+
+Parsing stream-json is plain JS and platform-neutral. Spawning is where the cross-platform work is, and it is all Windows:
+
+1. **Prompt over stdin, not argv.** `claude -p` reads the prompt from stdin. Passing it as an argv arg hits the Windows ~32KB command-line limit and is a shell-escaping/injection surface. So: `spawn(claudePath, ["-p", "--output-format", "stream-json", "--mcp-config", cfgPath, ...resumeArgs])`, then `child.stdin.write(prompt); child.stdin.end()`. argv carries only flags.
+2. **Resolve `claude.cmd` without a shell.** On Windows the `claude` bin is `claude.cmd` (npm shim); `spawn("claude", …)` without `shell:true` throws ENOENT because it won't resolve `.cmd`. Resolve the real executable path (walk PATH for `claude`, `claude.cmd`, `claude.exe`) and spawn that directly. Do **not** use `shell:true` (re-introduces the escaping/injection surface).
+3. **MCP config to `os.tmpdir()`.** Write the `--mcp-config` JSON to `path.join(os.tmpdir(), …)`, never a hardcoded `/tmp`. Clean it up on process exit.
+4. **NDJSON parsing.** Buffer stdout, split on `\n`, `JSON.parse` each non-empty line, and strip a trailing `\r` before parse so Windows `\r\n` pipes parse cleanly.
+
+These mirror the kind of cross-platform work `chorus.mjs` already does (Windows `__dirname` patching, PGlite symlinks), so the package's all-platform publish promise (CLAUDE.md pitfall #9) is upheld.
+
+## Concurrency model
+
+The `idea_root` session anchor (one Claude session per root idea) and the requirement that wakes not block the SSE loop together force a specific concurrency design — otherwise two notifications resolving to the same root idea would launch two `claude --resume <sameSessionId>` subprocesses against one session, corrupting it.
+
+- **Across root ideas → parallel.** Different root ideas have different sessions; their wakes run concurrently (bounded by a small max-concurrency cap to avoid spawning unboundedly many subprocesses under a burst).
+- **Within one root idea → serial FIFO.** All wakes keyed to the same root idea run one at a time. The second wake for a root idea waits for the first subprocess to exit before spawning (and only then does it know the session id to `--resume`, since a fresh session's id is captured from the first run's output).
+- **SSE loop never blocks.** On each notification the router resolves the root-idea key, then calls `WakeQueue.enqueue(key, task)` and returns immediately. The queue owns subprocess lifecycle; the listener keeps consuming events.
+- **Backfilled wakes use the same queue**, so a reconnect burst for one root idea also serializes correctly rather than racing.
+
+`WakeQueue` is a per-key FIFO with a global concurrency cap — a small in-memory structure (map of key → running/pending), no new dependency. A wake that throws is logged and the next queued wake for that key proceeds (a poisoned wake must not wedge the key's queue forever).
+
+## Prompt construction
+
+Per-notification-action prompt builders (ported shape from the OpenClaw event-router): e.g. `task_assigned` → "[Chorus] Task assigned: <title>. Task UUID … Project UUID … Use chorus_get_task to review, then chorus_claim_task to start." Claude is headless and acts only through MCP tools; the daemon does not need to interpret Claude's output for correctness (state lands in Chorus via tool calls). The transcript is captured for the future relay but is not load-bearing for this change.
+
+## Implementation Plan
+
+1. CLI scaffolding + subcommand router + credential resolver + `chorus login` (foundation).
+2. Connection layer: port MCP client + SSE listener + reconnect/backfill.
+3. Lineage resolver + persisted session map.
+4. Cross-platform headless spawner + stream-json capture (parallel with 2/3).
+5. Wake orchestration: event-router + prompt builders + the per-root-idea `WakeQueue` wiring 2/3/4 together + no-op upload hooks.
+6. Integration checkpoint: end-to-end daemon run + bin packaging/`files` field.
+
+## Risks & Mitigations
+
+- **`claude` CLI flags drift** (`-p`, `--output-format stream-json`, `--resume`, `--mcp-config`): developers must verify exact flag names/shape against the installed Claude Code CLI docs rather than relying on memory; treat the spawner's arg list as a single place to update.
+- **stream-json schema for session id capture**: the field that carries the session id on a fresh run must be confirmed against actual `claude -p --output-format stream-json` output (likely the initial `system`/`init` event). Verify empirically before relying on it.
+- **Credential fallback to plugin config**: the path/shape of the Claude Code chorus plugin's stored url+key must be read defensively (file may be absent / differently shaped); treat as best-effort last resort.
+- **No new deps**: resist pulling an SSE or MCP client library; the OpenClaw plugin's hand-rolled fetch-based SSE + the MCP SDK already in the repo are the reference. If the MCP SDK can't be reused without bloating the CLI bundle, a minimal fetch-based JSON-RPC client against `/api/mcp` is acceptable.
+- **Daemon must never die on a single bad wake**: all per-event work is wrapped so a spawn/parse failure logs and continues (no-silent-errors, but also no crash-loop).

--- a/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/proposal.md
+++ b/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/proposal.md
@@ -1,0 +1,35 @@
+# Add Chorus CLI daemon core
+
+## Why
+
+The `chorus` npm CLI (`chorus.mjs`) today is **only a Next.js server launcher** — it has no subcommands and no client mode. There is no way for an operation a human performs in the Chorus UI (assigning a task to an agent) to reach a local coding agent. Users who run Claude Code locally must manually poll Chorus and copy task context by hand.
+
+We want the CLI to additionally act as a **lightweight client daemon**: connect to a remote Chorus server as an agent, subscribe to that agent's notification stream, and on `task_assigned` **wake a local headless Claude Code** to do the work — so "operate the Chorus UI" directly drives the local agent.
+
+`../multica` (a Go daemon with WebSocket wakeup that spawns an agent subprocess per task) was the reference, but it is too heavy: an always-on system daemon, per-task isolated workspace directories, repo caches, and garbage collection. We take only its light **spawn-and-capture + resume** core and skip the heavy surroundings. The in-repo OpenClaw plugin (`packages/openclaw-plugin/`) already proves the reusable spine: SSE listener → event-router (route by `notification.action`) → wake. The only OpenClaw-specific piece is the wake call itself (`runEmbeddedAgent`, an in-process host primitive); this change replaces it with a subprocess spawn of `claude` and ports the rest nearly verbatim.
+
+## What Changes
+
+- **New `chorus daemon` subcommand** on the existing CLI: authenticate as an agent, open an SSE subscription to `/api/events/notifications`, and on relevant notifications wake a local headless Claude Code.
+- **New `chorus login` subcommand** + layered credential resolution: explicit flags > `CHORUS_URL` / `CHORUS_API_KEY` env > `~/.chorus/daemon.json` (written by `chorus login`) > fallback to the Claude Code chorus plugin's stored url+key. `chorus login` validates the key and echoes the resolved agent identity.
+- **Lineage-anchored session continuity**: each inbound event is walked up the Chorus lineage (`task → proposal → idea`, then `idea.parentUuid`) to its **root idea**; the local Claude session id is keyed on that root idea. Same root → `--resume` the same session; new root → fresh session. A local `rootIdea → sessionId` map file persists this.
+- **Cross-platform headless spawner**: spawn `claude -p` with `--output-format stream-json --mcp-config <chorus>`, feeding the prompt over **stdin** (not argv) and parsing the NDJSON output. Robust on Windows: resolve the real `claude.cmd` path without `shell:true`, write the MCP config to `os.tmpdir()`, strip `\r` when line-splitting.
+- **Reconnect-with-backfill**: on SSE reconnect, fetch unhandled notifications and re-fire wakes (port of the OpenClaw plugin's `onReconnect` logic), so dispatches that arrived while the daemon was briefly disconnected are not lost.
+
+### Out of scope (split to the derived idea & later work)
+
+- The **DaemonConnection** data model, the dedicated "Daemons" management UI page, the real-time transcript-relay panel, heartbeat-timeout offline marking, and the "waiting for daemon" UI badge are all owned by the derived idea **"Daemon 连接可观测与管理"**. This change carries **zero** server/UI/DB changes; it only adds the npm-side daemon and reserves upload hooks (connection-register / session-register / transcript-report) for that derived idea to consume later.
+- inbound bidirectional relay (typing in the UI to inject the next Claude turn) is deferred.
+- always-on system daemon management (systemd/launchd), per-task workspace isolation, repo caches, and GC — explicitly avoided (multica's "heavy").
+
+## Capabilities
+
+- **cli-daemon** — the `chorus daemon` runtime: notification subscription, lineage→root-idea session mapping, headless Claude spawn + stream-json capture, reconnect backfill, and the reserved upload hooks.
+- **cli-auth** — the `chorus login` command and the layered credential/address resolution used by the daemon.
+
+## Impact
+
+- Affected code: `chorus.mjs` (gains subcommand routing); new daemon modules under the CLI surface; reuse of the OpenClaw plugin's SSE/event-router/MCP-client logic as a portable internal module.
+- No database migration, no API route changes, no UI changes in this change.
+- Dependency posture: **no new npm dependencies** (CLAUDE.md pitfall #9). The daemon shells out to the user's existing `claude` binary; stream-json parsing is plain JS.
+- Existing behavior (`chorus` with no subcommand → launch the server) is preserved; `daemon` and `login` are additive subcommands.

--- a/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/specs/cli-auth/spec.md
+++ b/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/specs/cli-auth/spec.md
@@ -1,0 +1,51 @@
+# cli-auth
+
+## ADDED Requirements
+
+### Requirement: Layered credential and address resolution
+
+The CLI SHALL resolve the Chorus server URL and `cho_` API key from multiple sources in a fixed precedence order, using the first source that yields a complete pair. The precedence SHALL be: (1) explicit command-line flags (`--url`, `--api-key`), (2) environment variables (`CHORUS_URL`, `CHORUS_API_KEY`), (3) the login file at `~/.chorus/daemon.json`, (4) a best-effort fallback to credentials already stored by the Claude Code chorus plugin. The resolver SHALL report which source supplied the credentials and, on failure, SHALL emit a single human-actionable error naming the sources it tried.
+
+#### Scenario: Flags win over all other sources
+
+- **WHEN** the user runs the daemon with both `--url`/`--api-key` flags set and `CHORUS_URL`/`CHORUS_API_KEY` also present in the environment
+- **THEN** the resolver uses the flag values and reports the source as the flags
+
+#### Scenario: Environment used when no flags
+
+- **WHEN** no credential flags are passed but `CHORUS_URL` and `CHORUS_API_KEY` are set in the environment
+- **THEN** the resolver uses the environment values
+
+#### Scenario: Login file used when no flags or env
+
+- **WHEN** no credential flags or environment variables are present and `~/.chorus/daemon.json` contains a valid url + apiKey
+- **THEN** the resolver loads and uses the values from that file
+
+#### Scenario: Plugin config used as last resort
+
+- **WHEN** no flags, no environment variables, and no login file are available, but the Claude Code chorus plugin has previously stored a url + key
+- **THEN** the resolver falls back to the plugin-stored credentials and reports the source as the plugin fallback
+
+#### Scenario: Actionable error when nothing resolves
+
+- **WHEN** none of the four sources yields a complete url + apiKey pair
+- **THEN** the CLI exits non-zero with one error message that lists every source that was tried and how to supply credentials
+
+### Requirement: Interactive login command
+
+The CLI SHALL provide a `chorus login` subcommand that accepts a server URL and `cho_` API key (via flags or interactive prompt), validates the key against the server by fetching the authenticated agent identity, and on success persists `{ url, apiKey, agentUuid, agentName }` to `~/.chorus/daemon.json` with owner-only file permissions. On validation failure it SHALL NOT write the file. When the API key is entered interactively, the input SHALL be masked (not echoed to the terminal).
+
+#### Scenario: Successful login persists credentials and echoes identity
+
+- **WHEN** the user runs `chorus login` with a reachable URL and a valid `cho_` API key
+- **THEN** the command fetches and displays the resolved agent identity (name + uuid) and writes the credentials to `~/.chorus/daemon.json` with owner-only permissions
+
+#### Scenario: Interactive key entry is masked
+
+- **WHEN** the user is prompted interactively for the `cho_` API key
+- **THEN** the typed key is not echoed to the terminal
+
+#### Scenario: Invalid key is rejected without writing
+
+- **WHEN** the user runs `chorus login` with an invalid or revoked API key
+- **THEN** the command reports the authentication failure and does not create or overwrite `~/.chorus/daemon.json`

--- a/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/specs/cli-daemon/spec.md
+++ b/openspec/changes/archive/2026-06-14-add-chorus-cli-daemon/specs/cli-daemon/spec.md
@@ -1,0 +1,96 @@
+# cli-daemon
+
+## ADDED Requirements
+
+### Requirement: Daemon subcommand and notification subscription
+
+The CLI SHALL provide a `chorus daemon` subcommand that runs a long-lived client process. On start it SHALL resolve credentials (see cli-auth), open a Server-Sent Events subscription to the remote Chorus notification stream (`/api/events/notifications`) authenticated with the `cho_` API key, and remain running until terminated. Adding the `daemon` and `login` subcommands SHALL NOT change the behavior of invoking the CLI with no subcommand (which continues to launch the Chorus server).
+
+#### Scenario: Daemon connects and subscribes
+
+- **WHEN** the user runs `chorus daemon` with resolvable credentials
+- **THEN** the process authenticates, opens the notification SSE subscription, logs the connected agent identity, and stays running
+
+#### Scenario: Bare CLI still launches the server
+
+- **WHEN** the user runs `chorus` with no subcommand (or the existing server flags)
+- **THEN** the Chorus server launches exactly as before, with no daemon behavior triggered
+
+### Requirement: Task-dispatch wake of local headless Claude Code
+
+On receiving a relevant notification (at minimum `task_assigned`), the daemon SHALL spawn a local headless Claude Code subprocess (`claude -p` with `--output-format stream-json` and the Chorus MCP server configured via `--mcp-config`) to act on the dispatched work. The daemon SHALL feed the prompt to the subprocess over stdin rather than as a command-line argument. Each wake SHALL be non-blocking with respect to the notification subscription, and a failure of one wake SHALL be logged visibly without terminating the daemon.
+
+#### Scenario: Task assignment wakes Claude Code
+
+- **WHEN** the subscribed agent receives a `task_assigned` notification
+- **THEN** the daemon spawns a headless `claude -p` subprocess wired to the Chorus MCP server, passing the task context prompt over stdin, and the subprocess can act via `chorus_*` MCP tools
+
+#### Scenario: One failed wake does not kill the daemon
+
+- **WHEN** a spawned subprocess fails to start or exits with an error
+- **THEN** the daemon logs the failure visibly and continues processing subsequent notifications
+
+### Requirement: Lineage-anchored session continuity
+
+The daemon SHALL key each local Claude session on the **root idea** of the dispatched entity. It SHALL resolve any inbound event up the Chorus lineage (`task → proposal → idea`, then following `idea.parentUuid`) to its topmost idea, and SHALL maintain a persisted map from root idea to Claude session id. When a notification resolves to a root idea that already has a session, the daemon SHALL resume that session (`--resume`); when it resolves to a new root idea, the daemon SHALL start a fresh session and persist the newly created session id. When no idea ancestor exists, the daemon SHALL fall back to a per-entity session key.
+
+#### Scenario: Same root idea resumes the same session
+
+- **WHEN** two notifications (e.g. a task execution then a later proposal rejection) both resolve up the lineage to the same root idea
+- **THEN** the second wake resumes the same Claude session id used by the first via `--resume`
+
+#### Scenario: Different root idea starts a fresh session
+
+- **WHEN** a notification resolves to a root idea that has no recorded session
+- **THEN** the daemon starts a fresh Claude session, captures the new session id from the subprocess output, and persists it under that root idea
+
+### Requirement: Per-root-idea wake serialization
+
+Because each root idea maps to a single Claude session, the daemon SHALL ensure that at most one wake runs at a time for any given root-idea session key, while allowing wakes for different root ideas to run concurrently. Wakes targeting the same root idea SHALL be queued and executed in arrival order, so the daemon never runs two concurrent subprocesses that resume the same session. Enqueuing a wake SHALL NOT block the notification subscription loop, and a failing wake SHALL NOT permanently block subsequent wakes for the same root idea.
+
+#### Scenario: Two notifications for the same root idea run sequentially
+
+- **WHEN** two notifications that resolve to the same root idea arrive in close succession
+- **THEN** the daemon runs the first wake to completion before spawning the second, so no two concurrent subprocesses resume the same session id
+
+#### Scenario: Notifications for different root ideas run concurrently
+
+- **WHEN** two notifications that resolve to different root ideas arrive in close succession
+- **THEN** the daemon may run both wakes concurrently (each on its own session)
+
+#### Scenario: A failed wake does not wedge the queue
+
+- **WHEN** a queued wake for a root idea fails or its subprocess errors
+- **THEN** the failure is logged and the next queued wake for that same root idea still proceeds
+
+### Requirement: Cross-platform headless spawn
+
+The daemon's subprocess spawning SHALL work on Linux, macOS, and Windows without relying on a shell. It SHALL resolve the real `claude` executable path (including the Windows `claude.cmd` shim) and spawn it directly without `shell:true`. It SHALL write the MCP configuration file to the OS temporary directory (`os.tmpdir()`), not a hardcoded path. It SHALL parse the subprocess's newline-delimited JSON output line by line, tolerating Windows `\r\n` line endings.
+
+#### Scenario: Windows spawn resolves the .cmd shim without a shell
+
+- **WHEN** the daemon runs on Windows where `claude` is installed as `claude.cmd`
+- **THEN** it resolves and spawns the real `claude.cmd` path directly without `shell:true`, and the prompt is delivered over stdin
+
+#### Scenario: Stream-json output parses across platforms
+
+- **WHEN** the subprocess emits newline-delimited JSON with `\r\n` line endings on Windows
+- **THEN** the daemon strips the trailing carriage return and parses each line as JSON without error
+
+### Requirement: Reconnect with backfill
+
+When the notification subscription drops and reconnects, the daemon SHALL fetch notifications that arrived while it was disconnected and re-fire any wakes that were missed, so a dispatch that occurred during a brief disconnection is not silently lost.
+
+#### Scenario: Missed dispatch is recovered on reconnect
+
+- **WHEN** the subscription drops, a `task_assigned` notification is created during the gap, and the subscription then reconnects
+- **THEN** the daemon backfills the unhandled notification and wakes Claude Code for it
+
+### Requirement: Reserved upload hooks for observability
+
+The daemon SHALL define connection-register, session-register, and transcript-report hook points as no-op stubs in this change, so a future observability layer can report daemon connections, sessions, and live transcript messages to the server without modifying the wake path. This change SHALL NOT itself send connection, session, or transcript data to the server.
+
+#### Scenario: Hooks exist as no-ops
+
+- **WHEN** the daemon connects, starts a session, and receives subprocess transcript messages
+- **THEN** the corresponding hook points are invoked but perform no server upload in this change

--- a/openspec/specs/cli-auth/spec.md
+++ b/openspec/specs/cli-auth/spec.md
@@ -1,0 +1,53 @@
+# cli-auth Specification
+
+## Purpose
+TBD - created by archiving change add-chorus-cli-daemon. Update Purpose after archive.
+## Requirements
+### Requirement: Layered credential and address resolution
+
+The CLI SHALL resolve the Chorus server URL and `cho_` API key from multiple sources in a fixed precedence order, using the first source that yields a complete pair. The precedence SHALL be: (1) explicit command-line flags (`--url`, `--api-key`), (2) environment variables (`CHORUS_URL`, `CHORUS_API_KEY`), (3) the login file at `~/.chorus/daemon.json`, (4) a best-effort fallback to credentials already stored by the Claude Code chorus plugin. The resolver SHALL report which source supplied the credentials and, on failure, SHALL emit a single human-actionable error naming the sources it tried.
+
+#### Scenario: Flags win over all other sources
+
+- **WHEN** the user runs the daemon with both `--url`/`--api-key` flags set and `CHORUS_URL`/`CHORUS_API_KEY` also present in the environment
+- **THEN** the resolver uses the flag values and reports the source as the flags
+
+#### Scenario: Environment used when no flags
+
+- **WHEN** no credential flags are passed but `CHORUS_URL` and `CHORUS_API_KEY` are set in the environment
+- **THEN** the resolver uses the environment values
+
+#### Scenario: Login file used when no flags or env
+
+- **WHEN** no credential flags or environment variables are present and `~/.chorus/daemon.json` contains a valid url + apiKey
+- **THEN** the resolver loads and uses the values from that file
+
+#### Scenario: Plugin config used as last resort
+
+- **WHEN** no flags, no environment variables, and no login file are available, but the Claude Code chorus plugin has previously stored a url + key
+- **THEN** the resolver falls back to the plugin-stored credentials and reports the source as the plugin fallback
+
+#### Scenario: Actionable error when nothing resolves
+
+- **WHEN** none of the four sources yields a complete url + apiKey pair
+- **THEN** the CLI exits non-zero with one error message that lists every source that was tried and how to supply credentials
+
+### Requirement: Interactive login command
+
+The CLI SHALL provide a `chorus login` subcommand that accepts a server URL and `cho_` API key (via flags or interactive prompt), validates the key against the server by fetching the authenticated agent identity, and on success persists `{ url, apiKey, agentUuid, agentName }` to `~/.chorus/daemon.json` with owner-only file permissions. On validation failure it SHALL NOT write the file. When the API key is entered interactively, the input SHALL be masked (not echoed to the terminal).
+
+#### Scenario: Successful login persists credentials and echoes identity
+
+- **WHEN** the user runs `chorus login` with a reachable URL and a valid `cho_` API key
+- **THEN** the command fetches and displays the resolved agent identity (name + uuid) and writes the credentials to `~/.chorus/daemon.json` with owner-only permissions
+
+#### Scenario: Interactive key entry is masked
+
+- **WHEN** the user is prompted interactively for the `cho_` API key
+- **THEN** the typed key is not echoed to the terminal
+
+#### Scenario: Invalid key is rejected without writing
+
+- **WHEN** the user runs `chorus login` with an invalid or revoked API key
+- **THEN** the command reports the authentication failure and does not create or overwrite `~/.chorus/daemon.json`
+

--- a/openspec/specs/cli-daemon/spec.md
+++ b/openspec/specs/cli-daemon/spec.md
@@ -1,0 +1,98 @@
+# cli-daemon Specification
+
+## Purpose
+TBD - created by archiving change add-chorus-cli-daemon. Update Purpose after archive.
+## Requirements
+### Requirement: Daemon subcommand and notification subscription
+
+The CLI SHALL provide a `chorus daemon` subcommand that runs a long-lived client process. On start it SHALL resolve credentials (see cli-auth), open a Server-Sent Events subscription to the remote Chorus notification stream (`/api/events/notifications`) authenticated with the `cho_` API key, and remain running until terminated. Adding the `daemon` and `login` subcommands SHALL NOT change the behavior of invoking the CLI with no subcommand (which continues to launch the Chorus server).
+
+#### Scenario: Daemon connects and subscribes
+
+- **WHEN** the user runs `chorus daemon` with resolvable credentials
+- **THEN** the process authenticates, opens the notification SSE subscription, logs the connected agent identity, and stays running
+
+#### Scenario: Bare CLI still launches the server
+
+- **WHEN** the user runs `chorus` with no subcommand (or the existing server flags)
+- **THEN** the Chorus server launches exactly as before, with no daemon behavior triggered
+
+### Requirement: Task-dispatch wake of local headless Claude Code
+
+On receiving a relevant notification (at minimum `task_assigned`), the daemon SHALL spawn a local headless Claude Code subprocess (`claude -p` with `--output-format stream-json` and the Chorus MCP server configured via `--mcp-config`) to act on the dispatched work. The daemon SHALL feed the prompt to the subprocess over stdin rather than as a command-line argument. Each wake SHALL be non-blocking with respect to the notification subscription, and a failure of one wake SHALL be logged visibly without terminating the daemon.
+
+#### Scenario: Task assignment wakes Claude Code
+
+- **WHEN** the subscribed agent receives a `task_assigned` notification
+- **THEN** the daemon spawns a headless `claude -p` subprocess wired to the Chorus MCP server, passing the task context prompt over stdin, and the subprocess can act via `chorus_*` MCP tools
+
+#### Scenario: One failed wake does not kill the daemon
+
+- **WHEN** a spawned subprocess fails to start or exits with an error
+- **THEN** the daemon logs the failure visibly and continues processing subsequent notifications
+
+### Requirement: Lineage-anchored session continuity
+
+The daemon SHALL key each local Claude session on the **root idea** of the dispatched entity. It SHALL resolve any inbound event up the Chorus lineage (`task → proposal → idea`, then following `idea.parentUuid`) to its topmost idea, and SHALL maintain a persisted map from root idea to Claude session id. When a notification resolves to a root idea that already has a session, the daemon SHALL resume that session (`--resume`); when it resolves to a new root idea, the daemon SHALL start a fresh session and persist the newly created session id. When no idea ancestor exists, the daemon SHALL fall back to a per-entity session key.
+
+#### Scenario: Same root idea resumes the same session
+
+- **WHEN** two notifications (e.g. a task execution then a later proposal rejection) both resolve up the lineage to the same root idea
+- **THEN** the second wake resumes the same Claude session id used by the first via `--resume`
+
+#### Scenario: Different root idea starts a fresh session
+
+- **WHEN** a notification resolves to a root idea that has no recorded session
+- **THEN** the daemon starts a fresh Claude session, captures the new session id from the subprocess output, and persists it under that root idea
+
+### Requirement: Per-root-idea wake serialization
+
+Because each root idea maps to a single Claude session, the daemon SHALL ensure that at most one wake runs at a time for any given root-idea session key, while allowing wakes for different root ideas to run concurrently. Wakes targeting the same root idea SHALL be queued and executed in arrival order, so the daemon never runs two concurrent subprocesses that resume the same session. Enqueuing a wake SHALL NOT block the notification subscription loop, and a failing wake SHALL NOT permanently block subsequent wakes for the same root idea.
+
+#### Scenario: Two notifications for the same root idea run sequentially
+
+- **WHEN** two notifications that resolve to the same root idea arrive in close succession
+- **THEN** the daemon runs the first wake to completion before spawning the second, so no two concurrent subprocesses resume the same session id
+
+#### Scenario: Notifications for different root ideas run concurrently
+
+- **WHEN** two notifications that resolve to different root ideas arrive in close succession
+- **THEN** the daemon may run both wakes concurrently (each on its own session)
+
+#### Scenario: A failed wake does not wedge the queue
+
+- **WHEN** a queued wake for a root idea fails or its subprocess errors
+- **THEN** the failure is logged and the next queued wake for that same root idea still proceeds
+
+### Requirement: Cross-platform headless spawn
+
+The daemon's subprocess spawning SHALL work on Linux, macOS, and Windows without relying on a shell. It SHALL resolve the real `claude` executable path (including the Windows `claude.cmd` shim) and spawn it directly without `shell:true`. It SHALL write the MCP configuration file to the OS temporary directory (`os.tmpdir()`), not a hardcoded path. It SHALL parse the subprocess's newline-delimited JSON output line by line, tolerating Windows `\r\n` line endings.
+
+#### Scenario: Windows spawn resolves the .cmd shim without a shell
+
+- **WHEN** the daemon runs on Windows where `claude` is installed as `claude.cmd`
+- **THEN** it resolves and spawns the real `claude.cmd` path directly without `shell:true`, and the prompt is delivered over stdin
+
+#### Scenario: Stream-json output parses across platforms
+
+- **WHEN** the subprocess emits newline-delimited JSON with `\r\n` line endings on Windows
+- **THEN** the daemon strips the trailing carriage return and parses each line as JSON without error
+
+### Requirement: Reconnect with backfill
+
+When the notification subscription drops and reconnects, the daemon SHALL fetch notifications that arrived while it was disconnected and re-fire any wakes that were missed, so a dispatch that occurred during a brief disconnection is not silently lost.
+
+#### Scenario: Missed dispatch is recovered on reconnect
+
+- **WHEN** the subscription drops, a `task_assigned` notification is created during the gap, and the subscription then reconnects
+- **THEN** the daemon backfills the unhandled notification and wakes Claude Code for it
+
+### Requirement: Reserved upload hooks for observability
+
+The daemon SHALL define connection-register, session-register, and transcript-report hook points as no-op stubs in this change, so a future observability layer can report daemon connections, sessions, and live transcript messages to the server without modifying the wake path. This change SHALL NOT itself send connection, session, or transcript data to the server.
+
+#### Scenario: Hooks exist as no-ops
+
+- **WHEN** the daemon connects, starts a session, and receives subprocess transcript messages
+- **THEN** the corresponding hook points are invoked but perform no server upload in this change
+

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "files": [
     "chorus.mjs",
+    "cli/**/*.mjs",
+    "!cli/**/__tests__/**",
     ".next/standalone/",
     "prisma/schema.prisma",
     "prisma/migrations/",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     reporters: process.env.GITHUB_ACTIONS === 'true' ? ['default', 'github-actions'] : ['default'],
     globals: true,
     environment: 'node',
-    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
+    include: ['src/**/__tests__/**/*.test.{ts,tsx}', 'cli/**/__tests__/**/*.test.mjs'],
     exclude: ['node_modules', '.next', 'packages'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
Adds a lightweight **client/daemon mode** to the `chorus` npm CLI. The daemon authenticates as an agent, holds a long-lived SSE subscription to the agent notification stream, and on a relevant notification spawns a local **headless `claude -p`** (wired to the Chorus MCP server) so an operation in the Chorus UI (e.g. assigning a task) directly drives a local Claude Code. Also adds a `chorus login` command + layered credential resolution.

Server/UI are **untouched** — this is npm-side only, with reserved no-op upload hooks for a future observability layer.

## Key design decisions
- **Headless subprocess, not the Agent SDK** — the SDK spawns the same CLI under the hood, so subprocess gives zero new npm deps + agent-agnostic (could drive codex/opencode).
- **Session anchored on root idea** — each event resolves up the lineage (`task → proposal.inputUuids[0] → idea → parentUuid`); same root → `--resume` one session, different root → new. A per-root-idea **WakeQueue** serializes wakes so two notifications under one idea never run `claude --resume <sameId>` concurrently; falls back to a per-entity key when there's no idea ancestor.
- **Session id is client-generated** via `claude --session-id` (verified against CLI 2.1.177) — removes the fragile "scrape the id from the init event" path.
- **Permission modes** — default allowlists Chorus MCP tools only (`--allowedTools "mcp__chorus__*"`); **`--yolo`** maps to `--dangerously-skip-permissions` for full autonomy. The posture is printed loudly at startup (⚠ on yolo). This fixes the "woke but did nothing" failure where headless `claude -p` auto-denies un-approved tools.
- **Wake actions** — wakes on `task_assigned`, `mentioned`, `elaboration_requested/answered`, `proposal_rejected/approved`, `idea_claimed`, `task_reopened`, `task_verified`. Deliberately ignores `comment_added` (fires on every comment, too noisy — an @mention arrives as `mentioned`), `task_status_changed`, `task_submitted_for_verify`, `report_created`.
- **Cross-platform spawn** — prompt over stdin (not argv, avoids Windows cmdline limit + injection), resolves `claude.cmd` via `cmd.exe /d /s /c` on Windows (`.cmd` isn't a PE executable), `os.tmpdir()` for the MCP config, CRLF-tolerant NDJSON + SSE parsing. Zero new dependencies.
- **Reconnect with backfill** — survives a server drop, auto-reconnects, and re-dispatches notifications missed during the gap (deduped against the live path via a shared `seen` set).

## Changed files
| File | Change |
|------|--------|
| `chorus.mjs` | Subcommand router (`daemon`/`login`, lazy-import); `--yolo` flag; help docs. Server path unchanged. |
| `cli/*.mjs` | New daemon: credentials, login, chorus-client (MCP), sse-listener, backfill, lineage, session-map, claude-spawner, mcp-config, wake-queue, prompts, upload-hooks, waker, event-router, daemon. |
| `cli/__tests__/*` | 11 test files (credentials, login, chorus-client, sse-listener, backfill, lineage, session-map, claude-spawner, wake-queue, wake-orchestration, daemon-integration). |
| `package.json` | `files`: ship `cli/**/*.mjs`, exclude `__tests__`. No dependency changes. |
| `vitest.config.ts` | Include `cli/**/__tests__/**/*.test.mjs`. |
| `openspec/...` | Archived `add-chorus-cli-daemon` change + cumulative `cli-auth` / `cli-daemon` specs. |

## Test plan
- [x] 96 cli unit/integration tests pass; full repo suite **1958 pass / 1 skip**, zero regressions.
- [x] `eslint cli/` clean (0 errors; pre-existing `no-console` warnings only).
- [x] Live on local dev: real `chorus daemon` → cross-actor `task_assigned` → SSE wake → spawned real Claude posted a comment via `chorus_add_comment` (default permission mode); reconnect + session `--resume` continuity verified; graceful SIGTERM shutdown.
- [x] Real subprocess checks: EPIPE on fast-exit no longer crashes the daemon; `--session-id`/`--resume` continuity against real `claude` 2.1.177.

## Known follow-ups (tracked as derived ideas in Chorus 0.11.0)
- Daemon connection observability + management UI (`DaemonConnection` model, transcript relay panel).
- Server-side lineage resolution endpoint to replace the daemon's multi-hop queries (and fix document / multi-idea attribution).

Generated with [Claude Code](https://claude.com/claude-code)