### PR TITLE
feat(daemon): DaemonSession persistent-conversation model (子1 foundation)

### DIFF
--- a/cli/__tests__/backfill-pending-turns.test.mjs
+++ b/cli/__tests__/backfill-pending-turns.test.mjs
@@ -1,0 +1,164 @@
+// cli/__tests__/backfill-pending-turns.test.mjs
+// Covers the reconnect-backfill re-deriving UNSTARTED (pending) turns from the turn
+// table for this connection's origin-pinned sessions (子1 —
+// daemon-session-conversation), so a lost delivery ping never loses an instruction.
+import { describe, it, expect, vi } from "vitest";
+import { createBackfill } from "../backfill.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+const DIRECT_IDEA = "11111111-1111-4111-8111-111111111111";
+
+function envelope(turns) {
+  return { ok: true, status: 200, json: async () => ({ success: true, data: { turns } }) };
+}
+
+describe("backfill pending-turns re-derivation", () => {
+  it("GETs /api/daemon/pending-turns with Bearer auth + connectionUuid, dispatches each pending turn", async () => {
+    const pendingTurns = [
+      { turnUuid: "t1", sessionId: DIRECT_IDEA, directIdeaUuid: DIRECT_IDEA, seq: 4, trigger: "human_instruction", promptText: "do X" },
+      { turnUuid: "t2", sessionId: DIRECT_IDEA, directIdeaUuid: DIRECT_IDEA, seq: 5, trigger: "human_instruction", promptText: "do Y" },
+    ];
+    const fetchImpl = vi.fn(async () => envelope(pendingTurns));
+    const mcpClient = { callTool: vi.fn(async () => ({ notifications: [] })) };
+    const dispatched = [];
+
+    const backfill = createBackfill({
+      mcpClient,
+      dispatch: () => {},
+      logger: silent,
+      url: "https://chorus.example.com/",
+      apiKey: "cho_secret",
+      getConnectionUuid: () => "conn-1",
+      dispatchPendingTurn: (t) => dispatched.push(t),
+      fetchImpl,
+    });
+
+    await backfill();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    expect(endpoint).toBe("https://chorus.example.com/api/daemon/pending-turns?connectionUuid=conn-1");
+    expect(init.headers.Authorization).toBe("Bearer cho_secret");
+    expect(dispatched).toEqual(pendingTurns);
+  });
+
+  it("skips pending-turn fetch entirely when the connectionUuid is not known yet", async () => {
+    const fetchImpl = vi.fn(async () => envelope([]));
+    const mcpClient = { callTool: vi.fn(async () => ({ notifications: [] })) };
+    const backfill = createBackfill({
+      mcpClient,
+      dispatch: () => {},
+      logger: silent,
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => null, // SSE handshake hasn't reported it
+      dispatchPendingTurn: vi.fn(),
+      fetchImpl,
+    });
+    await backfill();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("de-dupes pending turns already in the shared seen set (keyed turn:<uuid>), pre-check only", async () => {
+    const seen = new Set(["turn:t1"]); // t1 already handled live
+    const pendingTurns = [
+      { turnUuid: "t1", sessionId: DIRECT_IDEA, directIdeaUuid: DIRECT_IDEA, seq: 1, trigger: "human_instruction", promptText: "a" },
+      { turnUuid: "t2", sessionId: DIRECT_IDEA, directIdeaUuid: DIRECT_IDEA, seq: 2, trigger: "human_instruction", promptText: "b" },
+    ];
+    const fetchImpl = vi.fn(async () => envelope(pendingTurns));
+    const dispatched = [];
+    const backfill = createBackfill({
+      mcpClient: { callTool: vi.fn(async () => ({ notifications: [] })) },
+      dispatch: () => {},
+      seen,
+      logger: silent,
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      dispatchPendingTurn: (t) => dispatched.push(t),
+      fetchImpl,
+    });
+    await backfill();
+    // t1 skipped (already seen), t2 dispatched. Backfill must NOT mark seen itself
+    // (the router's dispatchPendingTurn owns marking) — so t2 stays unmarked here.
+    expect(dispatched.map((t) => t.turnUuid)).toEqual(["t2"]);
+    expect(seen.has("turn:t2")).toBe(false);
+  });
+
+  it("does both sources: notification backfill AND pending-turn backfill run", async () => {
+    const fetchImpl = vi.fn(async () => envelope([
+      { turnUuid: "t1", sessionId: DIRECT_IDEA, directIdeaUuid: DIRECT_IDEA, seq: 1, trigger: "human_instruction", promptText: "a" },
+    ]));
+    const mcpClient = { callTool: vi.fn(async () => ({ notifications: [{ uuid: "n1" }] })) };
+    const dispatchedEvents = [];
+    const dispatchedTurns = [];
+    const backfill = createBackfill({
+      mcpClient,
+      dispatch: (e) => dispatchedEvents.push(e),
+      logger: silent,
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      dispatchPendingTurn: (t) => dispatchedTurns.push(t),
+      fetchImpl,
+    });
+    await backfill();
+    expect(dispatchedEvents).toEqual([{ type: "new_notification", notificationUuid: "n1" }]);
+    expect(dispatchedTurns).toHaveLength(1);
+  });
+
+  it("a pending-turns fetch failure does not abort the notification backfill (sources isolated)", async () => {
+    const warns = [];
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const dispatchedEvents = [];
+    const backfill = createBackfill({
+      mcpClient: { callTool: vi.fn(async () => ({ notifications: [{ uuid: "n1" }] })) },
+      dispatch: (e) => dispatchedEvents.push(e),
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      dispatchPendingTurn: vi.fn(),
+      fetchImpl,
+    });
+    await expect(backfill()).resolves.toBeUndefined();
+    // The notification source still ran and dispatched.
+    expect(dispatchedEvents).toEqual([{ type: "new_notification", notificationUuid: "n1" }]);
+    expect(warns.join("")).toMatch(/pending-turns backfill request failed/);
+  });
+
+  it("when pending-turn wiring is absent, only the notification backfill runs (back-compat)", async () => {
+    const mcpClient = { callTool: vi.fn(async () => ({ notifications: [{ uuid: "n1" }] })) };
+    const dispatchedEvents = [];
+    // No url/apiKey/getConnectionUuid/dispatchPendingTurn — original behavior.
+    const backfill = createBackfill({
+      mcpClient,
+      dispatch: (e) => dispatchedEvents.push(e),
+      logger: silent,
+    });
+    await backfill();
+    expect(dispatchedEvents).toEqual([{ type: "new_notification", notificationUuid: "n1" }]);
+  });
+
+  it("handles a non-2xx pending-turns response (logged, no dispatch)", async () => {
+    const warns = [];
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) }));
+    const dispatchedTurns = [];
+    const backfill = createBackfill({
+      mcpClient: { callTool: vi.fn(async () => ({ notifications: [] })) },
+      dispatch: () => {},
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      dispatchPendingTurn: (t) => dispatchedTurns.push(t),
+      fetchImpl,
+    });
+    await backfill();
+    expect(dispatchedTurns).toHaveLength(0);
+    expect(warns.join("")).toMatch(/pending-turns backfill returned 404/);
+  });
+});

--- a/cli/__tests__/event-router-instruction.test.mjs
+++ b/cli/__tests__/event-router-instruction.test.mjs
@@ -1,0 +1,208 @@
+// cli/__tests__/event-router-instruction.test.mjs
+// Covers the event-router reading instructionText from the already-fetched
+// notification (no extra fetch) and threading it to the wake, plus the
+// dispatchPendingTurn backfill re-derivation entrypoint (子1 —
+// daemon-session-conversation).
+import { describe, it, expect, vi } from "vitest";
+import { EventRouter } from "../event-router.mjs";
+import { WAKE_ACTIONS, buildPrompt } from "../prompts.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+const DIRECT_IDEA = "11111111-1111-4111-8111-111111111111";
+
+function wire(notifications) {
+  const seen = new Set();
+  const enqueued = [];
+  const mcpClient = { callTool: vi.fn(async () => ({ notifications })) };
+  const waker = {
+    keyFor: vi.fn(async () => ({
+      key: `idea:${DIRECT_IDEA}`,
+      rootIdeaUuid: DIRECT_IDEA,
+      directIdeaUuid: DIRECT_IDEA,
+    })),
+    markQueued: vi.fn(),
+    wake: vi.fn(async () => {}),
+  };
+  const queue = { enqueue: (key, task) => enqueued.push({ key, task }) };
+  const router = new EventRouter({ mcpClient, waker, queue, wakeActions: WAKE_ACTIONS, seen, logger: silent });
+  return { seen, enqueued, mcpClient, waker, router };
+}
+
+const INSTRUCTION_NOTIF = {
+  uuid: "ni-1",
+  projectUuid: "proj-1",
+  entityType: "idea",
+  entityUuid: DIRECT_IDEA,
+  entityTitle: "My idea",
+  action: "human_instruction",
+  message: "",
+  actorType: "user",
+  actorUuid: "user-1",
+  actorName: "Alice",
+  instructionText: "Please add a retry with backoff to the uploader.",
+};
+
+describe("event-router human_instruction threading", () => {
+  it("reads instructionText from the already-fetched notification (single fetch) and threads it to wake", async () => {
+    const { enqueued, mcpClient, waker, router } = wire([INSTRUCTION_NOTIF]);
+    router.dispatch({ type: "new_notification", notificationUuid: "ni-1" });
+    await new Promise((res) => setTimeout(res, 0));
+
+    // Exactly ONE fetch (the list it already makes) — no extra round-trip.
+    expect(mcpClient.callTool).toHaveBeenCalledTimes(1);
+    expect(mcpClient.callTool).toHaveBeenCalledWith("chorus_get_notifications", {
+      status: "unread",
+      limit: 50,
+      autoMarkRead: false,
+    });
+
+    // It enqueued the wake; run the enqueued task to drive waker.wake (the queue is a
+    // spy that records tasks without auto-running them).
+    expect(enqueued).toHaveLength(1);
+    await enqueued[0].task();
+
+    // The notification (carrying instructionText) was threaded to wake unchanged.
+    expect(waker.wake).toHaveBeenCalledTimes(1);
+    const threadedNotif = waker.wake.mock.calls[0][0];
+    expect(threadedNotif.instructionText).toBe(
+      "Please add a retry with backoff to the uploader.",
+    );
+    // And buildPrompt over that threaded notification emits the instruction body.
+    const prompt = buildPrompt(threadedNotif);
+    expect(prompt).toContain("Please add a retry with backoff to the uploader.");
+    expect(prompt).toContain("instruction from a human");
+  });
+
+  it("skips a human_instruction with no instructionText (no contentless wake), logged", async () => {
+    const warns = [];
+    const noBody = { ...INSTRUCTION_NOTIF, instructionText: "" };
+    const mcpClient = { callTool: vi.fn(async () => ({ notifications: [noBody] })) };
+    const enqueued = [];
+    const waker = { keyFor: vi.fn(), markQueued: vi.fn(), wake: vi.fn(async () => {}) };
+    const router = new EventRouter({
+      mcpClient,
+      waker,
+      queue: { enqueue: (k, t) => enqueued.push({ k, t }) },
+      wakeActions: WAKE_ACTIONS,
+      seen: new Set(),
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+    router.dispatch({ type: "new_notification", notificationUuid: "ni-1" });
+    await new Promise((res) => setTimeout(res, 0));
+
+    expect(waker.wake).not.toHaveBeenCalled();
+    expect(enqueued).toHaveLength(0);
+    expect(warns.join("")).toMatch(/carries no instructionText/);
+  });
+});
+
+describe("event-router dispatchPendingTurn (backfill re-derivation)", () => {
+  function wirePending() {
+    const seen = new Set();
+    const enqueued = [];
+    const waker = { markQueued: vi.fn(), wake: vi.fn(async () => {}), keyFor: vi.fn() };
+    const queue = { enqueue: (key, task) => enqueued.push({ key, task }) };
+    const router = new EventRouter({
+      mcpClient: { callTool: vi.fn() },
+      waker,
+      queue,
+      wakeActions: WAKE_ACTIONS,
+      seen,
+      logger: silent,
+    });
+    return { seen, enqueued, waker, router };
+  }
+
+  it("re-runs a pending human_instruction turn directly from its turn ids (no lineage fetch), anchored on the direct idea", () => {
+    const { enqueued, waker, router } = wirePending();
+    router.dispatchPendingTurn({
+      turnUuid: "turn-1",
+      sessionId: DIRECT_IDEA,
+      directIdeaUuid: DIRECT_IDEA,
+      trigger: "human_instruction",
+      promptText: "Resume the deploy and verify health checks.",
+    });
+
+    // No lineage call — the key/attribution come straight from the turn ids.
+    expect(waker.keyFor).not.toHaveBeenCalled();
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].key).toBe(`idea:${DIRECT_IDEA}`);
+    expect(waker.markQueued).toHaveBeenCalledTimes(1);
+
+    // The synthetic notification threads the canonical promptText as instructionText
+    // and anchors entityUuid on the session id so the waker session matches.
+    const [n, key, attribution] = waker.markQueued.mock.calls[0];
+    expect(n.action).toBe("human_instruction");
+    expect(n.entityType).toBe("idea");
+    expect(n.entityUuid).toBe(DIRECT_IDEA);
+    expect(n.instructionText).toBe("Resume the deploy and verify health checks.");
+    expect(key).toBe(`idea:${DIRECT_IDEA}`);
+    expect(attribution.directIdeaUuid).toBe(DIRECT_IDEA);
+  });
+
+  it("anchors an ad-hoc (no direct idea) pending turn on the entity key", () => {
+    const { enqueued, router } = wirePending();
+    const adHocSession = "33333333-3333-4333-8333-333333333333";
+    router.dispatchPendingTurn({
+      turnUuid: "turn-2",
+      sessionId: adHocSession,
+      directIdeaUuid: null,
+      trigger: "human_instruction",
+      promptText: "do the thing",
+    });
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].key).toBe(`entity:task:${adHocSession}`);
+  });
+
+  it("dedupes a pending turn already handled (shared seen set, keyed turn:<uuid>)", () => {
+    const { seen, enqueued, router } = wirePending();
+    const turn = {
+      turnUuid: "turn-3",
+      sessionId: DIRECT_IDEA,
+      directIdeaUuid: DIRECT_IDEA,
+      trigger: "human_instruction",
+      promptText: "x",
+    };
+    router.dispatchPendingTurn(turn);
+    router.dispatchPendingTurn(turn); // second time → deduped
+    expect(enqueued).toHaveLength(1);
+    expect(seen.has("turn:turn-3")).toBe(true);
+  });
+
+  it("ignores non-human_instruction triggers (autonomous turns are re-driven by the notification backfill)", () => {
+    const { enqueued, router } = wirePending();
+    router.dispatchPendingTurn({
+      turnUuid: "turn-4",
+      sessionId: DIRECT_IDEA,
+      directIdeaUuid: DIRECT_IDEA,
+      trigger: "task_assigned",
+      promptText: null,
+    });
+    expect(enqueued).toHaveLength(0);
+  });
+
+  it("skips a malformed pending turn (missing turnUuid / sessionId / empty promptText), logged", () => {
+    const warns = [];
+    const seen = new Set();
+    const enqueued = [];
+    const router = new EventRouter({
+      mcpClient: { callTool: vi.fn() },
+      waker: { markQueued: vi.fn(), wake: vi.fn() },
+      queue: { enqueue: (k, t) => enqueued.push({ k, t }) },
+      wakeActions: WAKE_ACTIONS,
+      seen,
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+    router.dispatchPendingTurn({ sessionId: DIRECT_IDEA, trigger: "human_instruction", promptText: "x" }); // no turnUuid
+    router.dispatchPendingTurn({ turnUuid: "t", trigger: "human_instruction", promptText: "x" }); // no sessionId
+    router.dispatchPendingTurn({
+      turnUuid: "t2",
+      sessionId: DIRECT_IDEA,
+      trigger: "human_instruction",
+      promptText: "   ",
+    }); // blank body
+    expect(enqueued).toHaveLength(0);
+    expect(warns.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/cli/__tests__/transcript-upload-hooks.test.mjs
+++ b/cli/__tests__/transcript-upload-hooks.test.mjs
@@ -1,0 +1,382 @@
+// cli/__tests__/transcript-upload-hooks.test.mjs
+// Covers daemon-session-conversation (子1) step 6: the transcript upload hooks.
+// `onTranscriptMessage` keeps ONLY user/assistant text (dropping system/result
+// envelopes and thinking/tool_use/tool_result blocks), batches them, and POSTs to
+// /api/daemon/transcript for the current turn's session. `onSessionStart` pins the
+// session so subsequent messages attach to the right turn. The fire-and-forget +
+// warn-not-throw contract: an upload failure is LOGGED and never throws into the wake.
+//
+// Stream-json fixtures below are REAL shapes captured from Claude Code CLI 2.1.183
+// (verified against the install, per the task's hallucination guard), not invented.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  extractTranscriptText,
+  createTranscriptUploadHooks,
+  mergeUploadHooks,
+  createExecutionUploadHooks,
+  createNoopUploadHooks,
+} from "../upload-hooks.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+// ── Real captured stream-json envelopes (Claude Code 2.1.183) ──
+const SID = "e2dc21d0-3071-4bf7-84ae-f2c6dbe8ff24";
+
+const SYSTEM_INIT = { type: "system", subtype: "init", session_id: SID };
+const SYSTEM_THINKING_TOKENS = { type: "system", subtype: "thinking_tokens", session_id: SID };
+
+const ASSISTANT_THINKING = {
+  type: "assistant",
+  session_id: SID,
+  message: { role: "assistant", content: [{ type: "thinking", thinking: "Let me think about this." }] },
+};
+const ASSISTANT_TOOL_USE = {
+  type: "assistant",
+  session_id: SID,
+  message: {
+    role: "assistant",
+    content: [{ type: "tool_use", id: "toolu_1", name: "Read", input: { file_path: "/etc/hostname" } }],
+  },
+};
+const USER_TOOL_RESULT = {
+  type: "user",
+  session_id: SID,
+  message: { role: "user", content: [{ tool_use_id: "toolu_1", type: "tool_result", content: "1\tip-172\n" }] },
+};
+const ASSISTANT_TEXT = {
+  type: "assistant",
+  session_id: SID,
+  message: { role: "assistant", content: [{ type: "text", text: "The hostname is `ip-172`." }] },
+};
+const USER_TEXT_STRING = {
+  type: "user",
+  session_id: SID,
+  message: { role: "user", content: "Please read /etc/hostname." },
+};
+const RESULT_ENVELOPE = { type: "result", subtype: "success", session_id: SID, result: "done" };
+
+describe("extractTranscriptText — keep user/assistant text, drop everything else", () => {
+  it("keeps an assistant text message", () => {
+    expect(extractTranscriptText(ASSISTANT_TEXT)).toEqual({
+      role: "assistant",
+      text: "The hostname is `ip-172`.",
+    });
+  });
+
+  it("keeps a user message whose content is a plain string", () => {
+    expect(extractTranscriptText(USER_TEXT_STRING)).toEqual({
+      role: "user",
+      text: "Please read /etc/hostname.",
+    });
+  });
+
+  it("drops a thinking block (assistant)", () => {
+    expect(extractTranscriptText(ASSISTANT_THINKING)).toBeNull();
+  });
+
+  it("drops a tool_use block (assistant)", () => {
+    expect(extractTranscriptText(ASSISTANT_TOOL_USE)).toBeNull();
+  });
+
+  it("drops a tool_result block (rides inside a type:user message)", () => {
+    expect(extractTranscriptText(USER_TOOL_RESULT)).toBeNull();
+  });
+
+  it("drops system envelopes (init, thinking_tokens, hooks)", () => {
+    expect(extractTranscriptText(SYSTEM_INIT)).toBeNull();
+    expect(extractTranscriptText(SYSTEM_THINKING_TOKENS)).toBeNull();
+  });
+
+  it("drops the result envelope", () => {
+    expect(extractTranscriptText(RESULT_ENVELOPE)).toBeNull();
+  });
+
+  it("concatenates multiple text blocks of one message into one entry", () => {
+    const multi = {
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "Hello " }, { type: "text", text: "world" }] },
+    };
+    expect(extractTranscriptText(multi)).toEqual({ role: "assistant", text: "Hello world" });
+  });
+
+  it("keeps only the text blocks when text is mixed with tool_use", () => {
+    const mixed = {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Reading now." },
+          { type: "tool_use", id: "t", name: "Read", input: {} },
+        ],
+      },
+    };
+    expect(extractTranscriptText(mixed)).toEqual({ role: "assistant", text: "Reading now." });
+  });
+
+  it("drops a message whose text is only whitespace", () => {
+    const blank = { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "   " }] } };
+    expect(extractTranscriptText(blank)).toBeNull();
+  });
+
+  it("never throws on malformed / non-object / missing-message input (returns null)", () => {
+    expect(extractTranscriptText(null)).toBeNull();
+    expect(extractTranscriptText(undefined)).toBeNull();
+    expect(extractTranscriptText("a string")).toBeNull();
+    expect(extractTranscriptText(42)).toBeNull();
+    expect(extractTranscriptText({})).toBeNull();
+    expect(extractTranscriptText({ type: "assistant" })).toBeNull(); // no .message
+    expect(extractTranscriptText({ type: "assistant", message: {} })).toBeNull(); // no content
+    expect(extractTranscriptText({ type: "assistant", message: { content: 7 } })).toBeNull(); // weird content
+  });
+
+  it("falls back to the envelope type when message.role is absent", () => {
+    const noRole = { type: "user", message: { content: [{ type: "text", text: "hi" }] } };
+    expect(extractTranscriptText(noRole)).toEqual({ role: "user", text: "hi" });
+  });
+});
+
+/** A fake server: records every POST body and answers ok unless told otherwise. */
+function fakeServer({ ok = true, status = 200 } = {}) {
+  const posts = [];
+  const fetchImpl = vi.fn(async (url, init) => {
+    posts.push({ url: String(url), init, body: JSON.parse(init.body) });
+    return { ok, status, async json() { return { success: ok, data: {} }; } };
+  });
+  return { posts, fetchImpl };
+}
+
+describe("createTranscriptUploadHooks — batching + POST", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  /** Run pending debounce timers, then let the serialized upload chain settle. */
+  async function flush() {
+    await vi.runAllTimersAsync();
+  }
+
+  it("batches a burst of messages into ONE POST with only user/assistant text", async () => {
+    const { posts, fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({
+      url: "https://chorus.example/",
+      apiKey: "cho_secret",
+      logger: silent,
+      fetchImpl,
+      batchDelayMs: 50,
+    });
+
+    await hooks.onSessionStart({ rootIdeaKey: `idea:${SID}`, sessionId: SID, isNew: true });
+    // A realistic burst: thinking, tool_use, tool_result are dropped; two texts kept.
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_THINKING });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TOOL_USE });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: USER_TOOL_RESULT });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: USER_TEXT_STRING });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+
+    expect(fetchImpl).not.toHaveBeenCalled(); // debounced — nothing yet
+    await flush();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const { url, init, body } = posts[0];
+    expect(url).toBe("https://chorus.example/api/daemon/transcript");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer cho_secret",
+      "Content-Type": "application/json",
+    });
+    expect(body).toEqual({
+      sessionId: SID,
+      messages: [
+        { role: "user", text: "Please read /etc/hostname." },
+        { role: "assistant", text: "The hostname is `ip-172`." },
+      ],
+    });
+  });
+
+  it("does NOT post when a turn produced no user/assistant text (all dropped)", async () => {
+    const { fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_THINKING });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TOOL_USE });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: USER_TOOL_RESULT });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: SYSTEM_INIT });
+    await flush();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("attributes messages to the session id observed ON THE STREAM (no onSessionStart)", async () => {
+    const { posts, fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl });
+    // onSessionStart never called; the stream's session id is used instead.
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await flush();
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.sessionId).toBe(SID);
+  });
+
+  it("flushes the prior session's batch before re-pinning to a new session", async () => {
+    const { posts, fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl });
+    const SID2 = "11111111-1111-4111-8111-111111111111";
+
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    // New session starts before the debounce fired — the old batch must flush to SID.
+    await hooks.onSessionStart({ sessionId: SID2, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID2, message: USER_TEXT_STRING });
+    await flush();
+
+    expect(posts).toHaveLength(2);
+    const bySession = Object.fromEntries(posts.map((p) => [p.body.sessionId, p.body.messages]));
+    expect(bySession[SID]).toEqual([{ role: "assistant", text: "The hostname is `ip-172`." }]);
+    expect(bySession[SID2]).toEqual([{ role: "user", text: "Please read /etc/hostname." }]);
+  });
+
+  it("drops a batch with no session id (visible warning, no POST)", async () => {
+    const warns = [];
+    const { fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+    // A keepable message but with NO session id anywhere → can't attribute.
+    await hooks.onTranscriptMessage({ message: ASSISTANT_TEXT });
+    await flush();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(warns.join("")).toMatch(/no session id/i);
+  });
+});
+
+describe("createTranscriptUploadHooks — warn-not-throw (fire-and-forget)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("a network failure is logged and never throws into the wake path", async () => {
+    const warns = [];
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    // The hook call itself must not reject.
+    await expect(hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT })).resolves.toBeUndefined();
+    await vi.runAllTimersAsync();
+    expect(warns.join("")).toMatch(/transcript upload request failed/i);
+  });
+
+  it("a non-2xx response is logged and non-fatal", async () => {
+    const warns = [];
+    const { fetchImpl } = fakeServer({ ok: false, status: 404 });
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await vi.runAllTimersAsync();
+    expect(warns.join("")).toMatch(/transcript upload returned 404/);
+  });
+
+  it("an upload failure does not wedge the chain — a later batch still posts", async () => {
+    let call = 0;
+    const posts = [];
+    const fetchImpl = vi.fn(async (url, init) => {
+      call += 1;
+      if (call === 1) throw new Error("boom");
+      posts.push(JSON.parse(init.body));
+      return { ok: true, status: 200, async json() { return {}; } };
+    });
+    const hooks = createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl });
+
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await vi.runAllTimersAsync();
+    // Second turn/batch after the first failed.
+    await hooks.onTranscriptMessage({ sessionId: SID, message: USER_TEXT_STRING });
+    await vi.runAllTimersAsync();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].messages).toEqual([{ role: "user", text: "Please read /etc/hostname." }]);
+  });
+});
+
+describe("mergeUploadHooks — compose execution + transcript concerns", () => {
+  it("routes onSessionStart/onTranscriptMessage to transcript and onExecutionChange to execution", async () => {
+    const calls = [];
+    const transcript = {
+      ...createNoopUploadHooks(),
+      onSessionStart: async () => calls.push("ts:start"),
+      onTranscriptMessage: async () => calls.push("ts:msg"),
+    };
+    const execution = {
+      ...createNoopUploadHooks(),
+      onExecutionChange: () => calls.push("ex:change"),
+    };
+    const merged = mergeUploadHooks(execution, transcript, { logger: silent });
+
+    await merged.onSessionStart({ sessionId: SID });
+    await merged.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    merged.onExecutionChange();
+
+    expect(calls).toEqual(["ts:start", "ts:msg", "ex:change"]);
+  });
+
+  it("a throwing delegate never breaks the others or the caller", async () => {
+    const warns = [];
+    const good = { ...createNoopUploadHooks(), onSessionStart: async () => warns.push("good ran") };
+    const bad = {
+      ...createNoopUploadHooks(),
+      onSessionStart: async () => {
+        throw new Error("delegate boom");
+      },
+      onExecutionChange: () => {
+        throw new Error("sync boom");
+      },
+    };
+    const merged = mergeUploadHooks(bad, good, { logger: { ...silent, warn: (m) => warns.push(m) } });
+
+    await expect(merged.onSessionStart({ sessionId: SID })).resolves.toBeUndefined();
+    expect(() => merged.onExecutionChange()).not.toThrow();
+    expect(warns).toContain("good ran"); // the good delegate still ran
+    expect(warns.join("")).toMatch(/onSessionStart hook failed/);
+    expect(warns.join("")).toMatch(/onExecutionChange hook failed/);
+  });
+
+  it("ignores null/undefined hook sets and end-to-end real factories compose", async () => {
+    const { posts, fetchImpl } = fakeServer();
+    const merged = mergeUploadHooks(
+      null,
+      createExecutionUploadHooks({
+        url: "https://c",
+        apiKey: "k",
+        getConnectionUuid: () => "conn-1",
+        getSnapshot: () => [],
+        logger: silent,
+        fetchImpl,
+      }),
+      createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl, batchDelayMs: 0 }),
+      undefined,
+      { logger: silent }
+    );
+
+    await merged.onSessionStart({ sessionId: SID, isNew: true });
+    await merged.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    merged.onExecutionChange();
+    // Let both the (microtask) transcript flush and the execution chain settle.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const urls = posts.map((p) => p.url);
+    expect(urls).toContain("https://c/api/daemon/transcript");
+    expect(urls).toContain("https://c/api/daemon/execution-state");
+  });
+});

--- a/cli/__tests__/turn-reporter.test.mjs
+++ b/cli/__tests__/turn-reporter.test.mjs
@@ -1,0 +1,128 @@
+// cli/__tests__/turn-reporter.test.mjs
+// Covers the daemon → server turn-lifecycle reporter (子1 —
+// daemon-session-conversation): REST POST to /api/daemon/turn-advance, Bearer auth,
+// zero new deps, fire-and-forget never-throws.
+import { describe, it, expect, vi } from "vitest";
+import { createTurnReporter, TURN_STATUSES } from "../turn-reporter.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+function okFetch() {
+  return vi.fn(async () => ({ ok: true, status: 200 }));
+}
+
+describe("createTurnReporter", () => {
+  it("POSTs to /api/daemon/turn-advance with Bearer auth, connection + session + status", async () => {
+    const fetchImpl = okFetch();
+    const advance = createTurnReporter({
+      url: "https://chorus.example.com/",
+      apiKey: "cho_secret",
+      getConnectionUuid: () => "conn-1",
+      logger: silent,
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "running", entityType: "task", entityUuid: "task-9" });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    // Trailing slash on the base url is normalized away.
+    expect(endpoint).toBe("https://chorus.example.com/api/daemon/turn-advance");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer cho_secret");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({
+      connectionUuid: "conn-1",
+      sessionId: "idea-1",
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+  });
+
+  it("omits entityType/entityUuid when not both supplied (no partial linkage)", async () => {
+    const fetchImpl = okFetch();
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: silent,
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "ended", entityType: "task" }); // entityUuid missing
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body).toEqual({ connectionUuid: "conn-1", sessionId: "idea-1", status: "ended" });
+    expect(body).not.toHaveProperty("entityType");
+  });
+
+  it("skips (logged, no fetch) when the connection uuid is not known yet", async () => {
+    const fetchImpl = okFetch();
+    const warns = [];
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => null, // SSE handshake hasn't reported it
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "running" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(warns.join("")).toMatch(/no connection uuid yet/);
+  });
+
+  it("refuses a bad status / missing sessionId (logged, no fetch)", async () => {
+    const fetchImpl = okFetch();
+    const warns = [];
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "pending-typo" });
+    await advance({ sessionId: "", status: "running" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(warns.join("")).toMatch(/bad sessionId\/status/);
+  });
+
+  it("never throws on a network error — logs and resolves", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const warns = [];
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+
+    await expect(advance({ sessionId: "idea-1", status: "running" })).resolves.toBeUndefined();
+    expect(warns.join("")).toMatch(/turn-advance request failed/);
+  });
+
+  it("logs a non-2xx response (no throw)", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 409 }));
+    const warns = [];
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "ended" });
+    expect(warns.join("")).toMatch(/turn-advance returned 409/);
+  });
+
+  it("TURN_STATUSES is the strict lifecycle set", () => {
+    expect([...TURN_STATUSES].sort()).toEqual(["ended", "pending", "running"]);
+  });
+});

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -52,7 +52,11 @@ describe("buildPrompt", () => {
 
   it("builds a non-null prompt for every action in WAKE_ACTIONS (no dead/missing entries)", () => {
     for (const action of WAKE_ACTIONS) {
-      const p = buildPrompt({ ...TASK_NOTIF, action });
+      // human_instruction is a wake action only when it carries a free-text body — its
+      // actionable payload IS the instruction, so supply one for the coverage check
+      // (an empty-body human_instruction legitimately returns null; see its own test).
+      const extra = action === "human_instruction" ? { instructionText: "please rebase onto main" } : {};
+      const p = buildPrompt({ ...TASK_NOTIF, action, ...extra });
       expect(p, `WAKE_ACTIONS has "${action}" but buildPrompt returns null for it`).not.toBeNull();
     }
   });

--- a/cli/__tests__/waker-turn-lifecycle.test.mjs
+++ b/cli/__tests__/waker-turn-lifecycle.test.mjs
@@ -1,0 +1,171 @@
+// cli/__tests__/waker-turn-lifecycle.test.mjs
+// Covers the Waker advancing the server-side DaemonSessionTurn (子1 —
+// daemon-session-conversation): pending→running on spawn, running→ended on exit,
+// reusing the existing executions map / onChild hook (no parallel registry), with the
+// entity threaded so the server can stamp the executionUuid linkage.
+import { describe, it, expect, vi } from "vitest";
+import { Waker } from "../waker.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+const DIRECT_IDEA = "11111111-1111-4111-8111-111111111111";
+const ROOT_IDEA = "99999999-9999-4999-8999-999999999999";
+
+const TASK_NOTIF = {
+  uuid: "notif-1",
+  projectUuid: "proj-1",
+  entityType: "task",
+  entityUuid: "task-1",
+  entityTitle: "Build the thing",
+  action: "task_assigned",
+  message: "",
+  actorType: "user",
+  actorUuid: "user-1",
+  actorName: "Alice",
+};
+
+// A spawner that DOES invoke onChild (the live-spawn moment the running turn-advance
+// hangs off) before resolving with the given exit code.
+function spawnerThatSpawns(exitCode = 0) {
+  return {
+    wake: vi.fn(async ({ sessionId, onChild, onMessage }) => {
+      onChild?.({ pid: 4242, on: () => {}, kill: () => {} });
+      onMessage?.({ type: "system", session_id: sessionId });
+      return { sessionId, exitCode, isNew: true };
+    }),
+  };
+}
+
+// A spawner that NEVER calls onChild (e.g. a spawn that failed before the child
+// materialized) — the turn must stay pending and ended must NOT be attempted.
+function spawnerThatNeverSpawns() {
+  return {
+    wake: vi.fn(async ({ sessionId }) => ({ sessionId, exitCode: null, isNew: true })),
+  };
+}
+
+function makeWaker(overrides = {}) {
+  const advanceTurn = overrides.advanceTurn ?? vi.fn(async () => {});
+  const waker = new Waker({
+    creds: { url: "https://c", apiKey: "cho_x" },
+    lineage:
+      overrides.lineage ??
+      { resolve: vi.fn(async () => ({ rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA })) },
+    spawner: overrides.spawner ?? spawnerThatSpawns(0),
+    cwd: "/work/dir",
+    hooks: overrides.hooks,
+    logger: overrides.logger ?? silent,
+    writeMcpConfigFn: vi.fn(() => ({ path: "/tmp/m.json", cleanup: vi.fn() })),
+    isNewSessionFn: vi.fn(() => true),
+    reportInterrupt: vi.fn(async () => {}),
+    advanceTurn,
+  });
+  return { waker, advanceTurn, spawner: waker.spawner };
+}
+
+describe("Waker turn lifecycle (子1)", () => {
+  it("advances pending→running on spawn and running→ended on exit, keyed on the session id, with the entity for executionUuid linkage", async () => {
+    const { waker, advanceTurn } = makeWaker();
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(advanceTurn).toHaveBeenCalledTimes(2);
+    // running first, then ended — strict forward order.
+    expect(advanceTurn.mock.calls[0][0]).toEqual({
+      sessionId: DIRECT_IDEA, // the session anchor = direct idea uuid
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-1",
+    });
+    expect(advanceTurn.mock.calls[1][0]).toEqual({
+      sessionId: DIRECT_IDEA,
+      status: "ended",
+      entityType: "task",
+      entityUuid: "task-1",
+    });
+  });
+
+  it("anchors the turn on the entity's own uuid when there is no direct idea (ad-hoc session)", async () => {
+    const QUICK_TASK = "22222222-2222-4222-8222-222222222222";
+    const { waker, advanceTurn } = makeWaker({
+      lineage: { resolve: async () => ({ rootIdeaUuid: null, directIdeaUuid: null }) },
+    });
+    const notif = { ...TASK_NOTIF, entityUuid: QUICK_TASK };
+    const resolved = await waker.keyFor(notif);
+    await waker.wake(notif, resolved.key, resolved);
+
+    expect(advanceTurn).toHaveBeenCalledTimes(2);
+    expect(advanceTurn.mock.calls[0][0].sessionId).toBe(QUICK_TASK);
+    expect(advanceTurn.mock.calls[0][0].status).toBe("running");
+    expect(advanceTurn.mock.calls[1][0].status).toBe("ended");
+  });
+
+  it("still advances running→ended on a NON-ZERO exit (a turn ends regardless of exit code)", async () => {
+    const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatSpawns(2) });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const statuses = advanceTurn.mock.calls.map((c) => c[0].status);
+    expect(statuses).toEqual(["running", "ended"]);
+  });
+
+  it("does NOT attempt ended when the subprocess never spawned (turn stays pending; no illegal pending→ended)", async () => {
+    const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatNeverSpawns() });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    // onChild never fired → no running, and therefore no ended either.
+    expect(advanceTurn).not.toHaveBeenCalled();
+  });
+
+  it("reuses the existing executions map / onChild — the running entry still gets its child handle", async () => {
+    // Assert the turn-advance addition did NOT displace the 子3 child-capture: the
+    // running execution entry must still hold the live child for the interrupt path.
+    let capturedChild = null;
+    const spawner = {
+      wake: vi.fn(async ({ sessionId, onChild }) => {
+        const child = { pid: 7, on: () => {}, kill: () => {} };
+        onChild?.(child);
+        capturedChild = child;
+        return { sessionId, exitCode: 0, isNew: true };
+      }),
+    };
+    // Capture the running entry's child mid-wake via a spy on the snapshot.
+    const { waker, advanceTurn } = makeWaker({ spawner });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+    // The child was handed to onChild (子3 path intact) AND the turn advanced (子1).
+    expect(capturedChild).not.toBeNull();
+    expect(advanceTurn.mock.calls.map((c) => c[0].status)).toEqual(["running", "ended"]);
+  });
+
+  it("a throwing turn reporter never crashes the wake (logged + swallowed)", async () => {
+    const warns = [];
+    const { waker } = makeWaker({
+      advanceTurn: vi.fn(async () => {
+        throw new Error("reporter boom");
+      }),
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await expect(waker.wake(TASK_NOTIF, resolved.key, resolved)).resolves.toBeUndefined();
+    expect(warns.join("")).toMatch(/advanceTurn failed/);
+  });
+
+  it("defaults to a no-op-with-log reporter when none is injected (existing Wakers keep working)", async () => {
+    const infos = [];
+    // Build a Waker WITHOUT advanceTurn — the default no-op-with-log must be used.
+    const waker = new Waker({
+      creds: { url: "https://c", apiKey: "cho_x" },
+      lineage: { resolve: async () => ({ rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA }) },
+      spawner: spawnerThatSpawns(0),
+      cwd: "/work/dir",
+      logger: { ...silent, info: (m) => infos.push(m) },
+      writeMcpConfigFn: vi.fn(() => ({ path: "/tmp/m.json", cleanup: vi.fn() })),
+      isNewSessionFn: vi.fn(() => true),
+    });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await expect(waker.wake(TASK_NOTIF, resolved.key, resolved)).resolves.toBeUndefined();
+    expect(infos.join("")).toMatch(/no turn reporter wired/);
+  });
+});

--- a/cli/backfill.mjs
+++ b/cli/backfill.mjs
@@ -1,17 +1,33 @@
 // cli/backfill.mjs
-// Reconnect backfill: after the SSE stream reconnects, pull notifications that
-// arrived during the gap and hand each to the dispatch callback, so a dispatch
-// that occurred while the daemon was briefly disconnected is not lost
-// (cli-daemon spec "Reconnect with backfill"). Ported from the OpenClaw
-// plugin's onReconnect logic.
+// Reconnect backfill: after the SSE stream reconnects, recover anything that
+// arrived during the gap so a dispatch made while the daemon was briefly
+// disconnected is not lost (cli-daemon spec "Reconnect with backfill"). Two
+// sources, both re-driven through the SAME router/queue + shared `seen` set:
+//
+//   1. NOTIFICATIONS — pull unread notifications via MCP and re-emit each as a
+//      synthetic `new_notification` event (the original OpenClaw onReconnect logic).
+//      This recovers autonomous wakes (task_assigned / mentioned / elaboration / …),
+//      whose actionable payload lives on the re-fetchable notification.
+//
+//   2. PENDING TURNS — re-derive UNSTARTED (status `pending`) DaemonSessionTurns for
+//      this connection's origin-pinned sessions from the TURN TABLE (子1 —
+//      daemon-session-conversation), NOT from notifications. The turn is persisted at
+//      the notification chokepoint before/at notification creation, so it survives a
+//      lost delivery ping; a `human_instruction`'s free-text body lives ONLY on the
+//      turn, making the turn table its sole reliable backfill source. Read via
+//      `GET /api/daemon/pending-turns?connectionUuid=…` (Bearer agent key, global
+//      fetch — zero new deps), each re-dispatched through `router.dispatchPendingTurn`.
+//
+// De-dupes against the shared `seen` set so a reconnect storm doesn't double-wake.
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
 /**
- * Build an onReconnect handler that fetches unread notifications via MCP and
- * re-emits each as a synthetic `new_notification` event into `dispatch`.
- * De-dupes against notifications already seen this run so a reconnect storm
- * doesn't double-wake.
+ * Build an onReconnect handler that (1) re-emits missed unread notifications into
+ * `dispatch`, and (2) — when a connectionUuid + pending-turn dispatcher are wired —
+ * re-derives this connection's unstarted (pending) turns from the turn table and
+ * re-dispatches each. Both paths share the `seen` set so already-handled work is not
+ * re-run.
  *
  * @param {{
  *   mcpClient: { callTool: (name: string, args?: Record<string, unknown>) => Promise<unknown> },
@@ -19,6 +35,15 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
  *   seen?: Set<string>,
  *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
  *   limit?: number,
+ *   // 子1 — pending-turn backfill (all optional; when absent, only the notification
+ *   // backfill runs, preserving the original behavior/wiring):
+ *   url?: string,                              Chorus base URL (for the pending-turns read).
+ *   apiKey?: string,                           `cho_` agent API key.
+ *   getConnectionUuid?: () => (string|null),   The daemon's registered connection uuid
+ *                                              (learned from the SSE handshake). Null until
+ *                                              then — the pending-turns read is skipped while null.
+ *   dispatchPendingTurn?: (turn: { turnUuid: string, sessionId: string, directIdeaUuid: string|null, trigger: string, promptText: string|null }) => void,
+ *   fetchImpl?: typeof fetch,                  Injectable for tests.
  * }} opts
  * @returns {() => Promise<void>}
  */
@@ -27,8 +52,15 @@ export function createBackfill(opts) {
   const seen = opts.seen ?? new Set();
   const logger = opts.logger ?? NOOP_LOGGER;
   const limit = opts.limit ?? 50;
+  // 子1 pending-turn backfill wiring (optional).
+  const url = opts.url ? opts.url.replace(/\/$/, "") : null;
+  const apiKey = opts.apiKey ?? null;
+  const getConnectionUuid = opts.getConnectionUuid ?? null;
+  const dispatchPendingTurn = opts.dispatchPendingTurn ?? null;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
 
-  return async function backfill() {
+  /** Re-emit unread notifications missed during the gap (autonomous wakes). */
+  async function backfillNotifications() {
     let result;
     try {
       result = /** @type {{ notifications?: Array<{ uuid: string }> }} */ (
@@ -64,5 +96,74 @@ export function createBackfill(opts) {
     if (redispatched > 0) {
       logger.info(`[Chorus] backfill re-dispatched ${redispatched} missed notification(s)`);
     }
+  }
+
+  /**
+   * Re-derive this connection's UNSTARTED (pending) turns from the turn table (子1)
+   * and re-dispatch each through the router. No-op (silently skipped) when the
+   * pending-turn wiring is absent or the connectionUuid is not known yet. Never throws
+   * into the reconnect path — a failure is logged and swallowed.
+   */
+  async function backfillPendingTurns() {
+    if (!url || !apiKey || !getConnectionUuid || !dispatchPendingTurn) {
+      // Pending-turn backfill not wired (e.g. notification-only callers / older tests).
+      return;
+    }
+    const connectionUuid = getConnectionUuid();
+    if (!connectionUuid) {
+      // No connectionUuid yet (SSE handshake hasn't reported it): nothing to read
+      // against. Not an error — a normal early state on the very first connect.
+      return;
+    }
+
+    const endpoint = `${url}/api/daemon/pending-turns?connectionUuid=${encodeURIComponent(connectionUuid)}`;
+    let response;
+    try {
+      response = await fetchImpl(endpoint, {
+        headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+      });
+    } catch (err) {
+      logger.warn(`[Chorus] pending-turns backfill request failed: ${err}`);
+      return;
+    }
+    if (!response.ok) {
+      logger.warn(`[Chorus] pending-turns backfill returned ${response.status}`);
+      return;
+    }
+    let body;
+    try {
+      body = await response.json();
+    } catch (err) {
+      logger.warn(`[Chorus] pending-turns backfill: bad JSON: ${err}`);
+      return;
+    }
+    // API envelope: { success: true, data: { turns: [...] } }.
+    const data = body && typeof body === "object" ? body.data : undefined;
+    const turns = data && typeof data === "object" ? data.turns : undefined;
+    if (!Array.isArray(turns)) {
+      logger.warn("[Chorus] pending-turns backfill: no turns array in response");
+      return;
+    }
+
+    let redispatched = 0;
+    for (const t of turns) {
+      if (!t || typeof t.turnUuid !== "string") continue;
+      // The router (dispatchPendingTurn) is the single owner of marking-seen (keyed
+      // `turn:<uuid>`), exactly like the notification path — so do NOT mark here.
+      if (seen.has(`turn:${t.turnUuid}`)) continue;
+      redispatched++;
+      dispatchPendingTurn(t);
+    }
+    if (redispatched > 0) {
+      logger.info(`[Chorus] backfill re-derived ${redispatched} pending turn(s) from the turn table`);
+    }
+  }
+
+  return async function backfill() {
+    // Run both sources. Each swallows its own errors so one failing source never
+    // aborts the other (a notification-fetch failure must not lose pending turns, and
+    // vice versa).
+    await backfillNotifications();
+    await backfillPendingTurns();
   };
 }

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -21,9 +21,14 @@ import { WakeQueue } from "./wake-queue.mjs";
 import { Waker } from "./waker.mjs";
 import { LineageResolver } from "./lineage.mjs";
 import { ClaudeSpawner, resolveClaudePath } from "./claude-spawner.mjs";
-import { createExecutionUploadHooks } from "./upload-hooks.mjs";
+import {
+  createExecutionUploadHooks,
+  createTranscriptUploadHooks,
+  mergeUploadHooks,
+} from "./upload-hooks.mjs";
 import { WAKE_ACTIONS } from "./prompts.mjs";
 import { createInterruptReporter } from "./interrupt-reporter.mjs";
+import { createTurnReporter } from "./turn-reporter.mjs";
 import { createControlHandler } from "./control-handler.mjs";
 import { resolveSigintTimeoutMs } from "./daemon-config.mjs";
 
@@ -53,6 +58,7 @@ function defaultLogger() {
  *   maxConcurrency?: number,
  *   permissionMode?: "chorus"|"yolo",
  *   reportInterrupt?: (entityType: string, entityUuid: string, reason: "user"|"crash") => Promise<void>,
+ *   advanceTurn?: (params: { sessionId: string, status: "running"|"ended", entityType?: string|null, entityUuid?: string|null }) => Promise<void>,
  *   sigintTimeoutMs?: number,
  * }} [deps]
  */
@@ -73,6 +79,20 @@ export function buildDaemon(creds, deps = {}) {
   const reportInterrupt =
     deps.reportInterrupt ??
     createInterruptReporter({
+      url: creds.url,
+      apiKey: creds.apiKey,
+      getConnectionUuid: () => connectionState.connectionUuid,
+      logger,
+      fetchImpl: deps.fetchImpl,
+    });
+  // Turn-lifecycle reporter (子1 — daemon-session-conversation): REST POST with the
+  // daemon's Bearer key (zero new deps), injectable for tests. The waker calls it on a
+  // wake's spawn (→ running) and exit (→ ended) to advance the server-side
+  // DaemonSessionTurn the notification chokepoint created. Reads the connectionUuid
+  // lazily from the same box the SSE handshake fills.
+  const advanceTurn =
+    deps.advanceTurn ??
+    createTurnReporter({
       url: creds.url,
       apiKey: creds.apiKey,
       getConnectionUuid: () => connectionState.connectionUuid,
@@ -103,23 +123,41 @@ export function buildDaemon(creds, deps = {}) {
   // per-task registry (which reuses the already-resolved root-idea lineage).
   // Fire-and-forget; failures logged + non-fatal (see upload-hooks.mjs). The
   // hooks share the daemon's existing creds + zero new deps (global fetch).
+  // Transcript upload hooks (子1 — daemon-session-conversation): the waker's
+  // stream-json consumer (onMessage) and pre-spawn (onSessionStart) feed these,
+  // which keep only user/assistant text and batch-POST it to /api/daemon/transcript
+  // for the current turn (resolved server-side by the session business key the waker
+  // already anchors on). Same zero-dep, fire-and-forget, warn-not-throw contract as
+  // the execution hooks; no connectionUuid needed (the agent key + sessionId suffice).
+  // The two hook sets are MERGED into the single object the waker takes:
+  // onSessionStart/onTranscriptMessage fan out to the transcript hooks,
+  // onExecutionChange to the execution hooks.
   const hooks =
     deps.hooks ??
-    createExecutionUploadHooks({
-      url: creds.url,
-      apiKey: creds.apiKey,
-      getConnectionUuid: () => connectionState.connectionUuid,
-      getSnapshot: () => waker?.buildExecutionSnapshot() ?? [],
-      logger,
-      fetchImpl: deps.fetchImpl,
-    });
+    mergeUploadHooks(
+      createExecutionUploadHooks({
+        url: creds.url,
+        apiKey: creds.apiKey,
+        getConnectionUuid: () => connectionState.connectionUuid,
+        getSnapshot: () => waker?.buildExecutionSnapshot() ?? [],
+        logger,
+        fetchImpl: deps.fetchImpl,
+      }),
+      createTranscriptUploadHooks({
+        url: creds.url,
+        apiKey: creds.apiKey,
+        logger,
+        fetchImpl: deps.fetchImpl,
+      }),
+      { logger }
+    );
 
   // One dedup set shared by the router (live SSE path) and the reconnect
   // backfill, so a notification handled live is never re-woken on reconnect.
   const seen = new Set();
   // cwd: the daemon spawns all wakes in one working directory; the waker uses it
   // BOTH to probe the transcript (new-vs-resume) and to spawn, so they never diverge.
-  waker = new Waker({ creds, lineage, spawner, cwd: deps.cwd ?? process.cwd(), hooks, logger, reportInterrupt });
+  waker = new Waker({ creds, lineage, spawner, cwd: deps.cwd ?? process.cwd(), hooks, logger, reportInterrupt, advanceTurn });
   const router = new EventRouter({ mcpClient, waker, queue, wakeActions: WAKE_ACTIONS, seen, logger });
 
   // Reverse control channel (子3): the control handler verifies a control event
@@ -157,6 +195,16 @@ export function buildDaemon(creds, deps = {}) {
     dispatch: (event) => router.dispatch(event),
     seen,
     logger,
+    // 子1 — pending-turn backfill: re-derive unstarted turns from the turn table (NOT
+    // notifications) for this connection's origin-pinned sessions, so a lost delivery
+    // ping never loses an instruction. Shares the same router (dispatchPendingTurn) +
+    // seen set so a turn handled live (or by an earlier backfill) is not re-run. Reads
+    // the connectionUuid lazily from the SSE-handshake box.
+    url: creds.url,
+    apiKey: creds.apiKey,
+    getConnectionUuid: () => connectionState.connectionUuid,
+    dispatchPendingTurn: (turn) => router.dispatchPendingTurn?.(turn),
+    fetchImpl: deps.fetchImpl,
   });
 
   const sseListener =

--- a/cli/event-router.mjs
+++ b/cli/event-router.mjs
@@ -78,6 +78,23 @@ export class EventRouter {
       return;
     }
 
+    // 子1 — daemon-session-conversation: a `human_instruction` wake carries the human's
+    // free-text body denormalized onto the notification as `instructionText` (the server
+    // sets it at the notification chokepoint; the canonical copy is the turn's
+    // promptText). The daemon reads it from THIS already-fetched notification — NO extra
+    // round-trip — and threads it through to buildPrompt as the prompt body. For every
+    // other (autonomous) action `instructionText` is absent/null and ignored. Pass `n`
+    // through unchanged: it already carries `instructionText` from the notification list,
+    // so the field reaches keyFor → markQueued → wake → buildPrompt without a re-fetch.
+    if (n.action === "human_instruction" && !n.instructionText) {
+      // An instruction with no body is nothing to act on (buildPrompt would skip it).
+      // Surface it visibly rather than silently spawning a contentless wake.
+      this.logger.warn(
+        `[Chorus] human_instruction ${notificationUuid} carries no instructionText — skipping`
+      );
+      return;
+    }
+
     await this.#resolveAndEnqueue(n, notificationUuid);
   }
 
@@ -103,6 +120,86 @@ export class EventRouter {
     this.#resolveAndEnqueue(n, `resume:${entityType}:${entityUuid}`).catch((err) => {
       this.logger.error(`[Chorus] failed to dispatch resume for ${entityType}:${entityUuid}: ${err}`);
     });
+  }
+
+  /**
+   * Re-dispatch a backfilled PENDING TURN (子1 — daemon-session-conversation). On
+   * reconnect, the backfill re-derives unstarted turns from the TURN TABLE (the
+   * canonical source — see backfill.mjs) rather than from a possibly-lost notification
+   * ping, so a dropped delivery never loses an instruction. Each pending turn already
+   * carries its session anchor (`sessionId` + `directIdeaUuid`) and — for a
+   * `human_instruction` — its canonical free-text body (`promptText`). We re-run it
+   * through the SAME markQueued → enqueue path as a live wake, BUT skip `keyFor`'s
+   * lineage round-trip: the session key is reconstructed DIRECTLY from the turn's
+   * own ids (which are authoritative), so backfill needs no network beyond the
+   * pending-turns read. Deduped via the shared `seen` set keyed on the turn uuid so a
+   * pending turn already handled live (or by an earlier backfill) is not re-run.
+   * Synchronous + non-throwing, mirroring `dispatch`/`dispatchResume`.
+   *
+   * Only `human_instruction` pending turns are re-dispatched here: autonomous turns
+   * (task_assigned / mentioned / elaboration / resume) are re-driven by the
+   * notification backfill (their notifications are re-fetched), whereas a
+   * human_instruction's actionable payload lives ONLY on the turn — so the turn table
+   * is its sole reliable backfill source.
+   *
+   * @param {{ turnUuid?: string, sessionId?: string, directIdeaUuid?: string|null,
+   *           trigger?: string, promptText?: string|null }} pending
+   */
+  dispatchPendingTurn(pending) {
+    const turnUuid = pending?.turnUuid;
+    const sessionId = pending?.sessionId;
+    if (typeof turnUuid !== "string" || !turnUuid) {
+      this.logger.warn("[Chorus] pending-turn dispatch missing turnUuid, skipping");
+      return;
+    }
+    if (typeof sessionId !== "string" || !sessionId) {
+      this.logger.warn(`[Chorus] pending-turn ${turnUuid} missing sessionId, skipping`);
+      return;
+    }
+    // Only human_instruction is re-derived from the turn table (see doc above).
+    if (pending.trigger !== "human_instruction") {
+      return;
+    }
+    const instruction =
+      typeof pending.promptText === "string" ? pending.promptText.trim() : "";
+    if (!instruction) {
+      this.logger.warn(
+        `[Chorus] pending human_instruction turn ${turnUuid} has no promptText — skipping`
+      );
+      return;
+    }
+    // Shared dedup: a turn uuid keys the seen set so a backfilled pending turn already
+    // handled (live or earlier backfill) does not re-run. Marked BEFORE async work, as
+    // the live path does, so concurrent backfills collapse to one wake.
+    const seenKey = `turn:${turnUuid}`;
+    if (this.seen.has(seenKey)) return;
+    this.seen.add(seenKey);
+
+    const directIdeaUuid =
+      typeof pending.directIdeaUuid === "string" ? pending.directIdeaUuid : null;
+    // Reconstruct the wake's session anchor DIRECTLY from the turn's own ids (no
+    // lineage round-trip). The waker anchors the Claude session on
+    // `directIdeaUuid ?? entityUuid`, and the per-direct-idea queue keys on the same —
+    // so set entityUuid = sessionId so both align with the canonical session.
+    const n = {
+      action: "human_instruction",
+      // The session business key IS the entity anchor here: directIdeaUuid for an
+      // idea-anchored session, else the ad-hoc session id (the original entity uuid).
+      entityType: directIdeaUuid ? "idea" : "task",
+      entityUuid: sessionId,
+      instructionText: instruction,
+    };
+    const key = directIdeaUuid ? `idea:${directIdeaUuid}` : `entity:${n.entityType}:${sessionId}`;
+    const attribution = { key, rootIdeaUuid: directIdeaUuid, directIdeaUuid };
+
+    // Mark queued (snapshot) then enqueue on the same per-direct-idea lane as a live
+    // wake — non-throwing so a missing/failed hook never breaks backfill.
+    try {
+      this.waker.markQueued?.(n, key, attribution);
+    } catch (err) {
+      this.logger.warn(`[Chorus] markQueued failed for pending turn ${turnUuid}: ${err}`);
+    }
+    this.queue.enqueue(key, () => this.waker.wake(n, key, attribution));
   }
 
   /**

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -16,6 +16,11 @@
  * @property {string} actorType
  * @property {string} actorUuid
  * @property {string} actorName
+ * @property {string} [instructionText]  Free-text body of a `human_instruction` wake
+ *   (子1 — daemon-session-conversation). The server denormalizes the canonical turn
+ *   promptText onto the wake notification so the daemon reads it in the
+ *   `chorus_get_notifications` call it already makes (zero extra fetch); the
+ *   event-router threads it here. Present only for the `human_instruction` action.
  */
 
 /** @param {NotificationDetail} n @param {string} entityType */
@@ -107,6 +112,41 @@ export function buildPrompt(n) {
         `projectUuid: ${n.projectUuid}). Use chorus_get_unblocked_tasks (projectUuid: "${n.projectUuid}") ` +
         `to see whether this unblocked any tasks that are now ready to start.`
       );
+    case "human_instruction": {
+      // A human typed a free-text instruction for this daemon's session (子1 — the 子2
+      // UI send box, or a backfilled pending instruction). The canonical text lives on
+      // the server-side turn's promptText and is denormalized onto the wake
+      // notification as `instructionText`, so the daemon reads it WITHOUT an extra
+      // fetch and the event-router threads it here. The instruction is delivered on the
+      // session the daemon is already running (idea-anchored or the entity itself), so
+      // continuation is naturally `claude --resume` of that session. If the body is
+      // empty/missing there is nothing to act on — skip (no prompt) rather than spawn a
+      // contentless wake.
+      const instruction =
+        typeof n.instructionText === "string" ? n.instructionText.trim() : "";
+      if (!instruction) return null;
+      // Optional entity context: a human_instruction may be attached to an entity
+      // (task/idea/proposal/document) or be a bare session instruction. Include the
+      // entity hint only when present so the agent knows what it relates to.
+      const entityHint =
+        n.entityType && n.entityUuid
+          ? ` (regarding ${n.entityType} ${n.entityUuid}` +
+            (n.projectUuid ? `, projectUuid: ${n.projectUuid}` : "") +
+            `)`
+          : "";
+      const actorHint =
+        n.actorName && n.actorType && n.actorUuid
+          ? `\nWhen you have addressed it, reply with a comment @mentioning the requester: ` +
+            `@[${n.actorName}](${n.actorType}:${n.actorUuid})`
+          : "";
+      return (
+        `[Chorus] New instruction from a human${entityHint}:\n\n` +
+        `${instruction}\n\n` +
+        `Continue this session and act on the instruction above using the appropriate ` +
+        `chorus_* tools. Re-check the current state first (e.g. chorus_get_task / ` +
+        `chorus_get_idea / chorus_get_comments) if you need context.${actorHint}`
+      );
+    }
     default:
       return null;
   }
@@ -143,4 +183,11 @@ export const WAKE_ACTIONS = new Set([
   // (task / idea / proposal / document); arrives via the reverse CONTROL channel as
   // a synthetic dispatch, NOT a persisted notification.
   "resource_resumed",
+  // 子1 — daemon-session-conversation: a human-typed instruction for the daemon's
+  // session. Arrives as a persisted notification (recipient = the daemon agent)
+  // carrying the free-text body in `instructionText`; the event-router threads that
+  // body into buildPrompt. NOTE: buildPrompt's human_instruction branch returns null
+  // when the body is empty/missing (nothing to act on) — so this action is a wake
+  // action only when it actually carries instruction text.
+  "human_instruction",
 ]);

--- a/cli/turn-reporter.mjs
+++ b/cli/turn-reporter.mjs
@@ -1,0 +1,101 @@
+// cli/turn-reporter.mjs
+// Reports a wake's DaemonSessionTurn lifecycle transitions back to the Chorus server
+// (子1 — daemon-session-conversation). Every wake the daemon runs is one turn on a
+// persistent conversation; the server creates that turn (status `pending`) at the
+// notification chokepoint, and the daemon advances it:
+//   • on spawn      → pending → running
+//   • on subprocess exit → running → ended
+//
+// The daemon does NOT know the server-side turn uuid. It identifies the turn the SAME
+// way the transcript ingest does — by the session BUSINESS KEY (`sessionId` = the
+// dispatched entity's directIdeaUuid, or its own uuid for an ad-hoc session: exactly
+// the deterministic Claude session anchor the waker already computes). The server
+// resolves the agent's `(agentUuid, sessionId)` session and advances its most-recent
+// turn. The optional `entityType`/`entityUuid` let the server stamp the weak
+// executionUuid link from the live execution row.
+//
+// Transport: a plain REST POST to `/api/daemon/turn-advance` with the daemon's existing
+// Bearer agent key — the SAME zero-dep pattern as cli/interrupt-reporter.mjs and
+// cli/upload-hooks.mjs (global fetch, Node 18+). It adds NO new npm dependency
+// (CLAUDE.md pitfall #9) and no shell-out. It is fire-and-forget and NEVER throws into
+// the wake path: a failure is LOGGED (memory: no-silent-errors) and swallowed.
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/** Turn lifecycle states the server's turn-advance endpoint accepts. */
+export const TURN_STATUSES = new Set(["pending", "running", "ended"]);
+
+/**
+ * Build an `advanceTurn(params)` function the waker invokes on a wake's spawn (→
+ * running) and exit (→ ended). Returns a Promise that always resolves (never rejects)
+ * so it can never crash the wake path.
+ *
+ * @param {{
+ *   url: string,                          Chorus base URL.
+ *   apiKey: string,                       `cho_` agent API key.
+ *   getConnectionUuid: () => string|null, The daemon's registered connection uuid
+ *                                         (learned from the SSE handshake). Required —
+ *                                         a null/absent value skips the report (logged).
+ *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+ *   fetchImpl?: typeof fetch,             Injectable for tests.
+ * }} opts
+ * @returns {(params: { sessionId: string, status: "running"|"ended", entityType?: string|null, entityUuid?: string|null }) => Promise<void>}
+ */
+export function createTurnReporter(opts) {
+  const url = opts.url.replace(/\/$/, "");
+  const apiKey = opts.apiKey;
+  const getConnectionUuid = opts.getConnectionUuid ?? (() => null);
+  const logger = opts.logger ?? NOOP_LOGGER;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+
+  return async function advanceTurn({ sessionId, status, entityType, entityUuid }) {
+    if (typeof sessionId !== "string" || !sessionId || !TURN_STATUSES.has(status)) {
+      logger.warn(
+        `[Chorus] refusing to advance turn: bad sessionId/status (${sessionId}, ${status})`,
+      );
+      return;
+    }
+    const connectionUuid = getConnectionUuid();
+    if (!connectionUuid) {
+      // The server resolves the turn against a connection the agent owns; without our
+      // registered connection uuid there is nothing to address. Skip (logged) — this
+      // can only happen before the SSE handshake completed.
+      logger.warn(
+        `[Chorus] cannot advance turn for session ${sessionId} → ${status} — no connection uuid yet`,
+      );
+      return;
+    }
+
+    const body = {
+      connectionUuid,
+      sessionId,
+      status,
+      // entityType/entityUuid are optional — only sent when the wake has a recognized
+      // execution entity, so the server can resolve the weak executionUuid link.
+      ...(entityType && entityUuid ? { entityType, entityUuid } : {}),
+    };
+
+    let response;
+    try {
+      response = await fetchImpl(`${url}/api/daemon/turn-advance`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      logger.warn(`[Chorus] turn-advance request failed for session ${sessionId} → ${status}: ${err}`);
+      return;
+    }
+    if (!response.ok) {
+      logger.warn(
+        `[Chorus] turn-advance returned ${response.status} for session ${sessionId} → ${status}`,
+      );
+      return;
+    }
+    logger.info(`[Chorus] advanced turn for session ${sessionId} → ${status}`);
+  };
+}

--- a/cli/upload-hooks.mjs
+++ b/cli/upload-hooks.mjs
@@ -55,6 +55,282 @@ export function createNoopUploadHooks() {
 }
 
 /**
+ * Compose several `UploadHooks` into one. The waker takes a SINGLE hooks object, but
+ * the daemon now has two independent concerns — execution-state snapshots and
+ * transcript relay — each built by its own factory. This merges them so each named
+ * hook fans out to every set that defines it: `onSessionStart`/`onTranscriptMessage`
+ * route to the transcript hooks, `onExecutionChange` to the execution hooks, etc. Async
+ * hooks are awaited (all in parallel); the synchronous `onExecutionChange` is called
+ * directly. Each delegate is invoked inside its own try/catch so one set throwing can
+ * never break another or the wake path (warn-not-throw).
+ *
+ * @param {...(UploadHooks|undefined|null)} hookSets
+ * @param {{ logger?: { warn(m:string):void } }} [optsLast]  Last arg may be an options
+ *   object (logger). Distinguished from a hook set by the absence of hook methods.
+ * @returns {UploadHooks}
+ */
+export function mergeUploadHooks(...args) {
+  // Allow an optional trailing `{ logger }` options object.
+  let logger = NOOP_LOGGER;
+  const sets = [];
+  for (const a of args) {
+    if (!a) continue;
+    const looksLikeHooks =
+      typeof a.onConnect === "function" ||
+      typeof a.onSessionStart === "function" ||
+      typeof a.onTranscriptMessage === "function" ||
+      typeof a.onExecutionChange === "function";
+    if (!looksLikeHooks && a.logger) {
+      logger = a.logger;
+      continue;
+    }
+    sets.push(a);
+  }
+
+  async function fanOutAsync(name, info) {
+    await Promise.all(
+      sets.map(async (s) => {
+        const fn = s[name];
+        if (typeof fn !== "function") return;
+        try {
+          await fn.call(s, info);
+        } catch (err) {
+          logger.warn(`[Chorus] ${name} hook failed: ${err}`);
+        }
+      })
+    );
+  }
+
+  return {
+    onConnect: (info) => fanOutAsync("onConnect", info),
+    onSessionStart: (info) => fanOutAsync("onSessionStart", info),
+    onTranscriptMessage: (info) => fanOutAsync("onTranscriptMessage", info),
+    onExecutionChange: () => {
+      for (const s of sets) {
+        if (typeof s.onExecutionChange !== "function") continue;
+        try {
+          s.onExecutionChange();
+        } catch (err) {
+          logger.warn(`[Chorus] onExecutionChange hook failed: ${err}`);
+        }
+      }
+    },
+  };
+}
+
+// ─── Transcript upload (子1 — daemon-session-conversation) ──────────────────
+//
+// The daemon's stream-json consumer (claude-spawner → waker.onMessage) hands every
+// NDJSON object to `onTranscriptMessage`. Claude Code's stream-json (verified against
+// CLI 2.1.183) wraps each conversation message as:
+//
+//   { "type": "assistant" | "user", "session_id": "...",
+//     "message": { "role": "assistant" | "user",
+//                  "content": [ { "type": "text", "text": "..." },
+//                               { "type": "thinking", ... },
+//                               { "type": "tool_use", ... },
+//                               { "type": "tool_result", ... } ] } }
+//
+// `system` (init / hooks / thinking_tokens) and `result` envelopes are NOT
+// conversation messages. A `tool_result` block rides inside a `type:"user"` message,
+// so filtering MUST happen at the content-BLOCK level (keep only `text`), not at the
+// top-level type — otherwise a tool-result-only user message would leak. The server
+// ingest stores ONLY `user`/`assistant` text (see /api/daemon/transcript), so this
+// filter mirrors exactly what the server will persist.
+
+/** Top-level stream-json envelope types that carry a conversation message. */
+const CONVERSATION_TYPES = new Set(["user", "assistant"]);
+
+/**
+ * Extract the plain user/assistant TEXT from one Claude Code stream-json object,
+ * dropping everything that is not a conversation text block (system/result
+ * envelopes, thinking, tool_use, tool_result). Returns null when the object is not a
+ * keepable conversation message (so the caller can skip it). Never throws — a shape
+ * it doesn't recognize yields null rather than an error (defensive against CLI drift).
+ *
+ * @param {any} obj  One parsed stream-json NDJSON object.
+ * @returns {{ role: "user"|"assistant", text: string } | null}
+ */
+export function extractTranscriptText(obj) {
+  if (!obj || typeof obj !== "object") return null;
+  if (!CONVERSATION_TYPES.has(obj.type)) return null;
+
+  const message = obj.message;
+  if (!message || typeof message !== "object") return null;
+  // The persisted role is the message's role; fall back to the envelope type (they
+  // agree in practice, but the envelope is the documented discriminator).
+  const role = message.role === "user" || message.role === "assistant" ? message.role : obj.type;
+  if (role !== "user" && role !== "assistant") return null;
+
+  const content = message.content;
+  let text = "";
+  if (typeof content === "string") {
+    // Some message variants carry a bare string (e.g. an echoed initial prompt).
+    text = content;
+  } else if (Array.isArray(content)) {
+    // Keep ONLY `text` blocks — drop thinking / tool_use / tool_result. Concatenate
+    // the text blocks of one message into a single transcript entry (mirrors how a
+    // reader sees the message; the server stores one row per posted message).
+    const parts = [];
+    for (const block of content) {
+      if (block && typeof block === "object" && block.type === "text" && typeof block.text === "string") {
+        parts.push(block.text);
+      }
+    }
+    text = parts.join("");
+  } else {
+    return null;
+  }
+
+  // A message with no text (e.g. a user message that was purely a tool_result, or an
+  // assistant message that was purely tool_use/thinking) is dropped — nothing to store.
+  if (!text.trim()) return null;
+  return { role, text };
+}
+
+/**
+ * Build the transcript upload hooks (子1). The daemon's stream-json consumer calls
+ * `onTranscriptMessage` for every NDJSON object; this keeps only user/assistant text
+ * and batch-POSTs it to `POST /api/daemon/transcript`, targeting the current turn by
+ * the session BUSINESS KEY (`sessionId` = directIdeaUuid or the entity uuid — exactly
+ * what the waker anchors the Claude session on, and what turn-reporter advances). The
+ * server resolves the agent's `(agentUuid, sessionId)` session and appends to its
+ * most-recent turn. `onSessionStart` resets per-session batching state so a new run's
+ * messages attach to the right turn.
+ *
+ * Mirrors `createExecutionUploadHooks`: injectable `fetchImpl`, the daemon's existing
+ * Bearer creds, ZERO new deps (global fetch, Node 18+). Fire-and-forget + warn-not-throw:
+ * a failed upload is LOGGED (no-silent-errors) and never blocks/breaks the wake. Uploads
+ * are batched (debounced) so a burst of stream-json lines becomes few POSTs, and
+ * serialized on a chain so an earlier batch can't land after a later one.
+ *
+ * @param {{
+ *   url: string,                  Chorus base URL.
+ *   apiKey: string,               `cho_` agent API key.
+ *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+ *   fetchImpl?: typeof fetch,     Injectable for tests.
+ *   batchDelayMs?: number,        Debounce window for coalescing messages into one POST
+ *                                 (default 50ms). 0 → flush on the next microtask.
+ *   setTimeoutImpl?: typeof setTimeout,  Injectable timer for tests.
+ *   clearTimeoutImpl?: typeof clearTimeout,
+ * }} opts
+ * @returns {UploadHooks}
+ */
+export function createTranscriptUploadHooks(opts) {
+  const url = opts.url.replace(/\/$/, "");
+  const apiKey = opts.apiKey;
+  const logger = opts.logger ?? NOOP_LOGGER;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const batchDelayMs = opts.batchDelayMs ?? 50;
+  const setTimeoutImpl = opts.setTimeoutImpl ?? setTimeout;
+  const clearTimeoutImpl = opts.clearTimeoutImpl ?? clearTimeout;
+
+  // The session this batch belongs to (set by onSessionStart, and re-affirmed by each
+  // message's observed session id from the stream). Messages queued for one session
+  // are flushed before the session changes, so they always target the right turn.
+  let currentSessionId = null;
+  /** @type {Array<{ role: "user"|"assistant", text: string }>} */
+  let pending = [];
+  let timer = null;
+  // Serialize POSTs so an earlier batch can never land after a later one on the wire.
+  let chain = Promise.resolve();
+
+  /** POST one batch for a session. Never throws. */
+  async function upload(sessionId, messages) {
+    if (!sessionId || messages.length === 0) return;
+    const body = JSON.stringify({ sessionId, messages });
+
+    let response;
+    try {
+      response = await fetchImpl(`${url}/api/daemon/transcript`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body,
+      });
+    } catch (err) {
+      logger.warn(`[Chorus] transcript upload request failed: ${err}`);
+      return;
+    }
+    if (!response.ok) {
+      logger.warn(`[Chorus] transcript upload returned ${response.status}`);
+      return;
+    }
+    logger.info(`[Chorus] transcript uploaded (${messages.length} msg) for session ${sessionId}`);
+  }
+
+  /** Drain `pending` for `currentSessionId` into a serialized fire-and-forget POST. */
+  function flush() {
+    if (timer !== null) {
+      clearTimeoutImpl(timer);
+      timer = null;
+    }
+    if (pending.length === 0) return;
+    const sessionId = currentSessionId;
+    const batch = pending;
+    pending = [];
+    if (!sessionId) {
+      // No session to attribute the messages to (onSessionStart never ran / no id on
+      // the stream). Drop with a visible warning rather than mis-route (no-silent).
+      logger.warn(`[Chorus] dropping ${batch.length} transcript msg — no session id yet`);
+      return;
+    }
+    const run = () => upload(sessionId, batch);
+    chain = chain.then(run, run);
+  }
+
+  function scheduleFlush() {
+    if (timer !== null) return;
+    if (batchDelayMs <= 0) {
+      // Microtask flush — coalesces a synchronous burst, still off the hot path.
+      timer = setTimeoutImpl(flush, 0);
+    } else {
+      timer = setTimeoutImpl(flush, batchDelayMs);
+    }
+  }
+
+  return {
+    async onConnect() {},
+    /**
+     * A new (or resumed) Claude run started for this session. Flush any leftover
+     * messages from a prior session, then pin the batch to this session id so
+     * subsequent messages attach to the right turn. (子1 — onSessionStart contract.)
+     * @param {{ rootIdeaKey: string, sessionId: string, isNew: boolean }} info
+     */
+    async onSessionStart({ sessionId } = {}) {
+      // If the session changed mid-stream, flush the old session's pending batch first
+      // so its messages don't get re-tagged to the new session.
+      if (currentSessionId && currentSessionId !== sessionId) flush();
+      currentSessionId = sessionId || currentSessionId || null;
+    },
+    /**
+     * One stream-json object. Keep only user/assistant text; queue it for a batched
+     * POST. Fire-and-forget + non-throwing: any failure is logged inside `flush`/`upload`.
+     * @param {{ rootIdeaKey: string, sessionId: string, message: any }} info
+     */
+    async onTranscriptMessage({ sessionId, message } = {}) {
+      // The stream stamps the authoritative session id on every line; prefer it so a
+      // session resolved only from the stream (not onSessionStart) is still attributed.
+      if (sessionId) currentSessionId = sessionId;
+      let extracted;
+      try {
+        extracted = extractTranscriptText(message);
+      } catch (err) {
+        logger.warn(`[Chorus] transcript extract failed: ${err}`);
+        return;
+      }
+      if (!extracted) return; // not a keepable conversation text message
+      pending.push(extracted);
+      scheduleFlush();
+    },
+    onExecutionChange() {},
+  };
+}
+
+/**
  * Build the execution-state upload hooks. The returned `onExecutionChange()` is
  * synchronous and non-throwing: it kicks off a fire-and-forget POST and returns
  * immediately, so the wake path is never blocked. The transcript/session/connect

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -37,6 +37,13 @@ export class Waker {
    *     Injectable interrupt reporter (子3). Called when a wake's subprocess exits in
    *     an interrupted (user) or crashed (non-zero, no interrupt flag) state. Defaults
    *     to a no-op that logs — the daemon wires the REST reporter (interrupt-reporter.mjs).
+   *   advanceTurn?: (params: { sessionId: string, status: "running"|"ended", entityType?: string|null, entityUuid?: string|null }) => Promise<void>,
+   *     Injectable turn-lifecycle reporter (子1 — daemon-session-conversation). Called
+   *     on spawn (→ running) and on subprocess exit (→ ended) to advance the server-side
+   *     DaemonSessionTurn the notification chokepoint created (status `pending`). The
+   *     server resolves the turn by the session business key (`sessionId`) and stamps
+   *     the weak executionUuid link from entityType/entityUuid. Defaults to a no-op that
+   *     logs — the daemon wires the REST reporter (turn-reporter.mjs).
    * }} opts
    */
   constructor(opts) {
@@ -58,6 +65,17 @@ export class Waker {
       (async (entityType, entityUuid, reason) => {
         this.logger.info(
           `[Chorus] (no reporter wired) would report ${entityType}:${entityUuid} interrupted (reason=${reason})`
+        );
+      });
+    // Turn-lifecycle reporter (子1): default no-op-with-log so a Waker built without one
+    // (existing tests) keeps working; the daemon injects the REST reporter
+    // (turn-reporter.mjs). Advances the server-side turn pending→running on spawn and
+    // running→ended on subprocess exit, identified by the session business key.
+    this.advanceTurn =
+      opts.advanceTurn ??
+      (async ({ sessionId, status }) => {
+        this.logger.info(
+          `[Chorus] (no turn reporter wired) would advance turn for session ${sessionId} → ${status}`
         );
       });
     // Per-entity "interrupting" flags, set by the control handler the moment an
@@ -259,6 +277,17 @@ export class Waker {
 
       await this.hooks?.onSessionStart?.({ rootIdeaKey: key, sessionId: sessionId ?? "", isNew });
 
+      // Turn lifecycle (子1): the server created a `pending` turn for this wake at the
+      // notification chokepoint, keyed on the same session business key the daemon
+      // anchors the Claude session on (`sessionId` = directIdeaUuid, or the entity uuid
+      // for an ad-hoc session). Advance it pending→running the moment the subprocess
+      // spawns (in onChild — guaranteed to fire only on a successful spawn), and
+      // running→ended after it exits. `turnAdvancedToRunning` gates the ended report so
+      // a spawn that never started (onChild never fired) does not attempt an illegal
+      // pending→ended transition. There is no separate turn registry — the turn is
+      // identified server-side by `sessionId`, which the waker already has here.
+      let turnAdvancedToRunning = false;
+
       // Track the session id the stream reports so the transcript hook can use
       // it even before spawner.wake() returns. (Do NOT reference the awaited
       // `result` inside onMessage — it's in the temporal dead zone there.)
@@ -271,14 +300,25 @@ export class Waker {
         mcpConfigPath: cfg.path,
         // Capture the live child into the running execution entry the instant it
         // spawns (子3) so the control handler can interrupt it mid-wake. Guarded so
-        // a re-keyed/dropped entry never throws here.
+        // a re-keyed/dropped entry never throws here. ALSO advance the server turn
+        // pending→running here (子1) — same hook keying, no parallel registry — since
+        // this is the precise moment the subprocess actually started.
         onChild: (child) => {
           const entry = execKey ? this.executions.get(execKey) : null;
           if (entry && entry.status === "running") entry.child = child;
+          if (sessionId) {
+            turnAdvancedToRunning = true;
+            // Fire-and-forget; #advanceTurn swallows + logs its own failures so a
+            // turn-report error never crashes the spawn callback (no-silent-errors).
+            this.#advanceTurn(sessionId, "running", entity).catch(() => {});
+          }
         },
         onMessage: (message) => {
           if (message && typeof message.session_id === "string") observedSessionId = message.session_id;
-          // Fire-and-forget transcript hook (no-op in this change).
+          // Fire-and-forget transcript hook (子1): keeps only user/assistant text and
+          // batch-POSTs to /api/daemon/transcript for the current turn. Warn-not-throw
+          // inside the hook; the trailing .catch is belt-and-braces so a rejected hook
+          // promise can never surface as an unhandled rejection in the wake path.
           this.hooks
             ?.onTranscriptMessage?.({ rootIdeaKey: key, sessionId: observedSessionId, message })
             .catch(() => {});
@@ -292,6 +332,15 @@ export class Waker {
         this.logger.warn(
           `[Chorus] wake for ${key} exited non-zero (${result.exitCode})`
         );
+      }
+
+      // Turn lifecycle (子1): the subprocess has exited — advance the server turn
+      // running→ended, regardless of exit code (a turn ends whether the run was clean,
+      // crashed, or interrupted). Only when it actually reached `running` (a never-
+      // spawned wake left the turn `pending`; a pending→ended skip is rejected server-
+      // side as invalid_transition). Swallow-safe; never throws into the wake path.
+      if (sessionId && turnAdvancedToRunning) {
+        await this.#advanceTurn(sessionId, "ended", entity);
       }
 
       // Interrupt-vs-crash reporting (子3, Tech Design "Interrupt vs crash
@@ -354,6 +403,31 @@ export class Waker {
     } catch (err) {
       this.logger.warn(
         `[Chorus] reportInterrupt failed for ${entity.entityType}:${entity.entityUuid} (${reason}): ${err}`
+      );
+    }
+  }
+
+  /**
+   * Advance the server-side DaemonSessionTurn for this wake (子1) via the injected
+   * reporter. Identified server-side by the session business key (`sessionId`); the
+   * optional `entity` ({ entityType, entityUuid }) lets the server stamp the weak
+   * executionUuid link from the live execution row. Never throws into the wake path —
+   * a reporter failure is logged and swallowed (the REST reporter already swallows;
+   * this is belt-and-braces, matching #report).
+   * @param {string} sessionId @param {"running"|"ended"} status
+   * @param {{ entityType: string, entityUuid: string }|null} entity
+   */
+  async #advanceTurn(sessionId, status, entity) {
+    try {
+      await this.advanceTurn({
+        sessionId,
+        status,
+        entityType: entity?.entityType ?? null,
+        entityUuid: entity?.entityUuid ?? null,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `[Chorus] advanceTurn failed for session ${sessionId} → ${status}: ${err}`
       );
     }
   }

--- a/openspec/changes/archive/2026-06-19-daemon-session-conversation/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-19-daemon-session-conversation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/archive/2026-06-19-daemon-session-conversation/README.md
+++ b/openspec/changes/archive/2026-06-19-daemon-session-conversation/README.md
@@ -1,0 +1,3 @@
+# daemon-session-conversation
+
+DaemonSession persistent-conversation model: unify all daemon wakes as turns on a per-(agent,session) conversation, with per-turn transcript relay

--- a/openspec/changes/archive/2026-06-19-daemon-session-conversation/design.md
+++ b/openspec/changes/archive/2026-06-19-daemon-session-conversation/design.md
@@ -1,0 +1,164 @@
+# Technical Design: DaemonSession persistent-conversation model
+
+## Overview
+
+Promote the daemon's Claude session from a transient on-disk artifact to a first-class persisted **conversation**. A `DaemonSession` is keyed by `(agentUuid, sessionId)` and holds an ordered list of `DaemonSessionTurn` rows; every wake — autonomous (`task_assigned` / `mentioned` / `elaboration` / `resume`) or human (`human_instruction`) — is one turn. Each turn captures `user`/`assistant` transcript text (rolling window). This is the foundation layer (子1); the UI send box (子2) and the viewing/continue UI (子3) build on it.
+
+Two design tensions drive the shape, both resolved in elaboration:
+
+1. **Durable conversation vs. ephemeral execution.** `DaemonExecution` is a snapshot-reconciled "what is running/queued *right now*" projection — rows flip to `ended` when absent from the next snapshot. A conversation must outlive that. So `DaemonSession`/`DaemonSessionTurn` are a **separate, durable** layer; a turn *references* its execution row but does not change execution-state semantics.
+2. **Agent-stable identity vs. cwd-bound transcript.** A conversation's identity/history is stable across connection drops and restarts (keyed on `(agentUuid, sessionId)`). But `claude --resume <sessionId>` only works in the same cwd on the same machine (`~/.claude/projects/<cwd-escaped>/<sessionId>.jsonl`). So **continuation** is pinned to a fixed `originConnectionUuid`; an offline origin makes the session read-only rather than transferring it to another connection (which would `No conversation found`).
+
+## Architecture
+
+```
+Human types instruction (子2 UI)            Autonomous wake (task/@mention/elaboration/resume)
+            │                                              │
+            └───────────────┬──────────────────────────────┘
+                            ▼
+            notification.service.create / createBatch   ← single chokepoint
+                            │  (resolve/create DaemonSession via lineage.service;
+                            │   create DaemonSessionTurn status=pending;
+                            │   for human_instruction, denormalize promptText onto the notification)
+                            ▼
+        Notification (recipient = daemon agent)  ──SSE new_notification──▶ daemon
+                            │                                                  │
+                            │                              chorus_get_notifications (already happens)
+                            │                              → reads action + (for human) promptText
+                            ▼                                                  ▼
+                    [persisted, canonical                         WakeQueue (per-direct-idea serial)
+                     turn rows + backfill source]                            │
+                                                          spawn claude -p (--resume if transcript on disk)
+                                                                             │ turn pending→running
+                                                          stream-json user/assistant text
+                                                                             │
+                                              POST /api/daemon/transcript  ◀──┘ (append; rolling window)
+                                                                             │ turn running→ended
+                                              transcript:{...} SSE ─────────▶ viewer (子3)
+```
+
+## Data Model
+
+New Prisma models (`relationMode = "prisma"`, cascade on agent per convention). DDL-only migration, no backfill.
+
+```prisma
+model DaemonSession {
+  id                  Int      @id @default(autoincrement())
+  uuid                String   @unique @default(uuid())
+  companyUuid         String
+  agentUuid           String
+  agent               Agent    @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  // Stable business key: directIdeaUuid for an idea-anchored session, or a
+  // server-generated uuid for ad-hoc. Unique per agent.
+  sessionId           String
+  directIdeaUuid      String?  // null ⇒ ad-hoc (no idea lineage)
+  // The connection/cwd that owns the on-disk transcript. Fixed at creation;
+  // continuation is only ever routed here (cwd-bound --resume).
+  originConnectionUuid String
+  status              String   @default("active") // active | ended
+  title               String?
+  lastTurnAt          DateTime @default(now())
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+  turns               DaemonSessionTurn[]
+
+  @@unique([agentUuid, sessionId])
+  @@index([companyUuid, agentUuid])
+  @@index([originConnectionUuid])
+}
+
+model DaemonSessionTurn {
+  id            Int      @id @default(autoincrement())
+  uuid          String   @unique @default(uuid())
+  sessionUuid   String
+  session       DaemonSession @relation(fields: [sessionUuid], references: [uuid], onDelete: Cascade)
+  seq           Int      // monotonic per session
+  trigger       String   // task_assigned | mentioned | elaboration | resume | human_instruction
+  promptText    String?  // free-text body for human_instruction; null otherwise
+  status        String   @default("pending") // pending | running | ended
+  // Weak ref to the live execution row this turn corresponds to (no DB FK;
+  // DaemonExecution rows are reconciled/transient).
+  executionUuid String?
+  startedAt     DateTime?
+  endedAt       DateTime?
+  createdAt     DateTime @default(now())
+  messages      DaemonTranscriptMessage[]
+
+  @@unique([sessionUuid, seq])
+  @@index([sessionUuid, status])
+}
+
+model DaemonTranscriptMessage {
+  id          Int      @id @default(autoincrement())
+  uuid        String   @unique @default(uuid())
+  turnUuid    String
+  turn        DaemonSessionTurn @relation(fields: [turnUuid], references: [uuid], onDelete: Cascade)
+  role        String   // user | assistant  (tool/thinking NOT stored)
+  text        String   @db.Text
+  seq         Int      // order within turn; used for rolling-window trim
+  createdAt   DateTime @default(now())
+
+  @@index([turnUuid, seq])
+}
+```
+
+Additive nullable column on the existing `Notification` model (write-once denormalized copy, agent-recipient only):
+
+```prisma
+// On model Notification:
+  instructionText String?  // denormalized copy of a human_instruction turn's promptText;
+                           // canonical source is DaemonSessionTurn.promptText. Display/transport only.
+```
+
+**Why `DaemonTranscriptMessage` is its own table (not JSON on the turn):** append semantics + per-message rolling-window trim are cleaner as rows; avoids read-modify-write of a JSON blob under concurrent appends.
+
+## API Design
+
+- **`POST /api/daemon/transcript`** (new, agent-key, append). Body: `{ sessionId | turnUuid, messages: [{ role: "user"|"assistant", text }] }`. Validates the turn belongs to the authenticated agent's session within its company (404 non-disclosure otherwise — mirrors `daemon-execution.service.connectionBelongsToAgent`). Stores only `user`/`assistant` text; trims to the rolling-window max per session in application code. Publishes a `transcript:{sessionUuid}` event. Standard API envelope. No new permission bit.
+- **Reads** (used by 子3, but the owner-scoped read functions live here): `getVisibleSessions` / `getSessionTurns`, owner-scoped exactly like `daemon-execution.service.getVisibleExecutions` (`agent.ownerUuid` for users, own agent for agent keys, always `companyUuid`-scoped).
+- **No change** to `POST /api/daemon/execution-state` (snapshot-reconcile) or `POST /api/daemon/control` (interrupt/resume).
+
+### SSE contract — three triggers, one channel
+
+All live updates for a conversation ride a single per-session channel `transcript:{sessionUuid}` on the existing event bus (with the existing Redis fan-out). It is published on **three** triggers, so a 子3 viewer re-renders without polling or manual reload:
+
+1. **turn created** — a new `DaemonSessionTurn` row appears (server-side, at the notification chokepoint).
+2. **turn status changed** — `pending → running → ended` transitions (driven by the daemon's lifecycle reports landing in the service).
+3. **transcript appended** — new `user`/`assistant` messages added to a turn (the ingest endpoint).
+
+Because turn-create and turn-status-change both flow through the service layer's `createPendingTurn` / `advanceTurn` (the single chokepoint for those mutations), the publish for triggers (1) and (2) lives in `daemon-session.service` and fires for any caller of those functions; trigger (3)'s publish lives in the transcript ingest endpoint. The event payload identifies the session and the affected turn so the client can patch the right row. This is additive to the existing notification / presence / execution event types and does not alter them.
+
+## Module Contracts
+
+- **Session/turn mutations (server)** live in `daemon-session.service` (`resolveOrCreateSession`, `createPendingTurn`, `advanceTurn`). Contract: these are the **single chokepoint** for turn creation and status transitions, so they own publishing the `transcript:{sessionUuid}` SSE event for the "turn created" and "turn status changed" triggers (see SSE contract above) — any caller of these functions emits, no caller needs to remember to. `advanceTurn` publishes on each `pending→running→ended` transition.
+- **Turn creation call site (server)** is `notification.service` `create`/`createBatch` (the single chokepoint where every wake notification is born). Contract: resolve-or-create the `DaemonSession` (via `lineage.service` for `directIdeaUuid`; `originConnectionUuid` = the target connection resolved for this wake), then call `createPendingTurn`. For `human_instruction`, also set `Notification.instructionText` = the turn's `promptText`. Turn-creation failure is logged visibly and never aborts the already-created notification (no silent swallow).
+- **Turn lifecycle (daemon)**: the daemon transitions `pending → running` when it spawns, `running → ended` when the subprocess exits, reported via the existing MCP write path. `cli/waker.mjs` already tracks per-entity execution entries with the child handle and an `onChild` hook; the turn lifecycle hooks alongside this (`wake()` start → running, exit handler → ended), reusing the `executions` map keying.
+- **Transcript upload (daemon)**: implement the currently-no-op `onTranscriptMessage` / `onSessionStart` in `cli/upload-hooks.mjs` (the signatures already carry `{ rootIdeaKey, sessionId, message }`). Parse stream-json NDJSON, keep only `user`/`assistant` text blocks, batch-POST to `/api/daemon/transcript`. Mirror the `createExecutionUploadHooks` style (injectable `fetchImpl`, Bearer creds, warn-not-throw).
+- **Instruction read (daemon)**: no new fetch — `cli/event-router.mjs` already calls `chorus_get_notifications` and reads `n.action`; extend it to read `n.instructionText` for the `human_instruction` action and pass it through `markQueued`/`wake` as the prompt body. `cli/prompts.mjs` `buildPrompt` gains a `human_instruction` branch emitting that free text.
+- **Continuation pinning (server)**: dispatching a turn resolves the session's `originConnectionUuid`; if that connection is not `online` (registry `effectiveStatus` via `STALE_THRESHOLD_MS`), refuse with a clear "session read-only / origin offline" error and do not route elsewhere. (子2 surfaces this as a disabled send box.)
+
+## Implementation Plan
+
+1. **Schema + migration** — add `DaemonSession`, `DaemonSessionTurn`, `DaemonTranscriptMessage`, and `Notification.instructionText`; Prisma-CLI migration (DDL only); `prisma generate`.
+2. **Server: session/turn service** — resolve-or-create session, create/advance turns, owner-scoped reads, continuation-pinning check. Reuse `lineage.service` (directIdeaUuid) and the execution-service visibility pattern.
+3. **Server: turn creation at the notification chokepoint** — hook `notification.service` create/createBatch; denormalize `instructionText` for `human_instruction`; visible-failure logging.
+4. **Server: transcript ingest + SSE** — `POST /api/daemon/transcript` (append, text-only, rolling-window trim) + `transcript:{sessionUuid}` event on the existing bus/Redis fan-out.
+5. **Daemon: turn lifecycle + instruction read** — advance pending→running→ended in `waker.mjs`; read `instructionText` in `event-router.mjs`; `human_instruction` prompt in `prompts.mjs`.
+6. **Daemon: transcript upload hooks** — implement `onTranscriptMessage`/`onSessionStart` in `upload-hooks.mjs`; wire into the spawner's stream-json consumer.
+7. **Integration checkpoint** — end-to-end: an autonomous task wake and a (test-injected) human_instruction wake both produce turns on one `DaemonSession`, transcript text lands via ingest, SSE pushes it, and continuation refuses when origin is offline.
+
+## Risks & Mitigations
+
+- **Daemon hot-path change (every wake records a turn).** Mitigation: turn create is server-side at the notification chokepoint (daemon only advances status it already tracks); upload hooks are fire-and-forget warn-not-throw, never blocking the wake.
+- **`DaemonSession` vs `DaemonExecution` drift / duplication.** Mitigation: strict separation of concerns — execution = live snapshot (unchanged), session = durable history; turn holds a weak `executionUuid` link only. No reconcile logic touches sessions.
+- **Lost delivery ping.** Mitigation: the turn is persisted before/at notification creation; reconnect-backfill re-derives **unstarted** turns from the turn table (not from notifications), so a dropped SSE ping never loses an instruction. (Backfill query: pending turns on sessions whose origin is this reconnecting connection.)
+- **Privacy of stored text.** Mitigation: only `user`/`assistant` text (no tool args / paths-heavy output); rolling window bounds retention; owner-scoped reads; text is daemon-self-reported and display-only.
+- **`claude --resume` cwd binding.** Mitigation: continuation pinned to `originConnectionUuid`; offline origin ⇒ read-only, never re-routed. Verify the new-vs-resume disk probe (`isNewSession`) still keys on the origin cwd.
+- **External-tool specifics (Claude Code stream-json shapes, `--session-id`/`--resume` flags).** Mitigation: developers MUST verify message-type names and CLI flags against the installed `claude` version rather than LLM memory; the daemon already strips `\r` and parses NDJSON line-by-line.
+
+## Out of Scope (deferred to 子2 / 子3 or later)
+
+- UI send box for instructions (子2) and the transcript-viewing / continue-conversation UI (子3).
+- Full stream-json relay (tool calls, tool results, thinking) — text-only for now.
+- Full (non-windowed) transcript history / replay.
+- Multi-agent-driver (codex / opencode) transcript normalization.

--- a/openspec/changes/archive/2026-06-19-daemon-session-conversation/proposal.md
+++ b/openspec/changes/archive/2026-06-19-daemon-session-conversation/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The server has no model of a daemon's Claude **conversation**. A daemon anchors each Claude session on a `directIdeaUuid` and continues it with `claude --resume`, but that session lives only as a transient `--session-id` CLI argument plus an on-disk `~/.claude/projects/<cwd>/<id>.jsonl` transcript — invisible to Chorus. `AgentSession` models swarm sub-agent checkin/checkout (a different thing); `DaemonExecution` models the *live* running/queued snapshot (not durable conversation history). So today a user can see *that* a daemon is running a task, but never *what the agent said*, cannot review a finished session, and has no way to send the agent a new instruction from the UI.
+
+This change adds the missing layer: model the daemon's Claude session as a **persistent conversation (`DaemonSession`)** whose every wake — autonomous task dispatch, @mention, elaboration, resume, and human-typed instruction — is a **turn**. This is the foundation (子1) for sending instructions from the UI (子2) and viewing/continuing a session's transcript (子3). It is derived from the umbrella idea "daemon 会话 = 持久化对话" and reuses the daemon-core observation that an Idea is the mainline and task/@mention/elaboration are turns on it — promoting that line from an on-disk artifact to a first-class entity.
+
+## What Changes
+
+- **New `DaemonSession` model** — one persistent conversation per `(agentUuid, sessionId)`, where `sessionId` is the `directIdeaUuid` (or a server-generated uuid for an ad-hoc session). Carries a **fixed `originConnectionUuid`** (the connection/cwd that owns the on-disk transcript), `directIdeaUuid` (nullable; null ⇒ ad-hoc), `status` (`active` | `ended`), `title`, and `lastTurnAt`. Identity and history survive connection drops and daemon restarts.
+- **New `DaemonSessionTurn` model** — one row per wake on a session: `seq`, `trigger` (`task_assigned` | `mentioned` | `elaboration` | `resume` | `human_instruction`), `promptText` (the free-text body for a human instruction; null for autonomous triggers), `status` (`pending` | `running` | `ended`), `startedAt`, `endedAt`.
+- **New per-turn transcript storage** — `user` + `assistant` text messages only (no tool calls / thinking / raw output), kept as a **rolling window** (most-recent-N per session) to bound size and privacy exposure.
+- **Server creates the turn at the notification chokepoint** — the existing `notification.service` `create`/`createBatch` is where every wake-triggering notification is born; the turn (`status = pending`) is created there, symmetric for human and autonomous triggers. `directIdeaUuid` resolution reuses `lineage.service`.
+- **The wake notification carries the instruction text** — for a `human_instruction` turn the notification (recipient = the daemon agent) carries the free-text body as a write-once denormalized copy, so the daemon reads it in the `chorus_get_notifications` call it already makes (zero extra round-trip). The **canonical** text lives on the turn; `reconnect-backfill` re-derives unstarted turns from the turn table, not from notifications — so a lost ping never loses an instruction.
+- **New per-turn transcript ingest endpoint** — `POST /api/daemon/transcript` (agent-key, append semantics), distinct from the snapshot-reconcile `execution-state` endpoint, plus an additive SSE push so a viewer sees turns/messages live.
+- **Daemon records a turn for every wake** — task_assigned / mentioned / elaboration / resume / human_instruction all become turns on the same `DaemonSession`. The daemon uploads `user`/`assistant` text per turn via the new ingest, landing the previously-no-op `onTranscriptMessage` / `onSessionStart` hooks.
+- **Continuation is pinned to the origin connection** — a turn can only be dispatched to the session's `originConnectionUuid`. If that connection is offline, the session is **read-only** (history still visible); it is never transferred to another connection, because `claude --resume` only works in the same cwd on the same machine.
+- **Owner-scoped visibility**, consistent with the daemon-connection registry and execution-state rules.
+
+This change delivers the **model + relay + turn-recording** foundation only. It does **not** include the UI send box (子2) or the transcript-viewing / continue-conversation UI (子3).
+
+## Capabilities
+
+### New Capabilities
+- `daemon-session-conversation`: the persistent `DaemonSession` + `DaemonSessionTurn` models, server-side turn creation at the notification chokepoint, the wake-notification instruction-text carrier, the per-turn transcript ingest endpoint + SSE, the all-wakes-record-a-turn daemon behavior, origin-connection-pinned continuation, and owner-scoped visibility.
+
+### Modified Capabilities
+<!-- None. DaemonExecution (daemon-execution-state) and the wake path (cli-daemon) are REUSED unchanged: DaemonExecution remains the live running/queued snapshot; a turn references its execution row but does not alter execution-state reconcile semantics. The notification model gains a denormalized instruction-text field, but that is an additive column delivered by this new capability, not a behavioral change to an existing spec's requirements. -->
+
+## Impact
+
+- **Schema (Prisma, DDL-only migration)**: new `DaemonSession`, `DaemonSessionTurn`, and per-turn transcript message storage; an additive nullable instruction-text column on `Notification`. `agent` relations cascade-delete consistent with existing models. No data backfill.
+- **Server**: turn creation hook in `notification.service`; `directIdeaUuid` resolution via `lineage.service`; new `POST /api/daemon/transcript` ingest + `transcript:{...}` SSE channel; owner-scoped read paths for sessions/turns; reconnect-backfill extended to re-derive unstarted turns.
+- **Daemon (npm CLI)**: every wake records turn start/end; `onTranscriptMessage` / `onSessionStart` upload hooks implemented (currently no-op); the daemon reads instruction text from the notification it already fetches; continuation honors `originConnectionUuid`.
+- **Reused unchanged**: `DaemonExecution` / `DaemonConnection` models, `WakeQueue` + reconnect-backfill, `control:{connectionUuid}` (still interrupt/resume only), the `directIdeaUuid` lineage anchor.
+- **Not in this change**: UI surfaces (子2/子3), full stream-json relay (tool calls / thinking), full-history (non-windowed) storage, multi-agent-driver transcript normalization.

--- a/openspec/changes/archive/2026-06-19-daemon-session-conversation/specs/daemon-session-conversation/spec.md
+++ b/openspec/changes/archive/2026-06-19-daemon-session-conversation/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,189 @@
+## ADDED Requirements
+
+### Requirement: The server SHALL persist a daemon Claude conversation as a DaemonSession keyed per agent and session id
+
+The server SHALL define a Prisma model `DaemonSession` representing one persistent daemon Claude conversation. It SHALL be uniquely keyed by `(agentUuid, sessionId)`, where `sessionId` is the conversation's stable business key — the `directIdeaUuid` for an idea-anchored session, or a server-generated uuid for an ad-hoc session. The model SHALL carry at least: `uuid` (public id), `companyUuid`, `agentUuid`, `sessionId`, `directIdeaUuid` (nullable — null marks an ad-hoc session with no idea lineage), `originConnectionUuid` (the `DaemonConnection.uuid` that owns the on-disk transcript, fixed at creation), `status` (`active` | `ended`), `title`, `createdAt`, `updatedAt`, and `lastTurnAt`. Its identity and history SHALL survive the holding connection going offline and the daemon restarting — a `DaemonSession` SHALL NOT be deleted or invalidated merely because its connection dropped. The model SHALL be created through a Prisma-CLI-generated migration containing only DDL (no data backfill), and its `agent` relation SHALL cascade-delete with its agent, matching existing model conventions.
+
+#### Scenario: A conversation is keyed per agent and session id
+
+- **GIVEN** a daemon agent A begins a Claude session whose session id is a direct idea uuid I
+- **WHEN** the server records the conversation
+- **THEN** a `DaemonSession` row MUST exist for `(agentUuid = A, sessionId = I)` with `directIdeaUuid = I`
+
+#### Scenario: A second wake on the same session reuses the same conversation row
+
+- **GIVEN** a `DaemonSession` already exists for `(agent A, session I)`
+- **WHEN** a later wake for the same `(A, I)` occurs
+- **THEN** the existing `DaemonSession` row MUST be reused rather than a second row created for `(A, I)`
+
+#### Scenario: Conversation history survives the connection going offline
+
+- **GIVEN** a `DaemonSession` whose `originConnectionUuid` connection has gone offline
+- **WHEN** the session is queried afterward
+- **THEN** the `DaemonSession` and its turns MUST still exist and be readable
+
+#### Scenario: The migration is DDL-only
+
+- **WHEN** the change is implemented
+- **THEN** the generated migration MUST contain only schema DDL
+- **AND** it MUST NOT contain data backfill statements
+
+### Requirement: Every daemon wake SHALL be recorded as a turn on its DaemonSession
+
+The server SHALL define a Prisma model `DaemonSessionTurn` representing one wake on a conversation. It SHALL carry at least: `uuid`, `sessionUuid` (referencing `DaemonSession.uuid`), `seq` (monotonic per session), `trigger` (one of `task_assigned`, `mentioned`, `elaboration`, `resume`, `human_instruction`), `promptText` (nullable — the free-text instruction body for a `human_instruction` turn, null for autonomous triggers), `status` (`pending` | `running` | `ended`), `startedAt` (nullable), `endedAt` (nullable), and `createdAt`. Every wake-triggering event — whether an autonomous dispatch (task assignment, @mention, elaboration request, resume) or a human-typed instruction — SHALL produce exactly one turn on the corresponding `DaemonSession`, distinguished only by `trigger`. A turn SHALL reference the live execution it corresponds to (so the conversation turn and the `DaemonExecution` row are linked) without altering `DaemonExecution` reconcile semantics.
+
+#### Scenario: An autonomous task dispatch records a turn
+
+- **GIVEN** a task is assigned to a daemon agent, producing a wake on session I
+- **WHEN** the server records the wake
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "task_assigned"`
+
+#### Scenario: A human instruction records a turn carrying its text
+
+- **GIVEN** a human submits a free-text instruction to session I
+- **WHEN** the server records it
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "human_instruction"` and `promptText` set to the submitted text
+
+#### Scenario: Turn trigger distinguishes wake kinds on one conversation
+
+- **GIVEN** session I has received a task assignment, an @mention, and a human instruction
+- **WHEN** the session's turns are listed
+- **THEN** all three MUST appear as turns on the same `DaemonSession`, distinguished by their `trigger` values
+
+#### Scenario: A turn links to its execution without changing execution semantics
+
+- **WHEN** a turn begins running and a `DaemonExecution` row reflects the running entity
+- **THEN** the turn MUST reference that execution
+- **AND** the `DaemonExecution` snapshot-reconcile behavior MUST be unchanged by the turn linkage
+
+### Requirement: The server SHALL create the turn at the notification chokepoint, symmetric for human and autonomous wakes
+
+The server SHALL create the `DaemonSessionTurn` (with `status = pending`) at the same centralized point where the wake-triggering `Notification` is created (`notification.service` `create` / `createBatch`), so human-typed and autonomous wakes are handled symmetrically by one code path. The turn's owning `DaemonSession` SHALL be resolved or created there, deriving `directIdeaUuid` via the existing lineage resolution (`lineage.service`). The daemon SHALL transition the turn from `pending` to `running` when it begins executing it, and to `ended` when the subprocess completes. Turn creation SHALL NOT block or break notification creation, and a failure to create the turn SHALL be logged visibly rather than silently swallowed.
+
+#### Scenario: A wake notification creates a pending turn
+
+- **GIVEN** a wake-triggering notification is created for a daemon agent
+- **WHEN** the notification chokepoint runs
+- **THEN** a `DaemonSessionTurn` with `status = "pending"` MUST be created on the resolved `DaemonSession`
+
+#### Scenario: The daemon advances the turn lifecycle
+
+- **GIVEN** a `pending` turn for an entity the daemon is about to run
+- **WHEN** the daemon starts the subprocess and later it completes
+- **THEN** the turn MUST transition `pending → running` on start and `running → ended` on completion
+
+#### Scenario: Turn creation failure does not break notification creation
+
+- **GIVEN** the notification is created but creating the associated turn fails
+- **THEN** the failure MUST be logged visibly
+- **AND** it MUST NOT silently succeed nor abort the notification that was already created
+
+### Requirement: A human-instruction wake notification SHALL carry the instruction text so the daemon needs no extra fetch
+
+For a `human_instruction` turn, the wake notification delivered to the daemon agent SHALL carry the free-text instruction body as a write-once denormalized copy, so the daemon obtains it in the same `chorus_get_notifications` call it already performs to read notification detail — adding no extra round-trip. The **canonical** instruction text SHALL be the turn's `promptText`; the notification copy SHALL be display/transport only and SHALL NOT be the source of truth. The notification carrying instruction text SHALL have recipient = the daemon agent (not a human), so it does not appear in a human's notification bell.
+
+#### Scenario: The daemon reads the instruction in its existing notification fetch
+
+- **GIVEN** a `human_instruction` turn with `promptText` set
+- **WHEN** the daemon fetches the wake notification detail it normally fetches
+- **THEN** the instruction text MUST be present in that response without a separate turn-fetch call
+
+#### Scenario: The turn is the source of truth for instruction text
+
+- **GIVEN** a human-instruction turn and its notification copy of the text
+- **WHEN** they are compared
+- **THEN** the turn's `promptText` MUST be treated as canonical, and reconnect-backfill MUST re-derive unstarted instructions from turns, not from notifications
+
+#### Scenario: The instruction notification targets the agent, not a human
+
+- **WHEN** the instruction-carrying notification is created
+- **THEN** its recipient MUST be the daemon agent
+- **AND** it MUST NOT surface in a human recipient's notification list
+
+### Requirement: The server SHALL expose an agent-callable endpoint that ingests per-turn transcript messages
+
+The server SHALL expose `POST /api/daemon/transcript` that accepts, from an authenticated daemon, transcript messages for a specific turn of one of the agent's own sessions. The endpoint SHALL require authentication by an agent API key, SHALL NOT be an MCP tool, and SHALL NOT introduce a new permission bit — the writable set is scoped to the authenticated agent's own sessions. It SHALL use the standard API envelope and SHALL reject a session/turn that does not belong to the authenticated agent within its company without revealing that another agent's session exists. The endpoint SHALL have **append** semantics (it adds messages to a turn), distinct from the snapshot-reconcile semantics of the execution-state ingest. Only `user` and `assistant` text messages SHALL be accepted/stored; tool-call, tool-result, and thinking content SHALL NOT be stored. Stored messages SHALL be retained as a **rolling window** of at most a configured maximum count per session, with older messages trimmed in application code (no data-mutating migration).
+
+#### Scenario: An unauthenticated transcript upload is rejected
+
+- **GIVEN** a request to `POST /api/daemon/transcript` with no valid agent key
+- **WHEN** the server handles it
+- **THEN** the response status MUST be 401 and no transcript message MUST be stored
+
+#### Scenario: Messages for the agent's own turn are appended
+
+- **GIVEN** an agent key whose agent owns session S with turn T
+- **WHEN** the agent posts `user`/`assistant` text messages for `(S, T)`
+- **THEN** the response MUST be the standard success envelope
+- **AND** the messages MUST be appended to turn T
+
+#### Scenario: A transcript upload for another agent's session is rejected without disclosure
+
+- **GIVEN** session S belongs to a different agent
+- **WHEN** an agent key that does not own S posts transcript for S
+- **THEN** the server MUST NOT store the messages
+- **AND** the response MUST be a not-found that does not confirm S exists
+
+#### Scenario: Non-text message kinds are not stored
+
+- **GIVEN** a transcript upload containing tool-call, tool-result, or thinking entries alongside text
+- **WHEN** the server ingests it
+- **THEN** only the `user` and `assistant` text MUST be stored
+- **AND** the non-text entries MUST NOT be persisted
+
+#### Scenario: Stored transcript is bounded by a rolling window
+
+- **GIVEN** a session whose stored messages already reach the configured maximum
+- **WHEN** newer messages are appended
+- **THEN** the oldest messages MUST be trimmed so the retained count does not exceed the maximum
+- **AND** the trimming MUST be performed in application code, not by a data-mutating migration
+
+### Requirement: Transcript and turn changes SHALL be pushed to subscribed clients over SSE
+
+The server SHALL publish a transcript/turn event on the existing event bus (with the existing Redis fan-out for multi-instance deployments) when a turn is created, when its status changes, or when new transcript messages are appended, so a subscribed client viewing the session re-renders without polling on a fast interval and without a manual reload. This SHALL be additive to the existing notification, presence, and execution event types and SHALL NOT alter them.
+
+#### Scenario: Appended transcript pushes an event
+
+- **GIVEN** a client subscribed to a session's transcript updates
+- **WHEN** the daemon appends new messages to a turn of that session
+- **THEN** a transcript/turn event MUST be published on the event bus
+- **AND** the subscribed client MUST update the displayed turn without a manual reload
+
+#### Scenario: Existing event types are unaffected
+
+- **WHEN** the transcript/turn event type is added
+- **THEN** the existing notification, presence, and execution event types MUST continue to function unchanged
+
+### Requirement: A daemon session's continuation SHALL be pinned to its origin connection
+
+A `DaemonSession` SHALL be continuable (a new turn dispatched to it) only on its `originConnectionUuid` — the connection whose machine and working directory hold the on-disk Claude transcript that `claude --resume <sessionId>` requires. When the origin connection is offline, the session SHALL be read-only: its history remains visible, but no new turn SHALL be dispatched to a different connection of the same agent. The server SHALL NOT route a session's turn to any connection other than its origin connection, because a resume against a different working directory or machine would fail to find the transcript.
+
+#### Scenario: A turn is dispatched only to the origin connection
+
+- **GIVEN** a `DaemonSession` whose `originConnectionUuid` is connection C
+- **WHEN** a new turn is dispatched for that session
+- **THEN** it MUST be delivered to connection C and to no other connection
+
+#### Scenario: An offline origin connection makes the session read-only
+
+- **GIVEN** a `DaemonSession` whose origin connection C is offline, while the same agent has another online connection D
+- **WHEN** a human attempts to add a turn to that session
+- **THEN** the attempt MUST be refused (the session is read-only) and the turn MUST NOT be routed to D
+- **AND** the session's existing history MUST remain readable
+
+### Requirement: Daemon session and turn visibility SHALL be owner-scoped
+
+The server SHALL scope session/turn reads so that a user caller sees only the sessions of agents the user owns (`agent.ownerUuid`), and an agent-key caller sees only its own sessions, every query `companyUuid`-scoped — identical to the daemon-connection and execution-state visibility rules. Sessions of an agent owned by a different user SHALL NOT be returned to other members of the same company, and visibility SHALL NOT cross company boundaries. No new permission bit SHALL be introduced.
+
+#### Scenario: A user sees only their own agents' sessions
+
+- **GIVEN** user U owns agent A and user V owns agent B in the same company, each with a daemon session
+- **WHEN** user U reads daemon sessions
+- **THEN** the result MUST include agent A's session
+- **AND** it MUST NOT include agent B's session
+
+#### Scenario: Session visibility never crosses company boundaries
+
+- **GIVEN** a daemon session belonging to an agent in company C2
+- **WHEN** a caller in company C1 reads daemon sessions
+- **THEN** the result MUST NOT include that session

--- a/openspec/specs/daemon-session-conversation/spec.md
+++ b/openspec/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,193 @@
+# daemon-session-conversation Specification
+
+## Purpose
+TBD - created by archiving change daemon-session-conversation. Update Purpose after archive.
+## Requirements
+### Requirement: The server SHALL persist a daemon Claude conversation as a DaemonSession keyed per agent and session id
+
+The server SHALL define a Prisma model `DaemonSession` representing one persistent daemon Claude conversation. It SHALL be uniquely keyed by `(agentUuid, sessionId)`, where `sessionId` is the conversation's stable business key — the `directIdeaUuid` for an idea-anchored session, or a server-generated uuid for an ad-hoc session. The model SHALL carry at least: `uuid` (public id), `companyUuid`, `agentUuid`, `sessionId`, `directIdeaUuid` (nullable — null marks an ad-hoc session with no idea lineage), `originConnectionUuid` (the `DaemonConnection.uuid` that owns the on-disk transcript, fixed at creation), `status` (`active` | `ended`), `title`, `createdAt`, `updatedAt`, and `lastTurnAt`. Its identity and history SHALL survive the holding connection going offline and the daemon restarting — a `DaemonSession` SHALL NOT be deleted or invalidated merely because its connection dropped. The model SHALL be created through a Prisma-CLI-generated migration containing only DDL (no data backfill), and its `agent` relation SHALL cascade-delete with its agent, matching existing model conventions.
+
+#### Scenario: A conversation is keyed per agent and session id
+
+- **GIVEN** a daemon agent A begins a Claude session whose session id is a direct idea uuid I
+- **WHEN** the server records the conversation
+- **THEN** a `DaemonSession` row MUST exist for `(agentUuid = A, sessionId = I)` with `directIdeaUuid = I`
+
+#### Scenario: A second wake on the same session reuses the same conversation row
+
+- **GIVEN** a `DaemonSession` already exists for `(agent A, session I)`
+- **WHEN** a later wake for the same `(A, I)` occurs
+- **THEN** the existing `DaemonSession` row MUST be reused rather than a second row created for `(A, I)`
+
+#### Scenario: Conversation history survives the connection going offline
+
+- **GIVEN** a `DaemonSession` whose `originConnectionUuid` connection has gone offline
+- **WHEN** the session is queried afterward
+- **THEN** the `DaemonSession` and its turns MUST still exist and be readable
+
+#### Scenario: The migration is DDL-only
+
+- **WHEN** the change is implemented
+- **THEN** the generated migration MUST contain only schema DDL
+- **AND** it MUST NOT contain data backfill statements
+
+### Requirement: Every daemon wake SHALL be recorded as a turn on its DaemonSession
+
+The server SHALL define a Prisma model `DaemonSessionTurn` representing one wake on a conversation. It SHALL carry at least: `uuid`, `sessionUuid` (referencing `DaemonSession.uuid`), `seq` (monotonic per session), `trigger` (one of `task_assigned`, `mentioned`, `elaboration`, `resume`, `human_instruction`), `promptText` (nullable — the free-text instruction body for a `human_instruction` turn, null for autonomous triggers), `status` (`pending` | `running` | `ended`), `startedAt` (nullable), `endedAt` (nullable), and `createdAt`. Every wake-triggering event — whether an autonomous dispatch (task assignment, @mention, elaboration request, resume) or a human-typed instruction — SHALL produce exactly one turn on the corresponding `DaemonSession`, distinguished only by `trigger`. A turn SHALL reference the live execution it corresponds to (so the conversation turn and the `DaemonExecution` row are linked) without altering `DaemonExecution` reconcile semantics.
+
+#### Scenario: An autonomous task dispatch records a turn
+
+- **GIVEN** a task is assigned to a daemon agent, producing a wake on session I
+- **WHEN** the server records the wake
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "task_assigned"`
+
+#### Scenario: A human instruction records a turn carrying its text
+
+- **GIVEN** a human submits a free-text instruction to session I
+- **WHEN** the server records it
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "human_instruction"` and `promptText` set to the submitted text
+
+#### Scenario: Turn trigger distinguishes wake kinds on one conversation
+
+- **GIVEN** session I has received a task assignment, an @mention, and a human instruction
+- **WHEN** the session's turns are listed
+- **THEN** all three MUST appear as turns on the same `DaemonSession`, distinguished by their `trigger` values
+
+#### Scenario: A turn links to its execution without changing execution semantics
+
+- **WHEN** a turn begins running and a `DaemonExecution` row reflects the running entity
+- **THEN** the turn MUST reference that execution
+- **AND** the `DaemonExecution` snapshot-reconcile behavior MUST be unchanged by the turn linkage
+
+### Requirement: The server SHALL create the turn at the notification chokepoint, symmetric for human and autonomous wakes
+
+The server SHALL create the `DaemonSessionTurn` (with `status = pending`) at the same centralized point where the wake-triggering `Notification` is created (`notification.service` `create` / `createBatch`), so human-typed and autonomous wakes are handled symmetrically by one code path. The turn's owning `DaemonSession` SHALL be resolved or created there, deriving `directIdeaUuid` via the existing lineage resolution (`lineage.service`). The daemon SHALL transition the turn from `pending` to `running` when it begins executing it, and to `ended` when the subprocess completes. Turn creation SHALL NOT block or break notification creation, and a failure to create the turn SHALL be logged visibly rather than silently swallowed.
+
+#### Scenario: A wake notification creates a pending turn
+
+- **GIVEN** a wake-triggering notification is created for a daemon agent
+- **WHEN** the notification chokepoint runs
+- **THEN** a `DaemonSessionTurn` with `status = "pending"` MUST be created on the resolved `DaemonSession`
+
+#### Scenario: The daemon advances the turn lifecycle
+
+- **GIVEN** a `pending` turn for an entity the daemon is about to run
+- **WHEN** the daemon starts the subprocess and later it completes
+- **THEN** the turn MUST transition `pending → running` on start and `running → ended` on completion
+
+#### Scenario: Turn creation failure does not break notification creation
+
+- **GIVEN** the notification is created but creating the associated turn fails
+- **THEN** the failure MUST be logged visibly
+- **AND** it MUST NOT silently succeed nor abort the notification that was already created
+
+### Requirement: A human-instruction wake notification SHALL carry the instruction text so the daemon needs no extra fetch
+
+For a `human_instruction` turn, the wake notification delivered to the daemon agent SHALL carry the free-text instruction body as a write-once denormalized copy, so the daemon obtains it in the same `chorus_get_notifications` call it already performs to read notification detail — adding no extra round-trip. The **canonical** instruction text SHALL be the turn's `promptText`; the notification copy SHALL be display/transport only and SHALL NOT be the source of truth. The notification carrying instruction text SHALL have recipient = the daemon agent (not a human), so it does not appear in a human's notification bell.
+
+#### Scenario: The daemon reads the instruction in its existing notification fetch
+
+- **GIVEN** a `human_instruction` turn with `promptText` set
+- **WHEN** the daemon fetches the wake notification detail it normally fetches
+- **THEN** the instruction text MUST be present in that response without a separate turn-fetch call
+
+#### Scenario: The turn is the source of truth for instruction text
+
+- **GIVEN** a human-instruction turn and its notification copy of the text
+- **WHEN** they are compared
+- **THEN** the turn's `promptText` MUST be treated as canonical, and reconnect-backfill MUST re-derive unstarted instructions from turns, not from notifications
+
+#### Scenario: The instruction notification targets the agent, not a human
+
+- **WHEN** the instruction-carrying notification is created
+- **THEN** its recipient MUST be the daemon agent
+- **AND** it MUST NOT surface in a human recipient's notification list
+
+### Requirement: The server SHALL expose an agent-callable endpoint that ingests per-turn transcript messages
+
+The server SHALL expose `POST /api/daemon/transcript` that accepts, from an authenticated daemon, transcript messages for a specific turn of one of the agent's own sessions. The endpoint SHALL require authentication by an agent API key, SHALL NOT be an MCP tool, and SHALL NOT introduce a new permission bit — the writable set is scoped to the authenticated agent's own sessions. It SHALL use the standard API envelope and SHALL reject a session/turn that does not belong to the authenticated agent within its company without revealing that another agent's session exists. The endpoint SHALL have **append** semantics (it adds messages to a turn), distinct from the snapshot-reconcile semantics of the execution-state ingest. Only `user` and `assistant` text messages SHALL be accepted/stored; tool-call, tool-result, and thinking content SHALL NOT be stored. Stored messages SHALL be retained as a **rolling window** of at most a configured maximum count per session, with older messages trimmed in application code (no data-mutating migration).
+
+#### Scenario: An unauthenticated transcript upload is rejected
+
+- **GIVEN** a request to `POST /api/daemon/transcript` with no valid agent key
+- **WHEN** the server handles it
+- **THEN** the response status MUST be 401 and no transcript message MUST be stored
+
+#### Scenario: Messages for the agent's own turn are appended
+
+- **GIVEN** an agent key whose agent owns session S with turn T
+- **WHEN** the agent posts `user`/`assistant` text messages for `(S, T)`
+- **THEN** the response MUST be the standard success envelope
+- **AND** the messages MUST be appended to turn T
+
+#### Scenario: A transcript upload for another agent's session is rejected without disclosure
+
+- **GIVEN** session S belongs to a different agent
+- **WHEN** an agent key that does not own S posts transcript for S
+- **THEN** the server MUST NOT store the messages
+- **AND** the response MUST be a not-found that does not confirm S exists
+
+#### Scenario: Non-text message kinds are not stored
+
+- **GIVEN** a transcript upload containing tool-call, tool-result, or thinking entries alongside text
+- **WHEN** the server ingests it
+- **THEN** only the `user` and `assistant` text MUST be stored
+- **AND** the non-text entries MUST NOT be persisted
+
+#### Scenario: Stored transcript is bounded by a rolling window
+
+- **GIVEN** a session whose stored messages already reach the configured maximum
+- **WHEN** newer messages are appended
+- **THEN** the oldest messages MUST be trimmed so the retained count does not exceed the maximum
+- **AND** the trimming MUST be performed in application code, not by a data-mutating migration
+
+### Requirement: Transcript and turn changes SHALL be pushed to subscribed clients over SSE
+
+The server SHALL publish a transcript/turn event on the existing event bus (with the existing Redis fan-out for multi-instance deployments) when a turn is created, when its status changes, or when new transcript messages are appended, so a subscribed client viewing the session re-renders without polling on a fast interval and without a manual reload. This SHALL be additive to the existing notification, presence, and execution event types and SHALL NOT alter them.
+
+#### Scenario: Appended transcript pushes an event
+
+- **GIVEN** a client subscribed to a session's transcript updates
+- **WHEN** the daemon appends new messages to a turn of that session
+- **THEN** a transcript/turn event MUST be published on the event bus
+- **AND** the subscribed client MUST update the displayed turn without a manual reload
+
+#### Scenario: Existing event types are unaffected
+
+- **WHEN** the transcript/turn event type is added
+- **THEN** the existing notification, presence, and execution event types MUST continue to function unchanged
+
+### Requirement: A daemon session's continuation SHALL be pinned to its origin connection
+
+A `DaemonSession` SHALL be continuable (a new turn dispatched to it) only on its `originConnectionUuid` — the connection whose machine and working directory hold the on-disk Claude transcript that `claude --resume <sessionId>` requires. When the origin connection is offline, the session SHALL be read-only: its history remains visible, but no new turn SHALL be dispatched to a different connection of the same agent. The server SHALL NOT route a session's turn to any connection other than its origin connection, because a resume against a different working directory or machine would fail to find the transcript.
+
+#### Scenario: A turn is dispatched only to the origin connection
+
+- **GIVEN** a `DaemonSession` whose `originConnectionUuid` is connection C
+- **WHEN** a new turn is dispatched for that session
+- **THEN** it MUST be delivered to connection C and to no other connection
+
+#### Scenario: An offline origin connection makes the session read-only
+
+- **GIVEN** a `DaemonSession` whose origin connection C is offline, while the same agent has another online connection D
+- **WHEN** a human attempts to add a turn to that session
+- **THEN** the attempt MUST be refused (the session is read-only) and the turn MUST NOT be routed to D
+- **AND** the session's existing history MUST remain readable
+
+### Requirement: Daemon session and turn visibility SHALL be owner-scoped
+
+The server SHALL scope session/turn reads so that a user caller sees only the sessions of agents the user owns (`agent.ownerUuid`), and an agent-key caller sees only its own sessions, every query `companyUuid`-scoped — identical to the daemon-connection and execution-state visibility rules. Sessions of an agent owned by a different user SHALL NOT be returned to other members of the same company, and visibility SHALL NOT cross company boundaries. No new permission bit SHALL be introduced.
+
+#### Scenario: A user sees only their own agents' sessions
+
+- **GIVEN** user U owns agent A and user V owns agent B in the same company, each with a daemon session
+- **WHEN** user U reads daemon sessions
+- **THEN** the result MUST include agent A's session
+- **AND** it MUST NOT include agent B's session
+
+#### Scenario: Session visibility never crosses company boundaries
+
+- **GIVEN** a daemon session belonging to an agent in company C2
+- **WHEN** a caller in company C1 reads daemon sessions
+- **THEN** the result MUST NOT include that session
+

--- a/prisma/migrations/20260619055322_daemon_session_conversation/migration.sql
+++ b/prisma/migrations/20260619055322_daemon_session_conversation/migration.sql
@@ -1,0 +1,77 @@
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN     "instructionText" TEXT;
+
+-- CreateTable
+CREATE TABLE "DaemonSession" (
+    "id" SERIAL NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "companyUuid" TEXT NOT NULL,
+    "agentUuid" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "directIdeaUuid" TEXT,
+    "originConnectionUuid" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "title" TEXT,
+    "lastTurnAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DaemonSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DaemonSessionTurn" (
+    "id" SERIAL NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "sessionUuid" TEXT NOT NULL,
+    "seq" INTEGER NOT NULL,
+    "trigger" TEXT NOT NULL,
+    "promptText" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "executionUuid" TEXT,
+    "startedAt" TIMESTAMP(3),
+    "endedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DaemonSessionTurn_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DaemonTranscriptMessage" (
+    "id" SERIAL NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "turnUuid" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "seq" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DaemonTranscriptMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonSession_uuid_key" ON "DaemonSession"("uuid");
+
+-- CreateIndex
+CREATE INDEX "DaemonSession_companyUuid_agentUuid_idx" ON "DaemonSession"("companyUuid", "agentUuid");
+
+-- CreateIndex
+CREATE INDEX "DaemonSession_originConnectionUuid_idx" ON "DaemonSession"("originConnectionUuid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonSession_agentUuid_sessionId_key" ON "DaemonSession"("agentUuid", "sessionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonSessionTurn_uuid_key" ON "DaemonSessionTurn"("uuid");
+
+-- CreateIndex
+CREATE INDEX "DaemonSessionTurn_sessionUuid_status_idx" ON "DaemonSessionTurn"("sessionUuid", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonSessionTurn_sessionUuid_seq_key" ON "DaemonSessionTurn"("sessionUuid", "seq");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonTranscriptMessage_uuid_key" ON "DaemonTranscriptMessage"("uuid");
+
+-- CreateIndex
+CREATE INDEX "DaemonTranscriptMessage_turnUuid_seq_idx" ON "DaemonTranscriptMessage"("turnUuid", "seq");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
   provider     = "postgresql"
-  relationMode = "prisma"  // Relations managed by Prisma, no DB-level foreign key constraints
+  relationMode = "prisma" // Relations managed by Prisma, no DB-level foreign key constraints
 }
 
 // Tenant
@@ -16,25 +16,25 @@ model Company {
   uuid         String   @unique @default(uuid())
   name         String
   // Email domain matching (used to identify Company during login)
-  emailDomains String[] @default([])  // e.g., ["example.com", "example.org"]
+  emailDomains String[] @default([]) // e.g., ["example.com", "example.org"]
   // OIDC configuration (per-Company login, PKCE only, no Client Secret)
-  oidcIssuer   String?  // OIDC Provider URL
-  oidcClientId String?  // Client ID
+  oidcIssuer   String? // OIDC Provider URL
+  oidcClientId String? // Client ID
   oidcEnabled  Boolean  @default(false)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  users      User[]
-  agents     Agent[]
-  apiKeys    ApiKey[]
-  projects   Project[]
-  ideas      Idea[]
-  documents  Document[]
-  tasks      Task[]
-  proposals  Proposal[]
-  activities Activity[]
-  comments   Comment[]
-  sessions   AgentSession[]
+  users             User[]
+  agents            Agent[]
+  apiKeys           ApiKey[]
+  projects          Project[]
+  ideas             Idea[]
+  documents         Document[]
+  tasks             Task[]
+  proposals         Proposal[]
+  activities        Activity[]
+  comments          Comment[]
+  sessions          AgentSession[]
   daemonConnections DaemonConnection[]
 }
 
@@ -44,7 +44,7 @@ model User {
   uuid        String   @unique @default(uuid())
   companyUuid String
   company     Company  @relation(fields: [companyUuid], references: [uuid])
-  oidcSub     String   // OIDC subject
+  oidcSub     String // OIDC subject
   email       String?
   name        String?
   avatarUrl   String?
@@ -63,20 +63,21 @@ model Agent {
   companyUuid  String
   company      Company   @relation(fields: [companyUuid], references: [uuid])
   name         String
-  roles        String[]  @default(["developer"])  // pm | developer (multi-select)
-  permissions  String[]  @default([])              // Custom permission bits (resource:action); merged with role presets at auth time
+  roles        String[]  @default(["developer"]) // pm | developer (multi-select)
+  permissions  String[]  @default([]) // Custom permission bits (resource:action); merged with role presets at auth time
   // Agent persona definition (Zero Context Injection)
-  persona      String?   // Custom persona description (brief)
-  systemPrompt String?   // Full system prompt (optional, overrides default template)
-  ownerUuid    String?   // User's UUID
+  persona      String? // Custom persona description (brief)
+  systemPrompt String? // Full system prompt (optional, overrides default template)
+  ownerUuid    String? // User's UUID
   owner        User?     @relation(fields: [ownerUuid], references: [uuid])
   lastActiveAt DateTime?
   createdAt    DateTime  @default(now())
 
-  apiKeys  ApiKey[]
-  sessions AgentSession[]
+  apiKeys           ApiKey[]
+  sessions          AgentSession[]
   daemonConnections DaemonConnection[]
-  daemonExecutions DaemonExecution[]
+  daemonExecutions  DaemonExecution[]
+  daemonSessions    DaemonSession[]
 
   @@index([companyUuid])
   @@index([ownerUuid])
@@ -88,11 +89,11 @@ model ApiKey {
   uuid        String    @unique @default(uuid())
   companyUuid String
   company     Company   @relation(fields: [companyUuid], references: [uuid])
-  agentUuid   String    // Agent's UUID
+  agentUuid   String // Agent's UUID
   agent       Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
-  keyHash     String    @unique    // API Key stored as hash
-  keyPrefix   String               // Key prefix for display (e.g., "cho_xxx...")
-  name        String?              // Optional descriptive name
+  keyHash     String    @unique // API Key stored as hash
+  keyPrefix   String // Key prefix for display (e.g., "cho_xxx...")
+  name        String? // Optional descriptive name
   lastUsed    DateTime?
   expiresAt   DateTime?
   revokedAt   DateTime?
@@ -123,7 +124,7 @@ model Project {
   company     Company  @relation(fields: [companyUuid], references: [uuid])
   name        String
   description String?
-  groupUuid   String?  // nullable FK → ProjectGroup.uuid
+  groupUuid   String? // nullable FK → ProjectGroup.uuid
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -139,31 +140,31 @@ model Project {
 
 // Idea (raw human input)
 model Idea {
-  id             Int       @id @default(autoincrement())
-  uuid           String    @unique @default(uuid())
-  companyUuid    String
-  company        Company   @relation(fields: [companyUuid], references: [uuid])
-  projectUuid    String
-  project        Project   @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
-  title          String
-  content        String?   // Text content
-  attachments    Json?     // Attachment list [{type, url, name}]
+  id                Int       @id @default(autoincrement())
+  uuid              String    @unique @default(uuid())
+  companyUuid       String
+  company           Company   @relation(fields: [companyUuid], references: [uuid])
+  projectUuid       String
+  project           Project   @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
+  title             String
+  content           String? // Text content
+  attachments       Json? // Attachment list [{type, url, name}]
   // Status and assignment (ARCHITECTURE.md §7.3)
-  status         String    @default("open")  // open | elaborating | elaborated (3-state model; post-elaboration status derived from Proposal+Task)
-  assigneeType   String?   // user | agent
-  assigneeUuid   String?   // User or Agent UUID (polymorphic)
-  assignedAt     DateTime? // Assignment timestamp
-  assignedByUuid String?   // User UUID (human assignment)
+  status            String    @default("open") // open | elaborating | elaborated (3-state model; post-elaboration status derived from Proposal+Task)
+  assigneeType      String? // user | agent
+  assigneeUuid      String? // User or Agent UUID (polymorphic)
+  assignedAt        DateTime? // Assignment timestamp
+  assignedByUuid    String? // User UUID (human assignment)
   // Elaboration (AI-DLC Stage 3 — structured requirements clarification)
-  elaborationDepth   String?  // "minimal" | "standard" | "comprehensive"
-  elaborationStatus  String?  // "pending_answers" | "validating" | "resolved"
+  elaborationDepth  String? // "minimal" | "standard" | "comprehensive"
+  elaborationStatus String? // "pending_answers" | "validating" | "resolved"
   // Lineage (single-parent forest — weak read-only relation, see openspec change add-idea-lineage)
-  parentUuid     String?   // Single parent Idea UUID (nullable = top-level). One undifferentiated edge; semantics by context.
-  parent         Idea?     @relation("IdeaLineage", fields: [parentUuid], references: [uuid], onDelete: Restrict, onUpdate: Restrict)
-  children       Idea[]    @relation("IdeaLineage")
-  createdByUuid  String    // User UUID
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  parentUuid        String? // Single parent Idea UUID (nullable = top-level). One undifferentiated edge; semantics by context.
+  parent            Idea?     @relation("IdeaLineage", fields: [parentUuid], references: [uuid], onDelete: Restrict, onUpdate: Restrict)
+  children          Idea[]    @relation("IdeaLineage")
+  createdByUuid     String // User UUID
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([companyUuid])
   @@index([projectUuid])
@@ -174,20 +175,20 @@ model Idea {
 
 // Document (PRD, tech design, etc. — Proposal output)
 model Document {
-  id            Int       @id @default(autoincrement())
-  uuid          String    @unique @default(uuid())
+  id            Int      @id @default(autoincrement())
+  uuid          String   @unique @default(uuid())
   companyUuid   String
-  company       Company   @relation(fields: [companyUuid], references: [uuid])
+  company       Company  @relation(fields: [companyUuid], references: [uuid])
   projectUuid   String
-  project       Project   @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
-  type          String    // prd | tech_design | adr | ...
+  project       Project  @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
+  type          String // prd | tech_design | adr | ...
   title         String
-  content       String?   // Markdown content
-  version       Int       @default(1)
-  proposalUuid  String?   // Source Proposal UUID (traceable)
-  createdByUuid String    // User or Agent UUID
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  content       String? // Markdown content
+  version       Int      @default(1)
+  proposalUuid  String? // Source Proposal UUID (traceable)
+  createdByUuid String // User or Agent UUID
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   @@index([companyUuid])
   @@index([projectUuid])
@@ -196,32 +197,32 @@ model Document {
 
 // Task (Proposal output or manually created)
 model Task {
-  id             Int       @id @default(autoincrement())
-  uuid           String    @unique @default(uuid())
-  companyUuid    String
-  company        Company   @relation(fields: [companyUuid], references: [uuid])
-  projectUuid    String
-  project        Project   @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
-  title          String
-  description    String?
+  id                      Int                   @id @default(autoincrement())
+  uuid                    String                @unique @default(uuid())
+  companyUuid             String
+  company                 Company               @relation(fields: [companyUuid], references: [uuid])
+  projectUuid             String
+  project                 Project               @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
+  title                   String
+  description             String?
   // Status and assignment (ARCHITECTURE.md §7.2)
-  status         String    @default("open")  // open | assigned | in_progress | to_verify | done | closed
-  priority       String    @default("medium") // low | medium | high
-  storyPoints    Float?    // Effort estimate (unit: Agent hours)
-  acceptanceCriteria String? // Acceptance criteria (Markdown)
-  assigneeType   String?   // user | agent
-  assigneeUuid   String?   // User or Agent UUID (polymorphic)
-  assignedAt     DateTime? // Assignment timestamp
-  assignedByUuid String?   // User UUID (human assignment)
-  proposalUuid   String?   // Source Proposal UUID (traceable, optional)
-  createdByUuid  String    // User or Agent UUID
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  status                  String                @default("open") // open | assigned | in_progress | to_verify | done | closed
+  priority                String                @default("medium") // low | medium | high
+  storyPoints             Float? // Effort estimate (unit: Agent hours)
+  acceptanceCriteria      String? // Acceptance criteria (Markdown)
+  assigneeType            String? // user | agent
+  assigneeUuid            String? // User or Agent UUID (polymorphic)
+  assignedAt              DateTime? // Assignment timestamp
+  assignedByUuid          String? // User UUID (human assignment)
+  proposalUuid            String? // Source Proposal UUID (traceable, optional)
+  createdByUuid           String // User or Agent UUID
+  createdAt               DateTime              @default(now())
+  updatedAt               DateTime              @updatedAt
   // Task dependencies (DAG)
-  dependsOn        TaskDependency[] @relation("taskDependencies")
-  dependedBy       TaskDependency[] @relation("taskDependedBy")
+  dependsOn               TaskDependency[]      @relation("taskDependencies")
+  dependedBy              TaskDependency[]      @relation("taskDependedBy")
   // Session checkins
-  sessionCheckins  SessionTaskCheckin[]
+  sessionCheckins         SessionTaskCheckin[]
   // Structured acceptance criteria (independent table)
   acceptanceCriteriaItems AcceptanceCriterion[]
 
@@ -255,16 +256,16 @@ model AcceptanceCriterion {
   description     String
   required        Boolean   @default(true)
   // Dev self-check (developer fills during work)
-  devStatus       String    @default("pending")  // pending | passed | failed
+  devStatus       String    @default("pending") // pending | passed | failed
   devEvidence     String?
-  devMarkedByType String?   // "user" | "agent"
-  devMarkedBy     String?   // UUID of marker
+  devMarkedByType String? // "user" | "agent"
+  devMarkedBy     String? // UUID of marker
   devMarkedAt     DateTime?
   // Admin verification (admin/user fills during verify)
-  status          String    @default("pending")  // pending | passed | failed
+  status          String    @default("pending") // pending | passed | failed
   evidence        String?
-  markedByType    String?   // "user" | "agent"
-  markedBy        String?   // UUID of marker
+  markedByType    String? // "user" | "agent"
+  markedBy        String? // UUID of marker
   markedAt        DateTime?
   sortOrder       Int       @default(0)
   createdAt       DateTime  @default(now())
@@ -275,32 +276,32 @@ model AcceptanceCriterion {
 
 // Proposal (container model: created by Agent/human, approved by human, contains document drafts and task drafts)
 model Proposal {
-  id              Int       @id @default(autoincrement())
-  uuid            String    @unique @default(uuid())
-  companyUuid     String
-  company         Company   @relation(fields: [companyUuid], references: [uuid])
-  projectUuid     String
-  project         Project   @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
-  title           String
-  description     String?
+  id          Int     @id @default(autoincrement())
+  uuid        String  @unique @default(uuid())
+  companyUuid String
+  company     Company @relation(fields: [companyUuid], references: [uuid])
+  projectUuid String
+  project     Project @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
+  title       String
+  description String?
 
   // Input source (what the Proposal is based on)
-  inputType       String    // idea | document
-  inputUuids      Json      // Array of UUID strings
+  inputType  String // idea | document
+  inputUuids Json // Array of UUID strings
 
   // Container contents (can include both documents and tasks)
-  documentDrafts  Json?     // Document draft list [{type, title, content}]
-  taskDrafts      Json?     // Task draft list [{title, description, storyPoints, priority, acceptanceCriteria}]
+  documentDrafts Json? // Document draft list [{type, title, content}]
+  taskDrafts     Json? // Task draft list [{title, description, storyPoints, priority, acceptanceCriteria}]
 
   // Status and approval
-  status          String    @default("draft")  // draft | pending | approved | rejected | revised
-  createdByUuid   String    // Agent or User UUID
-  createdByType   String    @default("agent") // agent | user
-  reviewedByUuid  String?   // User UUID
-  reviewNote      String?   // Review note
-  reviewedAt      DateTime?
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
+  status         String    @default("draft") // draft | pending | approved | rejected | revised
+  createdByUuid  String // Agent or User UUID
+  createdByType  String    @default("agent") // agent | user
+  reviewedByUuid String? // User UUID
+  reviewNote     String? // Review note
+  reviewedAt     DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   @@index([companyUuid])
   @@index([projectUuid])
@@ -313,11 +314,11 @@ model Comment {
   uuid        String   @unique @default(uuid())
   companyUuid String
   company     Company  @relation(fields: [companyUuid], references: [uuid])
-  targetType  String   // idea | proposal | task | document
-  targetUuid  String   // UUID of target entity (idea/proposal/task/document)
+  targetType  String // idea | proposal | task | document
+  targetUuid  String // UUID of target entity (idea/proposal/task/document)
   content     String
-  authorType  String   // user | agent
-  authorUuid  String   // User or Agent UUID
+  authorType  String // user | agent
+  authorUuid  String // User or Agent UUID
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -334,13 +335,13 @@ model Activity {
   projectUuid String
   project     Project  @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
   // Target entity (generic design)
-  targetType  String   // idea | task | proposal | document
-  targetUuid  String   // Target entity UUID
+  targetType  String // idea | task | proposal | document
+  targetUuid  String // Target entity UUID
   // Action info
-  actorType   String   // user | agent
-  actorUuid   String   // Actor UUID
-  action      String   // created | assigned | released | status_changed | submitted | approved | rejected | comment_added
-  value       Json?    // Action result value (e.g., new status, assignment target info)
+  actorType   String // user | agent
+  actorUuid   String // Actor UUID
+  action      String // created | assigned | released | status_changed | submitted | approved | rejected | comment_added
+  value       Json? // Action result value (e.g., new status, assignment target info)
   // Session attribution (denormalized to avoid joins)
   sessionUuid String?
   sessionName String?
@@ -354,19 +355,19 @@ model Activity {
 
 // Agent Session (sub-session for swarm mode observability)
 model AgentSession {
-  id              Int       @id @default(autoincrement())
-  uuid            String    @unique @default(uuid())
-  companyUuid     String
-  company         Company   @relation(fields: [companyUuid], references: [uuid])
-  agentUuid       String
-  agent           Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
-  name            String
-  description     String?
-  status          String    @default("active")  // active | closed
-  lastActiveAt    DateTime  @default(now())
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
-  taskCheckins    SessionTaskCheckin[]
+  id           Int                  @id @default(autoincrement())
+  uuid         String               @unique @default(uuid())
+  companyUuid  String
+  company      Company              @relation(fields: [companyUuid], references: [uuid])
+  agentUuid    String
+  agent        Agent                @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  name         String
+  description  String?
+  status       String               @default("active") // active | closed
+  lastActiveAt DateTime             @default(now())
+  createdAt    DateTime             @default(now())
+  updatedAt    DateTime             @updatedAt
+  taskCheckins SessionTaskCheckin[]
 
   @@index([companyUuid])
   @@index([agentUuid])
@@ -376,13 +377,13 @@ model AgentSession {
 
 // Session-Task checkin relation (many-to-many)
 model SessionTaskCheckin {
-  id              Int           @id @default(autoincrement())
-  sessionUuid     String
-  session         AgentSession  @relation(fields: [sessionUuid], references: [uuid], onDelete: Cascade)
-  taskUuid        String
-  task            Task          @relation(fields: [taskUuid], references: [uuid], onDelete: Cascade)
-  checkinAt       DateTime      @default(now())
-  checkoutAt      DateTime?
+  id          Int          @id @default(autoincrement())
+  sessionUuid String
+  session     AgentSession @relation(fields: [sessionUuid], references: [uuid], onDelete: Cascade)
+  taskUuid    String
+  task        Task         @relation(fields: [taskUuid], references: [uuid], onDelete: Cascade)
+  checkinAt   DateTime     @default(now())
+  checkoutAt  DateTime?
 
   @@unique([sessionUuid, taskUuid])
   @@index([sessionUuid])
@@ -393,29 +394,29 @@ model SessionTaskCheckin {
 // Mirrors AgentSession conventions (Int PK + uuid public id, application-level
 // company/agent relations, indexed status/liveness columns).
 model DaemonConnection {
-  id             Int       @id @default(autoincrement())
-  uuid           String    @unique @default(uuid())
-  companyUuid    String
-  company        Company   @relation(fields: [companyUuid], references: [uuid])
-  agentUuid      String
-  agent          Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  id          Int     @id @default(autoincrement())
+  uuid        String  @unique @default(uuid())
+  companyUuid String
+  company     Company @relation(fields: [companyUuid], references: [uuid])
+  agentUuid   String
+  agent       Agent   @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
 
-  clientType     String    // claude_code | openclaw | browser | other
-  clientVersion  String?   // self-reported, untrusted, display-only
+  clientType    String // claude_code | openclaw | browser | other
+  clientVersion String? // self-reported, untrusted, display-only
   // Self-reported hostname (display-only). Non-null with "" default: a @@unique
   // over a nullable column is broken for dedup because connectors treat each
   // null as distinct (Prisma docs), which would let reconnects accumulate rows.
   // Defaulting to "" makes (agentUuid, clientType, host) a deterministic upsert key.
-  host           String    @default("")
-  startedAt      DateTime? // self-reported daemon process start time
+  host          String    @default("")
+  startedAt     DateTime? // self-reported daemon process start time
 
   status         String    @default("online") // online | offline
   connectedAt    DateTime  @default(now())
   lastSeenAt     DateTime  @default(now())
   disconnectedAt DateTime?
 
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@unique([agentUuid, clientType, host])
   @@index([companyUuid])
@@ -438,11 +439,11 @@ model DaemonConnection {
 // with a DB-level back-relation so the cascade convention matches
 // DaemonConnection/ApiKey (delete an agent -> its execution rows go too).
 model DaemonExecution {
-  id             Int       @id @default(autoincrement())
-  uuid           String    @unique @default(uuid())
+  id             Int     @id @default(autoincrement())
+  uuid           String  @unique @default(uuid())
   companyUuid    String
   agentUuid      String
-  agent          Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  agent          Agent   @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
   // → DaemonConnection.uuid (weak ref, no DB FK — the row outlives the
   //   connection as history).
   connectionUuid String
@@ -461,7 +462,7 @@ model DaemonExecution {
   //   when the (now-gone) entity drops out of the daemon's next snapshot — so the
   //   UI keeps showing an "interrupted, resumable" row. It is cleared only when a
   //   resume re-dispatch transitions the entity back to running/queued.
-  status         String    // running | queued | ended | interrupted
+  status            String // running | queued | ended | interrupted
   // Discriminator for the `interrupted` status: `user` = an authorized
   // user-requested interrupt (manually resumable); `crash` = an unexpected
   // subprocess exit (auto-recovered via reconnect-backfill). Only set while
@@ -470,16 +471,92 @@ model DaemonExecution {
   // proposal / document wakes too — interruption is an execution-lifecycle fact,
   // keyed by the same connection+entity the row already tracks.
   interruptedReason String? // null | user | crash
-  startedAt      DateTime? // set when/once the row is running; null while queued
+  startedAt         DateTime? // set when/once the row is running; null while queued
 
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   // A resource appears at most once per connection: re-dispatch updates the
   // existing row (queued -> running -> ended) rather than inserting a duplicate.
   @@unique([connectionUuid, entityType, entityUuid])
   @@index([connectionUuid, status])
   @@index([companyUuid, agentUuid])
+}
+
+// Daemon persistent conversation — one row per (agentUuid, sessionId) Claude
+// session. Distinct from DaemonExecution (the live running/queued snapshot):
+// this is the DURABLE conversation layer. Its identity and history survive the
+// holding connection going offline and the daemon restarting; it is never
+// deleted merely because a connection dropped. A turn references its execution
+// row by uuid (weak ref) but does not alter execution-state reconcile semantics.
+// Only the `agent` relation is modeled with a DB-level back-relation so the
+// cascade convention matches DaemonConnection/DaemonExecution/ApiKey.
+model DaemonSession {
+  id                   Int                 @id @default(autoincrement())
+  uuid                 String              @unique @default(uuid())
+  companyUuid          String
+  agentUuid            String
+  agent                Agent               @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  // Stable business key: the directIdeaUuid for an idea-anchored session, or a
+  // server-generated uuid for an ad-hoc session. Unique per agent.
+  sessionId            String
+  directIdeaUuid       String? // null ⇒ ad-hoc (no idea lineage)
+  // → DaemonConnection.uuid (weak ref, no DB FK). The connection/cwd that owns
+  //   the on-disk Claude transcript. Fixed at creation; continuation is only ever
+  //   routed here, because `claude --resume <sessionId>` is cwd/machine-bound.
+  originConnectionUuid String
+  status               String              @default("active") // active | ended
+  title                String?
+  lastTurnAt           DateTime            @default(now())
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
+  turns                DaemonSessionTurn[]
+
+  @@unique([agentUuid, sessionId])
+  @@index([companyUuid, agentUuid])
+  @@index([originConnectionUuid])
+}
+
+// One turn (wake) on a DaemonSession. Every wake — autonomous (task_assigned /
+// mentioned / elaboration / resume) or human (human_instruction) — is exactly one
+// turn, distinguished only by `trigger`. Turn creation + status transitions are
+// the SSE chokepoint for the conversation's live updates.
+model DaemonSessionTurn {
+  id            Int                       @id @default(autoincrement())
+  uuid          String                    @unique @default(uuid())
+  sessionUuid   String
+  session       DaemonSession             @relation(fields: [sessionUuid], references: [uuid], onDelete: Cascade)
+  seq           Int // monotonic per session
+  trigger       String // task_assigned | mentioned | elaboration | resume | human_instruction
+  promptText    String? // free-text body for human_instruction; null otherwise (canonical source)
+  status        String                    @default("pending") // pending | running | ended
+  // Weak ref to the live DaemonExecution row this turn corresponds to (no DB FK;
+  // execution rows are reconciled/transient).
+  executionUuid String?
+  startedAt     DateTime?
+  endedAt       DateTime?
+  createdAt     DateTime                  @default(now())
+  messages      DaemonTranscriptMessage[]
+
+  @@unique([sessionUuid, seq])
+  @@index([sessionUuid, status])
+}
+
+// A single user/assistant transcript message on a turn. Tool-call, tool-result,
+// and thinking content are NOT stored. Its own table (not JSON on the turn) so
+// append + per-message rolling-window trim are clean row operations rather than
+// read-modify-write of a JSON blob under concurrent appends.
+model DaemonTranscriptMessage {
+  id        Int               @id @default(autoincrement())
+  uuid      String            @unique @default(uuid())
+  turnUuid  String
+  turn      DaemonSessionTurn @relation(fields: [turnUuid], references: [uuid], onDelete: Cascade)
+  role      String // user | assistant (tool/thinking NOT stored)
+  text      String            @db.Text
+  seq       Int // order within turn; used for rolling-window trim
+  createdAt DateTime          @default(now())
+
+  @@index([turnUuid, seq])
 }
 
 // Notification
@@ -489,19 +566,24 @@ model Notification {
   companyUuid     String
   projectUuid     String
   // Recipient (polymorphic: user | agent)
-  recipientType   String    // user | agent
+  recipientType   String // user | agent
   recipientUuid   String
   // Related entity
-  entityType      String    // task | idea | proposal | document | comment
+  entityType      String // task | idea | proposal | document | comment
   entityUuid      String
-  entityTitle     String    // Denormalized to avoid joins
-  projectName     String    // Denormalized for project badge UI
+  entityTitle     String // Denormalized to avoid joins
+  projectName     String // Denormalized for project badge UI
   // Action info
-  action          String    // assigned | status_changed | verified | reopened | submitted | approved | rejected | claimed | comment_added
-  message         String    // Human-readable message
-  actorType       String    // user | agent
+  action          String // assigned | status_changed | verified | reopened | submitted | approved | rejected | claimed | comment_added
+  message         String // Human-readable message
+  // Denormalized write-once copy of a human_instruction turn's promptText
+  // (DaemonSessionTurn.promptText is canonical). Display/transport only — lets the
+  // daemon read the instruction body in the chorus_get_notifications call it already
+  // makes, with no extra round-trip. Null for every non-instruction notification.
+  instructionText String?
+  actorType       String // user | agent
   actorUuid       String
-  actorName       String    // Denormalized to avoid joins
+  actorName       String // Denormalized to avoid joins
   // Status
   readAt          DateTime?
   archivedAt      DateTime?
@@ -516,26 +598,26 @@ model Notification {
 
 // Notification preferences
 model NotificationPreference {
-  id                  Int      @id @default(autoincrement())
-  uuid                String   @unique @default(uuid())
-  companyUuid         String
-  ownerType           String   // user | agent
-  ownerUuid           String
+  id                   Int      @id @default(autoincrement())
+  uuid                 String   @unique @default(uuid())
+  companyUuid          String
+  ownerType            String // user | agent
+  ownerUuid            String
   // Toggle for each notification type (all enabled by default)
-  taskAssigned        Boolean  @default(true)
-  taskStatusChanged   Boolean  @default(true)
-  taskVerified        Boolean  @default(true)
-  taskReopened        Boolean  @default(true)
-  proposalSubmitted   Boolean  @default(true)
-  proposalApproved    Boolean  @default(true)
-  proposalRejected    Boolean  @default(true)
-  ideaClaimed         Boolean  @default(true)
-  commentAdded        Boolean  @default(true)
-  elaborationRequested Boolean @default(true)
-  elaborationAnswered  Boolean @default(true)
-  mentioned            Boolean @default(true)
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  taskAssigned         Boolean  @default(true)
+  taskStatusChanged    Boolean  @default(true)
+  taskVerified         Boolean  @default(true)
+  taskReopened         Boolean  @default(true)
+  proposalSubmitted    Boolean  @default(true)
+  proposalApproved     Boolean  @default(true)
+  proposalRejected     Boolean  @default(true)
+  ideaClaimed          Boolean  @default(true)
+  commentAdded         Boolean  @default(true)
+  elaborationRequested Boolean  @default(true)
+  elaborationAnswered  Boolean  @default(true)
+  mentioned            Boolean  @default(true)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
 
   @@unique([ownerType, ownerUuid])
   @@index([companyUuid])
@@ -543,19 +625,19 @@ model NotificationPreference {
 
 // Mention (tracks @mentions in comments, tasks, ideas)
 model Mention {
-  id              Int      @id @default(autoincrement())
-  uuid            String   @unique @default(uuid())
-  companyUuid     String
+  id            Int      @id @default(autoincrement())
+  uuid          String   @unique @default(uuid())
+  companyUuid   String
   // Source: where the mention occurred
-  sourceType      String   // comment | task | idea
-  sourceUuid      String   // UUID of the comment, task, or idea
+  sourceType    String // comment | task | idea
+  sourceUuid    String // UUID of the comment, task, or idea
   // Target: who was mentioned
-  mentionedType   String   // user | agent
-  mentionedUuid   String
+  mentionedType String // user | agent
+  mentionedUuid String
   // Actor: who wrote the mention
-  actorType       String   // user | agent
-  actorUuid       String
-  createdAt       DateTime @default(now())
+  actorType     String // user | agent
+  actorUuid     String
+  createdAt     DateTime @default(now())
 
   @@index([companyUuid])
   @@index([mentionedType, mentionedUuid])
@@ -571,13 +653,13 @@ model ElaborationRound {
   roundNumber   Int
   status        String    @default("pending_answers") // pending_answers | answered | validated (needs_followup retained for legacy rows only — no longer written)
   isAppended    Boolean   @default(false) // true when created after the Idea was first resolved
-  createdByType String    // agent | user
+  createdByType String // agent | user
   createdByUuid String
   validatedAt   DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  questions     ElaborationQuestion[]
+  questions ElaborationQuestion[]
 
   @@index([ideaUuid])
   @@index([companyUuid])
@@ -585,25 +667,25 @@ model ElaborationRound {
 
 // Elaboration Question (individual Q&A item within a round)
 model ElaborationQuestion {
-  id               Int       @id @default(autoincrement())
-  uuid             String    @unique @default(uuid())
+  id               Int              @id @default(autoincrement())
+  uuid             String           @unique @default(uuid())
   roundUuid        String
   round            ElaborationRound @relation(fields: [roundUuid], references: [uuid], onDelete: Cascade)
-  questionId       String    // Round-scoped ID: "q1", "q2", etc.
+  questionId       String // Round-scoped ID: "q1", "q2", etc.
   text             String
-  category         String    // functional | non_functional | business_context | technical_context | user_scenario | scope
-  options          Json      // [{id, label, description?}] — 2-5 options
-  required         Boolean   @default(true)
+  category         String // functional | non_functional | business_context | technical_context | user_scenario | scope
+  options          Json // [{id, label, description?}] — 2-5 options
+  required         Boolean          @default(true)
   // Answer (null = unanswered)
   selectedOptionId String?
   customText       String?
   answeredAt       DateTime?
-  answeredByType   String?   // user | agent
+  answeredByType   String? // user | agent
   answeredByUuid   String?
   // Validation issue (null = no issue)
-  issueType        String?   // contradiction | ambiguity | incomplete
+  issueType        String? // contradiction | ambiguity | incomplete
   issueDescription String?
 
-  @@index([roundUuid])
   @@unique([roundUuid, questionId])
+  @@index([roundUuid])
 }

--- a/src/app/api/daemon/pending-turns/__tests__/route.test.ts
+++ b/src/app/api/daemon/pending-turns/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+const mockConnectionBelongsToAgent = vi.fn();
+const mockGetPendingTurnsForConnection = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+vi.mock("@/services/daemon-execution.service", () => ({
+  connectionBelongsToAgent: (...args: unknown[]) => mockConnectionBelongsToAgent(...args),
+}));
+
+vi.mock("@/services/daemon-session.service", () => ({
+  getPendingTurnsForConnection: (...args: unknown[]) => mockGetPendingTurnsForConnection(...args),
+}));
+
+import { GET } from "@/app/api/daemon/pending-turns/route";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+
+const agentAuth = { type: "agent", companyUuid, actorUuid: agentUuid, permissions: [] };
+const emptyCtx = { params: Promise.resolve({}) };
+
+function getRequest(query: string): NextRequest {
+  return new NextRequest(new URL(`http://localhost:3000/api/daemon/pending-turns${query}`));
+}
+
+const pendingTurns = [
+  { turnUuid: "t1", sessionUuid: "s1", sessionId: "idea-1", directIdeaUuid: "idea-1", seq: 1, trigger: "human_instruction", promptText: "do X" },
+  { turnUuid: "t2", sessionUuid: "s1", sessionId: "idea-1", directIdeaUuid: "idea-1", seq: 2, trigger: "human_instruction", promptText: "do Y" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue(agentAuth);
+  mockConnectionBelongsToAgent.mockResolvedValue(true);
+  mockGetPendingTurnsForConnection.mockResolvedValue(pendingTurns);
+});
+
+describe("GET /api/daemon/pending-turns", () => {
+  it("401 + no read when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+    const res = await GET(getRequest(`?connectionUuid=${connectionUuid}`), emptyCtx);
+    expect(res.status).toBe(401);
+    expect(mockGetPendingTurnsForConnection).not.toHaveBeenCalled();
+  });
+
+  it("returns this connection's pending turns: standard envelope, service stamped from auth", async () => {
+    const res = await GET(getRequest(`?connectionUuid=${connectionUuid}`), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { turns: pendingTurns }, meta: undefined });
+
+    expect(mockGetPendingTurnsForConnection).toHaveBeenCalledTimes(1);
+    const arg = mockGetPendingTurnsForConnection.mock.calls[0][0];
+    expect(arg.companyUuid).toBe(companyUuid);
+    expect(arg.agentUuid).toBe(agentUuid);
+    expect(arg.connectionUuid).toBe(connectionUuid);
+  });
+
+  it("400 when connectionUuid is missing", async () => {
+    const res = await GET(getRequest(""), emptyCtx);
+    expect(res.status).toBe(400);
+    expect(mockGetPendingTurnsForConnection).not.toHaveBeenCalled();
+  });
+
+  it("a connection the agent does not own → 404 (non-disclosure), service not called", async () => {
+    mockConnectionBelongsToAgent.mockResolvedValue(false);
+    const res = await GET(getRequest(`?connectionUuid=${connectionUuid}`), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(mockGetPendingTurnsForConnection).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when there are no pending turns", async () => {
+    mockGetPendingTurnsForConnection.mockResolvedValue([]);
+    const res = await GET(getRequest(`?connectionUuid=${connectionUuid}`), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data.turns).toEqual([]);
+  });
+});

--- a/src/app/api/daemon/pending-turns/route.ts
+++ b/src/app/api/daemon/pending-turns/route.ts
@@ -1,0 +1,53 @@
+// src/app/api/daemon/pending-turns/route.ts
+// Daemon reconnect-backfill read of UNSTARTED turns (子1 — daemon-session-conversation).
+//
+// GET — after the daemon's SSE stream reconnects, it re-derives the turns that arrived
+// during the gap from the TURN TABLE (the canonical source), NOT from notifications —
+// so a lost delivery ping never loses an instruction. This returns every `pending`
+// (unstarted) turn of the sessions whose origin is the daemon's own connection, for the
+// authenticated agent within its company.
+//
+// Auth mirrors the execution-state GET precedent: any valid auth context (notably an
+// agent API key) is accepted, there is NO MCP tool and NO new permission bit, and the
+// readable set is scoped to the caller's OWN sessions by the service. The connectionUuid
+// must belong to the authenticated agent; a connection the agent does not own (or that
+// does not exist) yields 404 — never a 403 that would confirm another agent's connection
+// exists.
+
+import { NextRequest } from "next/server";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import { connectionBelongsToAgent } from "@/services/daemon-execution.service";
+import { getPendingTurnsForConnection } from "@/services/daemon-session.service";
+
+// GET /api/daemon/pending-turns?connectionUuid=… — list this connection's origin-pinned
+// sessions' unstarted (pending) turns.
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) {
+    return errors.unauthorized();
+  }
+
+  const connectionUuid = request.nextUrl.searchParams.get("connectionUuid");
+  if (!connectionUuid) {
+    return errors.badRequest("connectionUuid is required");
+  }
+
+  // Ownership fence (self-scope): the connection must belong to the authenticated
+  // agent within its company. A connection owned by another agent (or non-existent) is
+  // 404 — never 403 — so it is indistinguishable from a non-existent one. The service
+  // additionally fences the session query on this agent + this origin connection.
+  const owns = await connectionBelongsToAgent(auth.companyUuid, auth.actorUuid, connectionUuid);
+  if (!owns) {
+    return errors.notFound("Connection");
+  }
+
+  const turns = await getPendingTurnsForConnection({
+    companyUuid: auth.companyUuid,
+    agentUuid: auth.actorUuid,
+    connectionUuid,
+  });
+
+  return success({ turns });
+});

--- a/src/app/api/daemon/transcript/__tests__/route.test.ts
+++ b/src/app/api/daemon/transcript/__tests__/route.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+const mockAppendTranscriptMessages = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+// Mock the service: the route is the unit under test. TRANSCRIPT_ROLES is re-exported
+// for the route's zod enum, so the mock must provide it verbatim.
+vi.mock("@/services/daemon-session.service", () => ({
+  TRANSCRIPT_ROLES: ["user", "assistant"],
+  appendTranscriptMessages: (...args: unknown[]) => mockAppendTranscriptMessages(...args),
+}));
+
+import { POST } from "@/app/api/daemon/transcript/route";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const ownerUuid = "owner-0000-0000-0000-000000000001";
+const turnUuid = "turn-0000-0000-0000-000000000001";
+const sessionId = "idea-0000-0000-0000-000000000001";
+
+const agentAuth = { type: "agent", companyUuid, actorUuid: agentUuid, permissions: [] };
+const userAuth = { type: "user", companyUuid, actorUuid: ownerUuid };
+
+const emptyCtx = { params: Promise.resolve({}) };
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest(new URL("http://localhost:3000/api/daemon/transcript"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  turnUuid,
+  messages: [
+    { role: "user", text: "do the thing" },
+    { role: "assistant", text: "done" },
+  ],
+};
+
+const okResult = {
+  ok: true,
+  appended: 2,
+  stored: 2,
+  messages: [
+    { uuid: "m1", turnUuid, role: "user", text: "do the thing", seq: 1, createdAt: "2026-06-15T03:00:00.000Z" },
+    { uuid: "m2", turnUuid, role: "assistant", text: "done", seq: 2, createdAt: "2026-06-15T03:00:01.000Z" },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue(agentAuth);
+  mockAppendTranscriptMessages.mockResolvedValue(okResult);
+});
+
+describe("POST /api/daemon/transcript", () => {
+  it("returns 401 and appends nothing when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await POST(postRequest(validBody), emptyCtx);
+
+    expect(res.status).toBe(401);
+    expect(mockAppendTranscriptMessages).not.toHaveBeenCalled();
+  });
+
+  it("appends a turn's transcript for the agent's own session: standard envelope", async () => {
+    const res = await POST(postRequest(validBody), emptyCtx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      data: { appended: 2, stored: 2, messages: okResult.messages },
+      meta: undefined,
+    });
+
+    // The service is called with company/agent stamped from the authenticated context
+    // (NOT trusted from the body), the turnUuid, a null sessionId, and the messages.
+    expect(mockAppendTranscriptMessages).toHaveBeenCalledTimes(1);
+    const arg = mockAppendTranscriptMessages.mock.calls[0][0];
+    expect(arg.companyUuid).toBe(companyUuid);
+    expect(arg.agentUuid).toBe(agentUuid);
+    expect(arg.turnUuid).toBe(turnUuid);
+    expect(arg.sessionId).toBeNull();
+    expect(arg.messages).toEqual(validBody.messages);
+  });
+
+  it("accepts the sessionId (business-key) path and passes a null turnUuid", async () => {
+    const res = await POST(
+      postRequest({ sessionId, messages: [{ role: "user", text: "hi" }] }),
+      emptyCtx,
+    );
+
+    expect(res.status).toBe(200);
+    const arg = mockAppendTranscriptMessages.mock.calls[0][0];
+    expect(arg.sessionId).toBe(sessionId);
+    expect(arg.turnUuid).toBeNull();
+  });
+
+  it("a turn/session the agent does not own → 404 not-found (non-disclosure)", async () => {
+    mockAppendTranscriptMessages.mockResolvedValue({ ok: false, reason: "not_found" });
+
+    const res = await POST(postRequest(validBody), emptyCtx);
+    const body = await res.json();
+
+    // 404 (not 403) — does not reveal the turn/session exists.
+    expect(res.status).toBe(404);
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("a USER caller is passed through with its own actorUuid as the agent scope", async () => {
+    // A user-key caller is scoped by the service to its own agents; the route forwards
+    // the authenticated actor unchanged.
+    mockGetAuthContext.mockResolvedValue(userAuth);
+    await POST(postRequest(validBody), emptyCtx);
+    const arg = mockAppendTranscriptMessages.mock.calls[0][0];
+    expect(arg.companyUuid).toBe(companyUuid);
+    expect(arg.agentUuid).toBe(ownerUuid);
+  });
+
+  it("rejects a body with NEITHER turnUuid nor sessionId (one-of refine) with 422", async () => {
+    const res = await POST(postRequest({ messages: [{ role: "user", text: "x" }] }), emptyCtx);
+    expect(res.status).toBe(422);
+    expect(mockAppendTranscriptMessages).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body with BOTH turnUuid and sessionId (one-of refine) with 422", async () => {
+    const res = await POST(
+      postRequest({ turnUuid, sessionId, messages: [{ role: "user", text: "x" }] }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(422);
+    expect(mockAppendTranscriptMessages).not.toHaveBeenCalled();
+  });
+
+  it("rejects a message with an unrecognized role (tool/thinking) at the zod boundary", async () => {
+    const res = await POST(
+      postRequest({ turnUuid, messages: [{ role: "tool_result", text: "x" }] }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(422);
+    expect(mockAppendTranscriptMessages).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing messages array with a validation error", async () => {
+    const res = await POST(postRequest({ turnUuid }), emptyCtx);
+    expect(res.status).toBe(422);
+    expect(mockAppendTranscriptMessages).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed (non-JSON) body with 400", async () => {
+    const req = new NextRequest(new URL("http://localhost:3000/api/daemon/transcript"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req, emptyCtx);
+    expect(res.status).toBe(400);
+    expect(mockAppendTranscriptMessages).not.toHaveBeenCalled();
+  });
+
+  it("accepts an empty messages array (no-op append) — service decides the outcome", async () => {
+    mockAppendTranscriptMessages.mockResolvedValue({ ok: true, appended: 0, stored: 5, messages: [] });
+    const res = await POST(postRequest({ turnUuid, messages: [] }), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data.appended).toBe(0);
+    expect(mockAppendTranscriptMessages).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/daemon/transcript/route.ts
+++ b/src/app/api/daemon/transcript/route.ts
@@ -1,0 +1,100 @@
+// src/app/api/daemon/transcript/route.ts
+// Daemon per-turn transcript ingest (子1 — daemon-session-conversation).
+//
+// POST — an authenticated daemon uploads the user/assistant transcript text for ONE
+// turn of one of its OWN sessions. Distinct from `execution-state` in two ways:
+//   - semantics are APPEND (this call ADDS messages to the turn), NOT the
+//     snapshot-reconcile of execution-state (which ends rows absent from the body), and
+//   - it stores ONLY `user`/`assistant` text — tool-call / tool-result / thinking
+//     content is dropped, never persisted.
+// After a successful append the service publishes a `transcript:{sessionUuid}` SSE
+// event (the `transcript_appended` trigger) on the existing event bus / Redis fan-out,
+// so a viewer re-renders live. Retained messages are bounded by a per-session rolling
+// window trimmed in application code (no data-mutating migration).
+//
+// Auth mirrors the execution-state / agent-connections precedent exactly: any valid
+// auth context (notably an agent API key) is accepted, there is NO MCP tool and NO new
+// permission bit, and the writable set is scoped to the caller's OWN sessions/turns by
+// the service. A turn/session the authenticated agent does not own (or that does not
+// exist) yields 404 — never a 403 that would confirm another agent's session exists.
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import {
+  TRANSCRIPT_ROLES,
+  appendTranscriptMessages,
+  type InboundTranscriptMessage,
+} from "@/services/daemon-session.service";
+
+// One inbound transcript message. `role` is constrained to the persisted roles
+// (`user` | `assistant`) at the boundary — a tool-call/tool-result/thinking entry is
+// expected to be stripped by the daemon, but the service also re-filters defensively.
+// `text` is the plain message body.
+const messageSchema = z.object({
+  role: z.enum([...TRANSCRIPT_ROLES]),
+  text: z.string(),
+});
+
+// Body: exactly one of `turnUuid` / `sessionId` plus the messages to append.
+//  - `turnUuid` targets a specific turn (the daemon's normal path), or
+//  - `sessionId` (the conversation BUSINESS KEY — directIdeaUuid or ad-hoc uuid, NOT
+//    the session's `uuid`) targets the session's most-recent turn.
+// `.refine` enforces the one-of so a body with neither (or both) is a 422, never a
+// silent mis-route.
+const bodySchema = z
+  .object({
+    turnUuid: z.string().min(1).optional(),
+    sessionId: z.string().min(1).optional(),
+    messages: z.array(messageSchema),
+  })
+  .refine((b) => Boolean(b.turnUuid) !== Boolean(b.sessionId), {
+    message: "Provide exactly one of turnUuid or sessionId",
+  });
+
+// POST /api/daemon/transcript — append a turn's user/assistant transcript text.
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) {
+    return errors.unauthorized();
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return errors.badRequest("Invalid JSON body");
+  }
+
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return errors.validationError(parsed.error.flatten());
+  }
+  const { turnUuid, sessionId, messages } = parsed.data;
+
+  // Ownership + append happen in the service (no turn/session business logic in the
+  // route, per convention). companyUuid/agentUuid are stamped from the authenticated
+  // context — never trusted from the body. A turn/session the agent does not own (or
+  // that does not exist) returns the SAME `not_found` so we never confirm another
+  // agent's session exists.
+  const result = await appendTranscriptMessages({
+    companyUuid: auth.companyUuid,
+    agentUuid: auth.actorUuid,
+    turnUuid: turnUuid ?? null,
+    sessionId: sessionId ?? null,
+    messages: messages as InboundTranscriptMessage[],
+  });
+
+  if (!result.ok) {
+    // 404 (not 403) — non-disclosure, indistinguishable from a non-existent turn.
+    return errors.notFound("Turn");
+  }
+
+  return success({
+    appended: result.appended,
+    stored: result.stored,
+    messages: result.messages,
+  });
+});

--- a/src/app/api/daemon/turn-advance/__tests__/route.test.ts
+++ b/src/app/api/daemon/turn-advance/__tests__/route.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+const mockConnectionBelongsToAgent = vi.fn();
+const mockAdvanceTurnForWake = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+// daemon-execution.service: the route uses connectionBelongsToAgent (ownership fence)
+// and EXECUTION_ENTITY_TYPES (zod enum). Provide both verbatim.
+vi.mock("@/services/daemon-execution.service", () => ({
+  EXECUTION_ENTITY_TYPES: ["task", "idea", "proposal", "document"],
+  connectionBelongsToAgent: (...args: unknown[]) => mockConnectionBelongsToAgent(...args),
+}));
+
+// daemon-session.service: TURN_STATUSES re-exported for the route's zod enum.
+vi.mock("@/services/daemon-session.service", () => ({
+  TURN_STATUSES: ["pending", "running", "ended"],
+  advanceTurnForWake: (...args: unknown[]) => mockAdvanceTurnForWake(...args),
+}));
+
+import { POST } from "@/app/api/daemon/turn-advance/route";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+const sessionId = "idea-0000-0000-0000-000000000001";
+
+const agentAuth = { type: "agent", companyUuid, actorUuid: agentUuid, permissions: [] };
+const emptyCtx = { params: Promise.resolve({}) };
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest(new URL("http://localhost:3000/api/daemon/turn-advance"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const turnView = {
+  uuid: "turn-1",
+  sessionUuid: "sess-1",
+  seq: 3,
+  trigger: "human_instruction",
+  promptText: "do X",
+  status: "running",
+  executionUuid: "exec-1",
+  startedAt: "2026-06-19T06:00:00.000Z",
+  endedAt: null,
+  createdAt: "2026-06-19T05:59:00.000Z",
+};
+
+const runningBody = { connectionUuid, sessionId, status: "running", entityType: "task", entityUuid: "task-9" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue(agentAuth);
+  mockConnectionBelongsToAgent.mockResolvedValue(true);
+  mockAdvanceTurnForWake.mockResolvedValue({ ok: true, turn: turnView });
+});
+
+describe("POST /api/daemon/turn-advance", () => {
+  it("401 + no advance when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+    const res = await POST(postRequest(runningBody), emptyCtx);
+    expect(res.status).toBe(401);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
+  it("advances the turn for the agent's own connection: standard envelope, service stamped from auth", async () => {
+    const res = await POST(postRequest(runningBody), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { turn: turnView }, meta: undefined });
+
+    expect(mockAdvanceTurnForWake).toHaveBeenCalledTimes(1);
+    const arg = mockAdvanceTurnForWake.mock.calls[0][0];
+    expect(arg.companyUuid).toBe(companyUuid); // stamped from auth, not the body
+    expect(arg.agentUuid).toBe(agentUuid);
+    expect(arg.connectionUuid).toBe(connectionUuid);
+    expect(arg.sessionId).toBe(sessionId);
+    expect(arg.status).toBe("running");
+    expect(arg.entityType).toBe("task");
+    expect(arg.entityUuid).toBe("task-9");
+  });
+
+  it("accepts a body WITHOUT the optional entity (null entityType/entityUuid to the service)", async () => {
+    const res = await POST(postRequest({ connectionUuid, sessionId, status: "ended" }), emptyCtx);
+    expect(res.status).toBe(200);
+    const arg = mockAdvanceTurnForWake.mock.calls[0][0];
+    expect(arg.entityType).toBeNull();
+    expect(arg.entityUuid).toBeNull();
+    expect(arg.status).toBe("ended");
+  });
+
+  it("a connection the agent does not own → 404 (non-disclosure), service not called", async () => {
+    mockConnectionBelongsToAgent.mockResolvedValue(false);
+    const res = await POST(postRequest(runningBody), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
+  it("a session/turn the agent does not own → 404 (service not_found)", async () => {
+    mockAdvanceTurnForWake.mockResolvedValue({ ok: false, reason: "not_found" });
+    const res = await POST(postRequest(runningBody), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("an illegal transition → 409 conflict (surfaced, not swallowed)", async () => {
+    mockAdvanceTurnForWake.mockResolvedValue({
+      ok: false,
+      reason: "invalid_transition",
+      from: "ended",
+      to: "running",
+    });
+    const res = await POST(postRequest(runningBody), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("CONFLICT");
+    expect(body.error.message).toMatch(/ended → running/);
+  });
+
+  it("rejects a bad status at the zod boundary (422)", async () => {
+    const res = await POST(postRequest({ connectionUuid, sessionId, status: "weird" }), emptyCtx);
+    expect(res.status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing connectionUuid / sessionId (422)", async () => {
+    expect((await POST(postRequest({ sessionId, status: "running" }), emptyCtx)).status).toBe(422);
+    expect((await POST(postRequest({ connectionUuid, status: "running" }), emptyCtx)).status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid JSON (400)", async () => {
+    const req = new NextRequest(new URL("http://localhost:3000/api/daemon/turn-advance"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(req, emptyCtx);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/daemon/turn-advance/route.ts
+++ b/src/app/api/daemon/turn-advance/route.ts
@@ -1,0 +1,98 @@
+// src/app/api/daemon/turn-advance/route.ts
+// Daemon → server turn lifecycle advance (子1 — daemon-session-conversation).
+//
+// POST — the daemon advances the lifecycle of the turn it is executing
+// (`pending → running → ended`) on ONE of its OWN sessions. It identifies the turn by
+// the session BUSINESS KEY (`sessionId` = the directIdeaUuid for an idea-anchored
+// session, or the entity uuid for an ad-hoc one — the deterministic Claude session
+// anchor the daemon already computes), NOT the server-side turn uuid, which the daemon
+// never learns. The service resolves the agent's `(agentUuid, sessionId)` session and
+// advances its most-recent turn through the single `advanceTurn` chokepoint (strict
+// ordering + `transcript:{sessionUuid}` SSE publish enforced there).
+//
+// Auth mirrors the execution-state / transcript precedent EXACTLY: any valid auth
+// context (notably an agent API key) is accepted, there is NO MCP tool and NO new
+// permission bit, and the writable set is scoped to the caller's OWN sessions/turns by
+// the service. The connectionUuid must belong to the authenticated agent (so the
+// optional executionUuid linkage is resolved against a connection the agent owns); a
+// connection or session the agent does not own (or that does not exist) yields 404 —
+// never a 403 that would confirm another agent's resource exists.
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import { connectionBelongsToAgent, EXECUTION_ENTITY_TYPES } from "@/services/daemon-execution.service";
+import { TURN_STATUSES, advanceTurnForWake } from "@/services/daemon-session.service";
+
+// Body: the connection reporting the advance, the session business key, the target
+// status, and the OPTIONAL wake-triggering entity (for the weak executionUuid link).
+// `startedAt`/`endedAt` are optional ISO-8601 strings (the service defaults them to the
+// transition time for the running/ended edges when omitted).
+const bodySchema = z.object({
+  connectionUuid: z.string().min(1),
+  sessionId: z.string().min(1),
+  status: z.enum([...TURN_STATUSES]),
+  entityType: z.enum([...EXECUTION_ENTITY_TYPES]).optional(),
+  entityUuid: z.string().min(1).optional(),
+  startedAt: z.coerce.date().nullish(),
+  endedAt: z.coerce.date().nullish(),
+});
+
+// POST /api/daemon/turn-advance — advance a turn's lifecycle by session business key.
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) {
+    return errors.unauthorized();
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return errors.badRequest("Invalid JSON body");
+  }
+
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return errors.validationError(parsed.error.flatten());
+  }
+  const { connectionUuid, sessionId, status, entityType, entityUuid, startedAt, endedAt } =
+    parsed.data;
+
+  // Ownership fence: the connection must belong to the authenticated agent within its
+  // company. A connection owned by another agent (or non-existent) is 404 — never 403
+  // — so we never confirm another agent's connection exists. (Same posture as
+  // execution-state POST.)
+  const owns = await connectionBelongsToAgent(auth.companyUuid, auth.actorUuid, connectionUuid);
+  if (!owns) {
+    return errors.notFound("Connection");
+  }
+
+  const result = await advanceTurnForWake({
+    companyUuid: auth.companyUuid,
+    agentUuid: auth.actorUuid,
+    connectionUuid,
+    sessionId,
+    status,
+    entityType: entityType ?? null,
+    entityUuid: entityUuid ?? null,
+    startedAt: startedAt ?? undefined,
+    endedAt: endedAt ?? undefined,
+  });
+
+  if (!result.ok) {
+    if (result.reason === "invalid_transition") {
+      // The daemon reported a transition that is not the single legal forward edge
+      // (e.g. a duplicate report). 409 conflict — surfaced, not silently swallowed.
+      return errors.conflict(
+        `Invalid turn transition ${result.from} → ${result.to}`,
+      );
+    }
+    // 404 (not 403) — non-disclosure, indistinguishable from a non-existent session/turn.
+    return errors.notFound("Turn");
+  }
+
+  return success({ turn: result.turn });
+});

--- a/src/services/__tests__/daemon-session-conversation.integration.test.ts
+++ b/src/services/__tests__/daemon-session-conversation.integration.test.ts
@@ -1,0 +1,701 @@
+// src/services/__tests__/daemon-session-conversation.integration.test.ts
+//
+// INTEGRATION CHECKPOINT (子1 — daemon-session-conversation, final task).
+//
+// Unlike the per-task unit tests — each of which mocks the daemon-session service or
+// prisma at a single boundary — this test wires the REAL composition together against
+// ONE stateful in-memory prisma fake plus the REAL in-process event bus:
+//
+//   notification.service.create            (REAL — the wake chokepoint)
+//     → notification-turn bridge           (REAL — maybeCreateTurnForWakeNotification)
+//       → daemon-session.service           (REAL — resolveOrCreateSession + createPendingTurn)
+//   /api/daemon/turn-advance route         (REAL handler — advanceTurnForWake)
+//   /api/daemon/transcript route           (REAL handler — appendTranscriptMessages)
+//   /api/daemon/pending-turns route        (REAL handler — getPendingTurnsForConnection)
+//   assertContinuable                      (REAL — origin-pinned read-only verdict)
+//
+// Only the leaf I/O is faked: prisma (a stateful store, so every function reads what
+// the previous one wrote — the thing per-task mocks cannot prove), the logger (silenced),
+// lineage (direct-idea resolution), and the connection registry's online/offline listing
+// (so the chokepoint pins an origin). The daemon-session functions themselves are NOT
+// mocked, so the seams are genuinely exercised.
+//
+// It drives the 5 scenario threads of the checkpoint task end-to-end at the service +
+// route layer:
+//   (1) an autonomous task_assigned wake creates a DaemonSession + a task_assigned turn;
+//       the daemon advances it pending → running → ended.
+//   (2) a human_instruction wake (notification carries instructionText; the daemon reads
+//       it with NO extra fetch) produces a SECOND turn on the SAME session, distinguished
+//       by trigger.
+//   (3) user/assistant transcript for both turns lands via POST /api/daemon/transcript
+//       (append, text-only, rolling window) and a transcript:{sessionUuid} SSE fires.
+//   (4) continuation refuses (session read-only) when originConnectionUuid is offline,
+//       and is never re-routed to another online connection of the same agent.
+//   (5) a dropped delivery ping + reconnect re-derives the unstarted (pending) turn from
+//       the turn table via the backfill read (instruction not lost).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Stateful in-memory prisma fake =====
+//
+// Supports exactly the query shapes the real code paths under test use. Each model is
+// an array of rows; ids/uuids auto-assigned on create. This is the crux of the
+// integration test: a SINGLE store the real functions write to and read from in turn.
+
+interface Row {
+  [k: string]: unknown;
+}
+
+function makeStore() {
+  const data = {
+    daemonSession: [] as Row[],
+    daemonSessionTurn: [] as Row[],
+    daemonTranscriptMessage: [] as Row[],
+    daemonConnection: [] as Row[],
+    daemonExecution: [] as Row[],
+    notification: [] as Row[],
+    notificationPreference: [] as Row[],
+  };
+  let autoId = 1;
+  let autoUuid = 1;
+  const nextId = () => autoId++;
+  const nextUuid = (prefix: string) => `${prefix}-${String(autoUuid++).padStart(4, "0")}`;
+  return { data, nextId, nextUuid };
+}
+
+type Store = ReturnType<typeof makeStore>;
+
+// Match a row against a Prisma `where` clause. Supports scalar equality, the
+// `{ not: ... }` / `{ in: [...] }` operators, and the nested relation filters the code
+// uses (turn.session.*, transcriptMessage.turn.sessionUuid, turn.session{agentUuid,...}).
+function matchWhere(store: Store, model: keyof Store["data"], row: Row, where: Row): boolean {
+  for (const [key, cond] of Object.entries(where ?? {})) {
+    if (cond === undefined) continue;
+
+    // Nested relation filters.
+    if (key === "session" && model === "daemonSessionTurn") {
+      const session = store.data.daemonSession.find((s) => s.uuid === row.sessionUuid);
+      if (!session) return false;
+      if (!matchWhere(store, "daemonSession", session, cond as Row)) return false;
+      continue;
+    }
+    if (key === "turn" && model === "daemonTranscriptMessage") {
+      const turn = store.data.daemonSessionTurn.find((t) => t.uuid === row.turnUuid);
+      if (!turn) return false;
+      if (!matchWhere(store, "daemonSessionTurn", turn, cond as Row)) return false;
+      continue;
+    }
+
+    const val = row[key];
+    if (cond !== null && typeof cond === "object") {
+      const c = cond as Row;
+      if ("not" in c) {
+        if (val === c.not) return false;
+        continue;
+      }
+      if ("in" in c) {
+        if (!Array.isArray(c.in) || !(c.in as unknown[]).includes(val)) return false;
+        continue;
+      }
+      // Unknown operator object — treat as no match to surface a gap loudly.
+      return false;
+    }
+    if (val !== cond) return false;
+  }
+  return true;
+}
+
+// Apply a Prisma `orderBy` (single object or array) to a list. Supports scalar fields
+// plus the `session.createdAt` nested order the backfill uses.
+function applyOrderBy(store: Store, model: keyof Store["data"], rows: Row[], orderBy: unknown): Row[] {
+  if (!orderBy) return rows;
+  const orders = Array.isArray(orderBy) ? orderBy : [orderBy];
+  return [...rows].sort((a, b) => {
+    for (const o of orders as Row[]) {
+      for (const [field, dir] of Object.entries(o)) {
+        let av: unknown;
+        let bv: unknown;
+        if (field === "session" && model === "daemonSessionTurn") {
+          const sa = store.data.daemonSession.find((s) => s.uuid === a.sessionUuid) ?? {};
+          const sb = store.data.daemonSession.find((s) => s.uuid === b.sessionUuid) ?? {};
+          const inner = Object.entries(dir as Row)[0];
+          av = (sa as Row)[inner[0]];
+          bv = (sb as Row)[inner[0]];
+          const d2 = inner[1];
+          const cmp = compare(av, bv);
+          if (cmp !== 0) return d2 === "desc" ? -cmp : cmp;
+          continue;
+        }
+        av = a[field];
+        bv = b[field];
+        const cmp = compare(av, bv);
+        if (cmp !== 0) return dir === "desc" ? -cmp : cmp;
+      }
+    }
+    return 0;
+  });
+}
+
+// Materialize a Prisma `select` for the one relation the code under test reads through
+// it: `daemonSessionTurn.select.session` (the backfill query). When a `select` names the
+// `session` relation, attach the related DaemonSession row (with its own nested select
+// applied) onto the result, so `row.session.sessionId` etc. resolve. Scalar selects are
+// left as-is (the services map full rows; extra fields are harmless). Never throws.
+function projectSelect(
+  store: Store,
+  model: keyof Store["data"],
+  row: Row,
+  select: Row | undefined,
+): Row {
+  if (!select) return row;
+  if (model === "daemonSessionTurn" && select.session) {
+    const session = store.data.daemonSession.find((s) => s.uuid === row.sessionUuid);
+    const sel = (select.session as Row).select as Row | undefined;
+    if (session) {
+      if (sel) {
+        const picked: Row = {};
+        for (const k of Object.keys(sel)) picked[k] = session[k];
+        row.session = picked;
+      } else {
+        row.session = { ...session };
+      }
+    } else {
+      row.session = null;
+    }
+  }
+  return row;
+}
+
+function compare(a: unknown, b: unknown): number {
+  if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  if (typeof a === "string" && typeof b === "string") return a < b ? -1 : a > b ? 1 : 0;
+  return 0;
+}
+
+function buildPrismaFake(store: Store) {
+  function findMany(model: keyof Store["data"], args: Row = {}) {
+    let rows = store.data[model].filter((r) => matchWhere(store, model, r, (args.where as Row) ?? {}));
+    rows = applyOrderBy(store, model, rows, args.orderBy);
+    if (typeof args.take === "number") rows = rows.slice(0, args.take as number);
+    return rows.map((r) => projectSelect(store, model, { ...r }, args.select as Row | undefined));
+  }
+  function findFirst(model: keyof Store["data"], args: Row = {}) {
+    const rows = findMany(model, args);
+    return rows.length > 0 ? rows[0] : null;
+  }
+  function count(model: keyof Store["data"], args: Row = {}) {
+    return store.data[model].filter((r) => matchWhere(store, model, r, (args.where as Row) ?? {})).length;
+  }
+
+  return {
+    daemonSession: {
+      upsert: vi.fn(async (args: Row) => {
+        const where = (args.where as Row).agentUuid_sessionId as Row;
+        const existing = store.data.daemonSession.find(
+          (s) => s.agentUuid === where.agentUuid && s.sessionId === where.sessionId,
+        );
+        if (existing) {
+          Object.assign(existing, args.update as Row, { updatedAt: new Date() });
+          return { ...existing };
+        }
+        const now = new Date();
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("session"),
+          status: "active",
+          title: null,
+          directIdeaUuid: null,
+          lastTurnAt: now,
+          createdAt: now,
+          updatedAt: now,
+          ...(args.create as Row),
+        };
+        store.data.daemonSession.push(row);
+        return { ...row };
+      }),
+      findUnique: vi.fn(async (args: Row) =>
+        findFirst("daemonSession", { where: args.where }),
+      ),
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonSession", args)),
+      findMany: vi.fn(async (args: Row) => findMany("daemonSession", args)),
+      update: vi.fn(async (args: Row) => {
+        const row = store.data.daemonSession.find((s) => s.uuid === (args.where as Row).uuid);
+        if (!row) throw new Error("session not found for update");
+        Object.assign(row, args.data as Row, { updatedAt: new Date() });
+        return { ...row };
+      }),
+    },
+    daemonSessionTurn: {
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonSessionTurn", args)),
+      findUnique: vi.fn(async (args: Row) =>
+        findFirst("daemonSessionTurn", { where: args.where }),
+      ),
+      findMany: vi.fn(async (args: Row) => findMany("daemonSessionTurn", args)),
+      create: vi.fn(async (args: Row) => {
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("turn"),
+          promptText: null,
+          executionUuid: null,
+          startedAt: null,
+          endedAt: null,
+          createdAt: new Date(),
+          ...(args.data as Row),
+        };
+        store.data.daemonSessionTurn.push(row);
+        return { ...row };
+      }),
+      update: vi.fn(async (args: Row) => {
+        const row = store.data.daemonSessionTurn.find((t) => t.uuid === (args.where as Row).uuid);
+        if (!row) throw new Error("turn not found for update");
+        Object.assign(row, args.data as Row);
+        return { ...row };
+      }),
+    },
+    daemonTranscriptMessage: {
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonTranscriptMessage", args)),
+      findMany: vi.fn(async (args: Row) => findMany("daemonTranscriptMessage", args)),
+      create: vi.fn(async (args: Row) => {
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("msg"),
+          createdAt: new Date(),
+          ...(args.data as Row),
+        };
+        store.data.daemonTranscriptMessage.push(row);
+        return { ...row };
+      }),
+      count: vi.fn(async (args: Row) => count("daemonTranscriptMessage", args)),
+      deleteMany: vi.fn(async (args: Row) => {
+        const where = (args.where as Row) ?? {};
+        const toDelete = store.data.daemonTranscriptMessage.filter((r) =>
+          matchWhere(store, "daemonTranscriptMessage", r, where),
+        );
+        store.data.daemonTranscriptMessage = store.data.daemonTranscriptMessage.filter(
+          (r) => !toDelete.includes(r),
+        );
+        return { count: toDelete.length };
+      }),
+    },
+    daemonConnection: {
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonConnection", args)),
+      count: vi.fn(async (args: Row) => count("daemonConnection", args)),
+    },
+    daemonExecution: {
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonExecution", args)),
+    },
+    notification: {
+      create: vi.fn(async (args: Row) => {
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("notif"),
+          readAt: null,
+          archivedAt: null,
+          instructionText: null,
+          createdAt: new Date(),
+          ...(args.data as Row),
+        };
+        store.data.notification.push(row);
+        return { ...row };
+      }),
+      count: vi.fn(async (args: Row) => count("notification", args)),
+      findMany: vi.fn(async (args: Row) => findMany("notification", args)),
+    },
+  };
+}
+
+// ===== Module mocks =====
+//
+// The store + prisma fake are built inside vi.hoisted so they exist when the hoisted
+// vi.mock factory below runs (factories are lifted above normal module-scope consts).
+
+const hoisted = vi.hoisted(() => {
+  // Re-declared here (not referencing module-scope helpers, which are not yet defined at
+  // hoist time) — the builders are pure functions defined ABOVE via function declarations,
+  // which ARE hoisted, so they are callable here.
+  const s = makeStore();
+  return { store: s, prismaFake: buildPrismaFake(s) };
+});
+const store = hoisted.store;
+const prismaFake = hoisted.prismaFake;
+vi.mock("@/lib/prisma", () => ({ prisma: hoisted.prismaFake }));
+
+// Silence the logger; the real event bus is used (in-process EventEmitter, Redis off).
+const mockLogger = vi.hoisted(() => {
+  const l = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn(), child: () => l };
+  return l;
+});
+vi.mock("@/lib/logger", () => ({
+  default: mockLogger,
+  // api-handler.ts (the route wrapper) builds a per-request logger; provide it so the
+  // REAL route handlers run.
+  createRequestLogger: () => mockLogger,
+}));
+
+// Lineage: a task under an idea resolves to that direct idea; everything else → null.
+const mockResolveRootIdea = vi.hoisted(() => vi.fn());
+vi.mock("@/services/lineage.service", () => ({
+  resolveRootIdea: mockResolveRootIdea,
+}));
+
+// Connection registry: the chokepoint asks for the agent's online connections to pin an
+// origin. We drive online/offline here. STALE_THRESHOLD_MS must be REAL (the session
+// service re-exports it and assertContinuable compares against it), so partially mock.
+const mockListConnectionsForAgent = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-connection.service", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    listConnectionsForAgent: mockListConnectionsForAgent,
+  };
+});
+
+// Auth: the route handlers call getAuthContext(request); return a fixed agent context.
+const COMPANY = "company-int-0001";
+const AGENT = "agent-int-0001";
+const mockGetAuthContext = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/auth", () => ({ getAuthContext: mockGetAuthContext }));
+
+// ===== Imports under test (REAL) =====
+import * as notificationService from "@/services/notification.service";
+import {
+  assertContinuable,
+  transcriptEventName,
+  type TranscriptEvent,
+} from "@/services/daemon-session.service";
+import { eventBus } from "@/lib/event-bus";
+import { POST as turnAdvanceRoutePOST } from "@/app/api/daemon/turn-advance/route";
+import { POST as transcriptRoutePOST } from "@/app/api/daemon/transcript/route";
+import { GET as pendingTurnsRouteGET } from "@/app/api/daemon/pending-turns/route";
+
+// ===== Fixtures =====
+const PROJECT = "project-int-0001";
+const IDEA = "idea-int-0001";
+const TASK = "task-int-0001";
+const ORIGIN_CONN = "conn-origin-0001";
+const OTHER_CONN = "conn-other-0002";
+
+function agentAuth() {
+  return { type: "agent", companyUuid: COMPANY, actorUuid: AGENT };
+}
+
+function postReq(url: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost${url}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: "Bearer cho_test" },
+    body: JSON.stringify(body),
+  });
+}
+
+function getReq(url: string): NextRequest {
+  return new NextRequest(`http://localhost${url}`, {
+    method: "GET",
+    headers: { authorization: "Bearer cho_test" },
+  });
+}
+
+// withErrorHandler-wrapped routes take (request, { params }) — these routes ignore
+// params, so an empty resolved-params context satisfies the signature (matches the
+// existing daemon route tests' convention). Thin wrappers bake it in so the call sites
+// pass only the request.
+const emptyCtx = { params: Promise.resolve({}) };
+const turnAdvancePOST = (req: NextRequest) => turnAdvanceRoutePOST(req, emptyCtx);
+const transcriptPOST = (req: NextRequest) => transcriptRoutePOST(req, emptyCtx);
+const pendingTurnsGET = (req: NextRequest) => pendingTurnsRouteGET(req, emptyCtx);
+
+// Seed an online origin connection and one other online connection for the agent.
+function seedConnections() {
+  const now = new Date();
+  store.data.daemonConnection.push(
+    {
+      id: store.nextId(),
+      uuid: ORIGIN_CONN,
+      companyUuid: COMPANY,
+      agentUuid: AGENT,
+      status: "online",
+      lastSeenAt: now,
+    },
+    {
+      id: store.nextId(),
+      uuid: OTHER_CONN,
+      companyUuid: COMPANY,
+      agentUuid: AGENT,
+      status: "online",
+      lastSeenAt: now,
+    },
+  );
+}
+
+const baseNotif = {
+  companyUuid: COMPANY,
+  projectUuid: PROJECT,
+  recipientType: "agent",
+  recipientUuid: AGENT,
+  entityType: "task",
+  entityUuid: TASK,
+  entityTitle: "Build the thing",
+  projectName: "Chorus 0.11.0",
+  actorType: "user",
+  actorUuid: "user-int-0001",
+  actorName: "Alice",
+};
+
+beforeEach(() => {
+  // Reset the store between tests.
+  for (const k of Object.keys(store.data) as (keyof Store["data"])[]) {
+    store.data[k].length = 0;
+  }
+  vi.clearAllMocks();
+
+  mockGetAuthContext.mockResolvedValue(agentAuth());
+  // task → direct idea IDEA; default for anything else null.
+  mockResolveRootIdea.mockImplementation(async (_company: string, type: string, uuid: string) => {
+    if (type === "task" && uuid === TASK) return { rootIdeaUuid: IDEA, directIdeaUuid: IDEA };
+    return { rootIdeaUuid: null, directIdeaUuid: null };
+  });
+  // Origin connection online by default.
+  mockListConnectionsForAgent.mockResolvedValue([
+    { uuid: ORIGIN_CONN, agentUuid: AGENT, effectiveStatus: "online" },
+    { uuid: OTHER_CONN, agentUuid: AGENT, effectiveStatus: "online" },
+  ]);
+  seedConnections();
+});
+
+// ===== Thread 1 + 2: two wakes, one session, distinguished by trigger; lifecycle =====
+
+describe("integration: autonomous + human turns on ONE DaemonSession, distinguished by trigger", () => {
+  it("creates a task_assigned turn then a human_instruction turn on the SAME session, and the daemon advances each pending→running→ended", async () => {
+    const events: TranscriptEvent[] = [];
+    const onEvent = (e: TranscriptEvent) => events.push(e);
+
+    // --- Thread 1: an autonomous task_assigned wake at the notification chokepoint ---
+    const notif1 = await notificationService.create({ ...baseNotif, action: "task_assigned", message: "Task assigned" });
+    expect(notif1.action).toBe("task_assigned");
+
+    // A DaemonSession keyed (AGENT, IDEA) exists, pinned to the online origin.
+    expect(store.data.daemonSession).toHaveLength(1);
+    const session = store.data.daemonSession[0];
+    expect(session.agentUuid).toBe(AGENT);
+    expect(session.sessionId).toBe(IDEA);
+    expect(session.directIdeaUuid).toBe(IDEA);
+    expect(session.originConnectionUuid).toBe(ORIGIN_CONN);
+    const sessionUuid = session.uuid as string;
+
+    // Subscribe to the per-session channel AFTER the session exists (turn-created for
+    // turn 1 already fired before we knew the uuid; we assert turn 1's row directly and
+    // capture SSE for the subsequent transitions + turn 2).
+    eventBus.on(transcriptEventName(sessionUuid), onEvent);
+
+    // Exactly one turn, trigger=task_assigned, status=pending, seq=1.
+    expect(store.data.daemonSessionTurn).toHaveLength(1);
+    const turn1 = store.data.daemonSessionTurn[0];
+    expect(turn1.trigger).toBe("task_assigned");
+    expect(turn1.status).toBe("pending");
+    expect(turn1.seq).toBe(1);
+    expect(turn1.promptText).toBeNull();
+
+    // Daemon advances turn 1 pending → running → ended via the REAL route handler,
+    // identifying the turn by the session business key (sessionId = IDEA).
+    const run1 = await turnAdvancePOST(
+      postReq("/api/daemon/turn-advance", {
+        connectionUuid: ORIGIN_CONN,
+        sessionId: IDEA,
+        status: "running",
+        entityType: "task",
+        entityUuid: TASK,
+      }),
+    );
+    expect(run1.status).toBe(200);
+    expect((store.data.daemonSessionTurn[0]).status).toBe("running");
+
+    const end1 = await turnAdvancePOST(
+      postReq("/api/daemon/turn-advance", {
+        connectionUuid: ORIGIN_CONN,
+        sessionId: IDEA,
+        status: "ended",
+      }),
+    );
+    expect(end1.status).toBe(200);
+    expect((store.data.daemonSessionTurn[0]).status).toBe("ended");
+
+    // --- Thread 2: a human_instruction wake — notification carries instructionText ---
+    const INSTRUCTION = "Please also update the changelog.";
+    const notif2 = await notificationService.create({
+      ...baseNotif,
+      action: "human_instruction",
+      message: "New instruction",
+      instructionText: INSTRUCTION,
+    });
+
+    // AC: the instruction text rides the SAME notification the daemon already fetches —
+    // no extra fetch. The read projection surfaces it.
+    expect(notif2.instructionText).toBe(INSTRUCTION);
+
+    // SAME session reused (still 1 session row), now with a SECOND turn.
+    expect(store.data.daemonSession).toHaveLength(1);
+    expect(store.data.daemonSessionTurn).toHaveLength(2);
+    const turn2 = store.data.daemonSessionTurn[1];
+    expect(turn2.sessionUuid).toBe(sessionUuid); // same conversation
+    expect(turn2.trigger).toBe("human_instruction");
+    expect(turn2.seq).toBe(2);
+    // AC: the TURN is the source of truth for the instruction text.
+    expect(turn2.promptText).toBe(INSTRUCTION);
+
+    // The two turns share one session, distinguished only by trigger.
+    const triggers = store.data.daemonSessionTurn.map((t) => t.trigger);
+    expect(triggers).toEqual(["task_assigned", "human_instruction"]);
+
+    // Daemon advances turn 2 (the most-recent turn) pending → running → ended.
+    await turnAdvancePOST(
+      postReq("/api/daemon/turn-advance", { connectionUuid: ORIGIN_CONN, sessionId: IDEA, status: "running" }),
+    );
+    await turnAdvancePOST(
+      postReq("/api/daemon/turn-advance", { connectionUuid: ORIGIN_CONN, sessionId: IDEA, status: "ended" }),
+    );
+    expect((store.data.daemonSessionTurn[1]).status).toBe("ended");
+
+    // SSE: turn_status_changed fired for the advances we captured (turn1 ended onward +
+    // turn2 created/advances). At minimum we saw turn_created for turn 2 and
+    // turn_status_changed transitions.
+    const kinds = events.map((e) => e.trigger);
+    expect(kinds).toContain("turn_status_changed");
+    expect(kinds).toContain("turn_created");
+  });
+});
+
+// ===== Thread 3: transcript append + SSE for both turns =====
+
+describe("integration: per-turn transcript ingest (append, text-only, rolling-window) + SSE", () => {
+  it("appends user/assistant text to a turn and fires a transcript_appended SSE event", async () => {
+    await notificationService.create({ ...baseNotif, action: "task_assigned", message: "Task assigned" });
+    const sessionUuid = store.data.daemonSession[0].uuid as string;
+
+    const appended: TranscriptEvent[] = [];
+    eventBus.on(transcriptEventName(sessionUuid), (e: TranscriptEvent) => {
+      if (e.trigger === "transcript_appended") appended.push(e);
+    });
+
+    // Daemon uploads transcript for the current turn via the REAL route, targeting by
+    // the session business key (sessionId = IDEA). Tool/thinking entries are not even
+    // sent by the daemon; the schema constrains roles to user/assistant — verify the
+    // text-only persistence by sending only those.
+    const res = await transcriptPOST(
+      postReq("/api/daemon/transcript", {
+        sessionId: IDEA,
+        messages: [
+          { role: "user", text: "Do the task." },
+          { role: "assistant", text: "On it." },
+          { role: "assistant", text: "   " }, // blank → dropped by the service filter
+        ],
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.appended).toBe(2); // blank dropped
+    expect(body.data.stored).toBe(2);
+
+    // Persisted only user/assistant text, in order, on turn 1.
+    expect(store.data.daemonTranscriptMessage).toHaveLength(2);
+    const texts = store.data.daemonTranscriptMessage.map((m) => m.text);
+    expect(texts).toEqual(["Do the task.", "On it."]);
+    const roles = store.data.daemonTranscriptMessage.map((m) => m.role);
+    expect(roles).toEqual(["user", "assistant"]);
+
+    // SSE transcript_appended fired exactly once for the non-empty append.
+    expect(appended).toHaveLength(1);
+    expect(appended[0].sessionUuid).toBe(sessionUuid);
+    expect(appended[0].companyUuid).toBe(COMPANY);
+  });
+
+  it("rejects a transcript upload for another agent's session without disclosure (404)", async () => {
+    await notificationService.create({ ...baseNotif, action: "task_assigned", message: "Task assigned" });
+    // Another agent's auth posting for OUR session business key → not found, no store.
+    mockGetAuthContext.mockResolvedValueOnce({ type: "agent", companyUuid: COMPANY, actorUuid: "agent-other-9999" });
+    const res = await transcriptPOST(
+      postReq("/api/daemon/transcript", {
+        sessionId: IDEA,
+        messages: [{ role: "user", text: "leak?" }],
+      }),
+    );
+    expect(res.status).toBe(404);
+    expect(store.data.daemonTranscriptMessage).toHaveLength(0);
+  });
+});
+
+// ===== Thread 4: continuation refused when origin offline; never re-routed =====
+
+describe("integration: continuation pinned to origin connection (read-only when offline)", () => {
+  it("refuses continuation when the origin connection is offline and never routes to another online connection", async () => {
+    await notificationService.create({ ...baseNotif, action: "task_assigned", message: "Task assigned" });
+    const sessionUuid = store.data.daemonSession[0].uuid as string;
+    expect(store.data.daemonSession[0].originConnectionUuid).toBe(ORIGIN_CONN);
+
+    // While origin online → continuable, resolves to the origin connection (only it).
+    const ok = await assertContinuable(COMPANY, sessionUuid);
+    expect(ok).toBe(ORIGIN_CONN);
+
+    // Take the ORIGIN connection offline (stale lastSeenAt) — the OTHER connection of
+    // the same agent stays online.
+    const origin = store.data.daemonConnection.find((c) => c.uuid === ORIGIN_CONN)!;
+    origin.lastSeenAt = new Date(Date.now() - 10 * 60_000); // well past STALE_THRESHOLD_MS
+
+    // Continuation must now refuse (read-only) and NEVER hand back the other online conn.
+    await expect(assertContinuable(COMPANY, sessionUuid)).rejects.toMatchObject({
+      code: "session_read_only",
+      originConnectionUuid: ORIGIN_CONN,
+    });
+
+    // History is still readable: the session + its turns survive the origin going offline.
+    expect(store.data.daemonSession).toHaveLength(1);
+    expect(store.data.daemonSessionTurn.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ===== Thread 5: dropped ping + reconnect re-derives the pending turn via backfill =====
+
+describe("integration: reconnect backfill re-derives the unstarted (pending) turn from the turn table", () => {
+  it("returns the pending human_instruction turn (with its promptText) for the origin connection, not from notifications", async () => {
+    const INSTRUCTION = "Re-run after the dropped ping.";
+    // A human_instruction wake creates a pending turn (simulating a wake whose SSE ping
+    // was dropped — the turn was persisted at the chokepoint regardless).
+    await notificationService.create({
+      ...baseNotif,
+      action: "human_instruction",
+      message: "Instruction",
+      instructionText: INSTRUCTION,
+    });
+    expect(store.data.daemonSessionTurn).toHaveLength(1);
+    expect(store.data.daemonSessionTurn[0].status).toBe("pending");
+
+    // Reconnect: the daemon reads its origin-pinned pending turns from the TURN TABLE via
+    // the REAL backfill route. The instruction's free-text body is preserved on the turn.
+    const res = await pendingTurnsGET(getReq(`/api/daemon/pending-turns?connectionUuid=${ORIGIN_CONN}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.turns).toHaveLength(1);
+    const t = body.data.turns[0];
+    expect(t.trigger).toBe("human_instruction");
+    expect(t.promptText).toBe(INSTRUCTION); // instruction NOT lost
+    expect(t.sessionId).toBe(IDEA);
+    expect(t.directIdeaUuid).toBe(IDEA);
+
+    // Once the daemon advances it to running, it no longer surfaces in the pending read.
+    await turnAdvancePOST(
+      postReq("/api/daemon/turn-advance", { connectionUuid: ORIGIN_CONN, sessionId: IDEA, status: "running" }),
+    );
+    const res2 = await pendingTurnsGET(getReq(`/api/daemon/pending-turns?connectionUuid=${ORIGIN_CONN}`));
+    const body2 = await res2.json();
+    expect(body2.data.turns).toHaveLength(0);
+  });
+
+  it("scopes the pending-turn backfill to the origin connection's own sessions (404 for a connection the agent does not own)", async () => {
+    await notificationService.create({ ...baseNotif, action: "human_instruction", message: "x", instructionText: "y" });
+    // A connectionUuid that does not belong to this agent → 404 non-disclosure.
+    const res = await pendingTurnsGET(getReq(`/api/daemon/pending-turns?connectionUuid=conn-not-mine-9999`));
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -1,0 +1,1219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Prisma mock =====
+const mockPrisma = vi.hoisted(() => ({
+  daemonSession: {
+    upsert: vi.fn(),
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
+  daemonSessionTurn: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  daemonTranscriptMessage: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    count: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  daemonConnection: {
+    findFirst: vi.fn(),
+  },
+  daemonExecution: {
+    findFirst: vi.fn(),
+  },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({ default: mockLogger }));
+
+// Mock the EventBus so the unit test does not pull the real event-bus → redis →
+// logger.child() chain and can assert the publish emit shape directly.
+const mockEventBus = vi.hoisted(() => ({ emit: vi.fn() }));
+vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
+
+// Mock lineage.service so resolveDirectIdeaUuid's reuse is asserted in isolation
+// (no idea/task DB walk).
+const mockResolveRootIdea = vi.hoisted(() => vi.fn());
+vi.mock("@/services/lineage.service", () => ({
+  resolveRootIdea: mockResolveRootIdea,
+}));
+
+// Mock the connection registry module so importing STALE_THRESHOLD_MS does not pull
+// its (logger-using) body; the real value is asserted against the literal below.
+vi.mock("@/services/daemon-connection.service", () => ({
+  STALE_THRESHOLD_MS: 90_000,
+}));
+
+import {
+  TURN_TRIGGERS,
+  TURN_STATUSES,
+  SESSION_STATUSES,
+  TRANSCRIPT_ROLES,
+  MAX_TRANSCRIPT_MESSAGES_PER_SESSION,
+  STALE_THRESHOLD_MS,
+  resolveOrCreateSession,
+  resolveDirectIdeaUuid,
+  createPendingTurn,
+  advanceTurn,
+  getVisibleSessions,
+  getSessionTurns,
+  assertContinuable,
+  appendTranscriptMessages,
+  advanceTurnForWake,
+  getPendingTurnsForConnection,
+  SessionReadOnlyError,
+  transcriptEventName,
+} from "@/services/daemon-session.service";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const otherCompanyUuid = "company-0000-0000-0000-000000000002";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const ownerUuid = "owner-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+const sessionUuid = "sess-0000-0000-0000-000000000001";
+const sessionId = "idea-0000-0000-0000-000000000001"; // directIdeaUuid as session id
+const turnUuid = "turn-0000-0000-0000-000000000001";
+
+function sessionRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    uuid: sessionUuid,
+    agentUuid,
+    sessionId,
+    directIdeaUuid: sessionId,
+    originConnectionUuid: connectionUuid,
+    status: "active",
+    title: null,
+    lastTurnAt: new Date("2026-06-15T03:00:00.000Z"),
+    createdAt: new Date("2026-06-15T03:00:00.000Z"),
+    updatedAt: new Date("2026-06-15T03:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function turnRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    uuid: turnUuid,
+    sessionUuid,
+    seq: 1,
+    trigger: "task_assigned",
+    promptText: null,
+    status: "pending",
+    executionUuid: null,
+    startedAt: null,
+    endedAt: null,
+    createdAt: new Date("2026-06-15T03:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+let transcriptSeqCounter = 0;
+function transcriptMessageRow(overrides: Partial<Record<string, unknown>> = {}) {
+  transcriptSeqCounter += 1;
+  return {
+    uuid: `msg-${transcriptSeqCounter}`,
+    turnUuid,
+    role: "assistant",
+    text: "hello",
+    seq: transcriptSeqCounter,
+    createdAt: new Date("2026-06-15T03:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  mockPrisma.daemonSession.upsert.mockResolvedValue(sessionRow());
+  mockPrisma.daemonSession.findUnique.mockResolvedValue({ uuid: sessionUuid, companyUuid });
+  mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+  mockPrisma.daemonSession.findMany.mockResolvedValue([]);
+  mockPrisma.daemonSession.update.mockResolvedValue(sessionRow());
+  mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue(null);
+  mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue(null);
+  mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
+  mockPrisma.daemonSessionTurn.create.mockResolvedValue(turnRow());
+  mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow());
+  mockPrisma.daemonTranscriptMessage.findFirst.mockResolvedValue(null);
+  mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
+  mockPrisma.daemonTranscriptMessage.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) =>
+    transcriptMessageRow(data),
+  );
+  mockPrisma.daemonTranscriptMessage.count.mockResolvedValue(0);
+  mockPrisma.daemonTranscriptMessage.deleteMany.mockResolvedValue({ count: 0 });
+  mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+  transcriptSeqCounter = 0;
+  mockResolveRootIdea.mockResolvedValue({ rootIdeaUuid: null, directIdeaUuid: null, lineage: [], resolvedVia: "not_found" });
+});
+
+// ===== Constants =====
+describe("constants", () => {
+  it("TURN_TRIGGERS covers the five wake kinds", () => {
+    expect([...TURN_TRIGGERS].sort()).toEqual(
+      ["elaboration", "human_instruction", "mentioned", "resume", "task_assigned"].sort(),
+    );
+  });
+
+  it("TURN_STATUSES are the strict forward lifecycle pending/running/ended", () => {
+    expect([...TURN_STATUSES]).toEqual(["pending", "running", "ended"]);
+  });
+
+  it("SESSION_STATUSES are active/ended", () => {
+    expect([...SESSION_STATUSES]).toEqual(["active", "ended"]);
+  });
+
+  it("re-exports the registry's STALE_THRESHOLD_MS (no second constant)", () => {
+    expect(STALE_THRESHOLD_MS).toBe(90_000);
+  });
+
+  it("transcriptEventName keys per session", () => {
+    expect(transcriptEventName(sessionUuid)).toBe(`transcript:${sessionUuid}`);
+  });
+
+  it("TRANSCRIPT_ROLES are exactly user/assistant (no tool/thinking)", () => {
+    expect([...TRANSCRIPT_ROLES]).toEqual(["user", "assistant"]);
+  });
+
+  it("MAX_TRANSCRIPT_MESSAGES_PER_SESSION is a positive named constant", () => {
+    expect(typeof MAX_TRANSCRIPT_MESSAGES_PER_SESSION).toBe("number");
+    expect(MAX_TRANSCRIPT_MESSAGES_PER_SESSION).toBeGreaterThan(0);
+  });
+});
+
+// ===== resolveOrCreateSession =====
+describe("resolveOrCreateSession", () => {
+  it("upserts on (agentUuid, sessionId) — the stable conversation key", async () => {
+    await resolveOrCreateSession({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      directIdeaUuid: sessionId,
+      originConnectionUuid: connectionUuid,
+    });
+    const arg = mockPrisma.daemonSession.upsert.mock.calls[0][0];
+    expect(arg.where).toEqual({ agentUuid_sessionId: { agentUuid, sessionId } });
+  });
+
+  it("CREATE fixes originConnectionUuid + directIdeaUuid + companyUuid at creation", async () => {
+    await resolveOrCreateSession({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      directIdeaUuid: sessionId,
+      originConnectionUuid: connectionUuid,
+    });
+    const create = mockPrisma.daemonSession.upsert.mock.calls[0][0].create;
+    expect(create.originConnectionUuid).toBe(connectionUuid);
+    expect(create.directIdeaUuid).toBe(sessionId);
+    expect(create.companyUuid).toBe(companyUuid);
+    expect(create.status).toBe("active");
+  });
+
+  it("UPDATE re-affirms companyUuid but does NOT touch originConnectionUuid/directIdeaUuid (write-once)", async () => {
+    await resolveOrCreateSession({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      directIdeaUuid: "a-different-idea",
+      originConnectionUuid: "a-different-connection",
+    });
+    const update = mockPrisma.daemonSession.upsert.mock.calls[0][0].update;
+    expect(update.companyUuid).toBe(companyUuid);
+    // The origin connection + direct idea are write-once: never in the UPDATE branch,
+    // so a later wake cannot move the origin (continuation is cwd-bound).
+    expect(update).not.toHaveProperty("originConnectionUuid");
+    expect(update).not.toHaveProperty("directIdeaUuid");
+  });
+
+  it("REUSES the existing row on a second wake (upsert resolves to the same uuid)", async () => {
+    // upsert is the resolve-or-create primitive; the mock returns the existing row.
+    mockPrisma.daemonSession.upsert.mockResolvedValue(sessionRow({ uuid: sessionUuid }));
+    const first = await resolveOrCreateSession({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      directIdeaUuid: sessionId,
+      originConnectionUuid: connectionUuid,
+    });
+    const second = await resolveOrCreateSession({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      directIdeaUuid: sessionId,
+      originConnectionUuid: connectionUuid,
+    });
+    expect(first.uuid).toBe(second.uuid);
+    // Both calls key on the SAME (agentUuid, sessionId) — no second business key.
+    expect(mockPrisma.daemonSession.upsert.mock.calls[0][0].where).toEqual(
+      mockPrisma.daemonSession.upsert.mock.calls[1][0].where,
+    );
+  });
+
+  it("coerces a missing directIdeaUuid to null (ad-hoc session)", async () => {
+    await resolveOrCreateSession({
+      companyUuid,
+      agentUuid,
+      sessionId: "adhoc-uuid",
+      originConnectionUuid: connectionUuid,
+    });
+    expect(mockPrisma.daemonSession.upsert.mock.calls[0][0].create.directIdeaUuid).toBeNull();
+  });
+
+  it("projects ISO-8601 timestamps in the view", async () => {
+    const view = await resolveOrCreateSession({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      directIdeaUuid: sessionId,
+      originConnectionUuid: connectionUuid,
+    });
+    expect(view.lastTurnAt).toBe("2026-06-15T03:00:00.000Z");
+    expect(view.createdAt).toBe("2026-06-15T03:00:00.000Z");
+    expect(view.directIdeaUuid).toBe(sessionId);
+  });
+
+  it("PROPAGATES a write failure (does not swallow — session must exist before a turn)", async () => {
+    mockPrisma.daemonSession.upsert.mockRejectedValue(new Error("db down"));
+    await expect(
+      resolveOrCreateSession({ companyUuid, agentUuid, sessionId, originConnectionUuid: connectionUuid }),
+    ).rejects.toThrow("db down");
+  });
+});
+
+// ===== resolveDirectIdeaUuid (lineage reuse) =====
+describe("resolveDirectIdeaUuid", () => {
+  it("delegates to lineage.service.resolveRootIdea and returns its directIdeaUuid", async () => {
+    mockResolveRootIdea.mockResolvedValue({
+      rootIdeaUuid: "root-i",
+      directIdeaUuid: "direct-i",
+      lineage: [],
+      resolvedVia: "via_proposal",
+    });
+    const result = await resolveDirectIdeaUuid(companyUuid, "task", "task-1");
+    expect(mockResolveRootIdea).toHaveBeenCalledWith(companyUuid, "task", "task-1");
+    expect(result).toBe("direct-i");
+  });
+
+  it("returns null when the entity has no idea ancestor (a success, not an error)", async () => {
+    mockResolveRootIdea.mockResolvedValue({
+      rootIdeaUuid: null,
+      directIdeaUuid: null,
+      lineage: [],
+      resolvedVia: "no_proposal",
+    });
+    await expect(resolveDirectIdeaUuid(companyUuid, "task", "task-1")).resolves.toBeNull();
+  });
+
+  it("PROPAGATES a lineage query failure", async () => {
+    mockResolveRootIdea.mockRejectedValue(new Error("db down"));
+    await expect(resolveDirectIdeaUuid(companyUuid, "task", "task-1")).rejects.toThrow("db down");
+  });
+});
+
+// ===== createPendingTurn =====
+describe("createPendingTurn", () => {
+  it("assigns seq=1 for the first turn (no prior turns), status=pending", async () => {
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue(null);
+    mockPrisma.daemonSessionTurn.create.mockResolvedValue(turnRow({ seq: 1 }));
+    const view = await createPendingTurn({ sessionUuid, trigger: "task_assigned" });
+    const createArg = mockPrisma.daemonSessionTurn.create.mock.calls[0][0];
+    expect(createArg.data.seq).toBe(1);
+    expect(createArg.data.status).toBe("pending");
+    expect(createArg.data.trigger).toBe("task_assigned");
+    expect(view.seq).toBe(1);
+  });
+
+  it("assigns a MONOTONIC seq = max(existing) + 1", async () => {
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ seq: 7 });
+    mockPrisma.daemonSessionTurn.create.mockResolvedValue(turnRow({ seq: 8 }));
+    await createPendingTurn({ sessionUuid, trigger: "mentioned" });
+    expect(mockPrisma.daemonSessionTurn.create.mock.calls[0][0].data.seq).toBe(8);
+    // The max read orders by seq desc, take the first (highest).
+    expect(mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0].orderBy).toEqual({ seq: "desc" });
+  });
+
+  it("H2 REGRESSION: retries on a P2002 seq conflict (concurrent same-session create) instead of dropping the turn", async () => {
+    // Two concurrent creates race for the same seq; the loser hits the
+    // @@unique([sessionUuid, seq]) → P2002. createPendingTurn must re-read the max and
+    // retry (landing a distinct seq), NOT let the turn be silently dropped.
+    mockPrisma.daemonSessionTurn.findFirst
+      .mockResolvedValueOnce({ seq: 4 }) // attempt 1 reads max=4 → tries seq=5
+      .mockResolvedValueOnce({ seq: 5 }); // attempt 2 re-reads max=5 → tries seq=6
+    mockPrisma.daemonSessionTurn.create
+      .mockRejectedValueOnce(Object.assign(new Error("unique"), { code: "P2002" }))
+      .mockResolvedValueOnce(turnRow({ seq: 6 }));
+
+    const view = await createPendingTurn({ sessionUuid, trigger: "mentioned" });
+
+    expect(mockPrisma.daemonSessionTurn.create).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.daemonSessionTurn.create.mock.calls[0][0].data.seq).toBe(5);
+    expect(mockPrisma.daemonSessionTurn.create.mock.calls[1][0].data.seq).toBe(6);
+    expect(view.seq).toBe(6);
+  });
+
+  it("H2: a non-P2002 create error propagates immediately (no retry, no swallow)", async () => {
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ seq: 1 });
+    mockPrisma.daemonSessionTurn.create.mockRejectedValue(
+      Object.assign(new Error("db down"), { code: "P1001" }),
+    );
+    await expect(createPendingTurn({ sessionUuid, trigger: "mentioned" })).rejects.toThrow("db down");
+    expect(mockPrisma.daemonSessionTurn.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("records promptText for a human_instruction turn (canonical instruction text)", async () => {
+    mockPrisma.daemonSessionTurn.create.mockResolvedValue(
+      turnRow({ trigger: "human_instruction", promptText: "please refactor X" }),
+    );
+    const view = await createPendingTurn({
+      sessionUuid,
+      trigger: "human_instruction",
+      promptText: "please refactor X",
+    });
+    expect(mockPrisma.daemonSessionTurn.create.mock.calls[0][0].data.promptText).toBe("please refactor X");
+    expect(view.promptText).toBe("please refactor X");
+  });
+
+  it("nulls promptText for an autonomous trigger", async () => {
+    await createPendingTurn({ sessionUuid, trigger: "task_assigned" });
+    expect(mockPrisma.daemonSessionTurn.create.mock.calls[0][0].data.promptText).toBeNull();
+  });
+
+  it("bumps the session's lastTurnAt", async () => {
+    await createPendingTurn({ sessionUuid, trigger: "task_assigned" });
+    const updateArg = mockPrisma.daemonSession.update.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ uuid: sessionUuid });
+    expect(updateArg.data.lastTurnAt).toBeInstanceOf(Date);
+  });
+
+  it("PUBLISHES the turn_created SSE event on transcript:{sessionUuid}", async () => {
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ uuid: sessionUuid, companyUuid });
+    mockPrisma.daemonSessionTurn.create.mockResolvedValue(turnRow({ seq: 1 }));
+    await createPendingTurn({ sessionUuid, trigger: "task_assigned" });
+    expect(mockEventBus.emit).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = mockEventBus.emit.mock.calls[0];
+    expect(eventName).toBe(`transcript:${sessionUuid}`);
+    expect(eventName).toBe(transcriptEventName(sessionUuid));
+    expect(payload.trigger).toBe("turn_created");
+    expect(payload.companyUuid).toBe(companyUuid);
+    expect(payload.sessionUuid).toBe(sessionUuid);
+    expect(payload.turn.uuid).toBe(turnUuid);
+    expect(payload.turn.status).toBe("pending");
+  });
+
+  it("throws when the sessionUuid does not resolve (a turn cannot exist without its session)", async () => {
+    mockPrisma.daemonSession.findUnique.mockResolvedValue(null);
+    await expect(createPendingTurn({ sessionUuid, trigger: "task_assigned" })).rejects.toThrow(
+      /not found/,
+    );
+    // No turn written, no event emitted on the failure path.
+    expect(mockPrisma.daemonSessionTurn.create).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("PROPAGATES a turn write failure (no silent swallow — a lost turn loses a wake)", async () => {
+    mockPrisma.daemonSessionTurn.create.mockRejectedValue(new Error("db down"));
+    await expect(createPendingTurn({ sessionUuid, trigger: "task_assigned" })).rejects.toThrow("db down");
+  });
+});
+
+// ===== advanceTurn (strict pending → running → ended) =====
+describe("advanceTurn", () => {
+  it("pending → running: updates status, records startedAt + executionUuid, emits turn_status_changed", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "pending",
+    });
+    const startedAt = new Date("2026-06-15T04:00:00.000Z");
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ status: "running", startedAt, executionUuid: "exec-1" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    const res = await advanceTurn(turnUuid, "running", { startedAt, executionUuid: "exec-1" });
+    expect(res).toMatchObject({ ok: true });
+    const updateArg = mockPrisma.daemonSessionTurn.update.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ uuid: turnUuid });
+    expect(updateArg.data.status).toBe("running");
+    expect(updateArg.data.startedAt).toBe(startedAt);
+    expect(updateArg.data.executionUuid).toBe("exec-1");
+
+    expect(mockEventBus.emit).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = mockEventBus.emit.mock.calls[0];
+    expect(eventName).toBe(`transcript:${sessionUuid}`);
+    expect(payload.trigger).toBe("turn_status_changed");
+    expect(payload.companyUuid).toBe(companyUuid);
+    expect(payload.turn.status).toBe("running");
+  });
+
+  it("running → ended: updates status, records endedAt, emits turn_status_changed", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    const endedAt = new Date("2026-06-15T05:00:00.000Z");
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow({ status: "ended", endedAt }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    const res = await advanceTurn(turnUuid, "ended", { endedAt });
+    expect(res).toMatchObject({ ok: true });
+    expect(mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data.endedAt).toBe(endedAt);
+    expect(mockEventBus.emit.mock.calls[0][1].trigger).toBe("turn_status_changed");
+  });
+
+  it("REJECTS a skip (pending → ended) as invalid_transition and writes nothing", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "pending",
+    });
+    const res = await advanceTurn(turnUuid, "ended");
+    expect(res).toEqual({ ok: false, reason: "invalid_transition", from: "pending", to: "ended" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("REJECTS a backward move (running → pending) as invalid_transition", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    const res = await advanceTurn(turnUuid, "pending");
+    expect(res).toMatchObject({ ok: false, reason: "invalid_transition", from: "running", to: "pending" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("REJECTS re-applying the same status (running → running)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    const res = await advanceTurn(turnUuid, "running");
+    expect(res).toMatchObject({ ok: false, reason: "invalid_transition" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("REJECTS any transition out of the terminal ended state", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "ended",
+    });
+    const res = await advanceTurn(turnUuid, "running");
+    expect(res).toMatchObject({ ok: false, reason: "invalid_transition", from: "ended" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found when the turn does not exist (no update, no emit)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue(null);
+    const res = await advanceTurn(turnUuid, "running");
+    expect(res).toEqual({ ok: false, reason: "not_found" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("M2: THROWS (no tenant-less SSE) if the session is missing for a just-updated turn", async () => {
+    // The turn updates fine, but its session lookup returns null (torn write / corruption).
+    // advanceTurn must throw rather than emit an event with companyUuid: "" that a future
+    // 子3 SSE consumer's multi-tenancy fence could mishandle.
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "pending",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow({ status: "running" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue(null);
+
+    await expect(advanceTurn(turnUuid, "running")).rejects.toThrow(/session .* missing/);
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("leaves unspecified opt columns untouched (only status when no opts)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "pending",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow({ status: "running" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+    await advanceTurn(turnUuid, "running");
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data).toEqual({ status: "running" });
+    expect(data).not.toHaveProperty("startedAt");
+    expect(data).not.toHaveProperty("endedAt");
+    expect(data).not.toHaveProperty("executionUuid");
+  });
+
+  it("PROPAGATES a write failure on a legal transition", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "pending",
+    });
+    mockPrisma.daemonSessionTurn.update.mockRejectedValue(new Error("db down"));
+    await expect(advanceTurn(turnUuid, "running")).rejects.toThrow("db down");
+  });
+});
+
+// ===== getVisibleSessions (owner/self + companyUuid scoping) =====
+describe("getVisibleSessions", () => {
+  it("USER caller: owner-scoped via agent.ownerUuid, companyUuid-scoped, ordered lastTurnAt desc", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([sessionRow()]);
+    const result = await getVisibleSessions({ type: "user", companyUuid, actorUuid: ownerUuid });
+    expect(mockPrisma.daemonSession.findMany.mock.calls[0][0]).toEqual({
+      where: { companyUuid, agent: { ownerUuid } },
+      orderBy: { lastTurnAt: "desc" },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].uuid).toBe(sessionUuid);
+  });
+
+  it("super_admin caller is owner-scoped too (the agent relation, not the company at large)", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([]);
+    await getVisibleSessions({ type: "super_admin", companyUuid, actorUuid: ownerUuid });
+    const arg = mockPrisma.daemonSession.findMany.mock.calls[0][0];
+    expect(arg.where.agent).toEqual({ ownerUuid });
+    expect(arg.where.agentUuid).toBeUndefined();
+  });
+
+  it("AGENT-KEY caller: self-scoped via agentUuid (not the owner relation)", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([]);
+    await getVisibleSessions({ type: "agent", companyUuid, actorUuid: agentUuid });
+    expect(mockPrisma.daemonSession.findMany.mock.calls[0][0].where).toEqual({
+      companyUuid,
+      agentUuid,
+    });
+  });
+
+  it("the where clause always carries the caller's companyUuid (never crosses companies)", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([]);
+    await getVisibleSessions({ type: "user", companyUuid: otherCompanyUuid, actorUuid: ownerUuid });
+    expect(mockPrisma.daemonSession.findMany.mock.calls[0][0].where.companyUuid).toBe(otherCompanyUuid);
+  });
+
+  it("PROPAGATES a query error (read, does NOT swallow to [])", async () => {
+    mockPrisma.daemonSession.findMany.mockRejectedValue(new Error("db down"));
+    await expect(
+      getVisibleSessions({ type: "user", companyUuid, actorUuid: ownerUuid }),
+    ).rejects.toThrow("db down");
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});
+
+// ===== getSessionTurns (visibility fence + 404 non-disclosure) =====
+describe("getSessionTurns", () => {
+  it("USER caller: resolves the session under owner-scope, returns ordered turns", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t1", seq: 1 }),
+      turnRow({ uuid: "t2", seq: 2 }),
+    ]);
+    const result = await getSessionTurns({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid);
+    expect(mockPrisma.daemonSession.findFirst.mock.calls[0][0].where).toEqual({
+      uuid: sessionUuid,
+      companyUuid,
+      agent: { ownerUuid },
+    });
+    expect(mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0]).toEqual({
+      where: { sessionUuid },
+      orderBy: { seq: "asc" },
+    });
+    expect(result?.map((t) => t.uuid)).toEqual(["t1", "t2"]);
+  });
+
+  it("AGENT-KEY caller: resolves the session under self-scope (agentUuid)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    await getSessionTurns({ type: "agent", companyUuid, actorUuid: agentUuid }, sessionUuid);
+    expect(mockPrisma.daemonSession.findFirst.mock.calls[0][0].where).toEqual({
+      uuid: sessionUuid,
+      companyUuid,
+      agentUuid,
+    });
+  });
+
+  it("returns null (404 non-disclosure) when the session is NOT visible to the caller", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+    const result = await getSessionTurns({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid);
+    expect(result).toBeNull();
+    // It must NOT then query turns for a session the caller cannot see.
+    expect(mockPrisma.daemonSessionTurn.findMany).not.toHaveBeenCalled();
+  });
+
+  it("cross-company: a session in another company is not visible (companyUuid in the fence)", async () => {
+    // The fence query carries the caller's company; the session row resolves to null.
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+    const result = await getSessionTurns(
+      { type: "user", companyUuid: otherCompanyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+    );
+    expect(mockPrisma.daemonSession.findFirst.mock.calls[0][0].where.companyUuid).toBe(otherCompanyUuid);
+    expect(result).toBeNull();
+  });
+
+  it("a visible session with zero turns returns an empty array (not null)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
+    const result = await getSessionTurns({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid);
+    expect(result).toEqual([]);
+  });
+
+  it("PROPAGATES a query error (read, does not swallow)", async () => {
+    mockPrisma.daemonSession.findFirst.mockRejectedValue(new Error("db down"));
+    await expect(
+      getSessionTurns({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid),
+    ).rejects.toThrow("db down");
+  });
+});
+
+// ===== assertContinuable (origin-connection pinning) =====
+describe("assertContinuable", () => {
+  it("returns the originConnectionUuid when the origin is effectively ONLINE", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({ status: "online", lastSeenAt: new Date() });
+    const origin = await assertContinuable(companyUuid, sessionUuid);
+    expect(origin).toBe(connectionUuid);
+    // It resolves the SESSION's origin connection — scoped by companyUuid.
+    expect(mockPrisma.daemonSession.findFirst.mock.calls[0][0].where).toEqual({
+      uuid: sessionUuid,
+      companyUuid,
+    });
+    // And checks exactly that connection (the origin) — never any other.
+    expect(mockPrisma.daemonConnection.findFirst.mock.calls[0][0].where).toEqual({
+      uuid: connectionUuid,
+      companyUuid,
+    });
+  });
+
+  it("REFUSES (SessionReadOnlyError) when the origin connection is OFFLINE — never re-routes", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({ status: "offline", lastSeenAt: new Date() });
+    await expect(assertContinuable(companyUuid, sessionUuid)).rejects.toBeInstanceOf(SessionReadOnlyError);
+    // Only the origin connection was ever looked up — no fallback connection query.
+    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.daemonConnection.findFirst.mock.calls[0][0].where.uuid).toBe(connectionUuid);
+  });
+
+  it("REFUSES when the origin's lastSeenAt is STALE (older than STALE_THRESHOLD_MS) even if status=online", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+      status: "online",
+      lastSeenAt: new Date(Date.now() - (STALE_THRESHOLD_MS + 1_000)),
+    });
+    await expect(assertContinuable(companyUuid, sessionUuid)).rejects.toBeInstanceOf(SessionReadOnlyError);
+  });
+
+  it("REFUSES when the origin connection no longer exists (deleted/foreign cannot be online)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    await expect(assertContinuable(companyUuid, sessionUuid)).rejects.toBeInstanceOf(SessionReadOnlyError);
+  });
+
+  it("the SessionReadOnlyError carries the offending originConnectionUuid + a stable code", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({ status: "offline", lastSeenAt: new Date() });
+    await assertContinuable(companyUuid, sessionUuid).catch((err) => {
+      expect(err).toBeInstanceOf(SessionReadOnlyError);
+      expect(err.code).toBe("session_read_only");
+      expect(err.originConnectionUuid).toBe(connectionUuid);
+    });
+    expect.assertions(3);
+  });
+
+  it("throws a plain not-found error when the session does not resolve in-company", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+    await expect(assertContinuable(companyUuid, sessionUuid)).rejects.toThrow(/not found/);
+    // It must not even attempt to resolve a connection for a non-existent session.
+    expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("treats lastSeenAt exactly at the threshold as still fresh → ONLINE (inclusive boundary)", async () => {
+    // Freeze the clock so the elapsed is EXACTLY the threshold inside the service
+    // (Date.now() at fixture-build and inside assertContinuable would otherwise drift
+    // a few ms, tipping just past the boundary).
+    const fixedNow = new Date("2026-06-15T12:00:00.000Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+      status: "online",
+      lastSeenAt: new Date(fixedNow - STALE_THRESHOLD_MS),
+    });
+    await expect(assertContinuable(companyUuid, sessionUuid)).resolves.toBe(connectionUuid);
+    vi.useRealTimers();
+  });
+});
+
+// ===== appendTranscriptMessages =====
+describe("appendTranscriptMessages", () => {
+  // Default happy path: the turnUuid resolves to an owned turn, no prior messages.
+  function ownedTurn() {
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: turnUuid, sessionUuid });
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue(turnRow({ status: "running" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ uuid: sessionUuid, companyUuid });
+  }
+
+  it("resolves the turn under the OWNER scope (turn's session must match agent+company)", async () => {
+    ownedTurn();
+    await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [{ role: "user", text: "hi" }],
+    });
+    const where = mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0].where;
+    expect(where.uuid).toBe(turnUuid);
+    // Ownership is enforced through the session relation, not a separate query.
+    expect(where.session).toEqual({ agentUuid, companyUuid });
+  });
+
+  it("returns not_found (404 non-disclosure) when the turn is not owned / does not exist", async () => {
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue(null);
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [{ role: "user", text: "hi" }],
+    });
+    expect(result).toEqual({ ok: false, reason: "not_found" });
+    // Negative path stores nothing and emits nothing.
+    expect(mockPrisma.daemonTranscriptMessage.create).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("sessionId path resolves the agent's session then its RUNNING turn (not most-recent seq)", async () => {
+    // The session is resolved by (agentUuid, companyUuid, sessionId), then the RUNNING
+    // turn is targeted — so a running turn's output never mis-attaches to a newer
+    // `pending` turn created mid-run (H1's transcript variant).
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: turnUuid, sessionUuid });
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue(turnRow({ status: "running" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ uuid: sessionUuid, companyUuid });
+
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      messages: [{ role: "assistant", text: "ok" }],
+    });
+    expect(result.ok).toBe(true);
+    const sessionWhere = mockPrisma.daemonSession.findFirst.mock.calls[0][0].where;
+    expect(sessionWhere).toEqual({ agentUuid, companyUuid, sessionId });
+    // Running turn, oldest-first (status: running). NOT seq desc.
+    const turnQuery = mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0];
+    expect(turnQuery.where).toEqual({ sessionUuid, status: "running" });
+    expect(turnQuery.orderBy).toEqual({ seq: "asc" });
+  });
+
+  it("sessionId path FALLS BACK to most-recent turn when none is running (late flush)", async () => {
+    // No running turn (e.g. a trailing flush just after the turn ended) → fall back to
+    // the highest-seq turn so trailing lines still land on the turn they belong to.
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    // First findFirst (status: running) → null; second (fallback, seq desc) → the turn.
+    mockPrisma.daemonSessionTurn.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ uuid: turnUuid, sessionUuid });
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue(turnRow({ status: "ended" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ uuid: sessionUuid, companyUuid });
+
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      messages: [{ role: "assistant", text: "trailing" }],
+    });
+    expect(result.ok).toBe(true);
+    const runningQuery = mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0];
+    expect(runningQuery.where).toEqual({ sessionUuid, status: "running" });
+    const fallbackQuery = mockPrisma.daemonSessionTurn.findFirst.mock.calls[1][0];
+    expect(fallbackQuery.where).toEqual({ sessionUuid });
+    expect(fallbackQuery.orderBy).toEqual({ seq: "desc" });
+  });
+
+  it("sessionId path → not_found when the session has no turn yet", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue(null);
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      messages: [{ role: "user", text: "hi" }],
+    });
+    expect(result).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  it("sessionId path → not_found when the session is not owned / does not exist", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      sessionId,
+      messages: [{ role: "user", text: "hi" }],
+    });
+    expect(result).toEqual({ ok: false, reason: "not_found" });
+    // Must NOT try to resolve a turn for a non-resolving session.
+    expect(mockPrisma.daemonSessionTurn.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("appends ONLY user/assistant text — drops tool-call/tool-result/thinking and blanks", async () => {
+    ownedTurn();
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [
+        { role: "user", text: "real user text" },
+        // The following are NOT user/assistant text — must be filtered out:
+        { role: "tool_use", text: "rm -rf" } as unknown as { role: "user"; text: string },
+        { role: "tool_result", text: "exit 0" } as unknown as { role: "assistant"; text: string },
+        { role: "thinking", text: "hmm" } as unknown as { role: "assistant"; text: string },
+        { role: "assistant", text: "real assistant text" },
+        { role: "user", text: "   " }, // blank text → dropped
+      ],
+    });
+    expect(result.ok && result.appended).toBe(2);
+    // Exactly two creates — the two text messages.
+    expect(mockPrisma.daemonTranscriptMessage.create).toHaveBeenCalledTimes(2);
+    const texts = mockPrisma.daemonTranscriptMessage.create.mock.calls.map((c) => c[0].data.text);
+    expect(texts).toEqual(["real user text", "real assistant text"]);
+    const roles = mockPrisma.daemonTranscriptMessage.create.mock.calls.map((c) => c[0].data.role);
+    expect(roles).toEqual(["user", "assistant"]);
+  });
+
+  it("assigns a monotonic per-turn seq continuing from the existing max", async () => {
+    ownedTurn();
+    // The turn already has messages up to seq 7.
+    mockPrisma.daemonTranscriptMessage.findFirst.mockResolvedValue({ seq: 7 });
+    await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [
+        { role: "user", text: "a" },
+        { role: "assistant", text: "b" },
+      ],
+    });
+    const seqs = mockPrisma.daemonTranscriptMessage.create.mock.calls.map((c) => c[0].data.seq);
+    expect(seqs).toEqual([8, 9]);
+    // seq lookup ordered seq desc to read the current max off the index.
+    expect(mockPrisma.daemonTranscriptMessage.findFirst.mock.calls[0][0].orderBy).toEqual({
+      seq: "desc",
+    });
+  });
+
+  it("an all-filtered upload is a no-op success: appends 0, no create, no emit", async () => {
+    ownedTurn();
+    mockPrisma.daemonTranscriptMessage.count.mockResolvedValue(3);
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [{ role: "tool_use", text: "x" } as unknown as { role: "user"; text: string }],
+    });
+    expect(result).toEqual({ ok: true, appended: 0, stored: 3, messages: [] });
+    expect(mockPrisma.daemonTranscriptMessage.create).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("ROLLING WINDOW: trims oldest overflow back to the cap, in application code", async () => {
+    ownedTurn();
+    // After inserting, the session count exceeds the cap by 3.
+    const over = MAX_TRANSCRIPT_MESSAGES_PER_SESSION + 3;
+    // count() is called inside trim (first) and again for the returned `stored`.
+    mockPrisma.daemonTranscriptMessage.count
+      .mockResolvedValueOnce(over) // inside trimSessionTranscript
+      .mockResolvedValueOnce(MAX_TRANSCRIPT_MESSAGES_PER_SESSION); // final stored count
+    // The 3 oldest messages the trim deletes.
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      { uuid: "old-1" },
+      { uuid: "old-2" },
+      { uuid: "old-3" },
+    ]);
+
+    const result = await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [{ role: "user", text: "newest" }],
+    });
+
+    expect(result.ok).toBe(true);
+    // Oldest-first selection, limited to the overflow count, across the session's turns.
+    const findManyArg = mockPrisma.daemonTranscriptMessage.findMany.mock.calls[0][0];
+    expect(findManyArg.where).toEqual({ turn: { sessionUuid } });
+    // Tiebreak on the globally-monotonic `id`, not per-turn `seq` (deterministic
+    // oldest-first across turns that share a createdAt millisecond).
+    expect(findManyArg.orderBy).toEqual([{ createdAt: "asc" }, { id: "asc" }]);
+    expect(findManyArg.take).toBe(3);
+    // Deletes exactly the overflow uuids — no migration, plain deleteMany.
+    expect(mockPrisma.daemonTranscriptMessage.deleteMany).toHaveBeenCalledWith({
+      where: { uuid: { in: ["old-1", "old-2", "old-3"] } },
+    });
+  });
+
+  it("ROLLING WINDOW: no trim when the session is within the cap", async () => {
+    ownedTurn();
+    mockPrisma.daemonTranscriptMessage.count.mockResolvedValue(
+      MAX_TRANSCRIPT_MESSAGES_PER_SESSION - 1,
+    );
+    await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [{ role: "user", text: "still under" }],
+    });
+    expect(mockPrisma.daemonTranscriptMessage.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonTranscriptMessage.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("SSE: publishes the transcript_appended trigger on the shared transcript:{sessionUuid} channel", async () => {
+    ownedTurn();
+    mockPrisma.daemonTranscriptMessage.count.mockResolvedValue(1);
+    await appendTranscriptMessages({
+      companyUuid,
+      agentUuid,
+      turnUuid,
+      messages: [{ role: "assistant", text: "live update" }],
+    });
+    expect(mockEventBus.emit).toHaveBeenCalledTimes(1);
+    const [channel, event] = mockEventBus.emit.mock.calls[0];
+    // SAME channel helper the turn-create/turn-status triggers use — one channel per
+    // conversation, additive to the existing event types.
+    expect(channel).toBe(transcriptEventName(sessionUuid));
+    expect(event.trigger).toBe("transcript_appended");
+    expect(event.sessionUuid).toBe(sessionUuid);
+    expect(event.companyUuid).toBe(companyUuid);
+    expect(event.turn.uuid).toBe(turnUuid);
+  });
+
+  it("does NOT swallow a write failure (a lost transcript append loses history)", async () => {
+    ownedTurn();
+    mockPrisma.daemonTranscriptMessage.create.mockRejectedValue(new Error("db down"));
+    await expect(
+      appendTranscriptMessages({
+        companyUuid,
+        agentUuid,
+        turnUuid,
+        messages: [{ role: "user", text: "hi" }],
+      }),
+    ).rejects.toThrow(/db down/);
+  });
+});
+
+// ===== advanceTurnForWake (daemon → server, by session business key) =====
+describe("advanceTurnForWake", () => {
+  // Resolve the agent's own session, then the turn matching the FROM-status (pending for
+  // →running, running for →ended), so advanceTurn (which findUnique's the turn) succeeds.
+  function ownedSessionWithLatestTurn(turnStatus = "pending") {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    // findFirst resolves the turn by status (oldest-first) — return the matching turn.
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: turnUuid });
+    // advanceTurn's own lookups:
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: turnStatus,
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      seq: 3,
+      trigger: "human_instruction",
+      promptText: "do X",
+      status: turnStatus === "pending" ? "running" : "ended",
+      executionUuid: "exec-1",
+      startedAt: new Date("2026-06-19T06:00:00.000Z"),
+      endedAt: null,
+      createdAt: new Date("2026-06-19T05:59:00.000Z"),
+    });
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+  }
+
+  it("resolves the agent's own session + latest turn and advances pending→running, stamping executionUuid from the (connection,entity) execution row", async () => {
+    ownedSessionWithLatestTurn("pending");
+    mockPrisma.daemonExecution.findFirst.mockResolvedValue({ uuid: "exec-1" });
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+
+    expect(res).toMatchObject({ ok: true });
+    // Session resolved under the agent + company + business-key fence.
+    expect(mockPrisma.daemonSession.findFirst).toHaveBeenCalledWith({
+      where: { agentUuid, companyUuid, sessionId },
+      select: { uuid: true },
+    });
+    // Execution row resolved for the weak link.
+    expect(mockPrisma.daemonExecution.findFirst).toHaveBeenCalledWith({
+      where: { companyUuid, connectionUuid, entityType: "task", entityUuid: "task-9" },
+      select: { uuid: true },
+    });
+    // advanceTurn wrote running + a startedAt + the resolved executionUuid.
+    const updateArg = mockPrisma.daemonSessionTurn.update.mock.calls[0][0];
+    expect(updateArg.data.status).toBe("running");
+    expect(updateArg.data.executionUuid).toBe("exec-1");
+    expect(updateArg.data.startedAt).toBeInstanceOf(Date);
+  });
+
+  it("H1 REGRESSION: resolves the turn by STATUS (→running picks oldest pending; →ended picks running), not by most-recent seq", async () => {
+    // → running must target the OLDEST still-pending turn (FIFO), not the highest seq —
+    // otherwise a newer pending turn created mid-run would be mis-targeted and the real
+    // running turn would never reach `ended` (stuck-running bug).
+    ownedSessionWithLatestTurn("pending");
+    await advanceTurnForWake({ companyUuid, agentUuid, connectionUuid, sessionId, status: "running" });
+    const runningResolve = mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0];
+    expect(runningResolve.where).toEqual({ sessionUuid, status: "pending" });
+    expect(runningResolve.orderBy).toEqual({ seq: "asc" });
+
+    vi.clearAllMocks();
+
+    // → ended must target the RUNNING turn (the one whose subprocess just exited).
+    ownedSessionWithLatestTurn("running");
+    await advanceTurnForWake({ companyUuid, agentUuid, connectionUuid, sessionId, status: "ended" });
+    const endedResolve = mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0];
+    expect(endedResolve.where).toEqual({ sessionUuid, status: "running" });
+    expect(endedResolve.orderBy).toEqual({ seq: "asc" });
+  });
+
+  it("running→ended defaults endedAt and does NOT resolve an execution row when no entity is given", async () => {
+    ownedSessionWithLatestTurn("running");
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "ended",
+      // no entityType/entityUuid
+    });
+
+    expect(res).toMatchObject({ ok: true });
+    expect(mockPrisma.daemonExecution.findFirst).not.toHaveBeenCalled();
+    const updateArg = mockPrisma.daemonSessionTurn.update.mock.calls[0][0];
+    expect(updateArg.data.status).toBe("ended");
+    expect(updateArg.data.endedAt).toBeInstanceOf(Date);
+    // executionUuid is left untouched (undefined) when no entity is supplied.
+    expect(updateArg.data).not.toHaveProperty("executionUuid");
+  });
+
+  it("returns not_found when the agent has no such session (non-disclosure)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "running",
+    });
+    expect(res).toEqual({ ok: false, reason: "not_found" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found when the session has no turn yet", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue(null);
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "running",
+    });
+    expect(res).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  it("surfaces an illegal transition from advanceTurn as invalid_transition (does not silently succeed)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: turnUuid });
+    // Turn is already ended → pending→ended skip / re-apply is rejected by advanceTurn.
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "ended",
+    });
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "running",
+    });
+    expect(res).toMatchObject({ ok: false, reason: "invalid_transition", from: "ended", to: "running" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+});
+
+// ===== getPendingTurnsForConnection (backfill read of unstarted turns) =====
+describe("getPendingTurnsForConnection", () => {
+  it("lists pending turns of the connection's origin-pinned, agent-owned sessions, mapped to the backfill view", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      {
+        uuid: "t1",
+        sessionUuid: "s1",
+        seq: 4,
+        trigger: "human_instruction",
+        promptText: "do X",
+        session: { sessionId: "idea-1", directIdeaUuid: "idea-1" },
+      },
+      {
+        uuid: "t2",
+        sessionUuid: "s2",
+        seq: 1,
+        trigger: "human_instruction",
+        promptText: "do Y",
+        session: { sessionId: "adhoc-2", directIdeaUuid: null },
+      },
+    ]);
+
+    const turns = await getPendingTurnsForConnection({ companyUuid, agentUuid, connectionUuid });
+
+    // The query fences status=pending AND session owner-scope AND origin pinning.
+    const whereArg = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0].where;
+    expect(whereArg.status).toBe("pending");
+    expect(whereArg.session).toEqual({
+      companyUuid,
+      agentUuid,
+      originConnectionUuid: connectionUuid,
+    });
+
+    expect(turns).toEqual([
+      { turnUuid: "t1", sessionUuid: "s1", sessionId: "idea-1", directIdeaUuid: "idea-1", seq: 4, trigger: "human_instruction", promptText: "do X" },
+      { turnUuid: "t2", sessionUuid: "s2", sessionId: "adhoc-2", directIdeaUuid: null, seq: 1, trigger: "human_instruction", promptText: "do Y" },
+    ]);
+  });
+
+  it("returns an empty list (not an error) when there are no pending turns", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
+    const turns = await getPendingTurnsForConnection({ companyUuid, agentUuid, connectionUuid });
+    expect(turns).toEqual([]);
+  });
+
+  it("does NOT swallow a query failure (a missed pending turn loses an instruction)", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockRejectedValue(new Error("db down"));
+    await expect(
+      getPendingTurnsForConnection({ companyUuid, agentUuid, connectionUuid }),
+    ).rejects.toThrow(/db down/);
+  });
+});

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Mocks =====
+// The bridge composes three services + the logger. Mock them all so this is a true
+// unit test of the mapping / resolution / failure-isolation logic, with no DB.
+
+const mockListConnectionsForAgent = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-connection.service", () => ({
+  listConnectionsForAgent: mockListConnectionsForAgent,
+}));
+
+const mockResolveOrCreateSession = vi.hoisted(() => vi.fn());
+const mockCreatePendingTurn = vi.hoisted(() => vi.fn());
+const mockResolveDirectIdeaUuid = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-session.service", () => ({
+  resolveOrCreateSession: mockResolveOrCreateSession,
+  createPendingTurn: mockCreatePendingTurn,
+  resolveDirectIdeaUuid: mockResolveDirectIdeaUuid,
+}));
+
+// Capture logger.error so we can assert the VISIBLE-failure (no silent swallow) rule.
+// The child logger object is built at hoist time so the module-level
+// `logger.child(...)` call (evaluated at import) returns a stable spy-bearing object.
+const mockChildLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+const mockLoggerError = mockChildLogger.error;
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({
+  default: { ...mockLogger, child: () => mockChildLogger },
+}));
+
+import {
+  maybeCreateTurnForWakeNotification,
+  triggerForAction,
+  NOTIFICATION_ACTION_TO_TURN_TRIGGER,
+  type WakeNotificationContext,
+} from "@/services/notification-turn";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+const ideaUuid = "idea-0000-0000-0000-000000000001";
+const taskUuid = "task-0000-0000-0000-000000000001";
+const sessionUuid = "session-0000-0000-0000-000000000001";
+
+function onlineConn(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: connectionUuid,
+    agentUuid,
+    agentName: "Daemon Agent",
+    clientType: "claude_code",
+    clientVersion: null,
+    host: "host-1",
+    startedAt: null,
+    status: "online",
+    effectiveStatus: "online" as const,
+    connectedAt: "2026-06-19T00:00:00.000Z",
+    lastSeenAt: "2026-06-19T00:00:00.000Z",
+    disconnectedAt: null,
+    ...overrides,
+  };
+}
+
+function offlineConn(overrides: Record<string, unknown> = {}) {
+  return onlineConn({ status: "offline", effectiveStatus: "offline", ...overrides });
+}
+
+function sessionView(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: sessionUuid,
+    agentUuid,
+    sessionId: ideaUuid,
+    directIdeaUuid: ideaUuid,
+    originConnectionUuid: connectionUuid,
+    status: "active",
+    title: null,
+    lastTurnAt: "2026-06-19T00:00:00.000Z",
+    createdAt: "2026-06-19T00:00:00.000Z",
+    updatedAt: "2026-06-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function turnView(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: "turn-0000-0000-0000-000000000001",
+    sessionUuid,
+    seq: 1,
+    trigger: "task_assigned",
+    promptText: null,
+    status: "pending",
+    executionUuid: null,
+    startedAt: null,
+    endedAt: null,
+    createdAt: "2026-06-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function ctx(overrides: Partial<WakeNotificationContext> = {}): WakeNotificationContext {
+  return {
+    companyUuid,
+    recipientType: "agent",
+    recipientUuid: agentUuid,
+    entityType: "task",
+    entityUuid: taskUuid,
+    action: "task_assigned",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default happy path: one online connection, lineage resolves to an idea, session
+  // resolves, turn created.
+  mockListConnectionsForAgent.mockResolvedValue([onlineConn()]);
+  mockResolveDirectIdeaUuid.mockResolvedValue(ideaUuid);
+  mockResolveOrCreateSession.mockResolvedValue(sessionView());
+  mockCreatePendingTurn.mockImplementation(async (p: { trigger: string; promptText?: string | null }) =>
+    turnView({ trigger: p.trigger, promptText: p.promptText ?? null }),
+  );
+});
+
+// ===== Action → trigger mapping =====
+describe("triggerForAction / NOTIFICATION_ACTION_TO_TURN_TRIGGER", () => {
+  it("maps @mention to the mentioned trigger", () => {
+    expect(triggerForAction("mentioned")).toBe("mentioned");
+  });
+
+  it("maps elaboration request and answer to the elaboration trigger", () => {
+    expect(triggerForAction("elaboration_requested")).toBe("elaboration");
+    expect(triggerForAction("elaboration_answered")).toBe("elaboration");
+  });
+
+  it("maps the human-typed instruction to the human_instruction trigger", () => {
+    expect(triggerForAction("human_instruction")).toBe("human_instruction");
+  });
+
+  it("maps every autonomous task-style dispatch to the task_assigned trigger", () => {
+    for (const action of [
+      "task_assigned",
+      "task_reopened",
+      "task_verified",
+      "idea_claimed",
+      "proposal_approved",
+      "proposal_rejected",
+    ]) {
+      expect(triggerForAction(action)).toBe("task_assigned");
+    }
+  });
+
+  it("returns null for non-wake-triggering notification actions", () => {
+    for (const action of [
+      "task_status_changed",
+      "task_submitted_for_verify",
+      "comment_added",
+      "report_created",
+      "count_update",
+      "agent_checkin",
+    ]) {
+      expect(triggerForAction(action)).toBeNull();
+    }
+  });
+
+  it("does NOT include resource_resumed (synthetic control-channel dispatch, never a persisted notification)", () => {
+    expect(NOTIFICATION_ACTION_TO_TURN_TRIGGER).not.toHaveProperty("resource_resumed");
+    expect(triggerForAction("resource_resumed")).toBeNull();
+  });
+
+  it("every mapped trigger value is a member of the 5-value turn-trigger taxonomy", () => {
+    const allowed = new Set([
+      "task_assigned",
+      "mentioned",
+      "elaboration",
+      "resume",
+      "human_instruction",
+    ]);
+    for (const trigger of Object.values(NOTIFICATION_ACTION_TO_TURN_TRIGGER)) {
+      expect(allowed.has(trigger)).toBe(true);
+    }
+  });
+});
+
+// ===== maybeCreateTurnForWakeNotification — happy paths per wake kind =====
+describe("maybeCreateTurnForWakeNotification — creates exactly one pending turn per wake kind", () => {
+  const cases: { action: string; trigger: string }[] = [
+    { action: "task_assigned", trigger: "task_assigned" },
+    { action: "mentioned", trigger: "mentioned" },
+    { action: "elaboration_requested", trigger: "elaboration" },
+    { action: "elaboration_answered", trigger: "elaboration" },
+    { action: "task_reopened", trigger: "task_assigned" },
+    { action: "task_verified", trigger: "task_assigned" },
+    { action: "idea_claimed", trigger: "task_assigned" },
+    { action: "proposal_approved", trigger: "task_assigned" },
+    { action: "proposal_rejected", trigger: "task_assigned" },
+  ];
+
+  for (const { action, trigger } of cases) {
+    it(`action "${action}" → one pending turn with trigger "${trigger}"`, async () => {
+      const result = await maybeCreateTurnForWakeNotification(ctx({ action }));
+
+      expect(mockCreatePendingTurn).toHaveBeenCalledTimes(1);
+      expect(mockCreatePendingTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionUuid, trigger }),
+      );
+      expect(result?.trigger).toBe(trigger);
+      expect(result?.status).toBe("pending");
+    });
+  }
+
+  it("resolves the session keyed on the entity's direct idea (lineage) and pins the online origin connection", async () => {
+    await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(mockResolveDirectIdeaUuid).toHaveBeenCalledWith(companyUuid, "task", taskUuid);
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyUuid,
+        agentUuid,
+        sessionId: ideaUuid,
+        directIdeaUuid: ideaUuid,
+        originConnectionUuid: connectionUuid,
+      }),
+    );
+  });
+
+  it("falls back to the entity uuid as sessionId (ad-hoc) when lineage finds no idea", async () => {
+    mockResolveDirectIdeaUuid.mockResolvedValue(null);
+
+    await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: taskUuid, directIdeaUuid: null }),
+    );
+  });
+
+  it("does NOT walk lineage for a non-lineage entityType (e.g. comment); uses the entity uuid as sessionId", async () => {
+    await maybeCreateTurnForWakeNotification(
+      ctx({ action: "mentioned", entityType: "comment", entityUuid: "comment-1" }),
+    );
+
+    expect(mockResolveDirectIdeaUuid).not.toHaveBeenCalled();
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "comment-1", directIdeaUuid: null }),
+    );
+  });
+
+  it("picks the first online connection when several connections exist (origin-pinned)", async () => {
+    const fresh = "conn-fresh";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: fresh }),
+      onlineConn({ uuid: "conn-older" }),
+      offlineConn({ uuid: "conn-offline" }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: fresh }),
+    );
+  });
+});
+
+// ===== human_instruction — promptText denormalization =====
+describe("maybeCreateTurnForWakeNotification — human_instruction promptText", () => {
+  it("sets the turn's promptText to the notification's instructionText (canonical lives on the turn)", async () => {
+    await maybeCreateTurnForWakeNotification(
+      ctx({ action: "human_instruction", instructionText: "Please update the README" }),
+    );
+
+    expect(mockCreatePendingTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "human_instruction",
+        promptText: "Please update the README",
+      }),
+    );
+  });
+
+  it("leaves promptText null for autonomous (non-human_instruction) triggers even if instructionText is somehow present", async () => {
+    await maybeCreateTurnForWakeNotification(
+      ctx({ action: "task_assigned", instructionText: "ignored for autonomous wakes" }),
+    );
+
+    expect(mockCreatePendingTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: "task_assigned", promptText: null }),
+    );
+  });
+
+  it("tolerates a missing instructionText on a human_instruction (promptText null)", async () => {
+    await maybeCreateTurnForWakeNotification(ctx({ action: "human_instruction" }));
+
+    expect(mockCreatePendingTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: "human_instruction", promptText: null }),
+    );
+  });
+});
+
+// ===== Skip conditions (no turn, no error) =====
+describe("maybeCreateTurnForWakeNotification — skips without creating a turn", () => {
+  it("skips a human recipient (only agents can be daemons)", async () => {
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ recipientType: "user", recipientUuid: "user-1", action: "task_assigned" }),
+    );
+
+    expect(result).toBeNull();
+    expect(mockListConnectionsForAgent).not.toHaveBeenCalled();
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+  });
+
+  it("skips a non-wake-triggering action before touching any service", async () => {
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ action: "comment_added" }),
+    );
+
+    expect(result).toBeNull();
+    expect(mockListConnectionsForAgent).not.toHaveBeenCalled();
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+  });
+
+  it("skips when the agent has no online connection (no daemon to wake)", async () => {
+    mockListConnectionsForAgent.mockResolvedValue([offlineConn()]);
+
+    const result = await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(result).toBeNull();
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+    // A skip is NOT an error — nothing logged.
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("skips when the agent has no connections at all", async () => {
+    mockListConnectionsForAgent.mockResolvedValue([]);
+
+    const result = await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(result).toBeNull();
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+  });
+});
+
+// ===== Failure isolation (no silent errors; never aborts the notification) =====
+describe("maybeCreateTurnForWakeNotification — failure isolation", () => {
+  it("logs visibly and returns null (does not throw) when connection resolution throws", async () => {
+    mockListConnectionsForAgent.mockRejectedValue(new Error("db down"));
+
+    const result = await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(result).toBeNull();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), action: "task_assigned", agentUuid }),
+      expect.stringContaining("Failed to create DaemonSessionTurn"),
+    );
+  });
+
+  it("logs visibly and returns null when lineage resolution throws", async () => {
+    mockResolveDirectIdeaUuid.mockRejectedValue(new Error("lineage walk failed"));
+
+    const result = await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(result).toBeNull();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs visibly and returns null when session resolution throws", async () => {
+    mockResolveOrCreateSession.mockRejectedValue(new Error("upsert conflict"));
+
+    const result = await maybeCreateTurnForWakeNotification(ctx({ action: "mentioned" }));
+
+    expect(result).toBeNull();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs visibly and returns null when turn creation itself throws (the failure being isolated)", async () => {
+    mockCreatePendingTurn.mockRejectedValue(new Error("turn create failed"));
+
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ action: "human_instruction", instructionText: "do it" }),
+    );
+
+    expect(result).toBeNull();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    // The thrown error never escapes — the caller (notification chokepoint) is unaffected.
+  });
+
+  it("does not log on a successful turn creation", async () => {
+    await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/notification.service.test.ts
+++ b/src/services/__tests__/notification.service.test.ts
@@ -23,6 +23,16 @@ const mockEventBus = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
 
+// Mock the wake-notification → DaemonSessionTurn bridge so this suite stays focused on
+// the notification chokepoint itself (the bridge's own action→trigger / instruction /
+// failure-isolation behavior is exhaustively covered in notification-turn.test.ts).
+// Mocking it also keeps the daemon-session / connection / lineage chains out of this
+// unit test. We still assert the chokepoint INVOKES it for each created notification.
+const mockMaybeCreateTurn = vi.hoisted(() => vi.fn());
+vi.mock("@/services/notification-turn", () => ({
+  maybeCreateTurnForWakeNotification: mockMaybeCreateTurn,
+}));
+
 import {
   create,
   createBatch,
@@ -72,6 +82,9 @@ function makeNotifRecord(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The bridge resolves to null by default (no turn created) — its real behavior is
+  // tested separately; here we only care that the chokepoint calls it.
+  mockMaybeCreateTurn.mockResolvedValue(null);
 });
 
 // ===== create =====
@@ -90,6 +103,89 @@ describe("create", () => {
       `notification:user:${recipientUuid}`,
       expect.objectContaining({ type: "new_notification", unreadCount: 5 })
     );
+  });
+
+  it("should persist instructionText (write-once denormalized copy) and pass it to the turn bridge", async () => {
+    const params = makeNotifParams({
+      recipientType: "agent",
+      recipientUuid: "agent-0000-0000-0000-000000000099",
+      action: "human_instruction",
+      instructionText: "Please refactor the auth module",
+    });
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord(params));
+    mockPrisma.notification.count.mockResolvedValue(1);
+
+    await create(params);
+
+    // The denormalized copy is written onto the notification row.
+    expect(mockPrisma.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          instructionText: "Please refactor the auth module",
+        }),
+      })
+    );
+    // The chokepoint invokes the bridge with the full params (incl. instructionText).
+    expect(mockMaybeCreateTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "human_instruction",
+        instructionText: "Please refactor the auth module",
+      })
+    );
+  });
+
+  it("should default instructionText to null when absent", async () => {
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord());
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    await create(makeNotifParams());
+
+    expect(mockPrisma.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ instructionText: null }),
+      })
+    );
+  });
+
+  it("should invoke the turn bridge once after creating the notification", async () => {
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord());
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    await create(makeNotifParams());
+
+    expect(mockMaybeCreateTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces instructionText in the READ projection so the daemon reads it with no extra fetch (子1)", async () => {
+    // The daemon's event-router reads n.instructionText from the chorus_get_notifications
+    // result — so the formatted projection MUST carry it through.
+    mockPrisma.notification.create.mockResolvedValue(
+      makeNotifRecord({ action: "human_instruction", instructionText: "Please rebase onto main" }),
+    );
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    const result = await create(makeNotifParams());
+    expect(result.instructionText).toBe("Please rebase onto main");
+  });
+
+  it("defaults the projected instructionText to null for a non-instruction notification", async () => {
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord()); // no instructionText column
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    const result = await create(makeNotifParams());
+    expect(result.instructionText).toBeNull();
+  });
+
+  it("should still return the notification when the turn bridge resolves (failure-isolated)", async () => {
+    // The bridge never throws (it logs+swallows internally), but assert create() does
+    // not depend on the bridge's outcome: the notification is returned regardless.
+    mockMaybeCreateTurn.mockResolvedValue(null);
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord());
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    const result = await create(makeNotifParams());
+
+    expect(result.uuid).toBe(notifUuid);
   });
 });
 
@@ -128,6 +224,49 @@ describe("createBatch", () => {
 
     // Same recipient => one emit
     expect(mockEventBus.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should invoke the turn bridge once per notification param (not deduped)", async () => {
+    const recipient2 = "agent-0000-0000-0000-000000000002";
+    const params1 = makeNotifParams({ recipientType: "agent", action: "task_assigned" });
+    const params2 = makeNotifParams({
+      recipientType: "agent",
+      recipientUuid: recipient2,
+      action: "mentioned",
+    });
+    mockPrisma.notification.create
+      .mockResolvedValueOnce(makeNotifRecord(params1))
+      .mockResolvedValueOnce(makeNotifRecord(params2));
+    mockPrisma.notification.count.mockResolvedValue(1);
+
+    await createBatch([params1, params2]);
+
+    // One bridge call per param (the bridge itself decides whether a turn is created).
+    expect(mockMaybeCreateTurn).toHaveBeenCalledTimes(2);
+    expect(mockMaybeCreateTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "task_assigned" })
+    );
+    expect(mockMaybeCreateTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "mentioned" })
+    );
+  });
+
+  it("should persist instructionText per notification in the batch", async () => {
+    const params = makeNotifParams({
+      recipientType: "agent",
+      action: "human_instruction",
+      instructionText: "do the thing",
+    });
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord(params));
+    mockPrisma.notification.count.mockResolvedValue(1);
+
+    await createBatch([params]);
+
+    expect(mockPrisma.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ instructionText: "do the thing" }),
+      })
+    );
   });
 });
 

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -1,0 +1,1134 @@
+// src/services/daemon-session.service.ts
+// Daemon Session Service — the DURABLE conversation layer for a daemon's Claude
+// session (子1 — daemon-session-conversation). Where `daemon-execution.service`
+// models the *live* running/queued snapshot a connection reports (rows flip to
+// `ended` when absent from the next snapshot), THIS module models a persistent
+// conversation that OUTLIVES that: a `DaemonSession` keyed `(agentUuid, sessionId)`
+// holds an ordered list of `DaemonSessionTurn` rows, one per wake — autonomous
+// (task_assigned / mentioned / elaboration / resume) or human (human_instruction).
+// Identity and history survive the holding connection going offline and the daemon
+// restarting; a session is NEVER deleted merely because its connection dropped.
+//
+// This is the SINGLE chokepoint for two mutations — turn creation and turn status
+// transitions — so it OWNS publishing the live-update SSE triggers (see "SSE
+// contract" below). The route layer and the notification chokepoint call into here;
+// no turn/session business logic lives in routes (service-layer convention).
+//
+// It reuses, never re-models:
+//   - `lineage.service.resolveRootIdea` for `directIdeaUuid` resolution, and
+//   - the connection registry's exported `STALE_THRESHOLD_MS` for the single
+//     offline/staleness verdict used by `assertContinuable` (no second constant).
+//
+// Continuation is PINNED to the session's `originConnectionUuid`: a turn is only
+// ever continued on the cwd/machine that holds the on-disk `claude --resume`
+// transcript. An offline origin makes the session read-only (history still
+// visible); it is NEVER re-routed to another connection of the same agent, because
+// a resume against a different working directory would `No conversation found`.
+
+import { prisma } from "@/lib/prisma";
+import { eventBus } from "@/lib/event-bus";
+import { resolveRootIdea, type LineageEntityType } from "@/services/lineage.service";
+// The single offline/staleness verdict lives in the connection registry. Import it
+// here (rather than restate the number) so producer (the SSE heartbeat that bumps
+// lastSeenAt) and this consumer can never drift — exactly as the execution service
+// re-exports it.
+import { STALE_THRESHOLD_MS } from "@/services/daemon-connection.service";
+
+// Re-export so callers that need the offline threshold can import it from the
+// session service without reaching for a second constant — there is exactly one
+// staleness threshold in the system and it lives in the connection registry.
+export { STALE_THRESHOLD_MS };
+
+// ===== Constants =====
+
+// The wake kinds a turn can represent. Every wake — autonomous or human — is one
+// turn, distinguished only by `trigger`. A non-conforming value is rejected at the
+// route/chokepoint zod boundary, so the service can assume validity.
+export const TURN_TRIGGERS = [
+  "task_assigned",
+  "mentioned",
+  "elaboration",
+  "resume",
+  "human_instruction",
+] as const;
+export type TurnTrigger = (typeof TURN_TRIGGERS)[number];
+
+// A turn's lifecycle states, in strict forward order. The daemon advances a turn
+// `pending → running → ended`; this service enforces that ordering (no skips, no
+// backward transitions) in `advanceTurn`.
+export const TURN_STATUSES = ["pending", "running", "ended"] as const;
+export type TurnStatus = (typeof TURN_STATUSES)[number];
+
+// The two session lifecycle states. A session is `active` until explicitly ended;
+// it stays readable (its turns/transcript) regardless of state — `ended` is history,
+// never a delete.
+export const SESSION_STATUSES = ["active", "ended"] as const;
+export type SessionStatus = (typeof SESSION_STATUSES)[number];
+
+// The ONLY transcript message roles persisted. The daemon's stream-json carries
+// tool-call / tool-result / thinking blocks too, but the ingest deliberately stores
+// only `user`/`assistant` TEXT — bounding privacy exposure and keeping the stored
+// transcript a clean human-readable conversation. A non-conforming role is dropped
+// (filtered, not rejected — a tool block alongside text must not fail the whole
+// upload) at the service boundary.
+export const TRANSCRIPT_ROLES = ["user", "assistant"] as const;
+export type TranscriptRole = (typeof TRANSCRIPT_ROLES)[number];
+
+// Rolling-window cap: the maximum number of transcript messages RETAINED per session
+// (across all of its turns). When an append pushes the session's stored count over
+// this, the OLDEST messages are trimmed back to the cap — in application code, NOT a
+// data-mutating migration (the spec forbids backfill/DML in migrations). A named
+// constant so the bound is single-sourced and adjustable without touching call sites.
+export const MAX_TRANSCRIPT_MESSAGES_PER_SESSION = 200;
+
+// ===== Types =====
+
+/**
+ * Read projection of a `DaemonSession` row. Timestamps are ISO-8601 strings so the
+ * client renders elapsed/last-active without re-touching Date objects across the
+ * wire — mirrors `daemon-execution.service`'s `ExecutionView` shape.
+ */
+export interface SessionView {
+  uuid: string;
+  agentUuid: string;
+  sessionId: string;
+  directIdeaUuid: string | null;
+  originConnectionUuid: string;
+  status: string; // active | ended
+  title: string | null;
+  lastTurnAt: string; // ISO-8601
+  createdAt: string; // ISO-8601
+  updatedAt: string; // ISO-8601
+}
+
+/**
+ * Read projection of a `DaemonSessionTurn` row, ordered by `seq` for a session's
+ * transcript view. Timestamps are ISO-8601 strings (null while unset).
+ */
+export interface TurnView {
+  uuid: string;
+  sessionUuid: string;
+  seq: number;
+  trigger: string;
+  promptText: string | null;
+  status: string; // pending | running | ended
+  executionUuid: string | null;
+  startedAt: string | null; // ISO-8601
+  endedAt: string | null; // ISO-8601
+  createdAt: string; // ISO-8601
+}
+
+/**
+ * Payload pushed on the per-session `transcript:{sessionUuid}` EventBus channel for
+ * the "turn created" and "turn status changed" triggers (the transcript-append
+ * trigger — a later task — reuses the SAME channel/payload shape). It carries the
+ * `sessionUuid` so a subscriber can filter to the session it is viewing, a `trigger`
+ * discriminator so the client knows which of the three SSE triggers fired, and the
+ * affected `turn` so the client can patch exactly that row without a follow-up read.
+ * The `companyUuid` is carried so the SSE route can enforce multi-tenancy before
+ * forwarding (consistent with the change/presence/execution handlers, which drop
+ * events from other companies).
+ */
+export interface TranscriptEvent {
+  companyUuid: string;
+  sessionUuid: string;
+  // Which SSE trigger produced this event. `turn_created` and `turn_status_changed`
+  // are owned by THIS service (the single chokepoint for those mutations);
+  // `transcript_appended` is published by the transcript ingest endpoint (a later
+  // task) on the same channel.
+  trigger: "turn_created" | "turn_status_changed" | "transcript_appended";
+  turn: TurnView;
+}
+
+// Subset of the DaemonSession row the mapper reads. Kept structural (not the Prisma
+// generated type) so the mapper is trivially unit-testable with plain fixtures —
+// mirrors the connection/execution services' row-interface pattern.
+interface DaemonSessionRow {
+  uuid: string;
+  agentUuid: string;
+  sessionId: string;
+  directIdeaUuid: string | null;
+  originConnectionUuid: string;
+  status: string;
+  title: string | null;
+  lastTurnAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface DaemonSessionTurnRow {
+  uuid: string;
+  sessionUuid: string;
+  seq: number;
+  trigger: string;
+  promptText: string | null;
+  status: string;
+  executionUuid: string | null;
+  startedAt: Date | null;
+  endedAt: Date | null;
+  createdAt: Date;
+}
+
+// ===== Helpers =====
+
+function toSessionView(row: DaemonSessionRow): SessionView {
+  return {
+    uuid: row.uuid,
+    agentUuid: row.agentUuid,
+    sessionId: row.sessionId,
+    directIdeaUuid: row.directIdeaUuid,
+    originConnectionUuid: row.originConnectionUuid,
+    status: row.status,
+    title: row.title,
+    lastTurnAt: row.lastTurnAt.toISOString(),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function toTurnView(row: DaemonSessionTurnRow): TurnView {
+  return {
+    uuid: row.uuid,
+    sessionUuid: row.sessionUuid,
+    seq: row.seq,
+    trigger: row.trigger,
+    promptText: row.promptText,
+    status: row.status,
+    executionUuid: row.executionUuid,
+    startedAt: row.startedAt ? row.startedAt.toISOString() : null,
+    endedAt: row.endedAt ? row.endedAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+// Owner-scope (user / super_admin) vs self-scope (agent key) — identical to
+// `daemon-execution.service.getVisibleExecutions` / `connectionVisibleToCaller`:
+//  - an AGENT-KEY caller sees only its own sessions (`agentUuid === actorUuid`),
+//  - a USER / super_admin caller sees only sessions of agents it owns
+//    (`agent.ownerUuid === actorUuid`),
+// every query additionally companyUuid-scoped by the caller. No new permission bit.
+function ownerScope(auth: {
+  type: string;
+  actorUuid: string;
+}): { agentUuid: string } | { agent: { ownerUuid: string } } {
+  return auth.type === "agent"
+    ? { agentUuid: auth.actorUuid }
+    : { agent: { ownerUuid: auth.actorUuid } };
+}
+
+// ===== SSE event publish =====
+//
+// One channel per conversation: `transcript:{sessionUuid}`. The spec's "SSE contract
+// — three triggers, one channel" routes ALL live updates for a session here. This
+// service owns triggers (1) turn created and (2) turn status changed; the transcript
+// ingest endpoint (a later task) publishes trigger (3) append on the SAME channel
+// using the SAME `transcriptEventName` helper and `TranscriptEvent` payload shape.
+
+/** EventBus channel name for a daemon session's transcript/turn live updates. */
+export function transcriptEventName(sessionUuid: string): string {
+  return `transcript:${sessionUuid}`;
+}
+
+/**
+ * Publish a transcript/turn event on the `transcript:{sessionUuid}` channel. The
+ * `eventBus.emit` override fans this out over the existing Redis channel for
+ * multi-instance deployments — purely additive to the existing notification /
+ * presence / execution / control events, touching none of them.
+ *
+ * This is the internal publish used by `createPendingTurn` (trigger `turn_created`)
+ * and `advanceTurn` (trigger `turn_status_changed`). Unlike the execution service's
+ * fire-and-forget teardown publish, these fire on the request/mutation path: an emit
+ * is synchronous and does not touch the DB, so there is nothing to swallow — a
+ * failure in the in-memory emit would be a programming error, not a transient teardown
+ * race.
+ */
+function publishTranscriptEvent(event: TranscriptEvent): void {
+  eventBus.emit(transcriptEventName(event.sessionUuid), event);
+}
+
+// ===== Resolve / create session =====
+
+/**
+ * Resolve-or-create the `DaemonSession` for `(agentUuid, sessionId)`, the stable
+ * conversation business key. `sessionId` is the `directIdeaUuid` for an idea-anchored
+ * session or a server-generated uuid for an ad-hoc session; it is supplied by the
+ * caller (the notification chokepoint), which is also where lineage is resolved.
+ *
+ * Upsert semantics on the `@@unique([agentUuid, sessionId])`:
+ *  - CREATE stamps `originConnectionUuid` (the connection/cwd that owns the on-disk
+ *    transcript) and `directIdeaUuid` (nullable) ONCE, at creation. Both are FIXED
+ *    thereafter: a later wake on the same `(agent, session)` reuses the existing row
+ *    and does NOT move the origin connection (continuation is cwd-bound) nor re-derive
+ *    the direct idea.
+ *  - UPDATE (the row already exists) re-affirms only `companyUuid` from the
+ *    authenticated context (multi-tenancy: never trusted from the request body). It
+ *    deliberately does NOT touch `originConnectionUuid` / `directIdeaUuid` — those are
+ *    write-once. `lastTurnAt` is bumped by `createPendingTurn` (the turn write), not
+ *    here, so a resolve without a turn does not falsely advance the conversation clock.
+ *
+ * `directIdeaUuid` may be passed pre-resolved by the caller; when omitted (or null) and
+ * the session is being created, this still records null (ad-hoc). The companyUuid is
+ * stamped on the row. A query failure propagates (a write that does NOT swallow — the
+ * session must exist before a turn is appended to it).
+ */
+export async function resolveOrCreateSession(params: {
+  companyUuid: string;
+  agentUuid: string;
+  sessionId: string;
+  directIdeaUuid?: string | null;
+  originConnectionUuid: string;
+}): Promise<SessionView> {
+  const row = await prisma.daemonSession.upsert({
+    where: {
+      agentUuid_sessionId: {
+        agentUuid: params.agentUuid,
+        sessionId: params.sessionId,
+      },
+    },
+    create: {
+      companyUuid: params.companyUuid,
+      agentUuid: params.agentUuid,
+      sessionId: params.sessionId,
+      directIdeaUuid: params.directIdeaUuid ?? null,
+      originConnectionUuid: params.originConnectionUuid,
+      status: "active",
+    },
+    update: {
+      // Re-affirm companyUuid from the authenticated context. originConnectionUuid
+      // and directIdeaUuid are write-once — intentionally NOT updated here.
+      companyUuid: params.companyUuid,
+    },
+  });
+  return toSessionView(row);
+}
+
+/**
+ * Resolve the `directIdeaUuid` for an entity via the shared lineage resolver, so the
+ * notification chokepoint can derive a session's idea anchor without re-implementing
+ * the multi-hop walk. Returns the direct idea uuid (the FIRST idea node on the
+ * lineage), or null when the entity has no idea ancestor (a success, not an error —
+ * the session is then ad-hoc and keyed on a server-generated uuid by the caller).
+ * companyUuid-scoped via the lineage getters; a query failure propagates.
+ */
+export async function resolveDirectIdeaUuid(
+  companyUuid: string,
+  entityType: LineageEntityType,
+  entityUuid: string,
+): Promise<string | null> {
+  const result = await resolveRootIdea(companyUuid, entityType, entityUuid);
+  return result.directIdeaUuid;
+}
+
+// ===== Turn lifecycle =====
+
+/**
+ * Create a `pending` turn on a session — the SINGLE turn-creation chokepoint. Called
+ * by the notification chokepoint (every wake) and by the instruction send path.
+ *
+ *  - Assigns a MONOTONIC per-session `seq`: max(existing seq) + 1, starting at 1 for
+ *    the first turn. Computed from the table so it survives restarts (the
+ *    `@@unique([sessionUuid, seq])` is the integrity backstop).
+ *  - Sets `status = "pending"`, records `trigger` and (for `human_instruction`) the
+ *    free-text `promptText` (null for autonomous triggers — the canonical instruction
+ *    text lives HERE, the notification only carries a denormalized copy).
+ *  - Bumps the session's `lastTurnAt` so the conversation list orders by recency.
+ *  - PUBLISHES the `turn_created` SSE trigger on `transcript:{sessionUuid}` so any
+ *    caller emits without remembering to (a 子3 viewer sees the new turn appear live).
+ *
+ * The session is looked up to obtain its companyUuid (for the event) and to fail
+ * clearly if the sessionUuid does not resolve — a turn cannot exist without its
+ * session. A query/write failure propagates (no silent swallow): a lost turn would
+ * lose a wake.
+ */
+export async function createPendingTurn(params: {
+  sessionUuid: string;
+  trigger: TurnTrigger;
+  promptText?: string | null;
+  executionUuid?: string | null;
+}): Promise<TurnView> {
+  // The session must exist and carries the companyUuid the SSE event needs. (The
+  // caller — the notification chokepoint — has just resolved/created it.)
+  const session = await prisma.daemonSession.findUnique({
+    where: { uuid: params.sessionUuid },
+    select: { uuid: true, companyUuid: true },
+  });
+  if (!session) {
+    throw new Error(`DaemonSession ${params.sessionUuid} not found`);
+  }
+
+  // Monotonic per-session seq = max(existing) + 1; 1 for the first turn. Ordering by
+  // seq desc + take 1 reads the current max cheaply off the (sessionUuid, seq) unique.
+  //
+  // The read-then-write is NOT atomic, so two concurrent creates for the SAME session
+  // (e.g. a task-assign and an @mention notification landing together, from separate
+  // request handlers) can both read the same max and try the same seq. The
+  // `@@unique([sessionUuid, seq])` rejects the loser with P2002 — we retry (re-reading
+  // the max) instead of letting that turn be silently dropped. Bounded retries keep a
+  // genuinely persistent failure from looping. Same session serializes its own wakes in
+  // the daemon WakeQueue, so contention here is rare and resolves in one extra attempt.
+  let row: Awaited<ReturnType<typeof prisma.daemonSessionTurn.create>> | null = null;
+  const MAX_SEQ_ATTEMPTS = 5;
+  for (let attempt = 0; attempt < MAX_SEQ_ATTEMPTS; attempt++) {
+    const last = await prisma.daemonSessionTurn.findFirst({
+      where: { sessionUuid: params.sessionUuid },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+    const seq = (last?.seq ?? 0) + 1;
+    try {
+      row = await prisma.daemonSessionTurn.create({
+        data: {
+          sessionUuid: params.sessionUuid,
+          seq,
+          trigger: params.trigger,
+          promptText: params.promptText ?? null,
+          status: "pending",
+          executionUuid: params.executionUuid ?? null,
+        },
+      });
+      break;
+    } catch (e) {
+      // P2002 = unique-constraint violation on (sessionUuid, seq): another create won
+      // the race for this seq. Re-read the max and retry. Any other error propagates.
+      const isSeqConflict =
+        typeof e === "object" &&
+        e !== null &&
+        "code" in e &&
+        (e as { code: string }).code === "P2002";
+      if (isSeqConflict && attempt < MAX_SEQ_ATTEMPTS - 1) continue;
+      throw e;
+    }
+  }
+  if (!row) {
+    // Exhausted retries — surface visibly (no silent drop), the caller's bridge logs it.
+    throw new Error(
+      `createPendingTurn: could not allocate a unique seq for session ${params.sessionUuid} after ${MAX_SEQ_ATTEMPTS} attempts`,
+    );
+  }
+
+  // Bump the conversation clock so the session list orders by most-recent turn.
+  await prisma.daemonSession.update({
+    where: { uuid: params.sessionUuid },
+    data: { lastTurnAt: new Date() },
+  });
+
+  const view = toTurnView(row);
+  // Trigger (1): turn created. Owned here because this IS the single turn-creation
+  // chokepoint — emit happens for every caller.
+  publishTranscriptEvent({
+    companyUuid: session.companyUuid,
+    sessionUuid: params.sessionUuid,
+    trigger: "turn_created",
+    turn: view,
+  });
+  return view;
+}
+
+/** Outcome of an attempted turn status transition, so the route maps a precise code. */
+export type AdvanceTurnResult =
+  | { ok: true; turn: TurnView }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "invalid_transition"; from: string; to: string };
+
+// The single legal forward edge for each status. Enforces strict
+// pending → running → ended with no skips and no backward moves. A status with no
+// outgoing edge (`ended`) is terminal. Re-applying the SAME status is also rejected
+// (an idempotent no-op would otherwise hide a double-report bug and re-emit SSE).
+const NEXT_TURN_STATUS: Record<TurnStatus, TurnStatus | null> = {
+  pending: "running",
+  running: "ended",
+  ended: null,
+};
+
+/**
+ * Advance a turn through its lifecycle — the SINGLE turn-status chokepoint. Enforces
+ * strict `pending → running → ended`: only the one legal forward edge from the turn's
+ * current status is allowed; a skip (`pending → ended`), a backward move
+ * (`running → pending`), or re-applying the same status is rejected as
+ * `invalid_transition` and writes nothing. A turn that does not exist is `not_found`.
+ *
+ * On a legal transition it:
+ *  - sets the new `status`, and optionally records `startedAt` (the daemon's spawn
+ *    time, typically on → running), `endedAt` (subprocess exit, on → ended), and the
+ *    weak `executionUuid` link to the live `DaemonExecution` row (recorded without
+ *    altering execution-state reconcile semantics), and
+ *  - PUBLISHES the `turn_status_changed` SSE trigger on `transcript:{sessionUuid}` so
+ *    a viewer sees the turn flip pending → running → ended live, for any caller.
+ *
+ * A query/write failure propagates (no silent swallow). The session lookup supplies
+ * the companyUuid the SSE event carries.
+ */
+export async function advanceTurn(
+  turnUuid: string,
+  status: TurnStatus,
+  opts: { startedAt?: Date | null; endedAt?: Date | null; executionUuid?: string | null } = {},
+): Promise<AdvanceTurnResult> {
+  const turn = await prisma.daemonSessionTurn.findUnique({
+    where: { uuid: turnUuid },
+    select: { uuid: true, sessionUuid: true, status: true },
+  });
+  if (!turn) return { ok: false, reason: "not_found" };
+
+  // The turn's persisted status must be a known lifecycle value to have a legal edge;
+  // a foreign value (should never happen) has no outgoing edge → invalid_transition.
+  const current = turn.status as TurnStatus;
+  const legalNext = NEXT_TURN_STATUS[current] ?? null;
+  if (status !== legalNext) {
+    return { ok: false, reason: "invalid_transition", from: turn.status, to: status };
+  }
+
+  // Only the fields relevant to a transition are written; absent opts leave the
+  // column untouched (so a → running transition need not clear endedAt, etc.).
+  const data: {
+    status: TurnStatus;
+    startedAt?: Date | null;
+    endedAt?: Date | null;
+    executionUuid?: string | null;
+  } = { status };
+  if (opts.startedAt !== undefined) data.startedAt = opts.startedAt;
+  if (opts.endedAt !== undefined) data.endedAt = opts.endedAt;
+  if (opts.executionUuid !== undefined) data.executionUuid = opts.executionUuid;
+
+  const updated = await prisma.daemonSessionTurn.update({
+    where: { uuid: turnUuid },
+    data,
+  });
+
+  // The session carries the companyUuid the SSE event needs. The turn was just updated
+  // via its session FK, so the session always resolves; a missing one means a torn
+  // write/data corruption — throw rather than emit a tenant-less event (companyUuid: "")
+  // that a future 子3 SSE consumer's multi-tenancy fence could mishandle.
+  const session = await prisma.daemonSession.findUnique({
+    where: { uuid: turn.sessionUuid },
+    select: { companyUuid: true },
+  });
+  if (!session) {
+    throw new Error(
+      `advanceTurn: session ${turn.sessionUuid} missing for just-updated turn ${turnUuid}`,
+    );
+  }
+
+  const view = toTurnView(updated);
+  // Trigger (2): turn status changed. Owned here because this IS the single
+  // status-transition chokepoint — emit happens for every caller, every transition.
+  publishTranscriptEvent({
+    companyUuid: session.companyUuid,
+    sessionUuid: turn.sessionUuid,
+    trigger: "turn_status_changed",
+    turn: view,
+  });
+  return { ok: true, turn: view };
+}
+
+// ===== Owner-scoped reads =====
+//
+// As with the connection/execution registries' read functions, these deliberately do
+// NOT swallow-and-log to an empty list: a query failure propagates so the route
+// surfaces a 500. An empty list MUST mean genuinely zero rows, not a hidden error.
+
+/**
+ * List the daemon sessions visible to a caller, scoped EXACTLY like
+ * `daemon-execution.service.getVisibleExecutions`:
+ *  - a USER / super_admin caller sees only sessions of agents it owns
+ *    (`agent.ownerUuid === actorUuid`), and
+ *  - an AGENT-KEY caller sees only its own sessions (`agentUuid === actorUuid`),
+ * every query companyUuid-scoped. Sessions of an agent owned by a different user — or
+ * in a different company — are never returned. No new permission bit.
+ *
+ * Ordered most-recent-conversation first (`lastTurnAt` desc). A READ that does NOT
+ * swallow — a query failure propagates.
+ */
+export async function getVisibleSessions(auth: {
+  type: string;
+  companyUuid: string;
+  actorUuid: string;
+}): Promise<SessionView[]> {
+  const rows = await prisma.daemonSession.findMany({
+    where: { companyUuid: auth.companyUuid, ...ownerScope(auth) },
+    orderBy: { lastTurnAt: "desc" },
+  });
+  return rows.map(toSessionView);
+}
+
+/**
+ * List the turns of a single session, ordered by `seq`, applying the SAME owner/self
+ * + companyUuid visibility fence as `getVisibleSessions`. The session is first
+ * resolved under the caller's visibility scope; a session that does not exist, lives
+ * in another company, or belongs to an agent the caller does not own all yield the
+ * SAME `null` — so the read route returns one 404 in every negative case without
+ * revealing another caller's session exists (non-disclosure, exactly like
+ * `daemon-execution.service.connectionVisibleToCaller`).
+ *
+ * Returns `null` when the session is not visible (the route maps to 404), or the
+ * ordered turn views (possibly empty) when it is. A READ that does NOT swallow.
+ */
+export async function getSessionTurns(
+  auth: { type: string; companyUuid: string; actorUuid: string },
+  sessionUuid: string,
+): Promise<TurnView[] | null> {
+  const session = await prisma.daemonSession.findFirst({
+    where: { uuid: sessionUuid, companyUuid: auth.companyUuid, ...ownerScope(auth) },
+    select: { uuid: true },
+  });
+  if (!session) return null; // not visible → 404 non-disclosure
+
+  const turns = await prisma.daemonSessionTurn.findMany({
+    where: { sessionUuid },
+    orderBy: { seq: "asc" },
+  });
+  return turns.map(toTurnView);
+}
+
+// ===== Continuation pinning =====
+
+/** Outcome of `assertContinuable` so the caller maps a precise status code. */
+export type ContinuableResult =
+  | { ok: true; originConnectionUuid: string }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "origin_offline"; originConnectionUuid: string };
+
+/**
+ * The read-only error thrown when a session's origin connection is offline. A
+ * continuation (a new turn dispatched to the session) requires `claude --resume
+ * <sessionId>` in the SAME cwd on the SAME machine — i.e. the session's
+ * `originConnectionUuid` must be effectively ONLINE. When it is not, the session is
+ * READ-ONLY (its history stays visible) and the turn is NEVER routed to another
+ * connection of the same agent. Callers (子2's send box) surface this as a disabled
+ * input; the message is intentionally clear about why.
+ */
+export class SessionReadOnlyError extends Error {
+  readonly code = "session_read_only";
+  readonly originConnectionUuid: string;
+  constructor(originConnectionUuid: string) {
+    super(
+      "This session is read-only: its origin connection is offline. " +
+        "A daemon session can only be continued on the connection that holds its " +
+        "on-disk transcript (claude --resume is cwd/machine-bound), so it is never " +
+        "routed to another connection.",
+    );
+    this.name = "SessionReadOnlyError";
+    this.originConnectionUuid = originConnectionUuid;
+  }
+}
+
+/**
+ * Assert that a session can be CONTINUED — i.e. a new turn may be dispatched to it.
+ * Resolves the session's FIXED `originConnectionUuid` and checks that connection is
+ * effectively ONLINE using the SAME verdict the connection read API renders:
+ * `status === "online" && now - lastSeenAt <= STALE_THRESHOLD_MS` (the registry's
+ * single staleness threshold, reused — NOT a new constant). It NEVER considers any
+ * other connection of the same agent: continuation is pinned to the origin, full stop.
+ *
+ * Throws `SessionReadOnlyError` when the origin is offline/stale (the caller renders a
+ * read-only / origin-offline error and does not route elsewhere). Throws a plain
+ * not-found Error when the session does not resolve in-company. companyUuid-scoped; a
+ * READ that does NOT swallow.
+ *
+ * Returns the resolved `originConnectionUuid` on success so the dispatch path targets
+ * exactly that connection (and only that one).
+ */
+export async function assertContinuable(
+  companyUuid: string,
+  sessionUuid: string,
+): Promise<string> {
+  const session = await prisma.daemonSession.findFirst({
+    where: { uuid: sessionUuid, companyUuid },
+    select: { originConnectionUuid: true },
+  });
+  if (!session) {
+    throw new Error(`DaemonSession ${sessionUuid} not found`);
+  }
+
+  const conn = await prisma.daemonConnection.findFirst({
+    where: { uuid: session.originConnectionUuid, companyUuid },
+    select: { status: true, lastSeenAt: true },
+  });
+  const online =
+    conn != null &&
+    conn.status === "online" &&
+    Date.now() - conn.lastSeenAt.getTime() <= STALE_THRESHOLD_MS;
+  if (!online) {
+    // Read-only: origin offline. NEVER route to another connection.
+    throw new SessionReadOnlyError(session.originConnectionUuid);
+  }
+  return session.originConnectionUuid;
+}
+
+// ===== Transcript ingest (append, text-only, rolling-window) =====
+//
+// The per-turn transcript relay. Where `daemon-execution.service.reconcileSnapshot`
+// treats its body as the AUTHORITATIVE full state (rows flip to `ended` when absent),
+// transcript ingest has APPEND semantics: each call ADDS messages to a turn and never
+// removes a message because it was absent from this call. The only removal is the
+// rolling-window trim (oldest-first) once the session's retained count exceeds
+// `MAX_TRANSCRIPT_MESSAGES_PER_SESSION` — done here in application code, not a
+// migration. Only `user`/`assistant` text survives the filter; tool-call /
+// tool-result / thinking content is dropped (not stored). After a successful append it
+// publishes the `transcript_appended` trigger on the SAME `transcript:{sessionUuid}`
+// channel the turn-create/turn-status-change triggers use (one channel per
+// conversation), additive to the existing notification/presence/execution events.
+
+/**
+ * A single inbound transcript message from the daemon. `role` is constrained to the
+ * persisted roles at the route's zod boundary; any other role (tool/thinking) is
+ * filtered out by the service rather than reaching this type. `text` is the plain
+ * message body — empty/blank text is dropped (no empty rows persisted).
+ */
+export interface InboundTranscriptMessage {
+  role: TranscriptRole;
+  text: string;
+}
+
+/**
+ * Read projection of a persisted `DaemonTranscriptMessage`, ordered within a turn by
+ * `seq`. Returned to a viewer (子3) and echoed back from the ingest so the caller can
+ * confirm what landed. `createdAt` is an ISO-8601 string across the wire.
+ */
+export interface TranscriptMessageView {
+  uuid: string;
+  turnUuid: string;
+  role: string; // user | assistant
+  text: string;
+  seq: number;
+  createdAt: string; // ISO-8601
+}
+
+interface DaemonTranscriptMessageRow {
+  uuid: string;
+  turnUuid: string;
+  role: string;
+  text: string;
+  seq: number;
+  createdAt: Date;
+}
+
+function toTranscriptMessageView(row: DaemonTranscriptMessageRow): TranscriptMessageView {
+  return {
+    uuid: row.uuid,
+    turnUuid: row.turnUuid,
+    role: row.role,
+    text: row.text,
+    seq: row.seq,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Outcome of an attempted transcript append, so the route maps a precise status code.
+ * `not_found` is the SINGLE negative verdict for every non-disclosure case — the turn
+ * does not exist, the session does not exist, or either belongs to a different
+ * agent/company — so the route returns one 404 without revealing another agent's
+ * session/turn exists (mirrors `daemon-execution.service.connectionBelongsToAgent`).
+ */
+export type AppendTranscriptResult =
+  | { ok: true; appended: number; stored: number; messages: TranscriptMessageView[] }
+  | { ok: false; reason: "not_found" };
+
+// Keep only persistable messages: a recognized `user`/`assistant` role AND non-blank
+// text. Tool-call / tool-result / thinking entries (any other role) are dropped, as is
+// an empty/whitespace-only body — text-only, no empty rows. The route's zod schema
+// already constrains `role`, but this is the service-level backstop so the filtering
+// invariant holds regardless of caller.
+function filterPersistableMessages(
+  messages: InboundTranscriptMessage[],
+): InboundTranscriptMessage[] {
+  return messages.filter(
+    (m) =>
+      (TRANSCRIPT_ROLES as readonly string[]).includes(m.role) &&
+      typeof m.text === "string" &&
+      m.text.trim().length > 0,
+  );
+}
+
+/**
+ * Append transcript messages to one turn of a session the authenticated agent owns.
+ *
+ * Resolution: EXACTLY one of `turnUuid` / `sessionId` identifies the target turn —
+ *  - `turnUuid` appends to that specific turn (the daemon's normal path: it knows the
+ *    turn it is executing), after verifying the turn's session belongs to the agent
+ *    within its company; or
+ *  - `sessionId` (the conversation business key — `directIdeaUuid` or the ad-hoc uuid,
+ *    NOT the session's `uuid`) resolves the agent's `(agentUuid, sessionId)` session
+ *    and appends to its most-recent turn (highest `seq`).
+ * Every negative case (unknown turn/session, foreign agent, cross-company, or a session
+ * with no turn yet) yields the SAME `not_found` so the route is non-disclosing.
+ *
+ * Append semantics: messages are filtered to `user`/`assistant` text, then inserted
+ * with a monotonic per-turn `seq` (max existing + 1, in order). Nothing is removed for
+ * being absent from this call.
+ *
+ * Rolling-window trim: after insert, if the SESSION's total retained message count
+ * exceeds `MAX_TRANSCRIPT_MESSAGES_PER_SESSION`, the oldest messages (across the
+ * session's turns, ordered by createdAt then seq) are deleted back to the cap — in
+ * application code. No migration mutates data.
+ *
+ * On success it publishes the `transcript_appended` trigger on
+ * `transcript:{sessionUuid}` carrying the turn view, so a 子3 viewer patches that turn
+ * live. A query/write failure propagates (no silent swallow): a lost transcript append
+ * loses conversation history. An all-filtered (no persistable messages) call is a
+ * success that appends 0 and does NOT emit (no change to show).
+ */
+export async function appendTranscriptMessages(params: {
+  companyUuid: string;
+  agentUuid: string;
+  turnUuid?: string | null;
+  sessionId?: string | null;
+  messages: InboundTranscriptMessage[];
+}): Promise<AppendTranscriptResult> {
+  // Resolve the target turn under the caller's ownership scope. Both paths fence on
+  // the authenticated company + agent so a turn/session of another agent (or another
+  // company) is indistinguishable from a non-existent one.
+  let turn: { uuid: string; sessionUuid: string } | null = null;
+
+  if (params.turnUuid) {
+    // turnUuid path: the turn must exist AND its session must belong to this agent in
+    // this company. A single owner-scoped query over the relation enforces both.
+    const row = await prisma.daemonSessionTurn.findFirst({
+      where: {
+        uuid: params.turnUuid,
+        session: { agentUuid: params.agentUuid, companyUuid: params.companyUuid },
+      },
+      select: { uuid: true, sessionUuid: true },
+    });
+    turn = row;
+  } else if (params.sessionId) {
+    // sessionId path: resolve the agent's own session by the (agentUuid, sessionId)
+    // business key, then target its most-recent turn.
+    const session = await prisma.daemonSession.findFirst({
+      where: {
+        agentUuid: params.agentUuid,
+        companyUuid: params.companyUuid,
+        sessionId: params.sessionId,
+      },
+      select: { uuid: true },
+    });
+    if (session) {
+      // Attach transcript to the turn actively producing output — the `running` turn —
+      // rather than the highest-seq turn. Under the per-session WakeQueue at most one
+      // turn runs at a time, so this is unambiguous; targeting most-recent seq could
+      // mis-attach a running turn's output to a newer `pending` turn created mid-run
+      // (the transcript variant of the advanceTurnForWake fix). Fall back to the most-
+      // recent turn when none is `running` (e.g. a late flush just after the turn ended),
+      // so trailing lines still land on the turn they belong to.
+      const running = await prisma.daemonSessionTurn.findFirst({
+        where: { sessionUuid: session.uuid, status: "running" },
+        orderBy: { seq: "asc" },
+        select: { uuid: true, sessionUuid: true },
+      });
+      turn =
+        running ??
+        (await prisma.daemonSessionTurn.findFirst({
+          where: { sessionUuid: session.uuid },
+          orderBy: { seq: "desc" },
+          select: { uuid: true, sessionUuid: true },
+        }));
+    }
+  }
+
+  if (!turn) return { ok: false, reason: "not_found" }; // non-disclosure 404
+
+  const sessionUuid = turn.sessionUuid;
+
+  // Text-only filter: drop tool/thinking and empty bodies. An all-dropped upload is a
+  // valid no-op append (success, 0 appended) — it must not 4xx.
+  const persistable = filterPersistableMessages(params.messages);
+
+  let appendedViews: TranscriptMessageView[] = [];
+  if (persistable.length > 0) {
+    // Monotonic per-turn seq = max(existing) + 1, then increment per message so a
+    // multi-message batch keeps insertion order within the turn.
+    const last = await prisma.daemonTranscriptMessage.findFirst({
+      where: { turnUuid: turn.uuid },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+    let nextSeq = (last?.seq ?? 0) + 1;
+
+    const created: DaemonTranscriptMessageRow[] = [];
+    for (const msg of persistable) {
+      const row = await prisma.daemonTranscriptMessage.create({
+        data: {
+          turnUuid: turn.uuid,
+          role: msg.role,
+          text: msg.text,
+          seq: nextSeq,
+        },
+      });
+      created.push(row);
+      nextSeq += 1;
+    }
+    appendedViews = created.map(toTranscriptMessageView);
+
+    // Rolling-window trim, in application code (no migration). Count the session's
+    // retained messages across all its turns; if over the cap, delete the oldest
+    // (createdAt asc, then seq asc as a stable tiebreak) back down to the cap.
+    await trimSessionTranscript(sessionUuid);
+  }
+
+  const stored = await prisma.daemonTranscriptMessage.count({
+    where: { turn: { sessionUuid } },
+  });
+
+  // Publish trigger (3): transcript appended — only when something actually changed,
+  // so a no-op (all-filtered) call does not wake viewers for nothing.
+  if (appendedViews.length > 0) {
+    const turnRow = await prisma.daemonSessionTurn.findUnique({
+      where: { uuid: turn.uuid },
+    });
+    const session = await prisma.daemonSession.findUnique({
+      where: { uuid: sessionUuid },
+      select: { companyUuid: true },
+    });
+    if (turnRow) {
+      publishTranscriptEvent({
+        companyUuid: session?.companyUuid ?? params.companyUuid,
+        sessionUuid,
+        trigger: "transcript_appended",
+        turn: toTurnView(turnRow),
+      });
+    }
+  }
+
+  return { ok: true, appended: appendedViews.length, stored, messages: appendedViews };
+}
+
+/**
+ * Trim a session's transcript to the rolling-window cap. Counts the messages retained
+ * across ALL of the session's turns; if the count exceeds
+ * `MAX_TRANSCRIPT_MESSAGES_PER_SESSION`, deletes the oldest overflow (ordered by
+ * createdAt asc, then seq asc for a stable tiebreak within the same timestamp) so the
+ * retained count returns to exactly the cap. Application-code trim — there is NO
+ * data-mutating migration. A no-op when already within the cap. companyUuid-agnostic
+ * (the session uuid already scopes it); a query/write failure propagates.
+ */
+async function trimSessionTranscript(sessionUuid: string): Promise<void> {
+  const total = await prisma.daemonTranscriptMessage.count({
+    where: { turn: { sessionUuid } },
+  });
+  const overflow = total - MAX_TRANSCRIPT_MESSAGES_PER_SESSION;
+  if (overflow <= 0) return;
+
+  // Oldest `overflow` messages across the session's turns. Tiebreak on the globally-
+  // monotonic autoincrement `id`, NOT the per-turn `seq` (which resets to 1 each turn):
+  // two messages in different turns can share a `createdAt` millisecond, and a per-turn
+  // seq tiebreak could then delete a newer turn's message before an older turn's. `id`
+  // is insertion-monotonic across the whole table, making oldest-first deterministic.
+  const oldest = await prisma.daemonTranscriptMessage.findMany({
+    where: { turn: { sessionUuid } },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    take: overflow,
+    select: { uuid: true },
+  });
+  if (oldest.length === 0) return;
+  await prisma.daemonTranscriptMessage.deleteMany({
+    where: { uuid: { in: oldest.map((m) => m.uuid) } },
+  });
+}
+
+// ===== Daemon-driven turn advance (by session business key) =====
+//
+// The daemon advances a turn's lifecycle (`pending → running → ended`) over a REST
+// write surface — it does NOT know the server-side `turnUuid`. Instead it identifies
+// the turn the SAME way the transcript ingest's `sessionId` path does: by the agent's
+// `(agentUuid, sessionId)` session business key (`sessionId` = the `directIdeaUuid`
+// for an idea-anchored session, or the entity uuid for an ad-hoc one — exactly the
+// deterministic Claude session anchor the daemon already computes in `waker.wake`).
+// The most-recent turn (highest `seq`) of that session is the one being executed.
+//
+// This composes (never reimplements) `advanceTurn`, so the strict
+// `pending → running → ended` ordering and the `turn_status_changed` SSE publish are
+// enforced in the single chokepoint. The only addition here is RESOLUTION — finding
+// the right turn from a business key the daemon owns — plus stamping the weak
+// `executionUuid` link (resolved from the live `DaemonExecution` row for
+// `(connection, entity)`) when the caller supplies an entity, so the conversation turn
+// and the execution snapshot row are linked without the daemon needing to learn the
+// server-generated execution uuid.
+
+/**
+ * Outcome of a daemon-driven turn advance, so the route maps a precise status code.
+ * `not_found` is the SINGLE non-disclosure verdict (no session for this agent, or the
+ * session has no turn yet) — the route returns one 404 without revealing whether
+ * another agent's session exists, mirroring the transcript ingest.
+ */
+export type AdvanceTurnForWakeResult =
+  | { ok: true; turn: TurnView }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "invalid_transition"; from: string; to: string };
+
+/**
+ * Advance the most-recent turn of the agent's `(agentUuid, sessionId)` session to
+ * `status`, scoped to the authenticated agent within its company. Resolution mirrors
+ * `appendTranscriptMessages`' sessionId path (own session → its highest-`seq` turn);
+ * a session that does not resolve for this agent, or that has no turn yet, yields
+ * `not_found` (non-disclosure). The transition itself goes through `advanceTurn`, so
+ * an illegal transition surfaces as `invalid_transition` (the route maps it to a 409)
+ * rather than silently succeeding.
+ *
+ * When `entityType`/`entityUuid` are supplied AND the live `DaemonExecution` row for
+ * `(companyUuid, connectionUuid, entity)` resolves, its uuid is stamped onto the turn
+ * as the weak `executionUuid` link — recorded WITHOUT touching execution-state
+ * reconcile semantics. `startedAt`/`endedAt` default to the transition time for the
+ * `running`/`ended` edges respectively (the daemon's spawn/exit moment) unless the
+ * caller passes explicit timestamps. A query/write failure propagates (no swallow):
+ * a lost transition would strand a turn's lifecycle.
+ */
+export async function advanceTurnForWake(params: {
+  companyUuid: string;
+  agentUuid: string;
+  connectionUuid: string;
+  sessionId: string;
+  status: TurnStatus;
+  entityType?: string | null;
+  entityUuid?: string | null;
+  startedAt?: Date | null;
+  endedAt?: Date | null;
+}): Promise<AdvanceTurnForWakeResult> {
+  // Resolve the agent's OWN session by its business key (company + agent fenced).
+  const session = await prisma.daemonSession.findFirst({
+    where: {
+      agentUuid: params.agentUuid,
+      companyUuid: params.companyUuid,
+      sessionId: params.sessionId,
+    },
+    select: { uuid: true },
+  });
+  if (!session) return { ok: false, reason: "not_found" }; // non-disclosure 404
+
+  // Resolve the turn being executed by STATUS, not by most-recent seq. The daemon only
+  // ever drives `running` (on spawn) and `ended` (on subprocess exit), and same-session
+  // wakes are strictly serialized in the daemon's per-(agent,session) WakeQueue — so at
+  // most one turn is mid-flight at a time. Targeting "most-recent seq" was wrong: if a
+  // second wake created a newer `pending` turn while the current one was still running,
+  // the running turn's `→ended` would mis-target the newer pending turn (rejected as an
+  // invalid transition), stranding the real turn `running` forever. Status-based FIFO
+  // resolution fixes that without the daemon needing to learn the server turn uuid:
+  //   • → running : the OLDEST still-`pending` turn (the next queued wake to start).
+  //   • → ended   : the `running` turn (the one whose subprocess just exited).
+  // For any other target status, fall back to the oldest turn in the prior state.
+  const fromStatus =
+    params.status === "running" ? "pending" : params.status === "ended" ? "running" : null;
+  const turn = await prisma.daemonSessionTurn.findFirst({
+    where: {
+      sessionUuid: session.uuid,
+      ...(fromStatus ? { status: fromStatus } : {}),
+    },
+    // Oldest-first so a `→running` advance picks up the next queued turn in FIFO order.
+    orderBy: { seq: "asc" },
+    select: { uuid: true },
+  });
+  if (!turn) return { ok: false, reason: "not_found" };
+
+  // Weak executionUuid link: resolve the live DaemonExecution row for this
+  // connection + entity (when the caller named one). Recorded on the turn without
+  // altering execution-state reconcile semantics. A missing row is fine — the link is
+  // optional and a queued/ended execution may simply not be present.
+  let executionUuid: string | null | undefined;
+  if (params.entityType && params.entityUuid) {
+    const execution = await prisma.daemonExecution.findFirst({
+      where: {
+        companyUuid: params.companyUuid,
+        connectionUuid: params.connectionUuid,
+        entityType: params.entityType,
+        entityUuid: params.entityUuid,
+      },
+      select: { uuid: true },
+    });
+    executionUuid = execution?.uuid ?? null;
+  }
+
+  // Default the lifecycle timestamps to the transition moment for the matching edge,
+  // unless the caller passed explicit ones.
+  const now = new Date();
+  const startedAt =
+    params.startedAt !== undefined
+      ? params.startedAt
+      : params.status === "running"
+        ? now
+        : undefined;
+  const endedAt =
+    params.endedAt !== undefined
+      ? params.endedAt
+      : params.status === "ended"
+        ? now
+        : undefined;
+
+  const result = await advanceTurn(turn.uuid, params.status, {
+    ...(startedAt !== undefined ? { startedAt } : {}),
+    ...(endedAt !== undefined ? { endedAt } : {}),
+    ...(executionUuid !== undefined ? { executionUuid } : {}),
+  });
+
+  if (result.ok) return { ok: true, turn: result.turn };
+  if (result.reason === "not_found") return { ok: false, reason: "not_found" };
+  return { ok: false, reason: "invalid_transition", from: result.from, to: result.to };
+}
+
+// ===== Backfill read: unstarted (pending) turns for a connection's sessions =====
+
+/**
+ * A pending turn surfaced to the daemon's reconnect-backfill, with just enough to
+ * RE-DERIVE the wake from the turn table (the canonical source) rather than from a
+ * possibly-lost notification ping. Carries the session's business key + idea anchor so
+ * the daemon can re-key the wake on the same `(agent, session)` lane the live path
+ * uses, plus the `trigger`/`promptText` so a `human_instruction` re-runs with its
+ * canonical free-text body.
+ */
+export interface PendingTurnView {
+  turnUuid: string;
+  sessionUuid: string;
+  sessionId: string;
+  directIdeaUuid: string | null;
+  seq: number;
+  trigger: string;
+  promptText: string | null;
+}
+
+/**
+ * List the UNSTARTED (`status = "pending"`) turns of every session whose origin is the
+ * given connection, for the authenticated agent within its company. This is the
+ * reconnect-backfill source of truth: a lost delivery ping never loses an instruction,
+ * because the turn was persisted at the notification chokepoint before/at notification
+ * creation and is re-derived HERE from the turn table — NOT from notifications.
+ *
+ * Scoped to the caller's OWN sessions (`agentUuid === actorUuid`) AND pinned to the
+ * sessions this connection OWNS (`originConnectionUuid === connectionUuid`) — exactly
+ * the origin-pinning the continuation rule enforces: a daemon only ever re-runs turns
+ * for sessions whose on-disk transcript lives on its cwd/machine. Ordered oldest-first
+ * (`session.createdAt`, then turn `seq`) so a re-run respects arrival order. A READ
+ * that does NOT swallow — a query failure propagates.
+ */
+export async function getPendingTurnsForConnection(params: {
+  companyUuid: string;
+  agentUuid: string;
+  connectionUuid: string;
+}): Promise<PendingTurnView[]> {
+  const rows = await prisma.daemonSessionTurn.findMany({
+    where: {
+      status: "pending",
+      session: {
+        companyUuid: params.companyUuid,
+        agentUuid: params.agentUuid,
+        originConnectionUuid: params.connectionUuid,
+      },
+    },
+    orderBy: [{ session: { createdAt: "asc" } }, { seq: "asc" }],
+    select: {
+      uuid: true,
+      sessionUuid: true,
+      seq: true,
+      trigger: true,
+      promptText: true,
+      session: { select: { sessionId: true, directIdeaUuid: true } },
+    },
+  });
+
+  return rows.map((r) => ({
+    turnUuid: r.uuid,
+    sessionUuid: r.sessionUuid,
+    sessionId: r.session.sessionId,
+    directIdeaUuid: r.session.directIdeaUuid,
+    seq: r.seq,
+    trigger: r.trigger,
+    promptText: r.promptText,
+  }));
+}

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -1,0 +1,219 @@
+// src/services/notification-turn.ts
+// Wake-notification → DaemonSessionTurn bridge (子1 — daemon-session-conversation).
+//
+// `notification.service` create/createBatch is the SINGLE chokepoint where every
+// wake-triggering Notification row is born — symmetric for autonomous wakes
+// (task dispatch / @mention / elaboration / PM-flow transitions) and the human-typed
+// instruction (子2). This module is the bridge that, for such a notification destined
+// for a DAEMON agent, records the corresponding `DaemonSessionTurn` so the daemon's
+// Claude conversation gains one turn per wake.
+//
+// It NEVER reimplements session/turn logic — it composes the daemon-session service
+// (`resolveOrCreateSession` + `createPendingTurn` + `resolveDirectIdeaUuid`) and the
+// connection registry (`listConnectionsForAgent`, to pin the cwd-bound origin).
+//
+// FAILURE ISOLATION (repo "no silent errors" + the wake notification must always
+// survive): turn creation runs AFTER the notification row already exists, and any
+// throw is logged VISIBLY (never swallowed) but is NOT propagated — a lost turn must
+// never abort or block the notification that was already created. The caller invokes
+// this fire-and-forget; it returns the created turn (for tests / callers that want it)
+// or null when no turn was created (recipient is a human, the agent has no online
+// daemon, the action is not wake-triggering, or creation failed and was logged).
+
+import logger from "@/lib/logger";
+import {
+  resolveOrCreateSession,
+  createPendingTurn,
+  resolveDirectIdeaUuid,
+  type TurnTrigger,
+  type TurnView,
+} from "@/services/daemon-session.service";
+import { listConnectionsForAgent } from "@/services/daemon-connection.service";
+import type { LineageEntityType } from "@/services/lineage.service";
+
+const turnLogger = logger.child({ module: "notification-turn" });
+
+// ===== Action → trigger mapping =====
+//
+// The `Notification.action` values that imply the daemon should ACT are the daemon's
+// wake set (`cli/prompts.mjs` WAKE_ACTIONS) intersected with what actually flows
+// through `notification.service` (a persisted Notification row). Verified against the
+// code, NOT memory:
+//   - `notification-listener.ts` resolveNotificationType emits the prefixed action
+//     forms: task_assigned, task_verified, task_reopened, idea_claimed,
+//     proposal_approved, proposal_rejected, elaboration_requested,
+//     elaboration_answered (plus non-wake noise: task_status_changed,
+//     task_submitted_for_verify, comment_added, report_created).
+//   - `mention.service.ts` creates `action: "mentioned"` directly (bypasses the
+//     listener), which IS a wake action.
+//   - `resource_resumed` is a SYNTHETIC control-channel dispatch (子3) — it is NEVER
+//     a persisted Notification, so it cannot reach this chokepoint and is therefore
+//     deliberately absent here.
+//   - `human_instruction` is the UI-sent instruction (子2): the chokepoint receives a
+//     Notification with that action and the free-text body in `instructionText`.
+//
+// The `DaemonSessionTurn.trigger` enum is the NARROW 5-value taxonomy
+// (task_assigned | mentioned | elaboration | resume | human_instruction). This table
+// collapses each wake action into its canonical trigger category so every
+// wake-triggering notification yields exactly one turn:
+//   - @mention                                   → mentioned
+//   - elaboration request / answer               → elaboration
+//   - human-typed instruction                    → human_instruction
+//   - every other autonomous dispatch (task
+//     assignment, task reopen/verify unblock,
+//     idea claim, proposal approve/reject)       → task_assigned (the autonomous
+//                                                  task-dispatch trigger)
+//
+// A `Notification.action` NOT present in this table is not wake-triggering: no turn is
+// created (the daemon would not wake on it either). Exhaustive + explicit so a
+// reviewer sees exactly which actions map where — no implicit fallthrough.
+export const NOTIFICATION_ACTION_TO_TURN_TRIGGER: Record<string, TurnTrigger> = {
+  // @mention — the explicit "I need you" signal.
+  mentioned: "mentioned",
+  // Elaboration round opened / answered on an idea.
+  elaboration_requested: "elaboration",
+  elaboration_answered: "elaboration",
+  // Human-typed instruction (子2 UI send box). Canonical text on the turn; the
+  // notification carries a denormalized copy in `instructionText`.
+  human_instruction: "human_instruction",
+  // Autonomous task-style dispatches — all map to the task_assigned trigger.
+  task_assigned: "task_assigned",
+  task_reopened: "task_assigned",
+  task_verified: "task_assigned",
+  idea_claimed: "task_assigned",
+  proposal_approved: "task_assigned",
+  proposal_rejected: "task_assigned",
+};
+
+/**
+ * The `Notification.entityType` values that the lineage resolver understands. A
+ * notification can also target a `comment` (and the entityType column is free text),
+ * but lineage only walks task/document/proposal/idea — so a non-lineage entityType is
+ * treated as having no idea anchor (the session is then ad-hoc, keyed on the
+ * notification entity uuid) rather than throwing.
+ */
+const LINEAGE_ENTITY_TYPES = new Set<string>(["task", "document", "proposal", "idea"]);
+
+/**
+ * Resolve the trigger for a notification action, or null when the action is not
+ * wake-triggering (so the caller skips turn creation entirely).
+ */
+export function triggerForAction(action: string): TurnTrigger | null {
+  return NOTIFICATION_ACTION_TO_TURN_TRIGGER[action] ?? null;
+}
+
+/**
+ * Parameters this bridge needs from the notification chokepoint. A structural subset
+ * of `NotificationCreateParams` plus the optional human-instruction body — kept narrow
+ * so the bridge is trivially unit-testable with plain fixtures.
+ */
+export interface WakeNotificationContext {
+  companyUuid: string;
+  recipientType: string;
+  recipientUuid: string;
+  entityType: string;
+  entityUuid: string;
+  action: string;
+  // Free-text body for a `human_instruction` notification (子2). The canonical copy
+  // lives on the created turn's `promptText`; the notification row carries the
+  // denormalized copy. Null/undefined for autonomous wakes.
+  instructionText?: string | null;
+}
+
+/**
+ * For a wake-triggering notification destined for a DAEMON agent, record the matching
+ * `DaemonSessionTurn`. Composes (never reimplements) the daemon-session service:
+ *
+ *  1. Map `action → trigger`; bail (null) if the action is not wake-triggering.
+ *  2. Only agent recipients can be daemons — bail for `user` recipients.
+ *  3. Resolve the agent's ONLINE origin connection (`listConnectionsForAgent`, already
+ *     sorted online-first; the first `effectiveStatus === "online"` entry owns the
+ *     cwd-bound transcript). No online connection ⇒ no daemon to wake ⇒ bail (null).
+ *  4. Derive the session id: the entity's `directIdeaUuid` via lineage when the
+ *     entityType is lineage-walkable, else the entity uuid (ad-hoc session). This is
+ *     the stable `(agentUuid, sessionId)` business key.
+ *  5. `resolveOrCreateSession` (stamps origin + directIdeaUuid write-once) then
+ *     `createPendingTurn` with the mapped trigger. For `human_instruction`, the turn's
+ *     `promptText` is the instruction body (canonical).
+ *
+ * FAILURE ISOLATION: any throw from steps 3-5 is caught, logged VISIBLY, and swallowed
+ * to null — a turn-creation failure MUST NOT abort or block the already-created
+ * notification (the notification row exists before this runs). Returns the created
+ * `TurnView`, or null when no turn was created (not wake-triggering, human recipient,
+ * agent offline, or a logged failure).
+ */
+export async function maybeCreateTurnForWakeNotification(
+  ctx: WakeNotificationContext,
+): Promise<TurnView | null> {
+  // (1) Not a wake-triggering action → no turn (and the daemon would not wake either).
+  const trigger = triggerForAction(ctx.action);
+  if (!trigger) return null;
+
+  // (2) Only agents can be daemons; a human recipient never owns a daemon session.
+  if (ctx.recipientType !== "agent") return null;
+
+  try {
+    // (3) Resolve the agent's online origin connection (cwd-bound transcript owner).
+    // listConnectionsForAgent is sorted online-first, then lastSeenAt desc, so the
+    // first online entry is the freshest connection to pin the session to.
+    const connections = await listConnectionsForAgent(
+      ctx.companyUuid,
+      ctx.recipientUuid,
+    );
+    const origin = connections.find((c) => c.effectiveStatus === "online");
+    if (!origin) {
+      // No online daemon for this agent — nothing to wake, so no turn. (Not an error:
+      // a notification can target an agent with no running daemon.)
+      return null;
+    }
+
+    // (4) Session id = the entity's direct idea (when lineage-walkable), else the
+    // entity uuid (ad-hoc). directIdeaUuid stays null for an ad-hoc session.
+    let directIdeaUuid: string | null = null;
+    if (LINEAGE_ENTITY_TYPES.has(ctx.entityType)) {
+      directIdeaUuid = await resolveDirectIdeaUuid(
+        ctx.companyUuid,
+        ctx.entityType as LineageEntityType,
+        ctx.entityUuid,
+      );
+    }
+    const sessionId = directIdeaUuid ?? ctx.entityUuid;
+
+    // (5) Resolve-or-create the session (origin + directIdeaUuid write-once on create),
+    // then append the pending turn. For human_instruction the canonical free-text body
+    // lives on the turn's promptText.
+    const session = await resolveOrCreateSession({
+      companyUuid: ctx.companyUuid,
+      agentUuid: ctx.recipientUuid,
+      sessionId,
+      directIdeaUuid,
+      originConnectionUuid: origin.uuid,
+    });
+
+    const promptText =
+      trigger === "human_instruction" ? ctx.instructionText ?? null : null;
+
+    const turn = await createPendingTurn({
+      sessionUuid: session.uuid,
+      trigger,
+      promptText,
+    });
+    return turn;
+  } catch (error) {
+    // VISIBLE failure (repo "no silent errors"): log with full context but DO NOT
+    // rethrow — the notification was already created and must not be aborted by a
+    // turn-creation failure.
+    turnLogger.error(
+      {
+        err: error,
+        companyUuid: ctx.companyUuid,
+        agentUuid: ctx.recipientUuid,
+        action: ctx.action,
+        entityType: ctx.entityType,
+        entityUuid: ctx.entityUuid,
+      },
+      "Failed to create DaemonSessionTurn for wake notification (notification was still created)",
+    );
+    return null;
+  }
+}

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -4,6 +4,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { eventBus } from "@/lib/event-bus";
+import { maybeCreateTurnForWakeNotification } from "@/services/notification-turn";
 
 // ===== Type Definitions =====
 
@@ -21,6 +22,11 @@ export interface NotificationCreateParams {
   actorType: string;
   actorUuid: string;
   actorName: string;
+  // Free-text instruction body for a `human_instruction` wake notification (子2 UI
+  // send box). Persisted as a write-once denormalized copy on the row; the canonical
+  // copy lives on the created `DaemonSessionTurn.promptText`. Null for every
+  // non-instruction notification.
+  instructionText?: string | null;
 }
 
 export interface NotificationListParams {
@@ -51,6 +57,14 @@ export interface NotificationResponse {
   readAt: string | null;
   archivedAt: string | null;
   createdAt: string;
+  // Write-once denormalized copy of a `human_instruction` turn's free-text body
+  // (子1 — daemon-session-conversation). Present (non-null) ONLY for an agent-recipient
+  // `human_instruction` notification; null for every other action. The CANONICAL source
+  // is `DaemonSessionTurn.promptText` — this copy is transport-only, so the daemon reads
+  // the instruction in the `chorus_get_notifications` call it already makes (zero extra
+  // fetch). Surfaced here in the read projection so the daemon's event-router can thread
+  // it into the wake prompt.
+  instructionText: string | null;
 }
 
 export interface NotificationPreferenceFields {
@@ -105,6 +119,7 @@ function formatNotification(n: {
   readAt: Date | null;
   archivedAt: Date | null;
   createdAt: Date;
+  instructionText?: string | null;
 }): NotificationResponse {
   return {
     uuid: n.uuid,
@@ -123,6 +138,8 @@ function formatNotification(n: {
     readAt: n.readAt?.toISOString() ?? null,
     archivedAt: n.archivedAt?.toISOString() ?? null,
     createdAt: n.createdAt.toISOString(),
+    // Denormalized human_instruction body (子1) — null for every non-instruction action.
+    instructionText: n.instructionText ?? null,
   };
 }
 
@@ -149,6 +166,9 @@ export async function create(
       actorType: params.actorType,
       actorUuid: params.actorUuid,
       actorName: params.actorName,
+      // Write-once denormalized copy of a human_instruction turn's prompt; null for
+      // every other notification. The canonical copy is the turn's promptText.
+      instructionText: params.instructionText ?? null,
     },
   });
 
@@ -170,6 +190,13 @@ export async function create(
     entityUuid: params.entityUuid,
     projectUuid: params.projectUuid,
   });
+
+  // After the notification row exists, record the matching DaemonSessionTurn for a
+  // wake-triggering notification destined for a daemon agent. This is the single
+  // chokepoint where every wake notification is born, so human and autonomous wakes
+  // are handled symmetrically. The bridge is failure-isolated (logs + swallows): a
+  // turn-creation failure MUST NOT abort or block this already-created notification.
+  await maybeCreateTurnForWakeNotification(params);
 
   return formatNotification(notification);
 }
@@ -198,6 +225,8 @@ export async function createBatch(
           actorType: params.actorType,
           actorUuid: params.actorUuid,
           actorName: params.actorName,
+          // Write-once denormalized copy (null for every non-instruction notification).
+          instructionText: params.instructionText ?? null,
         },
       })
     )
@@ -232,6 +261,16 @@ export async function createBatch(
       entityUuid: matchParams?.entityUuid,
       projectUuid: matchParams?.projectUuid,
     });
+  }
+
+  // After all notification rows exist, record a DaemonSessionTurn for each
+  // wake-triggering notification destined for a daemon agent (symmetric with create()).
+  // Each attempt is failure-isolated inside the bridge: a turn-creation failure logs
+  // and is swallowed, never aborting the notifications that were already created. Run
+  // sequentially so per-session monotonic turn `seq` allocation is not raced when one
+  // batch carries multiple wakes for the same agent session.
+  for (const params of notifications) {
+    await maybeCreateTurnForWakeNotification(params);
   }
 
   return created.map(formatNotification);


### PR DESCRIPTION
## Summary
- Models each daemon Claude session as a **persistent conversation** (`DaemonSession`) whose every wake — autonomous (`task_assigned`/`mentioned`/`elaboration`/`resume`) and human (`human_instruction`) — is a **turn**, with per-turn user/assistant transcript relay.
- Server creates the turn at the **notification chokepoint**; the wake notification **carries the instruction text** so the daemon needs no extra fetch (canonical text lives on the turn).
- **Continuation is pinned to the origin connection** (cwd+machine that owns the on-disk transcript) — an offline origin makes the session **read-only**, never re-routed (because `claude --resume` is cwd-bound).
- Owner-scoped visibility; DDL-only migration.
- Foundation (子1) for UI instruction-injection (子2, idea `5fe8cc2f`) and transcript viewing/continue (子3, idea `25fe9cb7`). Idea `7039f1cf`; OpenSpec change `daemon-session-conversation` (archived).

## Changed files
| Area | Files |
|------|-------|
| Schema | `prisma/schema.prisma` (+`DaemonSession`/`DaemonSessionTurn`/`DaemonTranscriptMessage` + `Notification.instructionText`), DDL-only migration `20260619055322` |
| Services | `daemon-session.service.ts` (new), `notification-turn.ts` (new), `notification.service.ts` (chokepoint turn creation) |
| Routes | `POST /api/daemon/transcript`, `POST /api/daemon/turn-advance`, `GET /api/daemon/pending-turns` (all new; agent-key, owner-scoped 404 non-disclosure, no new permission bit) |
| Daemon CLI | `waker`, `event-router`, `prompts`, `upload-hooks`, `backfill`, `daemon` (mod), `turn-reporter` (new) — zero new deps |
| Tests | 8 new + 2 updated test files |
| Spec | OpenSpec change archived + `openspec/specs/daemon-session-conversation/spec.md` |

## Review fixes (independent review found 0 BLOCKER, 2 HIGH + 3 lower — all fixed before this PR)
| ID | Fix |
|----|-----|
| **H1** | `advanceTurnForWake` resolves the turn by **status** (FIFO: →running picks oldest pending, →ended picks running), not most-recent seq — a turn created mid-run no longer strands the running turn permanently |
| **H2** | `createPendingTurn` **retries on a P2002** `(sessionUuid, seq)` conflict instead of silently dropping a concurrent same-session turn |
| **M1** | rolling-window trim tiebreaks on the globally-monotonic `id`, not per-turn `seq` |
| **M2** | `advanceTurn` throws rather than emitting a tenant-less SSE event if the session is missing |
| **L1** | transcript `sessionId` path attaches to the **running** turn (fallback most-recent) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full suite **2548 passed / 1 skipped** (+5 regression tests for H1/H2/M1/M2)
- [x] Integration test (real cross-module composition over one store + real event bus, 5 threads)
- [x] Independent code review (general-purpose agent) — 0 BLOCKER; all findings fixed
- [x] E2E: 3 new daemon endpoints mounted + auth-gated (401/405) on running dev server; login + app shell render (no regression)
- [ ] True browser+`claude` daemon e2e — not runnable headless; deferred to 子2/子3 (which add UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)