### PR TITLE
feat(daemon): self-reported SSE connection metadata + server-side registry

### DIFF
--- a/cli/__tests__/sse-listener.test.mjs
+++ b/cli/__tests__/sse-listener.test.mjs
@@ -1,8 +1,20 @@
 // cli/__tests__/sse-listener.test.mjs
 // Covers cli-daemon spec "Daemon subcommand and notification subscription"
-// (SSE parsing) and the backoff/reconnect behavior.
+// (SSE parsing), the backoff/reconnect behavior, and the self-report query
+// params the listener appends to the notification SSE URL.
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { SseListener } from "../sse-listener.mjs";
+
+// The version the listener self-reports comes from the chorus CLI's own
+// package.json (one level above cli/) — assert against that same source rather
+// than a hardcoded literal, so a version bump doesn't break the test.
+const CLI_VERSION = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json"), "utf8")
+).version;
 
 /** Build a fetch Response whose body streams the given chunks then ends. */
 function streamingResponse(chunks, { ok = true, status = 200 } = {}) {
@@ -45,11 +57,13 @@ describe("SseListener parsing", () => {
       { type: "new_notification", notificationUuid: "n1" },
       { type: "count_update", unreadCount: 3 },
     ]);
-    // Sent Bearer auth to the right endpoint
-    expect(fetchImpl).toHaveBeenCalledWith(
-      "https://chorus.example/api/events/notifications",
-      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer cho_x" }) })
+    // Sent Bearer auth to the notification endpoint (now carrying self-report
+    // query params — assert the path + Bearer header, params covered below).
+    const [calledUrl, calledInit] = fetchImpl.mock.calls[0];
+    expect(calledUrl).toMatch(
+      /^https:\/\/chorus\.example\/api\/events\/notifications\?/
     );
+    expect(calledInit.headers).toMatchObject({ Authorization: "Bearer cho_x" });
   });
 
   it("strips trailing CR so CRLF transports parse", async () => {
@@ -86,6 +100,89 @@ describe("SseListener parsing", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(events).toEqual([{ ok: true }]);
     expect(warns.join("")).toMatch(/parse error/i);
+  });
+});
+
+describe("SseListener self-report URL", () => {
+  /** Capture the URL passed to fetch on connect. */
+  function captureUrl(listenerOpts = {}) {
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse([": connected\n\n"])
+    );
+    const listener = new SseListener({
+      url: "https://chorus.example/",
+      apiKey: "cho_x",
+      onEvent: () => {},
+      logger: silentLogger,
+      fetchImpl,
+      ...listenerOpts,
+    });
+    return { listener, fetchImpl };
+  }
+
+  it("appends clientType=claude_code + version + host + startedAt", async () => {
+    const { listener, fetchImpl } = captureUrl();
+    await listener.connect();
+
+    const url = new URL(fetchImpl.mock.calls[0][0]);
+    expect(url.origin + url.pathname).toBe(
+      "https://chorus.example/api/events/notifications"
+    );
+    expect(url.searchParams.get("clientType")).toBe("claude_code");
+    // Version is the CLI's real package version, not a hardcoded literal.
+    expect(url.searchParams.get("clientVersion")).toBe(CLI_VERSION);
+    expect(url.searchParams.get("host")).toBe(hostname());
+    // startedAt is a valid ISO-8601 timestamp.
+    const startedAt = url.searchParams.get("startedAt");
+    expect(startedAt).toBeTruthy();
+    expect(Number.isNaN(Date.parse(startedAt))).toBe(false);
+    expect(new Date(startedAt).toISOString()).toBe(startedAt);
+
+    listener.disconnect();
+  });
+
+  it("re-sends the same self-report params on reconnect", async () => {
+    vi.useFakeTimers();
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call++;
+      if (call === 1) return { ok: false, status: 503, body: null };
+      return streamingResponse([": connected\n\n"]);
+    });
+    const listener = new SseListener({
+      url: "https://chorus.example/",
+      apiKey: "cho_x",
+      onEvent: () => {},
+      logger: silentLogger,
+      fetchImpl,
+      initialDelayMs: 1000,
+    });
+
+    await listener.connect(); // first attempt → reconnecting
+    await vi.advanceTimersByTimeAsync(1000); // reconnect fires
+
+    expect(call).toBe(2);
+    const firstUrl = fetchImpl.mock.calls[0][0];
+    const secondUrl = fetchImpl.mock.calls[1][0];
+    // The reconnect re-sends the byte-identical URL (params included).
+    expect(secondUrl).toBe(firstUrl);
+    const u = new URL(secondUrl);
+    expect(u.searchParams.get("clientType")).toBe("claude_code");
+    expect(u.searchParams.get("clientVersion")).toBe(CLI_VERSION);
+
+    vi.useRealTimers();
+    listener.disconnect();
+  });
+
+  it("keeps the Bearer header and Accept header on the self-reporting request", async () => {
+    const { listener, fetchImpl } = captureUrl({ apiKey: "cho_secret" });
+    await listener.connect();
+    const init = fetchImpl.mock.calls[0][1];
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer cho_secret",
+      Accept: "text/event-stream",
+    });
+    listener.disconnect();
   });
 });
 

--- a/cli/sse-listener.mjs
+++ b/cli/sse-listener.mjs
@@ -6,11 +6,46 @@
 // Endpoint: GET /api/events/notifications, Bearer <cho_ key>. Verified against
 // src/app/api/events/notifications/route.ts: getAuthContext accepts the Bearer
 // API key; data lines are `data: <json>\n\n`, heartbeats are `: ...` comments.
+//
+// Self-report: the listener appends ?clientType=claude_code&clientVersion=…&
+// host=…&startedAt=… to the endpoint so the server's DaemonConnection registry
+// (src/services/daemon-connection.service.ts → parseSelfReport) can record which
+// client is on the other end. The CLI reports clientType=claude_code (it only
+// drives a local Claude Code subprocess — not a generic "daemon"). These params
+// are display-only metadata; auth remains the unchanged Bearer header.
+
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const INITIAL_DELAY_MS = 1_000;
 const MAX_DELAY_MS = 30_000;
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+// chorus CLI version — read from the package's own package.json (the chorus CLI
+// is `@chorus-aidlc/chorus`, whose package.json sits one level above cli/). This
+// is the same source `chorus.mjs` uses for `--version`, so the self-reported
+// version always matches the installed CLI rather than a hardcoded literal.
+// Defensive: fall back to "0.0.0" if the file is unreadable for any reason — a
+// missing version must never block the daemon from connecting.
+function readCliVersion() {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8"));
+    return typeof pkg.version === "string" && pkg.version ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+const CLI_VERSION = readCliVersion();
+
+// Daemon process start time, captured once at module load. ISO-8601 string is
+// recomputed at URL-construction time from this fixed Date so reconnects report
+// the original start, not the reconnect moment.
+const PROCESS_STARTED_AT = new Date();
 
 /**
  * @typedef {Object} SseListenerOptions
@@ -37,6 +72,16 @@ export class SseListener {
     this.initialDelayMs = opts.initialDelayMs ?? INITIAL_DELAY_MS;
     this.maxDelayMs = opts.maxDelayMs ?? MAX_DELAY_MS;
 
+    // Build the self-reporting endpoint URL once and reuse it across every
+    // (re)connect, so the reconnect path always re-sends the same params.
+    const params = new URLSearchParams({
+      clientType: "claude_code",
+      clientVersion: CLI_VERSION,
+      host: hostname(),
+      startedAt: PROCESS_STARTED_AT.toISOString(),
+    });
+    this.endpoint = `${this.url}/api/events/notifications?${params.toString()}`;
+
     this.status = "disconnected";
     /** @type {AbortController | null} */
     this.abortController = null;
@@ -51,10 +96,9 @@ export class SseListener {
     const abortController = new AbortController();
     this.abortController = abortController;
 
-    const endpoint = `${this.url}/api/events/notifications`;
     let response;
     try {
-      response = await this.fetchImpl(endpoint, {
+      response = await this.fetchImpl(this.endpoint, {
         headers: { Authorization: `Bearer ${this.apiKey}`, Accept: "text/event-stream" },
         signal: abortController.signal,
       });

--- a/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/README.md
+++ b/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/README.md
@@ -1,0 +1,3 @@
+# add-daemon-connection-tracking
+
+SSE connections self-report client metadata; server persists a DaemonConnection registry with liveness tracking

--- a/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/design.md
+++ b/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/design.md
@@ -1,0 +1,242 @@
+# Technical Design: Daemon connection self-reporting + server-side registry
+
+## Overview
+
+Capture a small, self-reported metadata bundle for every long-lived daemon SSE
+connection, and persist it in a DB-backed registry the server keeps alive and
+reaps. The design has three moving parts:
+
+1. **Wire contract** — clients append query params to the SSE URL.
+2. **Persistence** — a `DaemonConnection` Prisma model + a thin service.
+3. **Lifecycle + liveness** — the SSE route registers on connect, deregisters on
+   `abort`, and bumps `lastSeenAt` from the heartbeat interval it already runs.
+
+The guiding constraint is **minimal server-side surface, zero CLI heartbeat**.
+The only genuinely new infrastructure is one table and one service; everything
+else hangs off plumbing that already exists (the SSE route, its `request.signal`
+abort, its 30s `setInterval`).
+
+## Architecture
+
+```
+┌─────────────────────┐   GET /api/events/notifications        ┌────────────────────────┐
+│ chorus CLI daemon   │   ?clientType=claude_code&...           │  SSE route handler     │
+│ (cli/sse-listener)  │ ──────────────────────────────────────▶│  (per ECS instance)    │
+└─────────────────────┘                                         │                        │
+┌─────────────────────┐   GET /api/events/notifications         │  on connect → register │
+│ OpenClaw plugin     │   ?clientType=openclaw&...               │  on abort   → mark off │
+│ (sse-listener.ts)   │ ──────────────────────────────────────▶│  30s tick   → touch    │
+└─────────────────────┘                                         └───────────┬────────────┘
+                                                                            │
+                                                          daemon-connection.service
+                                                                            │
+                                                                  ┌─────────▼─────────┐
+                                                                  │  DaemonConnection │  (Postgres)
+                                                                  │  status/lastSeenAt│  cross-instance
+                                                                  └───────────────────┘
+```
+
+Because the table is in Postgres, a connection registered by the instance that
+holds the socket is visible to a query served by the *other* ECS instance — which
+is exactly what `f2fe9a7f`'s read API will need. An in-memory map could not do
+this without a Redis broadcast layer; the DB gives cross-instance visibility and
+durable history for free, at the cost of a few small writes per connection
+(one on connect, one per 30s tick, one on disconnect).
+
+## Data Model
+
+New Prisma model. Mirrors `AgentSession`'s conventions: `Int` autoincrement PK +
+`uuid` public id, `companyUuid` + application-level `company` relation,
+`agentUuid` + cascade `agent` relation, indexed status/liveness columns.
+
+```prisma
+model DaemonConnection {
+  id             Int       @id @default(autoincrement())
+  uuid           String    @unique @default(uuid())
+  companyUuid    String
+  company        Company   @relation(fields: [companyUuid], references: [uuid])
+  agentUuid      String
+  agent          Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+
+  clientType     String    // claude_code | openclaw | browser | other
+  clientVersion  String?   // self-reported, untrusted, display-only
+  host           String?   // self-reported hostname, display-only
+  startedAt      DateTime? // self-reported daemon process start time
+
+  status         String    @default("online")  // online | offline
+  connectedAt    DateTime  @default(now())
+  lastSeenAt     DateTime  @default(now())
+  disconnectedAt DateTime?
+
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  @@index([companyUuid])
+  @@index([agentUuid])
+  @@index([status])
+  @@index([lastSeenAt])
+}
+```
+
+Back-relations (`daemonConnections DaemonConnection[]`) are added to `Company`
+and `Agent`, matching how `AgentSession` is wired. No FK to `AgentSession` —
+that link is `f2fe9a7f`'s decision.
+
+`clientType` is a free-form string (not a Prisma enum) to match the project's
+existing pattern (`Document.type`, `AgentSession.status` are all strings) and to
+avoid a migration when browser registration is added later. The allowed values
+are enforced in the service, not the DB.
+
+### Identity of a connection (upsert key)
+
+A daemon may reconnect (SSE drops + backoff reconnect is built into both
+listeners). We do **not** want a new row per reconnect of the same logical
+daemon, nor do we want two daemons on two hosts to collide. The natural identity
+is `(agentUuid, clientType, host)`:
+
+- `registerConnection` upserts on `(agentUuid, clientType, host)`: if a row
+  exists, flip it back to `online` and refresh `connectedAt`/`lastSeenAt`;
+  else insert. This keeps reconnects idempotent and history compact.
+- A `@@unique([agentUuid, clientType, host])` constraint backs the upsert. `host`
+  is nullable; when null we treat it as the empty string for uniqueness so a
+  host-less self-report still upserts deterministically.
+
+> Tradeoff: keying on self-reported `host` means a spoofed/changed host yields a
+> separate row. That is acceptable — the fields are display-only and untrusted by
+> design, and a distinct host genuinely is a distinct connection for display.
+
+## API Design
+
+No new HTTP endpoint and no new MCP tool. The only contract change is the set of
+**optional query params** accepted on the two existing SSE routes:
+
+| Param | Meaning | Example |
+|---|---|---|
+| `clientType` | client kind | `claude_code`, `openclaw` |
+| `clientVersion` | client semver | `0.11.0` |
+| `host` | hostname | `mac-studio.local` |
+| `startedAt` | process start, ISO-8601 | `2026-06-15T03:00:00.000Z` |
+
+Auth is unchanged — Bearer (`cho_` key) for daemons, cookie for browser. These
+params never feed authorization; they are read after `getAuthContext` succeeds
+and used only to populate the registry row.
+
+Registration is gated on `clientType` being a recognized **daemon** value
+(`claude_code` | `openclaw`). `browser`, `other`, unknown, or absent → the route
+runs exactly as today and writes no row.
+
+## Module Contracts
+
+`src/services/daemon-connection.service.ts` (all functions `companyUuid`-scoped,
+all swallow-and-log on failure so SSE setup is never blocked by a registry write):
+
+```ts
+// Recognized daemon client types eligible for registration in this change.
+export const DAEMON_CLIENT_TYPES = ["claude_code", "openclaw"] as const;
+
+export interface SelfReport {
+  clientType: string;          // raw query value
+  clientVersion?: string | null;
+  host?: string | null;
+  startedAt?: Date | null;
+}
+
+// Upsert on (agentUuid, clientType, host). Returns the row uuid, or null when
+// clientType is not a recognized daemon type (caller then skips lifecycle).
+export async function registerConnection(
+  companyUuid: string, agentUuid: string, report: SelfReport
+): Promise<string | null>;
+
+// abort → status=offline, disconnectedAt=now. No-op if uuid is null/absent.
+export async function markDisconnected(
+  companyUuid: string, connectionUuid: string
+): Promise<void>;
+
+// heartbeat tick → bump lastSeenAt (and ensure status=online). Cheap UPDATE.
+export async function touchConnection(
+  companyUuid: string, connectionUuid: string
+): Promise<void>;
+```
+
+**Liveness contract (the rule `f2fe9a7f`'s reader MUST apply):** a connection is
+*effectively online* iff `status === "online"` AND
+`now - lastSeenAt <= STALE_THRESHOLD_MS`. The threshold is ~90s = 3× the 30s
+heartbeat, tolerating one missed tick. This change exports the constant so the
+future reader uses the same value; it does not itself read.
+
+### SSE route wiring (both routes, same shape)
+
+```
+auth = getAuthContext(req)            // unchanged
+report = parseSelfReport(req.nextUrl.searchParams)
+connUuid = await registerConnection(auth.companyUuid, auth.actorUuid, report)  // null if not a daemon
+
+start(controller):
+  ...existing subscribe + ": connected" ...
+  heartbeat = setInterval(() => {
+    send(": heartbeat\n\n")
+    if (connUuid) void touchConnection(auth.companyUuid, connUuid)   // NEW
+  }, 30_000)
+  req.signal.addEventListener("abort", () => {
+    ...existing cleanup...
+    if (connUuid) void markDisconnected(auth.companyUuid, connUuid)  // NEW
+  })
+```
+
+All registry calls are fire-and-forget (`void` + internal try/catch) — a registry
+write must never delay or break event delivery.
+
+### Client self-report (both listeners, same shape)
+
+`cli/sse-listener.mjs` and `packages/openclaw-plugin/src/sse-listener.ts` already
+build `${url}/api/events/notifications`. Each appends a query string:
+
+```js
+const params = new URLSearchParams({
+  clientType: "claude_code",            // "openclaw" in the plugin
+  clientVersion: PKG_VERSION,           // from package.json / build constant
+  host: os.hostname(),
+  startedAt: processStart.toISOString(),
+});
+const endpoint = `${base}/api/events/notifications?${params}`;
+```
+
+The chorus CLI computes `clientVersion` from its own package version and
+`startedAt` from a module-load timestamp; the OpenClaw plugin does the equivalent
+in its TS runtime. Both keep their existing Bearer header and reconnect logic.
+
+## Implementation Plan
+
+1. **Schema + migration** — add `DaemonConnection` to `schema.prisma` (+
+   back-relations), generate the migration via the Prisma CLI, run
+   `prisma generate`.
+2. **Service** — `daemon-connection.service.ts` with the three functions + the
+   `DAEMON_CLIENT_TYPES` / `STALE_THRESHOLD_MS` constants + `parseSelfReport`.
+3. **Route wiring** — add register/touch/disconnect to both SSE routes.
+4. **Clients** — append query params in both listeners.
+
+Tasks 1→2→3 are a chain (route needs the service needs the model). Task 4
+(clients) depends only on the wire contract being fixed, but its acceptance
+(rows actually appear) depends on 3, so it is ordered after 3 and serves as the
+end-to-end integration checkpoint.
+
+## Risks & Mitigations
+
+- **Registry write latency on the hot connect path.** Mitigation: all service
+  calls are fire-and-forget with internal try/catch; the stream is set up
+  regardless. A failed registry write logs and is dropped, never surfaced to the
+  client.
+- **Row churn from reconnect storms.** Mitigation: upsert on
+  `(agentUuid, clientType, host)` means a reconnect refreshes one row rather than
+  inserting; `lastSeenAt` history is not retained per-tick (we overwrite).
+- **Stale `online` rows after instance crash.** Mitigation: the
+  `status==="online" && lastSeenAt fresh` read rule; the crashed instance's
+  heartbeat interval stops, so `lastSeenAt` goes stale within ~90s. No sweeper job
+  is required for correctness of the read; a background reaper that flips long-
+  stale rows to `offline` is explicitly deferred to `f2fe9a7f` (it is a
+  read-side nicety, not needed for collection).
+- **Spoofed self-report.** Accepted by design — `clientVersion`/`host` are
+  display-only and never authorize anything; auth remains Bearer/cookie.
+- **Multi-tenancy.** Every service function is `companyUuid`-scoped and derives
+  `companyUuid`/`agentUuid` from the authenticated context, never from the
+  client-supplied params.

--- a/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/proposal.md
+++ b/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/proposal.md
@@ -1,0 +1,161 @@
+# Proposal: Daemon connection self-reporting + server-side registry
+
+## Why
+
+Both the Chorus CLI daemon and the OpenClaw plugin hold a long-lived SSE
+subscription to `/api/events/notifications` to receive task dispatches. The
+browser dashboard holds the same kind of long-lived connection to `/api/events`.
+Today the server is **blind** to these connections: both SSE routes parse only
+the auth identity (`${auth.type}:${auth.actorUuid}`) and register nothing. There
+is no connection registry anywhere in the codebase (grep-confirmed).
+
+Concretely, the server cannot answer any of:
+
+- Which client is on the other end — chorus CLI (Claude Code), OpenClaw plugin,
+  browser, or something else?
+- What version is it, what host is it running on, when did it connect, is it
+  still alive?
+- The same agent may hold several connections — they are indistinguishable.
+
+This is the **data-collection gap**. A future "Daemons" observability UI (derived
+idea `f2fe9a7f`) cannot list active connections because that information has
+never been captured. This change closes the gap: connections **self-report** a
+small metadata bundle at connect time, and the server **persists** them in a
+registry it can keep alive and reap.
+
+This change is deliberately the **collection + liveness layer only**. It does
+**not** build a read API, a UI, or any link to `AgentSession`. Those belong to
+`f2fe9a7f` (the consumption/observability layer), which builds on the registry
+this change lands.
+
+## What Changes
+
+- **New Prisma model `DaemonConnection`** — persists one row per registered SSE
+  connection: `companyUuid`, `agentUuid`, `clientType` (enum-like string:
+  `claude_code` | `openclaw` | `browser` | `other`), `clientVersion`, `host`,
+  `startedAt` (process start, self-reported), `connectedAt`, `lastSeenAt`,
+  `status` (`online` | `offline`), `disconnectedAt`. This is a real DB table
+  (one new migration) so the registry is **durable and cross-instance visible** —
+  production runs 2 ECS tasks behind an ALB, so an in-memory map on the instance
+  holding the socket would be invisible to a query that lands on the other
+  instance.
+
+- **SSE connections self-report via query params** — clients append
+  `?clientType=…&clientVersion=…&host=…&startedAt=…` to the SSE URL. Query
+  params (not headers) are the single contract because a future browser
+  `EventSource` can only set query params, never custom headers; daemon and
+  browser thus share one path. The auth mechanism is unchanged (Bearer / cookie);
+  these params are **display-only metadata and never participate in
+  authorization** — they are client-supplied and therefore untrusted.
+
+- **Registry scope = daemon clients only, table reserves `clientType` for
+  browser** — only connections that self-report a machine `clientType`
+  (`claude_code`, `openclaw`) are registered in this change. The `browser` and
+  `other` enum values exist in the column so browser registration can be added
+  later **without a migration**, but browser SSE connections are not registered
+  now (they are high-churn and overlap the existing presence system).
+
+- **Connection lifecycle on the SSE route** — on connect with a daemon
+  `clientType`, the route registers (upsert) a `DaemonConnection` row as `online`
+  with `connectedAt`/`lastSeenAt = now`. On the stream's `abort` event (graceful
+  disconnect: process exit, Ctrl-C, network close) the route marks the row
+  `offline` with `disconnectedAt = now`. **Primary liveness signal = `abort`.**
+
+- **Liveness safety net via the existing 30s heartbeat interval** — the SSE
+  routes already run `setInterval(…, 30_000)` to push keep-alive comments. This
+  change has that same interval also bump `lastSeenAt`. The interval dies with
+  the instance process, so if an instance hard-crashes (OOM, kill, deploy roll)
+  and its `abort` never fires, `lastSeenAt` simply stops advancing. A reader then
+  treats `status === "online" && lastSeenAt` older than a staleness threshold
+  (~90s) as effectively offline. **No CLI heartbeat is added** — SSE is
+  one-way and the daemon sends nothing after connect; the server-side interval is
+  the entire liveness mechanism.
+
+- **Both real clients self-report** — `cli/sse-listener.mjs` appends
+  `clientType=claude_code` (the CLI only drives Claude Code today, so it is not a
+  generic "daemon"); `packages/openclaw-plugin/src/sse-listener.ts` appends
+  `clientType=openclaw`. Both already use `fetch` against the same endpoint, so
+  this is a URL-construction change on each.
+
+- **Wire the reserved `onConnect` upload hook** — the daemon already defines a
+  no-op `onConnect({host, agentUuid})` hook (`cli/upload-hooks.mjs`) reserved for
+  this work. This change may use that hook point as the place the daemon computes
+  its self-report bundle, keeping the wake path untouched. The hook still
+  performs no *upload* — registration happens server-side from the query params.
+
+- **Visibility is owner-scoped (contract only, enforced when the read API
+  lands)** — a connection's self-reported metadata (`host`, `clientVersion`) is
+  mildly sensitive. The spec fixes the rule now — only the owning agent's owner
+  may see a connection — so `f2fe9a7f`'s read API and UI inherit it. This change
+  ships no read endpoint, so there is nothing to enforce yet, but the requirement
+  is recorded to bind the consumer.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-connection-registry`: the server-side `DaemonConnection` model, the
+  register/deregister lifecycle on the SSE route, heartbeat-driven liveness with
+  the abort-primary + staleness-safety-net model, and the owner-scoped visibility
+  contract for downstream consumers.
+
+### Modified Capabilities
+
+- `cli-daemon`: the chorus CLI daemon's SSE subscription SHALL append the
+  self-report query params (`clientType=claude_code`, version, host, startedAt)
+  when opening the notification stream.
+- `openclaw-event-bridge`: the OpenClaw plugin's SSE notification listener SHALL
+  append the same self-report query params with `clientType=openclaw`.
+
+## Impact
+
+- **Schema**: one new migration adding the `DaemonConnection` model. Per project
+  convention, the schema is edited and the migration generated via the Prisma CLI
+  (no hand-written SQL, DDL-only). `relationMode = "prisma"` — the `agent` /
+  `company` relations are application-level, matching `AgentSession`.
+
+- **Backend code**:
+  - `prisma/schema.prisma` — new `DaemonConnection` model + back-relations on
+    `Company` and `Agent`.
+  - `src/services/daemon-connection.service.ts` (new) — `registerConnection`,
+    `markDisconnected`, `touchConnection` (bump `lastSeenAt`), all
+    `companyUuid`-scoped. Pure persistence; no read/query API in this change.
+  - `src/app/api/events/notifications/route.ts` and `src/app/api/events/route.ts`
+    — parse the self-report query params, call the service on connect / abort,
+    and bump `lastSeenAt` from the existing 30s interval. Registration is gated
+    on a recognized daemon `clientType`; absent/browser/unknown → no row written
+    in this change.
+
+- **Client code**:
+  - `cli/sse-listener.mjs` — append query params to the endpoint URL;
+    `clientType=claude_code`, `clientVersion` from the CLI package version, `host`
+    from `os.hostname()`, `startedAt` from process start.
+  - `packages/openclaw-plugin/src/sse-listener.ts` — same, `clientType=openclaw`.
+  - `cli/upload-hooks.mjs` — `onConnect` may compute/carry the bundle; remains a
+    no-op for *upload*.
+
+- **No UI** — the Daemons sidebar page, per-connection session view, and
+  transcript panel are all out of scope (they are `f2fe9a7f`). No `design.pen`
+  change, because this change adds no user-facing screen.
+
+- **No `AgentSession` change** — no `connectionUuid` FK is added. How a
+  daemon-woken Claude session relates to a connection is `f2fe9a7f`'s core design
+  question; adding the FK now would prejudge it.
+
+- **Runtime**: no new dependency, no new MCP tool, no new permission, no change to
+  the auth path. The only new network surface is the optional query params on an
+  existing endpoint.
+
+- **Backward compat**: fully additive. A client that does not self-report (older
+  daemon, browser) connects exactly as before and simply is not registered.
+
+## Boundary notes for `f2fe9a7f` (recorded so the consumer inherits them)
+
+1. **`DaemonConnection` modeling moves here.** `f2fe9a7f`'s notes tentatively
+   claimed the `DaemonConnection` table; this change absorbs it. `f2fe9a7f`
+   retains the read API, the Daemons UI, the per-connection session view, and the
+   transcript panel.
+2. **Visibility narrows to owner-scoped.** `f2fe9a7f`'s "all connections of the
+   company" global-view wording must narrow to owner-scoped to match the
+   visibility requirement here, or `f2fe9a7f` must explicitly re-open that
+   decision.

--- a/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/specs/cli-daemon/spec.md
+++ b/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/specs/cli-daemon/spec.md
@@ -1,0 +1,28 @@
+# cli-daemon Specification
+
+## ADDED Requirements
+
+### Requirement: The daemon SHALL self-report client metadata when opening the notification stream
+
+The chorus CLI daemon SHALL append self-report query parameters when it opens its
+SSE subscription to `/api/events/notifications`. The appended parameters SHALL be
+`clientType=claude_code`, `clientVersion` set to the chorus CLI package version,
+`host` set to the machine hostname, and `startedAt` set to the daemon process
+start time in ISO-8601. The `clientType` SHALL be `claude_code`
+(not a generic `daemon`) because the CLI drives a local Claude Code subprocess.
+This SHALL NOT change the authentication mechanism (the Bearer `cho_` API key
+header is unchanged) and SHALL NOT alter the daemon's reconnect or backfill
+behavior.
+
+#### Scenario: The daemon appends self-report params on connect
+
+- **WHEN** the chorus CLI daemon opens its notification SSE subscription
+- **THEN** the request URL MUST include `clientType=claude_code` together with the
+  CLI's `clientVersion`, the machine `host`, and the process `startedAt`
+- **AND** the `Authorization: Bearer <cho_ key>` header MUST be sent exactly as before
+
+#### Scenario: Reconnect re-sends the self-report params
+
+- **GIVEN** the daemon's SSE subscription drops and the backoff reconnect fires
+- **WHEN** the daemon re-opens the notification stream
+- **THEN** the reconnect request URL MUST again include the same self-report query parameters

--- a/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/specs/daemon-connection-registry/spec.md
+++ b/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/specs/daemon-connection-registry/spec.md
@@ -1,0 +1,189 @@
+# daemon-connection-registry Specification
+
+## ADDED Requirements
+
+### Requirement: The server SHALL persist registered daemon connections in a DaemonConnection model
+
+The server SHALL define a Prisma model `DaemonConnection` that stores one row per
+registered long-lived SSE connection from a daemon client. The model SHALL carry
+at least: `uuid` (public id), `companyUuid`, `agentUuid`, `clientType`,
+`clientVersion` (nullable), `host` (nullable), `startedAt` (nullable),
+`status` (defaulting to `online`), `connectedAt`, `lastSeenAt`, and
+`disconnectedAt` (nullable). The model SHALL be persisted in the database (not an
+in-memory structure) so that a connection registered by one server instance is
+readable by another instance, and SHALL be created through a Prisma-CLI-generated
+migration (no hand-written SQL). The `agent` relation SHALL cascade-delete with
+its agent, matching the existing `AgentSession` model conventions.
+
+#### Scenario: A daemon connection is persisted on registration
+
+- **GIVEN** an authenticated agent opens the notification SSE stream and
+  self-reports a recognized daemon `clientType`
+- **WHEN** the server registers the connection
+- **THEN** a `DaemonConnection` row MUST be persisted with `status = "online"`,
+  `connectedAt` and `lastSeenAt` set to the current time, and `companyUuid` /
+  `agentUuid` taken from the authenticated context
+- **AND** the row MUST be readable by a query executed on a different server
+  instance than the one holding the socket
+
+#### Scenario: The agent relation cascade-deletes
+
+- **GIVEN** a `DaemonConnection` row for some agent
+- **WHEN** that agent is deleted
+- **THEN** the agent's `DaemonConnection` rows MUST be deleted as well
+
+### Requirement: SSE connections SHALL self-report client metadata via query parameters
+
+The SSE endpoints `/api/events/notifications` and `/api/events` SHALL accept
+optional query parameters `clientType`, `clientVersion`, `host`, and `startedAt`
+that a connecting client uses to self-report its identity. The server SHALL read
+these parameters only after authentication succeeds and SHALL NOT use them for
+any authorization decision — authentication remains via Bearer API key or session
+cookie. Query parameters (not request headers) SHALL be the contract, so a future
+browser `EventSource` client (which cannot set custom headers) can use the same
+mechanism. A connection that supplies none of these parameters SHALL be served
+exactly as before this change.
+
+#### Scenario: Self-reported metadata populates the registry row
+
+- **WHEN** a client connects with `?clientType=claude_code&clientVersion=0.11.0&host=mac.local&startedAt=2026-06-15T03:00:00.000Z`
+- **THEN** the registered `DaemonConnection` row MUST record `clientType="claude_code"`,
+  `clientVersion="0.11.0"`, `host="mac.local"`, and `startedAt` parsed from the
+  supplied timestamp
+
+#### Scenario: Self-reported metadata is never used for authorization
+
+- **GIVEN** a connection whose query parameters claim an arbitrary `clientType` or `host`
+- **WHEN** the server processes the connection
+- **THEN** the authorization outcome MUST depend only on the Bearer key / session
+  cookie, identical to a connection that supplied no query parameters
+
+#### Scenario: A connection with no self-report params is served unchanged
+
+- **WHEN** a client connects to the SSE endpoint with no `clientType` (or related) query parameters
+- **THEN** the stream MUST be established exactly as before this change
+- **AND** no `DaemonConnection` row MUST be written for it
+
+### Requirement: Only recognized daemon client types SHALL be registered
+
+The server SHALL register a `DaemonConnection` row only when the self-reported
+`clientType` is a recognized daemon client type (`claude_code` or `openclaw`).
+The `clientType` column SHALL nonetheless permit the values `browser` and `other`
+so that registering browser connections can be added later without a schema
+migration, but in this change a `clientType` of `browser`, `other`, an
+unrecognized value, or an absent value SHALL NOT cause a row to be written.
+
+#### Scenario: A claude_code connection is registered
+
+- **WHEN** a connection self-reports `clientType=claude_code`
+- **THEN** a `DaemonConnection` row MUST be written
+
+#### Scenario: An openclaw connection is registered
+
+- **WHEN** a connection self-reports `clientType=openclaw`
+- **THEN** a `DaemonConnection` row MUST be written
+
+#### Scenario: A browser connection is not registered in this change
+
+- **WHEN** a connection self-reports `clientType=browser`
+- **THEN** no `DaemonConnection` row MUST be written
+- **AND** the SSE stream MUST still be established normally
+
+#### Scenario: An unrecognized client type is not registered
+
+- **WHEN** a connection self-reports a `clientType` that is neither `claude_code` nor `openclaw`
+- **THEN** no `DaemonConnection` row MUST be written
+
+### Requirement: A reconnecting daemon SHALL refresh its existing row rather than accumulate rows
+
+Registration SHALL be idempotent per logical daemon, keyed on
+`(agentUuid, clientType, host)`. When a daemon reconnects (for example after an
+SSE drop and backoff reconnect), the server SHALL refresh the existing matching
+row — setting `status = "online"` and updating `connectedAt` / `lastSeenAt` —
+rather than inserting a new row. Two daemons reporting different `host` values
+SHALL be distinct rows.
+
+#### Scenario: Reconnect refreshes the same row
+
+- **GIVEN** a `DaemonConnection` row exists for `(agent A, claude_code, host H)` in `offline` status
+- **WHEN** the same daemon reconnects self-reporting the same `clientType` and `host`
+- **THEN** the existing row MUST be flipped to `status = "online"` with a refreshed `connectedAt`
+- **AND** no second row for `(agent A, claude_code, host H)` MUST exist
+
+#### Scenario: Different hosts are distinct connections
+
+- **GIVEN** agent A runs the daemon on two machines with different hostnames
+- **WHEN** both connect self-reporting `clientType=claude_code` with their respective `host` values
+- **THEN** two distinct `DaemonConnection` rows MUST exist, one per host
+
+### Requirement: Connection liveness SHALL use abort as the primary signal with a heartbeat-driven staleness safety net
+
+The SSE route SHALL treat the stream's `abort` event as the primary
+disconnect signal: on `abort` (graceful client disconnect, process exit, or
+network close) the server SHALL mark the connection `offline` and set
+`disconnectedAt`. As a safety net for the case where the server instance itself
+dies (and therefore cannot run its `abort` handler), the SSE route's existing
+periodic heartbeat interval SHALL also update the connection's `lastSeenAt` on
+each tick. No client-to-server heartbeat SHALL be added — the daemon sends
+nothing after connecting, and the server-side interval is the sole liveness
+updater. The model SHALL define a documented staleness threshold (approximately
+three heartbeat intervals) such that a consumer treats a connection as
+effectively offline when `status = "online"` but `lastSeenAt` is older than that
+threshold.
+
+#### Scenario: Graceful disconnect marks the row offline immediately
+
+- **GIVEN** a registered `online` `DaemonConnection`
+- **WHEN** the client disconnects gracefully and the stream's `abort` event fires
+- **THEN** the row MUST be updated to `status = "offline"` with `disconnectedAt` set to the current time
+
+#### Scenario: Heartbeat tick advances lastSeenAt
+
+- **GIVEN** a registered `online` `DaemonConnection`
+- **WHEN** the SSE route's periodic heartbeat interval fires for that connection
+- **THEN** the row's `lastSeenAt` MUST be advanced to the current time
+
+#### Scenario: An instance crash leaves a row that reads as stale
+
+- **GIVEN** a registered `online` `DaemonConnection` whose holding instance hard-crashes so its `abort` never fires
+- **WHEN** more than the staleness threshold elapses with no heartbeat tick
+- **THEN** the row MUST remain `status = "online"` with a `lastSeenAt` no longer being advanced
+- **AND** a consumer applying the liveness rule (`status = "online"` AND `lastSeenAt` fresh) MUST treat it as effectively offline
+
+#### Scenario: No client-to-server heartbeat is introduced
+
+- **WHEN** the change is implemented
+- **THEN** the daemon clients MUST NOT send any periodic request to the server after the initial SSE connection
+- **AND** `lastSeenAt` MUST be advanced solely by the server-side heartbeat interval
+
+### Requirement: A registry write SHALL never block or break SSE event delivery
+
+The server SHALL perform all `DaemonConnection` registry operations (register,
+touch, mark-disconnected) without blocking the establishment or operation of the
+SSE stream, and a registry write SHALL NOT delay event delivery. A failure of any
+registry operation SHALL be logged and otherwise ignored;
+it SHALL NOT prevent the stream from being established, SHALL NOT interrupt event
+delivery, and SHALL NOT propagate an error to the client.
+
+#### Scenario: A failed registry write still serves the stream
+
+- **GIVEN** the registry persistence layer is failing (e.g. a transient DB error)
+- **WHEN** a client opens the SSE stream
+- **THEN** the stream MUST still be established and events MUST still be delivered
+- **AND** the failure MUST be logged rather than surfaced to the client
+
+### Requirement: Connection metadata visibility SHALL be owner-scoped
+
+The server SHALL make the self-reported metadata of a `DaemonConnection` (notably
+`host` and `clientVersion`) visible only to the user who owns the agent that holds
+the connection. Any future read API or UI built on this registry SHALL enforce
+owner-scoped visibility and SHALL NOT expose another agent's connection metadata
+to other members of the same company. This change introduces no read endpoint;
+the requirement binds the consumer (`f2fe9a7f`) that adds one.
+
+#### Scenario: Owner-scoped visibility is the binding contract
+
+- **GIVEN** a `DaemonConnection` belonging to an agent owned by user U
+- **WHEN** a future read API returns connection metadata
+- **THEN** it MUST return that connection only to user U (the agent's owner)
+- **AND** it MUST NOT return that connection's `host` or `clientVersion` to other members of U's company

--- a/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/specs/openclaw-event-bridge/spec.md
+++ b/openspec/changes/archive/2026-06-15-add-daemon-connection-tracking/specs/openclaw-event-bridge/spec.md
@@ -1,0 +1,29 @@
+# openclaw-event-bridge Specification
+
+## ADDED Requirements
+
+### Requirement: The OpenClaw plugin SHALL self-report client metadata when opening the notification stream
+
+The OpenClaw plugin's SSE notification listener SHALL append self-report query
+parameters when it opens its subscription to `/api/events/notifications`. The
+appended parameters SHALL be `clientType=openclaw`, `clientVersion` set to the
+plugin version, `host` set to the machine hostname, and `startedAt` set to the
+plugin process start time in ISO-8601. The `clientType` SHALL be `openclaw` so the server's
+connection registry can distinguish an OpenClaw daemon from a chorus CLI
+(`claude_code`) daemon. This SHALL NOT change the authentication mechanism (the
+Bearer `cho_` API key header is unchanged) and SHALL NOT alter the listener's
+reconnect behavior.
+
+#### Scenario: The OpenClaw listener appends self-report params on connect
+
+- **WHEN** the OpenClaw plugin opens its notification SSE subscription
+- **THEN** the request URL MUST include `clientType=openclaw` together with the
+  plugin's `clientVersion`, the machine `host`, and the process `startedAt`
+- **AND** the `Authorization: Bearer <cho_ key>` header MUST be sent exactly as before
+
+#### Scenario: The server distinguishes OpenClaw from chorus CLI connections
+
+- **GIVEN** one OpenClaw plugin and one chorus CLI daemon both connected for the same agent
+- **WHEN** the server registers each connection
+- **THEN** the OpenClaw connection MUST be recorded with `clientType = "openclaw"`
+- **AND** the chorus CLI connection MUST be recorded with `clientType = "claude_code"`

--- a/openspec/specs/cli-daemon/spec.md
+++ b/openspec/specs/cli-daemon/spec.md
@@ -125,3 +125,28 @@ The daemon SHALL define connection-register, session-register, and transcript-re
 - **WHEN** the daemon connects, starts a session, and receives subprocess transcript messages
 - **THEN** the corresponding hook points are invoked but perform no server upload in this change
 
+### Requirement: The daemon SHALL self-report client metadata when opening the notification stream
+
+The chorus CLI daemon SHALL append self-report query parameters when it opens its
+SSE subscription to `/api/events/notifications`. The appended parameters SHALL be
+`clientType=claude_code`, `clientVersion` set to the chorus CLI package version,
+`host` set to the machine hostname, and `startedAt` set to the daemon process
+start time in ISO-8601. The `clientType` SHALL be `claude_code`
+(not a generic `daemon`) because the CLI drives a local Claude Code subprocess.
+This SHALL NOT change the authentication mechanism (the Bearer `cho_` API key
+header is unchanged) and SHALL NOT alter the daemon's reconnect or backfill
+behavior.
+
+#### Scenario: The daemon appends self-report params on connect
+
+- **WHEN** the chorus CLI daemon opens its notification SSE subscription
+- **THEN** the request URL MUST include `clientType=claude_code` together with the
+  CLI's `clientVersion`, the machine `host`, and the process `startedAt`
+- **AND** the `Authorization: Bearer <cho_ key>` header MUST be sent exactly as before
+
+#### Scenario: Reconnect re-sends the self-report params
+
+- **GIVEN** the daemon's SSE subscription drops and the backoff reconnect fires
+- **WHEN** the daemon re-opens the notification stream
+- **THEN** the reconnect request URL MUST again include the same self-report query parameters
+

--- a/openspec/specs/daemon-connection-registry/spec.md
+++ b/openspec/specs/daemon-connection-registry/spec.md
@@ -1,0 +1,191 @@
+# daemon-connection-registry Specification
+
+## Purpose
+TBD - created by archiving change add-daemon-connection-tracking. Update Purpose after archive.
+## Requirements
+### Requirement: The server SHALL persist registered daemon connections in a DaemonConnection model
+
+The server SHALL define a Prisma model `DaemonConnection` that stores one row per
+registered long-lived SSE connection from a daemon client. The model SHALL carry
+at least: `uuid` (public id), `companyUuid`, `agentUuid`, `clientType`,
+`clientVersion` (nullable), `host` (nullable), `startedAt` (nullable),
+`status` (defaulting to `online`), `connectedAt`, `lastSeenAt`, and
+`disconnectedAt` (nullable). The model SHALL be persisted in the database (not an
+in-memory structure) so that a connection registered by one server instance is
+readable by another instance, and SHALL be created through a Prisma-CLI-generated
+migration (no hand-written SQL). The `agent` relation SHALL cascade-delete with
+its agent, matching the existing `AgentSession` model conventions.
+
+#### Scenario: A daemon connection is persisted on registration
+
+- **GIVEN** an authenticated agent opens the notification SSE stream and
+  self-reports a recognized daemon `clientType`
+- **WHEN** the server registers the connection
+- **THEN** a `DaemonConnection` row MUST be persisted with `status = "online"`,
+  `connectedAt` and `lastSeenAt` set to the current time, and `companyUuid` /
+  `agentUuid` taken from the authenticated context
+- **AND** the row MUST be readable by a query executed on a different server
+  instance than the one holding the socket
+
+#### Scenario: The agent relation cascade-deletes
+
+- **GIVEN** a `DaemonConnection` row for some agent
+- **WHEN** that agent is deleted
+- **THEN** the agent's `DaemonConnection` rows MUST be deleted as well
+
+### Requirement: SSE connections SHALL self-report client metadata via query parameters
+
+The SSE endpoints `/api/events/notifications` and `/api/events` SHALL accept
+optional query parameters `clientType`, `clientVersion`, `host`, and `startedAt`
+that a connecting client uses to self-report its identity. The server SHALL read
+these parameters only after authentication succeeds and SHALL NOT use them for
+any authorization decision — authentication remains via Bearer API key or session
+cookie. Query parameters (not request headers) SHALL be the contract, so a future
+browser `EventSource` client (which cannot set custom headers) can use the same
+mechanism. A connection that supplies none of these parameters SHALL be served
+exactly as before this change.
+
+#### Scenario: Self-reported metadata populates the registry row
+
+- **WHEN** a client connects with `?clientType=claude_code&clientVersion=0.11.0&host=mac.local&startedAt=2026-06-15T03:00:00.000Z`
+- **THEN** the registered `DaemonConnection` row MUST record `clientType="claude_code"`,
+  `clientVersion="0.11.0"`, `host="mac.local"`, and `startedAt` parsed from the
+  supplied timestamp
+
+#### Scenario: Self-reported metadata is never used for authorization
+
+- **GIVEN** a connection whose query parameters claim an arbitrary `clientType` or `host`
+- **WHEN** the server processes the connection
+- **THEN** the authorization outcome MUST depend only on the Bearer key / session
+  cookie, identical to a connection that supplied no query parameters
+
+#### Scenario: A connection with no self-report params is served unchanged
+
+- **WHEN** a client connects to the SSE endpoint with no `clientType` (or related) query parameters
+- **THEN** the stream MUST be established exactly as before this change
+- **AND** no `DaemonConnection` row MUST be written for it
+
+### Requirement: Only recognized daemon client types SHALL be registered
+
+The server SHALL register a `DaemonConnection` row only when the self-reported
+`clientType` is a recognized daemon client type (`claude_code` or `openclaw`).
+The `clientType` column SHALL nonetheless permit the values `browser` and `other`
+so that registering browser connections can be added later without a schema
+migration, but in this change a `clientType` of `browser`, `other`, an
+unrecognized value, or an absent value SHALL NOT cause a row to be written.
+
+#### Scenario: A claude_code connection is registered
+
+- **WHEN** a connection self-reports `clientType=claude_code`
+- **THEN** a `DaemonConnection` row MUST be written
+
+#### Scenario: An openclaw connection is registered
+
+- **WHEN** a connection self-reports `clientType=openclaw`
+- **THEN** a `DaemonConnection` row MUST be written
+
+#### Scenario: A browser connection is not registered in this change
+
+- **WHEN** a connection self-reports `clientType=browser`
+- **THEN** no `DaemonConnection` row MUST be written
+- **AND** the SSE stream MUST still be established normally
+
+#### Scenario: An unrecognized client type is not registered
+
+- **WHEN** a connection self-reports a `clientType` that is neither `claude_code` nor `openclaw`
+- **THEN** no `DaemonConnection` row MUST be written
+
+### Requirement: A reconnecting daemon SHALL refresh its existing row rather than accumulate rows
+
+Registration SHALL be idempotent per logical daemon, keyed on
+`(agentUuid, clientType, host)`. When a daemon reconnects (for example after an
+SSE drop and backoff reconnect), the server SHALL refresh the existing matching
+row — setting `status = "online"` and updating `connectedAt` / `lastSeenAt` —
+rather than inserting a new row. Two daemons reporting different `host` values
+SHALL be distinct rows.
+
+#### Scenario: Reconnect refreshes the same row
+
+- **GIVEN** a `DaemonConnection` row exists for `(agent A, claude_code, host H)` in `offline` status
+- **WHEN** the same daemon reconnects self-reporting the same `clientType` and `host`
+- **THEN** the existing row MUST be flipped to `status = "online"` with a refreshed `connectedAt`
+- **AND** no second row for `(agent A, claude_code, host H)` MUST exist
+
+#### Scenario: Different hosts are distinct connections
+
+- **GIVEN** agent A runs the daemon on two machines with different hostnames
+- **WHEN** both connect self-reporting `clientType=claude_code` with their respective `host` values
+- **THEN** two distinct `DaemonConnection` rows MUST exist, one per host
+
+### Requirement: Connection liveness SHALL use abort as the primary signal with a heartbeat-driven staleness safety net
+
+The SSE route SHALL treat the stream's `abort` event as the primary
+disconnect signal: on `abort` (graceful client disconnect, process exit, or
+network close) the server SHALL mark the connection `offline` and set
+`disconnectedAt`. As a safety net for the case where the server instance itself
+dies (and therefore cannot run its `abort` handler), the SSE route's existing
+periodic heartbeat interval SHALL also update the connection's `lastSeenAt` on
+each tick. No client-to-server heartbeat SHALL be added — the daemon sends
+nothing after connecting, and the server-side interval is the sole liveness
+updater. The model SHALL define a documented staleness threshold (approximately
+three heartbeat intervals) such that a consumer treats a connection as
+effectively offline when `status = "online"` but `lastSeenAt` is older than that
+threshold.
+
+#### Scenario: Graceful disconnect marks the row offline immediately
+
+- **GIVEN** a registered `online` `DaemonConnection`
+- **WHEN** the client disconnects gracefully and the stream's `abort` event fires
+- **THEN** the row MUST be updated to `status = "offline"` with `disconnectedAt` set to the current time
+
+#### Scenario: Heartbeat tick advances lastSeenAt
+
+- **GIVEN** a registered `online` `DaemonConnection`
+- **WHEN** the SSE route's periodic heartbeat interval fires for that connection
+- **THEN** the row's `lastSeenAt` MUST be advanced to the current time
+
+#### Scenario: An instance crash leaves a row that reads as stale
+
+- **GIVEN** a registered `online` `DaemonConnection` whose holding instance hard-crashes so its `abort` never fires
+- **WHEN** more than the staleness threshold elapses with no heartbeat tick
+- **THEN** the row MUST remain `status = "online"` with a `lastSeenAt` no longer being advanced
+- **AND** a consumer applying the liveness rule (`status = "online"` AND `lastSeenAt` fresh) MUST treat it as effectively offline
+
+#### Scenario: No client-to-server heartbeat is introduced
+
+- **WHEN** the change is implemented
+- **THEN** the daemon clients MUST NOT send any periodic request to the server after the initial SSE connection
+- **AND** `lastSeenAt` MUST be advanced solely by the server-side heartbeat interval
+
+### Requirement: A registry write SHALL never block or break SSE event delivery
+
+The server SHALL perform all `DaemonConnection` registry operations (register,
+touch, mark-disconnected) without blocking the establishment or operation of the
+SSE stream, and a registry write SHALL NOT delay event delivery. A failure of any
+registry operation SHALL be logged and otherwise ignored;
+it SHALL NOT prevent the stream from being established, SHALL NOT interrupt event
+delivery, and SHALL NOT propagate an error to the client.
+
+#### Scenario: A failed registry write still serves the stream
+
+- **GIVEN** the registry persistence layer is failing (e.g. a transient DB error)
+- **WHEN** a client opens the SSE stream
+- **THEN** the stream MUST still be established and events MUST still be delivered
+- **AND** the failure MUST be logged rather than surfaced to the client
+
+### Requirement: Connection metadata visibility SHALL be owner-scoped
+
+The server SHALL make the self-reported metadata of a `DaemonConnection` (notably
+`host` and `clientVersion`) visible only to the user who owns the agent that holds
+the connection. Any future read API or UI built on this registry SHALL enforce
+owner-scoped visibility and SHALL NOT expose another agent's connection metadata
+to other members of the same company. This change introduces no read endpoint;
+the requirement binds the consumer (`f2fe9a7f`) that adds one.
+
+#### Scenario: Owner-scoped visibility is the binding contract
+
+- **GIVEN** a `DaemonConnection` belonging to an agent owned by user U
+- **WHEN** a future read API returns connection metadata
+- **THEN** it MUST return that connection only to user U (the agent's owner)
+- **AND** it MUST NOT return that connection's `host` or `clientVersion` to other members of U's company
+

--- a/openspec/specs/daemon-connection-registry/spec.md
+++ b/openspec/specs/daemon-connection-registry/spec.md
@@ -1,7 +1,13 @@
 # daemon-connection-registry Specification
 
 ## Purpose
-TBD - created by archiving change add-daemon-connection-tracking. Update Purpose after archive.
+Defines the server-side registry of long-lived daemon SSE connections: the
+`DaemonConnection` model, the register/deregister lifecycle wired into the SSE
+routes, heartbeat-driven liveness (abort-primary with a `lastSeenAt` staleness
+safety net for instance crashes), and the owner-scoped visibility contract that
+binds any future read API. This is the data-collection + liveness layer only —
+the read API, the Daemons observability UI, the per-connection session view, and
+the `AgentSession` linkage are owned by the consuming capability (idea f2fe9a7f).
 ## Requirements
 ### Requirement: The server SHALL persist registered daemon connections in a DaemonConnection model
 

--- a/openspec/specs/openclaw-event-bridge/spec.md
+++ b/openspec/specs/openclaw-event-bridge/spec.md
@@ -71,3 +71,29 @@ When `autoStart` is enabled and a `task_assigned` notification arrives, the plug
 - **THEN** it MUST NOT call `chorus_claim_task`
 - **AND** it MUST still enqueue a wake informing the agent the task is available to review
 
+### Requirement: The OpenClaw plugin SHALL self-report client metadata when opening the notification stream
+
+The OpenClaw plugin's SSE notification listener SHALL append self-report query
+parameters when it opens its subscription to `/api/events/notifications`. The
+appended parameters SHALL be `clientType=openclaw`, `clientVersion` set to the
+plugin version, `host` set to the machine hostname, and `startedAt` set to the
+plugin process start time in ISO-8601. The `clientType` SHALL be `openclaw` so the server's
+connection registry can distinguish an OpenClaw daemon from a chorus CLI
+(`claude_code`) daemon. This SHALL NOT change the authentication mechanism (the
+Bearer `cho_` API key header is unchanged) and SHALL NOT alter the listener's
+reconnect behavior.
+
+#### Scenario: The OpenClaw listener appends self-report params on connect
+
+- **WHEN** the OpenClaw plugin opens its notification SSE subscription
+- **THEN** the request URL MUST include `clientType=openclaw` together with the
+  plugin's `clientVersion`, the machine `host`, and the process `startedAt`
+- **AND** the `Authorization: Bearer <cho_ key>` header MUST be sent exactly as before
+
+#### Scenario: The server distinguishes OpenClaw from chorus CLI connections
+
+- **GIVEN** one OpenClaw plugin and one chorus CLI daemon both connected for the same agent
+- **WHEN** the server registers each connection
+- **THEN** the OpenClaw connection MUST be recorded with `clientType = "openclaw"`
+- **AND** the chorus CLI connection MUST be recorded with `clientType = "claude_code"`
+

--- a/packages/openclaw-plugin/src/__tests__/sse-listener.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/sse-listener.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { ChorusSseListener } from "../sse-listener.js";
+
+// The version the listener self-reports comes from the plugin's own
+// package.json (one level above src/) — assert against that same source rather
+// than a hardcoded literal, so a version bump doesn't break the test.
+const PLUGIN_VERSION = (
+  JSON.parse(
+    readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json"), "utf8"),
+  ) as { version: string }
+).version;
 
 function makeLogger() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -124,11 +137,69 @@ describe("ChorusSseListener", () => {
     await listener.connect();
 
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe("https://c.example.com/api/events/notifications");
+    // The notification path is unchanged; self-report params now follow it.
+    expect(String(url)).toMatch(/^https:\/\/c\.example\.com\/api\/events\/notifications\?/);
     expect((init as RequestInit).headers).toMatchObject({
       Authorization: "Bearer cho_secret",
       Accept: "text/event-stream",
     });
+    listener.disconnect();
+  });
+
+  it("appends clientType=openclaw + version + host + startedAt to the SSE URL", async () => {
+    const fetchSpy = vi.fn(async () => streamingResponse([]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const listener = new ChorusSseListener({
+      chorusUrl: "https://c.example.com/",
+      apiKey: "cho_secret",
+      logger: makeLogger(),
+      onEvent: () => {},
+      onReconnect: async () => {},
+    });
+    await listener.connect();
+
+    const url = new URL(String(fetchSpy.mock.calls[0][0]));
+    expect(url.origin + url.pathname).toBe("https://c.example.com/api/events/notifications");
+    expect(url.searchParams.get("clientType")).toBe("openclaw");
+    // Version is the plugin's real package version, not a hardcoded literal.
+    expect(url.searchParams.get("clientVersion")).toBe(PLUGIN_VERSION);
+    expect(url.searchParams.get("host")).toBe(hostname());
+    const startedAt = url.searchParams.get("startedAt");
+    expect(startedAt).toBeTruthy();
+    expect(Number.isNaN(Date.parse(startedAt as string))).toBe(false);
+    expect(new Date(startedAt as string).toISOString()).toBe(startedAt);
+
+    listener.disconnect();
+  });
+
+  it("re-sends the same self-report params on reconnect", async () => {
+    vi.useFakeTimers();
+    let call = 0;
+    const fetchSpy = vi.fn(async () => {
+      call++;
+      if (call === 1) return { ok: false, status: 503 } as Response;
+      return streamingResponse([]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const listener = new ChorusSseListener({
+      chorusUrl: "https://c.example.com/",
+      apiKey: "cho_secret",
+      logger: makeLogger(),
+      onEvent: () => {},
+      onReconnect: async () => {},
+    });
+    await listener.connect(); // first attempt fails → reconnecting
+    await vi.advanceTimersByTimeAsync(1000); // backoff fires the reconnect
+
+    expect(call).toBe(2);
+    // The reconnect re-sends the byte-identical URL (params included).
+    expect(String(fetchSpy.mock.calls[1][0])).toBe(String(fetchSpy.mock.calls[0][0]));
+    const u = new URL(String(fetchSpy.mock.calls[1][0]));
+    expect(u.searchParams.get("clientType")).toBe("openclaw");
+    expect(u.searchParams.get("clientVersion")).toBe(PLUGIN_VERSION);
+
     listener.disconnect();
   });
 });

--- a/packages/openclaw-plugin/src/sse-listener.ts
+++ b/packages/openclaw-plugin/src/sse-listener.ts
@@ -1,3 +1,8 @@
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 export type SseListenerStatus = "connected" | "disconnected" | "reconnecting";
 
 export interface SseNotificationEvent {
@@ -19,8 +24,35 @@ export interface ChorusSseListenerOptions {
 const INITIAL_DELAY_MS = 1_000;
 const MAX_DELAY_MS = 30_000;
 
+// Plugin version — read from this package's own package.json so the value the
+// server's DaemonConnection registry records always matches the installed
+// plugin rather than a hardcoded literal. The compiled output lives in dist/
+// and the source in src/; both are one level under the package root, so
+// "../package.json" resolves to the package manifest in either case. Defensive:
+// fall back to "0.0.0" if the manifest is unreadable — a missing version must
+// never block the listener from connecting.
+function readPluginVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8")) as {
+      version?: unknown;
+    };
+    return typeof pkg.version === "string" && pkg.version ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+const PLUGIN_VERSION = readPluginVersion();
+
+// Plugin process start time, captured once at module load. Reconnects re-send
+// this original start (recomputed to ISO-8601 at URL-construction time), not the
+// reconnect moment.
+const PROCESS_STARTED_AT = new Date();
+
 export class ChorusSseListener {
   private readonly opts: ChorusSseListenerOptions;
+  private readonly endpoint: string;
   private _status: SseListenerStatus = "disconnected";
   private abortController: AbortController | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -28,6 +60,19 @@ export class ChorusSseListener {
 
   constructor(opts: ChorusSseListenerOptions) {
     this.opts = opts;
+
+    // Build the self-reporting endpoint URL once and reuse it across every
+    // (re)connect, so the reconnect path always re-sends the same params. The
+    // CLI reports clientType=openclaw so the server's connection registry can
+    // distinguish an OpenClaw daemon from a chorus CLI (claude_code) daemon.
+    // These params are display-only metadata; auth remains the Bearer header.
+    const params = new URLSearchParams({
+      clientType: "openclaw",
+      clientVersion: PLUGIN_VERSION,
+      host: hostname(),
+      startedAt: PROCESS_STARTED_AT.toISOString(),
+    });
+    this.endpoint = `${this.opts.chorusUrl.replace(/\/$/, "")}/api/events/notifications?${params.toString()}`;
   }
 
   get status(): SseListenerStatus {
@@ -41,11 +86,9 @@ export class ChorusSseListener {
     const abortController = new AbortController();
     this.abortController = abortController;
 
-    const url = `${this.opts.chorusUrl.replace(/\/$/, "")}/api/events/notifications`;
-
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await fetch(this.endpoint, {
         headers: {
           Authorization: `Bearer ${this.opts.apiKey}`,
           Accept: "text/event-stream",

--- a/prisma/migrations/20260615082309_add_daemon_connection/migration.sql
+++ b/prisma/migrations/20260615082309_add_daemon_connection/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "DaemonConnection" (
+    "id" SERIAL NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "companyUuid" TEXT NOT NULL,
+    "agentUuid" TEXT NOT NULL,
+    "clientType" TEXT NOT NULL,
+    "clientVersion" TEXT,
+    "host" TEXT NOT NULL DEFAULT '',
+    "startedAt" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'online',
+    "connectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "disconnectedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DaemonConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonConnection_uuid_key" ON "DaemonConnection"("uuid");
+
+-- CreateIndex
+CREATE INDEX "DaemonConnection_companyUuid_idx" ON "DaemonConnection"("companyUuid");
+
+-- CreateIndex
+CREATE INDEX "DaemonConnection_agentUuid_idx" ON "DaemonConnection"("agentUuid");
+
+-- CreateIndex
+CREATE INDEX "DaemonConnection_status_idx" ON "DaemonConnection"("status");
+
+-- CreateIndex
+CREATE INDEX "DaemonConnection_lastSeenAt_idx" ON "DaemonConnection"("lastSeenAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonConnection_agentUuid_clientType_host_key" ON "DaemonConnection"("agentUuid", "clientType", "host");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Company {
   activities Activity[]
   comments   Comment[]
   sessions   AgentSession[]
+  daemonConnections DaemonConnection[]
 }
 
 // User (human, OIDC login)
@@ -74,6 +75,7 @@ model Agent {
 
   apiKeys  ApiKey[]
   sessions AgentSession[]
+  daemonConnections DaemonConnection[]
 
   @@index([companyUuid])
   @@index([ownerUuid])
@@ -384,6 +386,41 @@ model SessionTaskCheckin {
   @@unique([sessionUuid, taskUuid])
   @@index([sessionUuid])
   @@index([taskUuid])
+}
+
+// Daemon SSE connection registry — one row per long-lived daemon SSE connection.
+// Mirrors AgentSession conventions (Int PK + uuid public id, application-level
+// company/agent relations, indexed status/liveness columns).
+model DaemonConnection {
+  id             Int       @id @default(autoincrement())
+  uuid           String    @unique @default(uuid())
+  companyUuid    String
+  company        Company   @relation(fields: [companyUuid], references: [uuid])
+  agentUuid      String
+  agent          Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+
+  clientType     String    // claude_code | openclaw | browser | other
+  clientVersion  String?   // self-reported, untrusted, display-only
+  // Self-reported hostname (display-only). Non-null with "" default: a @@unique
+  // over a nullable column is broken for dedup because connectors treat each
+  // null as distinct (Prisma docs), which would let reconnects accumulate rows.
+  // Defaulting to "" makes (agentUuid, clientType, host) a deterministic upsert key.
+  host           String    @default("")
+  startedAt      DateTime? // self-reported daemon process start time
+
+  status         String    @default("online") // online | offline
+  connectedAt    DateTime  @default(now())
+  lastSeenAt     DateTime  @default(now())
+  disconnectedAt DateTime?
+
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  @@unique([agentUuid, clientType, host])
+  @@index([companyUuid])
+  @@index([agentUuid])
+  @@index([status])
+  @@index([lastSeenAt])
 }
 
 // Notification

--- a/src/app/api/events/__tests__/route.test.ts
+++ b/src/app/api/events/__tests__/route.test.ts
@@ -36,6 +36,9 @@ import { GET } from "@/app/api/events/route";
 const companyUuid = "company-0000-0000-0000-000000000001";
 const actorUuid = "agent-0000-0000-0000-000000000001";
 const connectionUuid = "conn-0000-0000-0000-000000000001";
+// registerConnection now returns a {uuid, connectedAt} handle (the connectedAt
+// is a generation fence); touch/markDisconnected receive the whole handle.
+const connHandle = { uuid: connectionUuid, connectedAt: new Date("2026-06-15T03:00:00.000Z") };
 
 const agentAuth = { type: "agent", companyUuid, actorUuid, permissions: [] };
 
@@ -81,7 +84,7 @@ beforeEach(() => {
   mockGetAuthContext.mockResolvedValue(agentAuth);
   // Default: behave as a daemon connection.
   mockParseSelfReport.mockReturnValue({ clientType: "claude_code", host: "h" });
-  mockRegisterConnection.mockResolvedValue(connectionUuid);
+  mockRegisterConnection.mockResolvedValue(connHandle);
 });
 
 afterEach(() => {
@@ -120,7 +123,7 @@ describe("GET /api/events (change events SSE)", () => {
     expect(mockTouchConnection).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(30_000);
     expect(mockTouchConnection).toHaveBeenCalledTimes(1);
-    expect(mockTouchConnection).toHaveBeenCalledWith(companyUuid, connectionUuid);
+    expect(mockTouchConnection).toHaveBeenCalledWith(companyUuid, connHandle);
 
     await vi.advanceTimersByTimeAsync(30_000);
     expect(mockTouchConnection).toHaveBeenCalledTimes(2);
@@ -136,7 +139,7 @@ describe("GET /api/events (change events SSE)", () => {
     await Promise.resolve();
 
     expect(mockMarkDisconnected).toHaveBeenCalledTimes(1);
-    expect(mockMarkDisconnected).toHaveBeenCalledWith(companyUuid, connectionUuid);
+    expect(mockMarkDisconnected).toHaveBeenCalledWith(companyUuid, connHandle);
   });
 
   it("preserves projectUuid filtering: cross-project change events are dropped", async () => {

--- a/src/app/api/events/__tests__/route.test.ts
+++ b/src/app/api/events/__tests__/route.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+
+const mockEventBus = vi.hoisted(() => ({
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+}));
+
+const mockParseSelfReport = vi.fn();
+const mockRegisterConnection = vi.fn();
+const mockTouchConnection = vi.fn();
+const mockMarkDisconnected = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+vi.mock("@/lib/event-bus", () => ({
+  eventBus: mockEventBus,
+}));
+
+vi.mock("@/services/daemon-connection.service", () => ({
+  parseSelfReport: (...args: unknown[]) => mockParseSelfReport(...args),
+  registerConnection: (...args: unknown[]) => mockRegisterConnection(...args),
+  touchConnection: (...args: unknown[]) => mockTouchConnection(...args),
+  markDisconnected: (...args: unknown[]) => mockMarkDisconnected(...args),
+}));
+
+import { GET } from "@/app/api/events/route";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const actorUuid = "agent-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+
+const agentAuth = { type: "agent", companyUuid, actorUuid, permissions: [] };
+
+function makeRequest(query = "", signal?: AbortSignal): NextRequest {
+  const url = `http://localhost:3000/api/events${query ? `?${query}` : ""}`;
+  return new NextRequest(new URL(url), signal ? { signal } : undefined);
+}
+
+/**
+ * Drive the SSE response: start consuming the stream so its `start(controller)`
+ * callback runs synchronously, and collect every chunk decoded to text.
+ */
+async function startStream(res: Response) {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  const pump = (async () => {
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(decoder.decode(value, { stream: true }));
+      }
+    } catch {
+      // reader cancelled / stream closed
+    }
+  })();
+  // Let the start() microtask + first enqueue settle.
+  await flush();
+  return { chunks, pump, reader };
+}
+
+/**
+ * Drain the microtask queue so enqueued stream chunks are read by the pump.
+ * Microtask-only (no setTimeout) so it works under vi.useFakeTimers().
+ */
+async function flush() {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue(agentAuth);
+  // Default: behave as a daemon connection.
+  mockParseSelfReport.mockReturnValue({ clientType: "claude_code", host: "h" });
+  mockRegisterConnection.mockResolvedValue(connectionUuid);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET /api/events (change events SSE)", () => {
+  it("returns 401 without registering when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mockRegisterConnection).not.toHaveBeenCalled();
+    expect(mockParseSelfReport).not.toHaveBeenCalled();
+  });
+
+  it("registers on connect after auth using the authenticated company/actor (not query params)", async () => {
+    const res = await GET(makeRequest("clientType=claude_code&host=h"));
+    await startStream(res);
+
+    expect(mockRegisterConnection).toHaveBeenCalledTimes(1);
+    expect(mockRegisterConnection).toHaveBeenCalledWith(
+      companyUuid,
+      actorUuid,
+      { clientType: "claude_code", host: "h" },
+    );
+    // self-report is read from the request URL search params, after auth.
+    expect(mockParseSelfReport).toHaveBeenCalledTimes(1);
+    expect(mockParseSelfReport.mock.calls[0][0]).toBeInstanceOf(URLSearchParams);
+  });
+
+  it("touches the connection on each heartbeat tick (daemon clientType)", async () => {
+    vi.useFakeTimers();
+    const res = await GET(makeRequest("clientType=claude_code"));
+    await startStream(res);
+
+    expect(mockTouchConnection).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mockTouchConnection).toHaveBeenCalledTimes(1);
+    expect(mockTouchConnection).toHaveBeenCalledWith(companyUuid, connectionUuid);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mockTouchConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks disconnected on abort (daemon clientType)", async () => {
+    const ac = new AbortController();
+    const res = await GET(makeRequest("clientType=claude_code", ac.signal));
+    await startStream(res);
+
+    expect(mockMarkDisconnected).not.toHaveBeenCalled();
+    ac.abort();
+    await Promise.resolve();
+
+    expect(mockMarkDisconnected).toHaveBeenCalledTimes(1);
+    expect(mockMarkDisconnected).toHaveBeenCalledWith(companyUuid, connectionUuid);
+  });
+
+  it("preserves projectUuid filtering: cross-project change events are dropped", async () => {
+    const res = await GET(makeRequest("projectUuid=proj-1&clientType=claude_code"));
+    const { chunks } = await startStream(res);
+
+    // The route subscribed a change handler — grab it and exercise the filter.
+    const changeCall = mockEventBus.on.mock.calls.find((c) => c[0] === "change");
+    expect(changeCall).toBeDefined();
+    const handler = changeCall![1] as (e: Record<string, unknown>) => void;
+
+    const before = chunks.length;
+    // Wrong project → dropped.
+    handler({ companyUuid, projectUuid: "other", type: "x" });
+    await flush();
+    expect(chunks.length).toBe(before);
+    // Matching project → delivered.
+    handler({ companyUuid, projectUuid: "proj-1", type: "x" });
+    await flush();
+    expect(chunks.length).toBe(before + 1);
+    expect(chunks[chunks.length - 1]).toContain("proj-1");
+  });
+
+  it("drops change events from a different company (multi-tenancy)", async () => {
+    const res = await GET(makeRequest("clientType=claude_code"));
+    const { chunks } = await startStream(res);
+    const handler = mockEventBus.on.mock.calls.find((c) => c[0] === "change")![1] as (
+      e: Record<string, unknown>,
+    ) => void;
+
+    const before = chunks.length;
+    handler({ companyUuid: "other-company", type: "x" });
+    await flush();
+    expect(chunks.length).toBe(before);
+  });
+
+  describe("no-clientType / browser connection", () => {
+    beforeEach(() => {
+      mockParseSelfReport.mockReturnValue({ clientType: "", host: null });
+      // registerConnection returns null for a non-daemon clientType.
+      mockRegisterConnection.mockResolvedValue(null);
+    });
+
+    it("still streams (connected + heartbeat) but writes no registry row", async () => {
+      vi.useFakeTimers();
+      const ac = new AbortController();
+      const res = await GET(makeRequest("", ac.signal));
+      const { chunks } = await startStream(res);
+
+      // registerConnection was still consulted (returned null), but no lifecycle fired.
+      expect(mockRegisterConnection).toHaveBeenCalledTimes(1);
+      expect(chunks.join("")).toContain(": connected");
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      // Heartbeat still flows to the client...
+      expect(chunks.join("")).toContain(": heartbeat");
+      // ...but touch is skipped because connUuid is null.
+      expect(mockTouchConnection).not.toHaveBeenCalled();
+
+      ac.abort();
+      await Promise.resolve();
+      expect(mockMarkDisconnected).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not break the stream when registerConnection rejects (it cannot — it swallows)", async () => {
+    // The service never throws, but assert the route does not await-throw regardless.
+    mockRegisterConnection.mockResolvedValue(null);
+    const res = await GET(makeRequest("clientType=claude_code"));
+    const { chunks } = await startStream(res);
+    expect(res.status).toBe(200);
+    expect(chunks.join("")).toContain(": connected");
+  });
+});

--- a/src/app/api/events/notifications/__tests__/route.test.ts
+++ b/src/app/api/events/notifications/__tests__/route.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+
+const mockEventBus = vi.hoisted(() => ({
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+}));
+
+const mockParseSelfReport = vi.fn();
+const mockRegisterConnection = vi.fn();
+const mockTouchConnection = vi.fn();
+const mockMarkDisconnected = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+vi.mock("@/lib/event-bus", () => ({
+  eventBus: mockEventBus,
+}));
+
+vi.mock("@/services/daemon-connection.service", () => ({
+  parseSelfReport: (...args: unknown[]) => mockParseSelfReport(...args),
+  registerConnection: (...args: unknown[]) => mockRegisterConnection(...args),
+  touchConnection: (...args: unknown[]) => mockTouchConnection(...args),
+  markDisconnected: (...args: unknown[]) => mockMarkDisconnected(...args),
+}));
+
+import { GET } from "@/app/api/events/notifications/route";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const actorUuid = "agent-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+
+const agentAuth = { type: "agent", companyUuid, actorUuid, permissions: [] };
+
+function makeRequest(query = "", signal?: AbortSignal): NextRequest {
+  const url = `http://localhost:3000/api/events/notifications${query ? `?${query}` : ""}`;
+  return new NextRequest(new URL(url), signal ? { signal } : undefined);
+}
+
+async function startStream(res: Response) {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  (async () => {
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(decoder.decode(value, { stream: true }));
+      }
+    } catch {
+      // reader cancelled / stream closed
+    }
+  })();
+  await flush();
+  return { chunks, reader };
+}
+
+/**
+ * Drain the microtask queue so enqueued stream chunks are read by the pump.
+ * Microtask-only (no setTimeout) so it works under vi.useFakeTimers().
+ */
+async function flush() {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue(agentAuth);
+  mockParseSelfReport.mockReturnValue({ clientType: "openclaw", host: "h" });
+  mockRegisterConnection.mockResolvedValue(connectionUuid);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET /api/events/notifications (notification SSE)", () => {
+  it("returns 401 without registering when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mockRegisterConnection).not.toHaveBeenCalled();
+    expect(mockParseSelfReport).not.toHaveBeenCalled();
+  });
+
+  it("registers on connect after auth using the authenticated company/actor (not query params)", async () => {
+    const res = await GET(makeRequest("clientType=openclaw&host=h"));
+    await startStream(res);
+
+    expect(mockRegisterConnection).toHaveBeenCalledTimes(1);
+    expect(mockRegisterConnection).toHaveBeenCalledWith(
+      companyUuid,
+      actorUuid,
+      { clientType: "openclaw", host: "h" },
+    );
+    expect(mockParseSelfReport).toHaveBeenCalledTimes(1);
+    expect(mockParseSelfReport.mock.calls[0][0]).toBeInstanceOf(URLSearchParams);
+  });
+
+  it("subscribes to the per-user notification channel and delivers events", async () => {
+    const res = await GET(makeRequest("clientType=openclaw"));
+    const { chunks } = await startStream(res);
+
+    const onCall = mockEventBus.on.mock.calls.find((c) =>
+      String(c[0]).startsWith("notification:"),
+    );
+    expect(onCall).toBeDefined();
+    expect(onCall![0]).toBe(`notification:agent:${actorUuid}`);
+
+    const handler = onCall![1] as (e: Record<string, unknown>) => void;
+    const before = chunks.length;
+    handler({ type: "mention", id: 1 });
+    await flush();
+    expect(chunks.length).toBe(before + 1);
+    expect(chunks[chunks.length - 1]).toContain("mention");
+  });
+
+  it("touches the connection on each heartbeat tick (daemon clientType)", async () => {
+    vi.useFakeTimers();
+    const res = await GET(makeRequest("clientType=openclaw"));
+    await startStream(res);
+
+    expect(mockTouchConnection).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mockTouchConnection).toHaveBeenCalledTimes(1);
+    expect(mockTouchConnection).toHaveBeenCalledWith(companyUuid, connectionUuid);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mockTouchConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks disconnected on abort and unsubscribes the handler", async () => {
+    const ac = new AbortController();
+    const res = await GET(makeRequest("clientType=openclaw", ac.signal));
+    await startStream(res);
+
+    expect(mockMarkDisconnected).not.toHaveBeenCalled();
+    ac.abort();
+    await Promise.resolve();
+
+    expect(mockMarkDisconnected).toHaveBeenCalledTimes(1);
+    expect(mockMarkDisconnected).toHaveBeenCalledWith(companyUuid, connectionUuid);
+    expect(mockEventBus.off).toHaveBeenCalledWith(
+      `notification:agent:${actorUuid}`,
+      expect.any(Function),
+    );
+  });
+
+  describe("no-clientType / browser connection", () => {
+    beforeEach(() => {
+      mockParseSelfReport.mockReturnValue({ clientType: "", host: null });
+      mockRegisterConnection.mockResolvedValue(null);
+    });
+
+    it("still streams (connected + heartbeat) but writes no registry row", async () => {
+      vi.useFakeTimers();
+      const ac = new AbortController();
+      const res = await GET(makeRequest("", ac.signal));
+      const { chunks } = await startStream(res);
+
+      expect(mockRegisterConnection).toHaveBeenCalledTimes(1);
+      expect(chunks.join("")).toContain(": connected");
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(chunks.join("")).toContain(": heartbeat");
+      expect(mockTouchConnection).not.toHaveBeenCalled();
+
+      ac.abort();
+      await Promise.resolve();
+      expect(mockMarkDisconnected).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/events/notifications/__tests__/route.test.ts
+++ b/src/app/api/events/notifications/__tests__/route.test.ts
@@ -36,6 +36,9 @@ import { GET } from "@/app/api/events/notifications/route";
 const companyUuid = "company-0000-0000-0000-000000000001";
 const actorUuid = "agent-0000-0000-0000-000000000001";
 const connectionUuid = "conn-0000-0000-0000-000000000001";
+// registerConnection now returns a {uuid, connectedAt} handle (the connectedAt
+// is a generation fence); touch/markDisconnected receive the whole handle.
+const connHandle = { uuid: connectionUuid, connectedAt: new Date("2026-06-15T03:00:00.000Z") };
 
 const agentAuth = { type: "agent", companyUuid, actorUuid, permissions: [] };
 
@@ -75,7 +78,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockGetAuthContext.mockResolvedValue(agentAuth);
   mockParseSelfReport.mockReturnValue({ clientType: "openclaw", host: "h" });
-  mockRegisterConnection.mockResolvedValue(connectionUuid);
+  mockRegisterConnection.mockResolvedValue(connHandle);
 });
 
 afterEach(() => {
@@ -131,7 +134,7 @@ describe("GET /api/events/notifications (notification SSE)", () => {
     expect(mockTouchConnection).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(30_000);
     expect(mockTouchConnection).toHaveBeenCalledTimes(1);
-    expect(mockTouchConnection).toHaveBeenCalledWith(companyUuid, connectionUuid);
+    expect(mockTouchConnection).toHaveBeenCalledWith(companyUuid, connHandle);
 
     await vi.advanceTimersByTimeAsync(30_000);
     expect(mockTouchConnection).toHaveBeenCalledTimes(2);
@@ -147,7 +150,7 @@ describe("GET /api/events/notifications (notification SSE)", () => {
     await Promise.resolve();
 
     expect(mockMarkDisconnected).toHaveBeenCalledTimes(1);
-    expect(mockMarkDisconnected).toHaveBeenCalledWith(companyUuid, connectionUuid);
+    expect(mockMarkDisconnected).toHaveBeenCalledWith(companyUuid, connHandle);
     expect(mockEventBus.off).toHaveBeenCalledWith(
       `notification:agent:${actorUuid}`,
       expect.any(Function),

--- a/src/app/api/events/notifications/route.ts
+++ b/src/app/api/events/notifications/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
   // null, the lifecycle below is skipped and the route behaves exactly as before
   // (no DaemonConnection row is written).
   const report = parseSelfReport(request.nextUrl.searchParams);
-  const connUuid = await registerConnection(auth.companyUuid, auth.actorUuid, report);
+  const conn = await registerConnection(auth.companyUuid, auth.actorUuid, report);
 
   const userKey = `${auth.type}:${auth.actorUuid}`;
   const encoder = new TextEncoder();
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
         send(": heartbeat\n\n");
         // Liveness safety net: bump lastSeenAt. Fire-and-forget — the service
         // swallows + logs its own errors and never throws.
-        if (connUuid) void touchConnection(auth.companyUuid, connUuid);
+        if (conn) void touchConnection(auth.companyUuid, conn);
       }, 30_000);
 
       // Cleanup on abort (client disconnect)
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
         }
         // Primary disconnect signal: mark the registry row offline.
         // Fire-and-forget — never throws to the client.
-        if (connUuid) void markDisconnected(auth.companyUuid, connUuid);
+        if (conn) void markDisconnected(auth.companyUuid, conn);
       });
     },
   });

--- a/src/app/api/events/notifications/route.ts
+++ b/src/app/api/events/notifications/route.ts
@@ -4,6 +4,12 @@
 
 import { getAuthContext } from "@/lib/auth";
 import { eventBus } from "@/lib/event-bus";
+import {
+  parseSelfReport,
+  registerConnection,
+  touchConnection,
+  markDisconnected,
+} from "@/services/daemon-connection.service";
 import { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +19,14 @@ export async function GET(request: NextRequest) {
   if (!auth) {
     return new Response("Unauthorized", { status: 401 });
   }
+
+  // Self-report registry (auth is already settled above — these query params
+  // are read AFTER auth and never influence the authorization outcome).
+  // connUuid is null for non-daemon (browser/unknown/absent) clientType; when
+  // null, the lifecycle below is skipped and the route behaves exactly as before
+  // (no DaemonConnection row is written).
+  const report = parseSelfReport(request.nextUrl.searchParams);
+  const connUuid = await registerConnection(auth.companyUuid, auth.actorUuid, report);
 
   const userKey = `${auth.type}:${auth.actorUuid}`;
   const encoder = new TextEncoder();
@@ -40,6 +54,9 @@ export async function GET(request: NextRequest) {
       // Heartbeat every 30s to keep connection alive
       const heartbeat = setInterval(() => {
         send(": heartbeat\n\n");
+        // Liveness safety net: bump lastSeenAt. Fire-and-forget — the service
+        // swallows + logs its own errors and never throws.
+        if (connUuid) void touchConnection(auth.companyUuid, connUuid);
       }, 30_000);
 
       // Cleanup on abort (client disconnect)
@@ -51,6 +68,9 @@ export async function GET(request: NextRequest) {
         } catch {
           // Already closed
         }
+        // Primary disconnect signal: mark the registry row offline.
+        // Fire-and-forget — never throws to the client.
+        if (connUuid) void markDisconnected(auth.companyUuid, connUuid);
       });
     },
   });

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
   // null, the lifecycle below is skipped and the route behaves exactly as before
   // (no DaemonConnection row is written).
   const report = parseSelfReport(request.nextUrl.searchParams);
-  const connUuid = await registerConnection(auth.companyUuid, auth.actorUuid, report);
+  const conn = await registerConnection(auth.companyUuid, auth.actorUuid, report);
 
   const stream = new ReadableStream({
     start(controller) {
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
         send(": heartbeat\n\n");
         // Liveness safety net: bump lastSeenAt. Fire-and-forget — the service
         // swallows + logs its own errors and never throws.
-        if (connUuid) void touchConnection(auth.companyUuid, connUuid);
+        if (conn) void touchConnection(auth.companyUuid, conn);
       }, 30_000);
 
       // Cleanup on abort (client disconnect)
@@ -89,7 +89,7 @@ export async function GET(request: NextRequest) {
         }
         // Primary disconnect signal: mark the registry row offline.
         // Fire-and-forget — never throws to the client.
-        if (connUuid) void markDisconnected(auth.companyUuid, connUuid);
+        if (conn) void markDisconnected(auth.companyUuid, conn);
       });
     },
   });

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -4,6 +4,12 @@
 
 import { getAuthContext } from "@/lib/auth";
 import { eventBus, type RealtimeEvent, type PresenceEvent } from "@/lib/event-bus";
+import {
+  parseSelfReport,
+  registerConnection,
+  touchConnection,
+  markDisconnected,
+} from "@/services/daemon-connection.service";
 import { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -15,6 +21,14 @@ export async function GET(request: NextRequest) {
   }
 
   const projectUuid = request.nextUrl.searchParams.get("projectUuid");
+
+  // Self-report registry (auth is already settled above — these query params
+  // are read AFTER auth and never influence the authorization outcome).
+  // connUuid is null for non-daemon (browser/unknown/absent) clientType; when
+  // null, the lifecycle below is skipped and the route behaves exactly as before
+  // (no DaemonConnection row is written).
+  const report = parseSelfReport(request.nextUrl.searchParams);
+  const connUuid = await registerConnection(auth.companyUuid, auth.actorUuid, report);
 
   const stream = new ReadableStream({
     start(controller) {
@@ -58,6 +72,9 @@ export async function GET(request: NextRequest) {
       // Heartbeat every 30s to keep connection alive
       const heartbeat = setInterval(() => {
         send(": heartbeat\n\n");
+        // Liveness safety net: bump lastSeenAt. Fire-and-forget — the service
+        // swallows + logs its own errors and never throws.
+        if (connUuid) void touchConnection(auth.companyUuid, connUuid);
       }, 30_000);
 
       // Cleanup on abort (client disconnect)
@@ -70,6 +87,9 @@ export async function GET(request: NextRequest) {
         } catch {
           // Already closed
         }
+        // Primary disconnect signal: mark the registry row offline.
+        // Fire-and-forget — never throws to the client.
+        if (connUuid) void markDisconnected(auth.companyUuid, connUuid);
       });
     },
   });

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -31,6 +31,8 @@ import {
 const companyUuid = "company-0000-0000-0000-000000000001";
 const agentUuid = "agent-0000-0000-0000-000000000001";
 const connectionUuid = "conn-0000-0000-0000-000000000001";
+const connectedAt = new Date("2026-06-15T03:00:00.000Z");
+const handle = { uuid: connectionUuid, connectedAt };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -91,8 +93,8 @@ describe("parseSelfReport", () => {
 
 // ===== registerConnection =====
 describe("registerConnection", () => {
-  it("writes an online row for a daemon clientType and returns its uuid", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+  it("writes an online row for a daemon clientType and returns a {uuid, connectedAt} handle", async () => {
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
     const report: SelfReport = {
       clientType: "claude_code",
       clientVersion: "0.11.0",
@@ -102,7 +104,7 @@ describe("registerConnection", () => {
 
     const result = await registerConnection(companyUuid, agentUuid, report);
 
-    expect(result).toBe(connectionUuid);
+    expect(result).toEqual({ uuid: connectionUuid, connectedAt });
     expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
     const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
     // Upsert key is the composite unique (agentUuid, clientType, host).
@@ -118,19 +120,23 @@ describe("registerConnection", () => {
     expect(arg.create.host).toBe("mac.local");
     expect(arg.create.connectedAt).toBeInstanceOf(Date);
     expect(arg.create.lastSeenAt).toBeInstanceOf(Date);
-    // update branch flips back to online + clears disconnectedAt
+    // update branch flips back to online + clears disconnectedAt + refreshes
+    // connectedAt (the fencing token for an older generation's late calls).
     expect(arg.update.status).toBe("online");
     expect(arg.update.disconnectedAt).toBeNull();
+    expect(arg.update.connectedAt).toBeInstanceOf(Date);
     expect(arg.update.companyUuid).toBe(companyUuid);
+    // The handle's connectedAt comes from the persisted row, not the local clock.
+    expect(arg.select).toEqual({ uuid: true, connectedAt: true });
   });
 
   it("registers an openclaw clientType", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
     const result = await registerConnection(companyUuid, agentUuid, {
       clientType: "openclaw",
       host: "linux-box",
     });
-    expect(result).toBe(connectionUuid);
+    expect(result).toEqual({ uuid: connectionUuid, connectedAt });
     expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
   });
 
@@ -158,14 +164,14 @@ describe("registerConnection", () => {
   });
 
   it("upserts the same (agentUuid, clientType, host) row on reconnect rather than inserting", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
     const report: SelfReport = { clientType: "claude_code", host: "mac.local" };
 
     const first = await registerConnection(companyUuid, agentUuid, report);
     const second = await registerConnection(companyUuid, agentUuid, report);
 
-    expect(first).toBe(connectionUuid);
-    expect(second).toBe(connectionUuid);
+    expect(first).toEqual({ uuid: connectionUuid, connectedAt });
+    expect(second).toEqual({ uuid: connectionUuid, connectedAt });
     // Two upsert calls, both keyed on the same composite — never .create.
     expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(2);
     const firstWhere = mockPrisma.daemonConnection.upsert.mock.calls[0][0].where;
@@ -174,7 +180,7 @@ describe("registerConnection", () => {
   });
 
   it("defaults a missing host to '' so the composite key stays deterministic", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
     await registerConnection(companyUuid, agentUuid, { clientType: "claude_code" });
     const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
     expect(arg.where.agentUuid_clientType_host.host).toBe("");
@@ -182,7 +188,7 @@ describe("registerConnection", () => {
   });
 
   it("coerces missing clientVersion/startedAt to null", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
     await registerConnection(companyUuid, agentUuid, {
       clientType: "claude_code",
       host: "h",
@@ -205,38 +211,54 @@ describe("registerConnection", () => {
 
 // ===== markDisconnected =====
 describe("markDisconnected", () => {
-  it("sets status=offline + disconnectedAt, scoped by companyUuid + uuid", async () => {
+  it("sets status=offline + disconnectedAt, fenced by companyUuid + uuid + connectedAt", async () => {
     mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 1 });
-    await markDisconnected(companyUuid, connectionUuid);
+    await markDisconnected(companyUuid, handle);
     expect(mockPrisma.daemonConnection.updateMany).toHaveBeenCalledTimes(1);
     const arg = mockPrisma.daemonConnection.updateMany.mock.calls[0][0];
-    expect(arg.where).toEqual({ uuid: connectionUuid, companyUuid });
+    // connectedAt in the where clause is the generation fence: a stale abort
+    // from an older generation matches 0 rows once the row has been re-registered.
+    expect(arg.where).toEqual({ uuid: connectionUuid, companyUuid, connectedAt });
     expect(arg.data.status).toBe("offline");
     expect(arg.data.disconnectedAt).toBeInstanceOf(Date);
   });
 
+  it("matches 0 rows (no-op) when a newer generation has refreshed connectedAt", async () => {
+    // The conditional update simply affects 0 rows — the service neither throws
+    // nor logs an error for the stale-abort case.
+    mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 0 });
+    await expect(markDisconnected(companyUuid, handle)).resolves.toBeUndefined();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
   it("swallows + logs a persistence error (never throws)", async () => {
     mockPrisma.daemonConnection.updateMany.mockRejectedValue(new Error("db down"));
-    await expect(markDisconnected(companyUuid, connectionUuid)).resolves.toBeUndefined();
+    await expect(markDisconnected(companyUuid, handle)).resolves.toBeUndefined();
     expect(mockLogger.error).toHaveBeenCalledTimes(1);
   });
 });
 
 // ===== touchConnection =====
 describe("touchConnection", () => {
-  it("bumps lastSeenAt and ensures status=online, scoped by companyUuid + uuid", async () => {
+  it("bumps lastSeenAt and ensures status=online, fenced by companyUuid + uuid + connectedAt", async () => {
     mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 1 });
-    await touchConnection(companyUuid, connectionUuid);
+    await touchConnection(companyUuid, handle);
     expect(mockPrisma.daemonConnection.updateMany).toHaveBeenCalledTimes(1);
     const arg = mockPrisma.daemonConnection.updateMany.mock.calls[0][0];
-    expect(arg.where).toEqual({ uuid: connectionUuid, companyUuid });
+    expect(arg.where).toEqual({ uuid: connectionUuid, companyUuid, connectedAt });
     expect(arg.data.status).toBe("online");
     expect(arg.data.lastSeenAt).toBeInstanceOf(Date);
   });
 
+  it("matches 0 rows (no-op) when a newer generation has refreshed connectedAt", async () => {
+    mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 0 });
+    await expect(touchConnection(companyUuid, handle)).resolves.toBeUndefined();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
   it("swallows + logs a persistence error (never throws)", async () => {
     mockPrisma.daemonConnection.updateMany.mockRejectedValue(new Error("db down"));
-    await expect(touchConnection(companyUuid, connectionUuid)).resolves.toBeUndefined();
+    await expect(touchConnection(companyUuid, handle)).resolves.toBeUndefined();
     expect(mockLogger.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Prisma mock =====
+const mockPrisma = vi.hoisted(() => ({
+  daemonConnection: {
+    upsert: vi.fn(),
+    updateMany: vi.fn(),
+  },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({ default: mockLogger }));
+
+import {
+  DAEMON_CLIENT_TYPES,
+  STALE_THRESHOLD_MS,
+  parseSelfReport,
+  registerConnection,
+  markDisconnected,
+  touchConnection,
+  type SelfReport,
+} from "@/services/daemon-connection.service";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+// ===== Constants =====
+describe("constants", () => {
+  it("DAEMON_CLIENT_TYPES are exactly claude_code + openclaw", () => {
+    expect(DAEMON_CLIENT_TYPES).toEqual(["claude_code", "openclaw"]);
+  });
+
+  it("STALE_THRESHOLD_MS is 90s (3x the 30s heartbeat)", () => {
+    expect(STALE_THRESHOLD_MS).toBe(90_000);
+    expect(STALE_THRESHOLD_MS).toBe(3 * 30_000);
+  });
+});
+
+// ===== parseSelfReport =====
+describe("parseSelfReport", () => {
+  it("parses all params including a valid ISO-8601 startedAt", () => {
+    const params = new URLSearchParams({
+      clientType: "claude_code",
+      clientVersion: "0.11.0",
+      host: "mac.local",
+      startedAt: "2026-06-15T03:00:00.000Z",
+    });
+    const report = parseSelfReport(params);
+    expect(report.clientType).toBe("claude_code");
+    expect(report.clientVersion).toBe("0.11.0");
+    expect(report.host).toBe("mac.local");
+    expect(report.startedAt).toBeInstanceOf(Date);
+    expect(report.startedAt?.toISOString()).toBe("2026-06-15T03:00:00.000Z");
+  });
+
+  it("defaults missing string params: clientType='' and nullable fields null", () => {
+    const report = parseSelfReport(new URLSearchParams());
+    expect(report.clientType).toBe("");
+    expect(report.clientVersion).toBeNull();
+    expect(report.host).toBeNull();
+    expect(report.startedAt).toBeNull();
+  });
+
+  it("parses an unparseable startedAt to null (no Invalid Date)", () => {
+    const params = new URLSearchParams({
+      clientType: "openclaw",
+      startedAt: "not-a-date",
+    });
+    const report = parseSelfReport(params);
+    expect(report.startedAt).toBeNull();
+  });
+
+  it("parses an empty-string startedAt to null", () => {
+    const params = new URLSearchParams({ clientType: "claude_code", startedAt: "" });
+    expect(parseSelfReport(params).startedAt).toBeNull();
+  });
+});
+
+// ===== registerConnection =====
+describe("registerConnection", () => {
+  it("writes an online row for a daemon clientType and returns its uuid", async () => {
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    const report: SelfReport = {
+      clientType: "claude_code",
+      clientVersion: "0.11.0",
+      host: "mac.local",
+      startedAt: new Date("2026-06-15T03:00:00.000Z"),
+    };
+
+    const result = await registerConnection(companyUuid, agentUuid, report);
+
+    expect(result).toBe(connectionUuid);
+    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+    const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
+    // Upsert key is the composite unique (agentUuid, clientType, host).
+    expect(arg.where).toEqual({
+      agentUuid_clientType_host: {
+        agentUuid,
+        clientType: "claude_code",
+        host: "mac.local",
+      },
+    });
+    expect(arg.create.status).toBe("online");
+    expect(arg.create.companyUuid).toBe(companyUuid);
+    expect(arg.create.host).toBe("mac.local");
+    expect(arg.create.connectedAt).toBeInstanceOf(Date);
+    expect(arg.create.lastSeenAt).toBeInstanceOf(Date);
+    // update branch flips back to online + clears disconnectedAt
+    expect(arg.update.status).toBe("online");
+    expect(arg.update.disconnectedAt).toBeNull();
+    expect(arg.update.companyUuid).toBe(companyUuid);
+  });
+
+  it("registers an openclaw clientType", async () => {
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    const result = await registerConnection(companyUuid, agentUuid, {
+      clientType: "openclaw",
+      host: "linux-box",
+    });
+    expect(result).toBe(connectionUuid);
+    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null and writes nothing for a non-daemon clientType (browser)", async () => {
+    const result = await registerConnection(companyUuid, agentUuid, {
+      clientType: "browser",
+      host: "mac.local",
+    });
+    expect(result).toBeNull();
+    expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns null and writes nothing for an unrecognized clientType", async () => {
+    const result = await registerConnection(companyUuid, agentUuid, {
+      clientType: "something-else",
+    });
+    expect(result).toBeNull();
+    expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns null and writes nothing for an empty clientType", async () => {
+    const result = await registerConnection(companyUuid, agentUuid, { clientType: "" });
+    expect(result).toBeNull();
+    expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+  });
+
+  it("upserts the same (agentUuid, clientType, host) row on reconnect rather than inserting", async () => {
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    const report: SelfReport = { clientType: "claude_code", host: "mac.local" };
+
+    const first = await registerConnection(companyUuid, agentUuid, report);
+    const second = await registerConnection(companyUuid, agentUuid, report);
+
+    expect(first).toBe(connectionUuid);
+    expect(second).toBe(connectionUuid);
+    // Two upsert calls, both keyed on the same composite — never .create.
+    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(2);
+    const firstWhere = mockPrisma.daemonConnection.upsert.mock.calls[0][0].where;
+    const secondWhere = mockPrisma.daemonConnection.upsert.mock.calls[1][0].where;
+    expect(firstWhere).toEqual(secondWhere);
+  });
+
+  it("defaults a missing host to '' so the composite key stays deterministic", async () => {
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    await registerConnection(companyUuid, agentUuid, { clientType: "claude_code" });
+    const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
+    expect(arg.where.agentUuid_clientType_host.host).toBe("");
+    expect(arg.create.host).toBe("");
+  });
+
+  it("coerces missing clientVersion/startedAt to null", async () => {
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid });
+    await registerConnection(companyUuid, agentUuid, {
+      clientType: "claude_code",
+      host: "h",
+    });
+    const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
+    expect(arg.create.clientVersion).toBeNull();
+    expect(arg.create.startedAt).toBeNull();
+  });
+
+  it("swallows + logs a persistence error and returns null (never throws)", async () => {
+    mockPrisma.daemonConnection.upsert.mockRejectedValue(new Error("db down"));
+    const result = await registerConnection(companyUuid, agentUuid, {
+      clientType: "claude_code",
+      host: "mac.local",
+    });
+    expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===== markDisconnected =====
+describe("markDisconnected", () => {
+  it("sets status=offline + disconnectedAt, scoped by companyUuid + uuid", async () => {
+    mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 1 });
+    await markDisconnected(companyUuid, connectionUuid);
+    expect(mockPrisma.daemonConnection.updateMany).toHaveBeenCalledTimes(1);
+    const arg = mockPrisma.daemonConnection.updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ uuid: connectionUuid, companyUuid });
+    expect(arg.data.status).toBe("offline");
+    expect(arg.data.disconnectedAt).toBeInstanceOf(Date);
+  });
+
+  it("swallows + logs a persistence error (never throws)", async () => {
+    mockPrisma.daemonConnection.updateMany.mockRejectedValue(new Error("db down"));
+    await expect(markDisconnected(companyUuid, connectionUuid)).resolves.toBeUndefined();
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===== touchConnection =====
+describe("touchConnection", () => {
+  it("bumps lastSeenAt and ensures status=online, scoped by companyUuid + uuid", async () => {
+    mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 1 });
+    await touchConnection(companyUuid, connectionUuid);
+    expect(mockPrisma.daemonConnection.updateMany).toHaveBeenCalledTimes(1);
+    const arg = mockPrisma.daemonConnection.updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ uuid: connectionUuid, companyUuid });
+    expect(arg.data.status).toBe("online");
+    expect(arg.data.lastSeenAt).toBeInstanceOf(Date);
+  });
+
+  it("swallows + logs a persistence error (never throws)", async () => {
+    mockPrisma.daemonConnection.updateMany.mockRejectedValue(new Error("db down"));
+    await expect(touchConnection(companyUuid, connectionUuid)).resolves.toBeUndefined();
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -39,6 +39,20 @@ export interface SelfReport {
   startedAt?: Date | null;
 }
 
+/**
+ * Handle returned by `registerConnection`, identifying a specific connection
+ * *generation*. `connectedAt` is a fencing token: each (re)registration stamps a
+ * fresh `connectedAt` on the row, and the per-connection lifecycle calls
+ * (`touchConnection` / `markDisconnected`) only act on the row while it still
+ * carries the same `connectedAt`. This isolates connection generations: once a
+ * newer connection refreshes the row, an older generation's lingering heartbeat
+ * or late `abort` becomes a no-op instead of corrupting the newer row's status.
+ */
+export interface ConnectionHandle {
+  uuid: string;
+  connectedAt: Date;
+}
+
 // ===== Helpers =====
 
 function isDaemonClientType(value: string): value is DaemonClientType {
@@ -78,7 +92,8 @@ export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
 /**
  * Register (upsert) a daemon connection as `online`.
  *
- * Returns the row uuid on success, or `null` when:
+ * Returns a `ConnectionHandle` (`{ uuid, connectedAt }`) on success, or `null`
+ * when:
  *  - the clientType is not a recognized daemon type (the caller then skips the
  *    rest of the lifecycle — no touch / no markDisconnected), or
  *  - the persistence write fails (swallowed + logged).
@@ -89,12 +104,19 @@ export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
  * defaults to "" so the composite unique key is deterministic even for a
  * host-less self-report (Prisma treats null as distinct, which would defeat the
  * dedup — see schema comment).
+ *
+ * The returned `connectedAt` is the fencing token for the lifecycle calls: it is
+ * stamped fresh on every (re)registration, so a later reconnect's `connectedAt`
+ * differs from an earlier generation's. `touchConnection` / `markDisconnected`
+ * gate on it, so an older connection's late `abort` or lingering heartbeat
+ * cannot flip the newer generation's row (the "stale-abort-resurrects-offline"
+ * race).
  */
 export async function registerConnection(
   companyUuid: string,
   agentUuid: string,
   report: SelfReport,
-): Promise<string | null> {
+): Promise<ConnectionHandle | null> {
   if (!isDaemonClientType(report.clientType)) {
     return null;
   }
@@ -133,9 +155,9 @@ export async function registerConnection(
         lastSeenAt: now,
         disconnectedAt: null,
       },
-      select: { uuid: true },
+      select: { uuid: true, connectedAt: true },
     });
-    return row.uuid;
+    return { uuid: row.uuid, connectedAt: row.connectedAt };
   } catch (err) {
     logger.error(
       { err, companyUuid, agentUuid, clientType: report.clientType },
@@ -147,21 +169,24 @@ export async function registerConnection(
 
 /**
  * Mark a connection `offline` with `disconnectedAt = now` (primary disconnect
- * signal: the SSE stream's `abort` event). companyUuid-scoped. Swallows + logs
- * on failure; never throws to the caller.
+ * signal: the SSE stream's `abort` event). companyUuid-scoped and fenced on
+ * `connectedAt`: if a newer connection generation has since re-registered the
+ * row (refreshing `connectedAt`), this update matches 0 rows and is a no-op, so
+ * a stale `abort` from an old generation never flips a freshly-online row to
+ * `offline`. Swallows + logs on failure; never throws to the caller.
  */
 export async function markDisconnected(
   companyUuid: string,
-  connectionUuid: string,
+  handle: ConnectionHandle,
 ): Promise<void> {
   try {
     await prisma.daemonConnection.updateMany({
-      where: { uuid: connectionUuid, companyUuid },
+      where: { uuid: handle.uuid, companyUuid, connectedAt: handle.connectedAt },
       data: { status: "offline", disconnectedAt: new Date() },
     });
   } catch (err) {
     logger.error(
-      { err, companyUuid, connectionUuid },
+      { err, companyUuid, connectionUuid: handle.uuid },
       "Failed to mark daemon connection disconnected",
     );
   }
@@ -169,20 +194,24 @@ export async function markDisconnected(
 
 /**
  * Heartbeat tick → bump `lastSeenAt` (and ensure status stays `online`).
- * companyUuid-scoped. Swallows + logs on failure; never throws to the caller.
+ * companyUuid-scoped and fenced on `connectedAt`: a heartbeat from an old
+ * connection generation (whose row has since been re-registered by a newer
+ * generation) matches 0 rows and is a no-op, so it cannot resurrect or keep
+ * alive a row that now belongs to a different connection. Swallows + logs on
+ * failure; never throws to the caller.
  */
 export async function touchConnection(
   companyUuid: string,
-  connectionUuid: string,
+  handle: ConnectionHandle,
 ): Promise<void> {
   try {
     await prisma.daemonConnection.updateMany({
-      where: { uuid: connectionUuid, companyUuid },
+      where: { uuid: handle.uuid, companyUuid, connectedAt: handle.connectedAt },
       data: { status: "online", lastSeenAt: new Date() },
     });
   } catch (err) {
     logger.error(
-      { err, companyUuid, connectionUuid },
+      { err, companyUuid, connectionUuid: handle.uuid },
       "Failed to touch daemon connection",
     );
   }

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -1,0 +1,189 @@
+// src/services/daemon-connection.service.ts
+// Daemon Connection Registry Service — persistence layer for long-lived daemon
+// SSE connections. Collection + liveness only: no read/query API, no HTTP/MCP
+// endpoint, no AgentSession link, no UI (those are deferred to idea f2fe9a7f).
+//
+// All functions are companyUuid-scoped and swallow-and-log on failure: a registry
+// write must NEVER throw to the caller, so a failing DB write can never block or
+// break SSE stream setup / event delivery.
+
+import { prisma } from "@/lib/prisma";
+import logger from "@/lib/logger";
+
+// ===== Constants =====
+
+// Recognized daemon client types eligible for registration in this change.
+// The `clientType` column also reserves "browser" / "other" (see schema) so
+// browser registration can be added later without a migration, but only these
+// machine daemon types are registered now.
+export const DAEMON_CLIENT_TYPES = ["claude_code", "openclaw"] as const;
+export type DaemonClientType = (typeof DAEMON_CLIENT_TYPES)[number];
+
+// Staleness threshold for the liveness rule a downstream reader MUST apply:
+// a connection is *effectively online* iff status === "online" AND
+// (now - lastSeenAt) <= STALE_THRESHOLD_MS.
+//
+// Derivation: the SSE routes bump lastSeenAt from their existing 30s heartbeat
+// interval. 90s = 3 × 30s tolerates one fully-missed tick (plus jitter) before
+// a still-"online" row is treated as stale, while reaping a hard-crashed
+// instance's row within ~1.5 heartbeat windows. This change only exports the
+// constant; the reader (f2fe9a7f) applies it.
+export const STALE_THRESHOLD_MS = 90_000;
+
+// ===== Types =====
+
+export interface SelfReport {
+  clientType: string; // raw query value; gated against DAEMON_CLIENT_TYPES
+  clientVersion?: string | null;
+  host?: string | null;
+  startedAt?: Date | null;
+}
+
+// ===== Helpers =====
+
+function isDaemonClientType(value: string): value is DaemonClientType {
+  return (DAEMON_CLIENT_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Parse the optional self-report query params off an SSE request URL.
+ *
+ * `startedAt` is parsed defensively from ISO-8601 → Date | null: an absent or
+ * unparseable value yields null rather than an `Invalid Date`.
+ */
+export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
+  const clientType = searchParams.get("clientType") ?? "";
+  const clientVersion = searchParams.get("clientVersion");
+  const host = searchParams.get("host");
+
+  let startedAt: Date | null = null;
+  const startedAtRaw = searchParams.get("startedAt");
+  if (startedAtRaw) {
+    const parsed = new Date(startedAtRaw);
+    if (!Number.isNaN(parsed.getTime())) {
+      startedAt = parsed;
+    }
+  }
+
+  return {
+    clientType,
+    clientVersion: clientVersion ?? null,
+    host: host ?? null,
+    startedAt,
+  };
+}
+
+// ===== Service functions =====
+
+/**
+ * Register (upsert) a daemon connection as `online`.
+ *
+ * Returns the row uuid on success, or `null` when:
+ *  - the clientType is not a recognized daemon type (the caller then skips the
+ *    rest of the lifecycle — no touch / no markDisconnected), or
+ *  - the persistence write fails (swallowed + logged).
+ *
+ * Idempotent per logical daemon: keyed on (agentUuid, clientType, host). A
+ * reconnect refreshes the existing row (status→online, connectedAt/lastSeenAt
+ * refreshed, disconnectedAt cleared) rather than inserting a new one. `host`
+ * defaults to "" so the composite unique key is deterministic even for a
+ * host-less self-report (Prisma treats null as distinct, which would defeat the
+ * dedup — see schema comment).
+ */
+export async function registerConnection(
+  companyUuid: string,
+  agentUuid: string,
+  report: SelfReport,
+): Promise<string | null> {
+  if (!isDaemonClientType(report.clientType)) {
+    return null;
+  }
+
+  const host = report.host ?? "";
+  const now = new Date();
+
+  try {
+    const row = await prisma.daemonConnection.upsert({
+      where: {
+        agentUuid_clientType_host: {
+          agentUuid,
+          clientType: report.clientType,
+          host,
+        },
+      },
+      create: {
+        companyUuid,
+        agentUuid,
+        clientType: report.clientType,
+        clientVersion: report.clientVersion ?? null,
+        host,
+        startedAt: report.startedAt ?? null,
+        status: "online",
+        connectedAt: now,
+        lastSeenAt: now,
+        disconnectedAt: null,
+      },
+      update: {
+        // Multi-tenancy: re-affirm companyUuid from the authenticated context.
+        companyUuid,
+        clientVersion: report.clientVersion ?? null,
+        startedAt: report.startedAt ?? null,
+        status: "online",
+        connectedAt: now,
+        lastSeenAt: now,
+        disconnectedAt: null,
+      },
+      select: { uuid: true },
+    });
+    return row.uuid;
+  } catch (err) {
+    logger.error(
+      { err, companyUuid, agentUuid, clientType: report.clientType },
+      "Failed to register daemon connection",
+    );
+    return null;
+  }
+}
+
+/**
+ * Mark a connection `offline` with `disconnectedAt = now` (primary disconnect
+ * signal: the SSE stream's `abort` event). companyUuid-scoped. Swallows + logs
+ * on failure; never throws to the caller.
+ */
+export async function markDisconnected(
+  companyUuid: string,
+  connectionUuid: string,
+): Promise<void> {
+  try {
+    await prisma.daemonConnection.updateMany({
+      where: { uuid: connectionUuid, companyUuid },
+      data: { status: "offline", disconnectedAt: new Date() },
+    });
+  } catch (err) {
+    logger.error(
+      { err, companyUuid, connectionUuid },
+      "Failed to mark daemon connection disconnected",
+    );
+  }
+}
+
+/**
+ * Heartbeat tick → bump `lastSeenAt` (and ensure status stays `online`).
+ * companyUuid-scoped. Swallows + logs on failure; never throws to the caller.
+ */
+export async function touchConnection(
+  companyUuid: string,
+  connectionUuid: string,
+): Promise<void> {
+  try {
+    await prisma.daemonConnection.updateMany({
+      where: { uuid: connectionUuid, companyUuid },
+      data: { status: "online", lastSeenAt: new Date() },
+    });
+  } catch (err) {
+    logger.error(
+      { err, companyUuid, connectionUuid },
+      "Failed to touch daemon connection",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes idea **c152dcfc** ("SSE 连接自报元数据"). Makes long-lived daemon SSE connections **self-report** client metadata at connect time, and persists them server-side in a new `DaemonConnection` registry with reliable online/offline tracking.

This is deliberately the **data-collection + liveness layer only**. The read API, the Daemons observability UI, the per-connection session view, and the `AgentSession` linkage are all left to the derived idea **f2fe9a7f** (which this unblocks).

## How it works

- **Self-report contract** — clients append `?clientType=…&clientVersion=…&host=…&startedAt=…` to the SSE URL. Query params (not headers) so a future browser `EventSource`, which can't set headers, can use the same path. These params are display-only and **never** participate in auth (auth stays Bearer/cookie).
- **DB-backed registry** — a `DaemonConnection` row per logical daemon. DB (not in-memory/Redis) because prod runs 2 ECS tasks behind an ALB: a connection pinned to one instance must be visible to a query landing on the other. Reconnects upsert on `(agentUuid, clientType, host)`.
- **Liveness** — `abort` is the primary signal (graceful disconnect → `offline` immediately). The SSE route's existing 30s heartbeat interval also bumps `lastSeenAt`; since that interval dies with the instance process, it doubles as the instance-crash safety net (`status=online && lastSeenAt` fresh within ~90s = effectively online). **No client heartbeat added.**
- **Two clients self-report** — chorus CLI → `clientType=claude_code`, OpenClaw plugin → `clientType=openclaw` (versions read from each package.json).

## Backward compatibility

An old client or a browser that connects with **no `clientType`** (or an unknown one, or malformed params) connects **exactly as before** and writes no registry row. `parseSelfReport` never throws on absent/garbage input; `registerConnection` returns null before any DB write for non-daemon client types.

## Changed files

| File | Change |
|------|--------|
| `prisma/schema.prisma` + migration | New `DaemonConnection` model (DDL-only migration via Prisma CLI) |
| `src/services/daemon-connection.service.ts` (+ test) | register / markDisconnected / touchConnection, companyUuid-scoped, fire-and-forget |
| `src/app/api/events/route.ts`, `…/notifications/route.ts` (+ tests) | register on connect, offline on abort, touch on heartbeat |
| `cli/sse-listener.mjs` (+ test) | self-report `claude_code` |
| `packages/openclaw-plugin/src/sse-listener.ts` (+ test) | self-report `openclaw` |
| `openspec/specs/*`, `openspec/changes/archive/*` | archived OpenSpec change + cumulative specs |

## Test plan

- [x] `daemon-connection.service` unit tests (Prisma mocked): register/upsert/disconnect/touch/swallowed-error — 100% coverage on the new service
- [x] Both SSE route tests: daemon register-on-connect + touch-on-heartbeat + offline-on-abort; no-clientType connection still streams, writes nothing
- [x] Both client tests: URL self-report params + version-from-package.json + reconnect re-sends
- [x] Live E2E: real chorus CLI daemon → row appears online → `lastSeenAt` advances on tick → graceful shutdown → offline + `disconnectedAt` → reconnect refreshes same row → parallel openclaw → distinct row
- [x] Full suite green (2031 passed / 1 skipped); `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)