### PR TITLE
feat(elaboration): human Verify Elaborate button wakes daemon agent to write proposal

### DIFF
--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -77,12 +77,38 @@ describe("buildPrompt", () => {
     expect(pi).toContain("idea-7");
   });
 
+  it("elaboration_verified wakes the agent to WRITE the proposal, not answer questions (add-elaboration-verify-wake)", () => {
+    expect(WAKE_ACTIONS.has("elaboration_verified")).toBe(true);
+    const p = buildPrompt({
+      ...TASK_NOTIF,
+      action: "elaboration_verified",
+      entityType: "idea",
+      entityUuid: "idea-9",
+      entityTitle: "Ship the widget",
+    });
+    expect(p).not.toBeNull();
+    expect(p).toContain("idea-9"); // the idea uuid
+    expect(p).toContain("proj-1"); // project uuid for context
+    expect(p).toContain("VERIFIED"); // tells the agent the elaboration was verified
+    expect(p).toContain("elaborated"); // idea is now elaborated
+    // It must direct proposal authoring via the existing proposal flow...
+    expect(p).toContain("chorus_pm_create_proposal");
+    expect(p).toContain("chorus_get_idea");
+    expect(p).toContain("chorus_get_elaboration");
+    expect(p.toLowerCase()).toContain("write the proposal");
+    // ...and must NOT instruct the agent to answer elaboration questions or open a round.
+    expect(p).not.toContain("chorus_pm_validate_elaboration");
+    expect(p).not.toContain("chorus_pm_start_elaboration");
+    expect(p).toContain("@[Alice](user:user-1)"); // mention guidance
+  });
+
   it("WAKE_ACTIONS covers the agent-relevant server notifications and excludes the noisy ones", () => {
     for (const a of [
       "task_assigned",
       "mentioned",
       "elaboration_requested",
       "elaboration_answered",
+      "elaboration_verified",
       "proposal_rejected",
       "proposal_approved",
       "idea_claimed",

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -65,6 +65,18 @@ export function buildPrompt(n) {
         `answers, then either resolve the elaboration (chorus_pm_validate_elaboration) and proceed to a proposal, ` +
         `or open another round (chorus_pm_start_elaboration) if gaps remain.\n${mentionGuidance(n, "idea")}`
       );
+    case "elaboration_verified":
+      // A human clicked "Verify Elaborate" (add-elaboration-verify-wake). This is NOT a
+      // request to answer questions — the elaboration is DONE and the idea is now
+      // `elaborated`. The agent's job on this wake is to WRITE THE PROPOSAL via the
+      // existing proposal flow, anchored to the idea's same session that ran elaboration.
+      return (
+        `[Chorus] Elaboration for idea '${n.entityTitle}' was VERIFIED by a human ` +
+        `(ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). The idea is now elaborated — do NOT ` +
+        `answer elaboration questions. Proceed to WRITE THE PROPOSAL: gather context with chorus_get_idea and ` +
+        `chorus_get_elaboration, then author the proposal via the existing proposal flow ` +
+        `(chorus_pm_create_proposal / the proposal skill).\n${mentionGuidance(n, "idea")}`
+      );
     case "proposal_rejected":
       return (
         `[Chorus] Proposal '${n.entityTitle}' was REJECTED (proposalUuid: ${n.entityUuid}, ` +
@@ -173,6 +185,13 @@ export const WAKE_ACTIONS = new Set([
   "mentioned",
   "elaboration_requested",
   "elaboration_answered",
+  // add-elaboration-verify-wake: a human clicked "Verify Elaborate" — the elaboration is
+  // resolved and the idea is `elaborated`. This wakes the assigned daemon PM agent to WRITE
+  // THE PROPOSAL (distinct from elaboration_requested/answered, which mean "answer
+  // questions"). Arrives as a persisted notification (recipient = the idea's assigned agent),
+  // idea-rooted like the other elaboration wakes, so the session anchor/resume contract is
+  // unchanged. See buildPrompt's `elaboration_verified` case for the write-proposal prompt.
+  "elaboration_verified",
   "proposal_rejected",
   "proposal_approved",
   "idea_claimed",

--- a/messages/en.json
+++ b/messages/en.json
@@ -896,6 +896,10 @@
     "skipReasonPlaceholder": "e.g., Bug fix with clear reproduction steps",
     "skipReasonRequired": "Please provide a reason",
     "elaborationRequiredHint": "Complete or skip elaboration to create a proposal",
+    "verifyButton": "Verify Elaborate",
+    "verifying": "Verifying...",
+    "verifyFailed": "Failed to verify elaboration",
+    "verifiedQueuedHint": "Verified — the agent will write the proposal when it's available.",
     "category": {
       "functional": "Functional",
       "nonFunctional": "Non-functional",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -897,6 +897,10 @@
     "skipReasonPlaceholder": "例如：有明确复现步骤的bug修复",
     "skipReasonRequired": "请提供跳过原因",
     "elaborationRequiredHint": "完成或跳过需求澄清后才能创建方案",
+    "verifyButton": "完成细化",
+    "verifying": "确认中...",
+    "verifyFailed": "确认细化失败",
+    "verifiedQueuedHint": "已确认 — 智能体上线后将撰写方案。",
     "category": {
       "functional": "功能性",
       "nonFunctional": "非功能性",

--- a/openspec/changes/add-elaboration-verify-wake/.openspec.yaml
+++ b/openspec/changes/add-elaboration-verify-wake/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/add-elaboration-verify-wake/README.md
+++ b/openspec/changes/add-elaboration-verify-wake/README.md
@@ -1,0 +1,3 @@
+# add-elaboration-verify-wake
+
+Human 'Verify Elaborate' button resolves elaboration and wakes the daemon agent to write the proposal

--- a/openspec/changes/add-elaboration-verify-wake/design.md
+++ b/openspec/changes/add-elaboration-verify-wake/design.md
@@ -1,0 +1,130 @@
+# Design: Human "Verify Elaborate" → daemon writes the proposal
+
+## Overview
+
+This change adds the missing human-side "elaboration is confirmed, move forward" action and wires it to the existing daemon-session wake machinery so the assigned PM daemon agent writes the proposal. It is deliberately thin: it reuses the existing elaboration resolution state transition, the existing notification → turn → daemon-wake pipeline, and the existing proposal-authoring flow. The only genuinely new pieces are (a) a **user-callable** resolution entry point (because the existing one is agent-only) and (b) a **new wake action/trigger** (`elaboration_verified`) so the daemon can tell "go write the proposal" apart from "go answer questions."
+
+The design intentionally avoids:
+
+- a new Idea stored status (reuses the 3-state model + derived `planning`),
+- a new Prisma model or migration (`DaemonSessionTurn.trigger` is a free-form string; Idea status is unchanged),
+- a new MCP tool (the human path is a Next.js server action, not an agent tool),
+- a new permission bit (human authorization is company-scoped, matching existing human server actions),
+- changing how proposals are authored (the woken agent uses the existing proposal flow).
+
+## Key decisions (from elaboration)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| Q1 | **Human resolves, then wakes** (not wake-only). | Owner choice. The click resolves the elaboration synchronously via a new user-callable path, *then* wakes the agent only to write the proposal. |
+| Q2 | **New dedicated trigger** `elaboration_verified`. | The existing `elaboration` wake means "answer the questions." "Human verified → write proposal" is semantically different; conflating them would force the daemon to reverse-engineer intent from idea state. |
+| Q3 | **Queue + backfill** when the agent is offline. | Resolution is synchronous and never blocked by daemon liveness; the wake recovers through the existing reconnect notification-backfill. |
+| Q4 | **One final verify, all rounds answered.** | Single idea-level button, enabled only when no round is in `pending_answers` — matches the existing resolve precondition. |
+| Q5 | **Replace idea-panel button; keep the generic proposals-list entry.** | The idea-panel "Create Proposal" is the dead idea→proposal handoff; the proposals-list entry is a separate from-scratch authoring path, out of scope. |
+| Q6 | **Reuse derived `planning`.** | No new stored state; `elaborated` + no proposal already derives `planning`. |
+| R2 | **Skip / agent-self-validated ideas are out of scope.** | Owner choice. This change handles only the human-verify main line; other paths to `elaborated`-without-proposal are deferred. |
+
+## Architecture
+
+### End-to-end flow
+
+```
+Human answers all elaboration rounds (existing UI)
+        │
+        ▼
+[Verify Elaborate] button   ──(enabled iff: status=elaborating, ≥1 round, every round answered, not resolved)
+        │  server action: verifyElaborationAction(ideaUuid)
+        ▼
+elaborationService.verifyElaboration({ companyUuid, ideaUuid, actorUuid, actorType: "user" })
+        │  • precondition: ≥1 round, none pending_answers
+        │  • idea.status → elaborated ; elaborationStatus → resolved
+        │  • activity: action = "elaboration_verified"
+        ▼
+notification-listener:  idea:elaboration_verified  →  notification(action="elaboration_verified", recipient = idea's assigned AGENT)
+        │
+        ▼
+notification chokepoint (notification.service.createReturningTurn)
+        │  maybeCreateTurnForWakeNotification:
+        │    NOTIFICATION_ACTION_TO_TURN_TRIGGER["elaboration_verified"] = "elaboration_verified"
+        │    • online origin connection?  →  create pending turn + deliver_turn ping
+        │    • offline?                   →  no turn now; notification persists (backfill recovers)
+        ▼
+Daemon client (cli/event-router → waker → prompts.mjs)
+        │  WAKE_ACTIONS includes "elaboration_verified"
+        │  buildPrompt → "Idea is elaborated. Write the proposal via the proposal flow."
+        ▼
+Spawned Claude (PM agent)  →  chorus_pm_create_proposal + proposal skill  →  proposal drafted
+        │
+        ▼
+Idea derived status = planning (elaborated, no proposal yet) → building once tasks exist
+```
+
+### Why a new user-callable resolution path (not the existing tool)
+
+`resolveElaboration` (`elaboration.service.ts:275`) guards `idea.assigneeUuid !== actorUuid` and is surfaced only as `chorus_pm_validate_elaboration`, gated on `idea:admin`. The Idea's assignee is the **daemon agent**, and a human user holds neither the assignee identity nor agent permission bits. Chorus has **no project-level user roles** — human authorization in server actions is company-scoped + actor-type-gated (see `criteria-actions.ts`'s `auth.type === "user"` pattern). Therefore the human verify must be its own path:
+
+- **Server action** `verifyElaborationAction(ideaUuid)` — rejects unless `auth.type === "user"` (or `super_admin`); passes `auth.companyUuid` + `auth.actorUuid`.
+- **Service** `verifyElaboration({ companyUuid, ideaUuid, actorUuid, actorType })` — scopes the Idea by `companyUuid`, enforces the **same** structural precondition as resolve (≥1 round, no `pending_answers`), performs the **same** state transition (`elaborated` / `resolved`), but does **not** require the actor to be the assignee. It logs activity `action = "elaboration_verified"` (distinct from the agent path's `elaboration_resolved`) so the wake can be distinguished downstream.
+
+The existing agent-only tool and its `elaboration_resolved` activity are untouched.
+
+### The `elaboration_verified` wake — server side
+
+The daemon-session pipeline (PRs #332–#334) keys daemon prompts off the **notification action** (`cli/prompts.mjs` `WAKE_ACTIONS`), while the server collapses actions into `TURN_TRIGGERS` for the turn row. Adding `elaboration_verified` therefore touches both layers:
+
+1. `notification-listener.ts` — `resolveNotificationType` maps `idea:elaboration_verified` → notification type `elaboration_verified`; recipient resolution sends it to the **Idea's assigned agent** (the daemon), not a human. (Distinct from `elaboration_requested`/`elaboration_answered`.)
+2. `notification-turn.ts` — `NOTIFICATION_ACTION_TO_TURN_TRIGGER["elaboration_verified"] = "elaboration_verified"`.
+3. `daemon-session.service.ts` — `TURN_TRIGGERS` gains `"elaboration_verified"`.
+
+Everything else on the server (chokepoint turn creation, origin-only `deliver_turn`, offline persistence, reconnect-backfill) is reused unchanged — this is exactly the symmetry the chokepoint was built for.
+
+### The `elaboration_verified` wake — daemon side
+
+`cli/prompts.mjs`:
+
+- Add `"elaboration_verified"` to `WAKE_ACTIONS` so the event router treats it as a wake.
+- Add a prompt case: roughly *"[Chorus] Elaboration for idea '{title}' was verified by a human. The idea is now elaborated. Proceed to write the proposal: use chorus_get_idea + chorus_get_elaboration for context, then create the proposal via the proposal flow (chorus_pm_create_proposal …)."* The agent then runs the normal proposal skill in that woken turn.
+
+The session anchor / resume contract is unchanged — the wake is keyed to the Idea's session like every other idea-rooted wake, so the woken turn is the same conversation that ran elaboration.
+
+### Button gating & placement
+
+A single idea-level "Verify Elaborate" button. Enabled iff **all** hold:
+
+- `idea.status === "elaborating"`,
+- `idea.elaborationStatus !== "resolved"`,
+- the Idea has ≥1 elaboration round,
+- no round is in `pending_answers` (every required question answered).
+
+When disabled-because-unanswered, the surrounding copy directs the human to finish answering. After a successful click, the button is replaced by the derived `planning` status indicator ("agent is writing the proposal"). If the assigned agent is offline at click time, the action still succeeds and the UI shows an "agent will pick this up when it reconnects" hint.
+
+Placement (per Q5 + R2 button-location = both panels):
+
+- `/ideas` route `idea-detail-panel.tsx` — **replace** the existing "Create Proposal" button (`:582`).
+- Dashboard `dashboard/panels/idea-detail-panel.tsx` footer — **add** the button (today only Assign/Delete live there).
+
+The proposals-list `proposals/page.tsx` "Create Proposal" stays.
+
+### Data the button needs
+
+The elaboration data (rounds + per-round status) is already loaded into the idea-detail panels (it powers `elaboration-panel.tsx`). The "all rounds answered" predicate is computed client-side from that data; no new fetch is required. Server-side, `verifyElaboration` re-checks the precondition authoritatively (never trust the client's enable state).
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Client enables the button when a round is actually still pending (stale data). | Service re-validates "no `pending_answers`" authoritatively and rejects; the button enable state is a UX hint only. |
+| A human verifies but the assigned agent never comes online → proposal never written. | Accepted per Q3/Q5 (no manual fallback on the idea panel). Resolution still succeeds; the wake waits in backfill. The generic proposals-list entry remains as a last resort outside this idea's scope. |
+| Two surfaces (both panels) drift in gating logic. | Extract the enable predicate + verify call into one shared helper/hook used by both panels. |
+| Daemon `WAKE_ACTIONS` and server action enum diverge (new trigger added one place, not the other). | Spec scenarios assert both the server mapping and the daemon `prompts.mjs` case; the verify task's AC lists all touch-points. |
+| Recipient mis-targeting (human gets the wake notification instead of the agent). | `elaboration_verified` notification recipient is the Idea's **assigned agent**; spec scenario asserts it does not surface in a human's bell. |
+| Confusing `elaboration_verified` with `elaboration_answered` on the daemon. | Distinct action string + distinct prompt case; daemon prompt explicitly says "write the proposal," not "answer questions." |
+
+## Implementation order
+
+1. **Backend resolution path** — `verifyElaboration` service + `verifyElaborationAction` server action + `elaboration_verified` activity. (Unblocks everything; independently testable via the action.)
+2. **Wake wiring** — notification-listener mapping + recipient, `notification-turn` trigger map, `TURN_TRIGGERS` value. (Depends on the activity action existing.)
+3. **Daemon prompt** — `cli/prompts.mjs` `WAKE_ACTIONS` + case. (Depends on the trigger/action name being fixed.)
+4. **Frontend button** — shared enable predicate + both panels + i18n + post-verify/offline states. (Depends on the server action.)
+5. **Integration checkpoint** — end-to-end: answer rounds → click verify → idea elaborated → agent woken with write-proposal prompt (or queued when offline). (Depends on 1–4.)
+6. **design.pen + skill-doc note.**

--- a/openspec/changes/add-elaboration-verify-wake/proposal.md
+++ b/openspec/changes/add-elaboration-verify-wake/proposal.md
@@ -1,0 +1,72 @@
+# Proposal: Human "Verify Elaborate" button → wake daemon agent to write the proposal
+
+## Why
+
+Today the Idea-elaboration flow stops dead once a human finishes answering a round. The UI has no "I'm done — move this forward" action:
+
+1. **No forward affordance after answering.** A human answers the elaboration questions in `elaboration-panel.tsx` and… nothing. There is no button that says "elaboration is confirmed, proceed." Resolving an elaboration (`resolveElaboration` / `chorus_pm_validate_elaboration`) exists **only** as an `idea:admin` MCP tool whose service guard requires the caller to be the Idea's *assignee* — i.e. the agent itself. A human user is neither the assignee nor an admin agent, so a human literally cannot resolve from the UI today.
+
+2. **The human-facing "Create Proposal" button is the wrong job for a human.** The idea-detail panel footer (`src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx:582`) shows a "Create Proposal" button gated on `elaborationStatus === "resolved"` — but since no human can reach `resolved` from the UI, the button is effectively dead, and writing a proposal by hand is exactly the PM agent's job under Chorus's **Reversed Conversation** philosophy (AI proposes, human verifies). Asking a human to hand-author the proposal inverts the model.
+
+3. **No channel to tell the daemon agent "go write the proposal."** The 0.11.0 daemon-session line (PRs #332–#334) wakes a daemon agent on a fixed set of triggers and runs it as a conversation turn. There is no wake whose meaning is "the human verified the elaboration — now draft the proposal."
+
+The net experience we want: a human only ever **answers questions, then clicks one button**. The daemon PM agent picks it up and writes the proposal. That closes the Reversed Conversation loop in the UI.
+
+## What Changes
+
+- **New human-callable elaboration resolution.** Add a server action (`verifyElaborationAction`) + service path that lets an authenticated **user** (company-scoped) resolve an Idea's elaboration: `idea.status → elaborated`, `elaborationStatus → resolved`. This is distinct from the existing agent-only `chorus_pm_validate_elaboration` MCP tool, which is unchanged. The human's click **is** the human confirmation the resolution requires.
+
+- **New dedicated wake signal `elaboration_verified`.** Resolving via the human path emits an `elaboration_verified` activity → notification (recipient = the Idea's assigned daemon agent) → daemon wake. This is a new wake **action** that the daemon distinguishes from `elaboration_requested` / `elaboration_answered` (which mean "go answer questions"): `elaboration_verified` means **"the human confirmed — write the proposal."** A matching `elaboration_verified` value is added to the `DaemonSessionTurn.trigger` set for server/daemon symmetry.
+
+- **Daemon writes the proposal on wake.** The daemon client (`cli/prompts.mjs`) gets a new case for `elaboration_verified` instructing the woken agent: the Idea is now `elaborated`; proceed to author the proposal via the existing proposal flow (`chorus_pm_create_proposal` / proposal skill). No change to how proposals are written.
+
+- **"Verify Elaborate / 完成细化" button replaces the idea-panel "Create Proposal" button.** On **both** the `/ideas` route idea-detail panel (`idea-detail-panel.tsx`) and the dashboard idea-tracker detail panel (`dashboard/panels/idea-detail-panel.tsx`), render a single "Verify Elaborate" button, enabled only when the Idea is `elaborating`, has at least one elaboration round, and **every** round is fully answered (no `pending_answers`) and not yet resolved. On the `/ideas` panel this **replaces** the existing "Create Proposal" button.
+
+- **Generic proposals-list "Create Proposal" is kept.** The proposals-list page (`proposals/page.tsx`) "Create Proposal" entry — a from-scratch, not-idea-bound authoring path — is **not** removed; it is out of scope for the idea→proposal handoff.
+
+- **Offline = queue + backfill, no manual fallback.** If the assigned agent has no online daemon connection when the human verifies, the resolution still happens synchronously (idea → elaborated), and the wake is recovered through the existing reconnect notification-backfill. The UI surfaces that the agent will pick it up when it reconnects. No human "write it yourself" fallback is added on the idea panel.
+
+- **Idea status feedback reuses the derived `planning` state.** No new stored Idea status. After resolution, an `elaborated` Idea with no Proposal already derives the display status `planning`; the UI reuses that to signal "agent is drafting the proposal." The 3-stored-state Idea model is unchanged.
+
+- **i18n.** New keys for the button label, the post-verify status hint, and the offline hint in both `messages/en.json` and `messages/zh.json`.
+
+- **design.pen.** Update the idea-detail panel mock(s) to show the "Verify Elaborate" button in place of "Create Proposal."
+
+## Capabilities
+
+### New Capabilities
+
+- `elaboration-verify-wake`: The end-to-end "Verify Elaborate" feature — the UI button (placement, gating, replacement scope), the `elaboration_verified` wake that tells the daemon to write the proposal, the daemon's write-proposal behavior on that wake, the offline behavior, the reuse of derived `planning` status, and the explicit scope boundary.
+
+### Modified Capabilities
+
+- `elaboration-resolution`: Add a **human-callable** resolution path alongside the existing agent-only `chorus_pm_validate_elaboration` MCP tool. The existing admin-gated tool requirement is unchanged; this is purely additive.
+- `daemon-session-conversation`: Extend the `DaemonSessionTurn.trigger` enumeration with `elaboration_verified` so a human-verify wake is recorded as a distinct turn kind.
+
+## Impact
+
+- **Schema**: **zero migrations.** No new Idea status, no new model. `DaemonSessionTurn.trigger` is a free-form string in Prisma (the enumeration is a contract, not a DB enum), so adding `elaboration_verified` is a contract/code change, not DDL.
+- **Backend code**:
+  - `src/services/elaboration.service.ts` — new `verifyElaboration` path (user-actor, company-scoped, same "all rounds answered / ≥1 round" precondition as resolve, sets `elaborated`/`resolved`, logs `elaboration_verified` activity).
+  - `src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions.ts` — new `verifyElaborationAction` server action (gated on `auth.type === "user"`/`super_admin`, company-scoped).
+  - `src/services/notification-listener.ts` — map `idea:elaboration_verified` activity → `elaboration_verified` notification to the assigned agent.
+  - `src/services/notification-turn.ts` — map notification action `elaboration_verified` → turn trigger `elaboration_verified`.
+  - `src/services/daemon-session.service.ts` — add `elaboration_verified` to `TURN_TRIGGERS`.
+- **Daemon client code** (in-repo, `cli/`):
+  - `cli/prompts.mjs` — add `elaboration_verified` to `WAKE_ACTIONS` and a new prompt case ("write the proposal").
+- **Frontend code**:
+  - `src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx` — replace the "Create Proposal" button with the gated "Verify Elaborate" button + post-verify status.
+  - `src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx` — add the same "Verify Elaborate" button to the footer.
+  - `src/components/elaboration-panel.tsx` may expose whether all rounds are answered (or the panel computes it from the elaboration data already in props).
+- **i18n**: `messages/en.json` + `messages/zh.json` — new keys.
+- **Docs**: `docs/MCP_TOOLS.md` unchanged (no new MCP tool — the verify path is a server action, not an MCP tool). Skill docs (`public/skill/`, `public/chorus-plugin/skills/chorus/`) get a one-line note that the daemon wakes to write a proposal on human verify. `docs/design.pen` updated.
+- **Runtime**: no new dependencies, no migrations, no new MCP tool, no new permission bit.
+- **Backward compat**: fully additive. The existing agent-only resolve and the existing `elaboration` wake are unchanged. Ideas that reach `elaborated` via `skip_elaboration` or an agent's own MCP `validate` (i.e. **without** a human verify click) are explicitly **out of scope** — this change adds no new way to wake the agent for those.
+
+## Out of Scope
+
+- Waking the agent to write a proposal for Ideas that became `elaborated` **without** the human verify click (e.g. via `skip_elaboration`, or an agent calling `chorus_pm_validate_elaboration` itself). Deferred by explicit owner decision.
+- Changing how a proposal is authored — the woken agent still uses the existing proposal flow.
+- Removing the generic proposals-list "Create Proposal" entry.
+- New elaboration question-generation or answering mechanics — unchanged.
+- Introducing project-level user roles. The human-verify authorization is company-scoped (matching existing human-action patterns) until/unless project roles exist.

--- a/openspec/changes/add-elaboration-verify-wake/specs/daemon-session-conversation/spec.md
+++ b/openspec/changes/add-elaboration-verify-wake/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,37 @@
+# daemon-session-conversation Specification
+
+## MODIFIED Requirements
+
+### Requirement: Every daemon wake SHALL be recorded as a turn on its DaemonSession
+
+The server SHALL define a Prisma model `DaemonSessionTurn` representing one wake on a conversation. It SHALL carry at least: `uuid`, `sessionUuid` (referencing `DaemonSession.uuid`), `seq` (monotonic per session), `trigger` (one of `task_assigned`, `mentioned`, `elaboration`, `elaboration_verified`, `resume`, `human_instruction`), `promptText` (nullable — the free-text instruction body for a `human_instruction` turn, null for autonomous triggers), `status` (`pending` | `running` | `ended`), `startedAt` (nullable), `endedAt` (nullable), and `createdAt`. Every wake-triggering event — whether an autonomous dispatch (task assignment, @mention, elaboration request, elaboration verified, resume) or a human-typed instruction — SHALL produce exactly one turn on the corresponding `DaemonSession`, distinguished only by `trigger`. A turn SHALL reference the live execution it corresponds to (so the conversation turn and the `DaemonExecution` row are linked) without altering `DaemonExecution` reconcile semantics. The `trigger` field is a free-form string column; extending the enumeration SHALL NOT require a data-mutating migration.
+
+#### Scenario: An autonomous task dispatch records a turn
+
+- **GIVEN** a task is assigned to a daemon agent, producing a wake on session I
+- **WHEN** the server records the wake
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "task_assigned"`
+
+#### Scenario: A human instruction records a turn carrying its text
+
+- **GIVEN** a human submits a free-text instruction to session I
+- **WHEN** the server records it
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "human_instruction"` and `promptText` set to the submitted text
+
+#### Scenario: An elaboration-verified wake records a turn
+
+- **GIVEN** a human verifies the elaboration of an idea-anchored session I
+- **WHEN** the server records the wake
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "elaboration_verified"`
+
+#### Scenario: Turn trigger distinguishes wake kinds on one conversation
+
+- **GIVEN** session I has received a task assignment, an @mention, and a human instruction
+- **WHEN** the session's turns are listed
+- **THEN** all three MUST appear as turns on the same `DaemonSession`, distinguished by their `trigger` values
+
+#### Scenario: A turn links to its execution without changing execution semantics
+
+- **WHEN** a turn begins running and a `DaemonExecution` row reflects the running entity
+- **THEN** the turn MUST reference that execution
+- **AND** the `DaemonExecution` snapshot-reconcile behavior MUST be unchanged by the turn linkage

--- a/openspec/changes/add-elaboration-verify-wake/specs/elaboration-resolution/spec.md
+++ b/openspec/changes/add-elaboration-verify-wake/specs/elaboration-resolution/spec.md
@@ -1,0 +1,29 @@
+# elaboration-resolution Specification
+
+## ADDED Requirements
+
+### Requirement: A human-callable resolution path SHALL exist alongside the admin-gated MCP tool
+
+The system SHALL provide a human-callable elaboration resolution path that is additive to — and does NOT replace — the existing `chorus_pm_validate_elaboration` MCP tool. The human path SHALL be a Next.js server action gated on the caller's auth type being `user` (or `super_admin`) and SHALL scope the Idea by the caller's `companyUuid`. Unlike the agent-only tool, the human path SHALL NOT require the caller to be the Idea's assignee and SHALL NOT require any agent permission bit. It SHALL enforce the same structural preconditions as the agent path (the Idea has at least one round and no round is in `pending_answers`) and SHALL perform the same state transition (`status → elaborated`, `elaborationStatus → resolved`). The human path SHALL log an `elaboration_verified` activity (distinct from the agent path's `elaboration_resolved`).
+
+#### Scenario: Human path resolves without admin permission or assignee identity
+
+- **GIVEN** an Idea in `elaborating` status with every round answered, assigned to a daemon agent
+- **WHEN** an authenticated human user (not the assignee, holding no agent permission) invokes the human resolution path within the same company
+- **THEN** the Idea `status` MUST become `elaborated`
+- **AND** the Idea `elaborationStatus` MUST become `resolved`
+- **AND** an `elaboration_verified` activity MUST be logged
+
+#### Scenario: The admin-gated MCP tool is unchanged
+
+- **WHEN** an agent holding `idea:admin` calls `chorus_pm_validate_elaboration` on its assigned Idea with every round answered
+- **THEN** the Idea status becomes `elaborated`
+- **AND** the Idea `elaborationStatus` becomes `resolved`
+- **AND** an `elaboration_resolved` activity is logged
+- **AND** the agent-only assignee + `idea:admin` requirement of that tool is unchanged by the addition of the human path
+
+#### Scenario: Human path enforces the all-rounds-answered precondition
+
+- **WHEN** the human resolution path is invoked on an Idea that has at least one round still in `pending_answers`
+- **THEN** the call MUST fail without changing the Idea status
+- **AND** the failure MUST indicate some round(s) still have unanswered questions

--- a/openspec/changes/add-elaboration-verify-wake/specs/elaboration-verify-wake/spec.md
+++ b/openspec/changes/add-elaboration-verify-wake/specs/elaboration-verify-wake/spec.md
@@ -1,0 +1,168 @@
+# elaboration-verify-wake Specification
+
+## ADDED Requirements
+
+### Requirement: A human SHALL be able to verify (resolve) an Idea's elaboration from the UI
+
+The system SHALL provide a user-callable path that lets an authenticated human resolve an Idea's elaboration without requiring agent permissions or being the Idea's assignee. The path SHALL be exposed as a Next.js server action (NOT an MCP tool) that rejects callers whose auth type is not `user` (or `super_admin`), and SHALL scope the target Idea by the caller's `companyUuid`. On success it SHALL set the Idea `status` to `elaborated` and `elaborationStatus` to `resolved`, identical to the agent-side resolution's state transition. The human's click SHALL itself constitute the human confirmation that resolution requires — no separate confirmation step is needed.
+
+#### Scenario: A user verifies elaboration when all rounds are answered
+
+- **GIVEN** an Idea in `elaborating` status with at least one elaboration round and no round in `pending_answers`
+- **WHEN** an authenticated user invokes the verify-elaboration server action for that Idea in their company
+- **THEN** the Idea `status` MUST become `elaborated`
+- **AND** the Idea `elaborationStatus` MUST become `resolved`
+- **AND** the caller MUST NOT be required to be the Idea's assignee
+- **AND** the caller MUST NOT be required to hold any agent permission bit
+
+#### Scenario: An agent caller is rejected from the human verify path
+
+- **WHEN** a caller whose auth type is `agent` invokes the verify-elaboration server action
+- **THEN** the action MUST reject the call
+- **AND** the Idea status MUST be unchanged
+
+#### Scenario: Verify is refused when a round is still unanswered
+
+- **GIVEN** an Idea with at least one elaboration round in `pending_answers`
+- **WHEN** an authenticated user invokes the verify-elaboration server action
+- **THEN** the action MUST fail without changing the Idea status
+- **AND** the failure MUST indicate that some round(s) still have unanswered questions
+
+#### Scenario: Verify is refused when the Idea has no rounds
+
+- **GIVEN** an Idea in `elaborating` status with zero elaboration rounds
+- **WHEN** an authenticated user invokes the verify-elaboration server action
+- **THEN** the action MUST fail without changing the Idea status
+
+#### Scenario: Verify does not cross company boundaries
+
+- **GIVEN** an Idea belonging to company C2
+- **WHEN** a user authenticated in company C1 invokes the verify-elaboration server action for that Idea
+- **THEN** the action MUST NOT resolve the Idea
+- **AND** the response MUST NOT confirm the Idea exists in another company
+
+### Requirement: Human verification SHALL emit a distinct `elaboration_verified` signal
+
+Resolving an Idea's elaboration through the human verify path SHALL log an activity with action `elaboration_verified`, distinct from the agent path's `elaboration_resolved`. This distinct action SHALL be the basis for waking the Idea's assigned daemon agent to write the proposal, so that "the human verified — write the proposal" is distinguishable from "answer the elaboration questions" (`elaboration_requested` / `elaboration_answered`).
+
+#### Scenario: Verify logs the elaboration_verified activity
+
+- **WHEN** a user successfully resolves an Idea through the human verify path
+- **THEN** an activity with action `elaboration_verified` MUST be recorded for that Idea
+- **AND** it MUST be distinct from the `elaboration_resolved` activity emitted by the agent-only resolution tool
+
+### Requirement: The `elaboration_verified` event SHALL wake the Idea's assigned daemon agent to write the proposal
+
+The `elaboration_verified` activity SHALL produce a notification whose recipient is the Idea's **assigned agent** (the daemon), routed through the existing notification → daemon-wake pipeline. The notification MUST NOT surface in a human recipient's notification bell. When the assigned agent has an online daemon connection, a daemon wake SHALL be produced for the Idea's session telling the agent to write the proposal. The wake action SHALL be carried as `elaboration_verified` and distinguished from `elaboration_requested` / `elaboration_answered`.
+
+#### Scenario: Verified elaboration wakes the assigned agent
+
+- **GIVEN** an Idea assigned to a daemon agent that has an online daemon connection
+- **WHEN** a human verifies that Idea's elaboration
+- **THEN** a wake-triggering notification with action `elaboration_verified` MUST be created with the assigned agent as recipient
+- **AND** a daemon turn MUST be produced for the Idea's session
+
+#### Scenario: The verify wake notification does not reach humans
+
+- **WHEN** the `elaboration_verified` notification is created
+- **THEN** its recipient MUST be the Idea's assigned agent
+- **AND** it MUST NOT appear in any human recipient's notification list
+
+### Requirement: The woken daemon agent SHALL be instructed to write the proposal
+
+The daemon client SHALL treat `elaboration_verified` as a wake action and SHALL build a prompt directing the woken agent to author the proposal for the now-`elaborated` Idea using the existing proposal flow — NOT to answer elaboration questions. The wake SHALL be anchored to the Idea's existing daemon session so the proposal is written in the same conversation that ran the elaboration.
+
+#### Scenario: The daemon prompt directs proposal authoring on verify
+
+- **GIVEN** a daemon receives a wake whose action is `elaboration_verified` for an Idea
+- **WHEN** the daemon builds the prompt for the woken agent
+- **THEN** the prompt MUST instruct the agent that the Idea is elaborated and to write the proposal
+- **AND** the prompt MUST NOT instruct the agent to answer elaboration questions
+
+#### Scenario: elaboration_verified is recognized as a wake action
+
+- **WHEN** the daemon's wake-action set is inspected
+- **THEN** it MUST include `elaboration_verified`
+
+### Requirement: Verification SHALL succeed even when the assigned agent is offline, with the wake deferred
+
+When a human verifies an Idea whose assigned agent has no online daemon connection, the resolution SHALL still complete synchronously (Idea → `elaborated` / `resolved`). No live daemon turn is created at that moment; the wake SHALL be recovered through the existing reconnect notification-backfill when the agent's daemon next connects. The UI SHALL communicate that the agent will pick the work up when it comes online. No human "write the proposal yourself" fallback SHALL be added to the idea-detail panel.
+
+#### Scenario: Verify succeeds while the agent is offline
+
+- **GIVEN** an Idea assigned to a daemon agent with no online daemon connection
+- **WHEN** a human verifies the Idea's elaboration
+- **THEN** the Idea `status` MUST become `elaborated` and `elaborationStatus` `resolved`
+- **AND** the verify action MUST NOT fail due to the agent being offline
+
+#### Scenario: The deferred wake is recovered on reconnect
+
+- **GIVEN** a verify performed while the assigned agent was offline
+- **WHEN** the agent's daemon reconnects
+- **THEN** the agent MUST be able to recover the verify wake through the existing reconnect notification-backfill
+
+#### Scenario: No manual proposal fallback on the idea panel
+
+- **WHEN** the idea-detail panel renders for an Idea whose assigned agent is offline after verify
+- **THEN** the panel MUST NOT offer a human "create the proposal manually" affordance for that Idea
+
+### Requirement: The "Verify Elaborate" button SHALL replace the idea-panel "Create Proposal" button and be gated on full answering
+
+The idea-detail panels SHALL render a single idea-level "Verify Elaborate" button in place of the existing human-facing "Create Proposal" button. The button SHALL be enabled only when the Idea is in `elaborating` status, has at least one elaboration round, has no round in `pending_answers`, and is not already `resolved`. The button SHALL appear on BOTH the `/ideas` route idea-detail panel (replacing the existing "Create Proposal" button) AND the dashboard idea-tracker idea-detail panel. The label SHALL be sourced from i18n in both `en` and `zh` locales. The generic "Create Proposal" entry on the proposals-list page SHALL NOT be removed.
+
+#### Scenario: Button is enabled when every round is answered
+
+- **GIVEN** an Idea in `elaborating` status with one or more rounds, none in `pending_answers`, not yet `resolved`
+- **WHEN** the idea-detail panel renders
+- **THEN** a "Verify Elaborate" button MUST be rendered and enabled
+- **AND** the prior human-facing "Create Proposal" button MUST NOT be rendered on that panel
+
+#### Scenario: Button is disabled or absent while a round is unanswered
+
+- **GIVEN** an Idea with at least one round in `pending_answers`
+- **WHEN** the idea-detail panel renders
+- **THEN** the "Verify Elaborate" button MUST NOT be in an enabled, clickable state
+
+#### Scenario: Button appears on both idea-detail panels
+
+- **WHEN** the Idea is viewed on the `/ideas` route idea-detail panel and on the dashboard idea-tracker idea-detail panel
+- **THEN** both panels MUST render the "Verify Elaborate" button subject to the same gating
+
+#### Scenario: The button label is localized
+
+- **WHEN** the button renders under the `en` locale and under the `zh` locale
+- **THEN** its label MUST come from an i18n key present in both `messages/en.json` and `messages/zh.json`
+- **AND** the label MUST NOT be hardcoded in the component
+
+#### Scenario: The generic proposals-list Create Proposal entry is preserved
+
+- **WHEN** the proposals-list page renders
+- **THEN** its generic "Create Proposal" entry MUST still be present
+
+### Requirement: Post-verify status feedback SHALL reuse the derived `planning` state
+
+The feature SHALL NOT introduce a new stored Idea status. After verification, an `elaborated` Idea with no Proposal already derives the display status `planning`; the UI SHALL reuse that derived status to indicate the agent is drafting the proposal. The stored 3-state Idea model (`open` / `elaborating` / `elaborated`) SHALL be unchanged.
+
+#### Scenario: A verified Idea with no proposal shows planning
+
+- **GIVEN** an Idea that has just been verified (now `elaborated`) with no linked Proposal
+- **WHEN** its derived display status is computed
+- **THEN** the derived status MUST be `planning`
+- **AND** no new stored Idea status value MUST be introduced by this change
+
+### Requirement: Ideas reaching `elaborated` without a human verify click SHALL be out of scope
+
+This change SHALL NOT add any new mechanism to wake the agent to write a proposal for an Idea that became `elaborated` through a path other than the human verify click — specifically `skip_elaboration` or an agent calling the existing `chorus_pm_validate_elaboration` tool itself. Those paths SHALL retain their current behavior unchanged.
+
+#### Scenario: Skipped elaboration does not gain a new verify wake
+
+- **GIVEN** an Idea whose elaboration was resolved via `skip_elaboration`
+- **WHEN** that resolution completes
+- **THEN** this change MUST NOT introduce a new `elaboration_verified` wake for it
+- **AND** the skip behavior MUST be unchanged from before this change
+
+#### Scenario: Agent self-validation does not gain a new verify wake
+
+- **GIVEN** an Idea resolved by the assigned agent calling `chorus_pm_validate_elaboration`
+- **WHEN** that resolution completes
+- **THEN** this change MUST NOT introduce a new `elaboration_verified` wake for it

--- a/openspec/changes/add-elaboration-verify-wake/tasks.md
+++ b/openspec/changes/add-elaboration-verify-wake/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: add-elaboration-verify-wake
+
+## 1. Backend resolution path (human verify)
+- [ ] 1.1 Add `verifyElaboration` to `elaboration.service.ts` (user-actor, company-scoped, same precondition as resolve, sets elaborated/resolved, logs `elaboration_verified` activity)
+- [ ] 1.2 Add `verifyElaborationAction` server action in `ideas/[ideaUuid]/elaboration-actions.ts` (gated on auth.type user/super_admin)
+- [ ] 1.3 Unit tests: precondition, company scope, actor-type rejection, activity action
+
+## 2. Wake wiring
+- [ ] 2.1 `notification-listener.ts`: map `idea:elaboration_verified` → notification type, recipient = assigned agent
+- [ ] 2.2 `notification-turn.ts`: `NOTIFICATION_ACTION_TO_TURN_TRIGGER["elaboration_verified"] = "elaboration_verified"`
+- [ ] 2.3 `daemon-session.service.ts`: add `elaboration_verified` to `TURN_TRIGGERS`
+- [ ] 2.4 Tests: notification recipient is agent (not human), turn trigger value
+
+## 3. Daemon prompt
+- [ ] 3.1 `cli/prompts.mjs`: add `elaboration_verified` to `WAKE_ACTIONS`
+- [ ] 3.2 `cli/prompts.mjs`: add prompt case directing the agent to write the proposal (not answer questions)
+
+## 4. Frontend button
+- [ ] 4.1 Shared enable-predicate helper (status elaborating, ≥1 round, no pending_answers, not resolved)
+- [ ] 4.2 `/ideas` `idea-detail-panel.tsx`: replace Create Proposal with Verify Elaborate + post-verify/offline states
+- [ ] 4.3 dashboard `panels/idea-detail-panel.tsx`: add Verify Elaborate button
+- [ ] 4.4 i18n keys (button label, post-verify hint, offline hint) in en + zh
+- [ ] 4.5 Keep proposals-list generic Create Proposal
+
+## 5. Integration checkpoint
+- [ ] 5.1 E2E: answer rounds → verify → idea elaborated → agent woken with write-proposal prompt (online) / queued (offline)
+
+## 6. Docs & design
+- [ ] 6.1 Update `docs/design.pen` idea-detail panel mock(s)
+- [ ] 6.2 One-line skill-doc note (public/skill + chorus-plugin) on verify→write-proposal wake

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -527,7 +527,7 @@ model DaemonSessionTurn {
   sessionUuid   String
   session       DaemonSession             @relation(fields: [sessionUuid], references: [uuid], onDelete: Cascade)
   seq           Int // monotonic per session
-  trigger       String // task_assigned | mentioned | elaboration | resume | human_instruction
+  trigger       String // task_assigned | mentioned | elaboration | elaboration_verified | resume | human_instruction
   promptText    String? // free-text body for human_instruction; null otherwise (canonical source)
   status        String                    @default("pending") // pending | running | ended
   // Weak ref to the live DaemonExecution row this turn corresponds to (no DB FK;

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -303,4 +303,5 @@ This is a soft heuristic, not a rule — use judgment. Cycle prevention is autom
 ## Next
 
 - Once elaboration is resolved, use `/proposal` to create a Proposal with document and task drafts
+- **Human "Verify Elaborate" handoff:** when a human clicks **Verify Elaborate** on the idea-detail panel, Chorus resolves the elaboration and wakes the Idea's assigned daemon agent to write the proposal — so the woken agent picks up this idea→proposal handoff automatically (no human-authored proposal needed).
 - For platform overview and shared tools, see `/chorus`

--- a/public/skill/idea-chorus/SKILL.md
+++ b/public/skill/idea-chorus/SKILL.md
@@ -298,4 +298,5 @@ This is a soft heuristic, not a rule — use judgment. Cycle prevention is autom
 ## Next
 
 - Once elaboration is resolved, use the `proposal-chorus` skill (`<BASE_URL>/skill/proposal-chorus/SKILL.md`) to create a Proposal with document and task drafts
+- **Human "Verify Elaborate" handoff:** when a human clicks **Verify Elaborate** on the idea-detail panel, Chorus resolves the elaboration and wakes the Idea's assigned daemon agent to write the proposal — so the woken agent picks up this idea→proposal handoff automatically (no human-authored proposal needed).
 - For platform overview and shared tools, see the `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`)

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+//
+// UI tests for the dashboard idea-tracker IdeaDetailPanel footer "Verify
+// Elaborate" button (task: Frontend Verify Elaborate button). Covers:
+//  - the button is gated by the shared canVerifyElaboration predicate,
+//  - clicking calls verifyElaborationAction and shows the queued hint on success,
+//  - the failure path surfaces an inline error.
+// Heavy tab/child views are stubbed so the test focuses on the footer contract.
+
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { refreshMock } = vi.hoisted(() => ({ refreshMock: vi.fn() }));
+
+const {
+  getIdeaActionMock,
+  getProposalsForIdeaActionMock,
+  getTasksForProposalActionMock,
+  getTaskActionMock,
+  getElaborationActionMock,
+  verifyElaborationActionMock,
+} = vi.hoisted(() => ({
+  getIdeaActionMock: vi.fn(),
+  getProposalsForIdeaActionMock: vi.fn(),
+  getTasksForProposalActionMock: vi.fn(),
+  getTaskActionMock: vi.fn(),
+  getElaborationActionMock: vi.fn(),
+  verifyElaborationActionMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock, push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("../actions", () => ({
+  getIdeaAction: (...args: unknown[]) => getIdeaActionMock(...args),
+  getProposalsForIdeaAction: (...args: unknown[]) => getProposalsForIdeaActionMock(...args),
+  getTasksForProposalAction: (...args: unknown[]) => getTasksForProposalActionMock(...args),
+  getTaskAction: (...args: unknown[]) => getTaskActionMock(...args),
+}));
+
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions", () => ({
+  getElaborationAction: (...args: unknown[]) => getElaborationActionMock(...args),
+  verifyElaborationAction: (...args: unknown[]) => verifyElaborationActionMock(...args),
+}));
+
+// Realtime SSE hooks are no-ops in the test.
+vi.mock("@/contexts/realtime-context", () => ({
+  useRealtimeEntityTypeEvent: () => {},
+  useRealtimeEntityEvent: () => {},
+}));
+
+// Stub the tab/child views — they fetch their own data and are out of scope here.
+vi.mock("../elaboration-view", () => ({ ElaborationView: () => <div data-testid="elaboration-view" /> }));
+vi.mock("../proposal-view", () => ({ ProposalView: () => <div /> }));
+vi.mock("../overview-timeline", () => ({ OverviewTimeline: () => <div /> }));
+vi.mock("../reports-list", () => ({ ReportsList: () => <div /> }));
+vi.mock("../task-list-view", () => ({ TaskListView: () => <div /> }));
+vi.mock("../activity-comments-view", () => ({ ActivityCommentsView: () => <div /> }));
+vi.mock("../document-panel", () => ({ DocumentPanel: () => <div /> }));
+vi.mock("../move-idea-dialog", () => ({ MoveIdeaDialog: () => <div /> }));
+vi.mock("../set-parent-dialog", () => ({ SetParentDialog: () => <div /> }));
+vi.mock("../new-idea-dialog", () => ({ NewIdeaDialog: () => <div /> }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel", () => ({ TaskDetailPanel: () => <div /> }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal", () => ({ AssignIdeaModal: () => <div /> }));
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../../../../../messages/en.json")).default as Record<string, unknown>;
+  function resolveKey(ns: string, key: string): string {
+    const path = ns ? `${ns}.${key}`.split(".") : key.split(".");
+    let node: unknown = en;
+    for (const p of path) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return `${ns ? ns + "." : ""}${key}`;
+      }
+    }
+    return typeof node === "string" ? node : `${ns ? ns + "." : ""}${key}`;
+  }
+  const tCache = new Map<string, (key: string, values?: Record<string, unknown>) => string>();
+  return {
+    useTranslations: (ns?: string) => {
+      const k = ns ?? "";
+      let fn = tCache.get(k);
+      if (!fn) {
+        fn = (key) => resolveKey(k, key);
+        tCache.set(k, fn);
+      }
+      return fn;
+    },
+  };
+});
+
+(window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  onchange: null,
+  dispatchEvent: vi.fn(),
+})) as unknown as typeof window.matchMedia;
+
+import { IdeaDetailPanel } from "../idea-detail-panel";
+
+const IDEA_UUID = "00000000-0000-4000-8000-000000000111";
+const PROJECT_UUID = "00000000-0000-4000-8000-0000000000aa";
+const USER_UUID = "00000000-0000-4000-8000-0000000000bb";
+
+function ideaResponse(over: Record<string, unknown> = {}) {
+  return {
+    success: true as const,
+    data: {
+      uuid: IDEA_UUID,
+      title: "My Idea",
+      content: "body",
+      status: "elaborating",
+      elaborationStatus: "validating",
+      derivedStatus: "researching",
+      badgeHint: "answer_questions",
+      assignee: { type: "agent", uuid: "agent-1", name: "PM Bot", assignedAt: null, assignedBy: null },
+      createdAt: "2026-06-20T00:00:00.000Z",
+      parent: null,
+      parentUuid: null,
+      children: [],
+      descendantUuids: [],
+      ...over,
+    },
+  };
+}
+
+function elaborationResponse(roundStatus: string) {
+  return {
+    success: true as const,
+    data: {
+      ideaUuid: IDEA_UUID,
+      depth: "standard",
+      status: "pending_answers",
+      rounds: [
+        {
+          uuid: "round-1",
+          roundNumber: 1,
+          status: roundStatus,
+          isAppended: false,
+          createdBy: { type: "agent", uuid: "agent-1" },
+          validatedAt: null,
+          questions: [],
+          createdAt: "2026-06-20T00:00:00.000Z",
+        },
+      ],
+      summary: { totalQuestions: 1, answeredQuestions: 1, validatedRounds: 0, pendingRound: null },
+    },
+  };
+}
+
+function renderPanel() {
+  return render(
+    <IdeaDetailPanel
+      ideaUuid={IDEA_UUID}
+      projectUuid={PROJECT_UUID}
+      currentUserUuid={USER_UUID}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getIdeaActionMock.mockResolvedValue(ideaResponse());
+  getProposalsForIdeaActionMock.mockResolvedValue({ success: true, data: [] });
+  getTasksForProposalActionMock.mockResolvedValue({ success: true, data: [] });
+  getTaskActionMock.mockResolvedValue({ success: false });
+  getElaborationActionMock.mockResolvedValue(elaborationResponse("answered"));
+  verifyElaborationActionMock.mockResolvedValue({ success: true, data: {} });
+});
+
+describe("dashboard IdeaDetailPanel — Verify Elaborate footer button", () => {
+  it("renders an enabled Verify Elaborate button when every round is answered", async () => {
+    renderPanel();
+    const btn = (await screen.findByRole("button", { name: "Verify Elaborate" })) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("does not render the button while a round is still pending", async () => {
+    getElaborationActionMock.mockResolvedValue(elaborationResponse("pending_answers"));
+    renderPanel();
+    // The idea loads (Reassign button proves the footer rendered) but no verify button.
+    await screen.findByRole("button", { name: "Reassign" });
+    expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
+  });
+
+  it("does not render the button once elaboration is resolved", async () => {
+    getIdeaActionMock.mockResolvedValue(ideaResponse({ elaborationStatus: "resolved" }));
+    renderPanel();
+    await screen.findByRole("button", { name: "Reassign" });
+    expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
+  });
+
+  it("calls verifyElaborationAction on click and shows the queued hint on success", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    const btn = await screen.findByRole("button", { name: "Verify Elaborate" });
+    await user.click(btn);
+
+    await waitFor(() => {
+      expect(verifyElaborationActionMock).toHaveBeenCalledWith(IDEA_UUID);
+    });
+    expect(
+      await screen.findByText("Verified — the agent will write the proposal when it's available."),
+    ).toBeTruthy();
+    // No manual "Create Proposal" fallback on the idea panel.
+    expect(screen.queryByRole("button", { name: "Create Proposal" })).toBeNull();
+  });
+
+  it("surfaces an inline error and keeps the button when verify fails", async () => {
+    verifyElaborationActionMock.mockResolvedValueOnce({ success: false, error: "boom" });
+    const user = userEvent.setup();
+    renderPanel();
+    const btn = await screen.findByRole("button", { name: "Verify Elaborate" });
+    await user.click(btn);
+
+    await waitFor(() => expect(verifyElaborationActionMock).toHaveBeenCalled());
+    expect(await screen.findByText("boom")).toBeTruthy();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { Bot, Loader2 } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { ElaborationPanel } from "@/components/elaboration-panel";
-import { getElaborationAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions";
-import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
 import { MarkdownContent } from "@/components/markdown-content";
 import { motion } from "framer-motion";
 import { fadeIn } from "@/lib/animation";
@@ -17,37 +14,16 @@ import { AssigneeSection } from "./assignee-section";
 
 interface ElaborationViewProps {
   idea: IdeaResponse;
+  // Elaboration data is loaded once at the panel level and shared with the
+  // footer's "Verify Elaborate" gate — no separate fetch here.
+  elaboration: ElaborationResponse | null;
+  isLoading: boolean;
   onRefresh: () => Promise<void> | void;
 }
 
-export function ElaborationView({ idea, onRefresh }: ElaborationViewProps) {
+export function ElaborationView({ idea, elaboration, isLoading, onRefresh }: ElaborationViewProps) {
   const t = useTranslations("ideaTracker");
   const tCommon = useTranslations("common");
-
-  const [elaboration, setElaboration] = useState<ElaborationResponse | null>(
-    null
-  );
-  const [isLoading, setIsLoading] = useState(true);
-
-  const loadElaboration = useCallback(async () => {
-    const result = await getElaborationAction(idea.uuid);
-    if (result.success && result.data) {
-      setElaboration(result.data);
-    }
-    setIsLoading(false);
-  }, [idea.uuid]);
-
-  useEffect(() => {
-    loadElaboration();
-  }, [loadElaboration]);
-
-  // Subscribe to SSE events to refresh elaboration when idea changes
-  useRealtimeEntityTypeEvent("idea", loadElaboration);
-
-  const handleRefresh = async () => {
-    await loadElaboration();
-    await onRefresh();
-  };
 
   if (isLoading) {
     return (
@@ -70,7 +46,7 @@ export function ElaborationView({ idea, onRefresh }: ElaborationViewProps) {
           <ElaborationPanel
             ideaUuid={idea.uuid}
             elaboration={elaboration}
-            onRefresh={handleRefresh}
+            onRefresh={onRefresh}
           />
         </div>
       ) : idea.status === "open" ? (

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { X, Loader2, User, Trash2, ArrowRightLeft, Pencil, GitFork, CornerLeftUp, CornerDownRight } from "lucide-react";
+import { X, Loader2, User, Trash2, ArrowRightLeft, Pencil, GitFork, CornerLeftUp, CornerDownRight, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
@@ -37,8 +37,11 @@ import { SetParentDialog } from "./set-parent-dialog";
 import { NewIdeaDialog } from "../new-idea-dialog";
 import { deleteIdeaAction, updateIdeaAction } from "@/app/(dashboard)/projects/[uuid]/ideas/actions";
 import { getIdeaAction, getTaskAction, getProposalsForIdeaAction, getTasksForProposalAction } from "./actions";
+import { getElaborationAction, verifyElaborationAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions";
 import { AssignIdeaModal } from "@/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal";
 import type { IdeaResponse } from "@/services/idea.service";
+import type { ElaborationResponse } from "@/types/elaboration";
+import { canVerifyElaboration } from "@/lib/elaboration-verify";
 import { clientLogger } from "@/lib/logger-client";
 import { formatDateTime } from "@/lib/format-date";
 
@@ -174,6 +177,16 @@ export function IdeaDetailPanel({
   // Footer/modal state
   const [showAssignModal, setShowAssignModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Elaboration data — loaded once here and shared between the elaboration tab
+  // view and the footer's "Verify Elaborate" gate (no separate fetch each).
+  const [elaboration, setElaboration] = useState<ElaborationResponse | null>(null);
+  const [isLoadingElaboration, setIsLoadingElaboration] = useState(true);
+
+  // Verify elaboration state
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const [verified, setVerified] = useState(false);
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -322,6 +335,22 @@ export function IdeaDetailPanel({
   }, [fetchTasks]);
 
   useRealtimeEntityTypeEvent("task", fetchTasks);
+
+  // ===== Lift data fetching: Elaboration (shared by tab view + verify gate) =====
+  const fetchElaboration = useCallback(async () => {
+    if (!ideaUuidForFetch) return;
+    const result = await getElaborationAction(ideaUuidForFetch);
+    if (result.success && result.data) {
+      setElaboration(result.data);
+    }
+    setIsLoadingElaboration(false);
+  }, [ideaUuidForFetch]);
+
+  useEffect(() => {
+    fetchElaboration();
+  }, [fetchElaboration]);
+
+  useRealtimeEntityTypeEvent("idea", fetchElaboration);
 
   // ===== Tab visibility & default =====
   const visibleTabs = useMemo(
@@ -484,10 +513,40 @@ export function IdeaDetailPanel({
     }
   };
 
+  const handleVerify = async () => {
+    if (!idea) return;
+    setIsVerifying(true);
+    setVerifyError(null);
+
+    const result = await verifyElaborationAction(idea.uuid);
+
+    setIsVerifying(false);
+
+    if (result.success) {
+      // Idea → elaborated; derived display status becomes `planning` and the
+      // assigned daemon agent is woken (or backfilled when offline) to write
+      // the proposal. Agent liveness isn't known client-side, so a single
+      // queued hint covers both online + offline.
+      setVerified(true);
+      await fetchIdea();
+      router.refresh();
+    } else {
+      setVerifyError(result.error || t("elaboration.verifyFailed"));
+    }
+  };
+
   const status = idea?.derivedStatus || "todo";
   const canAssign = idea ? idea.status !== "elaborated" : false;
   const elaborationResolved = idea?.elaborationStatus === "resolved";
-  const showHelpText = idea?.status === "elaborating" && !elaborationResolved;
+  // Shared enable-predicate (same helper as the /ideas idea-detail panel) so
+  // the two surfaces never drift.
+  const canVerify = canVerifyElaboration({
+    ideaStatus: idea?.status,
+    elaborationStatus: idea?.elaborationStatus,
+    elaboration,
+  });
+  const showHelpText =
+    idea?.status === "elaborating" && !elaborationResolved && !canVerify && !verified;
 
   return (
     <>
@@ -760,7 +819,12 @@ export function IdeaDetailPanel({
                     <div style={{ display: activeTab === "elaboration" ? "block" : "none" }}>
                       <ElaborationView
                         idea={idea}
-                        onRefresh={fetchIdea}
+                        elaboration={elaboration}
+                        isLoading={isLoadingElaboration}
+                        onRefresh={async () => {
+                          await fetchElaboration();
+                          await fetchIdea();
+                        }}
                       />
                     </div>
                   )}
@@ -847,7 +911,37 @@ export function IdeaDetailPanel({
                     {idea.assignee ? t("common.reassign") : t("common.assign")}
                   </Button>
                 )}
-                <div className="flex-1 min-w-0">
+                <div className="flex-1 min-w-0 flex flex-wrap items-center gap-2">
+                  {/* Verify Elaborate — human "elaboration confirmed, agent
+                      writes the proposal" action, gated by the shared
+                      predicate. No manual create-proposal fallback here. */}
+                  {canVerify && !verified && (
+                    <Button
+                      className="bg-[#C67A52] hover:bg-[#B56A42] text-white"
+                      onClick={handleVerify}
+                      disabled={isVerifying}
+                    >
+                      {isVerifying ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          {t("elaboration.verifying")}
+                        </>
+                      ) : (
+                        <>
+                          <CheckCircle2 className="mr-2 h-4 w-4" />
+                          {t("elaboration.verifyButton")}
+                        </>
+                      )}
+                    </Button>
+                  )}
+                  {verified && (
+                    <span className="text-[11px] text-[#00796B]">
+                      {t("elaboration.verifiedQueuedHint")}
+                    </span>
+                  )}
+                  {verifyError && (
+                    <span className="text-[11px] text-destructive">{verifyError}</span>
+                  )}
                   {showHelpText && (
                     <span className="text-[11px] text-[#9A9A9A]">
                       {t("elaboration.elaborationRequiredHint")}

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/__tests__/elaboration-actions.test.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/__tests__/elaboration-actions.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { UserAuthContext } from "@/types/auth";
+
+const mockGetServerAuthContext = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/auth-server", () => ({
+  getServerAuthContext: mockGetServerAuthContext,
+}));
+
+const mockVerifyElaboration = vi.hoisted(() => vi.fn());
+vi.mock("@/services/elaboration.service", () => ({
+  // Sibling actions in the same module import these; stub them so the module
+  // loads without pulling in prisma transitively.
+  getElaboration: vi.fn(),
+  answerElaboration: vi.fn(),
+  skipElaboration: vi.fn(),
+  verifyElaboration: mockVerifyElaboration,
+}));
+
+const mockIdeaFindFirst = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/prisma", () => ({
+  prisma: { idea: { findFirst: mockIdeaFindFirst } },
+}));
+
+const mockRevalidatePath = vi.hoisted(() => vi.fn());
+vi.mock("next/cache", () => ({
+  revalidatePath: mockRevalidatePath,
+}));
+
+vi.mock("@/lib/logger", () => {
+  const noopLogger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => noopLogger),
+  };
+  return { default: noopLogger };
+});
+
+import { verifyElaborationAction } from "../elaboration-actions";
+
+const COMPANY_UUID = "company-1111";
+const IDEA_UUID = "idea-2222";
+const PROJECT_UUID = "project-3333";
+
+function userAuth(companyUuid = COMPANY_UUID): UserAuthContext {
+  return {
+    type: "user",
+    companyUuid,
+    actorUuid: "user-1",
+    email: "u@test.com",
+  };
+}
+
+describe("verifyElaborationAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns Unauthorized when there is no auth context", async () => {
+    mockGetServerAuthContext.mockResolvedValue(null);
+
+    const result = await verifyElaborationAction(IDEA_UUID);
+
+    expect(result).toEqual({ success: false, error: "Unauthorized" });
+    expect(mockVerifyElaboration).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent caller and never calls the service", async () => {
+    // getServerAuthContext only ever returns a user context in production, but
+    // the gate must defensively reject any non-user/non-super_admin actor type.
+    mockGetServerAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid: COMPANY_UUID,
+      actorUuid: "agent-1",
+    } as unknown as UserAuthContext);
+
+    const result = await verifyElaborationAction(IDEA_UUID);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Only users can verify elaboration");
+    expect(mockVerifyElaboration).not.toHaveBeenCalled();
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+
+  // NOTE: the action's gate also allows `auth.type === "super_admin"` for
+  // parity with sibling user-server-actions (e.g. criteria-actions.ts). That
+  // branch is defensive-only: getServerAuthContext() is typed
+  // `UserAuthContext | null` and only reads the OIDC / user_session cookies, so
+  // production never yields a super_admin context here (and SuperAdminAuthContext
+  // carries no companyUuid/actorUuid). We deliberately do NOT fabricate an
+  // impossible super_admin shape to "prove" that path works end-to-end — the
+  // user path below is the only reachable success path.
+
+  it("succeeds for a user, passing companyUuid/actorUuid/actorType to the service and revalidating", async () => {
+    mockGetServerAuthContext.mockResolvedValue(userAuth());
+    mockVerifyElaboration.mockResolvedValue({ ideaUuid: IDEA_UUID, rounds: [] });
+    mockIdeaFindFirst.mockResolvedValue({ uuid: IDEA_UUID, projectUuid: PROJECT_UUID });
+
+    const result = await verifyElaborationAction(IDEA_UUID);
+
+    expect(result).toEqual({ success: true, data: { ideaUuid: IDEA_UUID, rounds: [] } });
+    expect(mockVerifyElaboration).toHaveBeenCalledWith({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      actorUuid: "user-1",
+      actorType: "user",
+    });
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      `/projects/${PROJECT_UUID}/ideas/${IDEA_UUID}`
+    );
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      `/projects/${PROJECT_UUID}/ideas`
+    );
+  });
+
+  it("returns the underlying error message when the service throws (precondition failure)", async () => {
+    mockGetServerAuthContext.mockResolvedValue(userAuth());
+    mockVerifyElaboration.mockRejectedValue(
+      new Error("Cannot resolve: 1 round(s) still have unanswered questions")
+    );
+
+    const result = await verifyElaborationAction(IDEA_UUID);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Cannot resolve: 1 round(s) still have unanswered questions",
+    });
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions.ts
@@ -6,6 +6,7 @@ import {
   getElaboration,
   answerElaboration,
   skipElaboration,
+  verifyElaboration,
 } from "@/services/elaboration.service";
 import { prisma } from "@/lib/prisma";
 import type {
@@ -71,6 +72,46 @@ export async function submitElaborationAnswersAction(
     return {
       success: false,
       error: error instanceof Error ? error.message : "Failed to submit answers",
+    };
+  }
+}
+
+export async function verifyElaborationAction(
+  ideaUuid: string
+): Promise<{ success: boolean; data?: ElaborationResponse; error?: string }> {
+  const auth = await getServerAuthContext();
+  if (!auth) {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  // Human-only path: only authenticated users (or super admins) may verify an
+  // Idea's elaboration. Agents use the assignee-gated chorus_pm_validate_elaboration
+  // tool, not this server action.
+  if (auth.type !== "user" && auth.type !== "super_admin") {
+    return { success: false, error: "Only users can verify elaboration" };
+  }
+
+  try {
+    const data = await verifyElaboration({
+      companyUuid: auth.companyUuid,
+      ideaUuid,
+      actorUuid: auth.actorUuid,
+      actorType: auth.type,
+    });
+
+    // Revalidate the ideas page so the panel refreshes
+    const idea = await prisma.idea.findFirst({ where: { uuid: ideaUuid, companyUuid: auth.companyUuid } });
+    if (idea) {
+      revalidatePath(`/projects/${idea.projectUuid}/ideas/${ideaUuid}`);
+      revalidatePath(`/projects/${idea.projectUuid}/ideas`);
+    }
+
+    return { success: true, data };
+  } catch (error) {
+    logger.error({ err: error }, "Failed to verify elaboration");
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to verify elaboration",
     };
   }
 }

--- a/src/app/(dashboard)/projects/[uuid]/ideas/__tests__/idea-detail-verify.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/__tests__/idea-detail-verify.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+//
+// UI tests for the /ideas route IdeaDetailPanel "Verify Elaborate" button —
+// the replacement for the old human-facing "Create Proposal" button. Covers:
+//  - gating by the shared canVerifyElaboration predicate,
+//  - the old "Create Proposal" button is gone from this panel,
+//  - clicking calls verifyElaborationAction and shows the queued hint,
+//  - the failure path surfaces an inline error.
+
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { refreshMock } = vi.hoisted(() => ({ refreshMock: vi.fn() }));
+
+const {
+  getElaborationActionMock,
+  skipElaborationActionMock,
+  verifyElaborationActionMock,
+  getIdeaActivitiesActionMock,
+  updateIdeaActionMock,
+  deleteIdeaActionMock,
+} = vi.hoisted(() => ({
+  getElaborationActionMock: vi.fn(),
+  skipElaborationActionMock: vi.fn(),
+  verifyElaborationActionMock: vi.fn(),
+  getIdeaActivitiesActionMock: vi.fn(),
+  updateIdeaActionMock: vi.fn(),
+  deleteIdeaActionMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock, push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions", () => ({
+  getElaborationAction: (...args: unknown[]) => getElaborationActionMock(...args),
+  skipElaborationAction: (...args: unknown[]) => skipElaborationActionMock(...args),
+  verifyElaborationAction: (...args: unknown[]) => verifyElaborationActionMock(...args),
+}));
+
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/activity-actions", () => ({
+  getIdeaActivitiesAction: (...args: unknown[]) => getIdeaActivitiesActionMock(...args),
+}));
+
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/actions", () => ({
+  updateIdeaAction: (...args: unknown[]) => updateIdeaActionMock(...args),
+  deleteIdeaAction: (...args: unknown[]) => deleteIdeaActionMock(...args),
+}));
+
+vi.mock("@/contexts/realtime-context", () => ({
+  useRealtimeEntityTypeEvent: () => {},
+  useRealtimeEntityEvent: () => {},
+}));
+
+// Stub heavy children — not under test here.
+vi.mock("@/components/elaboration-panel", () => ({ ElaborationPanel: () => <div data-testid="elaboration-panel" /> }));
+vi.mock("@/components/unified-comments", () => ({ UnifiedComments: () => <div /> }));
+vi.mock("@/components/markdown-content", () => ({ MarkdownContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
+vi.mock("@/components/mention-renderer", () => ({ ContentWithMentions: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
+vi.mock("./assign-idea-modal", () => ({ AssignIdeaModal: () => <div /> }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/dashboard/panels/move-idea-dialog", () => ({ MoveIdeaDialog: () => <div /> }));
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../../../../messages/en.json")).default as Record<string, unknown>;
+  function resolveKey(ns: string, key: string): string {
+    const path = ns ? `${ns}.${key}`.split(".") : key.split(".");
+    let node: unknown = en;
+    for (const p of path) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return `${ns ? ns + "." : ""}${key}`;
+      }
+    }
+    return typeof node === "string" ? node : `${ns ? ns + "." : ""}${key}`;
+  }
+  const tCache = new Map<string, (key: string, values?: Record<string, unknown>) => string>();
+  return {
+    useTranslations: (ns?: string) => {
+      const k = ns ?? "";
+      let fn = tCache.get(k);
+      if (!fn) {
+        fn = (key) => resolveKey(k, key);
+        tCache.set(k, fn);
+      }
+      return fn;
+    },
+  };
+});
+
+import { IdeaDetailPanel } from "../idea-detail-panel";
+
+const IDEA_UUID = "00000000-0000-4000-8000-000000000111";
+const PROJECT_UUID = "00000000-0000-4000-8000-0000000000aa";
+const USER_UUID = "00000000-0000-4000-8000-0000000000bb";
+
+function idea(over: Record<string, unknown> = {}) {
+  return {
+    uuid: IDEA_UUID,
+    title: "My Idea",
+    content: "body",
+    status: "elaborating",
+    elaborationStatus: "validating",
+    assignee: { type: "agent", uuid: "agent-1", name: "PM Bot", assignedAt: null, assignedBy: null },
+    createdAt: "2026-06-20T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function elaborationResponse(roundStatus: string) {
+  return {
+    success: true as const,
+    data: {
+      ideaUuid: IDEA_UUID,
+      depth: "standard",
+      status: "pending_answers",
+      rounds: [
+        {
+          uuid: "round-1",
+          roundNumber: 1,
+          status: roundStatus,
+          isAppended: false,
+          createdBy: { type: "agent", uuid: "agent-1" },
+          validatedAt: null,
+          questions: [],
+          createdAt: "2026-06-20T00:00:00.000Z",
+        },
+      ],
+      summary: { totalQuestions: 1, answeredQuestions: 1, validatedRounds: 0, pendingRound: null },
+    },
+  };
+}
+
+function renderPanel(over: Record<string, unknown> = {}) {
+  return render(
+    <IdeaDetailPanel
+      idea={idea(over) as never}
+      projectUuid={PROJECT_UUID}
+      currentUserUuid={USER_UUID}
+      isUsedInProposal={false}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getIdeaActivitiesActionMock.mockResolvedValue({ activities: [] });
+  getElaborationActionMock.mockResolvedValue(elaborationResponse("answered"));
+  verifyElaborationActionMock.mockResolvedValue({ success: true, data: {} });
+});
+
+describe("/ideas IdeaDetailPanel — Verify Elaborate replaces Create Proposal", () => {
+  it("renders an enabled Verify Elaborate button when every round is answered", async () => {
+    renderPanel();
+    const btn = (await screen.findByRole("button", { name: "Verify Elaborate" })) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    // The old human-facing Create Proposal button must be gone from this panel.
+    expect(screen.queryByRole("button", { name: "Create Proposal" })).toBeNull();
+    expect(screen.queryByText("Create Proposal")).toBeNull();
+  });
+
+  it("does not render the verify button while a round is still pending", async () => {
+    getElaborationActionMock.mockResolvedValue(elaborationResponse("pending_answers"));
+    renderPanel();
+    await screen.findByRole("button", { name: "Reassign" });
+    expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
+  });
+
+  it("does not render the verify button once elaboration is resolved", async () => {
+    getElaborationActionMock.mockResolvedValue(elaborationResponse("answered"));
+    renderPanel({ elaborationStatus: "resolved" });
+    await screen.findByRole("button", { name: "Reassign" });
+    expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
+  });
+
+  it("calls verifyElaborationAction on click and shows the queued hint on success", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    const btn = await screen.findByRole("button", { name: "Verify Elaborate" });
+    await user.click(btn);
+
+    await waitFor(() => {
+      expect(verifyElaborationActionMock).toHaveBeenCalledWith(IDEA_UUID);
+    });
+    expect(
+      await screen.findByText("Verified — the agent will write the proposal when it's available."),
+    ).toBeTruthy();
+  });
+
+  it("surfaces an inline error and keeps the button when verify fails", async () => {
+    verifyElaborationActionMock.mockResolvedValueOnce({ success: false, error: "boom" });
+    const user = userEvent.setup();
+    renderPanel();
+    const btn = await screen.findByRole("button", { name: "Verify Elaborate" });
+    await user.click(btn);
+
+    await waitFor(() => expect(verifyElaborationActionMock).toHaveBeenCalled());
+    expect(await screen.findByText("boom")).toBeTruthy();
+    // Button still present after failure (verified flag not set).
+    expect(screen.getByRole("button", { name: "Verify Elaborate" })).toBeTruthy();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
@@ -2,9 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { X, Bot, User, FileText, Loader2, Pencil, Check, Trash2, ArrowRightLeft } from "lucide-react";
+import { X, Bot, User, CheckCircle2, Loader2, Pencil, Check, Trash2, ArrowRightLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -32,9 +31,10 @@ import { ContentWithMentions } from "@/components/mention-renderer";
 import { AssignIdeaModal } from "./assign-idea-modal";
 import { MoveIdeaDialog } from "@/app/(dashboard)/projects/[uuid]/dashboard/panels/move-idea-dialog";
 import { ElaborationPanel } from "@/components/elaboration-panel";
-import { getElaborationAction, skipElaborationAction } from "./[ideaUuid]/elaboration-actions";
+import { getElaborationAction, skipElaborationAction, verifyElaborationAction } from "./[ideaUuid]/elaboration-actions";
 import { useRealtimeEntityTypeEvent, useRealtimeEntityEvent } from "@/contexts/realtime-context";
 import type { ElaborationResponse } from "@/types/elaboration";
+import { canVerifyElaboration } from "@/lib/elaboration-verify";
 import { motion } from "framer-motion";
 import { fadeIn } from "@/lib/animation";
 import { formatDateTime } from "@/lib/format-date";
@@ -175,6 +175,11 @@ export function IdeaDetailPanel({
   const [isSkipping, setIsSkipping] = useState(false);
   const [skipError, setSkipError] = useState<string | null>(null);
 
+  // Verify elaboration state
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const [verified, setVerified] = useState(false);
+
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(idea.title);
@@ -197,9 +202,14 @@ export function IdeaDetailPanel({
 
   const canAssign = idea.status !== "elaborated";
   const elaborationResolved = idea.elaborationStatus === "resolved";
-  const canCreateProposal =
-    (idea.status === "elaborating" || idea.status === "elaborated") &&
-    elaborationResolved;
+  // Shared enable-predicate (also used by the dashboard idea-tracker panel) so
+  // the two surfaces never drift. Computed from the elaboration data already
+  // loaded into this panel — no extra fetch.
+  const canVerify = canVerifyElaboration({
+    ideaStatus: idea.status,
+    elaborationStatus: idea.elaborationStatus,
+    elaboration,
+  });
   const canSkipElaboration =
     idea.status === "elaborating" &&
     (!idea.elaborationStatus || idea.elaborationStatus !== "resolved") &&
@@ -273,6 +283,26 @@ export function IdeaDetailPanel({
       onDeleted?.();
       onClose();
       router.refresh();
+    }
+  };
+
+  const handleVerify = async () => {
+    setIsVerifying(true);
+    setVerifyError(null);
+
+    const result = await verifyElaborationAction(idea.uuid);
+
+    setIsVerifying(false);
+
+    if (result.success) {
+      // The Idea is now `elaborated`; its derived display status becomes
+      // `planning` and the assigned daemon agent is woken (or backfilled when
+      // offline) to write the proposal. We can't tell agent liveness apart
+      // client-side, so we surface a single queued hint that covers both.
+      setVerified(true);
+      router.refresh();
+    } else {
+      setVerifyError(result.error || t("elaboration.verifyFailed"));
     }
   };
 
@@ -564,7 +594,7 @@ export function IdeaDetailPanel({
                   </Button>
                 )}
                 {/* Middle area: help text or action buttons */}
-                <div className="flex-1 min-w-0">
+                <div className="flex-1 min-w-0 flex flex-wrap items-center gap-2">
                   {canSkipElaboration && (
                     <Button
                       variant="outline"
@@ -579,15 +609,38 @@ export function IdeaDetailPanel({
                       {t("elaboration.skipButton")}
                     </Button>
                   )}
-                  {canCreateProposal && (
-                    <Link href={`/projects/${projectUuid}/proposals/new?ideaUuid=${idea.uuid}`}>
-                      <Button className="bg-[#C67A52] hover:bg-[#B56A42] text-white">
-                        <FileText className="mr-2 h-4 w-4" />
-                        {t("proposals.createProposal")}
-                      </Button>
-                    </Link>
+                  {/* Verify Elaborate — the human "elaboration is confirmed, the
+                      agent should write the proposal" action. Replaces the old
+                      idea-panel "Create Proposal" button. No manual
+                      create-proposal fallback is offered here. */}
+                  {canVerify && !verified && (
+                    <Button
+                      className="bg-[#C67A52] hover:bg-[#B56A42] text-white"
+                      onClick={handleVerify}
+                      disabled={isVerifying}
+                    >
+                      {isVerifying ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          {t("elaboration.verifying")}
+                        </>
+                      ) : (
+                        <>
+                          <CheckCircle2 className="mr-2 h-4 w-4" />
+                          {t("elaboration.verifyButton")}
+                        </>
+                      )}
+                    </Button>
                   )}
-                  {idea.status === "elaborating" && !elaborationResolved && !canSkipElaboration && (
+                  {verified && (
+                    <span className="text-[11px] text-[#00796B]">
+                      {t("elaboration.verifiedQueuedHint")}
+                    </span>
+                  )}
+                  {verifyError && (
+                    <span className="text-[11px] text-destructive">{verifyError}</span>
+                  )}
+                  {idea.status === "elaborating" && !elaborationResolved && !canVerify && !verified && !canSkipElaboration && (
                     <span className="text-[11px] text-[#9A9A9A]">
                       {t("elaboration.elaborationRequiredHint")}
                     </span>

--- a/src/lib/__tests__/elaboration-verify.test.ts
+++ b/src/lib/__tests__/elaboration-verify.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { canVerifyElaboration } from "@/lib/elaboration-verify";
+import type { ElaborationResponse, ElaborationRoundResponse } from "@/types/elaboration";
+
+function round(status: string, roundNumber = 1): ElaborationRoundResponse {
+  return {
+    uuid: `round-${roundNumber}`,
+    roundNumber,
+    status,
+    isAppended: false,
+    createdBy: { type: "agent", uuid: "agent-1" },
+    validatedAt: null,
+    questions: [],
+    createdAt: "2026-06-20T00:00:00.000Z",
+  };
+}
+
+function elaboration(rounds: ElaborationRoundResponse[]): ElaborationResponse {
+  return {
+    ideaUuid: "idea-1",
+    depth: "standard",
+    status: "pending_answers",
+    rounds,
+    summary: {
+      totalQuestions: rounds.length,
+      answeredQuestions: rounds.length,
+      validatedRounds: 0,
+      pendingRound: null,
+    },
+  };
+}
+
+describe("canVerifyElaboration", () => {
+  it("is true when elaborating, not resolved, ≥1 round, no round pending", () => {
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborating",
+        elaborationStatus: "validating",
+        elaboration: elaboration([round("answered")]),
+      }),
+    ).toBe(true);
+  });
+
+  it("treats legacy answered statuses (validated / needs_followup) as answered", () => {
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborating",
+        elaborationStatus: "validating",
+        elaboration: elaboration([round("validated", 1), round("needs_followup", 2)]),
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when the idea is not in elaborating status", () => {
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborated",
+        elaborationStatus: "validating",
+        elaboration: elaboration([round("answered")]),
+      }),
+    ).toBe(false);
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "open",
+        elaborationStatus: null,
+        elaboration: elaboration([round("answered")]),
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when the elaboration is already resolved", () => {
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborating",
+        elaborationStatus: "resolved",
+        elaboration: elaboration([round("answered")]),
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when there are zero rounds", () => {
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborating",
+        elaborationStatus: "validating",
+        elaboration: elaboration([]),
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when any round is still pending_answers", () => {
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborating",
+        elaborationStatus: "pending_answers",
+        elaboration: elaboration([round("answered", 1), round("pending_answers", 2)]),
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when elaboration data is missing (null/undefined)", () => {
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborating",
+        elaborationStatus: "validating",
+        elaboration: null,
+      }),
+    ).toBe(false);
+    expect(
+      canVerifyElaboration({
+        ideaStatus: "elaborating",
+        elaborationStatus: undefined,
+        elaboration: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/elaboration-verify.ts
+++ b/src/lib/elaboration-verify.ts
@@ -1,0 +1,48 @@
+// Shared enable-predicate for the human-facing "Verify Elaborate" button.
+//
+// Both idea-detail panels (the `/ideas` route panel and the dashboard
+// idea-tracker panel) gate the button on the SAME predicate so the two
+// surfaces never drift. It is computed purely from elaboration data already
+// loaded into the panels — no extra fetch. The server action re-validates
+// the precondition authoritatively, so this is only a UX hint.
+
+import type { ElaborationResponse } from "@/types/elaboration";
+
+// A round is still awaiting answers iff its status is "pending_answers".
+// (The legacy "validated" / "needs_followup" statuses read as answered — see
+// src/types/elaboration.ts.)
+function isRoundPending(status: string): boolean {
+  return status === "pending_answers";
+}
+
+export interface CanVerifyElaborationInput {
+  /** Idea.status — the stored 3-state value (open | elaborating | elaborated). */
+  ideaStatus: string | null | undefined;
+  /** Idea.elaborationStatus — pending_answers | validating | resolved | null. */
+  elaborationStatus: string | null | undefined;
+  /** Elaboration data already loaded into the panel (rounds + per-round status). */
+  elaboration: ElaborationResponse | null | undefined;
+}
+
+/**
+ * Whether the human "Verify Elaborate" button should be enabled.
+ *
+ * Enabled iff ALL hold:
+ *  - the Idea is in `elaborating` status,
+ *  - the elaboration is not already `resolved`,
+ *  - the Idea has at least one elaboration round,
+ *  - no round is in `pending_answers` (every round is fully answered).
+ */
+export function canVerifyElaboration({
+  ideaStatus,
+  elaborationStatus,
+  elaboration,
+}: CanVerifyElaborationInput): boolean {
+  if (ideaStatus !== "elaborating") return false;
+  if (elaborationStatus === "resolved") return false;
+  if (!elaboration || elaboration.rounds.length === 0) return false;
+  if (elaboration.rounds.some((round) => isRoundPending(round.status))) {
+    return false;
+  }
+  return true;
+}

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -165,10 +165,22 @@ beforeEach(() => {
 
 // ===== Constants =====
 describe("constants", () => {
-  it("TURN_TRIGGERS covers the five wake kinds", () => {
+  it("TURN_TRIGGERS covers the six wake kinds (incl. the distinct elaboration_verified)", () => {
     expect([...TURN_TRIGGERS].sort()).toEqual(
-      ["elaboration", "human_instruction", "mentioned", "resume", "task_assigned"].sort(),
+      [
+        "elaboration",
+        "elaboration_verified",
+        "human_instruction",
+        "mentioned",
+        "resume",
+        "task_assigned",
+      ].sort(),
     );
+  });
+
+  it("TURN_TRIGGERS includes elaboration_verified as a member distinct from elaboration", () => {
+    expect(TURN_TRIGGERS).toContain("elaboration_verified");
+    expect(TURN_TRIGGERS).toContain("elaboration");
   });
 
   it("TURN_STATUSES are the strict forward lifecycle pending/running/ended", () => {

--- a/src/services/__tests__/elaboration-verify-wake.integration.test.ts
+++ b/src/services/__tests__/elaboration-verify-wake.integration.test.ts
@@ -1,0 +1,183 @@
+// src/services/__tests__/elaboration-verify-wake.integration.test.ts
+//
+// INTEGRATION CHECKPOINT for the add-elaboration-verify-wake feature (Tasks 1–4
+// combined). This is NOT a re-review of each unit — the per-task suites already
+// pin each end of the chain in isolation:
+//   - elaboration.service.test.ts     → verifyElaboration logs `elaboration_verified`
+//   - notification-listener.test.ts   → idea:elaboration_verified → agent-only recipient
+//   - notification-turn.test.ts       → action → distinct trigger; online/offline paths
+//   - daemon-session.service.test.ts  → TURN_TRIGGERS contains elaboration_verified
+//   - cli/wake-orchestration.test.mjs → WAKE_ACTIONS + write-proposal prompt
+//
+// What NO single unit test asserts is the SEAM the per-task reviews could not see:
+// that the ONE literal string `elaboration_verified` survives UNBROKEN across every
+// hop when the real maps are imported together. The activity action is a bare string
+// literal in elaboration.service.ts (not a shared constant), so a typo at any one seam
+// would silently break the chain while every per-task test (which hardcodes its own
+// copy of the string) stays green. This test imports the actual maps from THREE
+// modules — notification-turn (NOTIFICATION_ACTION_TO_TURN_TRIGGER + triggerForAction),
+// daemon-session (TURN_TRIGGERS), and cli/prompts (WAKE_ACTIONS + buildPrompt) — and
+// walks the string through them as ONE flow, so a single-seam mismatch fails HERE.
+//
+// The notification-listener seam (idea:elaboration_verified → elaboration_verified) is
+// the one map this test does NOT import live: resolveNotificationType is module-private
+// in notification-listener.ts and its only public entry, handleActivity, drags in prisma
+// + the full notification service (heavy DB mocking). That seam is instead anchored by
+// (a) the LISTENER_KEY assertion below over the shared literal, (b) the grep audit in the
+// integration report, and (c) notification-listener.test.ts (idea:elaboration_verified →
+// agent-only recipient). So the chain is end-to-end covered; only this one map is pinned
+// indirectly rather than imported.
+//
+// It also asserts the two intent-distinguishing properties that make the feature
+// correct: (a) the wake routes to the assigned AGENT and never a human, and (b) the
+// daemon prompt is the WRITE-THE-PROPOSAL case, NOT the answer-elaboration-questions
+// case.
+
+import { describe, it, expect, vi } from "vitest";
+
+// The notification-turn module composes daemon-session + daemon-connection + logger.
+// We import only its pure mapping table (NOTIFICATION_ACTION_TO_TURN_TRIGGER) and the
+// triggerForAction helper — but the module evaluates `logger.child(...)` at import, so
+// stub the logger to keep this a pure mapping test with no real logger/DB pull-in.
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    child: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+  },
+}));
+// daemon-connection.service / daemon-session.service are imported by notification-turn;
+// daemon-session is also imported here directly for TURN_TRIGGERS. We do NOT mock
+// daemon-session (we want the REAL TURN_TRIGGERS constant), but it pulls prisma at
+// import — the global prisma mock (src/__mocks__) handles that. daemon-connection is
+// only referenced inside an async function we never call, so no mock is needed for the
+// pure-table assertions below.
+
+import {
+  NOTIFICATION_ACTION_TO_TURN_TRIGGER,
+  triggerForAction,
+} from "@/services/notification-turn";
+import { TURN_TRIGGERS } from "@/services/daemon-session.service";
+// The daemon client lives in cli/ as plain .mjs; Vitest imports it directly (the
+// existing cli/__tests__/wake-orchestration.test.mjs proves the module is importable).
+import { buildPrompt, WAKE_ACTIONS } from "../../../cli/prompts.mjs";
+
+// ===== The single source-of-truth string =====
+//
+// This is the literal that elaboration.service.ts:verifyElaboration emits as the
+// activity `action`. If that literal is ever changed in the service, this constant
+// MUST be updated too — and the chain assertions below then prove every downstream map
+// was updated in lockstep (or fail loudly if one seam lagged).
+const ACTIVITY_ACTION = "elaboration_verified";
+
+// notification-listener's resolveNotificationType maps `${targetType}:${action}` →
+// notification type. For an idea-verify activity the key is this:
+const LISTENER_KEY = `idea:${ACTIVITY_ACTION}`;
+// …and it maps to this notification `action` (the value the notification row carries,
+// which is what reaches both notification-turn AND the daemon's buildPrompt/WAKE_ACTIONS).
+const NOTIFICATION_ACTION = "elaboration_verified";
+
+describe("add-elaboration-verify-wake — cross-module string-chain integration", () => {
+  it("the elaboration_verified literal survives every server→daemon hop unbroken", () => {
+    // Hop 1 — the activity action literal the service emits. (Pinned here; the service
+    // test asserts the service actually emits it.)
+    expect(ACTIVITY_ACTION).toBe("elaboration_verified");
+
+    // Hop 2 — notification-turn's action→trigger map keys off the NOTIFICATION action
+    // (the value produced from the activity), and yields the DISTINCT verified trigger.
+    expect(NOTIFICATION_ACTION_TO_TURN_TRIGGER[NOTIFICATION_ACTION]).toBe(
+      "elaboration_verified",
+    );
+    // …and the convenience resolver agrees (no implicit fallthrough to null).
+    expect(triggerForAction(NOTIFICATION_ACTION)).toBe("elaboration_verified");
+
+    // Hop 3 — the trigger that map produced MUST be a valid DaemonSessionTurn trigger,
+    // or createPendingTurn's zod boundary would reject every verified wake.
+    const trigger = triggerForAction(NOTIFICATION_ACTION)!;
+    expect(TURN_TRIGGERS).toContain(trigger);
+
+    // Hop 4 — the SAME notification action MUST be in the daemon's wake set, or the
+    // event-router would never enqueue a wake for it (server creates a turn the daemon
+    // ignores → dead chain).
+    expect(WAKE_ACTIONS.has(NOTIFICATION_ACTION)).toBe(true);
+
+    // Hop 5 — the daemon MUST build a non-null prompt for it (a WAKE_ACTIONS entry with
+    // no prompt is a dead wake).
+    const prompt = buildPrompt({
+      uuid: "n-1",
+      projectUuid: "proj-1",
+      entityType: "idea",
+      entityUuid: "idea-1",
+      entityTitle: "Some idea",
+      action: NOTIFICATION_ACTION,
+      message: "verified",
+      actorType: "user",
+      actorUuid: "user-1",
+      actorName: "Alice",
+    });
+    expect(prompt).not.toBeNull();
+  });
+
+  it("the verified trigger is DISTINCT from the answer-questions elaboration trigger at every layer", () => {
+    // The whole point of the feature: "human verified → write proposal" must never be
+    // collapsed into "answer the elaboration questions". Assert the distinction holds in
+    // both the turn-trigger taxonomy and the action→trigger map.
+    expect(triggerForAction(NOTIFICATION_ACTION)).not.toBe("elaboration");
+    expect(NOTIFICATION_ACTION_TO_TURN_TRIGGER["elaboration_requested"]).toBe("elaboration");
+    expect(NOTIFICATION_ACTION_TO_TURN_TRIGGER["elaboration_answered"]).toBe("elaboration");
+    expect(NOTIFICATION_ACTION_TO_TURN_TRIGGER["elaboration_verified"]).toBe("elaboration_verified");
+    expect(TURN_TRIGGERS).toContain("elaboration");
+    expect(TURN_TRIGGERS).toContain("elaboration_verified");
+  });
+
+  it("the daemon prompt for the verified wake says WRITE THE PROPOSAL, not answer questions", () => {
+    const verified = buildPrompt({
+      uuid: "n-1",
+      projectUuid: "proj-1",
+      entityType: "idea",
+      entityUuid: "idea-1",
+      entityTitle: "Onboarding revamp",
+      action: NOTIFICATION_ACTION,
+      message: "verified",
+      actorType: "user",
+      actorUuid: "user-1",
+      actorName: "Alice",
+    });
+    const answer = buildPrompt({
+      uuid: "n-2",
+      projectUuid: "proj-1",
+      entityType: "idea",
+      entityUuid: "idea-1",
+      entityTitle: "Onboarding revamp",
+      action: "elaboration_answered",
+      message: "answered",
+      actorType: "user",
+      actorUuid: "user-1",
+      actorName: "Alice",
+    });
+
+    // The verified case directs proposal authoring via the existing proposal flow…
+    expect(verified).toContain("chorus_pm_create_proposal");
+    expect(verified!.toLowerCase()).toContain("write the proposal");
+    // …and explicitly steers AWAY from answering questions.
+    expect(verified!.toLowerCase()).toContain("do not");
+    expect(verified!.toLowerCase()).toContain("elaborated");
+
+    // The two prompts are genuinely different (no accidental shared body), and the
+    // answer-questions case is the one that points at validate/start, not create.
+    expect(verified).not.toBe(answer);
+    expect(answer).toContain("chorus_pm_validate_elaboration");
+  });
+
+  it("the listener key for an idea-verify activity is exactly idea:elaboration_verified", () => {
+    // Guards the targetType:action concatenation the listener actually keys on. If the
+    // service ever changed the activity action, LISTENER_KEY changes with ACTIVITY_ACTION
+    // and this stays consistent — the regression we care about is a hand-edited typo in
+    // the listener map drifting from the emitter, which the listener unit test plus this
+    // shared-literal anchor jointly catch.
+    expect(LISTENER_KEY).toBe("idea:elaboration_verified");
+    expect(NOTIFICATION_ACTION).toBe(ACTIVITY_ACTION);
+  });
+});

--- a/src/services/__tests__/elaboration.service.test.ts
+++ b/src/services/__tests__/elaboration.service.test.ts
@@ -36,6 +36,7 @@ import {
   startElaboration,
   answerElaboration,
   resolveElaboration,
+  verifyElaboration,
   skipElaboration,
   getElaboration,
 } from "@/services/elaboration.service";
@@ -761,6 +762,144 @@ describe("resolveElaboration", () => {
         actorType: "agent",
       })
     ).rejects.toThrow("Idea not found");
+  });
+});
+
+describe("verifyElaboration", () => {
+  const USER_ACTOR = "user-9999-9999-9999-999999999999";
+
+  // verifyElaboration ends by calling getElaboration, which reads
+  // idea.findFirst + elaborationRound.findMany. The mocks below cover both the
+  // verify precondition reads and that final reload.
+  it("resolves the Idea for a user actor who is NOT the assignee (status=elaborated, elaborationStatus=resolved)", async () => {
+    const answeredRound = makeRound({ status: "answered", validatedAt: now });
+    // Idea is assigned to the daemon AGENT; the verifying actor is a different
+    // human user. verifyElaboration must NOT require actor === assignee.
+    mockPrisma.idea.findFirst.mockResolvedValue(
+      makeIdea({ assigneeUuid: ACTOR_UUID, elaborationStatus: "validating" })
+    );
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([answeredRound]);
+    mockPrisma.idea.update.mockResolvedValue({});
+
+    const result = await verifyElaboration({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      actorUuid: USER_ACTOR, // not the assignee
+      actorType: "user",
+    });
+
+    // Same Idea-level state transition as resolveElaboration; no per-round mutation.
+    expect(mockPrisma.elaborationRound.update).not.toHaveBeenCalled();
+    expect(mockPrisma.idea.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: IDEA_UUID },
+        data: { status: "elaborated", elaborationStatus: "resolved" },
+      })
+    );
+    expect(mockEventBus.emitChange).toHaveBeenCalled();
+    expect(result.ideaUuid).toBe(IDEA_UUID);
+    expect(Array.isArray(result.rounds)).toBe(true);
+  });
+
+  it("logs an `elaboration_verified` activity (distinct from `elaboration_resolved`)", async () => {
+    const answeredRound = makeRound({ status: "answered", validatedAt: now });
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([answeredRound]);
+    mockPrisma.idea.update.mockResolvedValue({});
+
+    await verifyElaboration({
+      companyUuid: COMPANY_UUID,
+      ideaUuid: IDEA_UUID,
+      actorUuid: USER_ACTOR,
+      actorType: "user",
+    });
+
+    expect(mockCreateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "elaboration_verified",
+        targetType: "idea",
+        targetUuid: IDEA_UUID,
+        value: expect.objectContaining({ totalRounds: 1 }),
+      })
+    );
+    // It must NOT use the agent path's action.
+    const loggedActions = mockCreateActivity.mock.calls.map((c) => c[0]?.action);
+    expect(loggedActions).not.toContain("elaboration_resolved");
+  });
+
+  it("treats a legacy `validated` round as answered (resolves fine)", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([
+      makeRound({ status: "validated", validatedAt: now }),
+    ]);
+    mockPrisma.idea.update.mockResolvedValue({});
+
+    await expect(
+      verifyElaboration({
+        companyUuid: COMPANY_UUID,
+        ideaUuid: IDEA_UUID,
+        actorUuid: USER_ACTOR,
+        actorType: "user",
+      })
+    ).resolves.toBeDefined();
+    expect(mockPrisma.idea.update).toHaveBeenCalled();
+  });
+
+  it("rejects when a round is still `pending_answers` and leaves the Idea unchanged", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([
+      makeRound({ status: "answered" }),
+      makeRound({ uuid: "round-2", status: "pending_answers" }),
+    ]);
+
+    await expect(
+      verifyElaboration({
+        companyUuid: COMPANY_UUID,
+        ideaUuid: IDEA_UUID,
+        actorUuid: USER_ACTOR,
+        actorType: "user",
+      })
+    ).rejects.toThrow("unanswered questions");
+    expect(mockPrisma.idea.update).not.toHaveBeenCalled();
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the Idea has zero rounds and leaves the Idea unchanged", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
+    mockPrisma.elaborationRound.findMany.mockResolvedValue([]);
+
+    await expect(
+      verifyElaboration({
+        companyUuid: COMPANY_UUID,
+        ideaUuid: IDEA_UUID,
+        actorUuid: USER_ACTOR,
+        actorType: "user",
+      })
+    ).rejects.toThrow("no elaboration rounds");
+    expect(mockPrisma.idea.update).not.toHaveBeenCalled();
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
+  it("company-scopes the Idea lookup: an Idea in another company is not found and not disclosed", async () => {
+    // findFirst is scoped by { uuid, companyUuid } — a cross-company Idea returns null.
+    mockPrisma.idea.findFirst.mockResolvedValue(null);
+
+    await expect(
+      verifyElaboration({
+        companyUuid: "other-company-uuid",
+        ideaUuid: IDEA_UUID,
+        actorUuid: USER_ACTOR,
+        actorType: "user",
+      })
+    ).rejects.toThrow("Idea not found");
+
+    // The Idea lookup must have been company-scoped (no disclosure across tenants).
+    expect(mockPrisma.idea.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: IDEA_UUID, companyUuid: "other-company-uuid" },
+      })
+    );
+    expect(mockPrisma.idea.update).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/__tests__/notification-listener.test.ts
+++ b/src/services/__tests__/notification-listener.test.ts
@@ -421,6 +421,24 @@ describe("notification-listener", () => {
       }
     });
 
+    it("should map idea:elaboration_verified to elaboration_verified", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "user-creator",
+        assigneeType: "agent",
+        assigneeUuid: "pm-agent",
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "elaboration_verified",
+        actorType: "user",
+        actorUuid: "user-verifier",
+      });
+      await handleActivity(event);
+      expect(mockNotificationService.createBatch).toHaveBeenCalled();
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      expect(call[0].action).toBe("elaboration_verified");
+    });
+
     it("should map comment_added for all entity types", async () => {
       const types = ["task", "idea", "proposal", "document"];
       for (const targetType of types) {
@@ -958,6 +976,101 @@ describe("notification-listener", () => {
       expect(ownerEntries).toHaveLength(1);
       // 2 agents + 1 dedupped shared owner = 3 entries total.
       expect(call).toHaveLength(3);
+    });
+  });
+
+  describe("elaboration_verified (human-verify → agent wake)", () => {
+    it("should target ONLY the Idea's assigned agent (the daemon), not the human creator", async () => {
+      mockPrisma.idea.findUnique.mockImplementation((opts: any) => {
+        if (opts.select?.title) return Promise.resolve({ title: "My Idea" });
+        return Promise.resolve({
+          createdByUuid: "user-creator",
+          assigneeType: "agent",
+          assigneeUuid: "pm-agent",
+        });
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "elaboration_verified",
+        actorType: "user",
+        actorUuid: "user-verifier",
+      });
+      await handleActivity(event);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      // Exactly one recipient: the assigned agent.
+      expect(call).toHaveLength(1);
+      expect(call[0].recipientType).toBe("agent");
+      expect(call[0].recipientUuid).toBe("pm-agent");
+      expect(call[0].action).toBe("elaboration_verified");
+    });
+
+    it("should NOT surface in any human's notification bell (no user recipient is produced)", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "user-creator",
+        assigneeType: "agent",
+        assigneeUuid: "pm-agent",
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "elaboration_verified",
+        actorType: "user",
+        actorUuid: "user-verifier",
+      });
+      await handleActivity(event);
+      const call = mockNotificationService.createBatch.mock.calls[0][0];
+      expect(call.every((n: any) => n.recipientType !== "user")).toBe(true);
+      // The human creator/verifier must never receive this wake.
+      expect(call.every((n: any) => n.recipientUuid !== "user-creator")).toBe(true);
+      expect(call.every((n: any) => n.recipientUuid !== "user-verifier")).toBe(true);
+    });
+
+    it("should produce NO notification when the Idea has no agent assignee (nothing to wake)", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "user-creator",
+        assigneeType: null,
+        assigneeUuid: null,
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "elaboration_verified",
+        actorType: "user",
+        actorUuid: "user-verifier",
+      });
+      await handleActivity(event);
+      expect(mockNotificationService.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("should produce NO notification when the Idea's assignee is a human (only daemons can be woken)", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "user-creator",
+        assigneeType: "user",
+        assigneeUuid: "human-assignee",
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "elaboration_verified",
+        actorType: "user",
+        actorUuid: "user-verifier",
+      });
+      await handleActivity(event);
+      expect(mockNotificationService.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("should bypass PREF_FIELD_MAP — getPreferences is never consulted (the agent wake is not preference-gated)", async () => {
+      mockPrisma.idea.findUnique.mockResolvedValue({
+        createdByUuid: "user-creator",
+        assigneeType: "agent",
+        assigneeUuid: "pm-agent",
+      });
+      const event = makeEvent({
+        targetType: "idea",
+        action: "elaboration_verified",
+        actorType: "user",
+        actorUuid: "user-verifier",
+      });
+      await handleActivity(event);
+      expect(mockNotificationService.getPreferences).not.toHaveBeenCalled();
+      expect(mockNotificationService.createBatch).toHaveBeenCalled();
     });
   });
 

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -142,6 +142,13 @@ describe("triggerForAction / NOTIFICATION_ACTION_TO_TURN_TRIGGER", () => {
     expect(triggerForAction("elaboration_answered")).toBe("elaboration");
   });
 
+  it("maps the human-verify wake to the distinct elaboration_verified trigger (NOT elaboration)", () => {
+    expect(triggerForAction("elaboration_verified")).toBe("elaboration_verified");
+    // It must be its own trigger so the daemon prompt can tell "write the proposal"
+    // apart from "answer the questions" — never collapsed into "elaboration".
+    expect(triggerForAction("elaboration_verified")).not.toBe("elaboration");
+  });
+
   it("maps the human-typed instruction to the human_instruction trigger", () => {
     expect(triggerForAction("human_instruction")).toBe("human_instruction");
   });
@@ -177,11 +184,12 @@ describe("triggerForAction / NOTIFICATION_ACTION_TO_TURN_TRIGGER", () => {
     expect(triggerForAction("resource_resumed")).toBeNull();
   });
 
-  it("every mapped trigger value is a member of the 5-value turn-trigger taxonomy", () => {
+  it("every mapped trigger value is a member of the 6-value turn-trigger taxonomy", () => {
     const allowed = new Set([
       "task_assigned",
       "mentioned",
       "elaboration",
+      "elaboration_verified",
       "resume",
       "human_instruction",
     ]);
@@ -198,6 +206,7 @@ describe("maybeCreateTurnForWakeNotification — creates exactly one pending tur
     { action: "mentioned", trigger: "mentioned" },
     { action: "elaboration_requested", trigger: "elaboration" },
     { action: "elaboration_answered", trigger: "elaboration" },
+    { action: "elaboration_verified", trigger: "elaboration_verified" },
     { action: "task_reopened", trigger: "task_assigned" },
     { action: "task_verified", trigger: "task_assigned" },
     { action: "idea_claimed", trigger: "task_assigned" },
@@ -252,6 +261,40 @@ describe("maybeCreateTurnForWakeNotification — creates exactly one pending tur
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: "comment-1", directIdeaUuid: null }),
     );
+  });
+
+  it("idea-anchored elaboration_verified wake records a turn on the idea's session with the distinct trigger", async () => {
+    // The verify wake targets the idea itself (entityType "idea"); lineage resolves
+    // it to its own directIdeaUuid and the turn carries the distinct trigger so the
+    // daemon knows to write the proposal (not answer questions).
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ action: "elaboration_verified", entityType: "idea", entityUuid: ideaUuid }),
+    );
+
+    expect(mockResolveDirectIdeaUuid).toHaveBeenCalledWith(companyUuid, "idea", ideaUuid);
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: connectionUuid }),
+    );
+    expect(mockCreatePendingTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionUuid, trigger: "elaboration_verified", promptText: null }),
+    );
+    expect(result?.trigger).toBe("elaboration_verified");
+    expect(result?.status).toBe("pending");
+  });
+
+  it("creates NO live turn for an offline agent on an elaboration_verified wake (notification persists for backfill)", async () => {
+    // Mirrors the offline/backfill contract: no online connection ⇒ no turn now, but
+    // the (already-created) notification survives for reconnect-backfill. No error.
+    mockListConnectionsForAgent.mockResolvedValue([offlineConn()]);
+
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ action: "elaboration_verified", entityType: "idea", entityUuid: ideaUuid }),
+    );
+
+    expect(result).toBeNull();
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
   it("picks the first online connection when several connections exist (origin-pinned)", async () => {

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -48,6 +48,7 @@ export const TURN_TRIGGERS = [
   "task_assigned",
   "mentioned",
   "elaboration",
+  "elaboration_verified",
   "resume",
   "human_instruction",
 ] as const;

--- a/src/services/elaboration.service.ts
+++ b/src/services/elaboration.service.ts
@@ -333,6 +333,83 @@ export async function resolveElaboration({
   return getElaboration({ companyUuid, ideaUuid });
 }
 
+// ===== Verify Elaboration (human-callable) =====
+
+/**
+ * Human-callable elaboration resolution path. Additive to — and does NOT
+ * replace — the agent-only `resolveElaboration` (surfaced as the
+ * `chorus_pm_validate_elaboration` MCP tool).
+ *
+ * Enforces the SAME structural precondition as `resolveElaboration` (the Idea
+ * has at least one round and no round is in `pending_answers`) and performs the
+ * SAME state transition (`status → elaborated`, `elaborationStatus →
+ * resolved`). CRITICAL DIFFERENCE: it does NOT require the actor to be the
+ * Idea's assignee — the human verifier is never the assignee (the daemon agent
+ * is). The Idea lookup is scoped by `companyUuid`. Logs activity with action
+ * `elaboration_verified` (distinct from the agent path's `elaboration_resolved`)
+ * so the downstream wake can tell "human verified → write proposal" apart from
+ * "agent self-validated."
+ */
+export async function verifyElaboration({
+  companyUuid,
+  ideaUuid,
+  actorUuid,
+  actorType,
+}: {
+  companyUuid: string;
+  ideaUuid: string;
+  actorUuid: string;
+  actorType: string;
+}): Promise<ElaborationResponse> {
+  // Scope the Idea by company. Unlike resolveElaboration, the actor is NOT
+  // required to be the assignee — the human verifier is a company user, not
+  // the assigned daemon agent.
+  const idea = await prisma.idea.findFirst({
+    where: { uuid: ideaUuid, companyUuid },
+  });
+  if (!idea) throw new Error("Idea not found");
+
+  // Same structural precondition as resolveElaboration: at least one round and
+  // every round answered (a round counts as answered once it leaves
+  // `pending_answers`; legacy `validated` rounds count the same as `answered`).
+  const rounds = await prisma.elaborationRound.findMany({
+    where: { ideaUuid, companyUuid },
+  });
+  if (rounds.length === 0) {
+    throw new Error("Cannot resolve: the Idea has no elaboration rounds");
+  }
+  const unanswered = rounds.filter((r) => r.status === "pending_answers");
+  if (unanswered.length > 0) {
+    throw new Error(
+      `Cannot resolve: ${unanswered.length} round(s) still have unanswered questions`
+    );
+  }
+
+  // Same state transition as resolveElaboration (Idea-level; round statuses
+  // untouched).
+  await prisma.idea.update({
+    where: { uuid: ideaUuid },
+    data: { status: "elaborated", elaborationStatus: "resolved" },
+  });
+
+  await activityService.createActivity({
+    companyUuid,
+    projectUuid: idea.projectUuid,
+    targetType: "idea",
+    targetUuid: ideaUuid,
+    actorType,
+    actorUuid,
+    action: "elaboration_verified",
+    value: {
+      totalRounds: rounds.length,
+    },
+  });
+
+  eventBus.emitChange({ companyUuid, projectUuid: idea.projectUuid, entityType: "idea", entityUuid: ideaUuid, action: "updated" });
+
+  return getElaboration({ companyUuid, ideaUuid });
+}
+
 // ===== Skip Elaboration =====
 
 export async function skipElaboration({

--- a/src/services/notification-listener.ts
+++ b/src/services/notification-listener.ts
@@ -32,6 +32,10 @@ function resolveNotificationType(action: string, targetType: string): string | n
     // elaboration events (target type is always "idea")
     "idea:elaboration_started": "elaboration_requested",
     "idea:elaboration_answered": "elaboration_answered",
+    // Human verified the elaboration → wake the Idea's assigned daemon agent to
+    // write the proposal. Recipient is the agent (resolved in resolveRecipients);
+    // deliberately NOT in PREF_FIELD_MAP so the agent wake is never preference-gated.
+    "idea:elaboration_verified": "elaboration_verified",
     // elaboration_followup is no longer emitted (the validate/follow-up
     // mechanism was removed); mapping retained for legacy activity rows.
     "idea:elaboration_followup": "elaboration_requested",
@@ -368,6 +372,24 @@ async function resolveRecipients(
       return ansRecipients;
     }
 
+    case "elaboration_verified": {
+      // Human verified the elaboration → wake ONLY the Idea's assigned daemon agent
+      // to write the proposal. This is an agent-only wake: the recipient list
+      // deliberately excludes the human creator (and any human), so it never
+      // surfaces in a human's notification bell. If the Idea has no assigned agent
+      // (or the assignee is a human), return [] — there is no daemon to wake — which
+      // the chokepoint already treats as a no-op (no silent error: the activity is
+      // still recorded, there is simply no wake recipient).
+      const verifiedIdea = await prisma.idea.findUnique({
+        where: { uuid: targetUuid },
+        select: { assigneeType: true, assigneeUuid: true },
+      });
+      if (verifiedIdea?.assigneeType === "agent" && verifiedIdea.assigneeUuid) {
+        return [{ type: "agent", uuid: verifiedIdea.assigneeUuid }];
+      }
+      return [];
+    }
+
     case "comment_added": {
       // Notify entity assignee + creator, but EXCLUDE the comment author
       const recipients: Recipient[] = [];
@@ -493,6 +515,8 @@ function buildMessage(
       return `${actorName} requested elaboration on idea "${entityTitle}"`;
     case "elaboration_answered":
       return `${actorName} answered elaboration questions for idea "${entityTitle}"`;
+    case "elaboration_verified":
+      return `${actorName} verified elaboration for idea "${entityTitle}" — write the proposal`;
     case "report_created":
       return `${actorName} generated a new report on idea "${entityTitle}"`;
     default:

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -52,12 +52,16 @@ const turnLogger = logger.child({ module: "notification-turn" });
 //   - `human_instruction` is the UI-sent instruction (子2): the chokepoint receives a
 //     Notification with that action and the free-text body in `instructionText`.
 //
-// The `DaemonSessionTurn.trigger` enum is the NARROW 5-value taxonomy
-// (task_assigned | mentioned | elaboration | resume | human_instruction). This table
-// collapses each wake action into its canonical trigger category so every
-// wake-triggering notification yields exactly one turn:
+// The `DaemonSessionTurn.trigger` enum is the NARROW 6-value taxonomy
+// (task_assigned | mentioned | elaboration | elaboration_verified | resume |
+// human_instruction). This table collapses each wake action into its canonical
+// trigger category so every wake-triggering notification yields exactly one turn:
 //   - @mention                                   → mentioned
 //   - elaboration request / answer               → elaboration
+//   - elaboration verified (human-verify wake)   → elaboration_verified (distinct from
+//                                                  the "answer the questions" elaboration
+//                                                  trigger — this one means "write the
+//                                                  proposal")
 //   - human-typed instruction                    → human_instruction
 //   - every other autonomous dispatch (task
 //     assignment, task reopen/verify unblock,
@@ -73,6 +77,10 @@ export const NOTIFICATION_ACTION_TO_TURN_TRIGGER: Record<string, TurnTrigger> = 
   // Elaboration round opened / answered on an idea.
   elaboration_requested: "elaboration",
   elaboration_answered: "elaboration",
+  // Human verified the elaboration → wake the assigned daemon agent to WRITE THE
+  // PROPOSAL. Distinct from the elaboration request/answer triggers ("answer the
+  // questions") so the daemon prompt can tell the two intents apart.
+  elaboration_verified: "elaboration_verified",
   // Human-typed instruction (子2 UI send box). Canonical text on the turn; the
   // notification carries a denormalized copy in `instructionText`.
   human_instruction: "human_instruction",


### PR DESCRIPTION
## Summary

Adds a human-clickable **"Verify Elaborate / 完成细化"** button that resolves an Idea's elaboration from the UI and wakes the assigned daemon PM agent to write the proposal — closing the **Reversed Conversation** loop (AI proposes, human verifies → advances). Replaces the dead human-facing "Create Proposal" button on the idea panel.

Implements idea `fed4f64c` (Chorus 0.11.0). Authored via OpenSpec change `add-elaboration-verify-wake`.

## What changed

- **New user-side resolution path** — `verifyElaboration` service + `verifyElaborationAction` server action. Company-scoped, gated on `auth.type === user`/`super_admin`. Distinct from the agent-only `chorus_pm_validate_elaboration` MCP tool (unchanged); drops the assignee check (a human verifies, not the agent), logs a distinct `elaboration_verified` activity.
- **New `elaboration_verified` wake** — activity → notification (recipient = the assigned **agent**, never a human; omitted from `PREF_FIELD_MAP` so it isn't preference-gated) → turn trigger → daemon `cli/prompts.mjs` prompt telling the woken agent to **write the proposal** (not answer questions). Reuses the existing notification chokepoint, origin-only delivery, and offline-backfill unchanged.
- **Frontend** — single gated "Verify Elaborate" button on **both** idea-detail panels (replaces "Create Proposal" on `/ideas`; added to the dashboard tracker panel). Enabled only when all rounds are answered. Reuses derived `planning` status post-verify; shows a queued hint. Generic proposals-list "Create Proposal" preserved. en + zh i18n.
- **Out of scope** (explicit owner decision): waking the agent for ideas that reach `elaborated` via `skip_elaboration` or an agent self-validating. `design.pen` mock update is tracked separately (environmentally blocked at author time).

## Changed files
| Area | Files |
|------|-------|
| Service + action | `src/services/elaboration.service.ts`, `.../ideas/[ideaUuid]/elaboration-actions.ts` |
| Wake pipeline | `src/services/notification-listener.ts`, `notification-turn.ts`, `daemon-session.service.ts` |
| Daemon client | `cli/prompts.mjs` |
| Frontend | `src/lib/elaboration-verify.ts`, both `idea-detail-panel.tsx`, `dashboard/panels/elaboration-view.tsx`, `messages/{en,zh}.json` |
| Schema comment | `prisma/schema.prisma` (comment-only; `trigger` is `String`, no migration) |
| Spec | `openspec/changes/add-elaboration-verify-wake/**` |
| Tests | service, action, listener, turn, daemon-session, cli wake-orchestration, shared-predicate, panel component, cross-module integration |

## Test plan
- [x] Full suite `pnpm test` — 2751 passed / 0 failed
- [x] `npx tsc --noEmit` clean; `pnpm lint` 0 errors
- [x] Cross-module integration test: `elaboration_verified` string-exact across all 6 server→daemon seams
- [x] Independent code review (adversarial, whole-feature) — SHIP WITH FIXES, fixes applied
- [x] **Real-browser e2e**: click Verify Elaborate → idea `elaborated`/`planning`, `elaboration_verified` activity + agent notification, offline queue path (no live daemon online), button replaced by queued hint
- [ ] design.pen mock update (tracked separately; environmentally blocked at author time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)