### PR TITLE
fix(agent-presence): stacked ExecutionRow on daemon detail page mobile drill-down

### DIFF
--- a/src/components/agent-presence/__tests__/connections-execution-view.test.tsx
+++ b/src/components/agent-presence/__tests__/connections-execution-view.test.tsx
@@ -534,3 +534,72 @@ describe("Agent Connections modal — interrupted rows + resume control", () => 
     expect(screen.queryByText("Nothing running")).toBeNull();
   });
 });
+
+// =====================================================================
+// Responsive row layout (continuation of b5bdcfa — the popover fix).
+//
+// b5bdcfa added a `stacked` ExecutionRow variant but wired it only into the
+// sidebar popover. The detail view now forwards its own `variant` to the rows:
+// the wide desktop master-detail pane stays "inline" (room to spare); the narrow
+// mobile drill-down uses "stacked" so a running row's title is no longer squeezed
+// by the elapsed timer + Interrupt/Resume controls.
+//
+// jsdom doesn't evaluate the `lg:` media queries, so the desktop master-detail
+// pane is always in the DOM and the mobile drill-down renders only after a card
+// tap. We therefore assert against the row geometry classes directly:
+//   - inline rows are a centered flex row (`items-center`, never `flex-col`),
+//   - stacked rows are `flex-col` with a two-line-clamped title.
+// =====================================================================
+describe("Agent Connections modal — responsive execution-row layout", () => {
+  it("desktop master-detail pane renders execution rows inline (unchanged)", async () => {
+    routeFetch([execView({ uuid: "run", status: "running", startedAt: NOW })]);
+    const { container } = await renderView();
+    await waitFor(() => expect(screen.getAllByText("Task run").length).toBeGreaterThan(0));
+
+    // On first paint the mobile drill-down is closed, so the only execution rows
+    // in the DOM belong to the always-present desktop pane — all must be inline.
+    const rows = container.querySelectorAll("li");
+    expect(rows.length).toBeGreaterThan(0);
+    rows.forEach((row) => {
+      expect(row.className).toContain("items-center");
+      expect(row.className).not.toContain("flex-col");
+    });
+  });
+
+  it("mobile drill-down renders execution rows stacked (title gets full width)", async () => {
+    routeFetch([
+      execView({
+        uuid: "run",
+        status: "running",
+        startedAt: NOW,
+        entityTitle: "A very long running task title that used to truncate",
+      }),
+    ]);
+    const { container } = await renderView();
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("A very long running task title that used to truncate").length,
+      ).toBeGreaterThan(0),
+    );
+
+    // Drill into the connection on mobile: the only `.lg:hidden` subtree on first
+    // paint is the mobile card list (the drill-down wrapper isn't mounted yet).
+    const mobileCard = container.querySelector(".lg\\:hidden button");
+    expect(mobileCard).not.toBeNull();
+    fireEvent.click(mobileCard!);
+
+    // The mobile detail pane now renders ExecutionRow with layout="stacked": a
+    // flex-col <li> whose title relaxes to a two-line clamp.
+    await waitFor(() =>
+      expect(container.querySelectorAll("li.flex-col").length).toBeGreaterThan(0),
+    );
+    const stackedRow = container.querySelector("li.flex-col");
+    expect(stackedRow?.textContent).toContain(
+      "A very long running task title that used to truncate",
+    );
+    // The Interrupt control survives the layout change (controls retained).
+    expect(
+      screen.getAllByRole("button", { name: "Interrupt this running execution" }).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/src/components/agent-presence/connections-view.tsx
+++ b/src/components/agent-presence/connections-view.tsx
@@ -103,6 +103,7 @@ function ExecutionPane({
   executions,
   nowMs,
   executionsLoaded,
+  rowLayout = "inline",
 }: {
   executions: ExecutionView[];
   nowMs: number;
@@ -111,6 +112,11 @@ function ExecutionPane({
   // connection has no rows yet, show a loading state rather than the "Nothing
   // running" empty state (which would be a false negative for a busy connection).
   executionsLoaded: boolean;
+  // Geometry of the execution rows, forwarded from the detail variant: the wide
+  // desktop master-detail pane uses "inline" (room to spare), the narrow mobile
+  // drill-down uses "stacked" so a running row's title is not squeezed by the
+  // elapsed timer + Interrupt/Resume controls (same fix the sidebar popover got).
+  rowLayout?: "inline" | "stacked";
 }) {
   const t = useTranslations("agentConnections");
 
@@ -172,14 +178,14 @@ function ExecutionPane({
           {running.length > 0 && (
             <ExecutionSection icon={Play} label={t("execRunning")} count={running.length}>
               {running.map((exec) => (
-                <ExecutionRow key={exec.uuid} exec={exec} nowMs={nowMs} />
+                <ExecutionRow key={exec.uuid} exec={exec} nowMs={nowMs} layout={rowLayout} />
               ))}
             </ExecutionSection>
           )}
           {queued.length > 0 && (
             <ExecutionSection icon={ListChecks} label={t("execQueued")} count={queued.length}>
               {queued.map((exec) => (
-                <ExecutionRow key={exec.uuid} exec={exec} nowMs={nowMs} />
+                <ExecutionRow key={exec.uuid} exec={exec} nowMs={nowMs} layout={rowLayout} />
               ))}
             </ExecutionSection>
           )}
@@ -190,7 +196,7 @@ function ExecutionPane({
               count={interrupted.length}
             >
               {interrupted.map((exec) => (
-                <ExecutionRow key={exec.uuid} exec={exec} nowMs={nowMs} />
+                <ExecutionRow key={exec.uuid} exec={exec} nowMs={nowMs} layout={rowLayout} />
               ))}
             </ExecutionSection>
           )}
@@ -402,6 +408,7 @@ function DetailContent({
               executions={executions}
               nowMs={nowMs}
               executionsLoaded={executionsLoaded}
+              rowLayout="inline"
             />
           </div>
         </div>
@@ -453,6 +460,7 @@ function DetailContent({
         executions={executions}
         nowMs={nowMs}
         executionsLoaded={executionsLoaded}
+        rowLayout="stacked"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
Continues the `b5bdcfa` fix. That commit added a `stacked` layout variant to the shared `ExecutionRow` component but wired it **only** into the sidebar presence popover. The agent daemon detail page — the relocated Agent Connections master-detail view (`connections-view.tsx`, hosted in the "View all" modal) — still rendered every row with the default `inline` layout, so on the narrow mobile drill-down a running task's title was squeezed by the elapsed timer + Interrupt/Resume controls (the same root problem the popover fix addressed, one surface short).

The fix reuses the same shared component and the already-shipped `stacked`/`inline` variant — no new layout code. Responsive by design: stacked only where width is constrained (mobile drill-down), inline on the wide desktop master-detail pane.

- `ExecutionPane` gains a `rowLayout?: "inline" | "stacked"` prop (default `"inline"`), forwarded to all three `ExecutionRow` instances (running / queued / interrupted).
- `DetailContent` passes `"inline"` from the desktop pane (byte-identical to before) and `"stacked"` from the mobile drill-down (title gets the full row width, controls drop to a second line).

## Changed files
| File | Change |
|------|--------|
| `src/components/agent-presence/connections-view.tsx` | `ExecutionPane` `rowLayout` pass-through prop; `DetailContent` sends `inline` (desktop) / `stacked` (mobile) |
| `src/components/agent-presence/__tests__/connections-execution-view.test.tsx` | +2 tests: desktop pane stays inline; mobile drill-down goes stacked with Interrupt retained |

## Test plan
- [x] `npx tsc --noEmit` — exit 0
- [x] `pnpm lint` — clean
- [x] agent-presence suites green (pill 13 + modal 8 + execution-view 16 = 37)
- [x] Live browser verification (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)