### PR TITLE
feat(daemon): message-level transcript pagination

### DIFF
--- a/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/README.md
+++ b/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/README.md
@@ -1,0 +1,3 @@
+# daemon-transcript-message-level-pagination
+
+Message-level transcript pagination for the daemon conversation read (replace turn-level window)

--- a/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/design.md
+++ b/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/design.md
@@ -1,0 +1,160 @@
+# Tech Design: Daemon transcript message-level pagination
+
+## Context
+
+`getSessionDetail(auth, sessionUuid, { limit?, beforeSeq? })` in
+`src/services/daemon-session.service.ts` currently:
+
+1. clamps `limit` to `[1, 200]` (default `DEFAULT_TRANSCRIPT_TURN_PAGE = 30`),
+2. fetches the newest `limit + 1` **turns** (`orderBy seq desc`, `take limit + 1`)
+   at/older than `beforeSeq`, using the extra row to compute `hasMore`,
+3. batch-loads **all** retained messages of those turns in one query,
+4. folds messages into turns, returns `{ session, turns, hasMore, oldestSeq }`
+   ascending by turn `seq`.
+
+The only caller is `src/components/agent-presence/chat/daemon-chat.tsx`
+(first paint: no params; "load earlier": `?beforeSeq=turns[0].seq`). The route
+`src/app/api/daemon-sessions/[sessionUuid]/route.ts` parses `?beforeSeq` + `?limit`.
+
+Verified facts grounding the design:
+
+- Real message `seq` starts at **1** within a turn (`appendTranscriptMessages`:
+  `nextSeq = (last?.seq ?? 0) + 1`), so `seq = 0` is a free slot for a synthetic
+  first message.
+- `DaemonTranscriptMessage` has a per-turn `seq` (`@@index([turnUuid, seq])`) and a
+  global autoincrement `id`; `DaemonSessionTurn` has a session-monotonic `seq`
+  (`@@unique([sessionUuid, seq])`).
+- The frontend already merges by **message uuid** (`mergeTurnPage`,
+  `applyTranscriptEvent`) and renders ascending by turn `seq`, inserting turns in
+  order — partial-turn bands already work.
+
+## Goals / Non-Goals
+
+**Goals**
+- Page the transcript by message, not turn, so one large turn can't force a heavy
+  first paint.
+- Keep `human_instruction` (promptText-only) turns visible under the new cursor.
+- Reuse the existing frontend merge + live-SSE machinery unchanged.
+- No schema change, no migration.
+
+**Non-Goals**
+- Per-message truncation / lazy-expand of a single long message (separate idea).
+- Changing the rolling-window cap `MAX_TRANSCRIPT_MESSAGES_PER_SESSION = 200`.
+- Preserving the old turn-level `?beforeSeq` contract in parallel.
+
+## Decisions
+
+### D1 — Page size: 20 messages (`DEFAULT_TRANSCRIPT_MESSAGE_PAGE = 20`)
+
+First paint and each "load earlier" return up to 20 messages. Smaller than the old
+30-turn default because the unit is now a single (possibly multi-KB) message. Kept
+as a named constant for later tuning. Still clamped to a sane range (`[1, 200]`).
+
+### D2 — Composite cursor `(beforeTurnSeq, beforeMsgSeq)`
+
+Two explicit query params (clearest semantics, independently testable) rather than
+one encoded value or the message's global `id` (an implementation detail; and the
+synthetic promptText message has no real `id`). The window predicate is:
+
+```
+turn.seq < beforeTurnSeq
+  OR (turn.seq = beforeTurnSeq AND message.seq < beforeMsgSeq)
+```
+
+Omitting both params loads the newest page. The response returns the next cursor as
+`oldestTurnSeq` / `oldestMsgSeq` (the `(turnSeq, msgSeq)` of the oldest message in
+the page), plus `hasMore`.
+
+### D3 — Every turn gets a positional `seq = 0` slot (generalizes the synthetic promptText)
+
+The pager rebuilds bands only from windowed messages, so a turn with zero messages
+in the window would vanish. The old turn-level pager always returned every turn,
+including one whose messages were all trimmed by the rolling-window cap (empty
+`messages[]`). To preserve that, the read projection gives **every** turn a
+positional slot at `(turn.seq, seq = 0)` in the unified message stream:
+
+- Turn with non-empty `promptText` → the slot is a synthetic *rendered* message:
+  `role = "user"`, `text = turn.promptText`.
+- Turn with `promptText = null` and no retained real messages (e.g. `agent_wake`
+  whose messages were trimmed) → the slot is a *placeholder* that reserves the
+  turn's position but contributes **no rendered message** (the band materializes
+  with an empty rendered list).
+- Turn with real messages and no promptText → the `seq = 0` placeholder still
+  reserves the position; the rendered messages are the real `seq >= 1` ones.
+
+Every slot carries `uuid = "synthetic:" + turnUuid` (stable, so the uuid-keyed
+merge de-dupes across pages, re-fetches, and live events), `turnUuid = turn.uuid`,
+`seq = 0`, `createdAt = turn.createdAt`. It is a **read/projection-layer** construct
+only — never persisted, no schema/`role` change. It counts toward the page size and
+participates in the composite cursor like any other message (a turn is reached "at
+its seq = 0 slot" exactly once).
+
+Implementation note: distinguish a *rendered* synthetic message (promptText case,
+included in the turn's rendered `messages[]`) from a *placeholder* slot (counted for
+paging/cursor, excluded from rendered `messages[]`). The simplest encoding is to
+always include the slot in the paging stream but only emit it into the band's
+rendered `messages[]` when it carries promptText text.
+
+### D4 — Query strategy
+
+Because messages belong to turns and we page across both, the cleanest correct
+approach within the 200-message session cap (small N — performance is a non-issue):
+
+1. Resolve the candidate window of turns: turns with `seq <= beforeTurnSeq` (or all
+   turns when no cursor), ordered `seq desc`.
+2. Build the unified message stream for those turns — real messages plus the
+   synthetic `seq = 0` per promptText-bearing turn — ordered by `(turn.seq desc,
+   msg.seq desc)`.
+3. Apply the composite `before` predicate, take `limit + 1` to compute `hasMore`,
+   then reverse to ascending.
+4. Group the page's messages back into their turns (turn metadata via the existing
+   `toTurnView`), producing `TurnWithMessagesView[]` ascending by turn `seq`, each
+   carrying only the messages that fell in this page (partial turns are expected).
+
+The synthetic message is generated in-memory from `turn.promptText`; the real
+messages come from one batched `findMany` over the candidate turns (same shape as
+today). The session cap bounds the candidate set, so loading candidate turns'
+messages and slicing in memory is acceptable and keeps the composite-cursor +
+synthetic-fold logic in one place (unit-testable with plain fixtures).
+
+### D5 — Replace, don't dual-run, the old contract
+
+`getSessionDetail`'s `{ limit, beforeSeq }` options become
+`{ limit, beforeTurnSeq, beforeMsgSeq }`; `oldestSeq` becomes `oldestTurnSeq` +
+`oldestMsgSeq`. The route parses the new params. The constant is renamed
+`DEFAULT_TRANSCRIPT_TURN_PAGE → DEFAULT_TRANSCRIPT_MESSAGE_PAGE`. Existing service
+tests for pagination are rewritten. No external API consumer exists (MCP does not
+expose this route).
+
+### D6 — Frontend cursor extraction (track the server-returned cursor)
+
+`daemon-chat.tsx`:
+- First paint: `GET /api/daemon-sessions/{uuid}` with no cursor params.
+- `loadEarlier`: cursor = the **server-returned** `oldestTurnSeq` / `oldestMsgSeq`
+  from the previously loaded page, passed as `?beforeTurnSeq=&beforeMsgSeq=`. The
+  frontend tracks these in state alongside `hasMoreEarlier` rather than deriving the
+  cursor from rendered messages — because an empty band (placeholder-only turn) has
+  no rendered message to read a `seq` from, and the placeholder's `(turnSeq, 0)` is
+  exactly what the server reports as the page's oldest position. This also removes
+  the dependency on `turns[0].messages[0]`.
+- `setHasMoreEarlier(Boolean(data.hasMore))` unchanged; `mergeTurnPage` /
+  `applyTranscriptEvent` unchanged (still uuid-keyed). The merge must tolerate a
+  turn arriving with an empty rendered `messages[]` (already supported — live
+  `turn_created` materializes `messages: []`).
+
+## Risks / Trade-offs
+
+- **Cursor off-by-one across the turn boundary.** The strict `<` on both `turnSeq`
+  and `msgSeq` with the `OR` predicate must not skip or re-emit the boundary
+  message. Covered by a dedicated service test crossing a turn boundary mid-page.
+- **Synthetic message uuid collision.** `synthetic:{turnUuid}` is unique per turn
+  and disjoint from real message uuids; merge de-dupes by uuid. A test asserts a
+  re-fetch/overlap doesn't double-render the synthetic message.
+- **Live event interplay.** A `transcript_appended` arriving during a fetch is
+  merged by uuid as today; the new cursor only affects the read window. A test
+  asserts live append + paged load don't duplicate.
+
+## Migration
+
+None. Composite order derives from existing `turn.seq` + `message.seq`; the
+synthetic message is computed at read time.

--- a/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/proposal.md
+++ b/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/proposal.md
@@ -1,0 +1,68 @@
+# Daemon transcript: message-level pagination
+
+## Why
+
+The daemon conversation modal's right-pane transcript paginates in **turns**: the
+first paint loads the latest `DEFAULT_TRANSCRIPT_TURN_PAGE = 30` turns and "load
+earlier" walks back by `turn.seq`. But a single turn is one agent wake/execution
+and can carry many multi-KB `user`/`assistant` messages, so the page unit is too
+coarse — even one turn can be a heavy payload, and 30 of them can blow the first
+paint up to hundreds of KB. Shrinking the turn count (a smaller `limit`) only
+masks the problem: the worst case is still "one enormous turn".
+
+The fix is to make the page unit a **message**, not a turn. The data model already
+supports it: `DaemonTranscriptMessage` is its own table (one row per message), each
+message carries a per-turn `seq` and each turn a session-monotonic `seq`, so the
+composite `(turn.seq, message.seq)` order is exactly the top-to-bottom render order
+— a natural message-level cursor with **no schema change and no migration**.
+
+## What Changes
+
+- **Read window becomes message-level.** `getSessionDetail` returns the newest
+  `DEFAULT_TRANSCRIPT_MESSAGE_PAGE = 20` *messages* at/older than a composite
+  cursor, rebuilds the (possibly partial) turn bands that own those messages, and
+  reports `hasMore` + the next cursor. The turn-level `DEFAULT_TRANSCRIPT_TURN_PAGE`
+  / `?beforeSeq` contract is **replaced**, not kept in parallel (no external
+  consumer — the only caller is this repo's `daemon-chat.tsx`).
+- **Composite cursor on the wire.** `GET /api/daemon-sessions/{uuid}` accepts
+  `?beforeTurnSeq=<T>&beforeMsgSeq=<M>`; the service filters
+  `turn.seq < T OR (turn.seq = T AND message.seq < M)`. The response carries the
+  next cursor as `oldestTurnSeq` / `oldestMsgSeq`.
+- **Every turn keeps a positional slot so no band is dropped.** Because the pager
+  rebuilds bands only from windowed messages, the read projection gives every turn a
+  `(turn.seq, seq = 0)` slot in the message stream. For a `human_instruction` turn
+  that slot is a synthetic `role = "user"` message carrying the `promptText` (real
+  messages start at `seq = 1`); for a prompt-less turn whose messages were all
+  trimmed by the rolling-window cap, the slot is a placeholder that reserves the
+  turn's position so it still returns as an empty band (matching the old turn-pager,
+  which never dropped such turns). Each slot carries a stable `uuid`
+  (`synthetic:{turnUuid}`) for uuid-keyed de-dupe, counts toward the page size, and
+  participates in the cursor. The slot is read-only — never persisted, no schema
+  change.
+- **Frontend cursor extraction.** First paint and "load earlier" track the
+  **server-returned** `oldestTurnSeq` / `oldestMsgSeq` cursor rather than deriving it
+  from `turns[0].seq` (an empty placeholder band has no rendered message to read a
+  `seq` from); everything else (the uuid-keyed `mergeTurnPage` /
+  `applyTranscriptEvent`, partial-turn bands, live SSE) is unchanged and only gains
+  targeted tests.
+
+## Capabilities
+
+- `daemon-session-transcript-read` (MODIFIED) — the single-session read API's
+  pagination contract changes from turn-window to message-window with a composite
+  cursor and synthetic-promptText folding.
+
+## Impact
+
+- **Code:** `src/services/daemon-session.service.ts` (`getSessionDetail`, page
+  constant, synthetic-message projection), `src/app/api/daemon-sessions/[sessionUuid]/route.ts`
+  (query-param parsing), `src/components/agent-presence/chat/daemon-chat.tsx`
+  (cursor extraction for first paint + `loadEarlier`).
+- **Tests:** `src/services/__tests__/daemon-session.service.test.ts` (rewrite the
+  pagination cases for message-window + composite cursor + synthetic promptText);
+  frontend merge/partial-band tests.
+- **No DB migration, no schema change** — composite order is computed from existing
+  `turn.seq` + `message.seq`.
+- **Out of scope:** per-message truncation / lazy-expand of a single very long
+  message (orthogonal follow-up); the rolling-window cap
+  `MAX_TRANSCRIPT_MESSAGES_PER_SESSION = 200` is untouched.

--- a/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/specs/daemon-session-transcript-read/spec.md
@@ -1,0 +1,104 @@
+# daemon-session-transcript-read Specification
+
+## ADDED Requirements
+
+### Requirement: Message-level transcript pagination with a composite cursor
+
+The single-session transcript read SHALL paginate the conversation by **message**,
+not by turn. `GET /api/daemon-sessions/{sessionUuid}` SHALL return at most
+`DEFAULT_TRANSCRIPT_MESSAGE_PAGE` (default 20) messages per page, newest-first
+windowed but returned in ascending render order, rebuilding the (possibly partial)
+turn bands that own the page's messages. The endpoint SHALL accept an optional
+composite cursor `beforeTurnSeq` + `beforeMsgSeq`; when supplied it SHALL return the
+messages strictly older than that cursor under the ordering
+`turn.seq DESC, message.seq DESC`, i.e. messages where
+`turn.seq < beforeTurnSeq OR (turn.seq = beforeTurnSeq AND message.seq < beforeMsgSeq)`.
+Omitting the cursor SHALL return the most recent page. The response SHALL report
+`hasMore` (whether older messages exist before this page) and the next cursor as
+`oldestTurnSeq` / `oldestMsgSeq` (the position of the oldest message in the page).
+The page size SHALL be clamped to a sane range so a hostile `limit` cannot request
+an unbounded scan. This message-level contract REPLACES the prior turn-level window
+(`DEFAULT_TRANSCRIPT_TURN_PAGE`, single `beforeSeq` cursor); the turn-level
+parameters SHALL NOT be retained in parallel.
+
+#### Scenario: First page returns the newest messages
+
+- **WHEN** a caller requests `GET /api/daemon-sessions/{sessionUuid}` with no cursor
+  for a visible session that has more than `DEFAULT_TRANSCRIPT_MESSAGE_PAGE` messages
+- **THEN** the response contains the newest `DEFAULT_TRANSCRIPT_MESSAGE_PAGE` messages,
+  grouped into their turns ascending by turn `seq` and message `seq`
+- **AND** `hasMore` is `true`
+- **AND** the response carries `oldestTurnSeq` / `oldestMsgSeq` for the oldest message returned
+
+#### Scenario: Load-earlier walks back by the composite cursor
+
+- **WHEN** the caller requests the same session with
+  `?beforeTurnSeq=<oldestTurnSeq>&beforeMsgSeq=<oldestMsgSeq>` from the previous page
+- **THEN** the response contains only messages strictly older than that composite
+  position (`turn.seq < beforeTurnSeq`, or equal turn with `message.seq < beforeMsgSeq`)
+- **AND** no message from the previous page is repeated and none between the pages is skipped
+
+#### Scenario: A page boundary falls inside a turn
+
+- **WHEN** a single turn holds more messages than fit in one page
+- **THEN** the turn appears as a partial band carrying only that page's messages,
+  and a subsequent load-earlier returns the remaining older messages of the same turn
+  merged into the same band
+
+#### Scenario: hasMore is false at the start of the conversation
+
+- **WHEN** the caller has paged back to the oldest retained message of the session
+- **THEN** the response for the earliest page reports `hasMore` is `false`
+
+### Requirement: Every turn keeps a positional slot so no turn band is dropped
+
+The read projection SHALL give every turn at least one positional slot at
+`(turn.seq, seq = 0)` in the unified message stream, so the message-level pager
+never drops a turn band. This preserves the turn-level pager's guarantee that every
+turn remains reachable — including a turn whose messages were all removed by the
+rolling-window cap, which the old pager returned with an empty message list. The
+slot behaves as follows:
+
+- For a turn with a non-empty `promptText` (e.g. a `human_instruction` turn), the
+  `seq = 0` slot SHALL carry a synthetic message with `role = "user"` and `text`
+  equal to the promptText.
+- For a turn with no `promptText` and no retained real messages (e.g. an autonomous
+  `agent_wake` turn whose messages were all trimmed), the `seq = 0` slot SHALL still
+  reserve the turn's place so the turn is returned as a band with an empty rendered
+  message list — never silently dropped.
+
+Each `seq = 0` slot SHALL carry a stable `uuid` derived from its turn so the
+frontend's uuid-keyed merge de-duplicates it across pages, re-fetches, and live
+events; SHALL sort ahead of the turn's real messages (which begin at `seq = 1`);
+SHALL count toward the page size; and SHALL participate in the composite cursor
+exactly like a real message. The slot SHALL exist only in the read projection — it
+SHALL NOT be persisted and SHALL NOT require any schema or message-role change.
+
+#### Scenario: A prompt-only turn is not skipped by the pager
+
+- **WHEN** the page window reaches a `human_instruction` turn that has a `promptText`
+  but no stored transcript messages
+- **THEN** that turn appears in the result as a band whose only message is the
+  synthetic `seq = 0`, `role = "user"` message carrying the promptText
+
+#### Scenario: A message-less, prompt-less turn is still returned as an empty band
+
+- **WHEN** the page window reaches a turn with `promptText = null` whose retained
+  transcript messages were all removed by the rolling-window cap
+- **THEN** that turn is still returned as a turn band (with an empty rendered message
+  list), not silently dropped from the transcript
+- **AND** it occupies exactly one position in the composite cursor sequence so paging
+  does not stall or loop on it
+
+#### Scenario: The synthetic message orders ahead of real messages in its turn
+
+- **WHEN** a turn has both a `promptText` and one or more stored `assistant`/`user`
+  messages (`seq >= 1`)
+- **THEN** the rebuilt turn band lists the synthetic promptText message first,
+  followed by the real messages in ascending `seq`
+
+#### Scenario: The positional slot is stable across an overlapping fetch
+
+- **WHEN** a page that includes a turn's `seq = 0` slot is merged with another page
+  or a live event that also references the same turn
+- **THEN** the slot is de-duplicated by its stable uuid and is not rendered twice

--- a/openspec/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/specs/daemon-session-transcript-read/spec.md
@@ -168,3 +168,104 @@ When a transcript message renders Markdown that contains a wide block — a tabl
 - **AND** the `min-width:0` shrink chain on the transcript markup SHALL be effective rather than defeated by an unbounded ancestor
 - **AND** the override SHALL be scoped to the daemon transcript scroll container, leaving other scroll areas unaffected
 
+### Requirement: Message-level transcript pagination with a composite cursor
+
+The single-session transcript read SHALL paginate the conversation by **message**,
+not by turn. `GET /api/daemon-sessions/{sessionUuid}` SHALL return at most
+`DEFAULT_TRANSCRIPT_MESSAGE_PAGE` (default 20) messages per page, newest-first
+windowed but returned in ascending render order, rebuilding the (possibly partial)
+turn bands that own the page's messages. The endpoint SHALL accept an optional
+composite cursor `beforeTurnSeq` + `beforeMsgSeq`; when supplied it SHALL return the
+messages strictly older than that cursor under the ordering
+`turn.seq DESC, message.seq DESC`, i.e. messages where
+`turn.seq < beforeTurnSeq OR (turn.seq = beforeTurnSeq AND message.seq < beforeMsgSeq)`.
+Omitting the cursor SHALL return the most recent page. The response SHALL report
+`hasMore` (whether older messages exist before this page) and the next cursor as
+`oldestTurnSeq` / `oldestMsgSeq` (the position of the oldest message in the page).
+The page size SHALL be clamped to a sane range so a hostile `limit` cannot request
+an unbounded scan. This message-level contract REPLACES the prior turn-level window
+(`DEFAULT_TRANSCRIPT_TURN_PAGE`, single `beforeSeq` cursor); the turn-level
+parameters SHALL NOT be retained in parallel.
+
+#### Scenario: First page returns the newest messages
+
+- **WHEN** a caller requests `GET /api/daemon-sessions/{sessionUuid}` with no cursor
+  for a visible session that has more than `DEFAULT_TRANSCRIPT_MESSAGE_PAGE` messages
+- **THEN** the response contains the newest `DEFAULT_TRANSCRIPT_MESSAGE_PAGE` messages,
+  grouped into their turns ascending by turn `seq` and message `seq`
+- **AND** `hasMore` is `true`
+- **AND** the response carries `oldestTurnSeq` / `oldestMsgSeq` for the oldest message returned
+
+#### Scenario: Load-earlier walks back by the composite cursor
+
+- **WHEN** the caller requests the same session with
+  `?beforeTurnSeq=<oldestTurnSeq>&beforeMsgSeq=<oldestMsgSeq>` from the previous page
+- **THEN** the response contains only messages strictly older than that composite
+  position (`turn.seq < beforeTurnSeq`, or equal turn with `message.seq < beforeMsgSeq`)
+- **AND** no message from the previous page is repeated and none between the pages is skipped
+
+#### Scenario: A page boundary falls inside a turn
+
+- **WHEN** a single turn holds more messages than fit in one page
+- **THEN** the turn appears as a partial band carrying only that page's messages,
+  and a subsequent load-earlier returns the remaining older messages of the same turn
+  merged into the same band
+
+#### Scenario: hasMore is false at the start of the conversation
+
+- **WHEN** the caller has paged back to the oldest retained message of the session
+- **THEN** the response for the earliest page reports `hasMore` is `false`
+
+### Requirement: Every turn keeps a positional slot so no turn band is dropped
+
+The read projection SHALL give every turn at least one positional slot at
+`(turn.seq, seq = 0)` in the unified message stream, so the message-level pager
+never drops a turn band. This preserves the turn-level pager's guarantee that every
+turn remains reachable — including a turn whose messages were all removed by the
+rolling-window cap, which the old pager returned with an empty message list. The
+slot behaves as follows:
+
+- For a turn with a non-empty `promptText` (e.g. a `human_instruction` turn), the
+  `seq = 0` slot SHALL carry a synthetic message with `role = "user"` and `text`
+  equal to the promptText.
+- For a turn with no `promptText` and no retained real messages (e.g. an autonomous
+  `agent_wake` turn whose messages were all trimmed), the `seq = 0` slot SHALL still
+  reserve the turn's place so the turn is returned as a band with an empty rendered
+  message list — never silently dropped.
+
+Each `seq = 0` slot SHALL carry a stable `uuid` derived from its turn so the
+frontend's uuid-keyed merge de-duplicates it across pages, re-fetches, and live
+events; SHALL sort ahead of the turn's real messages (which begin at `seq = 1`);
+SHALL count toward the page size; and SHALL participate in the composite cursor
+exactly like a real message. The slot SHALL exist only in the read projection — it
+SHALL NOT be persisted and SHALL NOT require any schema or message-role change.
+
+#### Scenario: A prompt-only turn is not skipped by the pager
+
+- **WHEN** the page window reaches a `human_instruction` turn that has a `promptText`
+  but no stored transcript messages
+- **THEN** that turn appears in the result as a band whose only message is the
+  synthetic `seq = 0`, `role = "user"` message carrying the promptText
+
+#### Scenario: A message-less, prompt-less turn is still returned as an empty band
+
+- **WHEN** the page window reaches a turn with `promptText = null` whose retained
+  transcript messages were all removed by the rolling-window cap
+- **THEN** that turn is still returned as a turn band (with an empty rendered message
+  list), not silently dropped from the transcript
+- **AND** it occupies exactly one position in the composite cursor sequence so paging
+  does not stall or loop on it
+
+#### Scenario: The synthetic message orders ahead of real messages in its turn
+
+- **WHEN** a turn has both a `promptText` and one or more stored `assistant`/`user`
+  messages (`seq >= 1`)
+- **THEN** the rebuilt turn band lists the synthetic promptText message first,
+  followed by the real messages in ascending `seq`
+
+#### Scenario: The positional slot is stable across an overlapping fetch
+
+- **WHEN** a page that includes a turn's `seq = 0` slot is merged with another page
+  or a live event that also references the same turn
+- **THEN** the slot is de-duplicated by its stable uuid and is not rendered twice
+

--- a/src/app/api/daemon-sessions/[sessionUuid]/__tests__/route.test.ts
+++ b/src/app/api/daemon-sessions/[sessionUuid]/__tests__/route.test.ts
@@ -25,7 +25,8 @@ const detail = {
   session: { uuid: sessionUuid, sessionId: "sid", directIdeaUuid: null },
   turns: [],
   hasMore: false,
-  oldestSeq: null,
+  oldestTurnSeq: null,
+  oldestMsgSeq: null,
 };
 
 function req(query = ""): NextRequest {
@@ -60,24 +61,47 @@ describe("GET /api/daemon-sessions/[sessionUuid]", () => {
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body).toEqual({ success: true, data: detail, meta: undefined });
-    // No query params → beforeSeq null, no limit forwarded.
+    // No query params → both cursor params null, no limit forwarded.
     expect(mockGetSessionDetail).toHaveBeenCalledWith(userAuth, sessionUuid, {
-      beforeSeq: null,
+      beforeTurnSeq: null,
+      beforeMsgSeq: null,
     });
   });
 
-  it("parses ?beforeSeq + ?limit and forwards them to the service", async () => {
-    await GET(req("?beforeSeq=12&limit=10"), ctx);
+  it("parses the composite ?beforeTurnSeq + ?beforeMsgSeq + ?limit and forwards them", async () => {
+    await GET(req("?beforeTurnSeq=12&beforeMsgSeq=3&limit=10"), ctx);
     expect(mockGetSessionDetail).toHaveBeenCalledWith(userAuth, sessionUuid, {
-      beforeSeq: 12,
+      beforeTurnSeq: 12,
+      beforeMsgSeq: 3,
       limit: 10,
     });
   });
 
-  it("ignores a non-numeric beforeSeq (falls back to the newest page)", async () => {
-    await GET(req("?beforeSeq=abc"), ctx);
+  it("forwards a turn-seq cursor with msgSeq null when only ?beforeTurnSeq is given", async () => {
+    // The service treats a null beforeMsgSeq as 0 within the equal-turn branch — a
+    // turn-only cursor walks back to that turn's slot. The route just parses.
+    await GET(req("?beforeTurnSeq=7"), ctx);
     expect(mockGetSessionDetail).toHaveBeenCalledWith(userAuth, sessionUuid, {
-      beforeSeq: null,
+      beforeTurnSeq: 7,
+      beforeMsgSeq: null,
+    });
+  });
+
+  it("ignores non-numeric cursor params (falls back to the newest page)", async () => {
+    await GET(req("?beforeTurnSeq=abc&beforeMsgSeq=xyz"), ctx);
+    expect(mockGetSessionDetail).toHaveBeenCalledWith(userAuth, sessionUuid, {
+      beforeTurnSeq: null,
+      beforeMsgSeq: null,
+    });
+  });
+
+  it("no longer reads the legacy ?beforeSeq turn cursor", async () => {
+    // The old turn-level cursor is removed; a stray ?beforeSeq is ignored entirely and
+    // the call falls back to the newest page (both composite params null).
+    await GET(req("?beforeSeq=99"), ctx);
+    expect(mockGetSessionDetail).toHaveBeenCalledWith(userAuth, sessionUuid, {
+      beforeTurnSeq: null,
+      beforeMsgSeq: null,
     });
   });
 });

--- a/src/app/api/daemon-sessions/[sessionUuid]/route.ts
+++ b/src/app/api/daemon-sessions/[sessionUuid]/route.ts
@@ -2,14 +2,18 @@
 // Owner-scoped single-session transcript read (子3 — daemon-session-transcript-read).
 //
 // GET — the caller's owner-scoped, company-fenced single daemon session WITH a PAGE of
-// its ordered turns (newest-first window), each turn carrying its retained
-// `user`/`assistant` transcript messages (via 子1's `getSessionDetail`). The chat-style
-// modal uses this for the right-pane transcript: the first paint loads the latest page,
-// and a "load earlier" affordance passes `?beforeSeq=<oldest loaded seq>` to walk back.
+// MESSAGES grouped into the turn bands that own them (newest-first window), each turn
+// carrying its retained `user`/`assistant` transcript messages plus a synthetic
+// promptText message for `human_instruction` turns (via `getSessionDetail`). The
+// chat-style modal uses this for the right-pane transcript: the first paint loads the
+// latest page, and a "load earlier" affordance passes the server-returned composite
+// cursor `?beforeTurnSeq=<oldestTurnSeq>&beforeMsgSeq=<oldestMsgSeq>` to walk back.
 // Live updates flow over the `transcript:{sessionUuid}` SSE channel (newer turns only).
 //
-// Query params (both optional): `beforeSeq` (cursor — load turns older than this seq)
-// and `limit` (page size in turns; the service clamps it to 1..200).
+// Query params (all optional): the composite cursor `beforeTurnSeq` + `beforeMsgSeq`
+// (load the messages strictly older than `turn.seq < T OR (turn.seq = T AND msg.seq < M)`)
+// and `limit` (page size in MESSAGES; the service clamps it to 1..200). The prior
+// turn-level `beforeSeq` cursor is removed.
 //
 // Auth posture mirrors /api/daemon-sessions and the daemon read routes: any valid auth
 // context (agent API key → its own session; user/super_admin → a session of an agent
@@ -36,15 +40,20 @@ export const GET = withErrorHandler<{ sessionUuid: string }>(
 
     const { sessionUuid } = await context.params;
 
-    // Parse the optional pagination cursor + page size. A non-numeric value is ignored
-    // (the service treats it as "newest page" / default size); the service clamps limit.
-    const beforeSeqRaw = request.nextUrl.searchParams.get("beforeSeq");
+    // Parse the optional composite cursor + page size. A non-numeric value is ignored
+    // (the service treats a null cursor as "newest page" and clamps the limit). The two
+    // cursor params are independent so the route stays a thin parse — the service applies
+    // the composite `turn.seq < T OR (turn.seq = T AND msg.seq < M)` predicate.
+    const beforeTurnSeqRaw = request.nextUrl.searchParams.get("beforeTurnSeq");
+    const beforeMsgSeqRaw = request.nextUrl.searchParams.get("beforeMsgSeq");
     const limitRaw = request.nextUrl.searchParams.get("limit");
-    const beforeSeqNum = beforeSeqRaw !== null ? Number(beforeSeqRaw) : NaN;
+    const beforeTurnSeqNum = beforeTurnSeqRaw !== null ? Number(beforeTurnSeqRaw) : NaN;
+    const beforeMsgSeqNum = beforeMsgSeqRaw !== null ? Number(beforeMsgSeqRaw) : NaN;
     const limitNum = limitRaw !== null ? Number(limitRaw) : NaN;
 
     const detail = await getSessionDetail(auth, sessionUuid, {
-      beforeSeq: Number.isFinite(beforeSeqNum) ? beforeSeqNum : null,
+      beforeTurnSeq: Number.isFinite(beforeTurnSeqNum) ? beforeTurnSeqNum : null,
+      beforeMsgSeq: Number.isFinite(beforeMsgSeqNum) ? beforeMsgSeqNum : null,
       ...(Number.isFinite(limitNum) ? { limit: limitNum } : {}),
     });
     if (!detail) {

--- a/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
+++ b/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
@@ -208,3 +208,143 @@ describe("mergeTurnPage", () => {
     expect(merged[0].messages.map((m) => m.uuid)).toEqual(["m1", "m2"]);
   });
 });
+
+// Message-level pagination scenarios (子 — composite-cursor extraction). These exercise
+// the SAME uuid-keyed `mergeTurnPage` / `applyTranscriptEvent` under the new pager's
+// realities: a single turn split across pages (partial bands), the synthetic `seq=0`
+// promptText slot (`uuid: "synthetic:{turnUuid}"`) returned in EVERY page that reaches
+// the turn, an empty placeholder band (a trimmed prompt-less turn → empty rendered
+// `messages[]`), and a live `transcript_appended` interleaved with a paged load. The
+// frontend functions are unchanged; these tests assert they already tolerate the new shape.
+describe("message-level pagination — partial-turn bands stitched across pages", () => {
+  it("stitches a partial-turn band across two load-earlier pages (newest page first)", () => {
+    // First paint returned only the NEWEST messages of a heavy turn t7 (m3, m4); the older
+    // load-earlier page returns the SAME turn's earlier messages (m1, m2). mergeTurnPage is
+    // called `(incomingOlder, prev)` in loadEarlier — the older page is the "existing" arg —
+    // so the band must end up with m1..m4 in ascending order, not duplicated.
+    const firstPaint = [turn({ uuid: "t7", seq: 7, messages: [msg({ uuid: "m3", seq: 3 }), msg({ uuid: "m4", seq: 4 })] })];
+    const olderPage = [turn({ uuid: "t7", seq: 7, messages: [msg({ uuid: "m1", seq: 1 }), msg({ uuid: "m2", seq: 2 })] })];
+    // loadEarlier merges as mergeTurnPage(olderPage, firstPaint): older is "existing", first paint "incoming".
+    const merged = mergeTurnPage(olderPage, firstPaint);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].uuid).toBe("t7");
+    // Older messages first (existing), then the newer page's messages appended — m1..m4.
+    expect(merged[0].messages.map((m) => m.uuid)).toEqual(["m1", "m2", "m3", "m4"]);
+  });
+
+  it("does not duplicate a message that overlaps the two pages of the same turn", () => {
+    // A boundary message (m2) appears in BOTH pages (an overlapping fetch). It de-dupes by uuid.
+    const olderPage = [turn({ uuid: "t7", seq: 7, messages: [msg({ uuid: "m1", seq: 1 }), msg({ uuid: "m2", seq: 2 })] })];
+    const newerPage = [turn({ uuid: "t7", seq: 7, messages: [msg({ uuid: "m2", seq: 2 }), msg({ uuid: "m3", seq: 3 })] })];
+    const merged = mergeTurnPage(olderPage, newerPage);
+    expect(merged[0].messages.map((m) => m.uuid)).toEqual(["m1", "m2", "m3"]);
+  });
+});
+
+describe("message-level pagination — synthetic seq=0 slot de-dupe", () => {
+  function syntheticMsg(turnUuid: string, text: string): TranscriptMessageView {
+    // Mirrors the server's projection: a promptText turn's slot is a RENDERED message with
+    // uuid `synthetic:{turnUuid}`, role user, seq 0, text = promptText.
+    return {
+      uuid: `synthetic:${turnUuid}`,
+      turnUuid,
+      role: "user",
+      text,
+      seq: 0,
+      createdAt: "2026-06-16T11:00:00.000Z",
+    };
+  }
+
+  it("de-dupes the synthetic promptText slot by uuid across an overlapping fetch", () => {
+    // A human_instruction turn t4's `seq=0` synthetic message is returned in BOTH the
+    // first-paint page and a load-earlier page that reaches the same turn. Merging must not
+    // render the prompt twice.
+    const synth = syntheticMsg("t4", "do the thing");
+    const firstPaint = [
+      turn({ uuid: "t4", seq: 4, trigger: "human_instruction", promptText: "do the thing", messages: [synth, msg({ uuid: "m1", seq: 1 })] }),
+    ];
+    const olderPage = [
+      turn({ uuid: "t4", seq: 4, trigger: "human_instruction", promptText: "do the thing", messages: [synth] }),
+    ];
+    const merged = mergeTurnPage(olderPage, firstPaint);
+    expect(merged).toHaveLength(1);
+    // The synthetic slot appears exactly once, ahead of the real seq>=1 message.
+    expect(merged[0].messages.map((m) => m.uuid)).toEqual(["synthetic:t4", "m1"]);
+    expect(merged[0].messages.filter((m) => m.uuid === "synthetic:t4")).toHaveLength(1);
+  });
+
+  it("a live transcript_appended carrying the synthetic slot again does not double-render it", () => {
+    const synth = syntheticMsg("t4", "do the thing");
+    const prev = [
+      turn({ uuid: "t4", seq: 4, trigger: "human_instruction", promptText: "do the thing", messages: [synth] }),
+    ];
+    const next = applyTranscriptEvent(prev, {
+      trigger: "transcript_appended",
+      turn: turn({ uuid: "t4", seq: 4 }),
+      // The append re-delivers the synthetic slot alongside a genuinely new real message.
+      messages: [synth, msg({ uuid: "m1", seq: 1, turnUuid: "t4" })],
+    });
+    expect(next[0].messages.map((m) => m.uuid)).toEqual(["synthetic:t4", "m1"]);
+  });
+});
+
+describe("message-level pagination — empty placeholder band", () => {
+  it("renders an empty-band (placeholder) turn without error and merges it by uuid", () => {
+    // A prompt-less turn whose real messages were all trimmed comes back as a band with an
+    // empty rendered messages[] (the server's placeholder-only slot). It must merge in
+    // order and not throw.
+    const firstPaint = [turn({ uuid: "t8", seq: 8, messages: [msg({ uuid: "m9", seq: 1 })] })];
+    const olderPage = [turn({ uuid: "t6", seq: 6, trigger: "agent_wake", promptText: null, messages: [] })];
+    const merged = mergeTurnPage(olderPage, firstPaint);
+    expect(merged.map((t) => t.uuid)).toEqual(["t6", "t8"]);
+    // The empty band survives with an empty rendered list — not dropped, no error.
+    expect(merged[0].messages).toEqual([]);
+  });
+
+  it("an empty-band turn arriving via applyTranscriptEvent renders without error", () => {
+    const prev = [turn({ uuid: "t8", seq: 8, messages: [msg({ uuid: "m9", seq: 1 })] })];
+    const next = applyTranscriptEvent(prev, {
+      trigger: "turn_created",
+      turn: turn({ uuid: "t9", seq: 9, trigger: "agent_wake", promptText: null }),
+      messages: [],
+    });
+    expect(next.map((t) => t.uuid)).toEqual(["t8", "t9"]);
+    expect(next[1].messages).toEqual([]);
+  });
+});
+
+describe("message-level pagination — live append during paging", () => {
+  it("a live transcript_appended during a load-earlier does not double-render the message", () => {
+    // Simulate the loadEarlier flow interleaved with a live SSE append on the NEWEST turn.
+    // 1) Initial window: t7 with m3,m4 (newest page).
+    let turns: TurnWithMessagesView[] = [
+      turn({ uuid: "t7", seq: 7, status: "running", messages: [msg({ uuid: "m3", seq: 3 }), msg({ uuid: "m4", seq: 4 })] }),
+    ];
+    // 2) A live append lands on t7 (m5) WHILE the older fetch is in flight.
+    turns = applyTranscriptEvent(turns, {
+      trigger: "transcript_appended",
+      turn: turn({ uuid: "t7", seq: 7 }),
+      messages: [msg({ uuid: "m5", seq: 5, turnUuid: "t7" })],
+    });
+    expect(turns[0].messages.map((m) => m.uuid)).toEqual(["m3", "m4", "m5"]);
+    // 3) The older page resolves with t7's earlier messages (m1, m2) — merge older-as-existing.
+    const olderPage = [turn({ uuid: "t7", seq: 7, messages: [msg({ uuid: "m1", seq: 1 }), msg({ uuid: "m2", seq: 2 })] })];
+    turns = mergeTurnPage(olderPage, turns);
+    // The live m5 is retained, the older m1/m2 are stitched in, nothing double-rendered.
+    expect(turns).toHaveLength(1);
+    expect(turns[0].messages.map((m) => m.uuid)).toEqual(["m1", "m2", "m3", "m4", "m5"]);
+  });
+
+  it("a live append re-delivered after a paged load de-dupes by uuid (no double-render)", () => {
+    // The older page already carried m2; a redundant live append re-delivers m2. De-duped.
+    let turns: TurnWithMessagesView[] = [
+      turn({ uuid: "t7", seq: 7, messages: [msg({ uuid: "m1", seq: 1 }), msg({ uuid: "m2", seq: 2 })] }),
+    ];
+    turns = applyTranscriptEvent(turns, {
+      trigger: "transcript_appended",
+      turn: turn({ uuid: "t7", seq: 7 }),
+      messages: [msg({ uuid: "m2", seq: 2, turnUuid: "t7" })],
+    });
+    expect(turns[0].messages.map((m) => m.uuid)).toEqual(["m1", "m2"]);
+  });
+});

--- a/src/components/agent-presence/__tests__/connections-modal.test.tsx
+++ b/src/components/agent-presence/__tests__/connections-modal.test.tsx
@@ -644,14 +644,15 @@ describe("Daemon chat modal — transcript pagination (load earlier)", () => {
   it("shows 'Load earlier' when hasMore, and clicking it prepends the older page", async () => {
     // Route: connections / executions / session list as usual, and the detail endpoint
     // returns the NEWEST page (hasMore:true) on the bare URL, the OLDER page on the
-    // `?beforeSeq=` cursor.
+    // composite `?beforeTurnSeq=&beforeMsgSeq=` cursor.
     mockAuthFetch.mockImplementation((url: string) => {
       if (typeof url === "string") {
         if (url.startsWith("/api/daemon/executions")) {
           return Promise.resolve({ ok: true, json: async () => ({ success: true, data: { executions: [] } }) });
         }
-        // Older page (cursor present): turns seq 1-2, no more before them.
-        if (/\/api\/daemon-sessions\/[^/?]+\?beforeSeq=/.test(url)) {
+        // Older page (cursor present): turns seq 1-2, no more before them. The composite
+        // cursor reports the page's oldest slot as (oldestTurnSeq:1, oldestMsgSeq:0).
+        if (/\/api\/daemon-sessions\/[^/?]+\?beforeTurnSeq=/.test(url)) {
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -663,12 +664,15 @@ describe("Daemon chat modal — transcript pagination (load earlier)", () => {
                   turn({ uuid: "t2", seq: 2, promptText: "second message" }),
                 ],
                 hasMore: false,
-                oldestSeq: 1,
+                oldestTurnSeq: 1,
+                oldestMsgSeq: 0,
               },
             }),
           });
         }
-        // Newest page (no cursor): turns seq 3-4, hasMore true (earlier turns exist).
+        // Newest page (no cursor): turns seq 3-4, hasMore true (earlier messages exist).
+        // These are promptText-only turns, so each turn's oldest slot is its synthetic
+        // (turn.seq, 0); the page's oldest is (oldestTurnSeq:3, oldestMsgSeq:0).
         if (/^\/api\/daemon-sessions\/[^/?]+$/.test(url)) {
           return Promise.resolve({
             ok: true,
@@ -681,7 +685,8 @@ describe("Daemon chat modal — transcript pagination (load earlier)", () => {
                   turn({ uuid: "t4", seq: 4, promptText: "LATEST message" }),
                 ],
                 hasMore: true,
-                oldestSeq: 3,
+                oldestTurnSeq: 3,
+                oldestMsgSeq: 0,
               },
             }),
           });
@@ -717,9 +722,12 @@ describe("Daemon chat modal — transcript pagination (load earlier)", () => {
     // The older page is prepended (the opening message now present), and the control
     // disappears (the older page reported hasMore:false).
     await waitFor(() => expect(screen.getAllByText("FIRST message").length).toBeGreaterThan(0));
-    // The cursor fetch used the oldest loaded seq (3) from the first page.
+    // The cursor fetch used the SERVER-RETURNED composite cursor (oldestTurnSeq:3,
+    // oldestMsgSeq:0) from the first page — NOT a seq derived from rendered turns.
     expect(
-      mockAuthFetch.mock.calls.some((c) => String(c[0]).includes("/api/daemon-sessions/s1?beforeSeq=3")),
+      mockAuthFetch.mock.calls.some((c) =>
+        String(c[0]).includes("/api/daemon-sessions/s1?beforeTurnSeq=3&beforeMsgSeq=0"),
+      ),
     ).toBe(true);
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: /load earlier/i })).toBeNull(),
@@ -734,12 +742,58 @@ describe("Daemon chat modal — transcript pagination (load earlier)", () => {
         session: sessionDetail,
         turns: [turn({ uuid: "t1", seq: 1, promptText: "only message" })],
         hasMore: false,
-        oldestSeq: 1,
+        oldestTurnSeq: 1,
+        oldestMsgSeq: 0,
       },
     });
     const { user } = await renderAndOpenModal();
     await user.click((await screen.findAllByText("Short chat"))[0].closest("button") as HTMLElement);
     await waitFor(() => expect(screen.getAllByText("only message").length).toBeGreaterThan(0));
     expect(screen.queryByRole("button", { name: /load earlier/i })).toBeNull();
+  });
+
+  it("renders a human_instruction prompt exactly ONCE even when the server folds it in as a synthetic seq=0 message", async () => {
+    // FAITHFUL server shape: the message-level read returns a human_instruction turn
+    // whose promptText is ALSO present in messages[] as the synthetic seq=0 user
+    // message (uuid `synthetic:{turnUuid}`). TurnBand renders the promptText as its
+    // canonical paragraph AND maps messages[] — so without de-duping the synthetic
+    // entry the instruction would render twice. This asserts exactly one occurrence
+    // PER rendered pane (jsdom mounts both the desktop and hidden mobile pane, so the
+    // count is one-per-pane, not a single global node).
+    const PROMPT = "ship the daemon pagination fix";
+    respondWith({
+      connections: [conn({ uuid: "1", agentUuid: "agent-1", agentName: "Alpha" })],
+      sessions: [session({ uuid: "s1", agentUuid: "agent-1", title: "Synthetic chat", originConnectionUuid: "1" })],
+      detail: {
+        session: sessionDetail,
+        turns: [
+          turn({
+            uuid: "t1",
+            seq: 1,
+            promptText: PROMPT,
+            messages: [
+              {
+                uuid: "synthetic:t1",
+                turnUuid: "t1",
+                role: "user",
+                text: PROMPT,
+                seq: 0,
+                createdAt: "2026-06-16T11:00:00.000Z",
+              },
+            ],
+          }),
+        ],
+        hasMore: false,
+        oldestTurnSeq: 1,
+        oldestMsgSeq: 0,
+      },
+    });
+    const { user } = await renderAndOpenModal();
+    await user.click((await screen.findAllByText("Synthetic chat"))[0].closest("button") as HTMLElement);
+    await waitFor(() => expect(screen.getAllByText(PROMPT).length).toBeGreaterThan(0));
+    // Desktop pane + hidden mobile pane each render the band once → exactly 2 nodes,
+    // i.e. ONE per pane. If the synthetic message leaked into the bubble list it would
+    // be 4 (two per pane).
+    expect(screen.getAllByText(PROMPT).length).toBe(2);
   });
 });

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -77,10 +77,11 @@ function clampInstructionName(opener: string): string {
 //  - transcript_appended → append the event's message tail to the affected turn,
 //    de-duped by message uuid (so a re-delivered event doesn't double-render)
 // Insert a turn into an ascending-by-`seq` array at its correct position (NOT blindly
-// appended). The transcript is rendered + paginated assuming ascending seq — `loadEarlier`
-// uses `turns[0].seq` as the older-page cursor and the transcript header/auto-scroll use
-// `turns[turns.length - 1]` as the newest turn — so a materialized turn with a lower seq
-// than the loaded window must land in order, not at the end. Returns a NEW array.
+// appended). The transcript is rendered + paginated assuming ascending seq — the
+// transcript header/auto-scroll use `turns[turns.length - 1]` as the newest turn, and
+// `loadEarlier` walks back via the server-returned `(oldestTurnSeq, oldestMsgSeq)` cursor
+// over this ascending window — so a materialized turn with a lower seq than the loaded
+// window must land in order, not at the end. Returns a NEW array.
 function insertTurnBySeq(
   turns: TurnWithMessagesView[],
   incoming: TurnWithMessagesView,
@@ -350,10 +351,20 @@ export function DaemonChat() {
   const [turns, setTurns] = useState<TurnWithMessagesView[]>([]);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState(false);
-  // Older-page pagination: whether earlier turns exist before the loaded window, and a
+  // Older-page pagination: whether earlier MESSAGES exist before the loaded window, and a
   // mid-flight flag for the "load earlier" fetch (separate from the first-paint load).
   const [hasMoreEarlier, setHasMoreEarlier] = useState(false);
   const [loadingEarlier, setLoadingEarlier] = useState(false);
+  // The SERVER-RETURNED composite cursor for the next "load earlier" — the position of the
+  // OLDEST slot/message in the currently-loaded window. Tracked in state (NOT derived from
+  // `turns[0]`) because the message-level pager gives every turn a `(turn.seq, 0)` slot,
+  // and an empty placeholder band (a turn whose messages were all trimmed) has NO rendered
+  // message to read a `seq` from — only the server's reported `oldestTurnSeq` / `oldestMsgSeq`
+  // accounts for that slot, so it is the authoritative cursor.
+  const [oldestCursor, setOldestCursor] = useState<{
+    turnSeq: number;
+    msgSeq: number;
+  } | null>(null);
   // Guard against an out-of-order response overwriting a newer selection.
   const detailReqRef = useRef(0);
 
@@ -374,18 +385,21 @@ export function DaemonChat() {
       setTurns([]);
       setDetailError(false);
       setHasMoreEarlier(false);
+      setOldestCursor(null);
       return;
     }
     const reqId = ++detailReqRef.current;
     setDetailLoading(true);
     setDetailError(false);
     setHasMoreEarlier(false);
+    setOldestCursor(null);
     // Clear the previous session's turns synchronously on switch, so `turns` only ever
     // accumulates the NEW session's live events during the fetch window (the subscribe
     // effect is keyed on the same openUuid). The fetch then MERGES its page with those.
     setTurns([]);
     (async () => {
       try {
+        // First paint: NO cursor params — the message-level pager returns the newest page.
         const res = await authFetch(`/api/daemon-sessions/${openUuid}`);
         if (reqId !== detailReqRef.current) return; // superseded
         if (!res.ok) {
@@ -403,6 +417,13 @@ export function DaemonChat() {
           // (the live copy wins, as it may carry a fresher message tail), sorted by seq.
           setTurns((prev) => mergeTurnPage(prev, data.turns ?? []));
           setHasMoreEarlier(Boolean(data.hasMore));
+          // Track the SERVER-RETURNED composite cursor (the page's oldest slot/message)
+          // for the next "load earlier". Null when the page is empty (no older fetch).
+          setOldestCursor(
+            data.oldestTurnSeq !== null && data.oldestMsgSeq !== null
+              ? { turnSeq: data.oldestTurnSeq, msgSeq: data.oldestMsgSeq }
+              : null,
+          );
         } else {
           setDetailError(true);
         }
@@ -416,19 +437,23 @@ export function DaemonChat() {
     })();
   }, [openUuid]);
 
-  // Load the page of turns OLDER than the earliest currently-loaded turn (cursor =
-  // `turns[0].seq`) and merge it in. `mergeTurnPage` unions by uuid + sorts by seq, so a
-  // raced live event, a re-click, or any ordering surprise can't double-insert or break
-  // the ascending invariant. Bound to the open session via `reqId` (a selection change
-  // supersedes an in-flight earlier-load).
+  // Load the page of MESSAGES older than the loaded window and merge it in. The cursor is
+  // the SERVER-RETURNED composite `(oldestTurnSeq, oldestMsgSeq)` of the previous page —
+  // NOT derived from `turns[0]`, because the page's oldest position may be an empty
+  // placeholder band's `(turn.seq, 0)` slot that has no rendered message to read a seq
+  // from. Passed as `?beforeTurnSeq=&beforeMsgSeq=`. `mergeTurnPage` unions by uuid + sorts
+  // by seq, so a partial-turn band stitches into its prior band, a re-delivered synthetic
+  // `seq=0` slot de-dupes by its stable `synthetic:{turnUuid}` uuid, and a raced live event
+  // can't double-insert or break the ascending invariant. Bound to the open session via
+  // `reqId` (a selection change supersedes an in-flight earlier-load).
   const loadEarlier = useCallback(async () => {
-    if (!openUuid || loadingEarlier || turns.length === 0) return;
-    const cursorSeq = turns[0].seq;
+    if (!openUuid || loadingEarlier || !oldestCursor) return;
+    const { turnSeq, msgSeq } = oldestCursor;
     const reqId = detailReqRef.current; // same generation as the open session
     setLoadingEarlier(true);
     try {
       const res = await authFetch(
-        `/api/daemon-sessions/${openUuid}?beforeSeq=${cursorSeq}`,
+        `/api/daemon-sessions/${openUuid}?beforeTurnSeq=${turnSeq}&beforeMsgSeq=${msgSeq}`,
       );
       if (reqId !== detailReqRef.current) return; // selection changed mid-flight
       if (!res.ok) return; // transient — the "load earlier" control stays available
@@ -438,13 +463,22 @@ export function DaemonChat() {
         const data = json.data as SessionDetailView;
         setTurns((prev) => mergeTurnPage(data.turns ?? [], prev));
         setHasMoreEarlier(Boolean(data.hasMore));
+        // Advance the cursor to the newly-loaded page's oldest position. When the page
+        // is empty (nothing older), keep the previous cursor untouched (hasMore is false,
+        // so the control disappears anyway).
+        if (data.oldestTurnSeq !== null && data.oldestMsgSeq !== null) {
+          setOldestCursor({
+            turnSeq: data.oldestTurnSeq,
+            msgSeq: data.oldestMsgSeq,
+          });
+        }
       }
     } catch (error) {
       clientLogger.error("Failed to load earlier transcript turns:", error);
     } finally {
       setLoadingEarlier(false);
     }
-  }, [openUuid, loadingEarlier, turns]);
+  }, [openUuid, loadingEarlier, oldestCursor]);
 
   // Subscribe to the open conversation's live transcript events and patch turns.
   // The provider only forwards events for the `?sessionUuid=` it subscribed (the

--- a/src/components/agent-presence/chat/turn-band.tsx
+++ b/src/components/agent-presence/chat/turn-band.tsx
@@ -80,6 +80,13 @@ export function TurnBand({
         ? t("turnStatusPending")
         : t("turnStatusEnded");
 
+  // Drop the synthetic promptText slot (uuid `synthetic:{turnUuid}`) the message-level
+  // read folds in for pagination — the prompt is already rendered as its canonical
+  // paragraph above, and the `synthetic:` prefix is disjoint from real message uuids.
+  const visibleMessages = turn.messages.filter(
+    (m) => !m.uuid.startsWith("synthetic:"),
+  );
+
   // Deep link for an entity-bearing turn, via the reused canonical href builder.
   const href = linkedExecution ? execHref(linkedExecution) : null;
   // Idea-anchored executions get an "Open idea" affordance; the rest "Open task"
@@ -157,10 +164,17 @@ export function TurnBand({
 
         {/* Messages — a quiet top-to-bottom transcript. A turn whose messages were
             trimmed by the rolling window (or that hasn't produced any yet) shows a
-            calm placeholder rather than an empty gap (no silent empty). */}
+            calm placeholder rather than an empty gap (no silent empty).
+
+            The message-level read folds a human_instruction's promptText in as a
+            synthetic `seq = 0` message (uuid `synthetic:{turnUuid}`) so the prompt
+            occupies a pagination slot — but the prompt is ALREADY rendered above as
+            its canonical paragraph, so we drop that synthetic entry here to avoid
+            rendering the instruction twice. Live `transcript_appended` events never
+            carry it, so skipping it keeps the GET and live render paths identical. */}
         <div className="mt-3 flex min-w-0 flex-col gap-3">
-          {turn.messages.length > 0 ? (
-            turn.messages.map((m) => (
+          {visibleMessages.length > 0 ? (
+            visibleMessages.map((m) => (
               <Message key={m.uuid} message={m} agentName={agentName} />
             ))
           ) : (

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -64,7 +64,7 @@ import {
   SESSION_STATUSES,
   TRANSCRIPT_ROLES,
   MAX_TRANSCRIPT_MESSAGES_PER_SESSION,
-  DEFAULT_TRANSCRIPT_TURN_PAGE,
+  DEFAULT_TRANSCRIPT_MESSAGE_PAGE,
   STALE_THRESHOLD_MS,
   resolveOrCreateSession,
   resolveDirectIdeaUuid,
@@ -759,19 +759,26 @@ describe("isSessionVisibleToCaller", () => {
   });
 });
 
-// ===== getSessionDetail (turns WITH messages, batched fold, 404 non-disclosure) =====
+// ===== getSessionDetail (MESSAGE-level pagination, composite cursor, synthetic slot) =====
+//
+// The service loads the candidate turns (`daemonSessionTurn.findMany`, seq DESC, fenced
+// `seq <= beforeTurnSeq` when a cursor is given), then their real messages in ONE
+// batched query (`daemonTranscriptMessage.findMany`, ordered (turnUuid asc, seq asc)).
+// It builds a unified `(turn.seq desc, msg.seq desc)` stream where every turn gets a
+// `(seq = 0)` slot — a RENDERED synthetic `user` message for a promptText turn, a
+// PLACEHOLDER otherwise — applies the composite `before` predicate, takes `limit + 1`,
+// reverses to ascending, and groups into bands. So a test just supplies candidate turns
+// + their messages and asserts the page bands + hasMore + (oldestTurnSeq, oldestMsgSeq).
 describe("getSessionDetail", () => {
-  it("VISIBLE session: returns { session, turns } with each turn's messages folded by seq", async () => {
+  it("VISIBLE session: returns { session, turns } with each turn's real messages folded ascending by seq", async () => {
     mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
-    // The page query orders seq DESC + takes a window; the service reverses it to
-    // ascending. The mock returns DESC (newest-first) as the real DB would, so the
-    // result is ascending [t1, t2].
+    // Candidate turns come back seq DESC (newest-first), as the real DB orders them.
     mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
       turnRow({ uuid: "t2", seq: 2 }),
       turnRow({ uuid: "t1", seq: 1 }),
     ]);
-    // The ONE batched message query returns messages for BOTH turns, ordered by
-    // (turnUuid, seq); the fold buckets each into its own turn in seq order.
+    // Real messages for BOTH turns, ordered (turnUuid asc, seq asc) as the query asks.
+    // (Default turns here are autonomous: promptText null → placeholder slots, not rendered.)
     mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
       transcriptMessageRow({ uuid: "m1", turnUuid: "t1", role: "user", text: "do X", seq: 1 }),
       transcriptMessageRow({ uuid: "m2", turnUuid: "t1", role: "assistant", text: "did X", seq: 2 }),
@@ -792,11 +799,14 @@ describe("getSessionDetail", () => {
     expect(result?.session.uuid).toBe(sessionUuid);
     // Returned ascending for top-to-bottom rendering, regardless of the DESC fetch.
     expect(result?.turns.map((t) => t.uuid)).toEqual(["t1", "t2"]);
-    // Pagination metadata: a single page that fit (no extra row) → no earlier page.
+    // Only 3 real messages total (< page size) → no earlier page.
     expect(result?.hasMore).toBe(false);
-    expect(result?.oldestSeq).toBe(1);
-    // Messages folded into the right turn, in seq order, using the existing
-    // TranscriptMessageView shape (uuid/turnUuid/role/text/seq/createdAt).
+    // Oldest message in the page = the placeholder slot of t1 (turnSeq 1, msgSeq 0),
+    // which sorts ahead of t1's real seq>=1 messages. The cursor is read from the SLOT.
+    expect(result?.oldestTurnSeq).toBe(1);
+    expect(result?.oldestMsgSeq).toBe(0);
+    // Real messages folded into the right turn, ascending by seq (placeholder slots emit
+    // nothing into the rendered list). TranscriptMessageView shape preserved.
     expect(result?.turns[0].messages.map((m) => m.uuid)).toEqual(["m1", "m2"]);
     expect(result?.turns[0].messages[0]).toEqual({
       uuid: "m1",
@@ -809,9 +819,8 @@ describe("getSessionDetail", () => {
     expect(result?.turns[1].messages.map((m) => m.uuid)).toEqual(["m3"]);
   });
 
-  it("loads ALL of the PAGE's messages in ONE batched query (no N+1): where turnUuid in [...] over the page turns", async () => {
+  it("loads candidate turns' messages in ONE batched query (no N+1), keyed on the candidate turn uuids", async () => {
     mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
-    // DESC fetch (newest-first); reversed to ascending t1,t2,t3 for the message query.
     mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
       turnRow({ uuid: "t3", seq: 3 }),
       turnRow({ uuid: "t2", seq: 2 }),
@@ -821,28 +830,277 @@ describe("getSessionDetail", () => {
 
     await getSessionDetail({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid);
 
-    // Exactly ONE message query regardless of turn count, keyed on the page's turn
-    // uuids (ascending), ordered by (turnUuid, seq).
+    // Exactly ONE message query regardless of turn count, keyed on the candidate turn
+    // uuids, ordered (turnUuid asc, seq asc).
     expect(mockPrisma.daemonTranscriptMessage.findMany).toHaveBeenCalledTimes(1);
     expect(mockPrisma.daemonTranscriptMessage.findMany.mock.calls[0][0]).toEqual({
-      where: { turnUuid: { in: ["t1", "t2", "t3"] } },
+      where: { turnUuid: { in: ["t3", "t2", "t1"] } },
       orderBy: [{ turnUuid: "asc" }, { seq: "asc" }],
     });
-    // The turn page query is seq DESC + windowed (take = limit + 1 to probe hasMore).
+    // Candidate turns are read seq DESC; with NO cursor there is no take cap (the page
+    // window is computed in memory over the message stream) and no seq filter.
     const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
     expect(turnArgs.orderBy).toEqual({ seq: "desc" });
-    expect(turnArgs.take).toBe(DEFAULT_TRANSCRIPT_TURN_PAGE + 1);
     expect(turnArgs.where).toEqual({ sessionUuid });
   });
 
-  it("a turn whose messages were all trimmed still appears WITH an empty messages array", async () => {
+  it("DEFAULT page size is DEFAULT_TRANSCRIPT_MESSAGE_PAGE (20) MESSAGES, not turns", async () => {
+    expect(DEFAULT_TRANSCRIPT_MESSAGE_PAGE).toBe(20);
     mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
-    // DESC fetch; reversed to ascending [t1, t2].
+    // One prompt-less turn with 25 real messages — more than the 20-message default.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([turnRow({ uuid: "t1", seq: 1 })]);
+    const msgs = Array.from({ length: 25 }, (_, i) =>
+      transcriptMessageRow({ uuid: `m${i + 1}`, turnUuid: "t1", seq: i + 1 }),
+    );
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue(msgs);
+
+    const result = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+    );
+
+    // The single turn is a PARTIAL band carrying only the newest 20 messages (seq 6..25);
+    // the placeholder slot (seq 0) plus the oldest 5 messages are older than the page.
+    expect(result?.turns).toHaveLength(1);
+    expect(result?.turns[0].messages).toHaveLength(20);
+    expect(result?.turns[0].messages[0].seq).toBe(6);
+    expect(result?.turns[0].messages[19].seq).toBe(25);
+    expect(result?.hasMore).toBe(true);
+    // The page's oldest message is seq 6 of turn 1 → the next composite cursor.
+    expect(result?.oldestTurnSeq).toBe(1);
+    expect(result?.oldestMsgSeq).toBe(6);
+  });
+
+  it("PAGE SIZE clamp: a non-positive or oversized limit is clamped to [1, 200] MESSAGES", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    // 3 messages on one prompt-less turn; limit 0 clamps to 1 → only the newest message.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([turnRow({ uuid: "t1", seq: 1 })]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      transcriptMessageRow({ uuid: "m1", turnUuid: "t1", seq: 1 }),
+      transcriptMessageRow({ uuid: "m2", turnUuid: "t1", seq: 2 }),
+      transcriptMessageRow({ uuid: "m3", turnUuid: "t1", seq: 3 }),
+    ]);
+
+    const clampedLow = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 0 },
+    );
+    // limit clamped to 1 → exactly the single newest message (seq 3), hasMore true.
+    expect(clampedLow?.turns[0].messages.map((m) => m.seq)).toEqual([3]);
+    expect(clampedLow?.hasMore).toBe(true);
+
+    // limit 9999 clamps to 200 (a no-op ceiling here) → the whole conversation fits.
+    const clampedHigh = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 9999 },
+    );
+    expect(clampedHigh?.turns[0].messages.map((m) => m.seq)).toEqual([1, 2, 3]);
+    expect(clampedHigh?.hasMore).toBe(false);
+  });
+
+  it("COMPOSITE CURSOR: candidate turns fenced seq <= beforeTurnSeq; messages strictly older than (T, M)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    // The cursor turn (seq 3) is INCLUDED in the candidate set (its older messages may
+    // still belong before the cursor); the service filters the stream by the composite
+    // predicate in memory.
     mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
-      turnRow({ uuid: "t2", seq: 2 }), // its messages were trimmed by the rolling window
+      turnRow({ uuid: "t3", seq: 3 }),
+      turnRow({ uuid: "t2", seq: 2 }),
       turnRow({ uuid: "t1", seq: 1 }),
     ]);
-    // Only t1 has retained messages; t2's are gone.
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      transcriptMessageRow({ uuid: "t3m1", turnUuid: "t3", seq: 1 }),
+      transcriptMessageRow({ uuid: "t3m2", turnUuid: "t3", seq: 2 }),
+      transcriptMessageRow({ uuid: "t3m3", turnUuid: "t3", seq: 3 }),
+      transcriptMessageRow({ uuid: "t2m1", turnUuid: "t2", seq: 1 }),
+    ]);
+
+    const result = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 50, beforeTurnSeq: 3, beforeMsgSeq: 2 },
+    );
+
+    // Candidate turn query fenced `seq <= beforeTurnSeq` (the cursor turn itself stays in
+    // so its older messages can be returned).
+    const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
+    expect(turnArgs.where).toEqual({ sessionUuid, seq: { lte: 3 } });
+    // Only messages strictly older than (turnSeq 3, msgSeq 2): t3's seq 1 (and its slot
+    // seq 0), plus all of t2 and t1's slots. t3's seq 2 and 3 are at/after the cursor →
+    // excluded. So t3 keeps only t3m1.
+    expect(result?.turns.find((t) => t.uuid === "t3")?.messages.map((m) => m.uuid)).toEqual([
+      "t3m1",
+    ]);
+    // No t3m2/t3m3 anywhere in the result (not repeated, not skipped past).
+    const allUuids = result?.turns.flatMap((t) => t.messages.map((m) => m.uuid)) ?? [];
+    expect(allUuids).not.toContain("t3m2");
+    expect(allUuids).not.toContain("t3m3");
+    expect(allUuids).toContain("t2m1");
+  });
+
+  it("COMPOSITE CURSOR: load-earlier across a turn boundary mid-page neither repeats nor skips the boundary message", async () => {
+    // First page: limit 2 over a session of two prompt-less turns —
+    //   t2 has real seq 1; t1 has real seq 1,2.
+    // Stream (turnSeq desc, msgSeq desc): (2,1)t2m1, (2,0)slot2, (1,2)t1m2, (1,1)t1m1, (1,0)slot1.
+    // Page 1 (newest 2): (2,1)t2m1, (2,0)slot2 → cursor (oldestTurnSeq 2, oldestMsgSeq 0).
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t2", seq: 2 }),
+      turnRow({ uuid: "t1", seq: 1 }),
+    ]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      transcriptMessageRow({ uuid: "t1m1", turnUuid: "t1", seq: 1 }),
+      transcriptMessageRow({ uuid: "t1m2", turnUuid: "t1", seq: 2 }),
+      transcriptMessageRow({ uuid: "t2m1", turnUuid: "t2", seq: 1 }),
+    ]);
+
+    const page1 = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 2 },
+    );
+    expect(page1?.turns.find((t) => t.uuid === "t2")?.messages.map((m) => m.uuid)).toEqual([
+      "t2m1",
+    ]);
+    expect(page1?.hasMore).toBe(true);
+    expect(page1?.oldestTurnSeq).toBe(2);
+    expect(page1?.oldestMsgSeq).toBe(0);
+
+    // Page 2: feed the page-1 cursor back. Candidates are now seq <= 2 (DB would return
+    // t2,t1; the service windows by the composite predicate). The window keeps everything
+    // strictly older than (2,0): t1m2 (1,2), t1m1 (1,1), slot1 (1,0).
+    vi.clearAllMocks();
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t2", seq: 2 }),
+      turnRow({ uuid: "t1", seq: 1 }),
+    ]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      transcriptMessageRow({ uuid: "t1m1", turnUuid: "t1", seq: 1 }),
+      transcriptMessageRow({ uuid: "t1m2", turnUuid: "t1", seq: 2 }),
+      transcriptMessageRow({ uuid: "t2m1", turnUuid: "t2", seq: 1 }),
+    ]);
+
+    const page2 = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 2, beforeTurnSeq: page1!.oldestTurnSeq!, beforeMsgSeq: page1!.oldestMsgSeq! },
+    );
+
+    // t2m1 (on page 1) is NOT repeated; t1's seq 1,2 (the boundary messages) are returned
+    // exactly once, none skipped. With limit 2 the page is the newest 2 older entries:
+    // t1m2 (1,2) and t1m1 (1,1); slot1 (1,0) is the +1 → hasMore true.
+    const page2Uuids = page2?.turns.flatMap((t) => t.messages.map((m) => m.uuid)) ?? [];
+    expect(page2Uuids).not.toContain("t2m1");
+    expect(page2?.turns.find((t) => t.uuid === "t1")?.messages.map((m) => m.uuid)).toEqual([
+      "t1m1",
+      "t1m2",
+    ]);
+    expect(page2?.hasMore).toBe(true);
+    // Next cursor = oldest in page 2 = t1m1 at (1,1).
+    expect(page2?.oldestTurnSeq).toBe(1);
+    expect(page2?.oldestMsgSeq).toBe(1);
+
+    // Page 3: the placeholder slot of t1 (1,0) is the only remaining entry → empty band,
+    // hasMore false (conversation start).
+    vi.clearAllMocks();
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([turnRow({ uuid: "t1", seq: 1 })]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      transcriptMessageRow({ uuid: "t1m1", turnUuid: "t1", seq: 1 }),
+      transcriptMessageRow({ uuid: "t1m2", turnUuid: "t1", seq: 2 }),
+    ]);
+    const page3 = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 2, beforeTurnSeq: page2!.oldestTurnSeq!, beforeMsgSeq: page2!.oldestMsgSeq! },
+    );
+    // Only t1's (1,0) slot is strictly older than (1,1) → an empty band, start reached.
+    expect(page3?.turns.map((t) => t.uuid)).toEqual(["t1"]);
+    expect(page3?.turns[0].messages).toEqual([]);
+    expect(page3?.hasMore).toBe(false);
+    expect(page3?.oldestTurnSeq).toBe(1);
+    expect(page3?.oldestMsgSeq).toBe(0);
+  });
+
+  it("SYNTHETIC PROMPT: a prompt-only human_instruction turn surfaces as a synthetic seq=0 user message", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    // A human_instruction turn with promptText but NO stored transcript messages.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t1", seq: 1, trigger: "human_instruction", promptText: "please refactor X" }),
+    ]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
+
+    const result = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+    );
+
+    expect(result?.turns).toHaveLength(1);
+    const band = result!.turns[0];
+    // The band's ONLY message is the synthetic seq=0, role=user message carrying the prompt,
+    // with the stable `synthetic:{turnUuid}` uuid and the turn's createdAt.
+    expect(band.messages).toHaveLength(1);
+    expect(band.messages[0]).toEqual({
+      uuid: "synthetic:t1",
+      turnUuid: "t1",
+      role: "user",
+      text: "please refactor X",
+      seq: 0,
+      createdAt: "2026-06-15T03:00:00.000Z",
+    });
+    // The synthetic slot is the page's oldest position (cursor read from the slot).
+    expect(result?.oldestTurnSeq).toBe(1);
+    expect(result?.oldestMsgSeq).toBe(0);
+    expect(result?.hasMore).toBe(false);
+  });
+
+  it("SYNTHETIC ORDERING: the synthetic prompt sorts AHEAD of the turn's real (seq>=1) messages", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t1", seq: 1, trigger: "human_instruction", promptText: "do the thing" }),
+    ]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      transcriptMessageRow({ uuid: "m1", turnUuid: "t1", role: "assistant", text: "working", seq: 1 }),
+      transcriptMessageRow({ uuid: "m2", turnUuid: "t1", role: "assistant", text: "done", seq: 2 }),
+    ]);
+
+    const result = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+    );
+
+    // Synthetic prompt first, then the real messages ascending by seq.
+    expect(result?.turns[0].messages.map((m) => m.uuid)).toEqual(["synthetic:t1", "m1", "m2"]);
+    expect(result?.turns[0].messages[0].seq).toBe(0);
+    expect(result?.turns[0].messages[0].role).toBe("user");
+  });
+
+  it("SYNTHETIC: NOT persisted — no create/update is ever issued for the synthetic slot (read/projection only)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t1", seq: 1, trigger: "human_instruction", promptText: "ephemeral" }),
+    ]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
+
+    await getSessionDetail({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid);
+
+    // The synthetic message exists only in the projection — never written to the DB.
+    expect(mockPrisma.daemonTranscriptMessage.create).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonSessionTurn.create).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("EMPTY BAND: a prompt-less turn whose messages were all trimmed is STILL returned (empty band), occupying ONE cursor position", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    // t2 is prompt-less (agent_wake) and its messages were ALL trimmed by the rolling
+    // window; t1 still has a message. Both must appear; neither is dropped.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t2", seq: 2, trigger: "task_assigned", promptText: null }),
+      turnRow({ uuid: "t1", seq: 1, trigger: "task_assigned", promptText: null }),
+    ]);
     mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
       transcriptMessageRow({ uuid: "m1", turnUuid: "t1", seq: 1 }),
     ]);
@@ -852,12 +1110,80 @@ describe("getSessionDetail", () => {
       sessionUuid,
     );
 
-    expect(result?.turns).toHaveLength(2);
-    expect(result?.turns[0].messages.map((m) => m.uuid)).toEqual(["m1"]);
-    expect(result?.turns[1].messages).toEqual([]); // still a turn, just no transcript
+    // Both turns present; t2 is an EMPTY band (its placeholder slot reserved the spot).
+    expect(result?.turns.map((t) => t.uuid)).toEqual(["t1", "t2"]);
+    expect(result?.turns.find((t) => t.uuid === "t2")?.messages).toEqual([]);
+    expect(result?.turns.find((t) => t.uuid === "t1")?.messages.map((m) => m.uuid)).toEqual([
+      "m1",
+    ]);
+    // The whole conversation is 3 stream entries (t2 slot, t1 m1, t1 slot) < page size.
+    expect(result?.hasMore).toBe(false);
   });
 
-  it("a visible session with ZERO turns returns empty turns AND issues NO message query", async () => {
+  it("EMPTY BAND: paging does NOT stall on a message-less prompt-less turn — its slot consumes exactly one position", async () => {
+    // Two prompt-less, message-less turns. With limit 1, page 1 is t2's slot only; the
+    // load-earlier cursor (2,0) must advance PAST it to t1's slot, not re-yield t2.
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t2", seq: 2, promptText: null }),
+      turnRow({ uuid: "t1", seq: 1, promptText: null }),
+    ]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
+
+    const page1 = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 1 },
+    );
+    // Page 1 = t2's empty band; t1's slot is the +1 probe → hasMore true.
+    expect(page1?.turns.map((t) => t.uuid)).toEqual(["t2"]);
+    expect(page1?.turns[0].messages).toEqual([]);
+    expect(page1?.hasMore).toBe(true);
+    expect(page1?.oldestTurnSeq).toBe(2);
+    expect(page1?.oldestMsgSeq).toBe(0);
+
+    // Page 2 with the page-1 cursor: strictly older than (2,0) is only t1's slot (1,0).
+    // Paging ADVANCED — it did not loop back on t2.
+    vi.clearAllMocks();
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t2", seq: 2, promptText: null }),
+      turnRow({ uuid: "t1", seq: 1, promptText: null }),
+    ]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
+    const page2 = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 1, beforeTurnSeq: page1!.oldestTurnSeq!, beforeMsgSeq: page1!.oldestMsgSeq! },
+    );
+    expect(page2?.turns.map((t) => t.uuid)).toEqual(["t1"]);
+    expect(page2?.turns[0].messages).toEqual([]);
+    expect(page2?.hasMore).toBe(false); // conversation start reached
+    expect(page2?.oldestTurnSeq).toBe(1);
+    expect(page2?.oldestMsgSeq).toBe(0);
+  });
+
+  it("HAS-MORE false at conversation START: paged back to the oldest retained entry", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    // The whole conversation: one prompt-less turn with 2 messages → 3 stream entries.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([turnRow({ uuid: "t1", seq: 1 })]);
+    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([
+      transcriptMessageRow({ uuid: "m1", turnUuid: "t1", seq: 1 }),
+      transcriptMessageRow({ uuid: "m2", turnUuid: "t1", seq: 2 }),
+    ]);
+
+    const result = await getSessionDetail(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      sessionUuid,
+      { limit: 50 },
+    );
+    expect(result?.hasMore).toBe(false);
+    // Oldest position = the turn's placeholder slot (1, 0).
+    expect(result?.oldestTurnSeq).toBe(1);
+    expect(result?.oldestMsgSeq).toBe(0);
+  });
+
+  it("a visible session with ZERO turns returns empty turns, NO message query, null composite cursor", async () => {
     mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
     mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
 
@@ -867,65 +1193,11 @@ describe("getSessionDetail", () => {
     );
 
     expect(result?.turns).toEqual([]);
-    // No turns → no turnUuids → the batched message query is skipped entirely.
+    // No candidate turns → no turnUuids → the batched message query is skipped entirely.
     expect(mockPrisma.daemonTranscriptMessage.findMany).not.toHaveBeenCalled();
     expect(result?.hasMore).toBe(false);
-    expect(result?.oldestSeq).toBeNull();
-  });
-
-  it("PAGINATION: a full page + an extra probe row → hasMore true, the probe row is dropped", async () => {
-    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
-    // limit=2 asks for take=3; the DB returns 3 (newest-first) → an older page exists.
-    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
-      turnRow({ uuid: "t5", seq: 5 }),
-      turnRow({ uuid: "t4", seq: 4 }),
-      turnRow({ uuid: "t3", seq: 3 }), // the +1 probe row — dropped from the page
-    ]);
-    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
-
-    const result = await getSessionDetail(
-      { type: "user", companyUuid, actorUuid: ownerUuid },
-      sessionUuid,
-      { limit: 2 },
-    );
-
-    // Only the page (2 turns) is returned, ascending; the probe row is dropped.
-    expect(result?.turns.map((t) => t.uuid)).toEqual(["t4", "t5"]);
-    expect(result?.hasMore).toBe(true);
-    // oldestSeq = the earliest turn in the page → the next `beforeSeq` cursor.
-    expect(result?.oldestSeq).toBe(4);
-    // The message query keyed only on the PAGE's turns (probe row excluded).
-    expect(mockPrisma.daemonTranscriptMessage.findMany.mock.calls[0][0].where).toEqual({
-      turnUuid: { in: ["t4", "t5"] },
-    });
-  });
-
-  it("PAGINATION: beforeSeq loads turns STRICTLY older than the cursor", async () => {
-    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
-    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([turnRow({ uuid: "t1", seq: 1 })]);
-    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
-
-    await getSessionDetail(
-      { type: "user", companyUuid, actorUuid: ownerUuid },
-      sessionUuid,
-      { limit: 2, beforeSeq: 4 },
-    );
-
-    const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
-    expect(turnArgs.where).toEqual({ sessionUuid, seq: { lt: 4 } });
-    expect(turnArgs.take).toBe(3); // limit 2 + 1 probe
-  });
-
-  it("PAGINATION: a non-positive or oversized limit is clamped to 1..200", async () => {
-    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
-    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
-    mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
-
-    await getSessionDetail({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid, { limit: 0 });
-    expect(mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0].take).toBe(2); // clamped to 1 (+1)
-
-    await getSessionDetail({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid, { limit: 9999 });
-    expect(mockPrisma.daemonSessionTurn.findMany.mock.calls[1][0].take).toBe(201); // clamped to 200 (+1)
+    expect(result?.oldestTurnSeq).toBeNull();
+    expect(result?.oldestMsgSeq).toBeNull();
   });
 
   it("AGENT-KEY caller: resolves the session under self-scope (agentUuid)", async () => {

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -639,120 +639,237 @@ export interface TurnWithMessagesView extends TurnView {
   messages: TranscriptMessageView[];
 }
 
-// Default page size for the transcript read — measured in TURNS (the structural unit
-// the chat renders as bands). A coding-agent session can be woken many times, so the
-// transcript is paged newest-first and "load earlier" walks backward by `seq`; per-
-// message volume is independently bounded by MAX_TRANSCRIPT_MESSAGES_PER_SESSION.
-export const DEFAULT_TRANSCRIPT_TURN_PAGE = 30;
+// Default page size for the transcript read — measured in MESSAGES (the unit a viewer
+// actually scrolls through), NOT turns. A single turn is one agent wake and can carry
+// many multi-KB user/assistant messages, so paging by turn makes the worst case "one
+// enormous turn"; paging by message bounds every page regardless of how heavy a turn
+// is. Smaller than the old 30-turn default because the unit is now a single message.
+// Per-message volume is independently bounded by MAX_TRANSCRIPT_MESSAGES_PER_SESSION.
+export const DEFAULT_TRANSCRIPT_MESSAGE_PAGE = 20;
 
 /**
  * Read projection for the single-session transcript route: the session plus a PAGE of
- * its ordered turns (each carrying its retained transcript messages), newest-first
- * windowed but returned in ascending `seq` order for top-to-bottom rendering. `hasMore`
- * is true when older turns exist before this page; `oldestSeq` is the `seq` of the
- * earliest turn in this page — the cursor a client passes as `beforeSeq` to load the
- * previous page. Both are null/false for an empty session.
+ * MESSAGES grouped into the (possibly partial) turn bands that own them, newest-first
+ * windowed but returned in ascending `(turn.seq, msg.seq)` order for top-to-bottom
+ * rendering. `hasMore` is true when older messages exist before this page; the next
+ * "load earlier" cursor is the position of the OLDEST message/slot in this page,
+ * carried as `oldestTurnSeq` + `oldestMsgSeq` (a composite cursor — the message-level
+ * generalization of the old single `oldestSeq`). An empty placeholder band (a turn
+ * whose messages were all trimmed) still yields a usable cursor via its `(turn.seq, 0)`
+ * slot, so the cursor is read from the page's oldest *slot*, not its oldest rendered
+ * message. Both seqs are null and `hasMore` is false for an empty session.
  */
 export interface SessionDetailView {
   session: SessionView;
   turns: TurnWithMessagesView[];
   hasMore: boolean;
-  oldestSeq: number | null;
+  oldestTurnSeq: number | null;
+  oldestMsgSeq: number | null;
+}
+
+// A single entry in the unified, MESSAGE-level paging stream. Every turn contributes a
+// positional slot at `(turn.seq, msgSeq = 0)` (see D3) so no turn band is ever dropped
+// by the message pager; real transcript messages contribute entries at `msgSeq >= 1`.
+// `rendered` is the message emitted into the turn band's rendered `messages[]` — the
+// real `TranscriptMessageView` for a real message, a SYNTHETIC promptText message for a
+// promptText-bearing turn's slot, and `null` for a placeholder slot (counted for
+// paging/cursor but contributing no rendered message). The synthetic/placeholder slot
+// is a read/projection-layer construct only: never persisted, no schema/role change.
+interface StreamEntry {
+  turnSeq: number;
+  msgSeq: number;
+  rendered: TranscriptMessageView | null;
 }
 
 /**
- * Read a single session WITH its turns-and-messages, applying the SAME owner/self +
- * companyUuid visibility fence as `getSessionTurns` / `getVisibleSessions`. The
- * session is first resolved under the caller's visibility scope; a session that does
- * not exist, lives in another company, or belongs to an agent the caller does not own
- * all yield the SAME `null` — so the read route returns one 404 in every negative case
- * without revealing another caller's session exists (non-disclosure, exactly like
- * `getSessionTurns`).
+ * Read a single session WITH a MESSAGE-level page of its turns-and-messages, applying
+ * the SAME owner/self + companyUuid visibility fence as `getSessionTurns` /
+ * `getVisibleSessions`. The session is first resolved under the caller's visibility
+ * scope; a session that does not exist, lives in another company, or belongs to an
+ * agent the caller does not own all yield the SAME `null` — so the read route returns
+ * one 404 in every negative case without revealing another caller's session exists
+ * (non-disclosure, exactly like `getSessionTurns`).
  *
- * On a visible session it loads the turns ordered by `seq`, then loads ALL their
- * transcript messages in ONE batched query (`where: { turnUuid: { in: [...] } }`,
- * ordered by `(turnUuid, seq)`) and folds the messages into their turns IN MEMORY —
- * no N+1, exactly one extra query regardless of turn count (and zero when the session
- * has no turns). The per-message projection reuses `toTranscriptMessageView` (the
- * ingest path's mapper) and the `TranscriptMessageView` shape — no new message type.
- * Messages trimmed by the rolling-window cap are simply absent; a turn whose messages
- * were all trimmed still appears with an empty `messages` array.
+ * Pagination is by MESSAGE, not turn (a single turn can carry many multi-KB messages,
+ * so a turn-window's worst case is "one enormous turn"). It builds a unified message
+ * stream where EVERY turn gets a positional slot at `(turn.seq, msgSeq = 0)`:
+ *  - a turn with non-empty `promptText` → the slot is a synthetic RENDERED message
+ *    (`role: "user"`, `text: promptText`, `uuid: "synthetic:" + turnUuid`), emitted
+ *    into the band's rendered `messages[]` ahead of the real `seq >= 1` messages;
+ *  - a prompt-less turn whose real messages were all trimmed by the rolling window →
+ *    the slot is a PLACEHOLDER counted for paging/cursor but NOT rendered (the band
+ *    materializes with an empty `messages[]`, matching the old turn-pager which never
+ *    dropped such a turn);
+ *  - a turn with real messages → the `(seq = 0)` placeholder reserves the position and
+ *    the rendered messages are the real ones.
+ * The stream is ordered `(turn.seq desc, msg.seq desc)`, the composite `before`
+ * predicate `turn.seq < T OR (turn.seq = T AND msg.seq < M)` is applied, `limit + 1`
+ * entries are taken (the extra one tells us `hasMore` without a count query), then the
+ * page is reversed to ascending and grouped back into `TurnWithMessagesView[]` (turn
+ * metadata via `toTurnView`; partial turns and empty placeholder bands are expected).
+ * Within the 200-message session cap the candidate turns' messages are loaded in ONE
+ * batched query and sliced in memory — N is bounded, so the composite-cursor +
+ * synthetic-fold logic stays in one place.
  *
- * Returns `null` when the session is not visible (the route maps to 404), or the
- * `{ session, turns }` detail when it is. A READ that does NOT swallow — a query
- * failure propagates so the route surfaces a 500 (never a degraded empty transcript).
+ * The next "load earlier" cursor is reported as `oldestTurnSeq` / `oldestMsgSeq` — the
+ * position of the page's OLDEST slot/message (so an empty placeholder band still yields
+ * a usable cursor). Returns `null` when the session is not visible (the route maps to
+ * 404), or the `{ session, turns, hasMore, oldestTurnSeq, oldestMsgSeq }` detail when
+ * it is. A READ that does NOT swallow — a query failure propagates so the route
+ * surfaces a 500 (never a degraded empty transcript).
  */
 export async function getSessionDetail(
   auth: { type: string; companyUuid: string; actorUuid: string },
   sessionUuid: string,
-  // Pagination (newest-first window over TURNS): `limit` caps how many turns this page
-  // returns (default DEFAULT_TRANSCRIPT_TURN_PAGE); `beforeSeq` loads the page of turns
-  // strictly OLDER than that seq (the "load earlier" cursor). Omitting `beforeSeq` loads
-  // the most recent page. A non-positive/oversized `limit` is clamped to a sane range.
-  opts: { limit?: number; beforeSeq?: number | null } = {},
+  // Pagination (newest-first window over MESSAGES): `limit` caps how many messages this
+  // page returns (default DEFAULT_TRANSCRIPT_MESSAGE_PAGE); the composite cursor
+  // `(beforeTurnSeq, beforeMsgSeq)` loads the messages strictly OLDER than that position
+  // under `turn.seq < T OR (turn.seq = T AND msg.seq < M)`. Omitting both loads the most
+  // recent page. A non-positive/oversized `limit` is clamped to a sane range.
+  opts: { limit?: number; beforeTurnSeq?: number | null; beforeMsgSeq?: number | null } = {},
 ): Promise<SessionDetailView | null> {
   const sessionRow = await prisma.daemonSession.findFirst({
     where: { uuid: sessionUuid, companyUuid: auth.companyUuid, ...ownerScope(auth) },
   });
   if (!sessionRow) return null; // not visible → 404 non-disclosure
 
-  // Clamp the page size: at least 1, at most 200 turns per page (a hard ceiling so a
-  // hostile `limit` can't ask for an unbounded scan).
+  // Clamp the page size: at least 1, at most 200 messages per page (a hard ceiling so a
+  // hostile `limit` can't ask for an unbounded scan; also the session retention cap).
   const limit = Math.min(
-    Math.max(1, Math.floor(opts.limit ?? DEFAULT_TRANSCRIPT_TURN_PAGE)),
+    Math.max(1, Math.floor(opts.limit ?? DEFAULT_TRANSCRIPT_MESSAGE_PAGE)),
     200,
   );
-  const beforeSeq =
-    typeof opts.beforeSeq === "number" && Number.isFinite(opts.beforeSeq)
-      ? opts.beforeSeq
+  const beforeTurnSeq =
+    typeof opts.beforeTurnSeq === "number" && Number.isFinite(opts.beforeTurnSeq)
+      ? opts.beforeTurnSeq
+      : null;
+  const beforeMsgSeq =
+    typeof opts.beforeMsgSeq === "number" && Number.isFinite(opts.beforeMsgSeq)
+      ? opts.beforeMsgSeq
       : null;
 
-  // Fetch the NEWEST `limit` turns at or before the cursor: order by seq DESC, take
-  // `limit + 1` so the extra row tells us whether an OLDER page exists (hasMore) without
-  // a separate count query. Then reverse to ascending for top-to-bottom rendering.
-  const pageDesc = await prisma.daemonSessionTurn.findMany({
+  // Candidate turn window: every turn at or before the cursor turn (`seq <= beforeTurnSeq`),
+  // or all turns when no cursor. NOTE: only messages are trimmed by the rolling-window cap
+  // (`trimSessionTranscript` deletes DaemonTranscriptMessage rows) — turns are NOT, so this
+  // set grows with the session's wake count (one turn per wake). For the conversational
+  // session sizes this read serves that is acceptable: we load these turns' messages in one
+  // batched query and slice the composite window in memory (D4), bounded per page by `limit`.
+  // If a session's turn count ever grows large enough to matter, bound this with a `take`
+  // heuristic (limit + margin, widen on underflow) rather than scanning all turns.
+  // Ordered seq DESC so the slot/message stream is newest-first before windowing.
+  const candidateTurns = await prisma.daemonSessionTurn.findMany({
     where: {
       sessionUuid,
-      ...(beforeSeq !== null ? { seq: { lt: beforeSeq } } : {}),
+      ...(beforeTurnSeq !== null ? { seq: { lte: beforeTurnSeq } } : {}),
     },
     orderBy: { seq: "desc" },
-    take: limit + 1,
   });
-  const hasMore = pageDesc.length > limit;
-  const pageTurns = (hasMore ? pageDesc.slice(0, limit) : pageDesc).reverse(); // ascending
 
-  // Load this page's turns' messages in ONE batched query, then fold in memory — no
-  // N+1. An empty page needs no message query at all.
-  const turnUuids = pageTurns.map((t) => t.uuid);
+  // Load the candidate turns' real messages in ONE batched query, then fold in memory —
+  // no N+1. An empty candidate set needs no message query at all.
+  const candidateTurnUuids = candidateTurns.map((t) => t.uuid);
   const messages =
-    turnUuids.length > 0
+    candidateTurnUuids.length > 0
       ? await prisma.daemonTranscriptMessage.findMany({
-          where: { turnUuid: { in: turnUuids } },
+          where: { turnUuid: { in: candidateTurnUuids } },
           orderBy: [{ turnUuid: "asc" }, { seq: "asc" }],
         })
       : [];
 
-  // Bucket the messages by their turnUuid so each turn gets exactly its own messages
-  // in seq order (the query already ordered by (turnUuid, seq), so each bucket is in
-  // seq order as appended). A turn with no retained messages keeps an empty array.
-  const messagesByTurn = new Map<string, TranscriptMessageView[]>();
+  // Bucket real messages by their turnUuid (each bucket already in ascending seq order
+  // from the query). A turn with no retained messages simply has no bucket.
+  const realByTurn = new Map<string, TranscriptMessageView[]>();
   for (const m of messages) {
     const view = toTranscriptMessageView(m);
-    const bucket = messagesByTurn.get(view.turnUuid);
+    const bucket = realByTurn.get(view.turnUuid);
     if (bucket) bucket.push(view);
-    else messagesByTurn.set(view.turnUuid, [view]);
+    else realByTurn.set(view.turnUuid, [view]);
   }
 
-  const turnsWithMessages: TurnWithMessagesView[] = pageTurns.map((t) => ({
-    ...toTurnView(t),
-    messages: messagesByTurn.get(t.uuid) ?? [],
-  }));
+  // Build the unified `(turn.seq desc, msg.seq desc)` stream. For each candidate turn
+  // (already seq DESC) emit its real messages newest-first, then its `seq = 0` slot last
+  // (smallest msgSeq sorts last within a turn under DESC). The slot is rendered for a
+  // promptText turn, a placeholder otherwise — but ALWAYS present so every turn occupies
+  // exactly one cursor position and no band is dropped.
+  const stream: StreamEntry[] = [];
+  for (const t of candidateTurns) {
+    const reals = realByTurn.get(t.uuid) ?? [];
+    for (let i = reals.length - 1; i >= 0; i--) {
+      stream.push({ turnSeq: t.seq, msgSeq: reals[i].seq, rendered: reals[i] });
+    }
+    const promptText = t.promptText;
+    const hasPrompt = typeof promptText === "string" && promptText.length > 0;
+    stream.push({
+      turnSeq: t.seq,
+      msgSeq: 0,
+      rendered: hasPrompt
+        ? {
+            uuid: `synthetic:${t.uuid}`,
+            turnUuid: t.uuid,
+            role: "user",
+            text: promptText as string,
+            seq: 0,
+            createdAt: t.createdAt.toISOString(),
+          }
+        : null,
+    });
+  }
+
+  // Apply the composite `before` predicate: keep entries strictly older than the cursor
+  // under `turn.seq < T OR (turn.seq = T AND msg.seq < M)`. With no cursor every entry
+  // passes. The stream is already (turnSeq desc, msgSeq desc) by construction.
+  const windowed =
+    beforeTurnSeq !== null
+      ? stream.filter(
+          (e) =>
+            e.turnSeq < beforeTurnSeq ||
+            (e.turnSeq === beforeTurnSeq && e.msgSeq < (beforeMsgSeq ?? 0)),
+        )
+      : stream;
+
+  // Take `limit + 1` newest entries: the extra entry (if present) proves an OLDER page
+  // exists (hasMore) without a separate count query.
+  const hasMore = windowed.length > limit;
+  const pageDesc = hasMore ? windowed.slice(0, limit) : windowed;
+  const pageAsc = [...pageDesc].reverse(); // ascending (turnSeq asc, msgSeq asc)
+
+  // The next "load earlier" cursor = the page's OLDEST slot/message position (the last
+  // entry of the newest-first page, i.e. the first of the ascending page). Read from the
+  // SLOT, so an empty placeholder band still yields a usable cursor.
+  const oldest = pageDesc.length > 0 ? pageDesc[pageDesc.length - 1] : null;
+
+  // Group the page's entries back into their turns, preserving ascending order of first
+  // appearance. A turn's band carries only this page's RENDERED messages (real ones plus
+  // a rendered synthetic promptText); a placeholder-only slot yields an empty band.
+  const turnMeta = new Map<string, DaemonSessionTurnRow>();
+  for (const t of candidateTurns) turnMeta.set(t.uuid, t);
+  const turnSeqToUuid = new Map<number, string>();
+  for (const t of candidateTurns) turnSeqToUuid.set(t.seq, t.uuid);
+
+  const renderedByTurnSeq = new Map<number, TranscriptMessageView[]>();
+  const orderedTurnSeqs: number[] = [];
+  for (const e of pageAsc) {
+    if (!renderedByTurnSeq.has(e.turnSeq)) {
+      renderedByTurnSeq.set(e.turnSeq, []);
+      orderedTurnSeqs.push(e.turnSeq);
+    }
+    if (e.rendered) renderedByTurnSeq.get(e.turnSeq)!.push(e.rendered);
+  }
+
+  const turnsWithMessages: TurnWithMessagesView[] = orderedTurnSeqs.map((seq) => {
+    const uuid = turnSeqToUuid.get(seq)!;
+    return {
+      ...toTurnView(turnMeta.get(uuid)!),
+      messages: renderedByTurnSeq.get(seq) ?? [],
+    };
+  });
 
   return {
     session: toSessionView(sessionRow),
     turns: turnsWithMessages,
     hasMore,
-    oldestSeq: turnsWithMessages.length > 0 ? turnsWithMessages[0].seq : null,
+    oldestTurnSeq: oldest ? oldest.turnSeq : null,
+    oldestMsgSeq: oldest ? oldest.msgSeq : null,
   };
 }
 


### PR DESCRIPTION
## Summary
The daemon conversation transcript paginated in **turns** — the first paint loaded the latest 30 turns and "load earlier" walked back by `turn.seq`. But one turn is a single agent wake and can carry many multi-KB messages, so the page unit was too coarse: even one turn could be a heavy first paint, and shrinking the turn count only masked the worst case ("one enormous turn").

This pages by **message** instead, using the composite `(turn.seq, message.seq)` order that already equals the top-to-bottom render order — **no schema change, no migration**.

- `getSessionDetail` returns the newest `DEFAULT_TRANSCRIPT_MESSAGE_PAGE` (20) messages at/older than a composite `(beforeTurnSeq, beforeMsgSeq)` cursor, rebuilds the (possibly partial) turn bands, and reports `hasMore` + `oldestTurnSeq`/`oldestMsgSeq`. The turn-level `DEFAULT_TRANSCRIPT_TURN_PAGE` / `?beforeSeq` contract is **replaced** (the only caller is this repo's `daemon-chat.tsx`; no external/MCP consumer).
- **Every turn keeps a positional `(turn.seq, 0)` slot** so no band is ever dropped: a synthetic `role:"user"` promptText message for `human_instruction` turns, a placeholder for prompt-less turns whose messages were all trimmed by the rolling-window cap (which the old pager returned as an empty band). The slot has a stable uuid `synthetic:{turnUuid}` and is read-only — never persisted, no schema/role change.
- Frontend tracks the **server-returned** `oldestTurnSeq`/`oldestMsgSeq` cursor (an empty placeholder band has no rendered message to derive a seq from); `mergeTurnPage` / `applyTranscriptEvent` stay uuid-keyed and unchanged.
- `TurnBand` drops the synthetic `seq=0` entry from its rendered bubble list so a `human_instruction` prompt renders **exactly once** (its canonical paragraph), identically on the GET and live SSE paths.

OpenSpec change `daemon-transcript-message-level-pagination` (archived in this PR); capability `daemon-session-transcript-read` spec updated.

## Changed files
| File | Change |
|------|--------|
| `src/services/daemon-session.service.ts` | Message-level window + composite cursor + per-turn `(seq,0)` slot in `getSessionDetail` |
| `src/app/api/daemon-sessions/[sessionUuid]/route.ts` | Parse `?beforeTurnSeq`+`?beforeMsgSeq` (+`?limit`); drop `?beforeSeq` |
| `src/components/agent-presence/chat/daemon-chat.tsx` | Track server-returned composite cursor for first paint + loadEarlier |
| `src/components/agent-presence/chat/turn-band.tsx` | Skip synthetic `seq=0` slot in rendered bubbles (prompt renders once) |
| `src/services/__tests__/daemon-session.service.test.ts` | Rewritten pagination tests (boundary, synthetic, empty-band, hasMore) |
| `src/app/api/daemon-sessions/[sessionUuid]/__tests__/route.test.ts` | Composite-cursor param parsing |
| `src/components/agent-presence/__tests__/apply-transcript-event.test.ts` | +partial-band stitch, synthetic de-dup, empty-band, live-append |
| `src/components/agent-presence/__tests__/connections-modal.test.tsx` | Load-earlier composite cursor + synthetic-renders-once regression |
| `openspec/specs/daemon-session-transcript-read/spec.md` | Updated capability spec (archived change merged back) |
| `openspec/changes/archive/2026-06-20-daemon-transcript-message-level-pagination/` | Archived OpenSpec change (proposal/design/spec) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 165 files / 2767 passed / 1 skipped
- [x] Independent adversarial review (caught + fixed the double-render bug now covered by a regression test)
- [x] Deployed to live env; prod `/login` 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)