### PR TITLE
feat(agent-connections): owner-scoped observability page + read API

### DIFF
--- a/docs/design.pen
+++ b/docs/design.pen
@@ -90270,6 +90270,1130 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "w2vg0Y",
+      "x": 12740,
+      "y": 0,
+      "name": "Chorus - Daemons",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#FAF8F4",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Ealss",
+          "name": "Sidebar",
+          "width": 220,
+          "height": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#E5E2DC",
+          "strokeWidth": {
+            "right": 1
+          },
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            24,
+            20
+          ],
+          "justifyContent": "space_between",
+          "children": [
+            {
+              "type": "frame",
+              "id": "I38RvV",
+              "name": "Sidebar Top",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 32,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "bfa13",
+                  "name": "Logo",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 4,
+                      "id": "bKURw",
+                      "name": "logoMark",
+                      "fill": "#C67A52",
+                      "width": 28,
+                      "height": 28
+                    },
+                    {
+                      "type": "text",
+                      "id": "lCZAl",
+                      "name": "logoText",
+                      "fill": "#2C2C2C",
+                      "content": "Chorus",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D6ht03",
+                  "name": "Navigation",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "uCght",
+                      "name": "navProjects",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "VxFtk",
+                          "name": "ProjectsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "folder",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Q8vJUC",
+                          "name": "ProjectsText",
+                          "fill": "#6B6B6B",
+                          "content": "Projects",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pSJk2",
+                      "name": "navActivity",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "IeUzo",
+                          "name": "ActivityIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "activity",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "JxjyR",
+                          "name": "ActivityText",
+                          "fill": "#6B6B6B",
+                          "content": "Activity",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CTXPN",
+                      "name": "navDaemons",
+                      "width": "fill_container",
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "s1kAE",
+                          "name": "DaemonsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "radio-tower",
+                          "library": "lucide",
+                          "fill": "#2C2C2C"
+                        },
+                        {
+                          "type": "text",
+                          "id": "nZcNw",
+                          "name": "DaemonsText",
+                          "fill": "#2C2C2C",
+                          "content": "Daemons",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VETH7",
+                      "name": "navSettings",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "qs4d5",
+                          "name": "SettingsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "settings",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Wt5GQ",
+                          "name": "SettingsText",
+                          "fill": "#6B6B6B",
+                          "content": "Settings",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "oif85",
+              "name": "Sidebar Bottom",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Y74vf",
+                  "name": "userProfile",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "taVUX",
+                      "name": "avatar",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#C67A52",
+                      "cornerRadius": 18,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "h4BDEI",
+                          "name": "avatarText",
+                          "fill": "#FFFFFF",
+                          "content": "A",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N4ybZS",
+                      "name": "userInfo",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PtoQZ",
+                          "name": "userName",
+                          "fill": "#2C2C2C",
+                          "content": "Alice Chen",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "HZizz",
+                          "name": "userRole",
+                          "fill": "#6B6B6B",
+                          "content": "Tech Lead",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "QUWIj",
+          "name": "Main Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            24,
+            32
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "O9lSi",
+              "name": "Top Bar",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "s0rVJO",
+                  "name": "breadcrumb",
+                  "fill": "#9A9A9A",
+                  "content": "Chorus / Daemons",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "ugp8M",
+                  "name": "topActions",
+                  "gap": 16,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "CXsGO",
+                      "name": "searchIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "search",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "HFEAS",
+                      "name": "bellIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "bell",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "y6Iteh",
+              "name": "Title Row",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "kjxBx",
+                  "name": "Title Section",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "duAxf",
+                      "name": "pageTitle",
+                      "fill": "#2C2C2C",
+                      "content": "Daemons",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 24,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "IKk7y",
+                      "name": "pageSubtitle",
+                      "fill": "#6B6B6B",
+                      "content": "Local agents connected to Chorus on your behalf. Showing your own connections only.",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "J8V2H1",
+                  "name": "Summary",
+                  "gap": 16,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "om9tS",
+                      "name": "2 online",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "lcg6R",
+                          "name": "dot",
+                          "fill": "#22C55E",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "text",
+                          "id": "WbVtL",
+                          "name": "lbl",
+                          "fill": "#6B6B6B",
+                          "content": "2 online",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LscD5",
+                      "name": "1 offline",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "zwHXc",
+                          "name": "dot",
+                          "fill": "#9A9A9A",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "text",
+                          "id": "bxGXp",
+                          "name": "lbl",
+                          "fill": "#6B6B6B",
+                          "content": "1 offline",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "L21Ge",
+              "name": "Connection List",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "id": "YJztY",
+                  "type": "ref",
+                  "ref": "zgnWA",
+                  "name": "conn claude_code online",
+                  "width": "fill_container",
+                  "descendants": {
+                    "zCeLj": {
+                      "icon": "chevron-up"
+                    }
+                  }
+                },
+                {
+                  "id": "knOQ2",
+                  "type": "ref",
+                  "ref": "zgnWA",
+                  "name": "conn openclaw online",
+                  "width": "fill_container",
+                  "descendants": {
+                    "sfLSI": {
+                      "icon": "bot"
+                    },
+                    "QHnl7": {
+                      "content": "openclaw"
+                    },
+                    "iTyRG": {
+                      "content": "v0.11.0"
+                    },
+                    "Tiqqd": {
+                      "content": "build-box-2.local"
+                    },
+                    "VnUj3": {
+                      "content": "1 root-idea session"
+                    },
+                    "Bxzgu": {
+                      "content": "connected 2h ago"
+                    },
+                    "d0GtzS": {
+                      "enabled": false
+                    },
+                    "WYlxF": {
+                      "enabled": false
+                    }
+                  }
+                },
+                {
+                  "id": "MoX9e",
+                  "type": "ref",
+                  "ref": "zgnWA",
+                  "name": "conn claude_code offline",
+                  "width": "fill_container",
+                  "descendants": {
+                    "X89uq5": {
+                      "fill": "#9A9A9A20"
+                    },
+                    "bKbUD": {
+                      "fill": "#9A9A9A"
+                    },
+                    "Gp1cs": {
+                      "content": "offline",
+                      "fill": "#6B6B6B"
+                    },
+                    "Tiqqd": {
+                      "content": "laptop.local"
+                    },
+                    "VnUj3": {
+                      "content": "1 root-idea session"
+                    },
+                    "M8DhhF": {
+                      "icon": "clock-3"
+                    },
+                    "Bxzgu": {
+                      "content": "last seen 3m ago"
+                    },
+                    "d0GtzS": {
+                      "enabled": false
+                    },
+                    "WYlxF": {
+                      "enabled": false
+                    },
+                    "u0zmeE": {
+                      "fill": "#9A9A9A"
+                    },
+                    "o3ZgS": {
+                      "fill": "#9A9A9A"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "zgnWA",
+      "x": 0,
+      "y": -200,
+      "name": "component/Daemon Card",
+      "reusable": true,
+      "width": 760,
+      "fill": "#FFFFFF",
+      "cornerRadius": 12,
+      "stroke": "#E5E0D8",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "yx6so",
+          "name": "Header",
+          "width": "fill_container",
+          "gap": 14,
+          "padding": 18,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "d2Rrp",
+              "name": "clientIconWrap",
+              "width": 40,
+              "height": 40,
+              "fill": "#F5F2EC",
+              "cornerRadius": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "sfLSI",
+                  "name": "clientIcon",
+                  "width": 20,
+                  "height": 20,
+                  "icon": "terminal",
+                  "library": "lucide",
+                  "fill": "#C67A52"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l1Hm0",
+              "name": "IdentityCol",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 5,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Rjmx9",
+                  "name": "NameRow",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "QHnl7",
+                      "name": "clientType",
+                      "fill": "#2C2C2C",
+                      "content": "claude_code",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Z9QDSM",
+                      "name": "versionBadge",
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 4,
+                      "padding": [
+                        2,
+                        7
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "iTyRG",
+                          "name": "versionText",
+                          "fill": "#6B6B6B",
+                          "content": "v0.11.0",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "X89uq5",
+                      "name": "statusBadge",
+                      "fill": "#22C55E20",
+                      "cornerRadius": 4,
+                      "gap": 5,
+                      "padding": [
+                        2,
+                        7
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "bKbUD",
+                          "name": "statusDot",
+                          "fill": "#22C55E",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "Gp1cs",
+                          "name": "statusText",
+                          "fill": "#16A34A",
+                          "content": "online",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IwyUU",
+                  "name": "MetaRow",
+                  "gap": 14,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Hcrim",
+                      "name": "meta_monitor",
+                      "gap": 5,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "tEEYt",
+                          "name": "i",
+                          "width": 13,
+                          "height": 13,
+                          "icon": "monitor",
+                          "library": "lucide",
+                          "fill": "#9A9A9A"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Tiqqd",
+                          "name": "t",
+                          "fill": "#6B6B6B",
+                          "content": "mac-studio.local",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "W2KKI",
+                      "name": "meta_link",
+                      "gap": 5,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "ixO2m",
+                          "name": "i",
+                          "width": 13,
+                          "height": 13,
+                          "icon": "link",
+                          "library": "lucide",
+                          "fill": "#9A9A9A"
+                        },
+                        {
+                          "type": "text",
+                          "id": "VnUj3",
+                          "name": "t",
+                          "fill": "#6B6B6B",
+                          "content": "2 root-idea sessions",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "z7hr2",
+                      "name": "meta_clock",
+                      "gap": 5,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "M8DhhF",
+                          "name": "i",
+                          "width": 13,
+                          "height": 13,
+                          "icon": "clock-3",
+                          "library": "lucide",
+                          "fill": "#9A9A9A"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Bxzgu",
+                          "name": "t",
+                          "fill": "#6B6B6B",
+                          "content": "connected 14m ago",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "icon",
+              "id": "zCeLj",
+              "name": "chevron",
+              "width": 18,
+              "height": 18,
+              "icon": "chevron-down",
+              "library": "lucide",
+              "fill": "#9A9A9A"
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "d0GtzS",
+          "name": "bodyDivider",
+          "fill": "#E5E0D8",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "frame",
+          "id": "WYlxF",
+          "name": "Body",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 10,
+          "padding": [
+            14,
+            18,
+            18,
+            18
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Nv3Cl",
+              "name": "SessionsHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "wjylG",
+                  "name": "sessionsTitle",
+                  "fill": "#2C2C2C",
+                  "content": "Root-idea sessions",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "Zu0y5",
+                  "name": "sessionsCount",
+                  "fill": "#9A9A9A",
+                  "content": "2 sessions",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "lfdvn",
+              "name": "session",
+              "width": "fill_container",
+              "fill": "#FAF8F4",
+              "cornerRadius": 10,
+              "stroke": "#E5E2DC",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 12,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "u0zmeE",
+                  "name": "ideaIcon",
+                  "width": 15,
+                  "height": 15,
+                  "icon": "lightbulb",
+                  "library": "lucide",
+                  "fill": "#C67A52"
+                },
+                {
+                  "type": "frame",
+                  "id": "VZaA0",
+                  "name": "sessionCol",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 3,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "E5I7pW",
+                      "name": "ideaTitle",
+                      "fill": "#2C2C2C",
+                      "content": "SSE 连接自报元数据：连接时带参数",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "d6x8P5",
+                      "name": "sessionSub",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "d04d7L",
+                          "name": "sessionBadge",
+                          "fill": "#22C55E20",
+                          "cornerRadius": 4,
+                          "gap": 4,
+                          "padding": [
+                            1,
+                            6
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "DrEII",
+                              "name": "d",
+                              "fill": "#22C55E",
+                              "width": 5,
+                              "height": 5
+                            },
+                            {
+                              "type": "text",
+                              "id": "upmfF",
+                              "name": "st",
+                              "fill": "#16A34A",
+                              "content": "running",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "fw91Z",
+                          "name": "lastSeen",
+                          "fill": "#9A9A9A",
+                          "content": "active 30s ago",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BImHx",
+                  "name": "transcriptBtn",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 7,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "oWuAd",
+                      "name": "tIcon",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "scroll-text",
+                      "library": "lucide",
+                      "fill": "#6B6B6B"
+                    },
+                    {
+                      "type": "text",
+                      "id": "rcP5V",
+                      "name": "tLabel",
+                      "fill": "#6B6B6B",
+                      "content": "Transcript",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zZtIx",
+              "name": "session",
+              "width": "fill_container",
+              "fill": "#FAF8F4",
+              "cornerRadius": 10,
+              "stroke": "#E5E2DC",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 12,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "o3ZgS",
+                  "name": "ideaIcon",
+                  "width": 15,
+                  "height": 15,
+                  "icon": "lightbulb",
+                  "library": "lucide",
+                  "fill": "#C67A52"
+                },
+                {
+                  "type": "frame",
+                  "id": "TgbqR",
+                  "name": "sessionCol",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 3,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pNBs0",
+                      "name": "ideaTitle",
+                      "fill": "#2C2C2C",
+                      "content": "Daemon 连接可观测与管理：UI 实时观察",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "O3D6Gp",
+                      "name": "sessionSub",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "N1BfaT",
+                          "name": "sessionBadge",
+                          "fill": "#9A9A9A20",
+                          "cornerRadius": 4,
+                          "gap": 4,
+                          "padding": [
+                            1,
+                            6
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "XwOvj",
+                              "name": "d",
+                              "fill": "#9A9A9A",
+                              "width": 5,
+                              "height": 5
+                            },
+                            {
+                              "type": "text",
+                              "id": "Y244C",
+                              "name": "st",
+                              "fill": "#6B6B6B",
+                              "content": "idle",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "M7wny",
+                          "name": "lastSeen",
+                          "fill": "#9A9A9A",
+                          "content": "active 12m ago",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "uZZUH",
+                  "name": "transcriptBtn",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 7,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "pXN3l",
+                      "name": "tIcon",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "scroll-text",
+                      "library": "lucide",
+                      "fill": "#6B6B6B"
+                    },
+                    {
+                      "type": "text",
+                      "id": "stJ1i",
+                      "name": "tLabel",
+                      "fill": "#6B6B6B",
+                      "content": "Transcript",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "themes": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -128,6 +128,7 @@
   },
   "nav": {
     "projects": "Projects",
+    "agentConnections": "Agent Connections",
     "settings": "Settings",
     "overview": "Overview",
     "documents": "Documents",
@@ -1347,5 +1348,30 @@
   "idea": {
     "reportsList": "REPORTS",
     "reportsAcrossProposals": "across all approved proposals"
+  },
+  "agentConnections": {
+    "title": "Agent Connections",
+    "subtitle": "Daemons you own that are connected to Chorus and listening for task dispatches.",
+    "summary": "{online} online · {total} total",
+    "loading": "Loading connections...",
+    "statusOnline": "Online",
+    "statusOffline": "Offline",
+    "fieldHost": "Host",
+    "fieldUptime": "Uptime",
+    "fieldLastActive": "Last active",
+    "fieldStarted": "Started",
+    "hostUnknown": "Unknown host",
+    "versionUnknown": "Unknown",
+    "clientClaudeCode": "Claude Code",
+    "clientOpenclaw": "OpenClaw",
+    "clientUnknown": "Unknown client",
+    "uptimeJustStarted": "Just started",
+    "uptimeMinutes": "{minutes}m",
+    "uptimeHoursMinutes": "{hours}h {minutes}m",
+    "uptimeDaysHours": "{days}d {hours}h",
+    "empty": {
+      "title": "No agent connections yet",
+      "body": "Start a daemon to connect an agent to Chorus. Run `chorus daemon` from your terminal, or enable the OpenClaw plugin, then this page will show it here."
+    }
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -128,6 +128,7 @@
   },
   "nav": {
     "projects": "项目",
+    "agentConnections": "智能体连接",
     "settings": "设置",
     "overview": "概览",
     "documents": "文档",
@@ -1348,5 +1349,30 @@
   "idea": {
     "reportsList": "总结报告",
     "reportsAcrossProposals": "覆盖所有已审批提案"
+  },
+  "agentConnections": {
+    "title": "智能体连接",
+    "subtitle": "你拥有的守护进程，已连接到 Chorus 并正在监听任务派发。",
+    "summary": "{online} 在线 · 共 {total} 个",
+    "loading": "正在加载连接...",
+    "statusOnline": "在线",
+    "statusOffline": "离线",
+    "fieldHost": "主机",
+    "fieldUptime": "在线时长",
+    "fieldLastActive": "最近活跃",
+    "fieldStarted": "启动于",
+    "hostUnknown": "未知主机",
+    "versionUnknown": "未知",
+    "clientClaudeCode": "Claude Code",
+    "clientOpenclaw": "OpenClaw",
+    "clientUnknown": "未知客户端",
+    "uptimeJustStarted": "刚刚启动",
+    "uptimeMinutes": "{minutes} 分钟",
+    "uptimeHoursMinutes": "{hours} 小时 {minutes} 分钟",
+    "uptimeDaysHours": "{days} 天 {hours} 小时",
+    "empty": {
+      "title": "暂无智能体连接",
+      "body": "启动一个守护进程以将智能体连接到 Chorus。在终端运行 `chorus daemon`，或启用 OpenClaw 插件，连接成功后即可在此页面看到。"
+    }
   }
 }

--- a/openspec/changes/archive/2026-06-15-add-agent-connection-observability/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-add-agent-connection-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-15-add-agent-connection-observability/README.md
+++ b/openspec/changes/archive/2026-06-15-add-agent-connection-observability/README.md
@@ -1,0 +1,3 @@
+# add-agent-connection-observability
+
+Owner-scoped Agent Connections observability page + read API over the DaemonConnection registry

--- a/openspec/changes/archive/2026-06-15-add-agent-connection-observability/design.md
+++ b/openspec/changes/archive/2026-06-15-add-agent-connection-observability/design.md
@@ -1,0 +1,212 @@
+# Technical Design: Agent Connections observability
+
+## Overview
+
+Expose the existing `DaemonConnection` registry through a thin, owner-scoped read
+path and render it as a live page. Three moving parts, all additive:
+
+1. **Read projection** — a service function that queries the registry scoped to
+   the caller and projects each row to a DTO carrying a server-derived
+   `effectiveStatus`.
+2. **REST endpoint** — `GET /api/agent-connections`, agent-key + cookie callable,
+   that branches the scope by auth type and returns the projection.
+3. **Page** — a polling client component + a new global nav item.
+
+The guiding constraint is **reuse, don't re-derive**: the liveness rule
+(`STALE_THRESHOLD_MS`) already lives in the service from the parent change; this
+change consumes that constant rather than restating it, so producer and consumer
+can never drift.
+
+## Architecture
+
+```
+┌────────────────────────┐  GET /api/agent-connections     ┌─────────────────────────┐
+│ Agent Connections page │ ───── poll every ~15s ─────────▶│  route handler          │
+│ (client component)     │                                 │  - getAuthContext       │
+└────────────────────────┘                                 │  - user → owner-scoped  │
+            ▲                                               │  - agent → self-scoped  │
+            │ effectiveStatus, host, uptime, lastSeen       └───────────┬─────────────┘
+            │                                                           │
+            └───────────────────────────────────────────────────────────
+                                                       listConnectionsForOwner / ...ForAgent
+                                                                        │
+                                                              ┌─────────▼─────────┐
+                                                              │  DaemonConnection │ (Postgres,
+                                                              │  + agent.ownerUuid│  already populated
+                                                              └───────────────────┘  by SSE routes)
+```
+
+The registry is written by the SSE routes (parent change); this change only
+reads. Because the table is in Postgres, the read is correct regardless of which
+ECS instance holds the socket or serves the GET.
+
+## Data flow & visibility
+
+`getAuthContext(request)` already returns a discriminated union (user / agent /
+super_admin). The endpoint branches on it:
+
+- **User caller** (cookie or user Bearer): visible set =
+  `prisma.daemonConnection.findMany({ where: { companyUuid, agent: { ownerUuid: user.uuid } } })`.
+  This is the owner-scoped rule the parent change fixed as a binding contract.
+- **Agent-key caller**: visible set =
+  `where: { companyUuid, agentUuid: auth.actorUuid }`. An agent key has no owner
+  to expand, so it sees only its own connections — the natural agent-side
+  analogue of owner-scoping, and what a daemon would call to confirm "am I
+  registered?".
+- **Super-admin**: treated as a user with no owner filter is **not** done here —
+  super-admin is out of the daemon-owner model; it falls through to the
+  agent/user branches by `auth.type`. (No special super-admin view in this slice.)
+
+All queries are `companyUuid`-scoped — multi-tenancy is never relaxed.
+
+## Module contracts
+
+### Service: `src/services/daemon-connection.service.ts` (additions only)
+
+```ts
+// Projection returned to callers. Raw status/lastSeenAt are included so the UI
+// can show "last active" + uptime; effectiveStatus is the liveness verdict.
+export interface ConnectionView {
+  uuid: string;
+  agentUuid: string;
+  clientType: string;
+  clientVersion: string | null;
+  host: string;            // "" when host-less (display can show a placeholder)
+  startedAt: string | null;     // ISO-8601
+  status: string;               // raw persisted status
+  effectiveStatus: "online" | "offline";
+  connectedAt: string;          // ISO-8601
+  lastSeenAt: string;           // ISO-8601
+  disconnectedAt: string | null;
+}
+
+// Owner-scoped: connections for agents owned by `ownerUuid`, within company.
+export async function listConnectionsForOwner(
+  companyUuid: string, ownerUuid: string
+): Promise<ConnectionView[]>;
+
+// Agent-key scoped: the calling agent's own connections, within company.
+export async function listConnectionsForAgent(
+  companyUuid: string, agentUuid: string
+): Promise<ConnectionView[]>;
+```
+
+**`effectiveStatus` derivation (the single source of truth):**
+
+```ts
+function projectStatus(row): "online" | "offline" {
+  const fresh = Date.now() - row.lastSeenAt.getTime() <= STALE_THRESHOLD_MS;
+  return row.status === "online" && fresh ? "online" : "offline";
+}
+```
+
+Reuses the module-level `STALE_THRESHOLD_MS = 90_000`. Both list functions share
+one internal mapper (`toConnectionView`) so the projection is defined once.
+Ordering: `effectiveStatus` online first, then `lastSeenAt` desc — most-relevant
+connections surface at the top.
+
+The read functions do **not** swallow-and-log like the write functions: a read
+failure is a real error the caller (the route) should surface as a 500 via
+`withErrorHandler`, not a silently-empty list that would falsely read as "no
+connections".
+
+### Route: `src/app/api/agent-connections/route.ts` (new)
+
+```ts
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) return errors.unauthorized();
+
+  let connections: ConnectionView[];
+  if (auth.type === "agent") {
+    connections = await listConnectionsForAgent(auth.companyUuid, auth.actorUuid);
+  } else {
+    // user / super_admin → owner-scoped by the acting user's uuid
+    connections = await listConnectionsForOwner(auth.companyUuid, auth.actorUuid);
+  }
+  return success({ connections });
+});
+```
+
+No permission-bit gate: visibility is enforced by the query scope itself
+(owner / self), and the data is the caller's own connection metadata. This
+matches the root-idea-resolution endpoint, which is likewise agent-key callable
+without a dedicated permission bit. Auth is still required (401 without it).
+
+### Page: `src/app/(dashboard)/agent-connections/page.tsx` (new)
+
+Client component (`"use client"`). Pattern mirrors the existing projects page:
+`useState` for the list + loading, a `useCallback` fetcher hitting
+`GET /api/agent-connections`, a `useEffect` that fetches on mount and sets a
+`setInterval(fetch, 15_000)` (cleared on unmount). No SSE subscription — polling
+is sufficient and avoids a new realtime event type. Renders:
+
+- Header: title + owner-scoped subtitle + online/total summary count.
+- One card per connection (shadcn `Card` + `Badge`): client-type label + version
+  pill, online/offline `Badge` from `effectiveStatus`, host row, uptime (from
+  `connectedAt`), last-active (from `lastSeenAt`).
+- Empty state when the list is empty: short copy on how to start a daemon
+  (`chorus daemon` / OpenClaw), all i18n.
+
+Relative-time rendering ("just now", "5 min ago") reuses the existing relative-
+time helper if one exists in the codebase; otherwise a small local formatter with
+i18n keys. All visible strings go through `t()`.
+
+### Nav: `src/app/(dashboard)/layout.tsx`
+
+Add to `globalNavItems`:
+
+```ts
+{ href: "/agent-connections", label: t("nav.agentConnections"), icon: RadioTower },
+```
+
+`RadioTower` imported from `lucide-react`. Active-state highlight is handled by
+the existing `isNavActive` logic (matches `/agent-connections`).
+
+## i18n keys (both `en` and `zh`)
+
+- `nav.agentConnections`
+- `agentConnections.title`, `.subtitle`, `.summaryOnline`, `.summaryOffline`
+- `agentConnections.statusOnline`, `.statusOffline`
+- `agentConnections.fieldHost`, `.fieldVersion`, `.fieldUptime`, `.fieldLastActive`,
+  `.fieldStarted`
+- `agentConnections.clientClaudeCode`, `.clientOpenclaw`, `.clientUnknown`
+- `agentConnections.empty.title`, `.empty.body`
+- relative-time keys as needed (`agentConnections.justNow`, `.minutesAgo`, etc.)
+  unless an existing shared time helper already provides them.
+
+## Testing strategy
+
+- **Service** (`__tests__/daemon-connection.service.test.ts`, extend existing):
+  - `listConnectionsForOwner` filters by `companyUuid` + `agent.ownerUuid` and maps
+    rows to `ConnectionView`.
+  - `listConnectionsForAgent` filters by `companyUuid` + `agentUuid`.
+  - `effectiveStatus`: row `status="online"` with fresh `lastSeenAt` → `online`;
+    `status="online"` with `lastSeenAt` older than `STALE_THRESHOLD_MS` → `offline`
+    (the staleness case); `status="offline"` → `offline` regardless of `lastSeenAt`.
+  - Boundary exactly at `STALE_THRESHOLD_MS`.
+  - Ordering: online-first then `lastSeenAt` desc.
+  - A read error propagates (does NOT swallow to `[]`).
+  Prisma + clock mocked (the existing test file already mocks both).
+
+- **Route** (`src/app/api/agent-connections/__tests__/route.test.ts`, new):
+  - 401 when unauthenticated.
+  - User auth → calls `listConnectionsForOwner(companyUuid, actorUuid)`.
+  - Agent auth → calls `listConnectionsForAgent(companyUuid, actorUuid)`.
+  - Returns `{ success: true, data: { connections } }`.
+  Service mocked.
+
+## Risks & mitigations
+
+- **Poll volume.** ~15s polling per open page is negligible (a single indexed
+  query scoped to one owner). Mitigation: the existing `@@index([companyUuid])` +
+  `@@index([agentUuid])` cover both scope branches; the join to `agent.ownerUuid`
+  uses the indexed `ownerUuid`.
+- **Stale `online` rows from a crashed instance.** Covered by `effectiveStatus` —
+  a row whose `lastSeenAt` stopped advancing reads as `offline` after 90s without
+  any reaper. No background job needed for read correctness.
+- **Clock for staleness.** Uses `Date.now()` server-side; tests mock the clock to
+  pin the boundary deterministically.
+- **Empty `host`.** The registry stores `""` for host-less self-reports (non-null
+  default). The DTO passes `""` through; the page shows a neutral placeholder
+  rather than an empty gap.

--- a/openspec/changes/archive/2026-06-15-add-agent-connection-observability/proposal.md
+++ b/openspec/changes/archive/2026-06-15-add-agent-connection-observability/proposal.md
@@ -1,0 +1,125 @@
+# Proposal: Agent Connections observability (read API + page)
+
+## Why
+
+The `DaemonConnection` registry now exists and is fed by live data: the chorus
+CLI daemon (`clientType=claude_code`) and the OpenClaw plugin
+(`clientType=openclaw`) both self-report at SSE connect time, and the server
+persists one row per connection with `status` / `lastSeenAt` liveness (shipped by
+the parent change `add-daemon-connection-tracking`). That change was deliberately
+**collection + liveness only** — it ships **no read API, no UI**.
+
+So today the data is captured but **nobody can see it**. A user running the
+daemon on their laptop has no way to confirm from Chorus that "my daemon is
+connected and listening for dispatches", nor to notice that it silently went
+offline. This change closes that consumption gap: an owner-scoped **Agent
+Connections** page, backed by a small read API over the existing registry.
+
+This change is the **observability slice** of idea `f2fe9a7f`. It does **not**
+build live transcript ingest or per-connection session nesting — both depend on a
+daemon-side stream-json upload protocol that does not exist yet (the parent
+daemon only wakes Claude Code and writes back through existing `chorus_*` MCP
+tools; `AgentSession` has no `connectionUuid` FK). Those, plus connection
+management verbs (forced disconnect, history), are explicitly deferred to a
+follow-on idea. What ships here is fully backed by data that exists today.
+
+## What Changes
+
+- **New read function on the registry service** —
+  `src/services/daemon-connection.service.ts` gains `listConnectionsForOwner` (and
+  a sibling for agent-key callers). It returns the caller's visible connections
+  with a server-derived `effectiveStatus`. The service is currently
+  write-only (`registerConnection` / `touchConnection` / `markDisconnected`); this
+  adds the first read path.
+
+- **Server-derived `effectiveStatus` is the single source of truth for liveness**
+  — the read function computes
+  `effectiveStatus = (status === "online" && now - lastSeenAt <= STALE_THRESHOLD_MS) ? "online" : "offline"`,
+  reusing the already-exported `STALE_THRESHOLD_MS` (90s) constant. The client
+  renders `effectiveStatus` verbatim and never re-implements the staleness rule.
+  This honors the registry change's documented liveness contract — the consumer
+  applies exactly the rule the producer specified.
+
+- **New REST endpoint `GET /api/agent-connections`** — gated, agent-key callable
+  **and** browser (user-cookie) callable, mirroring the just-merged root-idea
+  resolution endpoint's "REST, agent-key callable" decision (this surface is
+  **not** an MCP tool). Returns the visible connections as the API response
+  envelope. No new MCP tool, no new permission bit.
+
+- **Owner-scoped visibility, enforced server-side** — a **user** caller sees only
+  connections whose agent is owned by that user (`agent.ownerUuid === user.uuid`),
+  within their company. An **agent-key** caller sees only its own connections
+  (`agentUuid === auth.actorUuid`) — an agent key has no "owner" to expand. This
+  enforces the owner-scoped visibility requirement the parent change recorded as a
+  binding contract, and narrows idea `f2fe9a7f`'s original "company-global view"
+  wording to owner-scoped as the parent change's boundary note required.
+
+- **New top-level page `/agent-connections`** — a global sidebar item labeled
+  **"Agent Connections"** (zh: 智能体连接), peer to Projects and Settings, icon
+  `RadioTower`. Per explicit product instruction the tab is **not** called
+  "Daemons". The page lists the caller's connections as cards: client type +
+  version, online/offline badge (from `effectiveStatus`), host, uptime
+  (`connectedAt`), and last-active (`lastSeenAt`). It polls the read API on a ~15s
+  interval to reflect online↔offline transitions; no new SSE event type is added
+  (a 30s-per-connection touch would make SSE high-volume for marginal latency
+  gain). An empty state explains how to start a daemon. All strings are i18n
+  (`en` + `zh`).
+
+- **Read-only this slice** — display + automatic liveness only. No manual
+  disconnect/delete button: while a daemon is genuinely connected, its next 30s
+  heartbeat touch flips any externally-set `offline` back to `online` (and the
+  `connectedAt` fence means an external mark would not even stick against the live
+  generation), so a "disconnect" button would be misleading. Management verbs are
+  deferred with the transcript/session work.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-connection-observability`: the owner-scoped read API
+  (`GET /api/agent-connections`) over the `DaemonConnection` registry, the
+  server-derived `effectiveStatus` liveness projection, and the Agent Connections
+  observability page (nav item + polling list + empty state).
+
+## Impact
+
+- **Backend code**:
+  - `src/services/daemon-connection.service.ts` — new read function(s) returning
+    visible connections with `effectiveStatus`; reuses `STALE_THRESHOLD_MS`. No
+    change to the existing write functions.
+  - `src/app/api/agent-connections/route.ts` (new) — `GET` handler: resolve auth,
+    branch user (owner-scoped) vs agent-key (self-scoped), call the service, return
+    the standard response envelope via `withErrorHandler` + `success`/`errors.*`.
+
+- **Frontend code**:
+  - `src/app/(dashboard)/agent-connections/page.tsx` (new) — client component,
+    polls `GET /api/agent-connections` every ~15s, renders connection cards with
+    status badges, host, uptime, last-active, and an empty state.
+  - `src/app/(dashboard)/layout.tsx` — add the `/agent-connections` item to
+    `globalNavItems` with the `RadioTower` icon and `nav.agentConnections` label.
+  - `messages/en.json` + `messages/zh.json` — add `nav.agentConnections` and an
+    `agentConnections.*` namespace (title, subtitle, status labels, field labels,
+    empty state, relative-time strings).
+
+- **Design**: `docs/design.pen` already carries the reference frame for this page
+  (drawn during planning). The implemented page follows that frame; the `.pen`
+  is updated only if the implementation diverges.
+
+- **No schema change** — the `DaemonConnection` model already exists. No
+  migration. No `AgentSession` change (session nesting is deferred).
+
+- **No new dependency, no new MCP tool, no new permission bit, no change to the
+  auth path or the SSE routes.** The only new network surface is one additive REST
+  GET endpoint.
+
+- **Backward compat**: fully additive. Existing pages and the SSE registry write
+  path are untouched.
+
+## Out of scope (deferred to a follow-on idea)
+
+- Live transcript ingest + render (needs an undefined daemon-side upload protocol).
+- Per-connection `AgentSession` nesting (needs an `AgentSession.connectionUuid` FK
+  and daemon-side session registration).
+- Management verbs (forced disconnect with daemon-side teardown, history view).
+- A background reaper that flips long-stale `online` rows to `offline`
+  (`effectiveStatus` already covers the read correctly without it).

--- a/openspec/changes/archive/2026-06-15-add-agent-connection-observability/specs/agent-connection-observability/spec.md
+++ b/openspec/changes/archive/2026-06-15-add-agent-connection-observability/specs/agent-connection-observability/spec.md
@@ -1,0 +1,142 @@
+# agent-connection-observability Specification
+
+## ADDED Requirements
+
+### Requirement: The server SHALL expose a read API listing the caller's visible daemon connections
+
+The server SHALL expose `GET /api/agent-connections` returning the
+`DaemonConnection` rows visible to the authenticated caller. The endpoint SHALL
+require authentication and SHALL be callable both by a browser session (user
+cookie / user Bearer) and by an agent API key, mirroring the existing root-idea
+resolution endpoint's "REST, agent-key callable" contract. The endpoint SHALL NOT
+be implemented as an MCP tool and SHALL NOT introduce a new permission bit; the
+returned set is scoped by the query itself. The response SHALL use the standard
+API envelope (`{ success: true, data: { connections: [...] } }`).
+
+#### Scenario: Unauthenticated request is rejected
+
+- **GIVEN** a request to `GET /api/agent-connections` with no valid auth
+- **WHEN** the server handles it
+- **THEN** the response status MUST be 401 and no connection data MUST be returned
+
+#### Scenario: Authenticated request returns the standard envelope
+
+- **GIVEN** an authenticated caller
+- **WHEN** the caller requests `GET /api/agent-connections`
+- **THEN** the response MUST be `{ success: true, data: { connections } }` where
+  `connections` is the caller's visible connection list
+
+### Requirement: The read API SHALL scope visibility by owner for users and by self for agents
+
+The server SHALL scope the returned connections so that a **user** caller sees
+only connections whose agent is owned by that user (`agent.ownerUuid` equals the
+acting user's uuid) within the caller's company, and an **agent-key** caller sees
+only its own connections (`agentUuid` equals the calling agent's uuid) within the
+company. Every query SHALL be `companyUuid`-scoped. The API SHALL NOT return a
+connection belonging to an agent owned by a different user to other members of the
+same company, enforcing the owner-scoped visibility contract defined by the
+daemon-connection registry.
+
+#### Scenario: A user sees only connections for agents they own
+
+- **GIVEN** user U owns agent A, another user V owns agent B, both in the same company
+- **AND** agent A and agent B each hold a registered `DaemonConnection`
+- **WHEN** user U requests `GET /api/agent-connections`
+- **THEN** the response MUST include agent A's connection
+- **AND** the response MUST NOT include agent B's connection
+
+#### Scenario: An agent key sees only its own connections
+
+- **GIVEN** agent A holds a registered `DaemonConnection` and agent B holds another
+- **WHEN** a request authenticates with agent A's API key
+- **THEN** the response MUST include only agent A's connection
+
+#### Scenario: Visibility never crosses company boundaries
+
+- **GIVEN** a connection belonging to an agent in company C2
+- **WHEN** a caller in company C1 requests `GET /api/agent-connections`
+- **THEN** the response MUST NOT include that connection
+
+### Requirement: The server SHALL derive an effectiveStatus applying the staleness rule
+
+The server SHALL compute, for each returned connection, an `effectiveStatus` of
+`online` if and only if the persisted `status` is `online` AND the elapsed time
+since `lastSeenAt` is at most the registry's staleness threshold
+(`STALE_THRESHOLD_MS`); otherwise `effectiveStatus` SHALL be `offline`. The server
+SHALL reuse the staleness threshold constant exported by the daemon-connection
+registry rather than redefining the rule, so producer and consumer cannot drift.
+The projection SHALL also include the raw `status`, `connectedAt`, `lastSeenAt`,
+`clientType`, `clientVersion`, `host`, and `startedAt` so a client can render
+uptime and last-active without re-implementing liveness.
+
+#### Scenario: A fresh online row reads as online
+
+- **GIVEN** a connection with `status = "online"` and `lastSeenAt` within the staleness threshold
+- **WHEN** the read API projects it
+- **THEN** `effectiveStatus` MUST be `online`
+
+#### Scenario: A stale online row reads as offline
+
+- **GIVEN** a connection with `status = "online"` whose `lastSeenAt` is older than the staleness threshold
+- **WHEN** the read API projects it
+- **THEN** `effectiveStatus` MUST be `offline`
+
+#### Scenario: An offline row reads as offline regardless of lastSeenAt
+
+- **GIVEN** a connection with `status = "offline"`
+- **WHEN** the read API projects it
+- **THEN** `effectiveStatus` MUST be `offline`
+
+### Requirement: The dashboard SHALL provide an Agent Connections page reflecting live status
+
+The dashboard SHALL provide a top-level page at `/agent-connections`, reachable
+from a global sidebar navigation item labeled "Agent Connections" (and its
+localized equivalent), that lists the caller's visible connections. The page SHALL
+display, per connection, the client type and version, an online/offline indicator
+driven by the server-derived `effectiveStatus`, the host, the uptime (from
+`connectedAt`), and the last-active time (from `lastSeenAt`). The page SHALL
+refresh on a periodic interval so that online↔offline transitions appear without
+a manual reload, and SHALL show an empty state explaining how to start a daemon
+when the caller has no connections. All user-facing strings SHALL be localized in
+both supported locales. The navigation item SHALL NOT be labeled "Daemons".
+
+#### Scenario: The page lists the caller's connections
+
+- **GIVEN** an authenticated user with one online and one offline visible connection
+- **WHEN** the user opens `/agent-connections`
+- **THEN** the page MUST render both connections with their client type, host, and
+  an indicator reflecting each connection's `effectiveStatus`
+
+#### Scenario: The page shows an empty state with no connections
+
+- **GIVEN** an authenticated user with no visible connections
+- **WHEN** the user opens `/agent-connections`
+- **THEN** the page MUST render an empty state describing how to start a daemon
+  rather than an empty or broken list
+
+#### Scenario: The page refreshes to reflect status transitions
+
+- **GIVEN** the page is open showing an online connection
+- **WHEN** that connection later becomes offline and the refresh interval elapses
+- **THEN** the page MUST reflect the offline status without a manual reload
+
+### Requirement: This change SHALL add no management actions and no schema change
+
+The change SHALL be read-only over the existing registry: it SHALL NOT add a
+manual disconnect or delete control, SHALL NOT modify the `DaemonConnection`
+schema, SHALL NOT add a database migration, and SHALL NOT alter the SSE routes or
+the registry write path. A manual offline control is intentionally excluded
+because a genuinely connected daemon's next heartbeat would immediately flip the
+row back to online.
+
+#### Scenario: No manual disconnect control is present
+
+- **WHEN** a user views a connection on the Agent Connections page
+- **THEN** there MUST be no control that marks the connection offline or deletes it
+
+#### Scenario: No schema or migration is introduced
+
+- **WHEN** the change is implemented
+- **THEN** no change to the `DaemonConnection` Prisma model and no new database
+  migration MUST be introduced
+- **AND** the SSE routes and the registry write functions MUST remain unchanged

--- a/openspec/specs/agent-connection-observability/spec.md
+++ b/openspec/specs/agent-connection-observability/spec.md
@@ -1,0 +1,153 @@
+# agent-connection-observability Specification
+
+## Purpose
+Defines the owner-scoped observability layer over the daemon-connection registry:
+the `GET /api/agent-connections` read API (agent-key + user-cookie callable, not
+an MCP tool, no new permission bit), the server-derived `effectiveStatus` liveness
+projection that reuses the registry's `STALE_THRESHOLD_MS` so producer and consumer
+cannot drift, and the Agent Connections dashboard page (global nav item, periodic
+polling, empty state). Visibility is owner-scoped for users (`agent.ownerUuid`) and
+self-scoped for agent keys, enforcing the binding contract from the
+daemon-connection registry. This is the read/observability slice of idea f2fe9a7f;
+live transcript ingest, per-connection `AgentSession` nesting, and connection
+management verbs are out of scope and deferred to a follow-on.
+## Requirements
+### Requirement: The server SHALL expose a read API listing the caller's visible daemon connections
+
+The server SHALL expose `GET /api/agent-connections` returning the
+`DaemonConnection` rows visible to the authenticated caller. The endpoint SHALL
+require authentication and SHALL be callable both by a browser session (user
+cookie / user Bearer) and by an agent API key, mirroring the existing root-idea
+resolution endpoint's "REST, agent-key callable" contract. The endpoint SHALL NOT
+be implemented as an MCP tool and SHALL NOT introduce a new permission bit; the
+returned set is scoped by the query itself. The response SHALL use the standard
+API envelope (`{ success: true, data: { connections: [...] } }`).
+
+#### Scenario: Unauthenticated request is rejected
+
+- **GIVEN** a request to `GET /api/agent-connections` with no valid auth
+- **WHEN** the server handles it
+- **THEN** the response status MUST be 401 and no connection data MUST be returned
+
+#### Scenario: Authenticated request returns the standard envelope
+
+- **GIVEN** an authenticated caller
+- **WHEN** the caller requests `GET /api/agent-connections`
+- **THEN** the response MUST be `{ success: true, data: { connections } }` where
+  `connections` is the caller's visible connection list
+
+### Requirement: The read API SHALL scope visibility by owner for users and by self for agents
+
+The server SHALL scope the returned connections so that a **user** caller sees
+only connections whose agent is owned by that user (`agent.ownerUuid` equals the
+acting user's uuid) within the caller's company, and an **agent-key** caller sees
+only its own connections (`agentUuid` equals the calling agent's uuid) within the
+company. Every query SHALL be `companyUuid`-scoped. The API SHALL NOT return a
+connection belonging to an agent owned by a different user to other members of the
+same company, enforcing the owner-scoped visibility contract defined by the
+daemon-connection registry.
+
+#### Scenario: A user sees only connections for agents they own
+
+- **GIVEN** user U owns agent A, another user V owns agent B, both in the same company
+- **AND** agent A and agent B each hold a registered `DaemonConnection`
+- **WHEN** user U requests `GET /api/agent-connections`
+- **THEN** the response MUST include agent A's connection
+- **AND** the response MUST NOT include agent B's connection
+
+#### Scenario: An agent key sees only its own connections
+
+- **GIVEN** agent A holds a registered `DaemonConnection` and agent B holds another
+- **WHEN** a request authenticates with agent A's API key
+- **THEN** the response MUST include only agent A's connection
+
+#### Scenario: Visibility never crosses company boundaries
+
+- **GIVEN** a connection belonging to an agent in company C2
+- **WHEN** a caller in company C1 requests `GET /api/agent-connections`
+- **THEN** the response MUST NOT include that connection
+
+### Requirement: The server SHALL derive an effectiveStatus applying the staleness rule
+
+The server SHALL compute, for each returned connection, an `effectiveStatus` of
+`online` if and only if the persisted `status` is `online` AND the elapsed time
+since `lastSeenAt` is at most the registry's staleness threshold
+(`STALE_THRESHOLD_MS`); otherwise `effectiveStatus` SHALL be `offline`. The server
+SHALL reuse the staleness threshold constant exported by the daemon-connection
+registry rather than redefining the rule, so producer and consumer cannot drift.
+The projection SHALL also include the raw `status`, `connectedAt`, `lastSeenAt`,
+`clientType`, `clientVersion`, `host`, and `startedAt` so a client can render
+uptime and last-active without re-implementing liveness.
+
+#### Scenario: A fresh online row reads as online
+
+- **GIVEN** a connection with `status = "online"` and `lastSeenAt` within the staleness threshold
+- **WHEN** the read API projects it
+- **THEN** `effectiveStatus` MUST be `online`
+
+#### Scenario: A stale online row reads as offline
+
+- **GIVEN** a connection with `status = "online"` whose `lastSeenAt` is older than the staleness threshold
+- **WHEN** the read API projects it
+- **THEN** `effectiveStatus` MUST be `offline`
+
+#### Scenario: An offline row reads as offline regardless of lastSeenAt
+
+- **GIVEN** a connection with `status = "offline"`
+- **WHEN** the read API projects it
+- **THEN** `effectiveStatus` MUST be `offline`
+
+### Requirement: The dashboard SHALL provide an Agent Connections page reflecting live status
+
+The dashboard SHALL provide a top-level page at `/agent-connections`, reachable
+from a global sidebar navigation item labeled "Agent Connections" (and its
+localized equivalent), that lists the caller's visible connections. The page SHALL
+display, per connection, the client type and version, an online/offline indicator
+driven by the server-derived `effectiveStatus`, the host, the uptime (from
+`connectedAt`), and the last-active time (from `lastSeenAt`). The page SHALL
+refresh on a periodic interval so that online↔offline transitions appear without
+a manual reload, and SHALL show an empty state explaining how to start a daemon
+when the caller has no connections. All user-facing strings SHALL be localized in
+both supported locales. The navigation item SHALL NOT be labeled "Daemons".
+
+#### Scenario: The page lists the caller's connections
+
+- **GIVEN** an authenticated user with one online and one offline visible connection
+- **WHEN** the user opens `/agent-connections`
+- **THEN** the page MUST render both connections with their client type, host, and
+  an indicator reflecting each connection's `effectiveStatus`
+
+#### Scenario: The page shows an empty state with no connections
+
+- **GIVEN** an authenticated user with no visible connections
+- **WHEN** the user opens `/agent-connections`
+- **THEN** the page MUST render an empty state describing how to start a daemon
+  rather than an empty or broken list
+
+#### Scenario: The page refreshes to reflect status transitions
+
+- **GIVEN** the page is open showing an online connection
+- **WHEN** that connection later becomes offline and the refresh interval elapses
+- **THEN** the page MUST reflect the offline status without a manual reload
+
+### Requirement: This change SHALL add no management actions and no schema change
+
+The change SHALL be read-only over the existing registry: it SHALL NOT add a
+manual disconnect or delete control, SHALL NOT modify the `DaemonConnection`
+schema, SHALL NOT add a database migration, and SHALL NOT alter the SSE routes or
+the registry write path. A manual offline control is intentionally excluded
+because a genuinely connected daemon's next heartbeat would immediately flip the
+row back to online.
+
+#### Scenario: No manual disconnect control is present
+
+- **WHEN** a user views a connection on the Agent Connections page
+- **THEN** there MUST be no control that marks the connection offline or deletes it
+
+#### Scenario: No schema or migration is introduced
+
+- **WHEN** the change is implemented
+- **THEN** no change to the `DaemonConnection` Prisma model and no new database
+  migration MUST be introduced
+- **AND** the SSE routes and the registry write functions MUST remain unchanged
+

--- a/openspec/specs/agent-connection-observability/spec.md
+++ b/openspec/specs/agent-connection-observability/spec.md
@@ -103,12 +103,15 @@ The dashboard SHALL provide a top-level page at `/agent-connections`, reachable
 from a global sidebar navigation item labeled "Agent Connections" (and its
 localized equivalent), that lists the caller's visible connections. The page SHALL
 display, per connection, the client type and version, an online/offline indicator
-driven by the server-derived `effectiveStatus`, the host, the uptime (from
-`connectedAt`), and the last-active time (from `lastSeenAt`). The page SHALL
-refresh on a periodic interval so that online↔offline transitions appear without
-a manual reload, and SHALL show an empty state explaining how to start a daemon
-when the caller has no connections. All user-facing strings SHALL be localized in
-both supported locales. The navigation item SHALL NOT be labeled "Daemons".
+driven by the server-derived `effectiveStatus`, the host, and the last-active time
+(from `lastSeenAt`). The page SHALL display the uptime (from `connectedAt`) only
+for connections whose `effectiveStatus` is `online`; an offline connection SHALL
+NOT show an uptime, because `now - connectedAt` for a connection that is no longer
+up is an ever-growing, misleading value. The page SHALL refresh on a periodic
+interval so that online↔offline transitions appear without a manual reload, and
+SHALL show an empty state explaining how to start a daemon when the caller has no
+connections. All user-facing strings SHALL be localized in both supported locales.
+The navigation item SHALL NOT be labeled "Daemons".
 
 #### Scenario: The page lists the caller's connections
 
@@ -116,6 +119,13 @@ both supported locales. The navigation item SHALL NOT be labeled "Daemons".
 - **WHEN** the user opens `/agent-connections`
 - **THEN** the page MUST render both connections with their client type, host, and
   an indicator reflecting each connection's `effectiveStatus`
+
+#### Scenario: Uptime is shown only for online connections
+
+- **GIVEN** an online connection and an offline connection
+- **WHEN** the user opens `/agent-connections`
+- **THEN** the online connection MUST show an uptime derived from `connectedAt`
+- **AND** the offline connection MUST NOT show an uptime
 
 #### Scenario: The page shows an empty state with no connections
 

--- a/src/app/(dashboard)/agent-connections/page.tsx
+++ b/src/app/(dashboard)/agent-connections/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Bot, RadioTower, Server, Clock, Activity, CalendarClock } from "lucide-react";
+import { authFetch } from "@/lib/auth-client";
+import { clientLogger } from "@/lib/logger-client";
+
+// Shape returned by GET /api/agent-connections (see daemon-connection.service.ts → ConnectionView).
+interface ConnectionView {
+  uuid: string;
+  agentUuid: string;
+  clientType: string;
+  clientVersion: string | null;
+  host: string; // "" when host-less
+  startedAt: string | null;
+  status: string;
+  effectiveStatus: "online" | "offline";
+  connectedAt: string;
+  lastSeenAt: string;
+  disconnectedAt: string | null;
+}
+
+const POLL_INTERVAL_MS = 15_000;
+
+// Relative "last active" formatter — reuses the shared `time.*` i18n namespace
+// already used by the projects page, so wording stays consistent.
+function useRelativeTime() {
+  const t = useTranslations("time");
+  return (dateStr: string) => {
+    const diffMs = Date.now() - new Date(dateStr).getTime();
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffMinutes < 1) return t("justNow");
+    if (diffMinutes < 60) return t("minutesAgo", { minutes: diffMinutes });
+    if (diffHours < 24) return t("hoursAgo", { hours: diffHours });
+    return t("daysAgo", { days: diffDays });
+  };
+}
+
+// Uptime (duration since connectedAt) formatter — its own i18n keys since the
+// shared `time.*` namespace only covers "ago"-style relative time.
+function useUptime() {
+  const t = useTranslations("agentConnections");
+  return (connectedAt: string) => {
+    const diffMs = Date.now() - new Date(connectedAt).getTime();
+    const totalMinutes = Math.floor(diffMs / (1000 * 60));
+    if (totalMinutes < 1) return t("uptimeJustStarted");
+    const totalHours = Math.floor(totalMinutes / 60);
+    if (totalHours < 1) return t("uptimeMinutes", { minutes: totalMinutes });
+    const totalDays = Math.floor(totalHours / 24);
+    if (totalDays < 1) return t("uptimeHoursMinutes", { hours: totalHours, minutes: totalMinutes % 60 });
+    return t("uptimeDaysHours", { days: totalDays, hours: totalHours % 24 });
+  };
+}
+
+function useClientTypeLabel() {
+  const t = useTranslations("agentConnections");
+  return (clientType: string) => {
+    switch (clientType) {
+      case "claude_code":
+        return t("clientClaudeCode");
+      case "openclaw":
+        return t("clientOpenclaw");
+      default:
+        return t("clientUnknown");
+    }
+  };
+}
+
+function MetaRow({ icon: Icon, label, value }: { icon: typeof Server; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2 text-[12px]">
+      <Icon className="h-3.5 w-3.5 shrink-0 text-[#9A9A9A]" />
+      <span className="text-[#9A9A9A]">{label}</span>
+      <span className="truncate font-medium text-[#2C2C2C]">{value}</span>
+    </div>
+  );
+}
+
+function ConnectionCard({ connection }: { connection: ConnectionView }) {
+  const t = useTranslations("agentConnections");
+  const clientTypeLabel = useClientTypeLabel();
+  const formatRelative = useRelativeTime();
+  const formatUptime = useUptime();
+
+  const isOnline = connection.effectiveStatus === "online";
+  const host = connection.host === "" ? t("hostUnknown") : connection.host;
+  const version = connection.clientVersion ?? t("versionUnknown");
+
+  return (
+    <Card className="gap-3 rounded-xl border-[#E5E2DC] p-5 shadow-none">
+      {/* Header: client type + version pill, status badge */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#C67A5215]">
+            <Bot className="h-4 w-4 text-[#C67A52]" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-[14px] font-semibold text-[#2C2C2C]">
+                {clientTypeLabel(connection.clientType)}
+              </span>
+              <Badge
+                variant="secondary"
+                className="shrink-0 border-0 bg-[#F0EDE8] text-[10px] font-medium text-[#6B6B6B]"
+              >
+                {version}
+              </Badge>
+            </div>
+          </div>
+        </div>
+        <Badge
+          className={`shrink-0 gap-1.5 border-0 text-[11px] font-medium ${
+            isOnline ? "bg-[#DCFCE7] text-[#15803D]" : "bg-[#F0EDE8] text-[#6B6B6B]"
+          }`}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${isOnline ? "bg-[#22C55E]" : "bg-[#9A9A9A]"}`}
+            aria-hidden
+          />
+          {isOnline ? t("statusOnline") : t("statusOffline")}
+        </Badge>
+      </div>
+
+      {/* Meta */}
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <MetaRow icon={Server} label={t("fieldHost")} value={host} />
+        <MetaRow icon={Clock} label={t("fieldUptime")} value={formatUptime(connection.connectedAt)} />
+        <MetaRow icon={Activity} label={t("fieldLastActive")} value={formatRelative(connection.lastSeenAt)} />
+        {connection.startedAt && (
+          <MetaRow
+            icon={CalendarClock}
+            label={t("fieldStarted")}
+            value={formatRelative(connection.startedAt)}
+          />
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export default function AgentConnectionsPage() {
+  const t = useTranslations("agentConnections");
+  const [connections, setConnections] = useState<ConnectionView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchConnections = useCallback(async () => {
+    try {
+      const res = await authFetch("/api/agent-connections");
+      if (!res.ok) return;
+      const json = await res.json();
+      if (json.success) {
+        setConnections(json.data.connections ?? []);
+      }
+    } catch (error) {
+      clientLogger.error("Failed to fetch agent connections:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConnections();
+    const interval = setInterval(fetchConnections, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchConnections]);
+
+  const onlineCount = connections.filter((c) => c.effectiveStatus === "online").length;
+
+  return (
+    <div className="bg-[#FAF8F4] p-4 md:px-8 md:py-6">
+      {/* Header */}
+      <div className="mb-4 md:mb-6">
+        <div className="flex items-center gap-2.5">
+          <h1 className="text-2xl font-semibold text-[#2C2C2C]">{t("title")}</h1>
+          {!loading && (
+            <Badge
+              variant="secondary"
+              className="border-0 bg-[#F0EDE8] text-[11px] font-medium text-[#6B6B6B]"
+            >
+              {t("summary", { online: onlineCount, total: connections.length })}
+            </Badge>
+          )}
+        </div>
+        <p className="mt-1 text-sm text-[#6B6B6B]">{t("subtitle")}</p>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-[#6B6B6B]">{t("loading")}</p>
+      ) : connections.length === 0 ? (
+        <Card className="items-center gap-3 rounded-xl border-[#E5E2DC] p-8 text-center shadow-none md:p-12">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#C67A5215]">
+            <RadioTower className="h-6 w-6 text-[#C67A52]" />
+          </div>
+          <h2 className="text-base font-semibold text-[#2C2C2C]">{t("empty.title")}</h2>
+          <p className="max-w-md text-[13px] leading-relaxed text-[#6B6B6B]">{t("empty.body")}</p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {connections.map((connection) => (
+            <ConnectionCard key={connection.uuid} connection={connection} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/agent-connections/page.tsx
+++ b/src/app/(dashboard)/agent-connections/page.tsx
@@ -129,7 +129,12 @@ function ConnectionCard({ connection }: { connection: ConnectionView }) {
       {/* Meta */}
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <MetaRow icon={Server} label={t("fieldHost")} value={host} />
-        <MetaRow icon={Clock} label={t("fieldUptime")} value={formatUptime(connection.connectedAt)} />
+        {/* Uptime is only meaningful while the daemon is up — computing now-connectedAt
+            for an offline connection would show an ever-growing, misleading duration.
+            Offline connections convey their timing via "last active" below instead. */}
+        {isOnline && (
+          <MetaRow icon={Clock} label={t("fieldUptime")} value={formatUptime(connection.connectedAt)} />
+        )}
         <MetaRow icon={Activity} label={t("fieldLastActive")} value={formatRelative(connection.lastSeenAt)} />
         {connection.startedAt && (
           <MetaRow

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -14,6 +14,7 @@ import {
   CheckSquare,
   Activity,
   FolderKanban,
+  RadioTower,
   Settings,
   LogOut,
   Menu,
@@ -246,6 +247,7 @@ export default function DashboardLayout({
   // Global navigation items
   const globalNavItems = [
     { href: "/projects", label: t("nav.projects"), icon: FolderKanban },
+    { href: "/agent-connections", label: t("nav.agentConnections"), icon: RadioTower },
     { href: "/settings", label: t("nav.settings"), icon: Settings },
   ];
 

--- a/src/app/api/agent-connections/__tests__/route.test.ts
+++ b/src/app/api/agent-connections/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+const mockListConnectionsForOwner = vi.fn();
+const mockListConnectionsForAgent = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+vi.mock("@/services/daemon-connection.service", () => ({
+  listConnectionsForOwner: (...args: unknown[]) => mockListConnectionsForOwner(...args),
+  listConnectionsForAgent: (...args: unknown[]) => mockListConnectionsForAgent(...args),
+}));
+
+import { GET } from "@/app/api/agent-connections/route";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const actorUuid = "actor-0000-0000-0000-000000000001";
+
+const userAuth = { type: "user", companyUuid, actorUuid };
+const agentAuth = { type: "agent", companyUuid, actorUuid, permissions: [] };
+
+// A representative ConnectionView the mocked service returns; the route passes
+// it through verbatim, so the exact shape only needs to round-trip.
+const sampleConnections = [
+  {
+    uuid: "conn-1",
+    agentUuid: actorUuid,
+    clientType: "claude_code",
+    clientVersion: "0.11.0",
+    host: "laptop",
+    startedAt: "2026-06-15T03:00:00.000Z",
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: "2026-06-15T03:00:00.000Z",
+    lastSeenAt: "2026-06-15T03:00:30.000Z",
+    disconnectedAt: null,
+  },
+];
+
+function makeRequest(): NextRequest {
+  return new NextRequest(new URL("http://localhost:3000/api/agent-connections"));
+}
+
+// withErrorHandler-wrapped handlers take (request, context); this route has no
+// path params, so an empty params context satisfies the signature.
+const emptyCtx = { params: Promise.resolve({}) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListConnectionsForOwner.mockResolvedValue(sampleConnections);
+  mockListConnectionsForAgent.mockResolvedValue(sampleConnections);
+});
+
+describe("GET /api/agent-connections", () => {
+  it("returns 401 and calls neither list fn when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(), emptyCtx);
+
+    expect(res.status).toBe(401);
+    expect(mockListConnectionsForOwner).not.toHaveBeenCalled();
+    expect(mockListConnectionsForAgent).not.toHaveBeenCalled();
+  });
+
+  it("routes a user caller to listConnectionsForOwner(companyUuid, actorUuid)", async () => {
+    mockGetAuthContext.mockResolvedValue(userAuth);
+
+    const res = await GET(makeRequest(), emptyCtx);
+
+    expect(res.status).toBe(200);
+    expect(mockListConnectionsForOwner).toHaveBeenCalledTimes(1);
+    expect(mockListConnectionsForOwner).toHaveBeenCalledWith(companyUuid, actorUuid);
+    expect(mockListConnectionsForAgent).not.toHaveBeenCalled();
+  });
+
+  // Note: there is no super_admin case here. getAuthContext (the route's only
+  // auth call) returns AuthContext | null and never yields a SuperAdminAuthContext
+  // at runtime — every path resolves to "agent" or "user". The non-agent ("else")
+  // branch is therefore exercised by the user case above.
+
+  it("routes an agent caller to listConnectionsForAgent(companyUuid, actorUuid)", async () => {
+    mockGetAuthContext.mockResolvedValue(agentAuth);
+
+    const res = await GET(makeRequest(), emptyCtx);
+
+    expect(res.status).toBe(200);
+    expect(mockListConnectionsForAgent).toHaveBeenCalledTimes(1);
+    expect(mockListConnectionsForAgent).toHaveBeenCalledWith(companyUuid, actorUuid);
+    expect(mockListConnectionsForOwner).not.toHaveBeenCalled();
+  });
+
+  it("returns the standard envelope { success: true, data: { connections } } passing the service result through", async () => {
+    mockGetAuthContext.mockResolvedValue(userAuth);
+
+    const res = await GET(makeRequest(), emptyCtx);
+    const body = await res.json();
+
+    expect(body).toEqual({
+      success: true,
+      data: { connections: sampleConnections },
+      meta: undefined,
+    });
+  });
+});

--- a/src/app/api/agent-connections/route.ts
+++ b/src/app/api/agent-connections/route.ts
@@ -1,0 +1,32 @@
+// src/app/api/agent-connections/route.ts
+// Agent Connections API - List the daemon connections visible to the caller.
+//
+// Visibility is enforced by the query scope itself, not by a permission bit:
+//   - user / super_admin → connections of every agent they own (listConnectionsForOwner)
+//   - agent (API key)     → only the agent's own connections (listConnectionsForAgent)
+// This mirrors the root-idea-resolution endpoint precedent: no MCP tool, no new
+// permission bit, but auth is still required (401 without it).
+
+import { NextRequest } from "next/server";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import {
+  listConnectionsForOwner,
+  listConnectionsForAgent,
+} from "@/services/daemon-connection.service";
+
+// GET /api/agent-connections - List daemon connections visible to the caller
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) {
+    return errors.unauthorized();
+  }
+
+  const connections =
+    auth.type === "agent"
+      ? await listConnectionsForAgent(auth.companyUuid, auth.actorUuid)
+      : await listConnectionsForOwner(auth.companyUuid, auth.actorUuid);
+
+  return success({ connections });
+});

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -5,6 +5,7 @@ const mockPrisma = vi.hoisted(() => ({
   daemonConnection: {
     upsert: vi.fn(),
     updateMany: vi.fn(),
+    findMany: vi.fn(),
   },
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
@@ -24,6 +25,8 @@ import {
   registerConnection,
   markDisconnected,
   touchConnection,
+  listConnectionsForOwner,
+  listConnectionsForAgent,
   type SelfReport,
 } from "@/services/daemon-connection.service";
 
@@ -260,5 +263,224 @@ describe("touchConnection", () => {
     mockPrisma.daemonConnection.updateMany.mockRejectedValue(new Error("db down"));
     await expect(touchConnection(companyUuid, handle)).resolves.toBeUndefined();
     expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===== Read projection (listConnectionsForOwner / listConnectionsForAgent) =====
+
+// Pin "now" so the staleness boundary is deterministic. Date.now() in the
+// mapper is driven by the faked clock.
+const NOW = new Date("2026-06-15T04:00:00.000Z");
+const ownerUuid = "owner-0000-0000-0000-000000000001";
+
+// Build a DaemonConnection row fixture, dating lastSeenAt `agoMs` before NOW.
+function makeRow(
+  overrides: {
+    uuid?: string;
+    status?: string;
+    agoMs?: number; // how long before NOW lastSeenAt was
+    startedAt?: Date | null;
+    clientVersion?: string | null;
+    host?: string;
+    disconnectedAt?: Date | null;
+  } = {},
+) {
+  const agoMs = overrides.agoMs ?? 0;
+  return {
+    uuid: overrides.uuid ?? connectionUuid,
+    agentUuid,
+    clientType: "claude_code",
+    // Use `in` (not `??`) for the nullable fields so an explicit null override
+    // is honored rather than falling through to the default.
+    clientVersion: "clientVersion" in overrides ? overrides.clientVersion : "0.11.0",
+    host: overrides.host ?? "mac.local",
+    startedAt:
+      "startedAt" in overrides ? overrides.startedAt : new Date("2026-06-15T03:00:00.000Z"),
+    status: overrides.status ?? "online",
+    connectedAt: new Date("2026-06-15T03:30:00.000Z"),
+    lastSeenAt: new Date(NOW.getTime() - agoMs),
+    disconnectedAt: "disconnectedAt" in overrides ? overrides.disconnectedAt : null,
+  };
+}
+
+describe("listConnectionsForOwner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("filters by companyUuid + agent.ownerUuid and maps rows to ConnectionView", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([makeRow()]);
+
+    const result = await listConnectionsForOwner(companyUuid, ownerUuid);
+
+    expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.daemonConnection.findMany.mock.calls[0][0]).toEqual({
+      where: { companyUuid, agent: { ownerUuid } },
+    });
+    expect(result).toHaveLength(1);
+    const view = result[0];
+    // Full projection shape, with timestamps mapped to ISO strings.
+    expect(view).toEqual({
+      uuid: connectionUuid,
+      agentUuid,
+      clientType: "claude_code",
+      clientVersion: "0.11.0",
+      host: "mac.local",
+      startedAt: "2026-06-15T03:00:00.000Z",
+      status: "online",
+      effectiveStatus: "online",
+      connectedAt: "2026-06-15T03:30:00.000Z",
+      lastSeenAt: "2026-06-15T04:00:00.000Z",
+      disconnectedAt: null,
+    });
+  });
+
+  it("maps null startedAt / clientVersion / disconnectedAt through as null", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ startedAt: null, clientVersion: null, disconnectedAt: null, host: "" }),
+    ]);
+    const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(view.startedAt).toBeNull();
+    expect(view.clientVersion).toBeNull();
+    expect(view.disconnectedAt).toBeNull();
+    expect(view.host).toBe("");
+  });
+
+  it("returns an empty array when there are genuinely no rows", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
+    await expect(listConnectionsForOwner(companyUuid, ownerUuid)).resolves.toEqual([]);
+  });
+
+  it("PROPAGATES a query error (does NOT swallow to [] like the write functions)", async () => {
+    mockPrisma.daemonConnection.findMany.mockRejectedValue(new Error("db down"));
+    await expect(listConnectionsForOwner(companyUuid, ownerUuid)).rejects.toThrow("db down");
+    // Crucially, no swallow-and-log: the read path surfaces the error.
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("listConnectionsForAgent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("filters by companyUuid + agentUuid and maps rows to ConnectionView", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([makeRow()]);
+
+    const result = await listConnectionsForAgent(companyUuid, agentUuid);
+
+    expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.daemonConnection.findMany.mock.calls[0][0]).toEqual({
+      where: { companyUuid, agentUuid },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].uuid).toBe(connectionUuid);
+    expect(result[0].effectiveStatus).toBe("online");
+  });
+
+  it("PROPAGATES a query error (does NOT swallow to [])", async () => {
+    mockPrisma.daemonConnection.findMany.mockRejectedValue(new Error("db down"));
+    await expect(listConnectionsForAgent(companyUuid, agentUuid)).rejects.toThrow("db down");
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("effectiveStatus derivation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("online + fresh (lastSeenAt within threshold) → online", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ status: "online", agoMs: STALE_THRESHOLD_MS - 1 }),
+    ]);
+    const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(view.effectiveStatus).toBe("online");
+  });
+
+  it("online + stale (lastSeenAt older than threshold) → offline", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ status: "online", agoMs: STALE_THRESHOLD_MS + 1 }),
+    ]);
+    const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(view.effectiveStatus).toBe("offline");
+    // raw status is still passed through unchanged
+    expect(view.status).toBe("online");
+  });
+
+  it("online + exactly at the threshold → online (inclusive boundary)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ status: "online", agoMs: STALE_THRESHOLD_MS }),
+    ]);
+    const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(view.effectiveStatus).toBe("online");
+  });
+
+  it("online + one ms over the threshold → offline (just-over boundary)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ status: "online", agoMs: STALE_THRESHOLD_MS + 1 }),
+    ]);
+    const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(view.effectiveStatus).toBe("offline");
+  });
+
+  it("offline → offline regardless of a fresh lastSeenAt", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ status: "offline", agoMs: 0 }),
+    ]);
+    const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(view.effectiveStatus).toBe("offline");
+  });
+});
+
+describe("ordering", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("sorts online-first, then lastSeenAt desc", async () => {
+    // Build rows out of final order:
+    //  - offlineOld:  offline, lastSeenAt 1h ago
+    //  - onlineOld:   online + fresh, lastSeenAt 60s ago
+    //  - onlineNew:   online + fresh, lastSeenAt now
+    //  - offlineNew:  offline, lastSeenAt 30s ago
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ uuid: "offline-old", status: "offline", agoMs: 60 * 60 * 1000 }),
+      makeRow({ uuid: "online-old", status: "online", agoMs: 60_000 }),
+      makeRow({ uuid: "online-new", status: "online", agoMs: 0 }),
+      makeRow({ uuid: "offline-new", status: "offline", agoMs: 30_000 }),
+    ]);
+
+    const result = await listConnectionsForOwner(companyUuid, ownerUuid);
+
+    // Online (newest lastSeenAt first), then offline (newest lastSeenAt first).
+    expect(result.map((v) => v.uuid)).toEqual([
+      "online-new",
+      "online-old",
+      "offline-new",
+      "offline-old",
+    ]);
+    expect(result.map((v) => v.effectiveStatus)).toEqual([
+      "online",
+      "online",
+      "offline",
+      "offline",
+    ]);
+  });
+
+  it("treats a stale online row as offline for ordering purposes", async () => {
+    // A status=online but stale row must sort with the offline group, since
+    // ordering keys on effectiveStatus, not the raw status.
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ uuid: "stale-online", status: "online", agoMs: STALE_THRESHOLD_MS + 1 }),
+      makeRow({ uuid: "fresh-online", status: "online", agoMs: 0 }),
+    ]);
+    const result = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(result.map((v) => v.uuid)).toEqual(["fresh-online", "stale-online"]);
+    expect(result.map((v) => v.effectiveStatus)).toEqual(["online", "offline"]);
   });
 });

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -1,11 +1,16 @@
 // src/services/daemon-connection.service.ts
-// Daemon Connection Registry Service — persistence layer for long-lived daemon
-// SSE connections. Collection + liveness only: no read/query API, no HTTP/MCP
-// endpoint, no AgentSession link, no UI (those are deferred to idea f2fe9a7f).
+// Daemon Connection Registry Service — persistence + read projection for
+// long-lived daemon SSE connections.
 //
-// All functions are companyUuid-scoped and swallow-and-log on failure: a registry
-// write must NEVER throw to the caller, so a failing DB write can never block or
-// break SSE stream setup / event delivery.
+// All functions are companyUuid-scoped. The two error-handling regimes are
+// deliberately different:
+//   - WRITE functions (registerConnection / markDisconnected / touchConnection)
+//     swallow-and-log on failure: a registry write must NEVER throw to the
+//     caller, so a failing DB write can never block or break SSE stream setup /
+//     event delivery.
+//   - READ functions (listConnectionsForOwner / listConnectionsForAgent) do NOT
+//     swallow: a query failure propagates so the route surfaces a 500. An empty
+//     list must mean genuinely zero rows, not a hidden error.
 
 import { prisma } from "@/lib/prisma";
 import logger from "@/lib/logger";
@@ -53,10 +58,97 @@ export interface ConnectionHandle {
   connectedAt: Date;
 }
 
+/**
+ * Read projection of a `DaemonConnection` row returned to callers of the read
+ * API. The raw `status` and the timestamps are passed through so a client can
+ * render uptime and last-active without re-implementing liveness; the
+ * server-derived `effectiveStatus` is the single liveness verdict the client
+ * renders verbatim.
+ *
+ * Note the two distinct timestamps:
+ *  - `startedAt`   — self-reported daemon *process* start time (untrusted,
+ *                    display-only; may be null if the daemon did not report it).
+ *  - `connectedAt` — when *this* SSE connection registered with the server
+ *                    (server-stamped; the fencing token for the connection
+ *                    generation). Used for the "uptime" of the current
+ *                    connection, which is not the same as process uptime.
+ */
+export interface ConnectionView {
+  uuid: string;
+  agentUuid: string;
+  clientType: string;
+  clientVersion: string | null;
+  host: string; // "" when host-less (display can show a placeholder)
+  startedAt: string | null; // ISO-8601 — self-reported daemon process start
+  status: string; // raw persisted status
+  effectiveStatus: "online" | "offline";
+  connectedAt: string; // ISO-8601 — when this SSE connection registered
+  lastSeenAt: string; // ISO-8601
+  disconnectedAt: string | null;
+}
+
 // ===== Helpers =====
 
 function isDaemonClientType(value: string): value is DaemonClientType {
   return (DAEMON_CLIENT_TYPES as readonly string[]).includes(value);
+}
+
+// Subset of the DaemonConnection row the mapper reads. Kept structural (rather
+// than importing Prisma's generated type) so the mapper is trivially unit-
+// testable with plain fixture objects.
+interface DaemonConnectionRow {
+  uuid: string;
+  agentUuid: string;
+  clientType: string;
+  clientVersion: string | null;
+  host: string;
+  startedAt: Date | null;
+  status: string;
+  connectedAt: Date;
+  lastSeenAt: Date;
+  disconnectedAt: Date | null;
+}
+
+/**
+ * Map a persisted row to its `ConnectionView`, deriving `effectiveStatus` —
+ * the single source of truth for liveness. A connection is *effectively online*
+ * iff its raw `status` is the literal "online" AND its `lastSeenAt` is within
+ * `STALE_THRESHOLD_MS` of now; otherwise it is "offline". This REUSES the
+ * exported `STALE_THRESHOLD_MS` so producer (the SSE heartbeat) and consumer
+ * (this read path) can never drift. The boundary is inclusive: elapsed exactly
+ * equal to the threshold still counts as fresh → "online".
+ */
+function toConnectionView(row: DaemonConnectionRow): ConnectionView {
+  const fresh = Date.now() - row.lastSeenAt.getTime() <= STALE_THRESHOLD_MS;
+  const effectiveStatus = row.status === "online" && fresh ? "online" : "offline";
+
+  return {
+    uuid: row.uuid,
+    agentUuid: row.agentUuid,
+    clientType: row.clientType,
+    clientVersion: row.clientVersion,
+    host: row.host,
+    startedAt: row.startedAt ? row.startedAt.toISOString() : null,
+    status: row.status,
+    effectiveStatus,
+    connectedAt: row.connectedAt.toISOString(),
+    lastSeenAt: row.lastSeenAt.toISOString(),
+    disconnectedAt: row.disconnectedAt ? row.disconnectedAt.toISOString() : null,
+  };
+}
+
+/**
+ * Order the projected views online-first, then by `lastSeenAt` desc — the
+ * most-relevant connections surface at the top. Sorts a copy; does not mutate
+ * the input.
+ */
+function sortConnectionViews(views: ConnectionView[]): ConnectionView[] {
+  return [...views].sort((a, b) => {
+    if (a.effectiveStatus !== b.effectiveStatus) {
+      return a.effectiveStatus === "online" ? -1 : 1;
+    }
+    return b.lastSeenAt.localeCompare(a.lastSeenAt);
+  });
 }
 
 /**
@@ -215,4 +307,43 @@ export async function touchConnection(
       "Failed to touch daemon connection",
     );
   }
+}
+
+// ===== Read functions =====
+//
+// Unlike the write functions above, the read functions deliberately do NOT
+// swallow-and-log to an empty list. A query failure is a real error the caller
+// (the route) must surface (as a 500 via withErrorHandler) — an empty list MUST
+// mean genuinely zero rows, never "the DB threw". So these intentionally have no
+// try/catch: a rejected query propagates.
+
+/**
+ * List the daemon connections visible to a *user* owner: every connection whose
+ * agent is owned by `ownerUuid`, scoped to `companyUuid`. Projected to
+ * `ConnectionView` (with server-derived `effectiveStatus`) and ordered
+ * online-first then `lastSeenAt` desc.
+ */
+export async function listConnectionsForOwner(
+  companyUuid: string,
+  ownerUuid: string,
+): Promise<ConnectionView[]> {
+  const rows = await prisma.daemonConnection.findMany({
+    where: { companyUuid, agent: { ownerUuid } },
+  });
+  return sortConnectionViews(rows.map(toConnectionView));
+}
+
+/**
+ * List the daemon connections owned by a single agent (`agentUuid`), scoped to
+ * `companyUuid` — the agent-key analogue of owner-scoping ("am I registered?").
+ * Projected to `ConnectionView` and ordered online-first then `lastSeenAt` desc.
+ */
+export async function listConnectionsForAgent(
+  companyUuid: string,
+  agentUuid: string,
+): Promise<ConnectionView[]> {
+  const rows = await prisma.daemonConnection.findMany({
+    where: { companyUuid, agentUuid },
+  });
+  return sortConnectionViews(rows.map(toConnectionView));
 }


### PR DESCRIPTION
## Summary

Observability slice of idea **f2fe9a7f** (derived from the CLI-daemon stack). The `DaemonConnection` registry shipped in #319 is collection-only — data is captured but nothing surfaces it. This adds the first read surface over it: an owner-scoped **Agent Connections** page backed by a small REST read API.

Real `claude_code` / `openclaw` daemons already self-report into the registry, so this page is backed by live data today.

## What's in scope

- **Service read path** — `listConnectionsForOwner` / `listConnectionsForAgent` + a `ConnectionView` DTO, with a server-derived `effectiveStatus` that **reuses the registry's `STALE_THRESHOLD_MS`** (single source of truth for the liveness rule — producer and consumer can't drift). Read functions propagate errors, in deliberate contrast with the swallow-and-log write functions.
- **REST endpoint** — `GET /api/agent-connections`, agent-key **and** user-cookie callable, **not** an MCP tool, no new permission bit (mirrors the #318 root-idea-resolution precedent). `user`/`super_admin` → owner-scoped (`agent.ownerUuid`); `agent` → self-scoped (`agentUuid`). Every query is `companyUuid`-scoped.
- **Page** — `/agent-connections` global nav item (`RadioTower`, labeled **"Agent Connections"** — not "Daemons"), ~15s polling, online/offline badges from `effectiveStatus`, host / uptime / last-active, empty state. shadcn/ui only, full en/zh i18n.
- **OpenSpec** — change `add-agent-connection-observability` authored, archived, and the cumulative spec mirrored back.

## Intentionally deferred (recorded in elaboration + proposal Out-of-scope)

Live transcript ingest, per-connection `AgentSession` nesting, and management verbs (forced disconnect / history) all need a daemon-side stream-json upload protocol that doesn't exist yet — building them now would be speculative.

## Changed files

| File | Change |
|------|--------|
| `src/services/daemon-connection.service.ts` | + `ConnectionView`, `listConnectionsForOwner/ForAgent`, `effectiveStatus` projection (read-only additions) |
| `src/app/api/agent-connections/route.ts` | new `GET` endpoint (owner/self scoping) |
| `src/app/(dashboard)/agent-connections/page.tsx` | new polling page |
| `src/app/(dashboard)/layout.tsx` | + global nav item |
| `messages/{en,zh}.json` | + `nav.agentConnections` + `agentConnections.*` (21 keys each, parity verified) |
| `src/**/__tests__/*` | service +12 tests, route +4 tests |
| `openspec/**` | archived change + cumulative spec |
| `docs/design.pen` | reference frame for the page |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `vitest` — 38 tests pass (34 service + 4 route)
- [x] `eslint` on changed files — 0 errors
- [x] en/zh i18n key parity verified
- [x] **Local e2e (Playwright)**: logged in, page renders real data; verified offline staleness rendering, the green online badge via a live SSE connection, the live "1 online · 3 total" summary update, the agent-key self-scope (returns only its own connection), and owner-scoping isolation. Console clean (0 errors).

## Reviews

- Proposal reviewer: PASS WITH NOTES (0 blockers)
- Per-task reviewers: all PASS
- Independent adversarial code review: **SHIP** (0 blockers) — empirically verified that `actorUuid` resolves correctly as both a user's owner-id and an agent's self-id (the highest-risk owner-scoping point). Its 2 cosmetic notes (unused `fieldVersion` i18n key; redundant super_admin test for an unreachable runtime state) are **fixed in this PR**.

## Known follow-up

`docs/design.pen` frame is still titled "Chorus - Daemons" and carries a descoped expandable sessions body; it needs renaming to "Agent Connections" + removing that body to match the shipped read-only page (the Pencil editor was unreachable during the run). Tracked for a follow-up sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)