### PR TITLE
fix(agent-presence): daemon chat mobile fullscreen + contain wide markdown blocks

### DIFF
--- a/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/README.md
+++ b/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-chat-mobile-and-content-width
+
+Fix daemon conversation modal: mobile fullscreen layout + markdown content-width overflow

--- a/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/design.md
+++ b/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/design.md
@@ -1,0 +1,86 @@
+# Technical Design: Daemon chat mobile fullscreen + content-width fix
+
+## Overview
+
+Two CSS/layout-only fixes on the daemon conversation modal. No server, schema, API, or data changes. The component chain is:
+
+```
+AgentConnectionsModal (connections-modal.tsx)
+  └─ DialogContent                      ← problem 1: responsive sizing
+       └─ DaemonChat (daemon-chat.tsx)
+            ├─ mobile drill-down box     ← problem 1: full-height flex column
+            ├─ ConversationList
+            └─ TranscriptView (transcript-view.tsx)
+                 └─ TurnBand → Message (message.tsx)
+                      └─ MarkdownContent  ← problem 2: wide-block width constraint
+```
+
+## Problem 1 — Mobile fullscreen modal
+
+### Layout contract
+
+The whole modal is a single flex column whose total height is bounded by the viewport, so the inner transcript `ScrollArea` scrolls internally and the footer (reply input) is pinned to the bottom edge rather than pushing the dialog past the viewport.
+
+- **`DialogContent` (connections-modal.tsx):** responsive split at the `sm` breakpoint.
+  - Mobile (`< sm`): `h-dvh max-h-dvh w-screen max-w-none rounded-none border-0` — edge-to-edge fullscreen, no floating margins. Use `dvh` (dynamic viewport height), **not** `vh`, so the mobile browser URL bar collapsing/expanding cannot push the pinned input off-screen.
+  - Desktop (`sm+`): restore the floating, height-capped card — `sm:h-[92vh] sm:max-h-[92vh] sm:w-[min(96vw,1100px)] sm:max-w-[min(96vw,1100px)] sm:rounded-lg sm:border`.
+  - Stays padding-free (`p-0 gap-0 overflow-hidden flex flex-col`); the chat view owns its own padding and internal scroll regions.
+- **Mobile drill-down body (daemon-chat.tsx):** the `mobileDetailOpen` branch is a full-height flex column (`flex h-full min-h-0 flex-lg:hidden`): a non-shrinking back-button header row (`shrink-0`) plus a content region that takes the remaining height (`min-h-0 flex-1`) and owns its own scroll. Replaces the previous fixed `h-[70vh]` box that floated the footer mid-screen with dead space below.
+
+> **Source of truth:** the working tree already carries this exact change (verified in `connections-modal.tsx` and `daemon-chat.tsx`). This task's job is to confirm it is correct, complete (e.g. any other hardcoded mobile heights), and e2e-verified — not to redesign it. If it diverges from the contract above, reconcile to the contract.
+
+### Why the height chain must be unbroken
+
+For the footer to pin to the bottom, **every** ancestor from `DialogContent` down to the `TranscriptView` flex column must propagate a bounded height (`h-full`/`flex-1`) and allow shrinking (`min-h-0`). `TranscriptView` is already `flex h-full min-h-0 flex-col` with the body `ScrollArea` as `min-h-0 flex-1` and the footer as a static (non-scrolling) row, so once the drill-down box stops capping at `70vh` the existing structure does the rest. Watch for any intermediate wrapper that drops `min-h-0` — a single missing `min-h-0` makes a flex child refuse to shrink and reintroduces the overflow/dead-space.
+
+## Problem 2 — Wide markdown block content width
+
+### Root cause
+
+`message.tsx` renders an assistant reply as:
+
+```tsx
+<div className="prose prose-sm max-w-none break-words ...">
+  <MarkdownContent>{message.text}</MarkdownContent>
+</div>
+```
+
+`MarkdownContent` (Streamdown) emits raw `<table>` / `<pre>` / `<img>` with no width clamp. A wide table establishes a min-content width larger than the bubble; because no ancestor sets `min-w-0`, the flex/`prose` container grows to fit it and the whole transcript column (and the dialog on mobile) overflows horizontally.
+
+### Fix (scoped to the daemon transcript message)
+
+Constrain wide blocks at the message wrapper level, leaving the shared `MarkdownContent` / global markdown surfaces (Ideas / Comments / Documents) untouched:
+
+1. **Allow the wrapper to shrink:** the markdown wrapper (and its relevant flex ancestors inside the message/turn band) must carry `min-w-0` so a wide child cannot force the column wider than its track. This is the single most important fix — without `min-w-0`, intra-block scrolling never engages because the container itself expands.
+2. **Tables & code blocks scroll within their own region:** apply `overflow-x-auto` (with `max-w-full`) to the table and `<pre>` blocks so a wide table/code line scrolls horizontally inside its own box, preserving column alignment, instead of widening the bubble. Implement by targeting the rendered descendants from the message wrapper (e.g. scoped utility classes / `[&_table]:` / `[&_pre]:` arbitrary variants, or a thin wrapper) — chosen so it does **not** require editing the shared renderer.
+3. **Long words / URLs wrap:** `break-words` / `overflow-wrap: anywhere` (the wrapper already has `break-words`; ensure it actually applies to inline code and long links).
+4. **Images width-capped:** `max-w-full h-auto` so a wide image scales down to the bubble width.
+
+The human `user` side already renders verbatim with `whitespace-pre-wrap break-words` and is not markdown — leave it as-is (it is not the overflow source).
+
+### Behavior summary (from elaboration)
+
+| Block kind | Behavior |
+|---|---|
+| Table | horizontal scroll within its own region (layout preserved) |
+| Code block | horizontal scroll within its own region |
+| Long word / URL | wrap |
+| Wide image | scale down to container width (`max-w-full`) |
+| Bubble / container | width fixed — never blown out |
+
+### Scope guard
+
+Default is **scoped** to the daemon transcript message — smallest blast radius, no risk to Ideas / Comments / Documents which share `MarkdownContent`. Promote to the shared `MarkdownContent` / `streamdown-plugins` layer **only** if the fix is naturally global (e.g. a Streamdown control/class that belongs there) **and** a regression check on Ideas / Comments / Document detail pages confirms no visual change. Absent that confirmation, keep it scoped.
+
+## Verification
+
+Playwright e2e at a mobile viewport (per the idea's acceptance):
+- Open the daemon conversation modal, drill into a conversation. Assert: dialog is fullscreen (no rounded card / margins), the reply input is at the bottom edge, the transcript fills the middle and scrolls internally.
+- Render a conversation message containing a markdown **table** (and other wide blocks). Assert: no horizontal overflow of the document/container (`document.scrollWidth <= clientWidth` / the transcript track is not widened); the table scrolls within its own region.
+- Desktop viewport regression: the floating card + two-pane layout and behavior are unchanged.
+
+## Risks & Mitigations
+
+- **Risk:** `min-w-0` / overflow utilities placed too high leak into desktop two-pane and shift its layout. **Mitigation:** scope to the message/transcript subtree; verify desktop two-pane visually unchanged.
+- **Risk:** `dvh` support on older mobile browsers. **Mitigation:** `dvh` is broadly supported on current iOS/Android Safari/Chrome; the layout degrades gracefully to `100vh`-equivalent. No JS fallback needed.
+- **Risk:** Targeting rendered markdown descendants with arbitrary variants is brittle if Streamdown's DOM changes. **Mitigation:** keep selectors to standard semantic tags (`table`, `pre`, `img`) which Streamdown emits stably; the change is additive CSS and fails safe (no constraint) rather than crashing.

--- a/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/proposal.md
+++ b/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The chat-style daemon conversation modal ("View all" → `AgentConnectionsModal` → `DaemonChat` → `TranscriptView`) shipped in 子3 (`chat-style-daemon-ui`) has two display defects:
+
+1. **Mobile is not a native chat screen.** The `DialogContent` is a centered floating card at every breakpoint (`h-[92vh] w-[min(96vw,1100px)]` + rounding + border), and the mobile drill-down body was a fixed `h-[70vh]` box — so on a phone the modal floats with margins and the reply input sits mid-screen with dead space below it instead of pinned to the bottom edge.
+2. **Wide markdown blocks overflow horizontally.** Agent replies render Markdown through the shared `MarkdownContent` (Streamdown). A **table** (or other wide block — code block, long URL/word, wide image) has no width constraint, so it blows the bubble/container width out past the viewport, especially on a narrow phone.
+
+The fix makes the modal read like a native chat surface on mobile (fullscreen, input pinned to bottom, transcript fills the middle and scrolls), and constrains wide markdown blocks to the available conversation width — without regressing the desktop floating card / two-pane layout.
+
+## What Changes
+
+- **Mobile fullscreen modal.** On `< sm` the `DialogContent` fills the viewport edge-to-edge (`h-dvh w-screen`, no rounding/border); the mobile drill-down body becomes a full-height flex column so the transcript `ScrollArea` fills the middle and the reply input lands at the very bottom of the viewport. The desktop (`sm+`) floating, height-capped card and the desktop (`lg+`) two-pane layout are unchanged. (Largely realized in the working tree already; this change finalizes and e2e-verifies it.)
+- **Transcript content-width discipline.** Wide markdown blocks inside an agent transcript message are constrained to the bubble's available width: tables and code blocks scroll horizontally **within their own region** (layout preserved), long words/URLs wrap, images are width-capped — the message/container width never blows out. Scoped to the daemon transcript message renderer; the shared global Markdown renderer is left unchanged to avoid regressing Ideas / Comments / Documents.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `daemon-session-transcript-read`: add two requirements to the chat-style conversation surface — (a) the modal SHALL be a fullscreen, input-pinned-to-bottom layout on mobile while keeping the desktop floating card/two-pane, and (b) wide markdown blocks in a transcript message SHALL be constrained to the available content width (intra-block horizontal scroll / wrap) rather than overflowing the container.
+
+## Impact
+
+- **Code (UI only, no server / schema / API changes):**
+  - `src/components/agent-presence/connections-modal.tsx` — `DialogContent` responsive sizing (mobile `h-dvh w-screen rounded-none border-0`; desktop card restored at `sm:`).
+  - `src/components/agent-presence/chat/daemon-chat.tsx` — mobile drill-down container from fixed `h-[70vh]` to `flex h-full min-h-0 flex-1`.
+  - `src/components/agent-presence/chat/message.tsx` (and/or a scoped wrapper around `MarkdownContent`) — width constraints on wide markdown blocks within a transcript message.
+- **No** change to `MarkdownContent` / `streamdown-plugins` global behavior, so Ideas / Comments / Documents markdown rendering is untouched.
+- **Verification:** Playwright at a mobile viewport — fullscreen modal, input pinned to bottom, transcript fills & scrolls; a transcript containing a markdown table (and other wide blocks) does not overflow horizontally; desktop layout/behavior does not regress.

--- a/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/specs/daemon-session-transcript-read/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: The conversation surface SHALL be fullscreen on mobile with the reply input pinned to the bottom
+
+On a mobile-width viewport (below the `sm` breakpoint), the "View all" daemon conversation modal SHALL fill the viewport edge-to-edge — occupying the full dynamic viewport height and width with no rounded corners, border, or floating margin — so it reads like a native chat screen. The selected conversation's transcript SHALL fill the middle region and scroll within itself, and the reply/send input SHALL be pinned to the bottom edge of the viewport (not floated mid-screen with dead space below it). The modal height SHALL be measured against the dynamic viewport height so the mobile browser's collapsing/expanding URL bar cannot push the pinned input off-screen. On desktop-width viewports (`sm` and above) the modal SHALL remain the floating, height-capped card, and on `lg` and above the two-pane (conversation list + transcript) layout SHALL be unchanged.
+
+#### Scenario: Modal is fullscreen on a mobile viewport
+
+- **WHEN** a user opens the daemon conversation modal on a mobile-width viewport and drills into a conversation
+- **THEN** the modal fills the viewport edge-to-edge with no rounded card, border, or surrounding margin
+- **AND** the transcript fills the middle region and scrolls within itself
+- **AND** the reply/send input is pinned to the bottom edge of the viewport with no dead space below it
+
+#### Scenario: Desktop layout is preserved
+
+- **WHEN** the same modal is opened on a desktop-width viewport
+- **THEN** it renders as the floating, height-capped card
+- **AND** at the `lg`-and-above width the two-pane conversation-list + transcript layout and behavior are unchanged
+
+### Requirement: Wide markdown blocks in a transcript message SHALL be constrained to the available content width
+
+When a transcript message renders Markdown that contains a wide block — a table, a code block, a long word or URL, or a wide image — the block SHALL be constrained to the message's available content width rather than overflowing it. A table or code block SHALL scroll horizontally within its own region while preserving its layout; long words and URLs SHALL wrap; a wide image SHALL be scaled down to the available width. The message bubble, the transcript column, and the overall modal SHALL NOT be widened by such a block — no horizontal overflow of the conversation container SHALL occur, on mobile or desktop. This constraint applies to the daemon transcript message renderer; the change SHALL NOT alter the shared application-wide Markdown rendering behavior for Ideas, Comments, or Documents unless that behavior is verified to be unchanged.
+
+#### Scenario: A markdown table does not overflow the conversation
+
+- **WHEN** a transcript message contains a Markdown table wider than the available content width, rendered on a mobile-width viewport
+- **THEN** the conversation container does not overflow horizontally (the overall layout width is not blown out)
+- **AND** the table scrolls horizontally within its own region with its column layout preserved
+
+#### Scenario: Long words, URLs, and wide images are contained
+
+- **WHEN** a transcript message contains a very long unbroken word or URL, or an image wider than the content width
+- **THEN** the long word or URL wraps within the available width
+- **AND** the image is scaled down to fit the available width
+- **AND** the message bubble width is not widened past the conversation container
+
+#### Scenario: Shared markdown surfaces are not regressed
+
+- **WHEN** the transcript content-width constraint is implemented
+- **THEN** the rendering of Ideas, Comments, and Document markdown content is unchanged
+- **AND** any constraint applied at the shared renderer level is only retained if those surfaces are verified visually unchanged

--- a/openspec/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/specs/daemon-session-transcript-read/spec.md
@@ -121,3 +121,50 @@ being online.
 - **THEN** the surface shows a calm empty state that invites starting a
   conversation, never an error treatment
 
+### Requirement: The conversation surface SHALL be fullscreen on mobile with the reply input pinned to the bottom
+
+On a mobile-width viewport (below the `sm` breakpoint), the "View all" daemon conversation modal SHALL fill the viewport edge-to-edge — occupying the full dynamic viewport height and width with no rounded corners, border, or floating margin — so it reads like a native chat screen. The selected conversation's transcript SHALL fill the middle region and scroll within itself, and the reply/send input SHALL be pinned to the bottom edge of the viewport (not floated mid-screen with dead space below it). The modal height SHALL be measured against the dynamic viewport height so the mobile browser's collapsing/expanding URL bar cannot push the pinned input off-screen. On desktop-width viewports (`sm` and above) the modal SHALL remain the floating, height-capped card, and on `lg` and above the two-pane (conversation list + transcript) layout SHALL be unchanged.
+
+#### Scenario: Modal is fullscreen on a mobile viewport
+
+- **WHEN** a user opens the daemon conversation modal on a mobile-width viewport and drills into a conversation
+- **THEN** the modal fills the viewport edge-to-edge with no rounded card, border, or surrounding margin
+- **AND** the transcript fills the middle region and scrolls within itself
+- **AND** the reply/send input is pinned to the bottom edge of the viewport with no dead space below it
+
+#### Scenario: Desktop layout is preserved
+
+- **WHEN** the same modal is opened on a desktop-width viewport
+- **THEN** it renders as the floating, height-capped card
+- **AND** at the `lg`-and-above width the two-pane conversation-list + transcript layout and behavior are unchanged
+
+### Requirement: Wide markdown blocks in a transcript message SHALL be constrained to the available content width
+
+When a transcript message renders Markdown that contains a wide block — a table, a code block, a long word or URL, or a wide image — the block SHALL be constrained to the message's available content width rather than overflowing it. A table or code block SHALL scroll horizontally within its own region while preserving its layout; long words and URLs SHALL wrap; a wide image SHALL be scaled down to the available width. The message bubble, the transcript column, and the overall modal SHALL NOT be widened by such a block — no horizontal overflow of the conversation container SHALL occur, on mobile or desktop. This constraint applies to the daemon transcript message renderer; the change SHALL NOT alter the shared application-wide Markdown rendering behavior for Ideas, Comments, or Documents unless that behavior is verified to be unchanged.
+
+#### Scenario: A markdown table does not overflow the conversation
+
+- **WHEN** a transcript message contains a Markdown table wider than the available content width, rendered on a mobile-width viewport
+- **THEN** the conversation container does not overflow horizontally (the overall layout width is not blown out)
+- **AND** the table scrolls horizontally within its own region with its column layout preserved
+
+#### Scenario: Long words, URLs, and wide images are contained
+
+- **WHEN** a transcript message contains a very long unbroken word or URL, or an image wider than the content width
+- **THEN** the long word or URL wraps within the available width
+- **AND** the image is scaled down to fit the available width
+- **AND** the message bubble width is not widened past the conversation container
+
+#### Scenario: Shared markdown surfaces are not regressed
+
+- **WHEN** the transcript content-width constraint is implemented
+- **THEN** the rendering of Ideas, Comments, and Document markdown content is unchanged
+- **AND** any constraint applied at the shared renderer level is only retained if those surfaces are verified visually unchanged
+
+#### Scenario: The scrolling-ancestor content wrapper does not defeat the width constraint
+
+- **WHEN** the transcript is rendered inside a scroll container (e.g. Radix `ScrollArea`) whose viewport injects a content wrapper sized to its content's max-content width (such as an inline `display:table; min-width:100%` wrapper)
+- **THEN** that injected wrapper SHALL be constrained to the viewport width (e.g. forced to `display:block`) so a wide block cannot grow it past the viewport
+- **AND** the `min-width:0` shrink chain on the transcript markup SHALL be effective rather than defeated by an unbounded ancestor
+- **AND** the override SHALL be scoped to the daemon transcript scroll container, leaving other scroll areas unaffected
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,28 @@
   font-size: inherit;
 }
 
+/*
+ * Daemon transcript ScrollArea — contain wide markdown blocks on mobile.
+ *
+ * Radix `ScrollArea.Viewport` injects a content wrapper styled inline
+ * `min-width:100%; display:table`. A `display:table` box sizes to its content's
+ * max-content width, so a wide transcript block (a markdown TABLE, a long code
+ * block) makes that wrapper — and every descendant — grow past the viewport.
+ * The `min-w-0` chain in the transcript markup cannot shrink anything under an
+ * unbounded `display:table` ancestor, so the block was clipped by the viewport's
+ * `overflow-x:hidden` and read as "wider than the screen" on mobile. Forcing the
+ * injected child to `display:block` re-bounds it to the viewport width, which lets
+ * the `min-w-0` chain bite and lets Streamdown's own `overflow-x:auto` table
+ * wrapper scroll within its own region. Scoped to the daemon transcript via the
+ * `daemon-transcript-scroll` class set on that one ScrollArea (see
+ * components/agent-presence/chat/transcript-view.tsx) so the shared
+ * ui/scroll-area component — and every other ScrollArea — is unaffected.
+ */
+.daemon-transcript-scroll [data-slot="scroll-area-viewport"] > div {
+  display: block !important;
+  min-width: 0 !important;
+}
+
 @custom-variant dark (&:is(.dark *));
 @source "../../../node_modules/streamdown/dist/*.js";
 @source "../../../node_modules/@streamdown/mermaid/dist/*.js";

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -615,10 +615,15 @@ export function DaemonChat() {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#FAF8F4]">
-      {/* MOBILE drill-down detail */}
+      {/* MOBILE drill-down detail — a full-height flex column so the transcript
+          ScrollArea fills the middle and the reply input lands at the very bottom of
+          the (fullscreen on mobile) modal, not floating in a fixed-height box with
+          dead space below it. The back-button header is a non-shrinking row; the
+          content takes the remaining height (`min-h-0 flex-1`) and owns its own
+          internal scroll. */}
       {mobileDetailOpen && (
-        <div className="lg:hidden">
-          <div className="sticky top-0 z-10 flex items-center gap-1 border-b border-[#EFEBE4] bg-[#FAF8F4] px-3 py-2.5">
+        <div className="flex h-full min-h-0 flex-col lg:hidden">
+          <div className="flex shrink-0 items-center gap-1 border-b border-[#EFEBE4] bg-[#FAF8F4] px-3 py-2.5">
             <Button
               variant="ghost"
               size="sm"
@@ -629,7 +634,7 @@ export function DaemonChat() {
               {t("mobileBack")}
             </Button>
           </div>
-          <div className="h-[70vh]">{mobileDrillContent}</div>
+          <div className="min-h-0 flex-1">{mobileDrillContent}</div>
         </div>
       )}
 

--- a/src/components/agent-presence/chat/message.tsx
+++ b/src/components/agent-presence/chat/message.tsx
@@ -48,7 +48,10 @@ export function Message({
   const clock = formatClock(message.createdAt);
 
   return (
-    <div className="flex flex-col gap-1">
+    // `min-w-0` lets this message shrink below a wide child's min-content width
+    // (e.g. a wide markdown table) instead of forcing the transcript column —
+    // and on mobile the dialog — to scroll horizontally as a whole.
+    <div className="flex min-w-0 flex-col gap-1">
       <div className="flex items-baseline gap-2">
         <span
           className={`text-[11px] font-semibold uppercase tracking-wide ${
@@ -76,7 +79,18 @@ export function Message({
         // transcript reads like the rest of the app, not a flat wall of text.
         // `prose prose-sm max-w-none` scopes typography to the compact transcript
         // size, matching the idea/comment renderers.
-        <div className="prose prose-sm max-w-none break-words text-[13px] leading-relaxed text-[#2C2C2C]">
+        //
+        // Width discipline (SCOPED here — the shared MarkdownContent /
+        // streamdown-plugins layer is left untouched so Ideas / Comments /
+        // Documents are not regressed): a wide block (table / code / long URL /
+        // image) must NOT widen the transcript column or the mobile dialog. We
+        // (a) let the wrapper shrink (`min-w-0` + `max-w-full`) so it can never
+        // exceed its track, and (b) constrain Streamdown's rendered descendants
+        // via scoped arbitrary variants — `table`/`pre` become their own
+        // horizontal-scroll regions (`block overflow-x-auto max-w-full`,
+        // layout preserved), inline code & links wrap anywhere instead of
+        // forcing a min-content width, and images cap at the available width.
+        <div className="prose prose-sm w-full min-w-0 max-w-full break-words text-[13px] leading-relaxed text-[#2C2C2C] [&_a]:break-all [&_code]:[overflow-wrap:anywhere] [&_img]:h-auto [&_img]:max-w-full [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto">
           <MarkdownContent>{message.text}</MarkdownContent>
         </div>
       )}

--- a/src/components/agent-presence/chat/transcript-view.tsx
+++ b/src/components/agent-presence/chat/transcript-view.tsx
@@ -264,8 +264,28 @@ export function TranscriptView({
           {t("transcriptLoading")}
         </div>
       ) : (
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="flex flex-col gap-5 px-6 py-5">
+        // `daemon-transcript-scroll`: Radix `ScrollArea.Viewport` injects a content
+        // wrapper styled inline `display:table; min-width:100%`. A `display:table`
+        // box sizes to its content's max-content width, so a wide transcript block
+        // (a markdown TABLE, a long code block) makes that wrapper — and every
+        // descendant — grow past the viewport; the `min-w-0` chain below cannot
+        // shrink anything under an unbounded `display:table` ancestor, so the block
+        // is clipped by the viewport's `overflow-x:hidden` and reads as "wider than
+        // the screen" on mobile. A scoped rule in globals.css overrides that injected
+        // child to `display:block` (keyed by this class, NOT by editing the shared
+        // ui/scroll-area component), which re-bounds it to the viewport width, lets
+        // the `min-w-0` chain bite, and lets Streamdown's own `overflow-x:auto`
+        // table wrapper scroll within its own region. Verified by live mobile-viewport
+        // DOM measurement (a 3000px-wide table: the pane no longer overflows; the
+        // table scrolls inside its own region).
+        <ScrollArea className="daemon-transcript-scroll min-h-0 w-full flex-1">
+          {/* `min-w-0` keeps this column from expanding to a wide child's
+              min-content width (e.g. a wide transcript table) — paired with the
+              `display:block` override on the Radix viewport child (see the
+              `daemon-transcript-scroll` rule in globals.css); without that override
+              this alone is insufficient, since the viewport child is `display:table`
+              and sizes to content regardless of `min-w-0`. */}
+          <div className="flex w-full min-w-0 flex-col gap-5 px-6 py-5">
             {/* Privacy note — once per pane: the transcript is daemon-self-reported. */}
             <p className="flex items-start gap-1.5 text-[11px] leading-relaxed text-[#9A9A9A]">
               <Lock className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />

--- a/src/components/agent-presence/chat/turn-band.tsx
+++ b/src/components/agent-presence/chat/turn-band.tsx
@@ -158,7 +158,7 @@ export function TurnBand({
         {/* Messages — a quiet top-to-bottom transcript. A turn whose messages were
             trimmed by the rolling window (or that hasn't produced any yet) shows a
             calm placeholder rather than an empty gap (no silent empty). */}
-        <div className="mt-3 flex flex-col gap-3">
+        <div className="mt-3 flex min-w-0 flex-col gap-3">
           {turn.messages.length > 0 ? (
             turn.messages.map((m) => (
               <Message key={m.uuid} message={m} agentName={agentName} />

--- a/src/components/agent-presence/connections-modal.tsx
+++ b/src/components/agent-presence/connections-modal.tsx
@@ -35,11 +35,16 @@ export function AgentConnectionsModal() {
   return (
     <Dialog open={modalOpen} onOpenChange={setModalOpen}>
       <DialogContent
-        // Wide, tall, padding-free shell: the chat view owns its own layout, padding,
-        // and the (rare) mobile drill-down. The body is height-constrained so the
-        // two-pane transcript ScrollArea scrolls WITHIN the dialog rather than
-        // pushing the dialog past the viewport.
-        className="flex h-[92vh] max-h-[92vh] w-[min(96vw,1100px)] max-w-[min(96vw,1100px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-[min(96vw,1100px)]"
+        // Padding-free shell: the chat view owns its own layout, padding, and the
+        // mobile drill-down. The body is height-constrained so the transcript
+        // ScrollArea scrolls WITHIN the dialog rather than pushing it past the viewport.
+        //
+        // MOBILE (< sm): the modal fills the screen edge-to-edge (`h-dvh w-screen`,
+        // no rounding/border) so the conversation reads like a native chat screen —
+        // the transcript fills the middle and the reply input sits at the very bottom
+        // of the viewport. `dvh` (not `vh`) so the mobile URL bar can't push the input
+        // off-screen. DESKTOP (sm+): the floating, height-capped card is restored.
+        className="flex h-dvh max-h-dvh w-screen max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0 sm:h-[92vh] sm:max-h-[92vh] sm:w-[min(96vw,1100px)] sm:max-w-[min(96vw,1100px)] sm:rounded-lg sm:border"
       >
         {/* The view renders its own visible heading + subtitle; this hidden
             title + description satisfy the Radix Dialog accessibility


### PR DESCRIPTION
## Summary

Fixes two display defects in the chat-style daemon conversation modal ("View all" → `AgentConnectionsModal` → `DaemonChat` → `TranscriptView`), for idea 6589b935 (Chorus 0.11.0). UI-only — no server/schema/API changes.

1. **Mobile fullscreen.** The modal was a centered floating card at every breakpoint with the reply input mid-screen. It now fills the viewport edge-to-edge on mobile (`h-dvh w-screen`, no rounding/border; `dvh` so the mobile URL bar can't push the input off-screen) and restores the floating card + `lg` two-pane at `sm+`. The mobile drill-down is a full-height flex column so the transcript fills the middle and the reply input pins to the bottom.

2. **Wide markdown blocks no longer overflow.** Tables / code / long URLs / images in a transcript message blew out the conversation width on mobile.

   **Root cause** (found via live DOM measurement, not guessing): Radix `ScrollArea.Viewport` injects a content wrapper styled inline `display:table; min-width:100%`. A `display:table` box sizes to its content's max-content width, so a wide block grew that wrapper — and the whole chain — past the viewport; the `min-w-0` chain couldn't shrink anything under it, so the block was clipped by the viewport's `overflow-x:hidden` and read as "wider than the screen".

   **Fix:** a scoped `globals.css` rule (keyed by a `daemon-transcript-scroll` class on that one ScrollArea) forces the injected wrapper to `display:block`, re-bounding it to the viewport so the `min-w-0` chain + Streamdown's own `overflow-x:auto` table wrapper engage. `message`/`turn-band`/`transcript-view` also carry the `min-w-0` chain + scoped `[&_table]/[&_pre]/[&_a]/[&_code]/[&_img]` variants.

**Scope:** the shared `MarkdownContent` and `ui/scroll-area` components are untouched, so Ideas / Comments / Documents do not regress.

## Changed files
| File | Change |
|------|--------|
| `src/components/agent-presence/connections-modal.tsx` | DialogContent mobile fullscreen vs desktop card (`sm:`) |
| `src/components/agent-presence/chat/daemon-chat.tsx` | mobile drill-down → full-height flex column (no `h-[70vh]`) |
| `src/components/agent-presence/chat/transcript-view.tsx` | `daemon-transcript-scroll` class + `min-w-0` body |
| `src/components/agent-presence/chat/message.tsx` | `min-w-0` + scoped wide-block variants on the markdown wrapper |
| `src/components/agent-presence/chat/turn-band.tsx` | `min-w-0` on the messages container |
| `src/app/globals.css` | scoped rule forcing the Radix viewport child to `display:block` |
| `openspec/specs/daemon-session-transcript-read/spec.md` | +2 requirements + scrolling-ancestor root-cause scenario |
| `openspec/changes/archive/2026-06-20-fix-daemon-chat-mobile-and-content-width/` | archived OpenSpec change |

## Test plan
- [x] Live Playwright at mobile 390px: a 3000px+ table → no page/dialog horizontal overflow; table scrolls within its own region. Negative test confirmed the Radix `display:table` wrapper is the root cause.
- [x] Live Playwright at desktop 1280px: floating card + two-pane layout intact (no regression).
- [x] `npx tsc --noEmit` exit 0; `eslint` clean on touched files.
- [x] Scope: `ui/scroll-area.tsx` unchanged; only the daemon transcript ScrollArea is affected.
- [x] Independent task-reviewer verified with an 18-col ~4654px table (VERDICT: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)