### PR TITLE
feat(api): REST root-idea resolution endpoint + daemon per-notification resolve

### DIFF
--- a/cli/__tests__/daemon-integration.test.mjs
+++ b/cli/__tests__/daemon-integration.test.mjs
@@ -20,7 +20,7 @@ const TASK_NOTIF = {
   actorName: "Alice",
 };
 
-/** A mock MCP client answering the lineage walk + notification fetch. */
+/** A mock MCP client answering the notification fetch (backfill path). */
 function mockMcp() {
   return {
     disconnected: false,
@@ -28,12 +28,6 @@ function mockMcp() {
       switch (name) {
         case "chorus_get_notifications":
           return { notifications: [TASK_NOTIF] };
-        case "chorus_get_task":
-          return { proposalUuid: "prop-1" };
-        case "chorus_get_proposal":
-          return { inputType: "idea", inputUuids: ["root-idea"] };
-        case "chorus_get_idea":
-          return { parentUuid: null }; // root-idea is its own root
         default:
           return null;
       }
@@ -42,6 +36,26 @@ function mockMcp() {
       this.disconnected = true;
     },
   };
+}
+
+/**
+ * A fake fetch for the lineage REST endpoint. Resolves task-1 → root-idea via
+ * the standard success envelope; anything else → no idea ancestor.
+ */
+function lineageFetch() {
+  return async (url) => ({
+    ok: true,
+    status: 200,
+    async json() {
+      if (String(url).includes("/api/entities/task/task-1/root-idea")) {
+        return {
+          success: true,
+          data: { rootIdeaUuid: "root-idea", lineage: [], resolvedVia: "via_proposal" },
+        };
+      }
+      return { success: true, data: { rootIdeaUuid: null, lineage: [], resolvedVia: "not_found" } };
+    },
+  });
 }
 
 /** A mock SSE listener we can manually drive. */
@@ -82,6 +96,7 @@ describe("daemon integration: notification → spawn", () => {
       {
         logger: silent,
         mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
         spawner,
         sessionMap,
         makeSseListener: (o) => {
@@ -122,7 +137,13 @@ describe("daemon integration: notification → spawn", () => {
     let captured;
     const daemon = buildDaemon(
       { url: "https://c", apiKey: "k" },
-      { logger: silent, mcpClient: mcp, spawner, makeSseListener: (o) => (captured = new MockSse(o)) }
+      {
+        logger: silent,
+        mcpClient: mcp,
+        fetchImpl: lineageFetch(),
+        spawner,
+        makeSseListener: (o) => (captured = new MockSse(o)),
+      }
     );
     await daemon.start();
     captured.deliver({ type: "new_notification", notificationUuid: "notif-1" });

--- a/cli/__tests__/lineage.test.mjs
+++ b/cli/__tests__/lineage.test.mjs
@@ -1,235 +1,151 @@
 // cli/__tests__/lineage.test.mjs
-// Covers cli-daemon spec "Lineage-anchored session continuity" (resolution half),
-// including the server-first / client-walk-fallback behavior.
+// Covers cli-daemon spec "Lineage-anchored session continuity" (resolution half).
+// Resolution is a single REST call per notification to
+//   GET /api/entities/{type}/{uuid}/root-idea
+// with no client-side lineage walk. These tests drive a fake fetch.
 import { describe, it, expect } from "vitest";
 import { LineageResolver } from "../lineage.mjs";
 
 const silent = { info() {}, warn() {}, error() {} };
 
-/**
- * Build a fake MCP client from fixture maps. By default the server-side
- * chorus_resolve_root_idea tool is UNAVAILABLE (returns null, like an older
- * server) so the resolver exercises the client-side fallback walk — this keeps
- * the original walk fixtures meaningful. Pass `resolveRootIdea` to make the
- * server tool answer (the server-first path).
- * @param {object} [opts]
- * @param {(args:{entityType:string,entityUuid:string}) => any} [opts.resolveRootIdea]
- *   When provided, chorus_resolve_root_idea returns its result; otherwise null.
- */
-function fakeMcp({ tasks = {}, proposals = {}, ideas = {}, resolveRootIdea } = {}) {
+/** A fake fetch that records requested URLs and replies from a handler. */
+function fakeFetch(handler) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    return handler(url, init);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/** Build a JSON Response-like object (matches the subset LineageResolver uses). */
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
   return {
-    calls: [],
-    async callTool(name, args) {
-      this.calls.push([name, args]);
-      if (name === "chorus_resolve_root_idea") {
-        return resolveRootIdea ? resolveRootIdea(args) : null;
-      }
-      if (name === "chorus_get_task") return tasks[args.taskUuid] ?? null;
-      if (name === "chorus_get_proposal") return proposals[args.proposalUuid] ?? null;
-      if (name === "chorus_get_idea") return ideas[args.ideaUuid] ?? null;
-      return null;
+    ok,
+    status,
+    async json() {
+      return body;
     },
   };
 }
 
-describe("LineageResolver.rootIdeaFor", () => {
-  it("resolves a task → proposal → idea → root", async () => {
-    const mcp = fakeMcp({
-      tasks: { t1: { proposalUuid: "p1" } },
-      proposals: { p1: { inputType: "idea", inputUuids: ["child-idea"] } },
-      ideas: {
-        "child-idea": { parentUuid: "root-idea" },
-        "root-idea": { parentUuid: null },
-      },
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+/** Standard success envelope from the REST endpoint. */
+function rootIdeaData(data) {
+  return jsonResponse({ success: true, data });
+}
+
+const BASE = "http://chorus.test";
+
+function makeResolver(fetchImpl, logger = silent) {
+  return new LineageResolver({ url: BASE, apiKey: "cho_test", logger, fetchImpl });
+}
+
+describe("LineageResolver.rootIdeaFor (REST)", () => {
+  it("resolves an entity by calling the root-idea endpoint and using rootIdeaUuid", async () => {
+    const fetchImpl = fakeFetch(() =>
+      rootIdeaData({ rootIdeaUuid: "root-idea", lineage: [], resolvedVia: "via_proposal" })
+    );
+    const r = makeResolver(fetchImpl);
     const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
+
     expect(root).toBe("root-idea");
+    expect(fetchImpl.calls).toHaveLength(1);
+    expect(fetchImpl.calls[0].url).toBe(`${BASE}/api/entities/task/t1/root-idea`);
   });
 
-  it("resolves an idea event by walking parentUuid to the top", async () => {
-    const mcp = fakeMcp({
-      ideas: {
-        a: { parentUuid: "b" },
-        b: { parentUuid: "c" },
-        c: { parentUuid: null },
+  it("sends the Bearer agent key", async () => {
+    const fetchImpl = fakeFetch(() => rootIdeaData({ rootIdeaUuid: "x" }));
+    const r = new LineageResolver({ url: BASE, apiKey: "cho_secret", logger: silent, fetchImpl });
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "i" });
+
+    expect(fetchImpl.calls[0].init.headers.Authorization).toBe("Bearer cho_secret");
+  });
+
+  it("URL-encodes the entity type and uuid", async () => {
+    const fetchImpl = fakeFetch(() => rootIdeaData({ rootIdeaUuid: null }));
+    const r = makeResolver(fetchImpl);
+    await r.rootIdeaFor({ entityType: "task", entityUuid: "weird/uuid?x=1" });
+
+    expect(fetchImpl.calls[0].url).toBe(`${BASE}/api/entities/task/weird%2Fuuid%3Fx%3D1/root-idea`);
+  });
+
+  it("returns null when the server resolves to no idea ancestor", async () => {
+    const fetchImpl = fakeFetch(() =>
+      rootIdeaData({ rootIdeaUuid: null, lineage: [], resolvedVia: "no_proposal" })
+    );
+    const r = makeResolver(fetchImpl);
+    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
+  });
+
+  it("returns null (not throw) on a non-2xx response", async () => {
+    const fetchImpl = fakeFetch(() => jsonResponse({ success: false }, { ok: false, status: 500 }));
+    const r = makeResolver(fetchImpl);
+    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
+  });
+
+  it("returns null (not throw) when fetch rejects (server unreachable)", async () => {
+    const fetchImpl = fakeFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const r = makeResolver(fetchImpl);
+    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
+  });
+
+  it("returns null (not throw) on malformed JSON", async () => {
+    const fetchImpl = fakeFetch(() => ({
+      ok: true,
+      status: 200,
+      async json() {
+        throw new Error("invalid json");
       },
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    expect(await r.rootIdeaFor({ entityType: "idea", entityUuid: "a" })).toBe("c");
-  });
-
-  it("a top-level idea is its own root", async () => {
-    const mcp = fakeMcp({ ideas: { solo: { parentUuid: null } } });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    expect(await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" })).toBe("solo");
-  });
-
-  it("returns null for a quick task with no proposal (no idea ancestor)", async () => {
-    const mcp = fakeMcp({ tasks: { t: { proposalUuid: null } } });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    }));
+    const r = makeResolver(fetchImpl);
     expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
   });
 
-  it("returns null when proposal is document-typed (no idea input)", async () => {
-    const mcp = fakeMcp({
-      tasks: { t: { proposalUuid: "p" } },
-      proposals: { p: { inputType: "document", inputUuids: ["doc"] } },
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+  it("returns null on an unexpected response shape (no data.rootIdeaUuid)", async () => {
+    const fetchImpl = fakeFetch(() => jsonResponse({ success: true, data: { lineage: [] } }));
+    const r = makeResolver(fetchImpl);
     expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
   });
 
-  it("stops on a parent cycle without infinite-looping", async () => {
-    const warns = [];
-    const mcp = fakeMcp({
-      ideas: { a: { parentUuid: "b" }, b: { parentUuid: "a" } },
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: { ...silent, warn: (m) => warns.push(m) } });
-    const root = await r.rootIdeaFor({ entityType: "idea", entityUuid: "a" });
-    expect(["a", "b"]).toContain(root); // returns last-good, doesn't hang
-    expect(warns.join("")).toMatch(/cycle/i);
+  it("returns null when rootIdeaUuid is a non-string, non-null value", async () => {
+    const fetchImpl = fakeFetch(() => rootIdeaData({ rootIdeaUuid: 42 }));
+    const r = makeResolver(fetchImpl);
+    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
   });
 
-  it("caches resolution within a run (no duplicate MCP calls)", async () => {
-    const mcp = fakeMcp({ ideas: { solo: { parentUuid: null } } });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
-    await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
-    expect(mcp.calls.filter((c) => c[0] === "chorus_get_idea")).toHaveLength(1);
-  });
-
-  it("returns null (not throw) on a missing entityUuid", async () => {
-    const mcp = fakeMcp({});
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+  it("returns null (not throw, no request) on a missing entityUuid", async () => {
+    const fetchImpl = fakeFetch(() => rootIdeaData({ rootIdeaUuid: "x" }));
+    const r = makeResolver(fetchImpl);
     expect(await r.rootIdeaFor({ entityType: "task" })).toBeNull();
+    expect(fetchImpl.calls).toHaveLength(0); // never hit the network
   });
 
-  it("returns null (not throw) when an MCP call errors", async () => {
-    const mcp = {
-      async callTool() {
-        throw new Error("network down");
-      },
-    };
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
-  });
-});
-
-describe("LineageResolver server-first resolution", () => {
-  it("uses the server resolver's rootIdeaUuid and skips the client walk", async () => {
-    const mcp = fakeMcp({
-      // Client-walk fixtures intentionally absent — if the walk ran it'd return null.
-      resolveRootIdea: () => ({
-        rootIdeaUuid: "server-root",
-        lineage: [{ type: "task", uuid: "t1", title: "T1" }],
-        resolvedVia: "via_proposal",
-      }),
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
-
-    expect(root).toBe("server-root");
-    // server-first: the client-walk tools were never called
-    expect(mcp.calls.map((c) => c[0])).toEqual(["chorus_resolve_root_idea"]);
+  it("caches resolution within a run (one request per entity key)", async () => {
+    const fetchImpl = fakeFetch(() => rootIdeaData({ rootIdeaUuid: "solo" }));
+    const r = makeResolver(fetchImpl);
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
+    expect(fetchImpl.calls).toHaveLength(1); // second served from cache
   });
 
-  it("treats a well-formed null from the server as authoritative (no fallback)", async () => {
-    const mcp = fakeMcp({
-      // If the fallback walk ran on this task it would resolve to "would-be-root".
-      tasks: { t1: { proposalUuid: "p1" } },
-      proposals: { p1: { inputType: "idea", inputUuids: ["would-be-root"] } },
-      ideas: { "would-be-root": { parentUuid: null } },
-      resolveRootIdea: () => ({ rootIdeaUuid: null, lineage: [], resolvedVia: "no_proposal" }),
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
-
-    expect(root).toBeNull(); // server's null wins
-    expect(mcp.calls.map((c) => c[0])).toEqual(["chorus_resolve_root_idea"]); // no walk
+  it("caches a null result too (no repeat request for a no-ancestor entity)", async () => {
+    const fetchImpl = fakeFetch(() => rootIdeaData({ rootIdeaUuid: null }));
+    const r = makeResolver(fetchImpl);
+    await r.rootIdeaFor({ entityType: "task", entityUuid: "q" });
+    await r.rootIdeaFor({ entityType: "task", entityUuid: "q" });
+    expect(fetchImpl.calls).toHaveLength(1);
   });
 
-  it("falls back to the client walk when the server tool is unavailable (returns null)", async () => {
-    // resolveRootIdea omitted → tool returns null (older server / unknown tool).
-    const mcp = fakeMcp({
-      tasks: { t1: { proposalUuid: "p1" } },
-      proposals: { p1: { inputType: "idea", inputUuids: ["child"] } },
-      ideas: { child: { parentUuid: "root" }, root: { parentUuid: null } },
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
-
-    expect(root).toBe("root"); // resolved via the fallback walk
-    const names = mcp.calls.map((c) => c[0]);
-    expect(names[0]).toBe("chorus_resolve_root_idea"); // tried server first
-    expect(names).toContain("chorus_get_task"); // then walked client-side
-  });
-
-  it("falls back when the server tool throws (unknown-tool / persistent error)", async () => {
-    const mcp = {
-      calls: [],
-      async callTool(name, args) {
-        this.calls.push([name, args]);
-        if (name === "chorus_resolve_root_idea") {
-          throw new Error("MCP error -32601: Method not found");
-        }
-        if (name === "chorus_get_idea") return { a: { parentUuid: null } }[args.ideaUuid] ?? null;
-        return null;
-      },
-    };
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    const root = await r.rootIdeaFor({ entityType: "idea", entityUuid: "a" });
-
-    expect(root).toBe("a"); // fallback walk handled it
-    expect(mcp.calls.map((c) => c[0])).toContain("chorus_get_idea");
-  });
-
-  it("falls back on a non-conforming server shape (missing rootIdeaUuid)", async () => {
-    const mcp = fakeMcp({
-      ideas: { solo: { parentUuid: null } },
-      resolveRootIdea: () => ({ unexpected: "shape" }), // no rootIdeaUuid field
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    const root = await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
-
-    expect(root).toBe("solo"); // fell back to the walk
-    expect(mcp.calls.map((c) => c[0])).toContain("chorus_get_idea");
-  });
-
-  it("single-flights the cache across the server path (one resolve call per key)", async () => {
-    let serverCalls = 0;
-    const mcp = fakeMcp({
-      resolveRootIdea: () => {
-        serverCalls++;
-        return { rootIdeaUuid: "server-root", lineage: [], resolvedVia: "root_idea" };
-      },
-    });
-    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
-    await r.rootIdeaFor({ entityType: "idea", entityUuid: "x" });
-    await r.rootIdeaFor({ entityType: "idea", entityUuid: "x" });
-
-    expect(serverCalls).toBe(1); // second call served from cache
-  });
-
-  it("logs which path was taken (server vs fallback) — no silent attribution", async () => {
+  it("logs the resolution (no silent attribution)", async () => {
     const infos = [];
-    const logger = { ...silent, info: (m) => infos.push(m) };
-
-    const serverMcp = fakeMcp({
-      resolveRootIdea: () => ({ rootIdeaUuid: "r", lineage: [], resolvedVia: "root_idea" }),
-    });
-    await new LineageResolver({ mcpClient: serverMcp, logger }).rootIdeaFor({
-      entityType: "idea",
-      entityUuid: "x",
-    });
-    expect(infos.some((m) => /lineage\(server\)/.test(m))).toBe(true);
-
-    infos.length = 0;
-    const fallbackMcp = fakeMcp({ ideas: { y: { parentUuid: null } } }); // tool unavailable
-    await new LineageResolver({ mcpClient: fallbackMcp, logger }).rootIdeaFor({
-      entityType: "idea",
-      entityUuid: "y",
-    });
-    expect(infos.some((m) => /lineage\(fallback\)/.test(m))).toBe(true);
+    const fetchImpl = fakeFetch(() =>
+      rootIdeaData({ rootIdeaUuid: "r", resolvedVia: "root_idea" })
+    );
+    const r = makeResolver(fetchImpl, { ...silent, info: (m) => infos.push(m) });
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "x" });
+    expect(infos.some((m) => /lineage: idea:x → r \(root_idea\)/.test(m))).toBe(true);
   });
 });

--- a/cli/__tests__/lineage.test.mjs
+++ b/cli/__tests__/lineage.test.mjs
@@ -1,16 +1,29 @@
 // cli/__tests__/lineage.test.mjs
-// Covers cli-daemon spec "Lineage-anchored session continuity" (resolution half).
+// Covers cli-daemon spec "Lineage-anchored session continuity" (resolution half),
+// including the server-first / client-walk-fallback behavior.
 import { describe, it, expect } from "vitest";
 import { LineageResolver } from "../lineage.mjs";
 
 const silent = { info() {}, warn() {}, error() {} };
 
-/** Build a fake MCP client from fixture maps. */
-function fakeMcp({ tasks = {}, proposals = {}, ideas = {} } = {}) {
+/**
+ * Build a fake MCP client from fixture maps. By default the server-side
+ * chorus_resolve_root_idea tool is UNAVAILABLE (returns null, like an older
+ * server) so the resolver exercises the client-side fallback walk — this keeps
+ * the original walk fixtures meaningful. Pass `resolveRootIdea` to make the
+ * server tool answer (the server-first path).
+ * @param {object} [opts]
+ * @param {(args:{entityType:string,entityUuid:string}) => any} [opts.resolveRootIdea]
+ *   When provided, chorus_resolve_root_idea returns its result; otherwise null.
+ */
+function fakeMcp({ tasks = {}, proposals = {}, ideas = {}, resolveRootIdea } = {}) {
   return {
     calls: [],
     async callTool(name, args) {
       this.calls.push([name, args]);
+      if (name === "chorus_resolve_root_idea") {
+        return resolveRootIdea ? resolveRootIdea(args) : null;
+      }
       if (name === "chorus_get_task") return tasks[args.taskUuid] ?? null;
       if (name === "chorus_get_proposal") return proposals[args.proposalUuid] ?? null;
       if (name === "chorus_get_idea") return ideas[args.ideaUuid] ?? null;
@@ -100,5 +113,123 @@ describe("LineageResolver.rootIdeaFor", () => {
     };
     const r = new LineageResolver({ mcpClient: mcp, logger: silent });
     expect(await r.rootIdeaFor({ entityType: "task", entityUuid: "t" })).toBeNull();
+  });
+});
+
+describe("LineageResolver server-first resolution", () => {
+  it("uses the server resolver's rootIdeaUuid and skips the client walk", async () => {
+    const mcp = fakeMcp({
+      // Client-walk fixtures intentionally absent — if the walk ran it'd return null.
+      resolveRootIdea: () => ({
+        rootIdeaUuid: "server-root",
+        lineage: [{ type: "task", uuid: "t1", title: "T1" }],
+        resolvedVia: "via_proposal",
+      }),
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
+
+    expect(root).toBe("server-root");
+    // server-first: the client-walk tools were never called
+    expect(mcp.calls.map((c) => c[0])).toEqual(["chorus_resolve_root_idea"]);
+  });
+
+  it("treats a well-formed null from the server as authoritative (no fallback)", async () => {
+    const mcp = fakeMcp({
+      // If the fallback walk ran on this task it would resolve to "would-be-root".
+      tasks: { t1: { proposalUuid: "p1" } },
+      proposals: { p1: { inputType: "idea", inputUuids: ["would-be-root"] } },
+      ideas: { "would-be-root": { parentUuid: null } },
+      resolveRootIdea: () => ({ rootIdeaUuid: null, lineage: [], resolvedVia: "no_proposal" }),
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
+
+    expect(root).toBeNull(); // server's null wins
+    expect(mcp.calls.map((c) => c[0])).toEqual(["chorus_resolve_root_idea"]); // no walk
+  });
+
+  it("falls back to the client walk when the server tool is unavailable (returns null)", async () => {
+    // resolveRootIdea omitted → tool returns null (older server / unknown tool).
+    const mcp = fakeMcp({
+      tasks: { t1: { proposalUuid: "p1" } },
+      proposals: { p1: { inputType: "idea", inputUuids: ["child"] } },
+      ideas: { child: { parentUuid: "root" }, root: { parentUuid: null } },
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    const root = await r.rootIdeaFor({ entityType: "task", entityUuid: "t1" });
+
+    expect(root).toBe("root"); // resolved via the fallback walk
+    const names = mcp.calls.map((c) => c[0]);
+    expect(names[0]).toBe("chorus_resolve_root_idea"); // tried server first
+    expect(names).toContain("chorus_get_task"); // then walked client-side
+  });
+
+  it("falls back when the server tool throws (unknown-tool / persistent error)", async () => {
+    const mcp = {
+      calls: [],
+      async callTool(name, args) {
+        this.calls.push([name, args]);
+        if (name === "chorus_resolve_root_idea") {
+          throw new Error("MCP error -32601: Method not found");
+        }
+        if (name === "chorus_get_idea") return { a: { parentUuid: null } }[args.ideaUuid] ?? null;
+        return null;
+      },
+    };
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    const root = await r.rootIdeaFor({ entityType: "idea", entityUuid: "a" });
+
+    expect(root).toBe("a"); // fallback walk handled it
+    expect(mcp.calls.map((c) => c[0])).toContain("chorus_get_idea");
+  });
+
+  it("falls back on a non-conforming server shape (missing rootIdeaUuid)", async () => {
+    const mcp = fakeMcp({
+      ideas: { solo: { parentUuid: null } },
+      resolveRootIdea: () => ({ unexpected: "shape" }), // no rootIdeaUuid field
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    const root = await r.rootIdeaFor({ entityType: "idea", entityUuid: "solo" });
+
+    expect(root).toBe("solo"); // fell back to the walk
+    expect(mcp.calls.map((c) => c[0])).toContain("chorus_get_idea");
+  });
+
+  it("single-flights the cache across the server path (one resolve call per key)", async () => {
+    let serverCalls = 0;
+    const mcp = fakeMcp({
+      resolveRootIdea: () => {
+        serverCalls++;
+        return { rootIdeaUuid: "server-root", lineage: [], resolvedVia: "root_idea" };
+      },
+    });
+    const r = new LineageResolver({ mcpClient: mcp, logger: silent });
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "x" });
+    await r.rootIdeaFor({ entityType: "idea", entityUuid: "x" });
+
+    expect(serverCalls).toBe(1); // second call served from cache
+  });
+
+  it("logs which path was taken (server vs fallback) — no silent attribution", async () => {
+    const infos = [];
+    const logger = { ...silent, info: (m) => infos.push(m) };
+
+    const serverMcp = fakeMcp({
+      resolveRootIdea: () => ({ rootIdeaUuid: "r", lineage: [], resolvedVia: "root_idea" }),
+    });
+    await new LineageResolver({ mcpClient: serverMcp, logger }).rootIdeaFor({
+      entityType: "idea",
+      entityUuid: "x",
+    });
+    expect(infos.some((m) => /lineage\(server\)/.test(m))).toBe(true);
+
+    infos.length = 0;
+    const fallbackMcp = fakeMcp({ ideas: { y: { parentUuid: null } } }); // tool unavailable
+    await new LineageResolver({ mcpClient: fallbackMcp, logger }).rootIdeaFor({
+      entityType: "idea",
+      entityUuid: "y",
+    });
+    expect(infos.some((m) => /lineage\(fallback\)/.test(m))).toBe(true);
   });
 });

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -38,6 +38,8 @@ function defaultLogger() {
  * @param {{
  *   logger?: any,
  *   mcpClient?: any,
+ *   lineage?: any,
+ *   fetchImpl?: typeof fetch,
  *   sseListener?: any,
  *   spawner?: any,
  *   sessionMap?: any,
@@ -54,7 +56,11 @@ export function buildDaemon(creds, deps = {}) {
 
   const mcpClient =
     deps.mcpClient ?? new ChorusClient({ url: creds.url, apiKey: creds.apiKey, logger });
-  const lineage = new LineageResolver({ mcpClient, logger });
+  // Lineage resolution is a plain REST call (Bearer agent key) per notification —
+  // it does not go through the MCP client. (deps.fetchImpl is injectable for tests.)
+  const lineage =
+    deps.lineage ??
+    new LineageResolver({ url: creds.url, apiKey: creds.apiKey, logger, fetchImpl: deps.fetchImpl });
   const sessionMap = deps.sessionMap ?? new SessionMap({ logger });
   const spawner = deps.spawner ?? new ClaudeSpawner({ logger, permissionMode });
   const queue = new WakeQueue({ maxConcurrency: deps.maxConcurrency ?? 4, logger });

--- a/cli/lineage.mjs
+++ b/cli/lineage.mjs
@@ -2,48 +2,42 @@
 // Resolves any inbound Chorus notification to its ROOT idea, so the daemon can
 // key one Claude session per root idea (the idea_root anchor).
 //
-// SERVER-FIRST with a client-side fallback (cli-daemon spec "Lineage-anchored
-// session continuity"): the daemon prefers the server tool chorus_resolve_root_idea
-// (the single source of truth — it closes the document-attribution gap and defines
-// multi-idea semantics). When that tool is unavailable (an older server that does
-// not register it, or a transport error that survived ChorusClient's one retry),
-// the daemon falls back to the original client-side walk so attribution still
-// works against any server version. A well-formed server response — INCLUDING a
-// rootIdeaUuid of null — is authoritative and never triggers the fallback.
+// Resolution is fully SERVER-SIDE: every notification is resolved by a single
+// call to the standalone REST endpoint
+//   GET /api/entities/{type}/{uuid}/root-idea   (Bearer <cho_ agent key>)
+// which is the single source of truth for entity → root-idea attribution
+// (it closes the document-attribution gap and defines multi-idea semantics).
+// There is intentionally NO client-side lineage walk — the whole point of this
+// change is to stop the daemon re-implementing the Chorus data model.
 //
-// Client-side fallback walk (verified field chains against the repo):
-//   • get_task → { proposalUuid: string | null }            (task.service.ts)
-//   • get_proposal → { inputType, inputUuids: string[] }     (proposal.service.ts)
-//       an idea-derived proposal has inputType "idea" and inputUuids[0] = idea
-//   • get_idea → { parentUuid: string | null }               (idea.service.ts)
-//       walk parentUuid to the top of the single-parent lineage forest
-//
-// All Chorus reads go through the injected ChorusMcpClient.callTool (contract:
-// never hand-roll fetch). Returns null when there is no idea ancestor (e.g. a
-// quick task with no proposal/idea) so the caller can fall back to a per-entity
-// session key.
+// Uses global fetch (Node 18+), exactly like sse-listener.mjs, so it adds no
+// dependency and reuses the same Bearer auth path. On any failure (unreachable
+// server, non-2xx, malformed body) it returns null so the caller falls back to
+// a per-entity session key — "no root idea" is a normal, non-fatal outcome.
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
-const MAX_PARENT_HOPS = 50; // cycle/runaway guard
 
 export class LineageResolver {
   /**
    * @param {{
-   *   mcpClient: { callTool: (name: string, args?: Record<string, unknown>) => Promise<any> },
+   *   url: string,        Chorus base URL.
+   *   apiKey: string,     `cho_` agent API key.
    *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+   *   fetchImpl?: typeof fetch,  Injectable for tests.
    * }} opts
    */
   constructor(opts) {
-    this.mcp = opts.mcpClient;
+    this.url = opts.url.replace(/\/$/, "");
+    this.apiKey = opts.apiKey;
     this.logger = opts.logger ?? NOOP_LOGGER;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
     /** @type {Map<string, string|null>} per-run cache keyed by `${type}:${uuid}`. */
     this.cache = new Map();
   }
 
   /**
-   * Resolve an event to its root idea uuid, or null if none. Server-first: prefer
-   * the chorus_resolve_root_idea tool; fall back to the client-side walk only when
-   * that tool is unavailable. The per-run cache single-flights both paths.
+   * Resolve an event to its root idea uuid, or null if none. One REST call per
+   * notification; the per-run cache single-flights repeats of the same entity.
    * @param {{ entityType?: string, entityUuid?: string }} event
    * @returns {Promise<string|null>}
    */
@@ -57,122 +51,61 @@ export class LineageResolver {
     const cacheKey = `${entityType}:${entityUuid}`;
     if (this.cache.has(cacheKey)) return this.cache.get(cacheKey);
 
-    let root = null;
-    // 1) Prefer the server-side resolver (single source of truth).
-    const server = await this.#resolveViaServer(entityType, entityUuid);
-    if (server.ok) {
-      root = server.rootIdeaUuid;
-      this.logger.info(
-        `[Chorus] lineage(server): ${cacheKey} → ${root ?? "none"}` +
-          (server.resolvedVia ? ` (${server.resolvedVia})` : "")
-      );
-    } else {
-      // 2) Fall back to the client-side walk (older server / unavailable tool).
-      this.logger.info(
-        `[Chorus] lineage(fallback): ${cacheKey} — server resolver unavailable (${server.reason})`
-      );
-      try {
-        const startIdeaUuid = await this.#toIdeaUuid(entityType, entityUuid);
-        root = startIdeaUuid ? await this.#walkToRoot(startIdeaUuid) : null;
-      } catch (err) {
-        this.logger.warn(`[Chorus] lineage resolution failed for ${cacheKey}: ${err}`);
-        root = null;
-      }
-    }
+    const root = await this.#resolveViaServer(entityType, entityUuid);
     this.cache.set(cacheKey, root);
     return root;
   }
 
   /**
-   * Call the server-side chorus_resolve_root_idea tool. Returns a discriminated
-   * result: { ok:true, rootIdeaUuid, resolvedVia } when the server answered with a
-   * well-formed payload (rootIdeaUuid string-or-null — authoritative, including
-   * null), or { ok:false, reason } when the tool is unavailable / non-conforming /
-   * errored, signalling the caller to use the client-side fallback.
-   * @param {string} entityType @param {string} entityUuid
-   */
-  async #resolveViaServer(entityType, entityUuid) {
-    let result;
-    try {
-      result = await this.mcp.callTool("chorus_resolve_root_idea", { entityType, entityUuid });
-    } catch (err) {
-      // ChorusClient has already retried once on a transport/session error, so any
-      // throw here means: unknown tool (older server) or a persistent failure.
-      // Either way, fall back — the client walk is the safe path.
-      return { ok: false, reason: `call-error: ${err?.message ?? err}` };
-    }
-    // A well-formed response is an object carrying a rootIdeaUuid of string|null.
-    // Anything else (null, primitive, missing/!=type field) means the tool isn't
-    // really there (older server returned an empty/parse-fallback body) — fall back.
-    if (
-      result &&
-      typeof result === "object" &&
-      "rootIdeaUuid" in result &&
-      (typeof result.rootIdeaUuid === "string" || result.rootIdeaUuid === null)
-    ) {
-      return {
-        ok: true,
-        rootIdeaUuid: result.rootIdeaUuid,
-        resolvedVia: typeof result.resolvedVia === "string" ? result.resolvedVia : undefined,
-      };
-    }
-    return { ok: false, reason: "non-conforming-shape" };
-  }
-
-  /**
-   * Map an entity to the idea uuid it belongs to (not yet walked to root).
+   * Call GET /api/entities/{type}/{uuid}/root-idea and return the rootIdeaUuid
+   * (string | null). Returns null on any error so the caller degrades to a
+   * per-entity session key — never throws.
    * @param {string} entityType @param {string} entityUuid
    * @returns {Promise<string|null>}
    */
-  async #toIdeaUuid(entityType, entityUuid) {
-    switch (entityType) {
-      case "idea":
-        return entityUuid;
-      case "proposal":
-        return this.#ideaFromProposal(entityUuid);
-      case "task": {
-        const task = await this.mcp.callTool("chorus_get_task", { taskUuid: entityUuid });
-        const proposalUuid = task?.proposalUuid;
-        if (!proposalUuid) return null; // quick task, no proposal/idea ancestor
-        return this.#ideaFromProposal(proposalUuid);
-      }
-      case "document": {
-        // Documents materialize from a proposal; reuse the proposal path if the
-        // event carries one, else no idea ancestor.
-        return null;
-      }
-      default:
-        return null;
+  async #resolveViaServer(entityType, entityUuid) {
+    const endpoint =
+      `${this.url}/api/entities/${encodeURIComponent(entityType)}/` +
+      `${encodeURIComponent(entityUuid)}/root-idea`;
+    let response;
+    try {
+      response = await this.fetchImpl(endpoint, {
+        headers: { Authorization: `Bearer ${this.apiKey}`, Accept: "application/json" },
+      });
+    } catch (err) {
+      this.logger.warn(`[Chorus] lineage: request failed for ${entityType}:${entityUuid}: ${err}`);
+      return null;
     }
-  }
-
-  /** @param {string} proposalUuid @returns {Promise<string|null>} */
-  async #ideaFromProposal(proposalUuid) {
-    const proposal = await this.mcp.callTool("chorus_get_proposal", { proposalUuid });
-    if (proposal?.inputType !== "idea") return null;
-    const inputUuids = Array.isArray(proposal.inputUuids) ? proposal.inputUuids : [];
-    return inputUuids.length > 0 ? inputUuids[0] : null;
-  }
-
-  /**
-   * Walk parentUuid to the top of the lineage forest.
-   * @param {string} ideaUuid @returns {Promise<string>}
-   */
-  async #walkToRoot(ideaUuid) {
-    let current = ideaUuid;
-    const visited = new Set([current]);
-    for (let hop = 0; hop < MAX_PARENT_HOPS; hop++) {
-      const idea = await this.mcp.callTool("chorus_get_idea", { ideaUuid: current });
-      const parent = idea?.parentUuid;
-      if (!parent) return current; // reached a root
-      if (visited.has(parent)) {
-        this.logger.warn(`[Chorus] lineage: parent cycle detected at ${parent}, stopping`);
-        return current;
-      }
-      visited.add(parent);
-      current = parent;
+    if (!response.ok) {
+      this.logger.warn(
+        `[Chorus] lineage: server returned ${response.status} for ${entityType}:${entityUuid}`
+      );
+      return null;
     }
-    this.logger.warn(`[Chorus] lineage: exceeded ${MAX_PARENT_HOPS} parent hops, stopping at ${current}`);
-    return current;
+    let body;
+    try {
+      body = await response.json();
+    } catch (err) {
+      this.logger.warn(`[Chorus] lineage: bad JSON for ${entityType}:${entityUuid}: ${err}`);
+      return null;
+    }
+    // API envelope: { success: true, data: { rootIdeaUuid, lineage, resolvedVia, ... } }.
+    const data = body && typeof body === "object" ? body.data : undefined;
+    if (!data || typeof data !== "object" || !("rootIdeaUuid" in data)) {
+      this.logger.warn(
+        `[Chorus] lineage: unexpected response shape for ${entityType}:${entityUuid}`
+      );
+      return null;
+    }
+    const root = data.rootIdeaUuid;
+    if (root !== null && typeof root !== "string") {
+      this.logger.warn(`[Chorus] lineage: non-string rootIdeaUuid for ${entityType}:${entityUuid}`);
+      return null;
+    }
+    this.logger.info(
+      `[Chorus] lineage: ${entityType}:${entityUuid} → ${root ?? "none"}` +
+        (typeof data.resolvedVia === "string" ? ` (${data.resolvedVia})` : "")
+    );
+    return root;
   }
 }

--- a/cli/lineage.mjs
+++ b/cli/lineage.mjs
@@ -1,7 +1,17 @@
 // cli/lineage.mjs
 // Resolves any inbound Chorus notification to its ROOT idea, so the daemon can
-// key one Claude session per root idea (the idea_root anchor). Verified field
-// chains against the repo:
+// key one Claude session per root idea (the idea_root anchor).
+//
+// SERVER-FIRST with a client-side fallback (cli-daemon spec "Lineage-anchored
+// session continuity"): the daemon prefers the server tool chorus_resolve_root_idea
+// (the single source of truth — it closes the document-attribution gap and defines
+// multi-idea semantics). When that tool is unavailable (an older server that does
+// not register it, or a transport error that survived ChorusClient's one retry),
+// the daemon falls back to the original client-side walk so attribution still
+// works against any server version. A well-formed server response — INCLUDING a
+// rootIdeaUuid of null — is authoritative and never triggers the fallback.
+//
+// Client-side fallback walk (verified field chains against the repo):
 //   • get_task → { proposalUuid: string | null }            (task.service.ts)
 //   • get_proposal → { inputType, inputUuids: string[] }     (proposal.service.ts)
 //       an idea-derived proposal has inputType "idea" and inputUuids[0] = idea
@@ -31,7 +41,9 @@ export class LineageResolver {
   }
 
   /**
-   * Resolve an event to its root idea uuid, or null if none.
+   * Resolve an event to its root idea uuid, or null if none. Server-first: prefer
+   * the chorus_resolve_root_idea tool; fall back to the client-side walk only when
+   * that tool is unavailable. The per-run cache single-flights both paths.
    * @param {{ entityType?: string, entityUuid?: string }} event
    * @returns {Promise<string|null>}
    */
@@ -46,15 +58,65 @@ export class LineageResolver {
     if (this.cache.has(cacheKey)) return this.cache.get(cacheKey);
 
     let root = null;
-    try {
-      const startIdeaUuid = await this.#toIdeaUuid(entityType, entityUuid);
-      root = startIdeaUuid ? await this.#walkToRoot(startIdeaUuid) : null;
-    } catch (err) {
-      this.logger.warn(`[Chorus] lineage resolution failed for ${cacheKey}: ${err}`);
-      root = null;
+    // 1) Prefer the server-side resolver (single source of truth).
+    const server = await this.#resolveViaServer(entityType, entityUuid);
+    if (server.ok) {
+      root = server.rootIdeaUuid;
+      this.logger.info(
+        `[Chorus] lineage(server): ${cacheKey} → ${root ?? "none"}` +
+          (server.resolvedVia ? ` (${server.resolvedVia})` : "")
+      );
+    } else {
+      // 2) Fall back to the client-side walk (older server / unavailable tool).
+      this.logger.info(
+        `[Chorus] lineage(fallback): ${cacheKey} — server resolver unavailable (${server.reason})`
+      );
+      try {
+        const startIdeaUuid = await this.#toIdeaUuid(entityType, entityUuid);
+        root = startIdeaUuid ? await this.#walkToRoot(startIdeaUuid) : null;
+      } catch (err) {
+        this.logger.warn(`[Chorus] lineage resolution failed for ${cacheKey}: ${err}`);
+        root = null;
+      }
     }
     this.cache.set(cacheKey, root);
     return root;
+  }
+
+  /**
+   * Call the server-side chorus_resolve_root_idea tool. Returns a discriminated
+   * result: { ok:true, rootIdeaUuid, resolvedVia } when the server answered with a
+   * well-formed payload (rootIdeaUuid string-or-null — authoritative, including
+   * null), or { ok:false, reason } when the tool is unavailable / non-conforming /
+   * errored, signalling the caller to use the client-side fallback.
+   * @param {string} entityType @param {string} entityUuid
+   */
+  async #resolveViaServer(entityType, entityUuid) {
+    let result;
+    try {
+      result = await this.mcp.callTool("chorus_resolve_root_idea", { entityType, entityUuid });
+    } catch (err) {
+      // ChorusClient has already retried once on a transport/session error, so any
+      // throw here means: unknown tool (older server) or a persistent failure.
+      // Either way, fall back — the client walk is the safe path.
+      return { ok: false, reason: `call-error: ${err?.message ?? err}` };
+    }
+    // A well-formed response is an object carrying a rootIdeaUuid of string|null.
+    // Anything else (null, primitive, missing/!=type field) means the tool isn't
+    // really there (older server returned an empty/parse-fallback body) — fall back.
+    if (
+      result &&
+      typeof result === "object" &&
+      "rootIdeaUuid" in result &&
+      (typeof result.rootIdeaUuid === "string" || result.rootIdeaUuid === null)
+    ) {
+      return {
+        ok: true,
+        rootIdeaUuid: result.rootIdeaUuid,
+        resolvedVia: typeof result.resolvedVia === "string" ? result.resolvedVia : undefined,
+      };
+    }
+    return { ok: false, reason: "non-conforming-shape" };
   }
 
   /**

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -273,6 +273,36 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 
 **Output**: Idea details JSON, with `reports: DocumentResponse[]` (full Markdown content, sorted by `createdAt` desc; empty when none), `parent`, `children[]`, and `descendantUuids[]` lineage fields.
 
+### chorus_resolve_root_idea
+
+**Description**: Resolve any entity (task / document / proposal / idea) to the **root idea** of its lineage in a single server-side call — the single source of truth for entity→root-idea attribution (used by the Chorus CLI daemon to anchor one local Claude session per root idea). Walks `task`/`document` → `proposal` (when `inputType="idea"`) → idea, then follows `idea.parentUuid` to the topmost idea of the lineage forest. Public read tool, scoped to the caller's company; no permission gate.
+
+**Input**:
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| entityType | string | Yes | One of `task`, `document`, `proposal`, `idea` |
+| entityUuid | string | Yes | Entity UUID |
+
+**Output**: JSON object:
+| Field | Type | Description |
+|-------|------|-------------|
+| rootIdeaUuid | string \| null | Root idea UUID, or `null` when there is no idea ancestor. `null` is a **successful** result, not an error. |
+| lineage | array | Resolved path ordered child→root; each node is `{ type, uuid, title }`. |
+| resolvedVia | string | Why the result was produced (enum below). |
+| ambiguous | boolean? | Present and `true` only when a multi-idea proposal forced an `inputUuids[0]` choice. |
+| candidates | string[]? | When ambiguous: the resolved root idea UUID of each input idea (`candidates[0] === rootIdeaUuid`). |
+
+**`resolvedVia` values**:
+| Value | Meaning | rootIdeaUuid |
+|-------|---------|--------------|
+| `root_idea` | Entity is/resolved to an idea, walked to its root. | non-null |
+| `via_proposal` | task → proposal(`inputType="idea"`) → idea → root. | non-null |
+| `via_document_proposal` | document → proposal(`inputType="idea"`) → idea → root. | non-null |
+| `no_proposal` | Task/document with no `proposalUuid` (e.g. a quick task). | null |
+| `proposal_input_not_idea` | Proposal's `inputType` is not `"idea"` (or it has no input ideas). | null |
+| `standalone_document` | Document with no `proposalUuid`. | null |
+| `not_found` | Entity UUID not found in the caller's company. | null |
+
 ### chorus_get_documents
 
 **Description**: Get the list of documents for a project

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -273,35 +273,7 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 
 **Output**: Idea details JSON, with `reports: DocumentResponse[]` (full Markdown content, sorted by `createdAt` desc; empty when none), `parent`, `children[]`, and `descendantUuids[]` lineage fields.
 
-### chorus_resolve_root_idea
-
-**Description**: Resolve any entity (task / document / proposal / idea) to the **root idea** of its lineage in a single server-side call — the single source of truth for entity→root-idea attribution (used by the Chorus CLI daemon to anchor one local Claude session per root idea). Walks `task`/`document` → `proposal` (when `inputType="idea"`) → idea, then follows `idea.parentUuid` to the topmost idea of the lineage forest. Public read tool, scoped to the caller's company; no permission gate.
-
-**Input**:
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| entityType | string | Yes | One of `task`, `document`, `proposal`, `idea` |
-| entityUuid | string | Yes | Entity UUID |
-
-**Output**: JSON object:
-| Field | Type | Description |
-|-------|------|-------------|
-| rootIdeaUuid | string \| null | Root idea UUID, or `null` when there is no idea ancestor. `null` is a **successful** result, not an error. |
-| lineage | array | Resolved path ordered child→root; each node is `{ type, uuid, title }`. |
-| resolvedVia | string | Why the result was produced (enum below). |
-| ambiguous | boolean? | Present and `true` only when a multi-idea proposal forced an `inputUuids[0]` choice. |
-| candidates | string[]? | When ambiguous: the resolved root idea UUID of each input idea (`candidates[0] === rootIdeaUuid`). |
-
-**`resolvedVia` values**:
-| Value | Meaning | rootIdeaUuid |
-|-------|---------|--------------|
-| `root_idea` | Entity is/resolved to an idea, walked to its root. | non-null |
-| `via_proposal` | task → proposal(`inputType="idea"`) → idea → root. | non-null |
-| `via_document_proposal` | document → proposal(`inputType="idea"`) → idea → root. | non-null |
-| `no_proposal` | Task/document with no `proposalUuid` (e.g. a quick task). | null |
-| `proposal_input_not_idea` | Proposal's `inputType` is not `"idea"` (or it has no input ideas). | null |
-| `standalone_document` | Document with no `proposalUuid`. | null |
-| `not_found` | Entity UUID not found in the caller's company. | null |
+> Entity → root-idea lineage resolution is **not** an MCP tool. It is a standalone REST endpoint, `GET /api/entities/{type}/{uuid}/root-idea`, callable with any valid auth (including an agent API key) — see `docs/API.md` / the route at `src/app/api/entities/[type]/[uuid]/root-idea/`.
 
 ### chorus_get_documents
 

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/README.md
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/README.md
@@ -1,0 +1,3 @@
+# add-root-idea-resolution
+
+Server-side chorus_resolve_root_idea: resolve any entity to its root idea in one call; daemon prefers it with client-walk fallback

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/design.md
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/design.md
@@ -1,0 +1,160 @@
+# Design: root-idea resolution
+
+## Context
+
+`cli/lineage.mjs` (the daemon's client-side resolver) is the reference algorithm
+being ported to the server. Its walk:
+
+```
+entity → idea uuid → walk parentUuid to top
+  task     : get_task.proposalUuid → ideaFromProposal
+  proposal : ideaFromProposal
+  idea     : itself
+  document : null  (gap)
+  ideaFromProposal: get_proposal; inputType==="idea" ? inputUuids[0] : null  (multi-idea gap)
+```
+
+The data model (verified against `prisma/schema.prisma`):
+
+- `Task.proposalUuid: String?` (nullable; quick tasks have none)
+- `Document.proposalUuid: String?` (nullable; standalone docs have none)
+- `Proposal.inputType: String` + `Proposal.inputUuids: Json` (array; idea-derived
+  proposals set `inputType="idea"`, `inputUuids` = source idea uuids)
+- `Idea.parentUuid: String?` (single-parent forest edge)
+
+All four entities expose a raw `*ByUuid(companyUuid, uuid)` service getter
+(`getTaskByUuid`, `getProposalByUuid`, `getDocumentByUuid`, `getIdeaByUuid`) that is
+a plain `prisma.<model>.findFirst({ where: { uuid, companyUuid } })` — these are the
+building blocks. The service never crosses the company boundary.
+
+## Goals / Non-Goals
+
+- **Goal**: one server call resolves entity → root idea, as the single source of
+  truth; close the document gap; make multi-idea ambiguity explicit; keep the daemon
+  deterministic (one root → one session).
+- **Non-goal**: REST surface, notification-schema change, permission gating, changing
+  the daemon's cache/key/session-map.
+
+## Service contract — `resolveRootIdea`
+
+```
+resolveRootIdea(companyUuid, entityType, entityUuid) -> {
+  rootIdeaUuid: string | null,
+  lineage: Array<{ type: "task"|"document"|"proposal"|"idea", uuid: string, title: string | null }>,
+  resolvedVia: ResolvedVia,
+  ambiguous?: boolean,
+  candidates?: string[],   // root idea uuids, when ambiguous
+}
+```
+
+`ResolvedVia` enum and meaning:
+
+| value | meaning | rootIdeaUuid |
+|---|---|---|
+| `root_idea` | entity is an idea (or resolved idea) and walked to a root | non-null |
+| `via_proposal` | task → proposal(inputType=idea) → idea → root | non-null |
+| `via_document_proposal` | document → proposal(inputType=idea) → idea → root | non-null |
+| `no_proposal` | task/document with no proposalUuid (quick task / standalone) | null |
+| `proposal_input_not_idea` | proposal/derived has `inputType !== "idea"` | null |
+| `standalone_document` | document with no proposalUuid | null |
+| `not_found` | entity uuid not found in this company | null |
+
+`null` is a **successful** result, not an error — "no idea ancestor" is a legitimate
+outcome the daemon handles by falling back to a per-entity session key. This avoids
+the earlier `#isSessionExpired` trap where a literal "not found" string was
+misclassified.
+
+### Algorithm
+
+```
+1. Resolve entity → starting idea uuid + provenance:
+   - idea     → (entityUuid, root_idea)
+   - proposal → ideaFromProposal(proposal)
+   - task     → t = getTaskByUuid; t? : (no proposalUuid → null/no_proposal)
+                                        : ideaFromProposal(t.proposalUuid) [via_proposal]
+                not found → null/not_found
+   - document → d = getDocumentByUuid; d? : (no proposalUuid → null/standalone_document)
+                                            : ideaFromProposal(d.proposalUuid) [via_document_proposal]
+                not found → null/not_found
+2. ideaFromProposal(proposalUuid):
+   - p = getProposalByUuid; not found → null/not_found
+   - p.inputType !== "idea" → null/proposal_input_not_idea
+   - ideas = inputUuids (string[]); empty → null/proposal_input_not_idea
+   - startIdea = ideas[0]; ambiguous = ideas.length > 1; candidates = ideas
+3. walkToRoot(startIdea):
+   - follow getIdeaByUuid(...).parentUuid up to MAX_PARENT_HOPS (50)
+   - visited-set cycle guard (matches the client walk)
+   - returns the topmost idea uuid
+4. lineage[] is accumulated child→root as each hop resolves, carrying each entity's
+   title for the observability UI; the root idea's parentUuid resolution feeds the
+   ambiguity flags through unchanged.
+```
+
+The ambiguity flags reflect the **proposal** step (multi-idea input), independent of
+how deep the parent walk goes. When ambiguous, `candidates` are the **root ideas** of
+each `inputUuids` entry (each walked to its own top), so a future consumer sees the
+real set of main lines — but `rootIdeaUuid` remains `candidates[0]` to keep the
+daemon's session anchor single-valued.
+
+## MCP tool — `chorus_resolve_root_idea`
+
+Registered in `registerPublicTools` (public.ts), no permission gate, alongside
+`chorus_get_idea`:
+
+```
+inputSchema: { entityType: z.enum(["task","document","proposal","idea"]), entityUuid: z.string() }
+handler: resolveRootIdea(auth.companyUuid, entityType, entityUuid) → JSON.stringify
+```
+
+Not added to `permission-map.ts` (read tools are public there). Documented in
+`docs/MCP_TOOLS.md` as a public tool.
+
+## Daemon integration — `cli/lineage.mjs`
+
+`LineageResolver.rootIdeaFor` becomes **server-first with fallback**:
+
+```
+rootIdeaFor(event):
+  cache hit → return
+  try:
+    r = mcp.callTool("chorus_resolve_root_idea", { entityType, entityUuid })
+    if r is a well-formed object (has rootIdeaUuid field, possibly null):
+       root = r.rootIdeaUuid           // server is source of truth, incl. null
+  catch toolUnavailable(err):           // older server / tool not registered
+    root = <existing client-side walk>  // unchanged #toIdeaUuid/#walkToRoot path
+  cache.set; return root
+```
+
+- **Tool-unavailable detection**: the SDK surfaces an unknown tool as a tool/method
+  error. We must distinguish "tool not registered on this server" (→ fall back to the
+  client walk) from a transient transport error (already retried once by
+  `ChorusClient.callTool`) and from a legitimate `null` result (→ use it, do NOT fall
+  back). A `null` rootIdeaUuid in a well-formed response is authoritative — fallback
+  fires only when the call itself fails or returns a non-conforming shape.
+- The cache, key derivation, and session-map are untouched, so the per-root-idea
+  WakeQueue serialization and the existing tests' invariants hold.
+- The client-side `#toIdeaUuid` / `#walkToRoot` / `#ideaFromProposal` methods stay as
+  the fallback implementation — they are not deleted.
+
+## Risks / Trade-offs
+
+- **Server/daemon version skew** → mandatory fallback (chosen over hard dependency).
+- **Document attribution now active** → a document notification that previously fell
+  to `entity:document:` will now (correctly) join its idea's session. This is the
+  intended fix, not a regression; called out so reviewers expect the behavior change.
+- **Ambiguous multi-idea** → deterministic `candidates[0]` keeps session anchoring
+  stable; the flag lets a future UI surface the ambiguity rather than hiding it.
+
+## Migration
+
+None. Additive server tool; daemon change is backward-compatible via fallback. No
+schema change, no data migration.
+
+## Test plan
+
+- Service unit tests (`lineage.service.test.ts`): each entity type, each `resolvedVia`
+  branch, multi-idea ambiguity, cycle guard, cross-company isolation (getter returns
+  null for another company's uuid), deep parent walk.
+- Daemon tests (`lineage.test.mjs`): server-first happy path (uses server result incl.
+  null), fallback when the tool call throws an unavailable-tool error, no-fallback when
+  the server returns a well-formed null, cache still single-flight.

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/proposal.md
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/proposal.md
@@ -1,5 +1,14 @@
 # Server-side root-idea resolution endpoint
 
+> **Post-archive revision (2026-06-15):** this change originally exposed resolution as
+> a public MCP tool `chorus_resolve_root_idea`. Before merge, the exposure was changed
+> to a **standalone REST endpoint** `GET /api/entities/{type}/{uuid}/root-idea`
+> (callable with an agent API key, no permission gate), and the daemon was changed to
+> call it once per notification with **no client-side fallback walk**. The cumulative
+> specs in `openspec/specs/root-idea-resolution/` and `openspec/specs/cli-daemon/`
+> reflect the shipped REST design; the delta files below preserve the original MCP
+> proposal for history.
+
 ## Why
 
 The Chorus CLI daemon anchors each local Claude session on the **root idea** of a

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/proposal.md
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/proposal.md
@@ -1,0 +1,89 @@
+# Server-side root-idea resolution endpoint
+
+## Why
+
+The Chorus CLI daemon anchors each local Claude session on the **root idea** of a
+dispatched entity (same root → `--resume` the same session — the "main line"
+continuity that makes the daemon useful). To do that, every inbound notification
+must be attributed from its entity up to a root idea.
+
+Today that attribution runs **client-side** in `cli/lineage.mjs`, which re-implements
+Chorus's data model from the outside:
+
+- Task / Document carry only a nullable `proposalUuid` — no direct `ideaUuid`.
+- Proposal carries `inputType` + `inputUuids` (a JSON array) — no `ideaUuid` column.
+- Idea carries a single-parent `parentUuid` chain.
+
+So one task attribution costs `get_task` + `get_proposal` + N×`get_idea` =
+**3–4 serial MCP round-trips**, paid for every new root (cross-entity, or after a
+daemon restart). This duplication causes three concrete problems:
+
+1. **Multi-hop cost** — only a single-run in-memory cache mitigates it.
+2. **Client re-implements server semantics** — if the server changes lineage rules
+   (multi-idea proposals, documents directly attached to ideas), the client
+   silently mis-attributes. The single source of truth should live on the server.
+3. **Coverage gaps already shipped in `cli/lineage.mjs`:**
+   - **Documents are never attributed** — `lineage.mjs` returns `null`
+     unconditionally for documents, even when a document belongs to a proposal that
+     belongs to an idea. Those notifications fall to an isolated `entity:document:`
+     session instead of the idea's main line.
+   - **Multi-idea proposals take only `inputUuids[0]`** — a merged proposal's tasks
+     attribute to the first idea, which may not be the intended main line, with no
+     signal that the choice was ambiguous.
+
+## What Changes
+
+- **ADD** a public, read-only MCP tool `chorus_resolve_root_idea({ entityType, entityUuid })`
+  that resolves an entity to its root idea **server-side in one call** and returns:
+  - `rootIdeaUuid: string | null`
+  - `lineage: Array<{ type, uuid, title }>` — ordered child→root, zero-cost data for
+    the future observability UI (idea `f2fe9a7f` / `c152dcfc`)
+  - `resolvedVia: enum` — explains the outcome (`root_idea`, `via_proposal`,
+    `via_document_proposal`, `no_proposal`, `proposal_input_not_idea`,
+    `standalone_document`, `not_found`) so callers can log a clear attribution trail
+  - `ambiguous?: boolean` + `candidates?: string[]` — set when a multi-idea proposal
+    forced an `inputUuids[0]` choice
+- **ADD** a server lineage service (`resolveRootIdea`) that performs the walk using
+  the existing raw `*ByUuid` getters, all scoped by `companyUuid`. This is the new
+  single source of truth.
+- **CLOSE the document gap server-side**: documents attribute via
+  `document.proposalUuid → proposal → idea`; only a standalone document (no proposal)
+  returns `null`.
+- **DEFINE multi-idea semantics**: return the `inputUuids[0]` root as the main line
+  but flag `ambiguous` and list `candidates`, so the daemon stays deterministic
+  (one root → one session, the precondition for the WakeQueue's per-key serialization)
+  while the ambiguity is visible.
+- **MODIFY the daemon** (`cli/lineage.mjs`): prefer the server endpoint, **fall back**
+  to the existing client-side walk when the tool is unavailable (older server, tool
+  not registered, transport error). The cache / key / session-map are untouched —
+  zero-regression, progressive migration. A daemon is an npm package whose version
+  need not match the server's, so the fallback is mandatory, not optional.
+
+## Non-goals
+
+- **No REST endpoint.** The only consumer is the daemon, which talks MCP exclusively.
+  A REST surface has no consumer today; the lineage service is factored so a future
+  `GET /api/entities/{type}/{uuid}/root-idea` is a thin add if observability needs it.
+- **No notification-schema change.** Attaching `rootIdeaUuid` to every notification
+  (and a migration) benefits only the daemon and over-weights the notification table;
+  that belongs to the observability idea (`f2fe9a7f`) if "show the owning idea on
+  every notification" ever becomes a general UI need.
+- **No permission gate.** Like `chorus_get_idea` / `chorus_get_proposal`, this is a
+  public read tool, multi-tenant-scoped by `companyUuid`. The daemon's default
+  `allowedTools` already includes `mcp__chorus__*`.
+
+## Capabilities
+
+- `root-idea-resolution` (new) — the server tool + service contract and its
+  attribution semantics for every entity type.
+- `cli-daemon` (modified) — the lineage-anchored session-continuity requirement now
+  resolves via the server endpoint with a client-walk fallback.
+
+## Impact
+
+- New: `src/services/lineage.service.ts`, `chorus_resolve_root_idea` registration in
+  `src/mcp/tools/public.ts`, service tests, docs in `docs/MCP_TOOLS.md`.
+- Changed: `cli/lineage.mjs` (server-first + fallback), its tests, and the four
+  daemon skill/doc surfaces are unaffected (tool is public, no permission row).
+- Risk: low. The server tool is additive; the daemon change is guarded by a fallback
+  that preserves today's behavior byte-for-byte when the endpoint is absent.

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/specs/cli-daemon/spec.md
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/specs/cli-daemon/spec.md
@@ -1,0 +1,47 @@
+# cli-daemon Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Lineage-anchored session continuity
+
+The daemon SHALL key each local Claude session on the **root idea** of the dispatched
+entity. It SHALL resolve any inbound event to its root idea by **preferring the
+server-side `chorus_resolve_root_idea` tool** (the single source of truth), and SHALL
+**fall back** to a client-side lineage walk (`task → proposal → idea`, then following
+`idea.parentUuid`) only when that tool is unavailable — for example an older server
+that does not register it, or a transport failure. A well-formed server response SHALL
+be authoritative, including a `rootIdeaUuid` of `null`, which the daemon SHALL NOT
+override via the fallback walk. The daemon SHALL maintain a persisted map from root
+idea to Claude session id. When a notification resolves to a root idea that already
+has a session, the daemon SHALL resume that session (`--resume`); when it resolves to
+a new root idea, the daemon SHALL start a fresh session and persist the newly created
+session id. When no idea ancestor exists (a `null` root idea), the daemon SHALL fall
+back to a per-entity session key.
+
+#### Scenario: Same root idea resumes the same session
+
+- **WHEN** two notifications (e.g. a task execution then a later proposal rejection)
+  both resolve up the lineage to the same root idea
+- **THEN** the second wake resumes the same Claude session id used by the first via
+  `--resume`
+
+#### Scenario: Different root idea starts a fresh session
+
+- **WHEN** a notification resolves to a root idea that has no recorded session
+- **THEN** the daemon starts a fresh Claude session, captures the new session id from
+  the subprocess output, and persists it under that root idea
+
+#### Scenario: Server resolution is preferred when available
+
+- **WHEN** the server exposes `chorus_resolve_root_idea` and it returns a well-formed
+  response for an inbound event
+- **THEN** the daemon uses the server's `rootIdeaUuid` (including a `null` result)
+  without performing its own multi-hop lineage walk
+
+#### Scenario: Client walk is used when the server tool is unavailable
+
+- **WHEN** `chorus_resolve_root_idea` is not registered on the server or the call
+  fails at the transport layer
+- **THEN** the daemon falls back to its client-side `task → proposal → idea →
+  parentUuid` walk and anchors the session on the resulting root idea, preserving the
+  pre-existing behavior

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/specs/root-idea-resolution/spec.md
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/specs/root-idea-resolution/spec.md
@@ -1,0 +1,109 @@
+# root-idea-resolution Specification
+
+## ADDED Requirements
+
+### Requirement: Server-side root-idea resolution tool
+
+The Chorus MCP server SHALL expose a public, read-only tool
+`chorus_resolve_root_idea` that accepts `entityType` (one of `task`, `document`,
+`proposal`, `idea`) and `entityUuid`, and resolves the entity to the root idea of
+its lineage in a single call. The tool SHALL be available without a permission gate
+(consistent with `chorus_get_idea`), and all resolution SHALL be scoped to the
+caller's `companyUuid` so no cross-company entity is ever traversed or returned.
+
+The tool SHALL return an object containing `rootIdeaUuid` (a string, or `null` when
+no idea ancestor exists), a `lineage` array ordered from the input entity to the root
+idea where each element carries `type`, `uuid`, and `title`, and a `resolvedVia`
+string explaining the outcome.
+
+#### Scenario: Task with an idea-derived proposal resolves to the root idea
+
+- **WHEN** `chorus_resolve_root_idea` is called with `entityType: "task"` and a task
+  whose `proposalUuid` points to a proposal with `inputType: "idea"`
+- **THEN** the tool walks task → proposal → idea → `parentUuid` to the topmost idea
+  and returns that uuid as `rootIdeaUuid` with `resolvedVia: "via_proposal"`
+
+#### Scenario: Idea resolves to its own lineage root
+
+- **WHEN** the tool is called with `entityType: "idea"` for an idea that has a chain
+  of `parentUuid` ancestors
+- **THEN** it returns the topmost ancestor as `rootIdeaUuid` with
+  `resolvedVia: "root_idea"`
+
+#### Scenario: Resolution is scoped to the caller's company
+
+- **WHEN** the tool is called with an `entityUuid` that exists only in another company
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "not_found"` and never
+  reads or returns the other company's entity
+
+### Requirement: Document attribution via proposal
+
+The resolution tool SHALL attribute a document to a root idea by following
+`document.proposalUuid → proposal → idea`, closing the gap where documents were never
+attributed. A document with no `proposalUuid` SHALL resolve to `rootIdeaUuid: null`
+with `resolvedVia: "standalone_document"`.
+
+#### Scenario: Document of an idea-derived proposal resolves to the root idea
+
+- **WHEN** the tool is called with `entityType: "document"` for a document whose
+  `proposalUuid` points to a proposal with `inputType: "idea"`
+- **THEN** it returns the proposal's idea walked to its root as `rootIdeaUuid` with
+  `resolvedVia: "via_document_proposal"`
+
+#### Scenario: Standalone document has no idea ancestor
+
+- **WHEN** the tool is called for a document whose `proposalUuid` is null
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "standalone_document"`
+
+### Requirement: Explicit multi-idea ambiguity
+
+When a proposal's `inputUuids` contains more than one idea, the resolution tool SHALL
+return the root of the first input idea as `rootIdeaUuid` (keeping the result
+single-valued so a consumer's session anchoring stays deterministic), and SHALL set
+`ambiguous: true` with a `candidates` array listing the resolved root idea uuid of
+each input idea.
+
+#### Scenario: Merged proposal flags ambiguity but stays single-valued
+
+- **WHEN** the tool resolves a task whose proposal has `inputType: "idea"` and two or
+  more entries in `inputUuids`
+- **THEN** `rootIdeaUuid` is the root of `inputUuids[0]`, `ambiguous` is `true`, and
+  `candidates` lists the root idea of each input idea
+
+#### Scenario: Single-idea proposal is not ambiguous
+
+- **WHEN** the tool resolves an entity whose proposal has exactly one entry in
+  `inputUuids`
+- **THEN** `ambiguous` is absent or `false` and no `candidates` array is required
+
+### Requirement: No idea ancestor is a successful null, not an error
+
+The resolution tool SHALL treat the absence of an idea ancestor as a successful
+result with `rootIdeaUuid: null` and a `resolvedVia` value that names the reason
+(`no_proposal`, `proposal_input_not_idea`, `standalone_document`, or `not_found`).
+It SHALL NOT return a tool error for these cases, so a caller can distinguish "no
+ancestor" from a genuine failure without parsing error text.
+
+#### Scenario: Quick task with no proposal returns null
+
+- **WHEN** the tool is called for a task whose `proposalUuid` is null
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "no_proposal"` and the
+  call is not an error
+
+#### Scenario: Document-derived proposal returns null
+
+- **WHEN** the tool resolves an entity whose proposal has `inputType` other than
+  `"idea"`
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "proposal_input_not_idea"`
+
+### Requirement: Bounded, cycle-safe parent walk
+
+The resolution SHALL walk the `parentUuid` chain with a visited-set cycle guard and a
+bounded maximum hop count, returning the deepest reachable idea without looping
+indefinitely if the lineage data contains a cycle.
+
+#### Scenario: Cyclic lineage terminates at the entry idea
+
+- **WHEN** the `parentUuid` chain forms a cycle
+- **THEN** the walk detects the repeat via the visited set and returns without
+  exceeding the hop bound

--- a/openspec/changes/archive/2026-06-15-add-root-idea-resolution/tasks.md
+++ b/openspec/changes/archive/2026-06-15-add-root-idea-resolution/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## 1. Server lineage service
+
+- [ ] 1.1 Add `src/services/lineage.service.ts` with `resolveRootIdea(companyUuid, entityType, entityUuid)` using the raw `*ByUuid` getters, returning `{ rootIdeaUuid, lineage, resolvedVia, ambiguous?, candidates? }`.
+- [ ] 1.2 Implement entity→idea provenance (task/document/proposal/idea), the `ideaFromProposal` multi-idea handling, and the bounded cycle-safe `walkToRoot`.
+- [ ] 1.3 Unit tests covering every entity type, every `resolvedVia` branch, multi-idea ambiguity, cycle guard, cross-company isolation, and a deep parent walk.
+
+## 2. MCP tool registration
+
+- [ ] 2.1 Register `chorus_resolve_root_idea` in `src/mcp/tools/public.ts` (public, no gate) delegating to the service.
+- [ ] 2.2 Document the tool in `docs/MCP_TOOLS.md` as a public read tool.
+
+## 3. Daemon integration
+
+- [ ] 3.1 Change `cli/lineage.mjs` `rootIdeaFor` to server-first via `chorus_resolve_root_idea`, with the existing client walk retained as fallback (tool-unavailable detection; well-formed null is authoritative).
+- [ ] 3.2 Update `cli/__tests__/lineage.test.mjs`: server-first happy path, fallback on unavailable tool, no-fallback on well-formed null, cache single-flight.

--- a/openspec/specs/cli-daemon/spec.md
+++ b/openspec/specs/cli-daemon/spec.md
@@ -33,17 +33,47 @@ On receiving a relevant notification (at minimum `task_assigned`), the daemon SH
 
 ### Requirement: Lineage-anchored session continuity
 
-The daemon SHALL key each local Claude session on the **root idea** of the dispatched entity. It SHALL resolve any inbound event up the Chorus lineage (`task → proposal → idea`, then following `idea.parentUuid`) to its topmost idea, and SHALL maintain a persisted map from root idea to Claude session id. When a notification resolves to a root idea that already has a session, the daemon SHALL resume that session (`--resume`); when it resolves to a new root idea, the daemon SHALL start a fresh session and persist the newly created session id. When no idea ancestor exists, the daemon SHALL fall back to a per-entity session key.
+The daemon SHALL key each local Claude session on the **root idea** of the dispatched
+entity. It SHALL resolve any inbound event to its root idea by **preferring the
+server-side `chorus_resolve_root_idea` tool** (the single source of truth), and SHALL
+**fall back** to a client-side lineage walk (`task → proposal → idea`, then following
+`idea.parentUuid`) only when that tool is unavailable — for example an older server
+that does not register it, or a transport failure. A well-formed server response SHALL
+be authoritative, including a `rootIdeaUuid` of `null`, which the daemon SHALL NOT
+override via the fallback walk. The daemon SHALL maintain a persisted map from root
+idea to Claude session id. When a notification resolves to a root idea that already
+has a session, the daemon SHALL resume that session (`--resume`); when it resolves to
+a new root idea, the daemon SHALL start a fresh session and persist the newly created
+session id. When no idea ancestor exists (a `null` root idea), the daemon SHALL fall
+back to a per-entity session key.
 
 #### Scenario: Same root idea resumes the same session
 
-- **WHEN** two notifications (e.g. a task execution then a later proposal rejection) both resolve up the lineage to the same root idea
-- **THEN** the second wake resumes the same Claude session id used by the first via `--resume`
+- **WHEN** two notifications (e.g. a task execution then a later proposal rejection)
+  both resolve up the lineage to the same root idea
+- **THEN** the second wake resumes the same Claude session id used by the first via
+  `--resume`
 
 #### Scenario: Different root idea starts a fresh session
 
 - **WHEN** a notification resolves to a root idea that has no recorded session
-- **THEN** the daemon starts a fresh Claude session, captures the new session id from the subprocess output, and persists it under that root idea
+- **THEN** the daemon starts a fresh Claude session, captures the new session id from
+  the subprocess output, and persists it under that root idea
+
+#### Scenario: Server resolution is preferred when available
+
+- **WHEN** the server exposes `chorus_resolve_root_idea` and it returns a well-formed
+  response for an inbound event
+- **THEN** the daemon uses the server's `rootIdeaUuid` (including a `null` result)
+  without performing its own multi-hop lineage walk
+
+#### Scenario: Client walk is used when the server tool is unavailable
+
+- **WHEN** `chorus_resolve_root_idea` is not registered on the server or the call
+  fails at the transport layer
+- **THEN** the daemon falls back to its client-side `task → proposal → idea →
+  parentUuid` walk and anchors the session on the resulting root idea, preserving the
+  pre-existing behavior
 
 ### Requirement: Per-root-idea wake serialization
 

--- a/openspec/specs/cli-daemon/spec.md
+++ b/openspec/specs/cli-daemon/spec.md
@@ -34,23 +34,23 @@ On receiving a relevant notification (at minimum `task_assigned`), the daemon SH
 ### Requirement: Lineage-anchored session continuity
 
 The daemon SHALL key each local Claude session on the **root idea** of the dispatched
-entity. It SHALL resolve any inbound event to its root idea by **preferring the
-server-side `chorus_resolve_root_idea` tool** (the single source of truth), and SHALL
-**fall back** to a client-side lineage walk (`task → proposal → idea`, then following
-`idea.parentUuid`) only when that tool is unavailable — for example an older server
-that does not register it, or a transport failure. A well-formed server response SHALL
-be authoritative, including a `rootIdeaUuid` of `null`, which the daemon SHALL NOT
-override via the fallback walk. The daemon SHALL maintain a persisted map from root
-idea to Claude session id. When a notification resolves to a root idea that already
-has a session, the daemon SHALL resume that session (`--resume`); when it resolves to
-a new root idea, the daemon SHALL start a fresh session and persist the newly created
-session id. When no idea ancestor exists (a `null` root idea), the daemon SHALL fall
-back to a per-entity session key.
+entity. For each inbound notification it SHALL resolve the entity to its root idea by
+making a single call to the server-side REST endpoint
+`GET /api/entities/{type}/{uuid}/root-idea` (authenticated with its agent API key) —
+the single source of truth. The daemon SHALL NOT perform any client-side lineage walk
+of its own; the server's `rootIdeaUuid` (including `null`) is authoritative. The daemon
+SHALL maintain a persisted map from root idea to Claude session id. When a notification
+resolves to a root idea that already has a session, the daemon SHALL resume that session
+(`--resume`); when it resolves to a new root idea, the daemon SHALL start a fresh session
+and persist the newly created session id. When the endpoint returns no idea ancestor (a
+`null` root idea) or the call fails for any reason, the daemon SHALL fall back to a
+per-entity session key. Resolution results MAY be cached per run so the same entity is
+not resolved twice within one daemon run.
 
 #### Scenario: Same root idea resumes the same session
 
 - **WHEN** two notifications (e.g. a task execution then a later proposal rejection)
-  both resolve up the lineage to the same root idea
+  both resolve to the same root idea
 - **THEN** the second wake resumes the same Claude session id used by the first via
   `--resume`
 
@@ -60,20 +60,19 @@ back to a per-entity session key.
 - **THEN** the daemon starts a fresh Claude session, captures the new session id from
   the subprocess output, and persists it under that root idea
 
-#### Scenario: Server resolution is preferred when available
+#### Scenario: Each notification is resolved via the REST endpoint
 
-- **WHEN** the server exposes `chorus_resolve_root_idea` and it returns a well-formed
-  response for an inbound event
-- **THEN** the daemon uses the server's `rootIdeaUuid` (including a `null` result)
-  without performing its own multi-hop lineage walk
+- **WHEN** a notification arrives for an entity
+- **THEN** the daemon calls `GET /api/entities/{type}/{uuid}/root-idea` once and uses
+  the returned `rootIdeaUuid` (including a `null` result) without performing any local
+  lineage walk
 
-#### Scenario: Client walk is used when the server tool is unavailable
+#### Scenario: A failed or unreachable resolution degrades to a per-entity key
 
-- **WHEN** `chorus_resolve_root_idea` is not registered on the server or the call
-  fails at the transport layer
-- **THEN** the daemon falls back to its client-side `task → proposal → idea →
-  parentUuid` walk and anchors the session on the resulting root idea, preserving the
-  pre-existing behavior
+- **WHEN** the resolution endpoint is unreachable, returns a non-2xx status, or returns
+  a malformed body
+- **THEN** the daemon treats the entity as having no root idea and anchors the session
+  on a per-entity key, without crashing
 
 ### Requirement: Per-root-idea wake serialization
 

--- a/openspec/specs/root-idea-resolution/spec.md
+++ b/openspec/specs/root-idea-resolution/spec.md
@@ -1,0 +1,116 @@
+# root-idea-resolution Specification
+
+## Purpose
+Defines the server-side `chorus_resolve_root_idea` MCP tool — the single source of
+truth for attributing any entity (task / document / proposal / idea) up the Chorus
+lineage to its root idea. It powers the CLI daemon's per-root-idea session anchoring,
+closes the document-attribution gap, and gives multi-idea proposals explicit,
+deterministic semantics.
+
+## Requirements
+### Requirement: Server-side root-idea resolution tool
+
+The Chorus MCP server SHALL expose a public, read-only tool
+`chorus_resolve_root_idea` that accepts `entityType` (one of `task`, `document`,
+`proposal`, `idea`) and `entityUuid`, and resolves the entity to the root idea of
+its lineage in a single call. The tool SHALL be available without a permission gate
+(consistent with `chorus_get_idea`), and all resolution SHALL be scoped to the
+caller's `companyUuid` so no cross-company entity is ever traversed or returned.
+
+The tool SHALL return an object containing `rootIdeaUuid` (a string, or `null` when
+no idea ancestor exists), a `lineage` array ordered from the input entity to the root
+idea where each element carries `type`, `uuid`, and `title`, and a `resolvedVia`
+string explaining the outcome.
+
+#### Scenario: Task with an idea-derived proposal resolves to the root idea
+
+- **WHEN** `chorus_resolve_root_idea` is called with `entityType: "task"` and a task
+  whose `proposalUuid` points to a proposal with `inputType: "idea"`
+- **THEN** the tool walks task → proposal → idea → `parentUuid` to the topmost idea
+  and returns that uuid as `rootIdeaUuid` with `resolvedVia: "via_proposal"`
+
+#### Scenario: Idea resolves to its own lineage root
+
+- **WHEN** the tool is called with `entityType: "idea"` for an idea that has a chain
+  of `parentUuid` ancestors
+- **THEN** it returns the topmost ancestor as `rootIdeaUuid` with
+  `resolvedVia: "root_idea"`
+
+#### Scenario: Resolution is scoped to the caller's company
+
+- **WHEN** the tool is called with an `entityUuid` that exists only in another company
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "not_found"` and never
+  reads or returns the other company's entity
+
+### Requirement: Document attribution via proposal
+
+The resolution tool SHALL attribute a document to a root idea by following
+`document.proposalUuid → proposal → idea`, closing the gap where documents were never
+attributed. A document with no `proposalUuid` SHALL resolve to `rootIdeaUuid: null`
+with `resolvedVia: "standalone_document"`.
+
+#### Scenario: Document of an idea-derived proposal resolves to the root idea
+
+- **WHEN** the tool is called with `entityType: "document"` for a document whose
+  `proposalUuid` points to a proposal with `inputType: "idea"`
+- **THEN** it returns the proposal's idea walked to its root as `rootIdeaUuid` with
+  `resolvedVia: "via_document_proposal"`
+
+#### Scenario: Standalone document has no idea ancestor
+
+- **WHEN** the tool is called for a document whose `proposalUuid` is null
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "standalone_document"`
+
+### Requirement: Explicit multi-idea ambiguity
+
+When a proposal's `inputUuids` contains more than one idea, the resolution tool SHALL
+return the root of the first input idea as `rootIdeaUuid` (keeping the result
+single-valued so a consumer's session anchoring stays deterministic), and SHALL set
+`ambiguous: true` with a `candidates` array listing the resolved root idea uuid of
+each input idea.
+
+#### Scenario: Merged proposal flags ambiguity but stays single-valued
+
+- **WHEN** the tool resolves a task whose proposal has `inputType: "idea"` and two or
+  more entries in `inputUuids`
+- **THEN** `rootIdeaUuid` is the root of `inputUuids[0]`, `ambiguous` is `true`, and
+  `candidates` lists the root idea of each input idea
+
+#### Scenario: Single-idea proposal is not ambiguous
+
+- **WHEN** the tool resolves an entity whose proposal has exactly one entry in
+  `inputUuids`
+- **THEN** `ambiguous` is absent or `false` and no `candidates` array is required
+
+### Requirement: No idea ancestor is a successful null, not an error
+
+The resolution tool SHALL treat the absence of an idea ancestor as a successful
+result with `rootIdeaUuid: null` and a `resolvedVia` value that names the reason
+(`no_proposal`, `proposal_input_not_idea`, `standalone_document`, or `not_found`).
+It SHALL NOT return a tool error for these cases, so a caller can distinguish "no
+ancestor" from a genuine failure without parsing error text.
+
+#### Scenario: Quick task with no proposal returns null
+
+- **WHEN** the tool is called for a task whose `proposalUuid` is null
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "no_proposal"` and the
+  call is not an error
+
+#### Scenario: Document-derived proposal returns null
+
+- **WHEN** the tool resolves an entity whose proposal has `inputType` other than
+  `"idea"`
+- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "proposal_input_not_idea"`
+
+### Requirement: Bounded, cycle-safe parent walk
+
+The resolution SHALL walk the `parentUuid` chain with a visited-set cycle guard and a
+bounded maximum hop count, returning the deepest reachable idea without looping
+indefinitely if the lineage data contains a cycle.
+
+#### Scenario: Cyclic lineage terminates at the entry idea
+
+- **WHEN** the `parentUuid` chain forms a cycle
+- **THEN** the walk detects the repeat via the visited set and returns without
+  exceeding the hop bound
+

--- a/openspec/specs/root-idea-resolution/spec.md
+++ b/openspec/specs/root-idea-resolution/spec.md
@@ -1,69 +1,87 @@
 # root-idea-resolution Specification
 
 ## Purpose
-Defines the server-side `chorus_resolve_root_idea` MCP tool — the single source of
-truth for attributing any entity (task / document / proposal / idea) up the Chorus
-lineage to its root idea. It powers the CLI daemon's per-root-idea session anchoring,
-closes the document-attribution gap, and gives multi-idea proposals explicit,
-deterministic semantics.
+Defines the standalone REST endpoint `GET /api/entities/{type}/{uuid}/root-idea` —
+the single source of truth for attributing any entity (task / document / proposal /
+idea) up the Chorus lineage to its root idea. It powers the CLI daemon's per-root-idea
+session anchoring, closes the document-attribution gap, and gives multi-idea proposals
+explicit, deterministic semantics. It is deliberately NOT an MCP tool: it is a plain
+REST endpoint callable with any valid auth (notably an agent API key).
 
 ## Requirements
-### Requirement: Server-side root-idea resolution tool
+### Requirement: Standalone REST root-idea resolution endpoint
 
-The Chorus MCP server SHALL expose a public, read-only tool
-`chorus_resolve_root_idea` that accepts `entityType` (one of `task`, `document`,
-`proposal`, `idea`) and `entityUuid`, and resolves the entity to the root idea of
-its lineage in a single call. The tool SHALL be available without a permission gate
-(consistent with `chorus_get_idea`), and all resolution SHALL be scoped to the
-caller's `companyUuid` so no cross-company entity is ever traversed or returned.
+The Chorus server SHALL expose a REST endpoint
+`GET /api/entities/{type}/{uuid}/root-idea` where `{type}` is one of `task`,
+`document`, `proposal`, `idea` and `{uuid}` is the entity uuid, that resolves the
+entity to the root idea of its lineage in a single call. The endpoint SHALL be
+callable with any valid authentication context — in particular an agent API key
+(`Bearer cho_...`) — and SHALL NOT require any fine-grained permission gate. All
+resolution SHALL be scoped to the caller's `companyUuid` so no cross-company entity
+is ever traversed or returned. This capability SHALL NOT be exposed as an MCP tool.
 
-The tool SHALL return an object containing `rootIdeaUuid` (a string, or `null` when
-no idea ancestor exists), a `lineage` array ordered from the input entity to the root
-idea where each element carries `type`, `uuid`, and `title`, and a `resolvedVia`
-string explaining the outcome.
+The endpoint SHALL return the standard success envelope `{ success: true, data }`
+where `data` contains `rootIdeaUuid` (a string, or `null` when no idea ancestor
+exists), a `lineage` array ordered from the input entity to the root idea where each
+element carries `type`, `uuid`, and `title`, and a `resolvedVia` string explaining the
+outcome. An unrecognized `{type}` SHALL return HTTP 400; an unauthenticated request
+SHALL return HTTP 401.
 
 #### Scenario: Task with an idea-derived proposal resolves to the root idea
 
-- **WHEN** `chorus_resolve_root_idea` is called with `entityType: "task"` and a task
-  whose `proposalUuid` points to a proposal with `inputType: "idea"`
-- **THEN** the tool walks task → proposal → idea → `parentUuid` to the topmost idea
-  and returns that uuid as `rootIdeaUuid` with `resolvedVia: "via_proposal"`
+- **WHEN** `GET /api/entities/task/{uuid}/root-idea` is called for a task whose
+  `proposalUuid` points to a proposal with `inputType: "idea"`
+- **THEN** the endpoint walks task → proposal → idea → `parentUuid` to the topmost
+  idea and returns that uuid as `rootIdeaUuid` with `resolvedVia: "via_proposal"`
 
 #### Scenario: Idea resolves to its own lineage root
 
-- **WHEN** the tool is called with `entityType: "idea"` for an idea that has a chain
+- **WHEN** the endpoint is called with `type: "idea"` for an idea that has a chain
   of `parentUuid` ancestors
 - **THEN** it returns the topmost ancestor as `rootIdeaUuid` with
   `resolvedVia: "root_idea"`
 
+#### Scenario: Callable with an agent API key and no permission gate
+
+- **WHEN** the endpoint is called with an agent API key whose preset grants no
+  special permission
+- **THEN** the request succeeds and the lineage is resolved — there is no permission
+  short-circuit
+
 #### Scenario: Resolution is scoped to the caller's company
 
-- **WHEN** the tool is called with an `entityUuid` that exists only in another company
+- **WHEN** the endpoint is called with a `{uuid}` that exists only in another company
 - **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "not_found"` and never
   reads or returns the other company's entity
 
+#### Scenario: Unrecognized entity type is rejected
+
+- **WHEN** the endpoint is called with a `{type}` that is not one of `task`,
+  `document`, `proposal`, `idea`
+- **THEN** it returns HTTP 400 and does not attempt resolution
+
 ### Requirement: Document attribution via proposal
 
-The resolution tool SHALL attribute a document to a root idea by following
+The endpoint SHALL attribute a document to a root idea by following
 `document.proposalUuid → proposal → idea`, closing the gap where documents were never
 attributed. A document with no `proposalUuid` SHALL resolve to `rootIdeaUuid: null`
 with `resolvedVia: "standalone_document"`.
 
 #### Scenario: Document of an idea-derived proposal resolves to the root idea
 
-- **WHEN** the tool is called with `entityType: "document"` for a document whose
+- **WHEN** the endpoint is called with `type: "document"` for a document whose
   `proposalUuid` points to a proposal with `inputType: "idea"`
 - **THEN** it returns the proposal's idea walked to its root as `rootIdeaUuid` with
   `resolvedVia: "via_document_proposal"`
 
 #### Scenario: Standalone document has no idea ancestor
 
-- **WHEN** the tool is called for a document whose `proposalUuid` is null
+- **WHEN** the endpoint is called for a document whose `proposalUuid` is null
 - **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "standalone_document"`
 
 ### Requirement: Explicit multi-idea ambiguity
 
-When a proposal's `inputUuids` contains more than one idea, the resolution tool SHALL
+When a proposal's `inputUuids` contains more than one idea, the endpoint SHALL
 return the root of the first input idea as `rootIdeaUuid` (keeping the result
 single-valued so a consumer's session anchoring stays deterministic), and SHALL set
 `ambiguous: true` with a `candidates` array listing the resolved root idea uuid of
@@ -71,34 +89,33 @@ each input idea.
 
 #### Scenario: Merged proposal flags ambiguity but stays single-valued
 
-- **WHEN** the tool resolves a task whose proposal has `inputType: "idea"` and two or
-  more entries in `inputUuids`
+- **WHEN** the endpoint resolves a task whose proposal has `inputType: "idea"` and two
+  or more entries in `inputUuids`
 - **THEN** `rootIdeaUuid` is the root of `inputUuids[0]`, `ambiguous` is `true`, and
   `candidates` lists the root idea of each input idea
 
 #### Scenario: Single-idea proposal is not ambiguous
 
-- **WHEN** the tool resolves an entity whose proposal has exactly one entry in
+- **WHEN** the endpoint resolves an entity whose proposal has exactly one entry in
   `inputUuids`
 - **THEN** `ambiguous` is absent or `false` and no `candidates` array is required
 
 ### Requirement: No idea ancestor is a successful null, not an error
 
-The resolution tool SHALL treat the absence of an idea ancestor as a successful
-result with `rootIdeaUuid: null` and a `resolvedVia` value that names the reason
-(`no_proposal`, `proposal_input_not_idea`, `standalone_document`, or `not_found`).
-It SHALL NOT return a tool error for these cases, so a caller can distinguish "no
-ancestor" from a genuine failure without parsing error text.
+The endpoint SHALL treat the absence of an idea ancestor as a successful result with
+`rootIdeaUuid: null` and a `resolvedVia` value that names the reason (`no_proposal`,
+`proposal_input_not_idea`, `standalone_document`, or `not_found`). It SHALL NOT return
+an HTTP error status for these cases, so a caller can distinguish "no ancestor" from a
+genuine failure without parsing error text.
 
 #### Scenario: Quick task with no proposal returns null
 
-- **WHEN** the tool is called for a task whose `proposalUuid` is null
-- **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "no_proposal"` and the
-  call is not an error
+- **WHEN** the endpoint is called for a task whose `proposalUuid` is null
+- **THEN** it returns HTTP 200 with `rootIdeaUuid: null` and `resolvedVia: "no_proposal"`
 
 #### Scenario: Document-derived proposal returns null
 
-- **WHEN** the tool resolves an entity whose proposal has `inputType` other than
+- **WHEN** the endpoint resolves an entity whose proposal has `inputType` other than
   `"idea"`
 - **THEN** it returns `rootIdeaUuid: null` with `resolvedVia: "proposal_input_not_idea"`
 
@@ -113,4 +130,3 @@ indefinitely if the lineage data contains a cycle.
 - **WHEN** the `parentUuid` chain forms a cycle
 - **THEN** the walk detects the repeat via the visited set and returns without
   exceeding the hop bound
-

--- a/src/app/api/entities/[type]/[uuid]/root-idea/__tests__/route.test.ts
+++ b/src/app/api/entities/[type]/[uuid]/root-idea/__tests__/route.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+const mockResolveRootIdea = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+vi.mock("@/services/lineage.service", () => ({
+  resolveRootIdea: (...args: unknown[]) => mockResolveRootIdea(...args),
+}));
+
+import { GET } from "@/app/api/entities/[type]/[uuid]/root-idea/route";
+
+const companyUuid = "company-0000-0000-0000-000000000001";
+const agentAuth = { type: "agent", companyUuid, actorUuid: "agent-1", permissions: [] };
+
+function makeRequest(): NextRequest {
+  return new NextRequest(new URL("http://localhost:3000/api/entities/task/t1/root-idea"));
+}
+
+function makeContext(type: string, uuid: string) {
+  return { params: Promise.resolve({ type, uuid }) };
+}
+
+async function readJson(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+describe("GET /api/entities/[type]/[uuid]/root-idea", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue(agentAuth);
+  });
+
+  it("resolves and returns the service result in a success envelope", async () => {
+    const data = {
+      rootIdeaUuid: "root-1",
+      lineage: [{ type: "task", uuid: "t1", title: "T1" }],
+      resolvedVia: "via_proposal",
+    };
+    mockResolveRootIdea.mockResolvedValue(data);
+
+    const res = await GET(makeRequest(), makeContext("task", "t1"));
+    const body = await readJson(res);
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual(data);
+    expect(mockResolveRootIdea).toHaveBeenCalledWith(companyUuid, "task", "t1");
+  });
+
+  it("passes a null rootIdeaUuid through as a 200 success (not an error)", async () => {
+    mockResolveRootIdea.mockResolvedValue({
+      rootIdeaUuid: null,
+      lineage: [],
+      resolvedVia: "no_proposal",
+    });
+
+    const res = await GET(makeRequest(), makeContext("task", "quick"));
+    const body = await readJson(res);
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.rootIdeaUuid).toBeNull();
+  });
+
+  it("requires NO fine-grained permission — an agent with empty permissions succeeds", async () => {
+    mockResolveRootIdea.mockResolvedValue({ rootIdeaUuid: "r", lineage: [], resolvedVia: "root_idea" });
+
+    const res = await GET(makeRequest(), makeContext("idea", "i1"));
+
+    expect(res.status).toBe(200);
+    // resolution ran — no 403 short-circuit despite empty permissions
+    expect(mockResolveRootIdea).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts each valid entity type", async () => {
+    mockResolveRootIdea.mockResolvedValue({ rootIdeaUuid: null, lineage: [], resolvedVia: "not_found" });
+    for (const type of ["task", "document", "proposal", "idea"]) {
+      const res = await GET(makeRequest(), makeContext(type, "x"));
+      expect(res.status).toBe(200);
+    }
+    expect(mockResolveRootIdea).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns 400 for an invalid entity type and never calls the service", async () => {
+    const res = await GET(makeRequest(), makeContext("comment", "c1"));
+    const body = await readJson(res);
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(mockResolveRootIdea).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(), makeContext("task", "t1"));
+
+    expect(res.status).toBe(401);
+    expect(mockResolveRootIdea).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/entities/[type]/[uuid]/root-idea/route.ts
+++ b/src/app/api/entities/[type]/[uuid]/root-idea/route.ts
@@ -1,0 +1,49 @@
+// src/app/api/entities/[type]/[uuid]/root-idea/route.ts
+// Resolve any entity (task/document/proposal/idea) to its root idea in one call.
+// Standalone REST endpoint callable with any valid auth (notably an agent API
+// key) — no fine-grained permission gate. The CLI daemon calls this once per
+// inbound notification to anchor its local Claude session on the root idea.
+//
+// Tenant isolation (auth.companyUuid scoping) still applies — that's not a
+// permission, it's multi-tenancy safety, enforced inside the service's getters.
+
+import { NextRequest } from "next/server";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import {
+  resolveRootIdea,
+  type LineageEntityType,
+} from "@/services/lineage.service";
+
+type RouteContext = { params: Promise<{ type: string; uuid: string }> };
+
+const ENTITY_TYPES: readonly LineageEntityType[] = ["task", "document", "proposal", "idea"];
+
+function isEntityType(value: string): value is LineageEntityType {
+  return (ENTITY_TYPES as readonly string[]).includes(value);
+}
+
+// GET /api/entities/[type]/[uuid]/root-idea
+export const GET = withErrorHandler<{ type: string; uuid: string }>(
+  async (request: NextRequest, context: RouteContext) => {
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return errors.unauthorized();
+    }
+    // Intentionally no checkAgentPermission gate — any authenticated caller
+    // (agent key included) may resolve lineage. Resolution is read-only and
+    // scoped to auth.companyUuid inside the service.
+
+    const { type, uuid } = await context.params;
+    if (!isEntityType(type)) {
+      return errors.badRequest(
+        `Invalid entity type "${type}". Expected one of: ${ENTITY_TYPES.join(", ")}.`
+      );
+    }
+
+    const result = await resolveRootIdea(auth.companyUuid, type, uuid);
+    // A null rootIdeaUuid is a successful "no idea ancestor" result, not an error.
+    return success(result);
+  }
+);

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -22,7 +22,6 @@ import * as mentionService from "@/services/mention.service";
 import * as searchService from "@/services/search.service";
 import * as sessionService from "@/services/session.service";
 import * as checkinService from "@/services/checkin.service";
-import * as lineageService from "@/services/lineage.service";
 import { registerPermissionedTool } from "./register-helpers";
 import {
   ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE,
@@ -443,32 +442,6 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       }
       return {
         content: [{ type: "text", text: JSON.stringify(idea, null, 2) }],
-      };
-    }
-  );
-
-  // chorus_resolve_root_idea - Resolve any entity to its root idea (lineage attribution)
-  server.registerTool(
-    "chorus_resolve_root_idea",
-    {
-      description:
-        "Resolve any entity (task/document/proposal/idea) to the root idea of its lineage in a single call. Walks task/document → proposal (inputType=idea) → idea, then follows idea.parentUuid to the topmost idea. Returns { rootIdeaUuid (string|null), lineage[] (ordered child→root, each { type, uuid, title }), resolvedVia (root_idea|via_proposal|via_document_proposal|no_proposal|proposal_input_not_idea|standalone_document|not_found), ambiguous?, candidates? }. A null rootIdeaUuid is a SUCCESSFUL result meaning 'no idea ancestor' (e.g. a quick task or standalone document) — not an error. A multi-idea proposal returns the first input idea's root as rootIdeaUuid and sets ambiguous=true with candidates listing every input idea's root.",
-      inputSchema: z.object({
-        entityType: z
-          .enum(["task", "document", "proposal", "idea"])
-          .describe("Type of the entity to resolve"),
-        entityUuid: z.string().describe("Entity UUID"),
-      }),
-    },
-    async ({ entityType, entityUuid }) => {
-      const result = await lineageService.resolveRootIdea(
-        auth.companyUuid,
-        entityType,
-        entityUuid
-      );
-      // A null rootIdeaUuid is a normal success payload (no isError).
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       };
     }
   );

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -22,6 +22,7 @@ import * as mentionService from "@/services/mention.service";
 import * as searchService from "@/services/search.service";
 import * as sessionService from "@/services/session.service";
 import * as checkinService from "@/services/checkin.service";
+import * as lineageService from "@/services/lineage.service";
 import { registerPermissionedTool } from "./register-helpers";
 import {
   ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE,
@@ -442,6 +443,32 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       }
       return {
         content: [{ type: "text", text: JSON.stringify(idea, null, 2) }],
+      };
+    }
+  );
+
+  // chorus_resolve_root_idea - Resolve any entity to its root idea (lineage attribution)
+  server.registerTool(
+    "chorus_resolve_root_idea",
+    {
+      description:
+        "Resolve any entity (task/document/proposal/idea) to the root idea of its lineage in a single call. Walks task/document → proposal (inputType=idea) → idea, then follows idea.parentUuid to the topmost idea. Returns { rootIdeaUuid (string|null), lineage[] (ordered child→root, each { type, uuid, title }), resolvedVia (root_idea|via_proposal|via_document_proposal|no_proposal|proposal_input_not_idea|standalone_document|not_found), ambiguous?, candidates? }. A null rootIdeaUuid is a SUCCESSFUL result meaning 'no idea ancestor' (e.g. a quick task or standalone document) — not an error. A multi-idea proposal returns the first input idea's root as rootIdeaUuid and sets ambiguous=true with candidates listing every input idea's root.",
+      inputSchema: z.object({
+        entityType: z
+          .enum(["task", "document", "proposal", "idea"])
+          .describe("Type of the entity to resolve"),
+        entityUuid: z.string().describe("Entity UUID"),
+      }),
+    },
+    async ({ entityType, entityUuid }) => {
+      const result = await lineageService.resolveRootIdea(
+        auth.companyUuid,
+        entityType,
+        entityUuid
+      );
+      // A null rootIdeaUuid is a normal success payload (no isError).
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       };
     }
   );

--- a/src/services/__tests__/lineage.service.test.ts
+++ b/src/services/__tests__/lineage.service.test.ts
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Mocks (hoisted so vi.mock factories can reference them) =====
+// lineage.service calls exactly four raw getters; mock those directly so each
+// test controls the entity graph without touching prisma.
+
+const { mockGetTaskByUuid, mockGetProposalByUuid, mockGetDocumentByUuid, mockGetIdeaByUuid } =
+  vi.hoisted(() => ({
+    mockGetTaskByUuid: vi.fn(),
+    mockGetProposalByUuid: vi.fn(),
+    mockGetDocumentByUuid: vi.fn(),
+    mockGetIdeaByUuid: vi.fn(),
+  }));
+
+vi.mock("@/services/task.service", () => ({ getTaskByUuid: mockGetTaskByUuid }));
+vi.mock("@/services/proposal.service", () => ({ getProposalByUuid: mockGetProposalByUuid }));
+vi.mock("@/services/document.service", () => ({ getDocumentByUuid: mockGetDocumentByUuid }));
+vi.mock("@/services/idea.service", () => ({ getIdeaByUuid: mockGetIdeaByUuid }));
+
+import { resolveRootIdea, MAX_PARENT_HOPS } from "@/services/lineage.service";
+
+const COMPANY = "company-1111";
+const OTHER_COMPANY = "company-9999";
+
+// ---- Builders. Getters are companyUuid-scoped, so the fakes return the entity
+// only when asked for the right company (mirrors findFirst({ where:{uuid,companyUuid} })).
+
+type IdeaRow = { uuid: string; title: string; parentUuid: string | null };
+type TaskRow = { uuid: string; title: string; proposalUuid: string | null };
+type DocRow = { uuid: string; title: string; proposalUuid: string | null };
+type PropRow = { uuid: string; title: string; inputType: string; inputUuids: unknown };
+
+function installGraph(graph: {
+  ideas?: IdeaRow[];
+  tasks?: TaskRow[];
+  documents?: DocRow[];
+  proposals?: PropRow[];
+}) {
+  const ideas = new Map((graph.ideas ?? []).map((r) => [r.uuid, r]));
+  const tasks = new Map((graph.tasks ?? []).map((r) => [r.uuid, r]));
+  const docs = new Map((graph.documents ?? []).map((r) => [r.uuid, r]));
+  const props = new Map((graph.proposals ?? []).map((r) => [r.uuid, r]));
+
+  mockGetIdeaByUuid.mockImplementation(async (company: string, uuid: string) =>
+    company === COMPANY ? (ideas.get(uuid) ?? null) : null
+  );
+  mockGetTaskByUuid.mockImplementation(async (company: string, uuid: string) =>
+    company === COMPANY ? (tasks.get(uuid) ?? null) : null
+  );
+  mockGetDocumentByUuid.mockImplementation(async (company: string, uuid: string) =>
+    company === COMPANY ? (docs.get(uuid) ?? null) : null
+  );
+  mockGetProposalByUuid.mockImplementation(async (company: string, uuid: string) =>
+    company === COMPANY ? (props.get(uuid) ?? null) : null
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("lineage.service / resolveRootIdea", () => {
+  // ===== idea entity =====
+  describe("entityType: idea", () => {
+    it("walks parentUuid to the topmost idea (resolvedVia root_idea)", async () => {
+      installGraph({
+        ideas: [
+          { uuid: "i-root", title: "Root", parentUuid: null },
+          { uuid: "i-mid", title: "Mid", parentUuid: "i-root" },
+          { uuid: "i-leaf", title: "Leaf", parentUuid: "i-mid" },
+        ],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "idea", "i-leaf");
+
+      expect(res.rootIdeaUuid).toBe("i-root");
+      expect(res.resolvedVia).toBe("root_idea");
+      expect(res.lineage.map((n) => n.uuid)).toEqual(["i-leaf", "i-mid", "i-root"]);
+      expect(res.lineage.every((n) => n.type === "idea")).toBe(true);
+      expect(res.lineage[0].title).toBe("Leaf");
+      expect(res.ambiguous).toBeUndefined();
+    });
+
+    it("a top-level idea resolves to itself", async () => {
+      installGraph({ ideas: [{ uuid: "i-solo", title: "Solo", parentUuid: null }] });
+
+      const res = await resolveRootIdea(COMPANY, "idea", "i-solo");
+
+      expect(res.rootIdeaUuid).toBe("i-solo");
+      expect(res.resolvedVia).toBe("root_idea");
+      expect(res.lineage).toEqual([{ type: "idea", uuid: "i-solo", title: "Solo" }]);
+    });
+
+    it("a missing idea resolves to null/not_found (no throw)", async () => {
+      installGraph({ ideas: [] });
+
+      const res = await resolveRootIdea(COMPANY, "idea", "i-ghost");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("not_found");
+      expect(res.lineage).toEqual([]);
+    });
+  });
+
+  // ===== task entity =====
+  describe("entityType: task", () => {
+    it("task → idea-derived proposal → root (via_proposal)", async () => {
+      installGraph({
+        ideas: [
+          { uuid: "i-root", title: "Root", parentUuid: null },
+          { uuid: "i-child", title: "Child", parentUuid: "i-root" },
+        ],
+        proposals: [
+          { uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-child"] },
+        ],
+        tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p1" }],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "task", "t1");
+
+      expect(res.rootIdeaUuid).toBe("i-root");
+      expect(res.resolvedVia).toBe("via_proposal");
+      expect(res.lineage.map((n) => `${n.type}:${n.uuid}`)).toEqual([
+        "task:t1",
+        "proposal:p1",
+        "idea:i-child",
+        "idea:i-root",
+      ]);
+    });
+
+    it("quick task with no proposal → null/no_proposal", async () => {
+      installGraph({ tasks: [{ uuid: "t-quick", title: "Quick", proposalUuid: null }] });
+
+      const res = await resolveRootIdea(COMPANY, "task", "t-quick");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("no_proposal");
+      expect(res.lineage).toEqual([{ type: "task", uuid: "t-quick", title: "Quick" }]);
+    });
+
+    it("missing task → null/not_found", async () => {
+      installGraph({ tasks: [] });
+
+      const res = await resolveRootIdea(COMPANY, "task", "t-ghost");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("not_found");
+      expect(res.lineage).toEqual([]);
+    });
+  });
+
+  // ===== document entity (the closed gap) =====
+  describe("entityType: document", () => {
+    it("document → idea-derived proposal → root (via_document_proposal)", async () => {
+      installGraph({
+        ideas: [{ uuid: "i-root", title: "Root", parentUuid: null }],
+        proposals: [
+          { uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-root"] },
+        ],
+        documents: [{ uuid: "d1", title: "Spec", proposalUuid: "p1" }],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "document", "d1");
+
+      expect(res.rootIdeaUuid).toBe("i-root");
+      expect(res.resolvedVia).toBe("via_document_proposal");
+      expect(res.lineage.map((n) => `${n.type}:${n.uuid}`)).toEqual([
+        "document:d1",
+        "proposal:p1",
+        "idea:i-root",
+      ]);
+    });
+
+    it("standalone document (no proposalUuid) → null/standalone_document", async () => {
+      installGraph({ documents: [{ uuid: "d-solo", title: "Note", proposalUuid: null }] });
+
+      const res = await resolveRootIdea(COMPANY, "document", "d-solo");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("standalone_document");
+      expect(res.lineage).toEqual([{ type: "document", uuid: "d-solo", title: "Note" }]);
+    });
+
+    it("missing document → null/not_found", async () => {
+      installGraph({ documents: [] });
+
+      const res = await resolveRootIdea(COMPANY, "document", "d-ghost");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("not_found");
+    });
+  });
+
+  // ===== proposal entity =====
+  describe("entityType: proposal", () => {
+    it("idea-derived proposal resolves to the idea's root (root_idea)", async () => {
+      installGraph({
+        ideas: [
+          { uuid: "i-root", title: "Root", parentUuid: null },
+          { uuid: "i-child", title: "Child", parentUuid: "i-root" },
+        ],
+        proposals: [
+          { uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-child"] },
+        ],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p1");
+
+      expect(res.rootIdeaUuid).toBe("i-root");
+      expect(res.resolvedVia).toBe("root_idea");
+      expect(res.lineage.map((n) => `${n.type}:${n.uuid}`)).toEqual([
+        "proposal:p1",
+        "idea:i-child",
+        "idea:i-root",
+      ]);
+    });
+
+    it("document-derived proposal → null/proposal_input_not_idea", async () => {
+      installGraph({
+        proposals: [
+          { uuid: "p-doc", title: "PDoc", inputType: "document", inputUuids: ["d-src"] },
+        ],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p-doc");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("proposal_input_not_idea");
+      expect(res.lineage.map((n) => n.uuid)).toEqual(["p-doc"]);
+    });
+
+    it("idea-typed proposal with empty inputUuids → null/proposal_input_not_idea", async () => {
+      installGraph({
+        proposals: [{ uuid: "p-empty", title: "PE", inputType: "idea", inputUuids: [] }],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p-empty");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("proposal_input_not_idea");
+    });
+
+    it("non-array inputUuids is treated as empty", async () => {
+      installGraph({
+        proposals: [
+          { uuid: "p-bad", title: "PB", inputType: "idea", inputUuids: "not-an-array" },
+        ],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p-bad");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("proposal_input_not_idea");
+    });
+
+    it("missing proposal → null/not_found", async () => {
+      installGraph({ proposals: [] });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p-ghost");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("not_found");
+    });
+
+    it("proposal whose input idea is missing → null/not_found", async () => {
+      installGraph({
+        proposals: [
+          { uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-ghost"] },
+        ],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p1");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("not_found");
+    });
+  });
+
+  // ===== multi-idea ambiguity =====
+  describe("multi-idea proposal", () => {
+    it("returns inputUuids[0] root, flags ambiguous, lists each input idea's root", async () => {
+      installGraph({
+        ideas: [
+          { uuid: "i-root-a", title: "RootA", parentUuid: null },
+          { uuid: "i-a", title: "A", parentUuid: "i-root-a" },
+          { uuid: "i-root-b", title: "RootB", parentUuid: null },
+          { uuid: "i-b", title: "B", parentUuid: "i-root-b" },
+        ],
+        proposals: [
+          { uuid: "p-merge", title: "Merge", inputType: "idea", inputUuids: ["i-a", "i-b"] },
+        ],
+        tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p-merge" }],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "task", "t1");
+
+      expect(res.rootIdeaUuid).toBe("i-root-a"); // single-valued main line
+      expect(res.ambiguous).toBe(true);
+      expect(res.candidates).toEqual(["i-root-a", "i-root-b"]);
+      expect(res.candidates?.[0]).toBe(res.rootIdeaUuid);
+      // lineage follows only the primary line
+      expect(res.lineage.map((n) => `${n.type}:${n.uuid}`)).toEqual([
+        "task:t1",
+        "proposal:p-merge",
+        "idea:i-a",
+        "idea:i-root-a",
+      ]);
+    });
+
+    it("skips a missing candidate idea without failing the primary resolution", async () => {
+      installGraph({
+        ideas: [{ uuid: "i-a", title: "A", parentUuid: null }],
+        proposals: [
+          {
+            uuid: "p-merge",
+            title: "Merge",
+            inputType: "idea",
+            inputUuids: ["i-a", "i-ghost"],
+          },
+        ],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p-merge");
+
+      expect(res.rootIdeaUuid).toBe("i-a");
+      expect(res.ambiguous).toBe(true);
+      expect(res.candidates).toEqual(["i-a"]); // ghost skipped
+    });
+
+    it("single-idea proposal is not ambiguous", async () => {
+      installGraph({
+        ideas: [{ uuid: "i-a", title: "A", parentUuid: null }],
+        proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-a"] }],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "proposal", "p1");
+
+      expect(res.ambiguous).toBeUndefined();
+      expect(res.candidates).toBeUndefined();
+    });
+  });
+
+  // ===== cross-company isolation =====
+  describe("company scoping", () => {
+    it("an entity that exists only in another company → null/not_found", async () => {
+      // installGraph wires entities under COMPANY only; query with OTHER_COMPANY.
+      installGraph({ tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p1" }] });
+
+      const res = await resolveRootIdea(OTHER_COMPANY, "task", "t1");
+
+      expect(res.rootIdeaUuid).toBeNull();
+      expect(res.resolvedVia).toBe("not_found");
+      // never traversed past the (scoped) task lookup
+      expect(mockGetProposalByUuid).not.toHaveBeenCalled();
+    });
+
+    it("a parent idea in another company stops the walk at the boundary", async () => {
+      // i-child is in COMPANY but its parent i-foreign is not returned for COMPANY.
+      mockGetIdeaByUuid.mockImplementation(async (company: string, uuid: string) => {
+        if (company !== COMPANY) return null;
+        if (uuid === "i-child") return { uuid: "i-child", title: "Child", parentUuid: "i-foreign" };
+        return null; // i-foreign not visible to COMPANY
+      });
+
+      const res = await resolveRootIdea(COMPANY, "idea", "i-child");
+
+      expect(res.rootIdeaUuid).toBe("i-child"); // stops at boundary, not i-foreign
+      expect(res.resolvedVia).toBe("root_idea");
+      expect(res.lineage.map((n) => n.uuid)).toEqual(["i-child"]);
+    });
+  });
+
+  // ===== cycle + depth guards =====
+  describe("walk guards", () => {
+    it("a parentUuid cycle terminates without looping", async () => {
+      installGraph({
+        ideas: [
+          { uuid: "i-x", title: "X", parentUuid: "i-y" },
+          { uuid: "i-y", title: "Y", parentUuid: "i-x" }, // cycle
+        ],
+      });
+
+      const res = await resolveRootIdea(COMPANY, "idea", "i-x");
+
+      // walk: x → y (parent x already visited) → stop at y
+      expect(res.rootIdeaUuid).toBe("i-y");
+      expect(res.resolvedVia).toBe("root_idea");
+      expect(res.lineage.map((n) => n.uuid)).toEqual(["i-x", "i-y"]);
+    });
+
+    it("a chain longer than MAX_PARENT_HOPS stops at the hop bound", async () => {
+      // Build a deep linear chain i-0 (root) ← i-1 ← ... ← i-(N+5).
+      const depth = MAX_PARENT_HOPS + 5;
+      const ideas: IdeaRow[] = [];
+      for (let n = 0; n <= depth; n++) {
+        ideas.push({
+          uuid: `i-${n}`,
+          title: `I${n}`,
+          parentUuid: n === 0 ? null : `i-${n - 1}`,
+        });
+      }
+      installGraph({ ideas });
+
+      const res = await resolveRootIdea(COMPANY, "idea", `i-${depth}`);
+
+      // Bounded: the start node plus MAX_PARENT_HOPS parent hops, never reaching i-0.
+      expect(res.lineage.length).toBe(MAX_PARENT_HOPS + 1);
+      expect(res.rootIdeaUuid).toBe(`i-${depth - MAX_PARENT_HOPS}`);
+      expect(res.rootIdeaUuid).toBe(res.lineage[res.lineage.length - 1].uuid);
+      expect(res.rootIdeaUuid).not.toBe("i-0");
+    });
+  });
+
+  // ===== defensive default =====
+  it("an unknown entityType → null/not_found (no throw)", async () => {
+    installGraph({});
+    // @ts-expect-error — exercising the runtime default branch
+    const res = await resolveRootIdea(COMPANY, "comment", "c1");
+    expect(res.rootIdeaUuid).toBeNull();
+    expect(res.resolvedVia).toBe("not_found");
+  });
+});

--- a/src/services/lineage.service.ts
+++ b/src/services/lineage.service.ts
@@ -1,0 +1,221 @@
+// src/services/lineage.service.ts
+// Server-side "entity → root idea" resolution. Single source of truth for
+// attributing any entity (task / document / proposal / idea) up the Chorus
+// lineage to the topmost idea of its forest. This replaces the daemon's
+// client-side multi-hop walk (cli/lineage.mjs): the daemon now prefers calling
+// the chorus_resolve_root_idea MCP tool, which delegates here.
+//
+// Data model (prisma/schema.prisma):
+//   • Task.proposalUuid      String?  (nullable; quick tasks have none)
+//   • Document.proposalUuid  String?  (nullable; standalone docs have none)
+//   • Proposal.inputType     String   ("idea" | "document")
+//   • Proposal.inputUuids    Json     (string[]; for inputType="idea" these are idea uuids)
+//   • Idea.parentUuid        String?  (single-parent forest edge)
+//
+// Every read goes through the raw `*ByUuid(companyUuid, uuid)` getters, which
+// are `findFirst({ where: { uuid, companyUuid } })` — so the walk never crosses
+// the company boundary. A missing entity (or one in another company) resolves to
+// null/not_found, never a thrown error: "no idea ancestor" is a legitimate,
+// successful outcome the daemon handles by falling back to a per-entity session.
+
+import { getTaskByUuid } from "@/services/task.service";
+import { getProposalByUuid } from "@/services/proposal.service";
+import { getDocumentByUuid } from "@/services/document.service";
+import { getIdeaByUuid } from "@/services/idea.service";
+
+/** Entity kinds the resolver accepts as a starting point. */
+export type LineageEntityType = "task" | "document" | "proposal" | "idea";
+
+/** Why the resolution produced (or failed to produce) a root idea. */
+export type ResolvedVia =
+  | "root_idea" // entity is/resolved to an idea, walked to its root
+  | "via_proposal" // task → proposal(inputType=idea) → idea → root
+  | "via_document_proposal" // document → proposal(inputType=idea) → idea → root
+  | "no_proposal" // task/document with no proposalUuid (quick task / standalone)
+  | "proposal_input_not_idea" // proposal's inputType !== "idea" (or no input ideas)
+  | "standalone_document" // document with no proposalUuid
+  | "not_found"; // entity uuid not found in this company
+
+/** One hop on the resolved lineage path, ordered child (input entity) → root. */
+export interface LineageNode {
+  type: LineageEntityType;
+  uuid: string;
+  title: string | null;
+}
+
+export interface ResolveRootIdeaResult {
+  /** Root idea uuid, or null when there is no idea ancestor (a success, not an error). */
+  rootIdeaUuid: string | null;
+  /** The resolved path, ordered from the input entity to the root idea. */
+  lineage: LineageNode[];
+  /** Explains the outcome so callers can log a clear attribution trail. */
+  resolvedVia: ResolvedVia;
+  /** True when a multi-idea proposal forced an inputUuids[0] choice. */
+  ambiguous?: boolean;
+  /** When ambiguous: the root idea uuid of each input idea (candidates[0] === rootIdeaUuid). */
+  candidates?: string[];
+}
+
+/** Cycle / runaway guard for the parentUuid walk. Matches the client (cli/lineage.mjs). */
+export const MAX_PARENT_HOPS = 50;
+
+/**
+ * Resolve an entity to the root idea of its lineage, server-side, in one call.
+ *
+ * @param companyUuid Tenant scope — every getter is scoped to this; no cross-company reads.
+ * @param entityType  "task" | "document" | "proposal" | "idea".
+ * @param entityUuid  The entity's uuid.
+ */
+export async function resolveRootIdea(
+  companyUuid: string,
+  entityType: LineageEntityType,
+  entityUuid: string
+): Promise<ResolveRootIdeaResult> {
+  switch (entityType) {
+    case "idea":
+      return resolveFromIdea(companyUuid, entityUuid);
+    case "proposal":
+      return resolveFromProposal(companyUuid, entityUuid, "proposal");
+    case "task":
+      return resolveFromTask(companyUuid, entityUuid);
+    case "document":
+      return resolveFromDocument(companyUuid, entityUuid);
+    default:
+      // Unreachable for typed callers; defensive for runtime (e.g. MCP input).
+      return { rootIdeaUuid: null, lineage: [], resolvedVia: "not_found" };
+  }
+}
+
+/** Walk the entity's own idea chain to the root. */
+async function resolveFromIdea(
+  companyUuid: string,
+  ideaUuid: string
+): Promise<ResolveRootIdeaResult> {
+  const lineage: LineageNode[] = [];
+  const root = await walkToRoot(companyUuid, ideaUuid, lineage);
+  if (root === null) {
+    return { rootIdeaUuid: null, lineage: [], resolvedVia: "not_found" };
+  }
+  return { rootIdeaUuid: root, lineage, resolvedVia: "root_idea" };
+}
+
+async function resolveFromTask(
+  companyUuid: string,
+  taskUuid: string
+): Promise<ResolveRootIdeaResult> {
+  const task = await getTaskByUuid(companyUuid, taskUuid);
+  if (!task) {
+    return { rootIdeaUuid: null, lineage: [], resolvedVia: "not_found" };
+  }
+  const head: LineageNode = { type: "task", uuid: task.uuid, title: task.title };
+  if (!task.proposalUuid) {
+    return { rootIdeaUuid: null, lineage: [head], resolvedVia: "no_proposal" };
+  }
+  return resolveFromProposal(companyUuid, task.proposalUuid, "via_proposal", head);
+}
+
+async function resolveFromDocument(
+  companyUuid: string,
+  documentUuid: string
+): Promise<ResolveRootIdeaResult> {
+  const doc = await getDocumentByUuid(companyUuid, documentUuid);
+  if (!doc) {
+    return { rootIdeaUuid: null, lineage: [], resolvedVia: "not_found" };
+  }
+  const head: LineageNode = { type: "document", uuid: doc.uuid, title: doc.title };
+  if (!doc.proposalUuid) {
+    return { rootIdeaUuid: null, lineage: [head], resolvedVia: "standalone_document" };
+  }
+  return resolveFromProposal(companyUuid, doc.proposalUuid, "via_document_proposal", head);
+}
+
+/**
+ * Resolve a proposal to its root idea. `successVia` distinguishes the entry path
+ * (a bare proposal lookup vs. one reached through a task/document). `head` is an
+ * optional already-resolved child node to prepend to the lineage.
+ */
+async function resolveFromProposal(
+  companyUuid: string,
+  proposalUuid: string,
+  successVia: "proposal" | "via_proposal" | "via_document_proposal",
+  head?: LineageNode
+): Promise<ResolveRootIdeaResult> {
+  const lineage: LineageNode[] = head ? [head] : [];
+  const proposal = await getProposalByUuid(companyUuid, proposalUuid);
+  if (!proposal) {
+    return { rootIdeaUuid: null, lineage, resolvedVia: "not_found" };
+  }
+  lineage.push({ type: "proposal", uuid: proposal.uuid, title: proposal.title });
+
+  if (proposal.inputType !== "idea") {
+    return { rootIdeaUuid: null, lineage, resolvedVia: "proposal_input_not_idea" };
+  }
+  const inputUuids = normalizeUuidArray(proposal.inputUuids);
+  if (inputUuids.length === 0) {
+    return { rootIdeaUuid: null, lineage, resolvedVia: "proposal_input_not_idea" };
+  }
+
+  // Primary line = inputUuids[0]; append the idea chain to the lineage.
+  const primaryRoot = await walkToRoot(companyUuid, inputUuids[0], lineage);
+  if (primaryRoot === null) {
+    return { rootIdeaUuid: null, lineage, resolvedVia: "not_found" };
+  }
+
+  const resolvedVia: ResolvedVia =
+    successVia === "via_document_proposal"
+      ? "via_document_proposal"
+      : successVia === "via_proposal"
+        ? "via_proposal"
+        : "root_idea";
+
+  if (inputUuids.length === 1) {
+    return { rootIdeaUuid: primaryRoot, lineage, resolvedVia };
+  }
+
+  // Multi-idea proposal: stay single-valued (primaryRoot) but surface the
+  // ambiguity. candidates = the root of each input idea, walked independently.
+  // A candidate idea that is missing in this company is skipped (not fatal).
+  const candidates: string[] = [primaryRoot];
+  for (const ideaUuid of inputUuids.slice(1)) {
+    const root = await walkToRoot(companyUuid, ideaUuid);
+    if (root !== null) candidates.push(root);
+  }
+  return { rootIdeaUuid: primaryRoot, lineage, resolvedVia, ambiguous: true, candidates };
+}
+
+/**
+ * Walk the parentUuid chain to the top of the lineage forest, starting at
+ * `startIdeaUuid`. Bounded by MAX_PARENT_HOPS with a visited-set cycle guard.
+ * Each visited idea (including the start) is appended to `lineage` in child→root
+ * order when the array is supplied. Returns the topmost reachable idea uuid, or
+ * null when the start idea does not exist in this company.
+ */
+async function walkToRoot(
+  companyUuid: string,
+  startIdeaUuid: string,
+  lineage?: LineageNode[]
+): Promise<string | null> {
+  let idea = await getIdeaByUuid(companyUuid, startIdeaUuid);
+  if (!idea) return null; // start idea not in this company
+  lineage?.push({ type: "idea", uuid: idea.uuid, title: idea.title });
+  const visited = new Set<string>([idea.uuid]);
+  // Each iteration takes one parent hop; the returned uuid is always the last
+  // node appended to `lineage`, even when the hop bound is hit.
+  for (let hop = 0; hop < MAX_PARENT_HOPS; hop++) {
+    const parent = idea.parentUuid;
+    if (!parent) return idea.uuid; // reached a root
+    if (visited.has(parent)) return idea.uuid; // cycle — stop at the current node
+    visited.add(parent);
+    const parentIdea = await getIdeaByUuid(companyUuid, parent);
+    if (!parentIdea) return idea.uuid; // parent not in this company — stop here
+    lineage?.push({ type: "idea", uuid: parentIdea.uuid, title: parentIdea.title });
+    idea = parentIdea;
+  }
+  return idea.uuid; // hop bound hit — return deepest reached (== last lineage node)
+}
+
+/** Coerce a Prisma Json value into a string[] (proposal.inputUuids). */
+function normalizeUuidArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
+}


### PR DESCRIPTION
## Summary
Adds `GET /api/entities/{type}/{uuid}/root-idea`, a **standalone REST endpoint** that resolves any entity (task / document / proposal / idea) to its **root idea** in one call — the single source of truth for the CLI daemon's per-root-idea session anchoring. The daemon calls it once per inbound notification and no longer does any client-side lineage walk.

Derived from idea `85e7ec19` (follow-up to CLI-daemon-core `9b76ccd7`). It closes two real gaps the client-side `cli/lineage.mjs` had: documents were never attributed, and multi-idea proposals silently took `inputUuids[0]`.

> **Revised from the original proposal:** this started as a public MCP tool `chorus_resolve_root_idea`. Per review, it is now a REST endpoint callable with an agent API key (no permission gate), and the daemon resolves per notification via that endpoint with no fallback walk.

## What changed
| File | Change |
|------|--------|
| `src/app/api/entities/[type]/[uuid]/root-idea/route.ts` | **New.** `GET` resolver. `getAuthContext` (any agent key), **no `checkAgentPermission` gate**, `companyUuid`-scoped. 400 on invalid type, 401 unauthenticated; `null` rootIdeaUuid is a 200 success. Delegates to `resolveRootIdea`. |
| `src/services/lineage.service.ts` | Unchanged — still the single source of truth (`resolveRootIdea`), 100% covered. Only the exposure layer moved MCP→REST. |
| `src/mcp/tools/public.ts` + `docs/MCP_TOOLS.md` | **Removed** the `chorus_resolve_root_idea` MCP tool + its doc entry (doc now points to the REST route). |
| `cli/lineage.mjs` | Resolve via a single `fetch` to the REST endpoint per notification (Bearer agent key, `global fetch` — no new dep). **Deleted** the client-side `task→proposal→idea→parentUuid` walk. Per-run cache retained. Any error/unreachable → `null` (degrade to per-entity session key). |
| `cli/daemon.mjs` | `LineageResolver` wired with `{ url, apiKey }` (not the MCP client); `buildDaemon` gains injectable `fetchImpl`/`lineage` for tests. |
| Tests | New route test (6); rewritten daemon lineage tests (13, REST-driven); updated integration test. |
| `openspec/` | Cumulative `root-idea-resolution` + `cli-daemon` specs updated to the REST design and mirrored back byte-equal; archived proposal carries a post-archive revision note. |

## Design decisions
- **REST, not MCP** — per review: a plain endpoint callable with an agent key is simpler and the right surface; the service layer made the swap a thin exposure change.
- **No permission gate** — per review: any authenticated caller may resolve; still `companyUuid`-scoped for tenant isolation (not a permission).
- **No client-side fallback** — the daemon resolves once per notification via the endpoint; this fully retires the client-side lineage walk (the original goal of the idea). Errors degrade to a per-entity session key.

## Test plan
- [x] `pnpm test` — 1995 passed, 1 skipped, 0 failed
- [x] `npx tsc --noEmit` — clean; lint clean on changed source
- [x] **Live e2e** against the dev server: the REST endpoint returns the right result + HTTP status for task→proposal→idea (`via_proposal`/200), quick task (`null`/`no_proposal`/200), child idea (`root_idea`/200), invalid type (400), unauthenticated (401); the real daemon `LineageResolver` resolves all three via the endpoint with cache single-flight observed
- [x] OpenSpec cumulative specs mirrored back byte-equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)