### PR TITLE
feat(mention): agent online presence + active-task count in the @-mention dropdown

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -533,7 +533,7 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 
 ### chorus_search_mentionables
 
-**Description**: Search for users and agents that can be @mentioned. Returns name, type, and UUID. Use the UUID to write mentions as `@[Name](type:uuid)` in comment/description text.
+**Description**: Search for users and agents that can be @mentioned. Returns name, type, and UUID. Use the UUID to write mentions as `@[Name](type:uuid)` in comment/description text. For results of type `agent`, the entry also carries `online` (boolean: true iff the agent currently has a live daemon connection) and `activeCount` (number of tasks/resources its daemon is running or has queued; `0` when offline). User results do not carry these fields.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -545,7 +545,7 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 ```json
 [
   { "type": "user", "uuid": "...", "name": "Yifei", "email": "yifei@...", "avatarUrl": "..." },
-  { "type": "agent", "uuid": "...", "name": "Claude Dev", "roles": ["developer"] }
+  { "type": "agent", "uuid": "...", "name": "Claude Dev", "roles": ["developer"], "online": true, "activeCount": 2 }
 ]
 ```
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1385,5 +1385,11 @@
     "entityProposal": "Proposal",
     "entityDocument": "Document",
     "entityUnknown": "Resource"
+  },
+  "mention": {
+    "online": "Online",
+    "offline": "Offline",
+    "activeCount": "{count} active",
+    "idle": "Idle"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1386,5 +1386,11 @@
     "entityProposal": "提案",
     "entityDocument": "文档",
     "entityUnknown": "资源"
+  },
+  "mention": {
+    "online": "在线",
+    "offline": "离线",
+    "activeCount": "进行中 {count}",
+    "idle": "空闲"
   }
 }

--- a/openspec/changes/archive/2026-06-17-mention-agent-liveness/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-17-mention-agent-liveness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/archive/2026-06-17-mention-agent-liveness/README.md
+++ b/openspec/changes/archive/2026-06-17-mention-agent-liveness/README.md
@@ -1,0 +1,3 @@
+# mention-agent-liveness
+
+Show agent online dot + active-task count in the @-mention dropdown

--- a/openspec/changes/archive/2026-06-17-mention-agent-liveness/design.md
+++ b/openspec/changes/archive/2026-06-17-mention-agent-liveness/design.md
@@ -1,0 +1,160 @@
+# Technical Design: Agent liveness in the @-mention dropdown
+
+## Overview
+
+Add two fields to each **agent** candidate returned by the mention search —
+`online: boolean` and `activeCount: number` — and render them as a dot + count in
+the dropdown's agent rows. No new endpoint, no schema change, no new permission;
+the mention candidate set is already owner-scoped (a user sees only their own
+agents), which is exactly the scope the daemon-connection registry serves.
+
+Data flow:
+
+```
+GET /api/mentionables?q=…  (caller = user; agents owner-scoped)
+  → mentionService.searchMentionables
+      → (existing) resolve agent candidates
+      → (new) batch-enrich: for the agent uuids in the result,
+          • online      = has ≥1 effectively-online DaemonConnection
+          • activeCount = running/queued DaemonExecution rows on those live connections
+  → route returns enriched list verbatim
+  → mention-editor dropdown renders dot (online) + badge (activeCount>0) on agent rows
+```
+
+## Reuse, do not re-model
+
+- **`daemon-connection.service.ts`** owns the liveness rule. Reuse its exported
+  `STALE_THRESHOLD_MS` and the `effectiveStatus` derivation
+  (`status === "online" && now - lastSeenAt.getTime() <= STALE_THRESHOLD_MS`) —
+  do NOT restate the rule, so producer and consumer cannot drift. (Same constant
+  the connection page and the execution staleness gate already reuse.)
+- **`DaemonExecution`** (merged in PR #323) is the source for `activeCount`: rows
+  with `status` in (`running`, `queued`). It carries `agentUuid` and
+  `connectionUuid` directly, and is indexed `(connectionUuid, status)` and
+  `(companyUuid, agentUuid)`.
+- **`StatusDot`** visual language exists on the Agent Connections page
+  (`agent-connections/page.tsx`), but the dropdown renders raw DOM (not React),
+  so the dot here is a small inline element matching that palette — not an import.
+
+## Data Model
+
+None. No new model, no migration. Two **transport** fields are added to the
+existing `Mentionable` interface (`mention.service.ts`), both optional so the
+shape stays backward compatible and users simply omit them:
+
+```ts
+interface Mentionable {
+  type: "user" | "agent";
+  uuid: string;
+  name: string;
+  email?: string | null;
+  avatarUrl?: string | null;
+  roles?: string[];
+  online?: boolean;       // agents only
+  activeCount?: number;   // agents only; running/queued executions
+}
+```
+
+## Enrichment contract (the core)
+
+A single helper enriches the agent candidates after they're resolved, in BOTH
+branches of `searchMentionables` (the empty-query branch at ~:230-257 AND the
+search branch at ~:302-319 — easy to miss one; the empty-query branch is the
+common "popup just opened" case and MUST be enriched too):
+
+1. Collect the agent candidate uuids (`agentUuids`). If empty, skip (no queries).
+2. **Online set** — one query, companyUuid-scoped:
+   `prisma.daemonConnection.findMany({ where: { companyUuid, agentUuid: { in: agentUuids } }, select: { agentUuid, status, lastSeenAt } })`.
+   An agent is `online` iff ANY of its rows satisfies the `effectiveStatus`
+   online rule. Build a `Set<agentUuid>` of online agents.
+3. **Active counts** — one query, companyUuid-scoped:
+   count `running`/`queued` `DaemonExecution` rows grouped by `agentUuid` for
+   `agentUuid in agentUuids`. A `groupBy({ by: ['agentUuid'], where: { companyUuid, agentUuid: { in }, status: { in: ['running','queued'] } }, _count })`
+   yields the per-agent count in one round-trip. Build a `Map<agentUuid, number>`.
+   - **Liveness coherence**: `activeCount` must be 0 for an agent that is not
+     `online` (an offline agent shows no dot and no badge). The execution rows of
+     a stale/offline connection are excluded the same way the execution read path
+     does it — gate the count on the agent being in the online set (the simplest
+     correct rule: if `!online` then `activeCount = 0`). The implementer may
+     either filter the groupBy to live connections or zero-out non-online agents
+     after the fact; the AC only requires the coherent outcome.
+4. Map each agent candidate to `{ ...agent, online, activeCount }`. Users are
+   left untouched.
+
+Two queries total regardless of candidate count — no N+1. Both are
+companyUuid-scoped; the agent set is already owner-scoped by the existing search,
+so visibility is inherited (a user can only ever see their own agents here).
+
+## API Design
+
+- `GET /api/mentionables` — unchanged in shape; it already returns the service
+  result via `success(results)`. The enriched fields ride along automatically.
+- `chorus_search_mentionables` (MCP) — same: returns the service result. Its
+  LLM-facing description is updated to document `online` + `activeCount` on agent
+  entries so agent callers know the fields exist.
+- No new route, no new query param, no new permission gate.
+
+## Module Contracts
+
+- **One liveness rule, reused.** `online` is derived with the connection
+  registry's exact `effectiveStatus` formula and its single `STALE_THRESHOLD_MS`
+  — never a second threshold.
+- **`activeCount` is daemon-sourced and coherent with `online`.** It counts
+  `running`/`queued` `DaemonExecution` rows for the agent; it is 0 whenever the
+  agent is not `online`. (So the count never contradicts the dot.)
+- **Agent-only.** `online`/`activeCount` are populated for `type === "agent"`
+  candidates only; user candidates never carry them, and the dropdown never
+  renders a dot/badge on a user row.
+- **Additive + optional.** Both fields are optional on `Mentionable`; any
+  existing consumer that ignores them is unaffected.
+
+## Frontend (mention-editor.tsx)
+
+The dropdown is rendered as raw DOM in `createSuggestionPopupRenderer` →
+`renderList` (`mention-editor.tsx:223-272`). For an **agent** row:
+
+- Replace the existing roles line (`:261-266`) with a status line: a small green
+  dot when `online` (title `Online`), nothing when offline (title `Offline` on
+  the row's status slot if present) — the dot element carries the localized
+  tooltip; and, when `activeCount > 0`, a compact count badge (e.g. "▶ 3" /
+  localized "{n} active"). When `activeCount === 0`, no badge.
+- The `Mentionable` client type (top of the file) gains the two optional fields.
+- User rows are unchanged (name + email, no status line).
+- Reduced-motion: the dot is static (no pulse), so nothing to gate — consistent
+  with the idea's "restraint in the dropdown" decision.
+
+## Implementation Plan
+
+Single cohesive module (one task): service enrichment + type + MCP description +
+frontend render + i18n + tests. It's one vertical slice across a thin surface and
+splitting it would add Chorus task overhead for no isolation benefit.
+
+1. Service: `Mentionable` type + batched enrichment helper, wired into both
+   branches of `searchMentionables`. Unit tests (Prisma mocked): online iff any
+   live connection; activeCount from running/queued; offline ⇒ count 0; users
+   unenriched; empty-candidate set issues no liveness queries; companyUuid scope.
+2. MCP tool description + `docs/MCP_TOOLS.md`.
+3. Frontend: dropdown agent-row dot + count, remove roles line, extend client
+   type, localize en + zh. Update `docs/design.pen`.
+4. Verify: `tsc` + full suite; manual check that an online owned agent shows the
+   dot and (when its daemon is busy) the count, offline shows neither, users
+   unaffected.
+
+## Risks & Mitigations
+
+- **Missing the empty-query branch.** `searchMentionables` returns agents from
+  two code paths; enriching only the search branch would leave the just-opened
+  (empty-query) popup unlit. Mitigation: an AC + a unit test specifically for the
+  empty-query branch.
+- **`activeCount` contradicting the dot.** If counted naively, a stale connection's
+  rows could inflate the count for an agent shown offline. Mitigation: the
+  contract zeroes `activeCount` for non-online agents (and/or counts only live
+  connections), with a unit test for the offline⇒0 case.
+- **Dropdown is non-React DOM.** Changes are imperative string/DOM building, not
+  JSX — easy to introduce an unescaped-content or layout regression. Mitigation:
+  keep the dot/badge as simple spans matching the existing palette; the existing
+  page test + a render assertion guard the agent row.
+- **LLM-memory hazards.** Implementer must verify against code, not memory: the
+  exact `effectiveStatus`/`STALE_THRESHOLD_MS` export, the `DaemonExecution`
+  field names + active statuses, and the two candidate-producing branches in
+  `searchMentionables`.

--- a/openspec/changes/archive/2026-06-17-mention-agent-liveness/proposal.md
+++ b/openspec/changes/archive/2026-06-17-mention-agent-liveness/proposal.md
@@ -1,0 +1,104 @@
+# Proposal: Agent liveness in the @-mention dropdown
+
+## Why
+
+When a user @-mentions an agent to hand it work, the @-mention dropdown
+(`mention-editor.tsx`, driven by `GET /api/mentionables`) shows only the agent's
+name and roles — **not whether the agent has a live daemon connection**. So a
+user can @-mention an offline agent, the task sits at `assigned` with no daemon
+to pick it up, and there's no signal at the moment of decision.
+
+Bringing the "online" signal forward to the mention-selection moment avoids
+"assigned to an agent that nobody's running". And now that the daemon reports
+what it's executing (the just-merged `DaemonExecution` model), we can show one
+more decision-useful number right there: **how many tasks/resources that agent's
+daemon is currently working on** — so a user can prefer an idle online agent over
+a busy one.
+
+This is the third consumer of the daemon-connection observability layer (idea
+`f2fe9a7f`): siblings put liveness on a dedicated page and (planned) the sidebar;
+this one puts it at the point of dispatch.
+
+### Premise correction (verified against code)
+
+The idea originally assumed the mention dropdown lists **company-wide** agents, so
+the owner-scoped `GET /api/agent-connections` couldn't cover them and a new
+company-scoped endpoint would be needed. The code says otherwise:
+`mentionService.searchMentionables` (`src/services/mention.service.ts:288-319`,
+and the empty-query branch `:230-257`) returns agent candidates **owner-scoped** —
+a user sees only agents they own — exactly the scope the connection registry
+already serves. The mention editor's caller is always a human user. So **no new
+endpoint, no new permission, and no company-wide visibility change** are needed:
+the agents in the dropdown are precisely the agents whose liveness the existing
+owner-scoped data already covers.
+
+## What Changes
+
+- **`searchMentionables` enriches each AGENT candidate with two fields** (users
+  unchanged): `online: boolean` and `activeCount: number`.
+  - `online` reuses the daemon-connection registry's `effectiveStatus` rule
+    (`status === "online" && now - lastSeenAt <= STALE_THRESHOLD_MS`): an agent
+    is online iff it has at least one effectively-online `DaemonConnection`.
+  - `activeCount` is the number of `running`/`queued` `DaemonExecution` rows on
+    that agent's effectively-online connection(s) — the same source as the dot
+    (both come from the daemon). An offline agent is therefore naturally
+    `online: false, activeCount: 0`.
+  - Both are resolved in **batch** over the agent candidate set (one connection
+    query + one execution `groupBy`), not per-row — no N+1.
+- **`GET /api/mentionables` / `chorus_search_mentionables`** pass the enriched
+  fields straight through (the route already returns the service result; the MCP
+  tool description gains the two fields).
+- **`mention-editor.tsx` dropdown** renders, on **agent** rows only:
+  - a static green dot when `online` (with an `Online`/`Offline` title tooltip);
+    offline agents show no dot (the dropdown is a dense list — restraint over a
+    sea of grey dots);
+  - a small count badge **only when `activeCount > 0`**;
+  - and **removes the existing roles line** (the dot + count take its place).
+  - User candidates are untouched (no dot, no count — online is an agent/daemon
+    concept).
+- **Snapshot at open, no polling**: the dropdown is transient; each mention
+  search request naturally returns fresh `online`/`activeCount`, so no in-popup
+  polling is added.
+
+## Capabilities
+
+### New Capabilities
+
+- `mention-agent-liveness`: the agent-liveness enrichment of the @-mention
+  surface — what `online`/`activeCount` mean, how they're derived (reusing the
+  connection registry's `effectiveStatus` + `DaemonExecution`), their
+  owner-scoped visibility, and how the dropdown renders the dot + count on agent
+  rows (and not on user rows).
+
+### Modified Capabilities
+
+- `mcp-tool-surface`: `chorus_search_mentionables`'s returned agent shape gains
+  `online` + `activeCount`. (Additive; same permission gate, same tool.)
+
+## Impact
+
+- **Schema**: none. Reuses `DaemonConnection` and the existing `DaemonExecution`
+  model; no migration.
+- **Backend**: `src/services/mention.service.ts` (enrich agent candidates in both
+  the empty-query and search branches), reusing `STALE_THRESHOLD_MS` /
+  `effectiveStatus` from `daemon-connection.service.ts` and a batched
+  running/queued count from `DaemonExecution`. The `Mentionable` type gains
+  `online?: boolean` + `activeCount?: number`. `GET /api/mentionables` is
+  unchanged in shape (passes the service result through).
+- **MCP**: `chorus_search_mentionables` description updated to document the two
+  new agent fields; `docs/MCP_TOOLS.md` updated.
+- **Frontend**: `src/components/mention-editor.tsx` — add the dot + count to agent
+  rows, remove the roles line; `Mentionable` client type extended. New
+  user-facing strings (tooltip `Online`/`Offline`, count label) localized in
+  `en` + `zh`. `docs/design.pen` gets the dropdown agent-row mock.
+- **Visibility**: owner-scoped, unchanged — a user only ever sees their own
+  agents' liveness, identical to the connection page. No new permission bit.
+- **Dependency**: builds on the merged `DaemonExecution` model (PR #323) for
+  `activeCount`. The `online` half depends only on the pre-existing
+  `DaemonConnection` registry.
+- **Out of scope** (carried from the idea's non-goals): no online indicator on
+  already-inserted @mention chips; no "online-first" reordering of candidates; no
+  in-popup polling; no change to user candidates; no change to mention
+  search/ranking beyond adding the two fields.
+- **Backward compat**: fully additive. A client that ignores the new fields
+  renders exactly as before; the fields are optional on the type.

--- a/openspec/changes/archive/2026-06-17-mention-agent-liveness/specs/mcp-tool-surface/spec.md
+++ b/openspec/changes/archive/2026-06-17-mention-agent-liveness/specs/mcp-tool-surface/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: `chorus_search_mentionables` SHALL expose agent liveness fields
+
+The `chorus_search_mentionables` MCP tool SHALL return, for each result entry of
+type `agent`, the additive fields `online` (boolean) and `activeCount` (integer)
+described by the `mention-agent-liveness` capability, and its tool description SHALL
+document them so an agent caller knows the fields exist. The addition SHALL be
+backward compatible: it SHALL NOT remove or rename any existing result field, SHALL
+NOT change the tool's permission gate, and SHALL NOT add a new permission bit.
+Entries of type `user` SHALL NOT carry these fields.
+
+#### Scenario: Agent entries carry online and activeCount
+
+- **WHEN** `chorus_search_mentionables` returns a result entry of type `agent`
+- **THEN** the entry MUST include an `online` boolean and an `activeCount` integer
+
+#### Scenario: The tool's permission gate is unchanged
+
+- **WHEN** the liveness fields are added to `chorus_search_mentionables`
+- **THEN** the tool MUST remain exposed under its existing gate with no new permission bit
+- **AND** no existing result field MUST be removed or renamed

--- a/openspec/changes/archive/2026-06-17-mention-agent-liveness/specs/mention-agent-liveness/spec.md
+++ b/openspec/changes/archive/2026-06-17-mention-agent-liveness/specs/mention-agent-liveness/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: Mention search SHALL enrich agent candidates with online status
+
+The mention search SHALL include, for each candidate of type `agent`, an `online`
+boolean indicating whether that agent currently has at least one effectively-online
+daemon connection. This applies to the mention search service (`searchMentionables`)
+and both surfaces over it (`GET /api/mentionables` and `chorus_search_mentionables`).
+"Effectively online" SHALL reuse the
+daemon-connection registry's existing rule — the connection's `status` is `online`
+AND `now - lastSeenAt` is within the registry's `STALE_THRESHOLD_MS` — rather than
+defining a separate threshold, so producer and consumer cannot drift. The online
+determination SHALL be `companyUuid`-scoped and SHALL be computed in a single batch
+query over the agent candidate set (no per-candidate query). Candidates of type
+`user` SHALL NOT carry an `online` field. The field SHALL be additive — a consumer
+that ignores it behaves exactly as before — and SHALL NOT require a new permission
+bit or widen the existing owner-scoped visibility of agent candidates.
+
+#### Scenario: An owned agent with a live connection is online
+
+- **GIVEN** a user whose mention search returns an agent they own
+- **AND** that agent has a `DaemonConnection` with `status = "online"` and a `lastSeenAt` within `STALE_THRESHOLD_MS`
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `online: true`
+
+#### Scenario: An agent with no fresh connection is offline
+
+- **GIVEN** an agent candidate whose only `DaemonConnection` is `offline`, or whose `lastSeenAt` is older than `STALE_THRESHOLD_MS`, or which has no connection at all
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `online: false`
+
+#### Scenario: User candidates are not enriched
+
+- **WHEN** the mention search returns a candidate of type `user`
+- **THEN** that candidate MUST NOT carry an `online` field
+
+#### Scenario: Online is resolved in batch, not per candidate
+
+- **GIVEN** a mention search resolving N agent candidates
+- **WHEN** their online status is determined
+- **THEN** the server MUST resolve all N via a single batched, `companyUuid`-scoped connection query rather than one query per candidate
+- **AND** when there are zero agent candidates it MUST issue no liveness query at all
+
+### Requirement: Mention search SHALL report each agent's active execution count
+
+The mention search SHALL include, for each candidate of type `agent`, an
+`activeCount` integer giving the number of that agent's currently active daemon
+executions — `DaemonExecution` rows whose `status` is `running` or `queued`. The
+count SHALL be `companyUuid`-scoped and computed in a single batched aggregate over
+the agent candidate set (no per-candidate query). `activeCount` SHALL be coherent
+with `online`: an agent that is not `online` SHALL report `activeCount` of `0`, so
+the count never contradicts the online indicator. Candidates of type `user` SHALL
+NOT carry an `activeCount` field.
+
+#### Scenario: An online agent reports its running/queued count
+
+- **GIVEN** an online agent candidate whose daemon has 2 `running` and 1 `queued` `DaemonExecution` rows
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `activeCount: 3`
+
+#### Scenario: An online agent with no active executions reports zero
+
+- **GIVEN** an online agent candidate with no `running`/`queued` execution rows
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `activeCount: 0`
+
+#### Scenario: An offline agent reports zero regardless of stale rows
+
+- **GIVEN** an agent candidate that is not `online`
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `activeCount: 0`
+
+#### Scenario: Active count is resolved in batch
+
+- **GIVEN** a mention search resolving N agent candidates
+- **WHEN** their active counts are determined
+- **THEN** the server MUST resolve all N via a single batched, `companyUuid`-scoped aggregate query rather than one query per candidate
+
+### Requirement: The @-mention dropdown SHALL render agent liveness and demote roles
+
+The @-mention dropdown SHALL render, on each **agent** candidate row, a static
+online indicator dot when the candidate's `online` is true, with an accessible
+`Online`/`Offline` tooltip; an offline agent SHALL NOT render a dot. When the
+candidate's `activeCount` is greater than zero the row SHALL render a compact count
+badge; when `activeCount` is zero no badge SHALL be shown. The agent row SHALL no
+longer render the agent's roles line (the online dot and count replace it). The dot
+SHALL be static (no pulsing animation) to keep the dense dropdown calm. Rows for
+`user` candidates SHALL be unchanged — no dot, no count. All new user-facing strings
+(the `Online`/`Offline` tooltip and the count label) SHALL be localized in both
+supported locales. The dropdown SHALL take the liveness values from the candidate
+payload at open time and SHALL NOT poll while open.
+
+#### Scenario: An online agent row shows a dot and (when busy) a count
+
+- **GIVEN** the dropdown lists an agent candidate with `online: true` and `activeCount: 2`
+- **WHEN** the row renders
+- **THEN** it MUST show a static online dot with an `Online` tooltip
+- **AND** it MUST show a count badge reflecting 2
+- **AND** it MUST NOT show the agent's roles line
+
+#### Scenario: An online idle agent shows a dot but no count badge
+
+- **GIVEN** the dropdown lists an agent candidate with `online: true` and `activeCount: 0`
+- **WHEN** the row renders
+- **THEN** it MUST show the online dot
+- **AND** it MUST NOT show a count badge
+
+#### Scenario: An offline agent shows neither dot nor count
+
+- **GIVEN** the dropdown lists an agent candidate with `online: false`
+- **WHEN** the row renders
+- **THEN** it MUST NOT show an online dot
+- **AND** it MUST NOT show a count badge
+
+#### Scenario: User rows are unaffected
+
+- **WHEN** the dropdown renders a `user` candidate row
+- **THEN** it MUST render as before (name and email) with no online dot and no count badge

--- a/openspec/changes/archive/2026-06-17-mention-agent-liveness/tasks.md
+++ b/openspec/changes/archive/2026-06-17-mention-agent-liveness/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: Agent liveness in the @-mention dropdown
+
+> Chorus task drafts are the source of truth; this mirrors them for the change record.
+
+## 1. Agent liveness in the @-mention surface (service + MCP + dropdown UI)
+- [ ] `Mentionable` gains optional `online` + `activeCount`; batched enrichment helper wired into BOTH branches of `searchMentionables` (empty-query + search)
+- [ ] `online` reuses connection registry `effectiveStatus` + `STALE_THRESHOLD_MS` (one batched connection query, companyUuid-scoped)
+- [ ] `activeCount` = running/queued `DaemonExecution` per agent (one batched aggregate); coherent with online (offline ⇒ 0)
+- [ ] `chorus_search_mentionables` description + `docs/MCP_TOOLS.md` document the two agent fields
+- [ ] `mention-editor.tsx`: agent rows show static dot (online, Online/Offline tooltip) + count badge (>0 only); roles line removed; user rows unchanged; en+zh localized; `docs/design.pen` updated
+- [ ] Service unit tests (Prisma mocked) + dropdown render test; `tsc` clean; full suite green

--- a/openspec/specs/mcp-tool-surface/spec.md
+++ b/openspec/specs/mcp-tool-surface/spec.md
@@ -290,3 +290,24 @@ The MCP tools that edit tasks or task drafts (`chorus_pm_update_task_draft` and 
 - **THEN** the call MUST succeed
 - **AND** the task's `AcceptanceCriterion` rows MUST be replaced with the provided non-blank items
 
+### Requirement: `chorus_search_mentionables` SHALL expose agent liveness fields
+
+The `chorus_search_mentionables` MCP tool SHALL return, for each result entry of
+type `agent`, the additive fields `online` (boolean) and `activeCount` (integer)
+described by the `mention-agent-liveness` capability, and its tool description SHALL
+document them so an agent caller knows the fields exist. The addition SHALL be
+backward compatible: it SHALL NOT remove or rename any existing result field, SHALL
+NOT change the tool's permission gate, and SHALL NOT add a new permission bit.
+Entries of type `user` SHALL NOT carry these fields.
+
+#### Scenario: Agent entries carry online and activeCount
+
+- **WHEN** `chorus_search_mentionables` returns a result entry of type `agent`
+- **THEN** the entry MUST include an `online` boolean and an `activeCount` integer
+
+#### Scenario: The tool's permission gate is unchanged
+
+- **WHEN** the liveness fields are added to `chorus_search_mentionables`
+- **THEN** the tool MUST remain exposed under its existing gate with no new permission bit
+- **AND** no existing result field MUST be removed or renamed
+

--- a/openspec/specs/mention-agent-liveness/spec.md
+++ b/openspec/specs/mention-agent-liveness/spec.md
@@ -1,0 +1,131 @@
+# mention-agent-liveness Specification
+
+## Purpose
+Defines the agent-liveness enrichment of the @-mention surface: the mention search
+(`searchMentionables`, surfaced by `GET /api/mentionables` and
+`chorus_search_mentionables`) annotates each agent candidate with `online` (derived
+from the daemon-connection registry's `effectiveStatus` rule, reusing its single
+`STALE_THRESHOLD_MS`) and `activeCount` (running/queued `DaemonExecution` rows,
+coherent with `online` so an offline agent reports 0), both owner-scoped and batched;
+and the @-mention dropdown renders a static online dot plus a count-when-busy badge on
+agent rows (demoting the roles line), leaving user rows unchanged. No new endpoint,
+permission, or schema. This is the dispatch-point consumer of the daemon-connection
+observability layer (idea f2fe9a7f).
+## Requirements
+### Requirement: Mention search SHALL enrich agent candidates with online status
+
+The mention search SHALL include, for each candidate of type `agent`, an `online`
+boolean indicating whether that agent currently has at least one effectively-online
+daemon connection. This applies to the mention search service (`searchMentionables`)
+and both surfaces over it (`GET /api/mentionables` and `chorus_search_mentionables`).
+"Effectively online" SHALL reuse the
+daemon-connection registry's existing rule — the connection's `status` is `online`
+AND `now - lastSeenAt` is within the registry's `STALE_THRESHOLD_MS` — rather than
+defining a separate threshold, so producer and consumer cannot drift. The online
+determination SHALL be `companyUuid`-scoped and SHALL be computed in a single batch
+query over the agent candidate set (no per-candidate query). Candidates of type
+`user` SHALL NOT carry an `online` field. The field SHALL be additive — a consumer
+that ignores it behaves exactly as before — and SHALL NOT require a new permission
+bit or widen the existing owner-scoped visibility of agent candidates.
+
+#### Scenario: An owned agent with a live connection is online
+
+- **GIVEN** a user whose mention search returns an agent they own
+- **AND** that agent has a `DaemonConnection` with `status = "online"` and a `lastSeenAt` within `STALE_THRESHOLD_MS`
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `online: true`
+
+#### Scenario: An agent with no fresh connection is offline
+
+- **GIVEN** an agent candidate whose only `DaemonConnection` is `offline`, or whose `lastSeenAt` is older than `STALE_THRESHOLD_MS`, or which has no connection at all
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `online: false`
+
+#### Scenario: User candidates are not enriched
+
+- **WHEN** the mention search returns a candidate of type `user`
+- **THEN** that candidate MUST NOT carry an `online` field
+
+#### Scenario: Online is resolved in batch, not per candidate
+
+- **GIVEN** a mention search resolving N agent candidates
+- **WHEN** their online status is determined
+- **THEN** the server MUST resolve all N via a single batched, `companyUuid`-scoped connection query rather than one query per candidate
+- **AND** when there are zero agent candidates it MUST issue no liveness query at all
+
+### Requirement: Mention search SHALL report each agent's active execution count
+
+The mention search SHALL include, for each candidate of type `agent`, an
+`activeCount` integer giving the number of that agent's currently active daemon
+executions — `DaemonExecution` rows whose `status` is `running` or `queued`. The
+count SHALL be `companyUuid`-scoped and computed in a single batched aggregate over
+the agent candidate set (no per-candidate query). `activeCount` SHALL be coherent
+with `online`: an agent that is not `online` SHALL report `activeCount` of `0`, so
+the count never contradicts the online indicator. Candidates of type `user` SHALL
+NOT carry an `activeCount` field.
+
+#### Scenario: An online agent reports its running/queued count
+
+- **GIVEN** an online agent candidate whose daemon has 2 `running` and 1 `queued` `DaemonExecution` rows
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `activeCount: 3`
+
+#### Scenario: An online agent with no active executions reports zero
+
+- **GIVEN** an online agent candidate with no `running`/`queued` execution rows
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `activeCount: 0`
+
+#### Scenario: An offline agent reports zero regardless of stale rows
+
+- **GIVEN** an agent candidate that is not `online`
+- **WHEN** the mention search resolves the candidate list
+- **THEN** that agent candidate MUST carry `activeCount: 0`
+
+#### Scenario: Active count is resolved in batch
+
+- **GIVEN** a mention search resolving N agent candidates
+- **WHEN** their active counts are determined
+- **THEN** the server MUST resolve all N via a single batched, `companyUuid`-scoped aggregate query rather than one query per candidate
+
+### Requirement: The @-mention dropdown SHALL render agent liveness and demote roles
+
+The @-mention dropdown SHALL render, on each **agent** candidate row, a static
+online indicator dot when the candidate's `online` is true, with an accessible
+`Online`/`Offline` tooltip; an offline agent SHALL NOT render a dot. When the
+candidate's `activeCount` is greater than zero the row SHALL render a compact count
+badge; when `activeCount` is zero no badge SHALL be shown. The agent row SHALL no
+longer render the agent's roles line (the online dot and count replace it). The dot
+SHALL be static (no pulsing animation) to keep the dense dropdown calm. Rows for
+`user` candidates SHALL be unchanged — no dot, no count. All new user-facing strings
+(the `Online`/`Offline` tooltip and the count label) SHALL be localized in both
+supported locales. The dropdown SHALL take the liveness values from the candidate
+payload at open time and SHALL NOT poll while open.
+
+#### Scenario: An online agent row shows a dot and (when busy) a count
+
+- **GIVEN** the dropdown lists an agent candidate with `online: true` and `activeCount: 2`
+- **WHEN** the row renders
+- **THEN** it MUST show a static online dot with an `Online` tooltip
+- **AND** it MUST show a count badge reflecting 2
+- **AND** it MUST NOT show the agent's roles line
+
+#### Scenario: An online idle agent shows a dot but no count badge
+
+- **GIVEN** the dropdown lists an agent candidate with `online: true` and `activeCount: 0`
+- **WHEN** the row renders
+- **THEN** it MUST show the online dot
+- **AND** it MUST NOT show a count badge
+
+#### Scenario: An offline agent shows neither dot nor count
+
+- **GIVEN** the dropdown lists an agent candidate with `online: false`
+- **WHEN** the row renders
+- **THEN** it MUST NOT show an online dot
+- **AND** it MUST NOT show a count badge
+
+#### Scenario: User rows are unaffected
+
+- **WHEN** the dropdown renders a `user` candidate row
+- **THEN** it MUST render as before (name and email) with no online dot and no count badge
+

--- a/src/components/__tests__/mention-editor-popup.test.tsx
+++ b/src/components/__tests__/mention-editor-popup.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+//
+// Unit test for the @-mention dropdown row renderer (createSuggestionPopupRenderer).
+// Covers the agent-liveness UI from the mention-agent-liveness change:
+//   - an online agent row shows a green status dot (Online tooltip) and, when
+//     activeCount > 0, a count badge; the roles line is gone,
+//   - an online idle agent (activeCount 0) shows the dot but no badge,
+//   - an offline agent shows neither dot nor badge,
+//   - user rows are unchanged (name + email, no dot/badge).
+//
+// The renderer is module-level DOM-building (no React/Tiptap), so we exercise it
+// directly against a detached container + a stub command/labels — no editor boot.
+
+import { describe, it, expect, vi } from "vitest";
+import { createRef } from "react";
+import { createSuggestionPopupRenderer } from "@/components/mention-editor";
+
+const labels = {
+  online: "Online",
+  offline: "Offline",
+  idle: "Idle",
+  activeCount: (n: number) => `${n} active`,
+};
+
+function render(items: Array<Record<string, unknown>>) {
+  const container = document.createElement("div");
+  // keyDownRef shape matches the renderer's React.MutableRefObject param.
+  const keyDownRef = createRef<unknown>() as { current: unknown };
+  keyDownRef.current = null;
+  createSuggestionPopupRenderer(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    items as any,
+    false,
+    vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    keyDownRef as any,
+    container,
+    labels,
+  );
+  return container;
+}
+
+// Helper: the presence dot is the avatar-corner span with title="Online" and a
+// `ring` class (distinguishing it from any other titled element).
+function presenceDot(c: HTMLElement) {
+  return c.querySelector('span[title="Online"].ring-2');
+}
+
+describe("mention dropdown row renderer — agent liveness", () => {
+  it("online + busy agent: avatar-corner presence dot + 'N active' status text, no roles line", () => {
+    const c = render([
+      {
+        type: "agent",
+        uuid: "a1",
+        name: "AliceBot",
+        roles: ["pm_agent"],
+        online: true,
+        activeCount: 2,
+      },
+    ]);
+
+    // Presence dot sits on the avatar (absolute bottom-right, ringed), titled Online.
+    const dot = presenceDot(c);
+    expect(dot).not.toBeNull();
+    expect(dot!.className).toContain("absolute");
+    // Its parent is the avatar wrapper (relative), not the text info column.
+    expect(dot!.parentElement?.className).toContain("relative");
+
+    // Active-task count rendered as status text.
+    expect(c.textContent).toContain("2 active");
+
+    // The old roles line is gone.
+    expect(c.textContent).not.toContain("pm_agent");
+  });
+
+  it("online + idle agent: presence dot + explicit 'Idle' status (never a blank line)", () => {
+    const c = render([
+      { type: "agent", uuid: "a2", name: "IdleBot", online: true, activeCount: 0 },
+    ]);
+    expect(presenceDot(c)).not.toBeNull();
+    // Explicit idle status, not blank, and no active-count text.
+    expect(c.textContent).toContain("Idle");
+    expect(c.textContent).not.toContain("active");
+  });
+
+  it("offline agent: no presence dot, no status text", () => {
+    const c = render([
+      { type: "agent", uuid: "a3", name: "OffBot", online: false, activeCount: 0 },
+    ]);
+    expect(presenceDot(c)).toBeNull();
+    expect(c.textContent).not.toContain("Idle");
+    expect(c.textContent).not.toContain("active");
+    // The name still renders.
+    expect(c.textContent).toContain("OffBot");
+  });
+
+  it("user row is unchanged: name + email, no dot/status", () => {
+    const c = render([
+      { type: "user", uuid: "u1", name: "Alice", email: "alice@example.com" },
+    ]);
+    expect(c.textContent).toContain("Alice");
+    expect(c.textContent).toContain("alice@example.com");
+    expect(presenceDot(c)).toBeNull();
+    expect(c.textContent).not.toContain("Idle");
+    expect(c.textContent).not.toContain("active");
+  });
+});

--- a/src/components/mention-editor.tsx
+++ b/src/components/mention-editor.tsx
@@ -11,8 +11,20 @@ import React, {
 import { useEditor, EditorContent, type Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Mention from "@tiptap/extension-mention";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { isImeComposing } from "@/lib/ime";
+
+// Localized strings the (module-level, hook-less) popup renderer needs. Built in
+// the component via useTranslations and threaded through as plain strings.
+interface MentionPopupLabels {
+  online: string;
+  offline: string;
+  /** Status text for an online agent with no active work. */
+  idle: string;
+  /** Active-task count text for an online agent, e.g. "3 active". */
+  activeCount: (n: number) => string;
+}
 
 // Extend Mention to support custom `mentionType` attribute (user | agent)
 const CustomMention = Mention.extend({
@@ -39,6 +51,10 @@ interface Mentionable {
   name: string;
   email?: string;
   roles?: string[];
+  // Agent liveness (agents only; see mention.service.ts). `online` drives the
+  // status dot; `activeCount` drives the count badge (shown only when > 0).
+  online?: boolean;
+  activeCount?: number;
 }
 
 export interface MentionEditorProps {
@@ -181,13 +197,16 @@ function plainTextToEditorContent(text: string): Record<string, unknown> {
 
 // ── Imperative suggestion popup rendering ──────────────────────
 
-function createSuggestionPopupRenderer(
+// Exported for unit testing the row DOM (dot / count badge / roles-removed /
+// user-row-unchanged) without booting a full Tiptap editor + suggestion flow.
+export function createSuggestionPopupRenderer(
   items: Mentionable[],
   isLoading: boolean,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   command: (attrs: any) => void,
   keyDownRef: React.MutableRefObject<KeyDownHandler | null>,
-  container: HTMLDivElement
+  container: HTMLDivElement,
+  labels: MentionPopupLabels
 ) {
   container.innerHTML = "";
 
@@ -232,8 +251,14 @@ function createSuggestionPopupRenderer(
       }`;
       btn.onclick = () => doCommand(item);
 
+      // Avatar wrapped in a relative container so the agent presence dot can sit
+      // at the bottom-right corner of the avatar (the conventional presence-dot
+      // position), rather than on a separate status line.
+      const avatarWrap = document.createElement("div");
+      avatarWrap.className = "relative shrink-0";
+
       const avatar = document.createElement("div");
-      avatar.className = `flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${
+      avatar.className = `flex h-6 w-6 items-center justify-center rounded-full ${
         item.type === "agent"
           ? "bg-[#C67A52] text-white"
           : "bg-[#E5E0D8] text-[#6B6B6B]"
@@ -242,6 +267,19 @@ function createSuggestionPopupRenderer(
         item.type === "agent"
           ? '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>'
           : '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>';
+      avatarWrap.appendChild(avatar);
+
+      // Online presence dot at the avatar's bottom-right, online agents only.
+      // The white ring (border) lifts it off the avatar fill. Offline agents
+      // show no dot (the "Idle / N active" text line below carries the rest of
+      // the state, and a sea of grey corner dots would be noise).
+      if (item.type === "agent" && item.online) {
+        const dot = document.createElement("span");
+        dot.className =
+          "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full bg-[#22C55E] ring-2 ring-white";
+        dot.title = labels.online;
+        avatarWrap.appendChild(dot);
+      }
 
       const info = document.createElement("div");
       info.className = "min-w-0 flex-1";
@@ -258,14 +296,26 @@ function createSuggestionPopupRenderer(
         info.appendChild(emailEl);
       }
 
-      if (item.type === "agent" && item.roles && item.roles.length > 0) {
-        const rolesEl = document.createElement("div");
-        rolesEl.className = "truncate text-[10px] text-[#9A9A9A]";
-        rolesEl.textContent = item.roles.join(", ");
-        info.appendChild(rolesEl);
+      // Agent status line (replaces the old roles line). For an ONLINE agent we
+      // always show an explicit status — never a blank line: the active-task
+      // count when busy ("▶ N", green), or a muted "Idle" when it has no
+      // running/queued work. Offline agents show nothing here (the absent
+      // presence dot already conveys offline). User rows get no status line.
+      if (item.type === "agent" && item.online) {
+        const count = item.activeCount ?? 0;
+        const statusEl = document.createElement("div");
+        if (count > 0) {
+          statusEl.className =
+            "mt-0.5 truncate text-[10px] font-medium text-[#15803D]";
+          statusEl.textContent = `▶ ${labels.activeCount(count)}`;
+        } else {
+          statusEl.className = "mt-0.5 truncate text-[10px] text-[#9A9A9A]";
+          statusEl.textContent = labels.idle;
+        }
+        info.appendChild(statusEl);
       }
 
-      btn.appendChild(avatar);
+      btn.appendChild(avatarWrap);
       btn.appendChild(info);
       list.appendChild(btn);
     });
@@ -315,6 +365,23 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
     const [, forceUpdate] = useState(0);
     const isInternalUpdate = useRef(false);
 
+    // Localized labels for the popup's agent-liveness UI. Kept in a ref so the
+    // module-level renderer (called from Tiptap's long-lived suggestion
+    // callbacks) always reads current strings without a stale closure.
+    const t = useTranslations("mention");
+    const labelsRef = useRef<MentionPopupLabels>({
+      online: "",
+      offline: "",
+      idle: "",
+      activeCount: () => "",
+    });
+    labelsRef.current = {
+      online: t("online"),
+      offline: t("offline"),
+      idle: t("idle"),
+      activeCount: (n: number) => t("activeCount", { count: n }),
+    };
+
     // Fetch mentionables from API
     const fetchMentionables = useCallback(async (query: string) => {
       suggestionLoadingRef.current = true;
@@ -348,7 +415,8 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
           suggestionLoadingRef.current,
           currentCommandRef.current,
           keyDownRef,
-          popupRef.current
+          popupRef.current,
+          labelsRef.current
         );
       }
     });
@@ -425,7 +493,8 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
                     suggestionLoadingRef.current,
                     props.command,
                     keyDownRef,
-                    popup
+                    popup,
+                    labelsRef.current
                   );
                 },
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -455,7 +524,8 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
                       suggestionLoadingRef.current,
                       props.command,
                       keyDownRef,
-                      popupRef.current
+                      popupRef.current,
+                      labelsRef.current
                     );
                   }
                 },

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -734,7 +734,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_search_mentionables",
     {
-      description: "Search for users and agents that can be @mentioned. Returns name, type, and UUID. Use the UUID to write mentions as @[Name](type:uuid) in comment/description text.",
+      description: "Search for users and agents that can be @mentioned. Returns name, type, and UUID. Use the UUID to write mentions as @[Name](type:uuid) in comment/description text. For results of type \"agent\" the entry also carries `online` (boolean: true iff the agent currently has a live daemon connection) and `activeCount` (number of tasks/resources its daemon is running or has queued; 0 when offline). User results do not carry these fields.",
       inputSchema: z.object({
         query: z.string().describe("Name or keyword to search"),
         limit: z.number().optional().default(10).describe("Max results to return (default 10)"),

--- a/src/services/__tests__/mention.service.test.ts
+++ b/src/services/__tests__/mention.service.test.ts
@@ -21,6 +21,14 @@ const { mockPrisma, mockGetActorName, mockGetPreferences, mockCreateBatch } = vi
     comment: {
       findUnique: vi.fn(),
     },
+    // Agent-liveness enrichment (searchMentionables): online via connections,
+    // activeCount via execution groupBy.
+    daemonConnection: {
+      findMany: vi.fn(),
+    },
+    daemonExecution: {
+      groupBy: vi.fn(),
+    },
   },
   mockGetActorName: vi.fn().mockResolvedValue("Test Actor"),
   mockGetPreferences: vi.fn().mockResolvedValue({ mentioned: true }),
@@ -52,6 +60,10 @@ const SOURCE_UUID = "66666666-6666-6666-6666-666666666666";
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetPreferences.mockResolvedValue({ mentioned: true });
+  // Default liveness enrichment to "no connections / no executions" so existing
+  // searchMentionables tests (which return agents) don't hit undefined mocks.
+  mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
+  mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
 });
 
 describe("createMentions", () => {
@@ -328,5 +340,140 @@ describe("searchMentionables", () => {
         take: 50,
       })
     );
+  });
+});
+
+describe("searchMentionables — agent liveness enrichment", () => {
+  const FRESH = new Date(); // within STALE_THRESHOLD_MS
+  const STALE = new Date(Date.now() - 10 * 60_000); // 10 min ago → stale
+
+  it("marks an agent online iff it has an effectively-online connection, and reports activeCount (search branch)", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: AGENT_UUID, name: "AliceBot", roles: ["pm_agent"] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: AGENT_UUID, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([
+      { agentUuid: AGENT_UUID, _count: { _all: 3 } },
+    ]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "alice",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    const agent = results.find((r) => r.type === "agent")!;
+    expect(agent.online).toBe(true);
+    expect(agent.activeCount).toBe(3);
+
+    // Both liveness queries are companyUuid-scoped over the agent uuid set.
+    expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { companyUuid: COMPANY_UUID, agentUuid: { in: [AGENT_UUID] } },
+      })
+    );
+    const gb = mockPrisma.daemonExecution.groupBy.mock.calls[0][0];
+    expect(gb.by).toEqual(["agentUuid"]);
+    expect(gb.where.companyUuid).toBe(COMPANY_UUID);
+    expect(gb.where.agentUuid).toEqual({ in: [AGENT_UUID] });
+    expect(gb.where.status).toEqual({ in: ["running", "queued"] });
+  });
+
+  it("enriches agents in the EMPTY-query branch too (the popup-just-opened case)", async () => {
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: AGENT_UUID, name: "MyBot", roles: ["developer_agent"] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: AGENT_UUID, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([
+      { agentUuid: AGENT_UUID, _count: { _all: 1 } },
+    ]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].online).toBe(true);
+    expect(results[0].activeCount).toBe(1);
+    // Liveness WAS resolved even though the user-search branch never ran.
+    expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a stale connection as offline and forces activeCount to 0 (coherent with online)", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: AGENT_UUID, name: "StaleBot", roles: [] },
+    ]);
+    // Only connection is stale → not effectively online.
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: AGENT_UUID, status: "online", lastSeenAt: STALE },
+    ]);
+    // Even if execution rows exist, an offline agent must report 0.
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([
+      { agentUuid: AGENT_UUID, _count: { _all: 5 } },
+    ]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "stale",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    const agent = results.find((r) => r.type === "agent")!;
+    expect(agent.online).toBe(false);
+    expect(agent.activeCount).toBe(0);
+  });
+
+  it("reports online with activeCount 0 when the agent has a live connection but no active executions", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: AGENT_UUID, name: "IdleBot", roles: [] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: AGENT_UUID, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([]); // no active rows
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "idle",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    const agent = results.find((r) => r.type === "agent")!;
+    expect(agent.online).toBe(true);
+    expect(agent.activeCount).toBe(0);
+  });
+
+  it("does NOT enrich user candidates and issues NO liveness query when there are no agents", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      { uuid: USER_UUID, name: "Alice", email: "alice@example.com", avatarUrl: null },
+    ]);
+    mockPrisma.agent.findMany.mockResolvedValue([]); // no agents match
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "alice",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    const user = results.find((r) => r.type === "user")!;
+    expect(user.online).toBeUndefined();
+    expect(user.activeCount).toBeUndefined();
+    // Cheap empty path: zero agent candidates ⇒ no liveness/count query at all.
+    expect(mockPrisma.daemonConnection.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonExecution.groupBy).not.toHaveBeenCalled();
   });
 });

--- a/src/services/mention.service.ts
+++ b/src/services/mention.service.ts
@@ -5,6 +5,11 @@
 import { prisma } from "@/lib/prisma";
 import { getActorName } from "@/lib/uuid-resolver";
 import * as notificationService from "@/services/notification.service";
+// Reuse the daemon-connection registry's single liveness threshold and the
+// execution service's active-status set — do NOT restate either rule here, so
+// producer and consumer cannot drift.
+import { STALE_THRESHOLD_MS } from "@/services/daemon-connection.service";
+import { ACTIVE_EXECUTION_STATUSES } from "@/services/daemon-execution.service";
 
 // ===== Constants =====
 
@@ -28,6 +33,13 @@ export interface Mentionable {
   email?: string | null;
   avatarUrl?: string | null;
   roles?: string[];
+  // Agent liveness, populated for `type: "agent"` candidates only (users never
+  // carry these). `online` is true iff the agent has at least one effectively-
+  // online daemon connection; `activeCount` is the number of running/queued
+  // daemon executions for that agent and is coherent with `online` (an offline
+  // agent reports 0). See enrichAgentLiveness.
+  online?: boolean;
+  activeCount?: number;
 }
 
 export interface CreateMentionsParams {
@@ -205,6 +217,76 @@ export async function createMentions(params: CreateMentionsParams): Promise<void
 const DEFAULT_EMPTY_QUERY_LIMIT = 5;
 
 /**
+ * Enrich agent candidates in place with daemon liveness: `online` + `activeCount`.
+ *
+ * Resolves both in BATCH over the given agent uuids (two queries total, both
+ * companyUuid-scoped — never one query per candidate). When there are no agent
+ * candidates it issues NO query at all. Users are never passed in / never enriched.
+ *
+ * - `online`: an agent is online iff it has at least one effectively-online
+ *   `DaemonConnection`, applying the daemon-connection registry's exact rule
+ *   (`status === "online"` AND `now - lastSeenAt <= STALE_THRESHOLD_MS`). The
+ *   constant is imported, not restated, so the rule cannot drift.
+ * - `activeCount`: the number of `running`/`queued` `DaemonExecution` rows for the
+ *   agent. It is kept COHERENT with `online`: an agent that is not online reports
+ *   `0`, so the count never contradicts the dot. (We zero it out for non-online
+ *   agents rather than trusting raw rows that may belong to a stale connection.)
+ *
+ * Mutates the `online`/`activeCount` fields of the agent entries in `results`.
+ */
+async function enrichAgentLiveness(
+  companyUuid: string,
+  results: Mentionable[]
+): Promise<void> {
+  const agentUuids = results
+    .filter((r) => r.type === "agent")
+    .map((r) => r.uuid);
+  // Cheap empty path: no agents → no liveness/count queries at all.
+  if (agentUuids.length === 0) return;
+
+  const now = Date.now();
+
+  // 1. Online set — one batched, companyUuid-scoped connection query. An agent is
+  //    online iff ANY of its connections is effectively online (registry rule).
+  const connections = await prisma.daemonConnection.findMany({
+    where: { companyUuid, agentUuid: { in: agentUuids } },
+    select: { agentUuid: true, status: true, lastSeenAt: true },
+  });
+  const onlineAgentUuids = new Set<string>();
+  for (const c of connections) {
+    const fresh = now - c.lastSeenAt.getTime() <= STALE_THRESHOLD_MS;
+    if (c.status === "online" && fresh) {
+      onlineAgentUuids.add(c.agentUuid);
+    }
+  }
+
+  // 2. Active counts — one batched, companyUuid-scoped aggregate over running/
+  //    queued executions, grouped by agent.
+  const grouped = await prisma.daemonExecution.groupBy({
+    by: ["agentUuid"],
+    where: {
+      companyUuid,
+      agentUuid: { in: agentUuids },
+      status: { in: [...ACTIVE_EXECUTION_STATUSES] },
+    },
+    _count: { _all: true },
+  });
+  const countByAgent = new Map<string, number>();
+  for (const g of grouped) {
+    countByAgent.set(g.agentUuid, g._count._all);
+  }
+
+  // 3. Fold into the agent entries. activeCount is coherent with online: a
+  //    non-online agent reports 0 regardless of any stale-connection rows.
+  for (const r of results) {
+    if (r.type !== "agent") continue;
+    const online = onlineAgentUuids.has(r.uuid);
+    r.online = online;
+    r.activeCount = online ? countByAgent.get(r.uuid) ?? 0 : 0;
+  }
+}
+
+/**
  * Search for mentionable users and agents within a company.
  * Permission scoping:
  * - User caller: all company users + own agents (agents with ownerUuid = actorUuid)
@@ -253,6 +335,8 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
       }
     }
 
+    // Enrich the (agent-only) empty-query results with liveness before returning.
+    await enrichAgentLiveness(companyUuid, results);
     return results;
   }
   // Search users (all company users are mentionable)
@@ -318,7 +402,11 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
     });
   }
 
-  return results.slice(0, effectiveLimit);
+  const sliced = results.slice(0, effectiveLimit);
+  // Enrich only the agents that survive the slice (liveness queries are scoped to
+  // what we actually return).
+  await enrichAgentLiveness(companyUuid, sliced);
+  return sliced;
 }
 
 /**


### PR DESCRIPTION
## Summary

The @-mention dropdown now surfaces agent liveness at the point of dispatch. Each **agent** candidate gains two fields and the dropdown renders them on the agent row:

- **`online`** — reuses the daemon-connection registry's `effectiveStatus` rule and its single `STALE_THRESHOLD_MS` (no second threshold).
- **`activeCount`** — running/queued `DaemonExecution` rows, coherent with `online` (an offline agent reports `0`).
- Both resolved **owner-scoped** and **batched** (one connection query + one execution `groupBy`, no N+1); zero agent candidates issues no query; **users are never enriched**.

UI: a green **presence dot at the agent avatar's bottom-right corner** + an explicit status line — **"N active"** when busy, **"Idle"** when online with no work — replacing the old roles line. Offline agents and user rows are unchanged.

**No new endpoint, permission, or schema change.** Implements idea `999ddd93` (elaboration resolved over 2 rounds). OpenSpec change `mention-agent-liveness` archived; cumulative specs emitted for `mention-agent-liveness` + `mcp-tool-surface`.

## Changed files
| File | Change |
|------|--------|
| `src/services/mention.service.ts` | `Mentionable` gains `online`/`activeCount`; `enrichAgentLiveness` wired into both search branches |
| `src/components/mention-editor.tsx` | avatar-corner presence dot + Idle/N-active status line; roles line removed |
| `src/mcp/tools/public.ts`, `docs/MCP_TOOLS.md` | document the two agent fields on `chorus_search_mentionables` |
| `messages/{en,zh}.json` | new `mention` namespace (online/offline/idle/activeCount) |
| `src/services/__tests__/mention.service.test.ts`, `src/components/__tests__/mention-editor-popup.test.tsx` | +9 tests |
| `openspec/specs/{mention-agent-liveness,mcp-tool-surface}/spec.md`, `openspec/changes/archive/2026-06-17-mention-agent-liveness/` | spec capability + archived change |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` → 130 files, 2163 passed, 0 failed (+9 new)
- [x] eslint on changed source → 0 errors
- [x] **Real-browser e2e** (dev:local): online+busy → corner dot + "N active"; online+idle → corner dot + "Idle"; offline → no dot/status; users unenriched; offline-coherence (stale connection → 0) confirmed; 0 console errors

## Follow-up (non-blocking)
- `docs/design.pen` not updated — Pencil MCP editor unavailable in the headless build env; tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)