### PR TITLE
feat(openclaw): bidirectional daemon parity (control + reporting + shared REST client)

### DIFF
--- a/cli/__tests__/daemon-rest-client.test.mjs
+++ b/cli/__tests__/daemon-rest-client.test.mjs
@@ -1,0 +1,315 @@
+// cli/__tests__/daemon-rest-client.test.mjs
+// Covers the SHARED, host-agnostic daemon REST client (`cli/daemon-rest-client.mjs`) —
+// the single source of truth for the `/api/daemon/*` payload shapes consumed by BOTH the
+// chorus CLI daemon and the OpenClaw plugin. Two responsibilities are tested here:
+//   1. PAYLOAD SHAPES — each operation hits the exact server endpoint, with Bearer auth,
+//      the exact method, and the exact body the existing server route accepts.
+//   2. ERROR SURFACING — a network error, a non-2xx response, an empty/bad body, or a
+//      missing connectionUuid is LOGGED WITH CAUSE and SURFACED via the structured
+//      result (`{ ok: false, error|skipped }`) — never swallowed into a silent success,
+//      and never thrown (so a failed report can't crash the run).
+import { describe, it, expect, vi } from "vitest";
+import { createDaemonRestClient } from "../daemon-rest-client.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+function okFetch(status = 200, jsonBody) {
+  return vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => jsonBody,
+  }));
+}
+
+function makeClient(overrides = {}) {
+  return createDaemonRestClient({
+    url: "https://chorus.example.com/", // trailing slash exercised on purpose
+    apiKey: "cho_secret",
+    getConnectionUuid: () => "conn-1",
+    logger: silent,
+    fetchImpl: okFetch(),
+    ...overrides,
+  });
+}
+
+describe("createDaemonRestClient — payload shapes (single source of truth)", () => {
+  it("turnAdvance POSTs the exact server contract with Bearer auth", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+
+    const result = await client.turnAdvance({
+      sessionId: "idea-1",
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    // Trailing slash on the base url is normalized away.
+    expect(endpoint).toBe("https://chorus.example.com/api/daemon/turn-advance");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer cho_secret");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({
+      connectionUuid: "conn-1",
+      sessionId: "idea-1",
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+  });
+
+  it("turnAdvance omits entityType/entityUuid unless BOTH are present (no partial linkage)", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+
+    await client.turnAdvance({ sessionId: "idea-1", status: "ended", entityType: "task" }); // entityUuid missing
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body).toEqual({ connectionUuid: "conn-1", sessionId: "idea-1", status: "ended" });
+    expect(body).not.toHaveProperty("entityType");
+  });
+
+  it("transcript POSTs { sessionId, messages } and needs no connectionUuid", async () => {
+    const fetchImpl = okFetch();
+    // No getConnectionUuid wired — transcript must still POST (agent key + sessionId
+    // resolve the turn server-side).
+    const client = createDaemonRestClient({
+      url: "https://c",
+      apiKey: "cho_x",
+      logger: silent,
+      fetchImpl,
+    });
+
+    const messages = [
+      { role: "user", text: "hi" },
+      { role: "assistant", text: "hello" },
+    ];
+    const result = await client.transcript({ sessionId: "idea-1", messages });
+
+    expect(result.ok).toBe(true);
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    expect(endpoint).toBe("https://c/api/daemon/transcript");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer cho_x");
+    expect(JSON.parse(init.body)).toEqual({ sessionId: "idea-1", messages });
+  });
+
+  it("executionState POSTs { connectionUuid, executions } with the server snapshot shape", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+
+    const executions = [
+      { entityType: "task", entityUuid: "task-1", rootIdeaUuid: "root-1", status: "running", startedAt: "2026-06-20T00:00:00.000Z" },
+      { entityType: "task", entityUuid: "task-2", rootIdeaUuid: null, status: "queued", startedAt: null },
+    ];
+    const result = await client.executionState({ executions });
+
+    expect(result.ok).toBe(true);
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    expect(endpoint).toBe("https://chorus.example.com/api/daemon/execution-state");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ connectionUuid: "conn-1", executions });
+  });
+
+  it("reportInterrupt POSTs { connectionUuid, entityType, entityUuid, reason }", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+
+    const result = await client.reportInterrupt({
+      entityType: "daemon_session",
+      entityUuid: "sess-1",
+      reason: "user",
+    });
+
+    expect(result.ok).toBe(true);
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    expect(endpoint).toBe("https://chorus.example.com/api/daemon/report-interrupt");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer cho_secret");
+    expect(JSON.parse(init.body)).toEqual({
+      connectionUuid: "conn-1",
+      entityType: "daemon_session",
+      entityUuid: "sess-1",
+      reason: "user",
+    });
+  });
+
+  it("readPendingTurns GETs ?connectionUuid=… (encoded) and returns the parsed turns", async () => {
+    const turns = [
+      { turnUuid: "t-1", sessionId: "idea-1", directIdeaUuid: "idea-1", trigger: "human_instruction", promptText: "do it" },
+    ];
+    const fetchImpl = okFetch(200, { success: true, data: { turns } });
+    const client = makeClient({ fetchImpl, getConnectionUuid: () => "conn/1" });
+
+    const result = await client.readPendingTurns();
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ turns });
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    // No explicit method on a GET; connectionUuid is URL-encoded.
+    expect(endpoint).toBe("https://chorus.example.com/api/daemon/pending-turns?connectionUuid=conn%2F1");
+    expect(init.method).toBeUndefined();
+    expect(init.headers.Authorization).toBe("Bearer cho_secret");
+  });
+});
+
+describe("createDaemonRestClient — connectionUuid guards", () => {
+  it("turnAdvance skips (logged, no fetch) without a connection uuid", async () => {
+    const fetchImpl = okFetch();
+    const warns = [];
+    const client = makeClient({
+      fetchImpl,
+      getConnectionUuid: () => null,
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+
+    const result = await client.turnAdvance({ sessionId: "idea-1", status: "running" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: false, skipped: true });
+    expect(warns.join("")).toMatch(/no connection uuid yet/);
+  });
+
+  it("reportInterrupt skips (logged, no fetch) without a connection uuid", async () => {
+    const fetchImpl = okFetch();
+    const warns = [];
+    const client = makeClient({
+      fetchImpl,
+      getConnectionUuid: () => null,
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+
+    const result = await client.reportInterrupt({ entityType: "task", entityUuid: "task-9", reason: "user" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: false, skipped: true });
+    expect(warns.join("")).toMatch(/no connection uuid yet/);
+  });
+
+  it("executionState skips silently (NOT an error) without a connection uuid", async () => {
+    const fetchImpl = okFetch();
+    const warns = [];
+    const client = makeClient({
+      fetchImpl,
+      getConnectionUuid: () => null,
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+
+    const result = await client.executionState({ executions: [] });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: false, skipped: true });
+    // A pre-handshake snapshot is a normal early state — no warn noise.
+    expect(warns).toEqual([]);
+  });
+
+  it("readPendingTurns skips silently (NOT an error) without a connection uuid", async () => {
+    const fetchImpl = okFetch(200, { success: true, data: { turns: [] } });
+    const warns = [];
+    const client = makeClient({
+      fetchImpl,
+      getConnectionUuid: () => null,
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+
+    const result = await client.readPendingTurns();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: false, skipped: true });
+    expect(warns).toEqual([]);
+  });
+});
+
+describe("createDaemonRestClient — error surfacing (no silent errors)", () => {
+  it("a network error is logged WITH cause and surfaced, never thrown", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const warns = [];
+    const client = makeClient({ fetchImpl, logger: { ...silent, warn: (m) => warns.push(m) } });
+
+    const promise = client.turnAdvance({ sessionId: "idea-1", status: "running" });
+    await expect(promise).resolves.toBeTruthy(); // never rejects
+    const result = await promise;
+    expect(result).toMatchObject({ ok: false, status: null });
+    expect(result.error).toMatch(/turn-advance request failed/);
+    expect(result.error).toMatch(/ECONNREFUSED/); // the underlying cause is preserved
+    expect(warns.join("")).toMatch(/turn-advance request failed.*ECONNREFUSED/);
+  });
+
+  it("a non-2xx response is logged with its status and surfaced", async () => {
+    const fetchImpl = okFetch(409);
+    const warns = [];
+    const client = makeClient({ fetchImpl, logger: { ...silent, warn: (m) => warns.push(m) } });
+
+    const result = await client.turnAdvance({ sessionId: "idea-1", status: "ended" });
+    expect(result).toMatchObject({ ok: false, status: 409 });
+    expect(result.error).toMatch(/turn-advance returned 409/);
+    expect(warns.join("")).toMatch(/turn-advance returned 409/);
+  });
+
+  it("each POST op uses its own log label on failure", async () => {
+    const status = 404;
+    const cases = [
+      ["transcript", (c) => c.transcript({ sessionId: "s", messages: [{ role: "user", text: "x" }] }), /transcript upload returned 404/],
+      ["executionState", (c) => c.executionState({ executions: [] }), /execution-state upload returned 404/],
+      ["reportInterrupt", (c) => c.reportInterrupt({ entityType: "task", entityUuid: "t-1", reason: "crash" }), /report-interrupt returned 404/],
+    ];
+    for (const [, call, pattern] of cases) {
+      const warns = [];
+      const client = makeClient({ fetchImpl: okFetch(status), logger: { ...silent, warn: (m) => warns.push(m) } });
+      const result = await call(client);
+      expect(result).toMatchObject({ ok: false, status: 404 });
+      expect(warns.join("")).toMatch(pattern);
+    }
+  });
+
+  it("readPendingTurns surfaces a non-2xx with cause", async () => {
+    const warns = [];
+    const client = makeClient({ fetchImpl: okFetch(404), logger: { ...silent, warn: (m) => warns.push(m) } });
+    const result = await client.readPendingTurns();
+    expect(result).toMatchObject({ ok: false, status: 404 });
+    expect(result.error).toMatch(/pending-turns backfill returned 404/);
+    expect(warns.join("")).toMatch(/pending-turns backfill returned 404/);
+    expect(result.data).toBeUndefined(); // no silent empty success
+  });
+
+  it("readPendingTurns surfaces a bad JSON body", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    }));
+    const warns = [];
+    const client = makeClient({ fetchImpl, logger: { ...silent, warn: (m) => warns.push(m) } });
+    const result = await client.readPendingTurns();
+    expect(result).toMatchObject({ ok: false });
+    expect(result.error).toMatch(/pending-turns backfill: bad JSON/);
+    expect(warns.join("")).toMatch(/bad JSON/);
+  });
+
+  it("readPendingTurns surfaces a missing turns array (no silent empty result)", async () => {
+    const warns = [];
+    const client = makeClient({
+      fetchImpl: okFetch(200, { success: true, data: {} }), // no turns
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+    const result = await client.readPendingTurns();
+    expect(result).toMatchObject({ ok: false });
+    expect(result.error).toMatch(/no turns array/);
+    expect(warns.join("")).toMatch(/no turns array/);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("a network error never throws for ANY op (a failed report cannot crash the run)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const client = makeClient({ fetchImpl });
+    await expect(client.turnAdvance({ sessionId: "s", status: "running" })).resolves.toBeTruthy();
+    await expect(client.transcript({ sessionId: "s", messages: [{ role: "user", text: "x" }] })).resolves.toBeTruthy();
+    await expect(client.executionState({ executions: [] })).resolves.toBeTruthy();
+    await expect(client.reportInterrupt({ entityType: "task", entityUuid: "t", reason: "crash" })).resolves.toBeTruthy();
+    await expect(client.readPendingTurns()).resolves.toBeTruthy();
+  });
+});

--- a/cli/backfill.mjs
+++ b/cli/backfill.mjs
@@ -18,6 +18,13 @@
 //      `GET /api/daemon/pending-turns?connectionUuid=…` (Bearer agent key, global
 //      fetch — zero new deps), each re-dispatched through `router.dispatchPendingTurn`.
 //
+// The pending-turns READ goes through the SHARED daemon REST client
+// (`cli/daemon-rest-client.mjs`), which owns the `GET /api/daemon/pending-turns` request,
+// Bearer auth, the connectionUuid guard, and the no-silent-errors handling (network error
+// / non-2xx / bad JSON / missing turns array are all logged with cause and surfaced).
+// This module keeps only the backfill-domain concerns: the notification source, the
+// `onlyTurnUuid` precision filter, the `seen` dedup, and re-dispatch.
+//
 // De-dupes against the shared `seen` set so a reconnect storm doesn't double-wake.
 //
 // The returned `backfill` function also exposes `backfill.pendingTurnsOnly` — the
@@ -25,6 +32,8 @@
 // (子2 — origin-only live delivery) can reuse the EXACT same sweep without re-running the
 // notification source. Live ping and reconnect backfill therefore converge on one sweep +
 // one `seen` set, so a turn runs at most once regardless of which path observes it first.
+
+import { createDaemonRestClient } from "./daemon-rest-client.mjs";
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
@@ -59,11 +68,17 @@ export function createBackfill(opts) {
   const logger = opts.logger ?? NOOP_LOGGER;
   const limit = opts.limit ?? 50;
   // 子1 pending-turn backfill wiring (optional).
-  const url = opts.url ? opts.url.replace(/\/$/, "") : null;
+  const url = opts.url ?? null;
   const apiKey = opts.apiKey ?? null;
   const getConnectionUuid = opts.getConnectionUuid ?? null;
   const dispatchPendingTurn = opts.dispatchPendingTurn ?? null;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  // The pending-turns READ is delegated to the shared client. Built only when the
+  // pending-turn backfill is wired (url + apiKey + getConnectionUuid present); otherwise
+  // backfillPendingTurns is an early no-op (notification-only callers / older tests).
+  const pendingTurnsClient =
+    url && apiKey && getConnectionUuid
+      ? createDaemonRestClient({ url, apiKey, getConnectionUuid, fetchImpl: opts.fetchImpl, logger })
+      : null;
 
   /** Re-emit unread notifications missed during the gap (autonomous wakes). */
   async function backfillNotifications() {
@@ -119,45 +134,20 @@ export function createBackfill(opts) {
    * @param {string} [onlyTurnUuid]
    */
   async function backfillPendingTurns(onlyTurnUuid) {
-    if (!url || !apiKey || !getConnectionUuid || !dispatchPendingTurn) {
+    if (!pendingTurnsClient || !dispatchPendingTurn) {
       // Pending-turn backfill not wired (e.g. notification-only callers / older tests).
       return;
     }
-    const connectionUuid = getConnectionUuid();
-    if (!connectionUuid) {
-      // No connectionUuid yet (SSE handshake hasn't reported it): nothing to read
-      // against. Not an error — a normal early state on the very first connect.
+    // The shared client reads `GET /api/daemon/pending-turns?connectionUuid=…`, skipping
+    // (no log) while the connectionUuid is not known yet — a normal early state — and
+    // surfacing a network error / non-2xx / bad JSON / missing turns array with its cause
+    // (logged) as `result.ok === false`. We just consume the parsed turns; never throw.
+    const result = await pendingTurnsClient.readPendingTurns();
+    if (!result.ok || !result.data) {
+      // Either nothing to read yet (skipped) or a logged failure — nothing to dispatch.
       return;
     }
-
-    const endpoint = `${url}/api/daemon/pending-turns?connectionUuid=${encodeURIComponent(connectionUuid)}`;
-    let response;
-    try {
-      response = await fetchImpl(endpoint, {
-        headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
-      });
-    } catch (err) {
-      logger.warn(`[Chorus] pending-turns backfill request failed: ${err}`);
-      return;
-    }
-    if (!response.ok) {
-      logger.warn(`[Chorus] pending-turns backfill returned ${response.status}`);
-      return;
-    }
-    let body;
-    try {
-      body = await response.json();
-    } catch (err) {
-      logger.warn(`[Chorus] pending-turns backfill: bad JSON: ${err}`);
-      return;
-    }
-    // API envelope: { success: true, data: { turns: [...] } }.
-    const data = body && typeof body === "object" ? body.data : undefined;
-    const turns = data && typeof data === "object" ? data.turns : undefined;
-    if (!Array.isArray(turns)) {
-      logger.warn("[Chorus] pending-turns backfill: no turns array in response");
-      return;
-    }
+    const turns = result.data.turns;
 
     let redispatched = 0;
     for (const t of turns) {

--- a/cli/daemon-rest-client.mjs
+++ b/cli/daemon-rest-client.mjs
@@ -1,0 +1,272 @@
+// cli/daemon-rest-client.mjs
+// Shared, host-agnostic pure-REST client for the Chorus daemon → server reporting
+// surface (`/api/daemon/*`). It is the SINGLE SOURCE OF TRUTH for the payload shapes
+// the existing server endpoints accept, so the two daemon hosts — the chorus CLI daemon
+// (`cli/daemon.mjs`) and the OpenClaw plugin — cannot drift in the wire contract.
+//
+// The five operations and their EXACT server payload shapes (verified against
+// src/app/api/daemon/*/route.ts — the server is NOT changed by this work):
+//   turnAdvance      → POST /api/daemon/turn-advance
+//                      { connectionUuid, sessionId, status, entityType?, entityUuid? }
+//   transcript       → POST /api/daemon/transcript
+//                      { sessionId, messages: [{ role, text }] }
+//   executionState   → POST /api/daemon/execution-state
+//                      { connectionUuid, executions: [{ entityType, entityUuid,
+//                                                       rootIdeaUuid|null, status,
+//                                                       startedAt|null }] }
+//   reportInterrupt  → POST /api/daemon/report-interrupt
+//                      { connectionUuid, entityType, entityUuid, reason }
+//   readPendingTurns → GET  /api/daemon/pending-turns?connectionUuid=…
+//                      → { turns: [{ turnUuid, sessionId, directIdeaUuid, trigger,
+//                                    promptText }] }
+//
+// HARD CONSTRAINTS (this module is consumed verbatim by the OpenClaw plugin too):
+//   • ZERO daemon-host coupling — no child_process, no `claude` spawn, no stream-json
+//     parsing, no OpenClaw SDK import. Its only outbound effect is HTTP via the
+//     injected `fetchImpl` (global fetch on Node 18+). Adds NO new npm dependency
+//     (CLAUDE.md pitfall #9).
+//   • Bearer-only auth: every request carries `Authorization: Bearer <apiKey>`.
+//   • NO SILENT ERRORS (project policy): a network error, a non-2xx response, or an
+//     empty/bad body where a result is expected is LOGGED WITH ITS CAUSE and SURFACED to
+//     the caller via a structured result object — never swallowed into a silent success.
+//   • A failed report MUST NOT crash the run: every method RESOLVES (never rejects) with
+//     a `{ ok: false, ... }` result so a fire-and-forget caller can `await` it safely.
+//     The callers decide whether to react; the failure is already visible in the log.
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/**
+ * @typedef {Object} DaemonRestResult
+ * @property {boolean} ok           True only on a 2xx response (and, for reads, a
+ *                                  well-formed body). False on network error, non-2xx,
+ *                                  or a malformed/empty body.
+ * @property {number|null} status   HTTP status when a response was received; null on a
+ *                                  pre-flight skip or a network-level error.
+ * @property {string} [error]       Human-readable failure cause (also logged). Absent on
+ *                                  success.
+ * @property {boolean} [skipped]    True when the call was intentionally not issued (e.g.
+ *                                  an empty transcript batch); not an error.
+ * @property {*} [data]             Parsed response payload for read operations
+ *                                  (`readPendingTurns` → `{ turns: [...] }`).
+ */
+
+/**
+ * Build the shared daemon REST client. The inputs are entirely host-agnostic, which is
+ * exactly why the same module serves both daemon hosts.
+ *
+ * @param {{
+ *   url: string,                          Chorus base URL (a trailing slash is normalized
+ *                                         away so callers may pass either form).
+ *   apiKey: string,                       `cho_` agent API key for Bearer auth.
+ *   getConnectionUuid?: () => (string|null), The daemon's registered connection uuid,
+ *                                         learned from the SSE handshake. Read LAZILY on
+ *                                         every call so construction order does not matter.
+ *                                         The connection-scoped operations (turnAdvance,
+ *                                         executionState, reportInterrupt, readPendingTurns)
+ *                                         require it; a null value skips the call (logged).
+ *   fetchImpl?: typeof fetch,             Injectable for tests (defaults to global fetch).
+ *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+ * }} opts
+ * @returns {{
+ *   turnAdvance: (p: { sessionId: string, status: string, entityType?: string|null, entityUuid?: string|null }) => Promise<DaemonRestResult>,
+ *   transcript: (p: { sessionId: string, messages: Array<{ role: string, text: string }> }) => Promise<DaemonRestResult>,
+ *   executionState: (p: { executions: Array<Record<string, unknown>> }) => Promise<DaemonRestResult>,
+ *   reportInterrupt: (p: { entityType: string, entityUuid: string, reason: string }) => Promise<DaemonRestResult>,
+ *   readPendingTurns: () => Promise<DaemonRestResult>,
+ * }}
+ */
+export function createDaemonRestClient(opts) {
+  const url = opts.url.replace(/\/$/, "");
+  const apiKey = opts.apiKey;
+  const getConnectionUuid = opts.getConnectionUuid ?? (() => null);
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const logger = opts.logger ?? NOOP_LOGGER;
+
+  const jsonHeaders = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+
+  /**
+   * Issue one daemon report. Owns the transport + the no-silent-errors contract that is
+   * IDENTICAL across all four POST endpoints; only the `op` label (used in the log line)
+   * and the path differ. Never throws — returns a structured {@link DaemonRestResult}.
+   *
+   * @param {string} op      Operation label for the log line (matches each endpoint's
+   *                         established wording, e.g. "turn-advance",
+   *                         "execution-state upload", "transcript upload",
+   *                         "report-interrupt").
+   * @param {string} path    Endpoint path, e.g. "/api/daemon/turn-advance".
+   * @param {unknown} body   JSON-serializable request body.
+   * @param {string} [successLog]  Optional info line on success.
+   * @param {string} [context]     Optional " for <entity>"-style suffix appended AFTER the
+   *                         `<op> request failed` / `<op> returned <status>` core, so the
+   *                         failing entity stays visible in the log without disturbing the
+   *                         established op-prefixed message.
+   * @returns {Promise<DaemonRestResult>}
+   */
+  async function post(op, path, body, successLog, context = "") {
+    let response;
+    try {
+      response = await fetchImpl(`${url}${path}`, {
+        method: "POST",
+        headers: jsonHeaders,
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      // Network-level failure (DNS, connection refused, abort, …). Surface WITH cause.
+      const error = `${op} request failed${context}: ${err}`;
+      logger.warn(`[Chorus] ${error}`);
+      return { ok: false, status: null, error };
+    }
+    if (!response.ok) {
+      // Non-2xx. Surface WITH the status so a 4xx/5xx is debuggable.
+      const error = `${op} returned ${response.status}${context}`;
+      logger.warn(`[Chorus] ${error}`);
+      return { ok: false, status: response.status, error };
+    }
+    if (successLog) logger.info(`[Chorus] ${successLog}`);
+    return { ok: true, status: response.status };
+  }
+
+  return {
+    /**
+     * POST /api/daemon/turn-advance — advance a wake's DaemonSessionTurn lifecycle. The
+     * server resolves the turn by the session BUSINESS KEY (`sessionId`); the optional
+     * `entityType`/`entityUuid` stamp the weak executionUuid link. Requires the
+     * connectionUuid (the server addresses the turn against a connection the agent owns).
+     */
+    async turnAdvance({ sessionId, status, entityType, entityUuid }) {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        const error = `cannot advance turn for session ${sessionId} → ${status} — no connection uuid yet`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: null, error, skipped: true };
+      }
+      const body = {
+        connectionUuid,
+        sessionId,
+        status,
+        // Only sent when BOTH are present, so the server never gets a partial linkage.
+        ...(entityType && entityUuid ? { entityType, entityUuid } : {}),
+      };
+      return post(
+        "turn-advance",
+        "/api/daemon/turn-advance",
+        body,
+        `advanced turn for session ${sessionId} → ${status}`,
+      );
+    },
+
+    /**
+     * POST /api/daemon/transcript — append finalized user/assistant text to the current
+     * turn, targeted by the session BUSINESS KEY (`sessionId`). The caller is responsible
+     * for the content filter (only `{ role, text }` for user/assistant) and any batching.
+     * No connectionUuid needed (the agent key + sessionId resolve the turn server-side).
+     */
+    async transcript({ sessionId, messages }) {
+      return post(
+        "transcript upload",
+        "/api/daemon/transcript",
+        { sessionId, messages },
+        `transcript uploaded (${messages.length} msg) for session ${sessionId}`,
+      );
+    },
+
+    /**
+     * POST /api/daemon/execution-state — publish the connection's running/queued
+     * execution snapshot. The caller supplies the already-built `executions` array (in
+     * the server's `{ entityType, entityUuid, rootIdeaUuid|null, status, startedAt|null }`
+     * shape). Requires the connectionUuid to attribute the snapshot.
+     */
+    async executionState({ executions }) {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        // No connectionUuid yet (SSE handshake hasn't reported it): nothing to attribute
+        // the snapshot to. A normal early/edge state — surfaced as a skip, NOT an error.
+        return { ok: false, status: null, skipped: true };
+      }
+      return post(
+        "execution-state upload",
+        "/api/daemon/execution-state",
+        { connectionUuid, executions },
+        `execution-state uploaded (${executions.length} active)`,
+      );
+    },
+
+    /**
+     * POST /api/daemon/report-interrupt — record a wake's `interrupted` outcome
+     * (reason = "user" | "crash") on the server execution row keyed by connection +
+     * entity. Requires the connectionUuid to target the right execution row.
+     */
+    async reportInterrupt({ entityType, entityUuid, reason }) {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        const error = `cannot report interrupt for ${entityType}:${entityUuid} — no connection uuid yet`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: null, error, skipped: true };
+      }
+      return post(
+        "report-interrupt",
+        "/api/daemon/report-interrupt",
+        { connectionUuid, entityType, entityUuid, reason },
+        `reported ${entityType}:${entityUuid} interrupted (reason=${reason})`,
+        // Keep the failing entity visible in the failure log (restores the suffix the
+        // standalone interrupt reporter used to emit) without altering the asserted
+        // `report-interrupt request failed` / `report-interrupt returned <status>` prefix.
+        ` for ${entityType}:${entityUuid}`,
+      );
+    },
+
+    /**
+     * GET /api/daemon/pending-turns?connectionUuid=… — read this connection's unstarted
+     * (pending) turns from the turn table (the reconnect-backfill / deliver_turn source).
+     * Returns the parsed `{ turns: [...] }` data on success; a network error, a non-2xx,
+     * a bad JSON body, or a missing `turns` array is LOGGED with cause and surfaced as a
+     * failure result — never a silent empty success.
+     *
+     * @returns {Promise<DaemonRestResult & { data?: { turns: Array<{ turnUuid: string, sessionId: string, directIdeaUuid: string|null, trigger: string, promptText: string|null }> } }>}
+     */
+    async readPendingTurns() {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        // No connectionUuid yet: nothing to read against. A normal early state — skip.
+        return { ok: false, status: null, skipped: true };
+      }
+      const endpoint = `${url}/api/daemon/pending-turns?connectionUuid=${encodeURIComponent(connectionUuid)}`;
+      let response;
+      try {
+        response = await fetchImpl(endpoint, {
+          headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+        });
+      } catch (err) {
+        const error = `pending-turns backfill request failed: ${err}`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: null, error };
+      }
+      if (!response.ok) {
+        const error = `pending-turns backfill returned ${response.status}`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: response.status, error };
+      }
+      let parsed;
+      try {
+        parsed = await response.json();
+      } catch (err) {
+        const error = `pending-turns backfill: bad JSON: ${err}`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: response.status, error };
+      }
+      // API envelope: { success: true, data: { turns: [...] } }.
+      const data = parsed && typeof parsed === "object" ? parsed.data : undefined;
+      const turns = data && typeof data === "object" ? data.turns : undefined;
+      if (!Array.isArray(turns)) {
+        const error = "pending-turns backfill: no turns array in response";
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: response.status, error };
+      }
+      return { ok: true, status: response.status, data: { turns } };
+    },
+  };
+}

--- a/cli/interrupt-reporter.mjs
+++ b/cli/interrupt-reporter.mjs
@@ -13,11 +13,15 @@
 // for ANY recognized entity kind (not just tasks) and carries the daemon's own
 // `connectionUuid` so the server can target the right execution row.
 //
-// Transport: a plain REST POST to `/api/daemon/report-interrupt` with the daemon's
-// existing Bearer agent key — the SAME zero-dep pattern as cli/lineage.mjs and
-// cli/upload-hooks.mjs (global fetch, Node 18+). It adds NO new npm dependency
-// (CLAUDE.md pitfall #9) and no shell-out. It is fire-and-forget and NEVER throws
-// into the wake path: a failure is LOGGED (memory: no-silent-errors) and swallowed.
+// Transport: the SHARED daemon REST client (`cli/daemon-rest-client.mjs`) owns the actual
+// `POST /api/daemon/report-interrupt` request, its Bearer auth, and the no-silent-errors
+// transport contract — this module is the thin domain wrapper that validates the
+// entity/reason and maps the call into the client's `reportInterrupt` payload. It adds NO
+// new npm dependency (CLAUDE.md pitfall #9) and no shell-out. It is fire-and-forget and
+// NEVER throws into the wake path: a failure is LOGGED by the shared client (memory:
+// no-silent-errors) and the returned result is swallowed.
+
+import { createDaemonRestClient } from "./daemon-rest-client.mjs";
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
@@ -55,11 +59,17 @@ const REPORTABLE_ENTITY_TYPES = new Set([
  * @returns {(entityType: string, entityUuid: string, reason: "user"|"crash") => Promise<void>}
  */
 export function createInterruptReporter(opts) {
-  const url = opts.url.replace(/\/$/, "");
-  const apiKey = opts.apiKey;
-  const getConnectionUuid = opts.getConnectionUuid ?? (() => null);
   const logger = opts.logger ?? NOOP_LOGGER;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  // The shared client owns the request, Bearer auth, the connectionUuid guard, and the
+  // surface-not-swallow transport contract. This wrapper keeps only the interrupt-domain
+  // validation (entity kind / reason) that is NOT the client's concern.
+  const client = createDaemonRestClient({
+    url: opts.url,
+    apiKey: opts.apiKey,
+    getConnectionUuid: opts.getConnectionUuid ?? (() => null),
+    fetchImpl: opts.fetchImpl,
+    logger,
+  });
 
   return async function reportInterrupt(entityType, entityUuid, reason) {
     if (!REPORTABLE_ENTITY_TYPES.has(entityType) || !entityUuid || !INTERRUPT_REASONS.has(reason)) {
@@ -68,39 +78,10 @@ export function createInterruptReporter(opts) {
       );
       return;
     }
-    const connectionUuid = getConnectionUuid();
-    if (!connectionUuid) {
-      // The server targets the execution row by connection + entity; without our
-      // registered connection uuid there is nothing to address. Skip (logged) —
-      // this can only happen before the SSE handshake completed.
-      logger.warn(
-        `[Chorus] cannot report interrupt for ${entityType}:${entityUuid} — no connection uuid yet`,
-      );
-      return;
-    }
-
-    const endpoint = `${url}/api/daemon/report-interrupt`;
-    let response;
-    try {
-      response = await fetchImpl(endpoint, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify({ connectionUuid, entityType, entityUuid, reason }),
-      });
-    } catch (err) {
-      logger.warn(`[Chorus] report-interrupt request failed for ${entityType}:${entityUuid}: ${err}`);
-      return;
-    }
-    if (!response.ok) {
-      logger.warn(
-        `[Chorus] report-interrupt returned ${response.status} for ${entityType}:${entityUuid} (reason=${reason})`,
-      );
-      return;
-    }
-    logger.info(`[Chorus] reported ${entityType}:${entityUuid} interrupted (reason=${reason})`);
+    // The client resolves the connectionUuid lazily, validates it (logging
+    // "no connection uuid yet" when absent), POSTs the exact server payload, and logs the
+    // failure cause on a network error / non-2xx. We swallow the structured result so a
+    // failed report can never crash the wake path.
+    await client.reportInterrupt({ entityType, entityUuid, reason });
   };
 }

--- a/cli/turn-reporter.mjs
+++ b/cli/turn-reporter.mjs
@@ -14,11 +14,15 @@
 // turn. The optional `entityType`/`entityUuid` let the server stamp the weak
 // executionUuid link from the live execution row.
 //
-// Transport: a plain REST POST to `/api/daemon/turn-advance` with the daemon's existing
-// Bearer agent key — the SAME zero-dep pattern as cli/interrupt-reporter.mjs and
-// cli/upload-hooks.mjs (global fetch, Node 18+). It adds NO new npm dependency
-// (CLAUDE.md pitfall #9) and no shell-out. It is fire-and-forget and NEVER throws into
-// the wake path: a failure is LOGGED (memory: no-silent-errors) and swallowed.
+// Transport: the SHARED daemon REST client (`cli/daemon-rest-client.mjs`) owns the actual
+// `POST /api/daemon/turn-advance` request, its Bearer auth, and the no-silent-errors
+// transport contract — this module is the thin domain wrapper that validates the
+// status/sessionId and maps the wake's call into the client's `turnAdvance` payload. It
+// adds NO new npm dependency (CLAUDE.md pitfall #9) and no shell-out. It is
+// fire-and-forget and NEVER throws into the wake path: a failure is LOGGED by the shared
+// client (memory: no-silent-errors) and the returned result is swallowed.
+
+import { createDaemonRestClient } from "./daemon-rest-client.mjs";
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
@@ -42,11 +46,17 @@ export const TURN_STATUSES = new Set(["pending", "running", "ended"]);
  * @returns {(params: { sessionId: string, status: "running"|"ended", entityType?: string|null, entityUuid?: string|null }) => Promise<void>}
  */
 export function createTurnReporter(opts) {
-  const url = opts.url.replace(/\/$/, "");
-  const apiKey = opts.apiKey;
-  const getConnectionUuid = opts.getConnectionUuid ?? (() => null);
   const logger = opts.logger ?? NOOP_LOGGER;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  // The shared client owns the request, Bearer auth, the connectionUuid guard, and the
+  // surface-not-swallow transport contract. This wrapper keeps only the turn-domain
+  // validation (status / sessionId) that is NOT the client's concern.
+  const client = createDaemonRestClient({
+    url: opts.url,
+    apiKey: opts.apiKey,
+    getConnectionUuid: opts.getConnectionUuid ?? (() => null),
+    fetchImpl: opts.fetchImpl,
+    logger,
+  });
 
   return async function advanceTurn({ sessionId, status, entityType, entityUuid }) {
     if (typeof sessionId !== "string" || !sessionId || !TURN_STATUSES.has(status)) {
@@ -55,47 +65,11 @@ export function createTurnReporter(opts) {
       );
       return;
     }
-    const connectionUuid = getConnectionUuid();
-    if (!connectionUuid) {
-      // The server resolves the turn against a connection the agent owns; without our
-      // registered connection uuid there is nothing to address. Skip (logged) — this
-      // can only happen before the SSE handshake completed.
-      logger.warn(
-        `[Chorus] cannot advance turn for session ${sessionId} → ${status} — no connection uuid yet`,
-      );
-      return;
-    }
-
-    const body = {
-      connectionUuid,
-      sessionId,
-      status,
-      // entityType/entityUuid are optional — only sent when the wake has a recognized
-      // execution entity, so the server can resolve the weak executionUuid link.
-      ...(entityType && entityUuid ? { entityType, entityUuid } : {}),
-    };
-
-    let response;
-    try {
-      response = await fetchImpl(`${url}/api/daemon/turn-advance`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify(body),
-      });
-    } catch (err) {
-      logger.warn(`[Chorus] turn-advance request failed for session ${sessionId} → ${status}: ${err}`);
-      return;
-    }
-    if (!response.ok) {
-      logger.warn(
-        `[Chorus] turn-advance returned ${response.status} for session ${sessionId} → ${status}`,
-      );
-      return;
-    }
-    logger.info(`[Chorus] advanced turn for session ${sessionId} → ${status}`);
+    // The client resolves the connectionUuid lazily, validates it (logging
+    // "no connection uuid yet" when absent), POSTs the exact server payload — sending
+    // entityType/entityUuid only when both are present — and logs the failure cause on a
+    // network error / non-2xx. We swallow the structured result so a failed report can
+    // never crash the wake path.
+    await client.turnAdvance({ sessionId, status, entityType, entityUuid });
   };
 }

--- a/cli/upload-hooks.mjs
+++ b/cli/upload-hooks.mjs
@@ -18,6 +18,14 @@
 //
 // `status` is constrained to "running"/"queued"; "ended" is a server-only
 // terminal state the daemon never reports (the server rejects it).
+//
+// Transport: both the transcript POST and the execution-state POST go through the SHARED
+// daemon REST client (`cli/daemon-rest-client.mjs`), which owns the request, Bearer auth,
+// and the no-silent-errors transport contract. These hooks keep only the host-side
+// concerns the client does not own — batching/debounce + content extraction for the
+// transcript, and the snapshot build + serialized fire-and-forget chaining for both.
+
+import { createDaemonRestClient } from "./daemon-rest-client.mjs";
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
@@ -217,13 +225,18 @@ export function extractTranscriptText(obj) {
  * @returns {UploadHooks}
  */
 export function createTranscriptUploadHooks(opts) {
-  const url = opts.url.replace(/\/$/, "");
-  const apiKey = opts.apiKey;
   const logger = opts.logger ?? NOOP_LOGGER;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
   const batchDelayMs = opts.batchDelayMs ?? 50;
   const setTimeoutImpl = opts.setTimeoutImpl ?? setTimeout;
   const clearTimeoutImpl = opts.clearTimeoutImpl ?? clearTimeout;
+  // Transport via the shared client (transcript has no connectionUuid concern — the agent
+  // key + sessionId resolve the turn server-side, so getConnectionUuid is unused here).
+  const client = createDaemonRestClient({
+    url: opts.url,
+    apiKey: opts.apiKey,
+    fetchImpl: opts.fetchImpl,
+    logger,
+  });
 
   // The session this batch belongs to (set by onSessionStart, and re-affirmed by each
   // message's observed session id from the stream). Messages queued for one session
@@ -235,31 +248,14 @@ export function createTranscriptUploadHooks(opts) {
   // Serialize POSTs so an earlier batch can never land after a later one on the wire.
   let chain = Promise.resolve();
 
-  /** POST one batch for a session. Never throws. */
+  /** POST one batch for a session via the shared client. Never throws. */
   async function upload(sessionId, messages) {
     if (!sessionId || messages.length === 0) return;
-    const body = JSON.stringify({ sessionId, messages });
-
-    let response;
-    try {
-      response = await fetchImpl(`${url}/api/daemon/transcript`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body,
-      });
-    } catch (err) {
-      logger.warn(`[Chorus] transcript upload request failed: ${err}`);
-      return;
-    }
-    if (!response.ok) {
-      logger.warn(`[Chorus] transcript upload returned ${response.status}`);
-      return;
-    }
-    logger.info(`[Chorus] transcript uploaded (${messages.length} msg) for session ${sessionId}`);
+    // The client POSTs `{ sessionId, messages }` to /api/daemon/transcript with Bearer
+    // auth and logs "transcript upload request failed" / "transcript upload returned N"
+    // on failure (no-silent-errors) and "transcript uploaded (N msg) ..." on success. We
+    // swallow the structured result so a failed upload never breaks the wake path.
+    await client.transcript({ sessionId, messages });
   }
 
   /** Drain `pending` for `currentSessionId` into a serialized fire-and-forget POST. */
@@ -350,12 +346,19 @@ export function createTranscriptUploadHooks(opts) {
  * @returns {UploadHooks}
  */
 export function createExecutionUploadHooks(opts) {
-  const url = opts.url.replace(/\/$/, "");
-  const apiKey = opts.apiKey;
-  const getConnectionUuid = opts.getConnectionUuid;
   const getSnapshot = opts.getSnapshot;
   const logger = opts.logger ?? NOOP_LOGGER;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  // Transport via the shared client. It owns the connectionUuid guard (silent skip while
+  // the SSE handshake hasn't reported it — a normal early state, not an error), the
+  // request, Bearer auth, and the failure logging ("execution-state upload request failed"
+  // / "execution-state upload returned N") + success log.
+  const client = createDaemonRestClient({
+    url: opts.url,
+    apiKey: opts.apiKey,
+    getConnectionUuid: opts.getConnectionUuid,
+    fetchImpl: opts.fetchImpl,
+    logger,
+  });
 
   // Serialize uploads so two rapid transitions can't reorder on the wire (a
   // later snapshot must not land before an earlier one). The snapshot is
@@ -365,36 +368,9 @@ export function createExecutionUploadHooks(opts) {
   // collapsed into the subsequent "finished" upload.
   let chain = Promise.resolve();
 
-  /** POST a captured snapshot. Never throws. */
+  /** POST a captured snapshot via the shared client. Never throws. */
   async function upload(executions) {
-    const connectionUuid = getConnectionUuid();
-    if (!connectionUuid) {
-      // No connectionUuid yet (SSE handshake hasn't reported it): nothing to
-      // attribute the snapshot to. Not an error — a normal early/edge state.
-      return;
-    }
-    const body = JSON.stringify({ connectionUuid, executions });
-
-    let response;
-    try {
-      response = await fetchImpl(`${url}/api/daemon/execution-state`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body,
-      });
-    } catch (err) {
-      logger.warn(`[Chorus] execution-state upload request failed: ${err}`);
-      return;
-    }
-    if (!response.ok) {
-      logger.warn(`[Chorus] execution-state upload returned ${response.status}`);
-      return;
-    }
-    logger.info(`[Chorus] execution-state uploaded (${executions.length} active)`);
+    await client.executionState({ executions });
   }
 
   return {

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/README.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/README.md
@@ -1,0 +1,3 @@
+# align-openclaw-daemon-parity
+
+Bring the OpenClaw plugin to bidirectional daemon parity with cli/daemon.mjs

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/design.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/design.md
@@ -1,0 +1,103 @@
+# Technical Design: OpenClaw daemon bidirectional parity
+
+## Overview
+
+The Chorus daemon protocol has two halves: a **server half** (connection registry, execution-state, control channel, pending-turns, transcript-read — all already built and shipped for the CLI host) and a **host half** that opens the SSE stream, reports what it runs, and obeys reverse-control commands. The chorus CLI (`cli/daemon.mjs`) implements the host half against a spawned `claude` subprocess. This change implements the host half a **second time** for the OpenClaw plugin, whose host is an **in-process `runEmbeddedAgent`** call, not a subprocess — and factors the host-agnostic REST reporting into a shared client so the two hosts cannot drift.
+
+Nothing here touches the server. Every `/api/daemon/*` endpoint and the `control:{connectionUuid}` channel already exist; this change makes a second client speak the same protocol.
+
+## The host re-mapping (CLI subprocess → OpenClaw in-process)
+
+This is the crux. Each CLI-host mechanism maps to an OpenClaw-host mechanism; the **wire protocol to the server is identical**.
+
+| Concern | CLI host (`cli/daemon.mjs`) | OpenClaw host (this change) |
+|---|---|---|
+| Run an agent | spawn `claude -p --output-format stream-json` subprocess | `runtime.agent.runEmbeddedAgent(params)` in-process |
+| Resume same session | `claude --resume <directIdeaUuid>` (disk transcript probe) | derive `sessionKey` from business key → `getSessionEntry` resolves the existing `sessionId`/`sessionFile` |
+| Observe messages | parse subprocess `stream-json` line by line | inline callbacks `onAssistantMessageStart` / `onBlockReply` / `onToolResult` / `onReasoningStream` |
+| Mid-run interrupt | `SIGINT`→`SIGKILL` to the process group | `AbortController.abort()` whose `signal` was passed into `runEmbeddedAgent` |
+| Detect crash vs exit | subprocess non-zero exit code | `runEmbeddedAgent` promise rejects (or `result.meta.aborted` distinguishes user-abort) |
+| Concurrency | daemon `wake-queue.mjs` | OpenClaw built-in command-queue lanes (serial-per-session via sessionKey, parallel-across-session) where free; full policy is sibling idea `6fab91cd` |
+
+The server-facing payloads (`turn-advance`, `transcript`, `execution-state`, `report-interrupt`, `pending-turns`) are **byte-for-byte the same** regardless of host — which is exactly why they belong in a shared client.
+
+## Architecture
+
+```
+        Chorus server (UNCHANGED)
+   SSE /api/events/notifications ──connection_registered, new_notification, control──┐
+   REST /api/daemon/{turn-advance,transcript,execution-state,report-interrupt,pending-turns}
+                                                                                     │
+        OpenClaw plugin (packages/openclaw-plugin/src/)                              │
+   ┌─────────────────────────────────────────────────────────────────────┐         │
+   │ sse-listener  ── onConnectionId ─▶ connection-state (connectionUuid)  │◀────────┘
+   │               ── onControl ──────▶ control-handler                    │
+   │               ── onEvent ────────▶ event-router (wake path only)      │
+   │                                                                       │
+   │ control-handler ─ interrupt ─▶ abort registry .abort(entityKey)       │
+   │                  ─ resume ────▶ re-dispatch wake (synthetic resume)   │
+   │                  ─ deliver_turn ▶ pending-turns sweep (this conn)     │
+   │                                                                       │
+   │ openclaw-daemon-client                                                │
+   │   runEmbeddedAgent({ abortSignal, onBlockReply, ... })                │
+   │     ├─ on spawn  ─▶ daemon-rest-client.turnAdvance(running)           │
+   │     ├─ on message ▶ daemon-rest-client.transcript({role,text})       │
+   │     ├─ on done   ─▶ turnAdvance(ended) + execution-state snapshot     │
+   │     └─ on abort/reject ▶ report-interrupt(user|crash)                 │
+   └───────────────────────────────┬───────────────────────────────────────┘
+                                    │ imports
+                       daemon-rest-client  ◀── ALSO imported by cli/daemon.mjs
+```
+
+## Module contracts
+
+### `daemon-rest-client` (shared)
+- **Factory:** `createDaemonRestClient({ url, apiKey, getConnectionUuid, fetchImpl, logger })` → `{ turnAdvance, transcript, executionState, reportInterrupt, readPendingTurns }`.
+- **Auth:** `Authorization: Bearer <apiKey>` on every call (no other auth).
+- **Payload shapes (the single source of truth):**
+  - `turnAdvance({ connectionUuid, sessionId, status: "running"|"ended", entityType?, entityUuid? })` → `POST /api/daemon/turn-advance`
+  - `transcript({ sessionId, messages: [{ role: "user"|"assistant", text }] })` → `POST /api/daemon/transcript`
+  - `executionState({ connectionUuid, executions: [{ taskUuid, rootIdeaUuid|null, status, startedAt|null }] })` → `POST /api/daemon/execution-state`
+  - `reportInterrupt({ connectionUuid, entityType, entityUuid, reason: "user"|"crash" })` → `POST /api/daemon/report-interrupt`
+  - `readPendingTurns(connectionUuid)` → `GET /api/daemon/pending-turns?connectionUuid=…` → `{ turns: [{ turnUuid, sessionId, directIdeaUuid, trigger, promptText }] }`
+- **Constraint:** zero host coupling — no `child_process`, no `claude`, no stream-json, no OpenClaw imports. Pure REST + injected `fetchImpl`. Errors are surfaced (logged + thrown/returned), never silently swallowed.
+- **Extraction discipline:** the CLI daemon's existing reporter modules (`turn-reporter.mjs`, `upload-hooks.mjs`, `interrupt-reporter.mjs`, the pending-turns read in `backfill.mjs`) become thin wrappers over this client. The CLI daemon's existing test suite is the behavior-preservation oracle — it must stay green.
+
+### `connection-state` (OpenClaw)
+- Holds the live `connectionUuid` captured from `connection_registered`; exposes `getConnectionUuid()` to the rest client and control handler. Cleared/refreshed on reconnect.
+
+### `control-handler` (OpenClaw)
+- Receives forked `type:"control"` events. **Double-check before acting** (mirrors `daemon-interrupt-resume`): act only when `event.targetConnectionUuid === getConnectionUuid()` AND (for `interrupt`) the abort registry holds a live run for `{entityType, entityUuid}`. Otherwise log + ignore.
+- `interrupt` → `abortRegistry.get(key).abort()`.
+- `resume` → synthesize a resume wake for the entity → re-dispatch through the wake path (continues the same session).
+- `deliver_turn` → `readPendingTurns(connectionUuid)`, filter to `event.turnUuid` (full sweep if absent), run the unstarted turn.
+- **Never enqueues a wake for the control event itself** — control is not a wake.
+
+### `openclaw-daemon-client` (OpenClaw)
+- Wraps `runEmbeddedAgent` for a wake. Creates an `AbortController`, registers it under `entityType:entityUuid`, passes `abortSignal` + transcript callbacks into the run.
+- Lifecycle reporting via `daemon-rest-client`: `turnAdvance(running)` on spawn, `transcript(...)` per message, `turnAdvance(ended)` + execution snapshot on completion, `reportInterrupt(user|crash)` on abort/reject. De-registers the controller in a `finally`.
+- **Session mapping:** `sessionKey = deriveSessionKey(directIdeaUuid ?? entityUuid)`, resolved via `runtime.agent.session.getSessionEntry({ sessionKey, agentId })` so a resume/deliver_turn continues the same `sessionId`/`sessionFile`.
+
+## Idempotency & safety
+
+- **At-most-once turn execution:** live `deliver_turn` and reconnect backfill share a `seen` set keyed by `turn:<uuid>`, exactly as the CLI host does — a turn observed by either path is a no-op for the other.
+- **Interrupt double-check** prevents a stale/recycled `connectionUuid` from aborting the wrong run.
+- **No silent errors:** every rest-client call and the control handler log failures visibly (project policy). A failed report never crashes the run; a failed run still reports its terminal state.
+- **Offline send safety:** the server already refuses `deliver_turn` to an offline origin and recovers via pending-turns; the OpenClaw client inherits this for free by reading pending-turns on reconnect.
+
+## Risks & Mitigations
+
+- **R1 — CLI daemon regression during extraction.** Pulling reporters into the shared client could subtly change behavior. *Mitigation:* extraction is mechanical and behavior-preserving; the CLI daemon's existing tests gate it; do the extraction first, prove green, then add the OpenClaw consumer.
+- **R2 — SDK type surface drift.** Hand-declaring the real SDK surface in `openclaw-sdk.d.ts` can drift from upstream `../openclaw`. *Mitigation:* a task first checks whether `openclaw`'s published `dist/plugin-sdk` types are cleanly importable (preferred — always in sync); only hand-declare the **minimal** used surface if import is not viable, and type it against the verified real shapes. Verify SDK specifics against the real source, not LLM memory.
+- **R3 — In-process abort semantics.** `abortSignal` aborts cooperatively; a run mid-tool-call may take a moment to unwind. *Mitigation:* report `reason=user` and rely on `result.meta.aborted`; the execution row's `interrupted` status is sticky server-side, so the UI reflects the stop even before the run fully unwinds.
+- **R4 — Streaming callback fidelity.** Inline callbacks may surface partial/reasoning text we don't want in the transcript. *Mitigation:* post only finalized user/assistant text (the same filter the CLI host applies to stream-json — no thinking/tool internals), mapped to `{ role, text }`.
+- **R5 — Session-key collision.** A wrong derivation could resume into the wrong conversation. *Mitigation:* derive strictly from the business key (`directIdeaUuid` else `entityUuid`), matching the server's session identity; covered by an explicit resume/continuity test.
+
+## Implementation order
+
+1. Extract `daemon-rest-client`; refactor CLI daemon onto it; prove CLI tests green. (foundation)
+2. Type the real SDK surface in the plugin (`openclaw-plugin-sdk`). (unblocks typed calls)
+3. Capture `connection_registered` + control subscription/routing (`openclaw-event-bridge`).
+4. Build `openclaw-daemon-client`: run + lifecycle/transcript reporting + abort registry + session mapping + pending-turns backfill.
+5. Integration checkpoint: end-to-end wake → report → observe in UI → interrupt → resume → deliver_turn against a live local server.
+6. Skill-doc / design sync.

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/proposal.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/proposal.md
@@ -1,0 +1,54 @@
+# Proposal: Bring the OpenClaw plugin to bidirectional daemon parity with `cli/daemon.mjs`
+
+## Why
+
+The Chorus daemon protocol is **bidirectional**: a daemon host opens the notification SSE stream, the server registers a `DaemonConnection`, and from then on the server can observe what the daemon is running (execution-state), read its conversation (transcript), and steer it over a reverse control channel (interrupt / resume / deliver_turn). The 0.11.0 daemon line built the **entire server side** of this — `DaemonConnection`, `DaemonTaskExecution`, the `/api/daemon/*` REST ingest endpoints, the `control:{connectionUuid}` channel, pending-turns, transcript-read — and a fully bidirectional **chorus CLI** host (`cli/daemon.mjs`, `clientType=claude_code`).
+
+**The OpenClaw plugin — the second daemon host — never caught up.** It is single-direction only: it receives `new_notification` and wakes an in-process agent (`runEmbeddedAgent`), and that is all. Concretely (verified against the code, 2026-06-20):
+
+1. **It throws away its own identity.** The server sends `data: {type:"connection_registered", connectionUuid}` immediately after handshake (`api/events/notifications/route.ts`), but `ChorusSseListener` has no `onConnectionId` callback (`sse-listener.ts`), so the event falls through `event-router.dispatch` as `type !== "new_notification"` and is "ignored". With no `connectionUuid`, every downstream report and every control command is unaddressable.
+
+2. **It does not subscribe the reverse control channel.** The server opens `control:{connectionUuid}` per connection and pushes `interrupt` / `resume` / `deliver_turn`. The OpenClaw listener has no `onControl` fork, so: UI "Stop / Resume" on an OpenClaw connection does nothing, and UI→agent instruction injection (`deliver_turn`) never arrives.
+
+3. **It reports nothing.** `wake.ts` is fire-and-forget `runEmbeddedAgent` that only logs locally. It never POSTs `turn-advance`, `transcript`, `execution-state`, or `report-interrupt`. So in the UI an OpenClaw connection is a **black box**: visibly online, but you cannot see what it runs, read its conversation, or stop it.
+
+4. **It has no pending-turns safety net.** Its reconnect path only re-pulls unread notifications via MCP; it never reads the turn table, so a UI-issued instruction can neither be delivered live nor recovered on reconnect.
+
+**The blocker we feared was illusory.** Early analysis (idea round 1) concluded mid-run interrupt and live transcript "need an SDK fork." That was wrong: it was read off the plugin's hand-written `openclaw-sdk.d.ts`, which declares `runtime?: unknown` and `runEmbeddedAgent: (params) => Promise<unknown>` — a shim that **hides the real SDK**. The real `../openclaw` source shows `runEmbeddedAgent(params: RunEmbeddedAgentParams): Promise<EmbeddedAgentRunResult>` already takes `abortSignal?: AbortSignal` (relayed through the whole run) and a full set of per-message streaming callbacks (`onAssistantMessageStart` / `onBlockReply` / `onToolResult` / `onReasoningStream`), and `src/cron/isolated-agent/` already runs embedded agents this exact "wake → run → deliver" way with abort + stable-key session resume + a serial-per-session / parallel-across-session lane queue. **Full bidirectional parity is achievable within the existing SDK — no fork.**
+
+## What Changes
+
+Bring the OpenClaw plugin (`packages/openclaw-plugin/`) to the same bidirectional daemon protocol the CLI host implements, re-mapped to the OpenClaw **in-process `runEmbeddedAgent`** host (not a `claude --resume` subprocess). The **server side is unchanged** — every endpoint and channel this consumes already exists.
+
+- **Shared pure-REST daemon client (`daemon-rest-client`).** Extract the CLI daemon's reporter logic — `turn-advance`, `transcript`, `execution-state`, `report-interrupt`, and the `pending-turns` read — into one module that is the **single source of truth** for `/api/daemon/*` payload shapes, consumed by **both** `cli/daemon.mjs` and the OpenClaw plugin. These reporters were verified to be pure REST with zero host coupling (they need only `{ url, apiKey, getConnectionUuid, fetchImpl }`). The extraction is **behavior-preserving**: the CLI daemon keeps working and its existing tests stay green. Hand-porting a second copy into TS is explicitly rejected — drift in the payload contract is exactly the failure this idea exists to prevent.
+
+- **Capture `connection_registered` and subscribe the control channel (`openclaw-event-bridge`).** Add `onConnectionId` (store `connectionState.connectionUuid`) and `onControl` (fork `type:"control"` events to a control handler, **never** into the wake path) to the SSE listener. The control handler honors the same double-check the CLI daemon uses (`targetConnectionUuid === my uuid` AND I hold the entity) before acting on `interrupt`; routes `deliver_turn` to a connection-scoped pending-turns sweep; routes `resume` to a re-dispatch.
+
+- **In-process bidirectional daemon client (`openclaw-daemon-client`).** Re-implement the CLI host's run+report behaviors for the OpenClaw host:
+  - **Observability回传:** report turn lifecycle (`turn-advance`: pending→running on spawn, →ended on completion), an execution-state snapshot, and a **streaming transcript** fed by inline `runEmbeddedAgent` callbacks (`onAssistantMessageStart` / `onBlockReply` / `onToolResult`), posting the same `{ role, text }` shape the CLI host posts.
+  - **Real mid-run interrupt:** keep an `AbortController` per in-flight execution keyed by `entityType:entityUuid`; a control `interrupt` aborts the matching run (true mid-run stop via `abortSignal`), then `report-interrupt` fires `reason=user`; a `crash` (run rejects) reports `reason=crash`.
+  - **Session resume mapping:** derive the OpenClaw `sessionKey` deterministically from the DaemonSession business key (`sessionId = directIdeaUuid`, else `entityUuid`) so `resume` / `deliver_turn` re-enter the **same** OpenClaw session via the existing `getSessionEntry` resolution — the in-process analog of `claude --resume <directIdeaUuid>`.
+  - **Pending-turns backfill:** on reconnect, and on a `deliver_turn` ping, read connection-scoped pending turns from the turn table and run the unstarted `human_instruction` turn; live delivery and backfill are idempotent so a turn runs at most once.
+
+- **Declare the real SDK surface the plugin uses (`openclaw-plugin-sdk`).** Replace the opaque `runtime?: unknown` shim with a typed declaration of exactly the surface this work consumes — `runtime.agent.runEmbeddedAgent(params)` with `abortSignal` and the streaming callbacks, `runtime.agent.session.getSessionEntry` / `resolveSessionFilePath`, and the control/connection plumbing — typed against the real `../openclaw` shapes, so these calls are compile-time checked rather than `unknown`-cast. A task first verifies whether the published `openclaw` `dist/plugin-sdk` type defs are cleanly importable; if so, import them instead of hand-declaring.
+
+- **Skill docs + design.** Sync the four plugin skill surfaces per `plugin-maintenance` where the OpenClaw daemon behavior is documented, and update `docs/design.pen` only if a user-facing surface changes (this work is largely client-side plumbing; the Agent Connections UI already renders execution-state/transcript/controls produced by the server).
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-rest-client`: a shared, host-agnostic pure-REST client for the `/api/daemon/*` reporting surface (`turn-advance`, `transcript`, `execution-state`, `report-interrupt`, `pending-turns` read), consumed by both the chorus CLI daemon and the OpenClaw plugin as the single source of truth for those payload shapes.
+- `openclaw-daemon-client`: the OpenClaw in-process host's bidirectional daemon behavior — running a wake via `runEmbeddedAgent` with streaming-transcript callbacks, reporting turn lifecycle and execution-state, real mid-run interrupt via `AbortController`, deterministic session-resume mapping, and pending-turns backfill.
+
+### Modified Capabilities
+
+- `openclaw-event-bridge`: add `connection_registered` capture (own `connectionUuid`) and reverse `control:{connectionUuid}` channel subscription/routing (interrupt / resume / deliver_turn) that never enters the wake path.
+- `openclaw-plugin-sdk`: declare the real `runtime.agent.runEmbeddedAgent` (with `abortSignal` + streaming callbacks) and session-helper surface the plugin uses, replacing the opaque `runtime?: unknown` shim.
+
+## Impact
+
+- **Code:** `packages/openclaw-plugin/src/` (sse-listener, event-router, wake, new control-handler / reporters / connection-state modules, `openclaw-sdk.d.ts`); a new shared `daemon-rest-client` module; `cli/daemon.mjs` + its reporter modules refactored to consume the shared client (behavior-preserving).
+- **Server:** none. All `/api/daemon/*` endpoints, the `control:{connectionUuid}` channel, pending-turns, execution-state, and transcript-read already exist and are unchanged.
+- **UI:** none required for the protocol; the Agent Connections execution-state / transcript / interrupt-resume surfaces already render whatever any daemon host reports, so an OpenClaw connection becomes observable and controllable with no UI change. (Any OpenClaw-specific affordance, if added, follows the existing localized patterns and updates `docs/design.pen`.)
+- **Out of scope:** the daemon dispatch **concurrency model** (parallel/serial policy) is owned by sibling idea `6fab91cd` — this change single-flights correctly and leans on OpenClaw's built-in lanes where free, but does not define the cross-idea concurrency policy. No SDK fork (the real SDK suffices). No server schema or endpoint changes.

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/daemon-rest-client/spec.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/daemon-rest-client/spec.md
@@ -1,0 +1,51 @@
+# daemon-rest-client Specification
+
+## ADDED Requirements
+
+### Requirement: A shared host-agnostic client SHALL own the `/api/daemon/*` reporting payload shapes
+
+The system SHALL provide a single shared module that encapsulates every daemon→server report — `turn-advance`, `transcript`, `execution-state`, `report-interrupt`, and the `pending-turns` read — and SHALL be the single source of truth for those request/response shapes. The module SHALL be constructed from only host-agnostic inputs (`url`, `apiKey`, a `getConnectionUuid` accessor, an injectable `fetchImpl`, and an optional logger) and SHALL authenticate every request with the agent `Authorization: Bearer <apiKey>` header and no other mechanism. The module SHALL NOT import or reference any daemon-host-specific facility (no child-process spawning, no `claude` invocation, no stream-json parsing, no OpenClaw SDK), so that both the chorus CLI daemon and the OpenClaw plugin can consume it unchanged.
+
+#### Scenario: The client exposes the five daemon reporting operations
+
+- **WHEN** the shared client is constructed with `{ url, apiKey, getConnectionUuid, fetchImpl }`
+- **THEN** it MUST expose operations that POST to `/api/daemon/turn-advance`, `/api/daemon/transcript`, `/api/daemon/execution-state`, and `/api/daemon/report-interrupt`, and that GET `/api/daemon/pending-turns`
+- **AND** every request MUST carry the `Authorization: Bearer <apiKey>` header
+
+#### Scenario: The payload shapes match the existing server contract
+
+- **WHEN** the client issues each operation
+- **THEN** the `turn-advance` body MUST carry `{ connectionUuid, sessionId, status }` (with optional `entityType`/`entityUuid`), the `transcript` body MUST carry `{ sessionId, messages: [{ role, text }] }`, the `execution-state` body MUST carry `{ connectionUuid, executions: [{ taskUuid, rootIdeaUuid|null, status, startedAt|null }] }`, the `report-interrupt` body MUST carry `{ connectionUuid, entityType, entityUuid, reason }`, and the `pending-turns` read MUST be `GET /api/daemon/pending-turns?connectionUuid=<uuid>`
+- **AND** these MUST be the exact shapes the existing server endpoints already accept (no server change)
+
+#### Scenario: The client has zero daemon-host coupling
+
+- **WHEN** the shared module's source is inspected
+- **THEN** it MUST NOT import `child_process`, spawn `claude`, parse stream-json, or import any OpenClaw SDK symbol
+- **AND** its only outbound effect MUST be HTTP calls via the injected `fetchImpl`
+
+### Requirement: The chorus CLI daemon SHALL consume the shared client without behavior change
+
+The chorus CLI daemon (`cli/daemon.mjs` and its reporter modules) SHALL be refactored to issue its `/api/daemon/*` reports through the shared client rather than via independent hand-written fetch logic, so the CLI and OpenClaw hosts cannot drift in payload shape. The refactor SHALL be behavior-preserving: the CLI daemon's externally observable reporting SHALL be unchanged, and its existing automated test suite SHALL pass without modification to the assertions.
+
+#### Scenario: The CLI daemon's reports go through the shared client
+
+- **WHEN** the CLI daemon reports a turn advance, transcript, execution snapshot, interrupt, or reads pending turns
+- **THEN** it MUST do so by calling the shared client
+- **AND** it MUST NOT retain a parallel second implementation of those payload shapes
+
+#### Scenario: Existing CLI daemon tests stay green after extraction
+
+- **WHEN** the extraction refactor is complete
+- **THEN** the CLI daemon's existing test suite MUST pass without weakening or deleting its reporting assertions
+
+### Requirement: Reporting failures SHALL be surfaced, never silently swallowed
+
+A failed daemon report (network error, non-2xx response, empty body where a result is expected) SHALL be logged visibly and surfaced to the caller; it SHALL NOT be silently discarded. A reporting failure SHALL NOT crash the agent run that triggered it — a failed transcript or turn-advance post SHALL be logged and the run SHALL continue — but the failure MUST remain visible in logs for debugging.
+
+#### Scenario: A failed report is logged and surfaced
+
+- **GIVEN** a daemon report whose HTTP call fails or returns a non-2xx status
+- **WHEN** the client handles the failure
+- **THEN** it MUST log the failure with the underlying cause
+- **AND** it MUST NOT swallow the error into a silent success

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/openclaw-daemon-client/spec.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/openclaw-daemon-client/spec.md
@@ -1,0 +1,103 @@
+# openclaw-daemon-client Specification
+
+## ADDED Requirements
+
+### Requirement: The OpenClaw host SHALL report turn lifecycle and execution state for every wake it runs
+
+When the OpenClaw plugin runs a wake via `runEmbeddedAgent`, it SHALL report the turn lifecycle and execution state to the server through the shared daemon REST client, using its captured `connectionUuid`. It SHALL advance the turn to `running` when the run starts and to `ended` when the run completes, and it SHALL publish an execution-state snapshot reflecting the running (and any queued) entities for its connection, so the server's execution-state layer reconciles the OpenClaw connection identically to a chorus CLI connection. The session identifier used in these reports SHALL be the DaemonSession business key (`directIdeaUuid` when present, else the wake's `entityUuid`).
+
+#### Scenario: A wake reports running then ended
+
+- **GIVEN** the OpenClaw plugin has captured its `connectionUuid` and receives a wake for an entity
+- **WHEN** the embedded agent run starts
+- **THEN** the plugin MUST report a turn advance to `running` for that session
+- **AND** when the run completes, it MUST report a turn advance to `ended`
+
+#### Scenario: A running wake appears in the execution snapshot
+
+- **GIVEN** a wake currently running on the OpenClaw connection
+- **WHEN** the plugin publishes its execution-state snapshot
+- **THEN** the snapshot MUST include the running entity with its `rootIdeaUuid` (or null) and `startedAt`
+- **AND** the server MUST reconcile it so the connection's running task is visible in the Agent Connections surfaces
+
+#### Scenario: The session id is the business key
+
+- **WHEN** the plugin reports turn lifecycle or transcript for a wake
+- **THEN** the reported `sessionId` MUST be the wake's `directIdeaUuid` when it has an idea ancestor, otherwise the wake's `entityUuid`
+
+### Requirement: The OpenClaw host SHALL stream the conversation transcript from in-process run callbacks
+
+The OpenClaw plugin SHALL observe the embedded agent's messages via `runEmbeddedAgent`'s per-message callbacks (assistant message and block callbacks) and SHALL post them to the transcript endpoint through the shared client as `{ role, text }` messages, so the conversation is readable in the UI as it progresses. It SHALL post only finalized user/assistant visible text — it SHALL NOT post thinking/reasoning internals or tool-call internals as transcript messages — matching the content filter the chorus CLI host applies to its stream-json source.
+
+#### Scenario: Assistant output is posted as transcript
+
+- **GIVEN** a running embedded agent that produces assistant output
+- **WHEN** the plugin's per-message callback fires with finalized assistant text
+- **THEN** the plugin MUST post a transcript message with `role = "assistant"` and that text for the wake's session
+
+#### Scenario: Internals are not posted as transcript
+
+- **WHEN** the embedded agent emits reasoning/thinking or tool-call internal events
+- **THEN** the plugin MUST NOT post those as transcript messages
+- **AND** only finalized user/assistant visible text MUST appear in the transcript
+
+### Requirement: The OpenClaw host SHALL support real mid-run interrupt via AbortController
+
+The OpenClaw plugin SHALL maintain an `AbortController` per in-flight run, keyed by `entityType:entityUuid`, and SHALL pass its `abortSignal` into `runEmbeddedAgent`. On an authorized `interrupt` control command verified for its own connection and a held entity, the plugin SHALL abort the matching run — a true mid-run stop — and SHALL report the interrupt with `reason = "user"`. When a run ends unexpectedly (the run promise rejects without an interrupt request), the plugin SHALL report `reason = "crash"`. The controller SHALL be deregistered when the run settles so a stale controller cannot abort a later run.
+
+#### Scenario: An authorized interrupt aborts the running embedded agent
+
+- **GIVEN** the OpenClaw plugin is running a wake for entity E with a registered `AbortController`
+- **WHEN** it receives a verified `interrupt` control command for its connection and entity E
+- **THEN** it MUST call `abort()` on E's controller so the in-flight run is cancelled
+- **AND** it MUST report the interrupt with `reason = "user"`
+
+#### Scenario: An unexpected run failure reports a crash
+
+- **GIVEN** a running wake whose `runEmbeddedAgent` promise rejects with no interrupt requested
+- **WHEN** the plugin observes the rejection
+- **THEN** it MUST report the interrupt with `reason = "crash"`
+
+#### Scenario: A settled run deregisters its controller
+
+- **WHEN** a run completes, aborts, or rejects
+- **THEN** its `AbortController` MUST be removed from the in-flight registry
+- **AND** a subsequent interrupt for the same entity with no active run MUST be ignored (no run to abort)
+
+### Requirement: The OpenClaw host SHALL map a session to a stable key so resume and deliver_turn continue the same conversation
+
+The OpenClaw plugin SHALL derive the embedded-agent `sessionKey` deterministically from the DaemonSession business key (`directIdeaUuid` when present, else `entityUuid`) and SHALL resolve the existing session entry via the runtime session helper, so a `resume` re-dispatch or a `deliver_turn` instruction continues the **same** OpenClaw session (same `sessionId`/`sessionFile`) rather than starting a divergent one. This is the in-process analog of the chorus CLI host's `claude --resume <directIdeaUuid>`.
+
+#### Scenario: A resume continues the same session
+
+- **GIVEN** a session that previously ran for entity E and has an existing session entry
+- **WHEN** the plugin receives a `resume` control command for E and re-dispatches the wake
+- **THEN** it MUST resolve the same `sessionKey` derived from E's business key and continue the existing session entry rather than allocating a new `sessionId`
+
+#### Scenario: A delivered instruction continues the same session
+
+- **WHEN** the plugin runs a `human_instruction` turn obtained from the pending-turns read for an existing session
+- **THEN** it MUST run it under the same derived `sessionKey` so the instruction lands in the same conversation
+
+### Requirement: The OpenClaw host SHALL recover instructions via a connection-scoped pending-turns sweep
+
+The OpenClaw plugin SHALL read connection-scoped pending turns from the shared client on reconnect and on a `deliver_turn` control ping, and SHALL run any unstarted `human_instruction` turn. Live `deliver_turn` delivery and reconnect backfill SHALL be idempotent — a turn run by one path SHALL NOT be re-run by the other — using a seen-set keyed by turn uuid, matching the chorus CLI host's at-most-once guarantee.
+
+#### Scenario: A deliver_turn ping runs the targeted pending turn
+
+- **GIVEN** the plugin receives a verified `deliver_turn` control command carrying a `turnUuid` for its connection
+- **WHEN** it handles the command
+- **THEN** it MUST read connection-scoped pending turns, select the one matching `turnUuid`, and run it
+- **AND** it MUST NOT enqueue or run any other pending turn for that ping when a `turnUuid` is specified
+
+#### Scenario: A reconnecting plugin recovers a missed instruction
+
+- **GIVEN** an unstarted `human_instruction` turn created while the plugin was briefly disconnected
+- **WHEN** the plugin reconnects and runs its pending-turns backfill
+- **THEN** it MUST re-derive that turn from the pending-turns read and run it
+
+#### Scenario: Live delivery and backfill do not double-run a turn
+
+- **GIVEN** the same instruction turn observed by both the live `deliver_turn` path and a reconnect backfill sweep
+- **WHEN** both paths see it
+- **THEN** the turn MUST be run at most once (the later observation is a no-op via the shared seen-set keyed by turn uuid)

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/openclaw-event-bridge/spec.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/openclaw-event-bridge/spec.md
@@ -1,0 +1,46 @@
+# openclaw-event-bridge Specification
+
+## ADDED Requirements
+
+### Requirement: The plugin SHALL capture its own connectionUuid from the connection_registered event
+
+The OpenClaw plugin's SSE listener SHALL expose an `onConnectionId` callback and the server's post-handshake `connection_registered` event (carrying `connectionUuid`) SHALL be routed to it and stored as the connection's identity, rather than being discarded as an unhandled event. The stored `connectionUuid` SHALL be made available to the daemon reporting client and the control handler. On reconnect, the listener SHALL refresh the stored `connectionUuid` from the new `connection_registered` event. The `connection_registered` event SHALL NOT enter the wake path.
+
+#### Scenario: connection_registered populates the stored connectionUuid
+
+- **WHEN** the server sends a `connection_registered` event after the SSE handshake
+- **THEN** the plugin MUST store the supplied `connectionUuid` as its connection identity
+- **AND** that value MUST be readable by the daemon reporting client and the control handler
+
+#### Scenario: connection_registered is not treated as a wake
+
+- **WHEN** the `connection_registered` event is dispatched
+- **THEN** it MUST NOT enqueue a wake or spawn an agent run
+- **AND** it MUST NOT be logged as an ignored/unhandled event
+
+#### Scenario: Reconnect refreshes the connectionUuid
+
+- **GIVEN** an established connection whose stream drops and reconnects
+- **WHEN** the server sends a new `connection_registered` on reconnect
+- **THEN** the plugin MUST replace its stored `connectionUuid` with the new value
+
+### Requirement: The plugin SHALL subscribe and route the reverse control channel without entering the wake path
+
+The OpenClaw plugin's SSE listener SHALL expose an `onControl` callback and SHALL fork SSE events whose `type` is `control` to a control handler, distinct from the `new_notification` wake path. The control handler SHALL act on a command only when the event's `targetConnectionUuid` equals the plugin's stored `connectionUuid` (and, for `interrupt`, only when the plugin currently holds a running entity matching the command), and SHALL otherwise log and ignore the command. A control event SHALL NEVER enqueue a wake or spawn a new agent run for the control event itself. The handler SHALL route `interrupt`, `resume`, and `deliver_turn` to their respective behaviors (defined by the `openclaw-daemon-client` capability).
+
+#### Scenario: A control event is forked to the control handler, not the wake path
+
+- **WHEN** the plugin receives an SSE event with `type = "control"`
+- **THEN** it MUST route the event to the control handler via `onControl`
+- **AND** it MUST NOT enqueue a wake or spawn an agent run for the control event
+
+#### Scenario: A control command for another connection is ignored
+
+- **GIVEN** the plugin's stored `connectionUuid` is C
+- **WHEN** it receives a control command whose `targetConnectionUuid` is not C
+- **THEN** it MUST log and ignore the command and MUST NOT abort, resume, or deliver anything
+
+#### Scenario: The three control commands are routed
+
+- **WHEN** the control handler receives a verified `interrupt`, `resume`, or `deliver_turn` command for its own connection
+- **THEN** it MUST route `interrupt` to abort the matching in-flight run, `resume` to re-dispatch the entity's wake, and `deliver_turn` to the connection-scoped pending-turns sweep

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/openclaw-plugin-sdk/spec.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/specs/openclaw-plugin-sdk/spec.md
@@ -1,0 +1,35 @@
+# openclaw-plugin-sdk Specification
+
+## ADDED Requirements
+
+### Requirement: The plugin SHALL type the real runtime agent and session surface it consumes
+
+The plugin's SDK declaration (`openclaw-sdk.d.ts` or an imported equivalent) SHALL declare the real shapes of the OpenClaw runtime surface the daemon work consumes, replacing the opaque `runtime?: unknown` placeholder, so these calls are compile-time checked rather than `unknown`-cast. The declared surface SHALL include `runtime.agent.runEmbeddedAgent(params)` with at least the `abortSignal?: AbortSignal` parameter and the per-message streaming callbacks the plugin passes (assistant-message / block callbacks), the result fields the plugin reads (e.g. `meta.aborted`), and the session helpers `runtime.agent.session.getSessionEntry` and `resolveSessionFilePath`. The declared shapes SHALL be verified against the real `../openclaw` source rather than guessed.
+
+#### Scenario: runEmbeddedAgent is typed with abortSignal and streaming callbacks
+
+- **WHEN** the plugin's SDK declaration is read
+- **THEN** `runtime.agent.runEmbeddedAgent` MUST be declared with an `abortSignal?: AbortSignal` parameter and the per-message streaming callback parameters the plugin uses
+- **AND** `runtime` MUST NOT be declared as bare `unknown` for the surface the plugin calls
+
+#### Scenario: Session helpers are typed
+
+- **WHEN** the plugin resolves a session for resume/deliver_turn
+- **THEN** `runtime.agent.session.getSessionEntry` and `resolveSessionFilePath` MUST be declared with their real parameter and return shapes
+- **AND** the plugin's call sites MUST type-check against them without an `unknown` cast
+
+#### Scenario: Declared shapes match the real SDK
+
+- **WHEN** the declared surface is compared against the real `../openclaw` plugin SDK source
+- **THEN** the declared parameter and result shapes MUST match the real types (verified against source, not LLM memory)
+- **AND** where the published `openclaw` plugin-sdk type definitions are cleanly importable, the plugin SHALL prefer importing them over hand-declaring a parallel shim
+
+### Requirement: The typed SDK surface SHALL NOT add a build-time hard dependency on the full openclaw package
+
+Declaring or importing the real SDK types SHALL NOT introduce a hard runtime dependency on the full `openclaw` package into the separately-published `@chorus-aidlc/chorus-openclaw-plugin` build, and SHALL NOT add native bindings or postinstall scripts. If the published `openclaw` plugin-sdk types cannot be consumed without coupling the build to the full package, the plugin SHALL hand-declare only the minimal used surface instead.
+
+#### Scenario: The plugin package still builds standalone
+
+- **WHEN** the plugin package is built and packed
+- **THEN** typing the SDK surface MUST NOT require the full `openclaw` package as a runtime dependency
+- **AND** it MUST NOT introduce a postinstall script or a native-binding dependency

--- a/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/tasks.md
+++ b/openspec/changes/archive/2026-06-20-align-openclaw-daemon-parity/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: OpenClaw daemon bidirectional parity
+
+> Chorus task drafts are the source of truth; this list mirrors them for OpenSpec.
+
+## 1. Shared daemon REST client (foundation)
+- [ ] Extract `daemon-rest-client` (turn-advance / transcript / execution-state / report-interrupt / pending-turns) with `{url, apiKey, getConnectionUuid, fetchImpl, logger}` and zero host coupling.
+- [ ] Refactor `cli/daemon.mjs` reporters onto the shared client; prove existing CLI daemon tests stay green (behavior-preserving).
+
+## 2. Type the real SDK surface
+- [ ] Verify whether `openclaw` `dist/plugin-sdk` types are cleanly importable; otherwise hand-declare the minimal used surface (runEmbeddedAgent + abortSignal + streaming callbacks + session helpers) in `openclaw-sdk.d.ts`, verified against real source.
+
+## 3. connection_registered + control channel
+- [ ] Add `onConnectionId` (store connectionUuid; refresh on reconnect) and `onControl` (fork `type:"control"`, never wake) to the SSE listener; build the control-handler with the double-check.
+
+## 4. OpenClaw daemon client
+- [ ] Run wakes via `runEmbeddedAgent` with abortSignal + transcript callbacks; report turn lifecycle + execution snapshot; AbortController registry for real interrupt (user/crash); deterministic session-key mapping; pending-turns backfill with at-most-once seen-set.
+
+## 5. Integration checkpoint
+- [ ] End-to-end against a live local server: wake → observe execution+transcript in UI → interrupt → resume → deliver_turn, on the OpenClaw host.
+
+## 6. Docs & design
+- [ ] Sync the relevant plugin skill surfaces (plugin-maintenance) and update `docs/design.pen` only if a user-facing surface changes.

--- a/openspec/specs/daemon-rest-client/spec.md
+++ b/openspec/specs/daemon-rest-client/spec.md
@@ -1,0 +1,53 @@
+# daemon-rest-client Specification
+
+## Purpose
+TBD - created by archiving change align-openclaw-daemon-parity. Update Purpose after archive.
+## Requirements
+### Requirement: A shared host-agnostic client SHALL own the `/api/daemon/*` reporting payload shapes
+
+The system SHALL provide a single shared module that encapsulates every daemon→server report — `turn-advance`, `transcript`, `execution-state`, `report-interrupt`, and the `pending-turns` read — and SHALL be the single source of truth for those request/response shapes. The module SHALL be constructed from only host-agnostic inputs (`url`, `apiKey`, a `getConnectionUuid` accessor, an injectable `fetchImpl`, and an optional logger) and SHALL authenticate every request with the agent `Authorization: Bearer <apiKey>` header and no other mechanism. The module SHALL NOT import or reference any daemon-host-specific facility (no child-process spawning, no `claude` invocation, no stream-json parsing, no OpenClaw SDK), so that both the chorus CLI daemon and the OpenClaw plugin can consume it unchanged.
+
+#### Scenario: The client exposes the five daemon reporting operations
+
+- **WHEN** the shared client is constructed with `{ url, apiKey, getConnectionUuid, fetchImpl }`
+- **THEN** it MUST expose operations that POST to `/api/daemon/turn-advance`, `/api/daemon/transcript`, `/api/daemon/execution-state`, and `/api/daemon/report-interrupt`, and that GET `/api/daemon/pending-turns`
+- **AND** every request MUST carry the `Authorization: Bearer <apiKey>` header
+
+#### Scenario: The payload shapes match the existing server contract
+
+- **WHEN** the client issues each operation
+- **THEN** the `turn-advance` body MUST carry `{ connectionUuid, sessionId, status }` (with optional `entityType`/`entityUuid`), the `transcript` body MUST carry `{ sessionId, messages: [{ role, text }] }`, the `execution-state` body MUST carry `{ connectionUuid, executions: [{ taskUuid, rootIdeaUuid|null, status, startedAt|null }] }`, the `report-interrupt` body MUST carry `{ connectionUuid, entityType, entityUuid, reason }`, and the `pending-turns` read MUST be `GET /api/daemon/pending-turns?connectionUuid=<uuid>`
+- **AND** these MUST be the exact shapes the existing server endpoints already accept (no server change)
+
+#### Scenario: The client has zero daemon-host coupling
+
+- **WHEN** the shared module's source is inspected
+- **THEN** it MUST NOT import `child_process`, spawn `claude`, parse stream-json, or import any OpenClaw SDK symbol
+- **AND** its only outbound effect MUST be HTTP calls via the injected `fetchImpl`
+
+### Requirement: The chorus CLI daemon SHALL consume the shared client without behavior change
+
+The chorus CLI daemon (`cli/daemon.mjs` and its reporter modules) SHALL be refactored to issue its `/api/daemon/*` reports through the shared client rather than via independent hand-written fetch logic, so the CLI and OpenClaw hosts cannot drift in payload shape. The refactor SHALL be behavior-preserving: the CLI daemon's externally observable reporting SHALL be unchanged, and its existing automated test suite SHALL pass without modification to the assertions.
+
+#### Scenario: The CLI daemon's reports go through the shared client
+
+- **WHEN** the CLI daemon reports a turn advance, transcript, execution snapshot, interrupt, or reads pending turns
+- **THEN** it MUST do so by calling the shared client
+- **AND** it MUST NOT retain a parallel second implementation of those payload shapes
+
+#### Scenario: Existing CLI daemon tests stay green after extraction
+
+- **WHEN** the extraction refactor is complete
+- **THEN** the CLI daemon's existing test suite MUST pass without weakening or deleting its reporting assertions
+
+### Requirement: Reporting failures SHALL be surfaced, never silently swallowed
+
+A failed daemon report (network error, non-2xx response, empty body where a result is expected) SHALL be logged visibly and surfaced to the caller; it SHALL NOT be silently discarded. A reporting failure SHALL NOT crash the agent run that triggered it — a failed transcript or turn-advance post SHALL be logged and the run SHALL continue — but the failure MUST remain visible in logs for debugging.
+
+#### Scenario: A failed report is logged and surfaced
+
+- **GIVEN** a daemon report whose HTTP call fails or returns a non-2xx status
+- **WHEN** the client handles the failure
+- **THEN** it MUST log the failure with the underlying cause
+- **AND** it MUST NOT swallow the error into a silent success
+

--- a/openspec/specs/openclaw-daemon-client/spec.md
+++ b/openspec/specs/openclaw-daemon-client/spec.md
@@ -1,0 +1,105 @@
+# openclaw-daemon-client Specification
+
+## Purpose
+TBD - created by archiving change align-openclaw-daemon-parity. Update Purpose after archive.
+## Requirements
+### Requirement: The OpenClaw host SHALL report turn lifecycle and execution state for every wake it runs
+
+When the OpenClaw plugin runs a wake via `runEmbeddedAgent`, it SHALL report the turn lifecycle and execution state to the server through the shared daemon REST client, using its captured `connectionUuid`. It SHALL advance the turn to `running` when the run starts and to `ended` when the run completes, and it SHALL publish an execution-state snapshot reflecting the running (and any queued) entities for its connection, so the server's execution-state layer reconciles the OpenClaw connection identically to a chorus CLI connection. The session identifier used in these reports SHALL be the DaemonSession business key (`directIdeaUuid` when present, else the wake's `entityUuid`).
+
+#### Scenario: A wake reports running then ended
+
+- **GIVEN** the OpenClaw plugin has captured its `connectionUuid` and receives a wake for an entity
+- **WHEN** the embedded agent run starts
+- **THEN** the plugin MUST report a turn advance to `running` for that session
+- **AND** when the run completes, it MUST report a turn advance to `ended`
+
+#### Scenario: A running wake appears in the execution snapshot
+
+- **GIVEN** a wake currently running on the OpenClaw connection
+- **WHEN** the plugin publishes its execution-state snapshot
+- **THEN** the snapshot MUST include the running entity with its `rootIdeaUuid` (or null) and `startedAt`
+- **AND** the server MUST reconcile it so the connection's running task is visible in the Agent Connections surfaces
+
+#### Scenario: The session id is the business key
+
+- **WHEN** the plugin reports turn lifecycle or transcript for a wake
+- **THEN** the reported `sessionId` MUST be the wake's `directIdeaUuid` when it has an idea ancestor, otherwise the wake's `entityUuid`
+
+### Requirement: The OpenClaw host SHALL stream the conversation transcript from in-process run callbacks
+
+The OpenClaw plugin SHALL observe the embedded agent's messages via `runEmbeddedAgent`'s per-message callbacks (assistant message and block callbacks) and SHALL post them to the transcript endpoint through the shared client as `{ role, text }` messages, so the conversation is readable in the UI as it progresses. It SHALL post only finalized user/assistant visible text — it SHALL NOT post thinking/reasoning internals or tool-call internals as transcript messages — matching the content filter the chorus CLI host applies to its stream-json source.
+
+#### Scenario: Assistant output is posted as transcript
+
+- **GIVEN** a running embedded agent that produces assistant output
+- **WHEN** the plugin's per-message callback fires with finalized assistant text
+- **THEN** the plugin MUST post a transcript message with `role = "assistant"` and that text for the wake's session
+
+#### Scenario: Internals are not posted as transcript
+
+- **WHEN** the embedded agent emits reasoning/thinking or tool-call internal events
+- **THEN** the plugin MUST NOT post those as transcript messages
+- **AND** only finalized user/assistant visible text MUST appear in the transcript
+
+### Requirement: The OpenClaw host SHALL support real mid-run interrupt via AbortController
+
+The OpenClaw plugin SHALL maintain an `AbortController` per in-flight run, keyed by `entityType:entityUuid`, and SHALL pass its `abortSignal` into `runEmbeddedAgent`. On an authorized `interrupt` control command verified for its own connection and a held entity, the plugin SHALL abort the matching run — a true mid-run stop — and SHALL report the interrupt with `reason = "user"`. When a run ends unexpectedly (the run promise rejects without an interrupt request), the plugin SHALL report `reason = "crash"`. The controller SHALL be deregistered when the run settles so a stale controller cannot abort a later run.
+
+#### Scenario: An authorized interrupt aborts the running embedded agent
+
+- **GIVEN** the OpenClaw plugin is running a wake for entity E with a registered `AbortController`
+- **WHEN** it receives a verified `interrupt` control command for its connection and entity E
+- **THEN** it MUST call `abort()` on E's controller so the in-flight run is cancelled
+- **AND** it MUST report the interrupt with `reason = "user"`
+
+#### Scenario: An unexpected run failure reports a crash
+
+- **GIVEN** a running wake whose `runEmbeddedAgent` promise rejects with no interrupt requested
+- **WHEN** the plugin observes the rejection
+- **THEN** it MUST report the interrupt with `reason = "crash"`
+
+#### Scenario: A settled run deregisters its controller
+
+- **WHEN** a run completes, aborts, or rejects
+- **THEN** its `AbortController` MUST be removed from the in-flight registry
+- **AND** a subsequent interrupt for the same entity with no active run MUST be ignored (no run to abort)
+
+### Requirement: The OpenClaw host SHALL map a session to a stable key so resume and deliver_turn continue the same conversation
+
+The OpenClaw plugin SHALL derive the embedded-agent `sessionKey` deterministically from the DaemonSession business key (`directIdeaUuid` when present, else `entityUuid`) and SHALL resolve the existing session entry via the runtime session helper, so a `resume` re-dispatch or a `deliver_turn` instruction continues the **same** OpenClaw session (same `sessionId`/`sessionFile`) rather than starting a divergent one. This is the in-process analog of the chorus CLI host's `claude --resume <directIdeaUuid>`.
+
+#### Scenario: A resume continues the same session
+
+- **GIVEN** a session that previously ran for entity E and has an existing session entry
+- **WHEN** the plugin receives a `resume` control command for E and re-dispatches the wake
+- **THEN** it MUST resolve the same `sessionKey` derived from E's business key and continue the existing session entry rather than allocating a new `sessionId`
+
+#### Scenario: A delivered instruction continues the same session
+
+- **WHEN** the plugin runs a `human_instruction` turn obtained from the pending-turns read for an existing session
+- **THEN** it MUST run it under the same derived `sessionKey` so the instruction lands in the same conversation
+
+### Requirement: The OpenClaw host SHALL recover instructions via a connection-scoped pending-turns sweep
+
+The OpenClaw plugin SHALL read connection-scoped pending turns from the shared client on reconnect and on a `deliver_turn` control ping, and SHALL run any unstarted `human_instruction` turn. Live `deliver_turn` delivery and reconnect backfill SHALL be idempotent — a turn run by one path SHALL NOT be re-run by the other — using a seen-set keyed by turn uuid, matching the chorus CLI host's at-most-once guarantee.
+
+#### Scenario: A deliver_turn ping runs the targeted pending turn
+
+- **GIVEN** the plugin receives a verified `deliver_turn` control command carrying a `turnUuid` for its connection
+- **WHEN** it handles the command
+- **THEN** it MUST read connection-scoped pending turns, select the one matching `turnUuid`, and run it
+- **AND** it MUST NOT enqueue or run any other pending turn for that ping when a `turnUuid` is specified
+
+#### Scenario: A reconnecting plugin recovers a missed instruction
+
+- **GIVEN** an unstarted `human_instruction` turn created while the plugin was briefly disconnected
+- **WHEN** the plugin reconnects and runs its pending-turns backfill
+- **THEN** it MUST re-derive that turn from the pending-turns read and run it
+
+#### Scenario: Live delivery and backfill do not double-run a turn
+
+- **GIVEN** the same instruction turn observed by both the live `deliver_turn` path and a reconnect backfill sweep
+- **WHEN** both paths see it
+- **THEN** the turn MUST be run at most once (the later observation is a no-op via the shared seen-set keyed by turn uuid)
+

--- a/openspec/specs/openclaw-event-bridge/spec.md
+++ b/openspec/specs/openclaw-event-bridge/spec.md
@@ -97,3 +97,46 @@ reconnect behavior.
 - **THEN** the OpenClaw connection MUST be recorded with `clientType = "openclaw"`
 - **AND** the chorus CLI connection MUST be recorded with `clientType = "claude_code"`
 
+### Requirement: The plugin SHALL capture its own connectionUuid from the connection_registered event
+
+The OpenClaw plugin's SSE listener SHALL expose an `onConnectionId` callback and the server's post-handshake `connection_registered` event (carrying `connectionUuid`) SHALL be routed to it and stored as the connection's identity, rather than being discarded as an unhandled event. The stored `connectionUuid` SHALL be made available to the daemon reporting client and the control handler. On reconnect, the listener SHALL refresh the stored `connectionUuid` from the new `connection_registered` event. The `connection_registered` event SHALL NOT enter the wake path.
+
+#### Scenario: connection_registered populates the stored connectionUuid
+
+- **WHEN** the server sends a `connection_registered` event after the SSE handshake
+- **THEN** the plugin MUST store the supplied `connectionUuid` as its connection identity
+- **AND** that value MUST be readable by the daemon reporting client and the control handler
+
+#### Scenario: connection_registered is not treated as a wake
+
+- **WHEN** the `connection_registered` event is dispatched
+- **THEN** it MUST NOT enqueue a wake or spawn an agent run
+- **AND** it MUST NOT be logged as an ignored/unhandled event
+
+#### Scenario: Reconnect refreshes the connectionUuid
+
+- **GIVEN** an established connection whose stream drops and reconnects
+- **WHEN** the server sends a new `connection_registered` on reconnect
+- **THEN** the plugin MUST replace its stored `connectionUuid` with the new value
+
+### Requirement: The plugin SHALL subscribe and route the reverse control channel without entering the wake path
+
+The OpenClaw plugin's SSE listener SHALL expose an `onControl` callback and SHALL fork SSE events whose `type` is `control` to a control handler, distinct from the `new_notification` wake path. The control handler SHALL act on a command only when the event's `targetConnectionUuid` equals the plugin's stored `connectionUuid` (and, for `interrupt`, only when the plugin currently holds a running entity matching the command), and SHALL otherwise log and ignore the command. A control event SHALL NEVER enqueue a wake or spawn a new agent run for the control event itself. The handler SHALL route `interrupt`, `resume`, and `deliver_turn` to their respective behaviors (defined by the `openclaw-daemon-client` capability).
+
+#### Scenario: A control event is forked to the control handler, not the wake path
+
+- **WHEN** the plugin receives an SSE event with `type = "control"`
+- **THEN** it MUST route the event to the control handler via `onControl`
+- **AND** it MUST NOT enqueue a wake or spawn an agent run for the control event
+
+#### Scenario: A control command for another connection is ignored
+
+- **GIVEN** the plugin's stored `connectionUuid` is C
+- **WHEN** it receives a control command whose `targetConnectionUuid` is not C
+- **THEN** it MUST log and ignore the command and MUST NOT abort, resume, or deliver anything
+
+#### Scenario: The three control commands are routed
+
+- **WHEN** the control handler receives a verified `interrupt`, `resume`, or `deliver_turn` command for its own connection
+- **THEN** it MUST route `interrupt` to abort the matching in-flight run, `resume` to re-dispatch the entity's wake, and `deliver_turn` to the connection-scoped pending-turns sweep
+

--- a/openspec/specs/openclaw-plugin-sdk/spec.md
+++ b/openspec/specs/openclaw-plugin-sdk/spec.md
@@ -95,3 +95,35 @@ The plugin MUST pass `openclaw plugins build --entry ./dist/index.js --check` an
 - **THEN** it MUST report the manifest loads, the entry exports valid SDK metadata, and `openclaw.extensions`/`runtimeExtensions` resolve
 - **AND** it MUST NOT report an unknown or missing required manifest field
 
+### Requirement: The plugin SHALL type the real runtime agent and session surface it consumes
+
+The plugin's SDK declaration (`openclaw-sdk.d.ts` or an imported equivalent) SHALL declare the real shapes of the OpenClaw runtime surface the daemon work consumes, replacing the opaque `runtime?: unknown` placeholder, so these calls are compile-time checked rather than `unknown`-cast. The declared surface SHALL include `runtime.agent.runEmbeddedAgent(params)` with at least the `abortSignal?: AbortSignal` parameter and the per-message streaming callbacks the plugin passes (assistant-message / block callbacks), the result fields the plugin reads (e.g. `meta.aborted`), and the session helpers `runtime.agent.session.getSessionEntry` and `resolveSessionFilePath`. The declared shapes SHALL be verified against the real `../openclaw` source rather than guessed.
+
+#### Scenario: runEmbeddedAgent is typed with abortSignal and streaming callbacks
+
+- **WHEN** the plugin's SDK declaration is read
+- **THEN** `runtime.agent.runEmbeddedAgent` MUST be declared with an `abortSignal?: AbortSignal` parameter and the per-message streaming callback parameters the plugin uses
+- **AND** `runtime` MUST NOT be declared as bare `unknown` for the surface the plugin calls
+
+#### Scenario: Session helpers are typed
+
+- **WHEN** the plugin resolves a session for resume/deliver_turn
+- **THEN** `runtime.agent.session.getSessionEntry` and `resolveSessionFilePath` MUST be declared with their real parameter and return shapes
+- **AND** the plugin's call sites MUST type-check against them without an `unknown` cast
+
+#### Scenario: Declared shapes match the real SDK
+
+- **WHEN** the declared surface is compared against the real `../openclaw` plugin SDK source
+- **THEN** the declared parameter and result shapes MUST match the real types (verified against source, not LLM memory)
+- **AND** where the published `openclaw` plugin-sdk type definitions are cleanly importable, the plugin SHALL prefer importing them over hand-declaring a parallel shim
+
+### Requirement: The typed SDK surface SHALL NOT add a build-time hard dependency on the full openclaw package
+
+Declaring or importing the real SDK types SHALL NOT introduce a hard runtime dependency on the full `openclaw` package into the separately-published `@chorus-aidlc/chorus-openclaw-plugin` build, and SHALL NOT add native bindings or postinstall scripts. If the published `openclaw` plugin-sdk types cannot be consumed without coupling the build to the full package, the plugin SHALL hand-declare only the minimal used surface instead.
+
+#### Scenario: The plugin package still builds standalone
+
+- **WHEN** the plugin package is built and packed
+- **THEN** typing the SDK surface MUST NOT require the full `openclaw` package as a runtime dependency
+- **AND** it MUST NOT introduce a postinstall script or a native-binding dependency
+

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -314,17 +314,48 @@ Results are advisory — they do not hard-block approval or verification, but yo
 
 ---
 
-## SSE Event-Driven Model
+## SSE Event-Driven Model (Bidirectional Daemon Host)
 
-The OpenClaw Chorus plugin runs a background service that holds a **Server-Sent Events (SSE)** connection to the Chorus server and wakes the agent (via the plugin's in-process system-event bridge) when relevant events arrive. Instead of polling, the agent is notified the moment something needs its attention.
+The OpenClaw Chorus plugin runs a background service that holds a **Server-Sent Events (SSE)** connection to the Chorus server. It is a **fully bidirectional daemon host**, on a par with the Chorus CLI daemon: it is not just a receiver of notifications that wakes the agent — it also **registers a connection identity, reports its execution lifecycle back to the server, and accepts reverse control commands** (interrupt / resume / deliver an instruction turn) so a human in the Chorus UI can observe and steer an in-flight run. Instead of polling, the agent is notified the moment something needs its attention, and the server always has a live, controllable view of what this host is running.
 
-### How It Works
+### Inbound: notifications wake the agent
 
 1. The plugin connects to the Chorus SSE endpoint using the configured API Key
 2. When a notification event arrives, the plugin fetches the full notification details
 3. If `projectUuids` is configured, events from other projects are filtered out
-4. The plugin routes the event to the agent with context-rich instructions
+4. The plugin resolves the event's lineage and routes it to the agent (an in-process embedded-agent run) with context-rich instructions
 5. If `autoStart` is enabled, certain events (like `task_assigned`) auto-claim before waking the agent
+
+### Connection identity (`connection_registered`)
+
+Right after the SSE handshake, the server assigns this stream a **DaemonConnection** and reports its `connectionUuid` via a `connection_registered` data event. The plugin captures that uuid (refreshing it on every reconnect, so a recycled stream never carries a stale identity) and uses it as the single source of truth for "which connection am I." This identity is what makes the connection addressable: it appears in the Chorus **Agent Connections** UI, scopes the reverse control channel, and stamps every outbound report below.
+
+### Outbound: the daemon reports its lifecycle to the server
+
+While a woken run executes, the plugin reports back over the `/api/daemon/*` REST surface (host-agnostic, the same payload shapes the CLI daemon sends) so the connection's activity is observable in the UI in real time:
+
+| Report | What it conveys |
+|--------|-----------------|
+| **turn-advance** | Advances the wake's turn lifecycle (`running` → `ended`) so the UI knows when a turn starts and finishes |
+| **execution-state** | Publishes this connection's running/queued execution snapshot (entity, root idea, status, start time) — the live "what is this host doing" view |
+| **transcript** | Streams the finalized user/assistant text of the turn (only `{ role, text }` — no internals) so the run's transcript is visible in the UI |
+| **report-interrupt** | Records that a run ended as `interrupted` (reason `user` or `crash`) rather than completing |
+
+Reports are fire-and-forget and never crash the run: a network/non-2xx failure is logged with its cause and surfaced as a structured failure result, never silently swallowed.
+
+### Reverse control channel (interrupt / resume / deliver_turn)
+
+The server publishes control commands on a `control:{connectionUuid}` channel and forwards them as `type:"control"` SSE events. These are **forked away from the wake path** — a control event can never spawn a new agent run for itself. The plugin acts on a command only after a double-check: (1) the command's `targetConnectionUuid` matches this connection's own uuid (a stale/recycled uuid or another connection's command is ignored and logged), and (2) for `interrupt`, this host actually holds a running embedded-agent run for that entity.
+
+| Command | Effect |
+|---------|--------|
+| **interrupt** | Aborts the matching in-flight run (true mid-run stop via its AbortController), then reports `report-interrupt` |
+| **resume** | Re-dispatches the entity's wake to continue the **same** session (the synthetic "resume" wake; resolves lineage so it anchors on the same direct idea) |
+| **deliver_turn** | Runs a human instruction turn delivered into the conversation — precisely the one turn when a `turnUuid` is present (origin-only live delivery), or a full pending-turns sweep as a fallback for an older server |
+
+### Backfill on reconnect
+
+After an SSE gap, the plugin re-pulls (1) unread **notifications** missed during the gap and (2) this connection's unstarted **pending turns** from the turn table (the safety net for a `deliver_turn` ping lost while disconnected). The two sources share a seen-set, so a turn is run **at most once** across live delivery and backfill.
 
 ### Event Types
 

--- a/packages/openclaw-plugin/src/__tests__/connection-state.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/connection-state.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { ConnectionState } from "../connection-state.js";
+
+describe("ConnectionState", () => {
+  it("starts unregistered (null) before any connection_registered", () => {
+    const state = new ConnectionState();
+    expect(state.getConnectionUuid()).toBeNull();
+  });
+
+  it("captures the connectionUuid set from connection_registered", () => {
+    const state = new ConnectionState();
+    state.setConnectionUuid("conn-1");
+    expect(state.getConnectionUuid()).toBe("conn-1");
+  });
+
+  it("refreshes the connectionUuid on reconnect (overwrites the stale one)", () => {
+    const state = new ConnectionState();
+    state.setConnectionUuid("conn-old");
+    expect(state.getConnectionUuid()).toBe("conn-old");
+    // A reconnect registers a NEW DaemonConnection — the stale uuid must not linger.
+    state.setConnectionUuid("conn-new");
+    expect(state.getConnectionUuid()).toBe("conn-new");
+  });
+
+  it("clear() forgets the identity (back to null)", () => {
+    const state = new ConnectionState();
+    state.setConnectionUuid("conn-1");
+    state.clear();
+    expect(state.getConnectionUuid()).toBeNull();
+  });
+
+  it("exposes a getConnectionUuid accessor shaped for the rest client + control handler", () => {
+    const state = new ConnectionState();
+    state.setConnectionUuid("conn-x");
+    // The accessor is the exact `() => string | null` shape both consumers read.
+    const read: () => string | null = state.getConnectionUuid.bind(state);
+    expect(read()).toBe("conn-x");
+  });
+});

--- a/packages/openclaw-plugin/src/__tests__/control-handler.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/control-handler.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createControlHandler, type ControlBehaviorHooks, type ControlEvent } from "../control-handler.js";
+import { ConnectionState } from "../connection-state.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe("createControlHandler", () => {
+  let logger: ReturnType<typeof makeLogger>;
+  let onInterrupt: ReturnType<typeof vi.fn>;
+  let onResume: ReturnType<typeof vi.fn>;
+  let onDeliverTurn: ReturnType<typeof vi.fn>;
+  let isEntityRunning: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    onInterrupt = vi.fn();
+    onResume = vi.fn();
+    onDeliverTurn = vi.fn();
+    isEntityRunning = vi.fn(() => true);
+  });
+
+  /** Build a handler whose connection identity is `myUuid`. */
+  function build(myUuid: string | null, hooksOver: Partial<ControlBehaviorHooks> = {}) {
+    const connectionState = new ConnectionState();
+    if (myUuid) connectionState.setConnectionUuid(myUuid);
+    const hooks: ControlBehaviorHooks = {
+      isEntityRunning,
+      onInterrupt,
+      onResume,
+      onDeliverTurn,
+      ...hooksOver,
+    };
+    const onControl = createControlHandler({ connectionState, hooks, logger });
+    return { onControl, connectionState };
+  }
+
+  function noHookCalled() {
+    expect(onInterrupt).not.toHaveBeenCalled();
+    expect(onResume).not.toHaveBeenCalled();
+    expect(onDeliverTurn).not.toHaveBeenCalled();
+  }
+
+  // --- Command routing to the three hooks (own connection, all checks pass) ---
+
+  it("routes a verified interrupt to onInterrupt", () => {
+    const { onControl } = build("conn-1");
+    onControl({
+      type: "control",
+      command: "interrupt",
+      targetConnectionUuid: "conn-1",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+    expect(onInterrupt).toHaveBeenCalledWith("task", "task-9");
+    expect(onResume).not.toHaveBeenCalled();
+    expect(onDeliverTurn).not.toHaveBeenCalled();
+  });
+
+  it("routes a verified resume to onResume (no running-entity requirement)", () => {
+    // isEntityRunning=false on purpose — resume must NOT depend on a held run.
+    const { onControl } = build("conn-1", { isEntityRunning: () => false });
+    onControl({
+      type: "control",
+      command: "resume",
+      targetConnectionUuid: "conn-1",
+      entityType: "idea",
+      entityUuid: "idea-3",
+    });
+    expect(onResume).toHaveBeenCalledWith("idea", "idea-3");
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("routes a verified deliver_turn (with turnUuid) to onDeliverTurn precisely", () => {
+    const { onControl } = build("conn-1");
+    onControl({
+      type: "control",
+      command: "deliver_turn",
+      targetConnectionUuid: "conn-1",
+      turnUuid: "turn-7",
+    });
+    expect(onDeliverTurn).toHaveBeenCalledWith("turn-7");
+    expect(onInterrupt).not.toHaveBeenCalled();
+    expect(onResume).not.toHaveBeenCalled();
+  });
+
+  it("routes a deliver_turn WITHOUT turnUuid as a full-sweep fallback (undefined)", () => {
+    const { onControl } = build("conn-1");
+    onControl({
+      type: "control",
+      command: "deliver_turn",
+      targetConnectionUuid: "conn-1",
+    });
+    expect(onDeliverTurn).toHaveBeenCalledWith(undefined);
+  });
+
+  // --- Double-check ignore path 1: wrong connectionUuid (every command) ---
+
+  it("ignores interrupt for a DIFFERENT connection (Check 1 fail) + logs", () => {
+    const { onControl } = build("conn-1");
+    onControl({
+      type: "control",
+      command: "interrupt",
+      targetConnectionUuid: "conn-OTHER",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+    noHookCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("ignoring interrupt for connection conn-OTHER"));
+  });
+
+  it("ignores resume / deliver_turn for a different connection too", () => {
+    const { onControl } = build("conn-1");
+    onControl({ type: "control", command: "resume", targetConnectionUuid: "conn-X", entityType: "task", entityUuid: "t" });
+    onControl({ type: "control", command: "deliver_turn", targetConnectionUuid: "conn-X", turnUuid: "turn-1" });
+    noHookCalled();
+  });
+
+  it("ignores any command before the handshake (no connectionUuid yet) + logs", () => {
+    const { onControl } = build(null);
+    onControl({
+      type: "control",
+      command: "interrupt",
+      targetConnectionUuid: "conn-1",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+    noHookCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("<unregistered>"));
+  });
+
+  // --- Double-check ignore path 2: interrupt with no running entity held ---
+
+  it("ignores interrupt when the entity is NOT running (Check 2 fail) + logs", () => {
+    const { onControl } = build("conn-1", { isEntityRunning: () => false });
+    onControl({
+      type: "control",
+      command: "interrupt",
+      targetConnectionUuid: "conn-1",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+    expect(onInterrupt).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("no running embedded-agent run"));
+  });
+
+  it("interrupt consults isEntityRunning with the command's entity", () => {
+    const probe = vi.fn(() => true);
+    const { onControl } = build("conn-1", { isEntityRunning: probe });
+    onControl({
+      type: "control",
+      command: "interrupt",
+      targetConnectionUuid: "conn-1",
+      entityType: "proposal",
+      entityUuid: "prop-2",
+    });
+    expect(probe).toHaveBeenCalledWith("proposal", "prop-2");
+    expect(onInterrupt).toHaveBeenCalledWith("proposal", "prop-2");
+  });
+
+  it("defaults isEntityRunning to false (no registry) — interrupt is a safe no-op", () => {
+    const connectionState = new ConnectionState();
+    connectionState.setConnectionUuid("conn-1");
+    // No isEntityRunning provided at all.
+    const onControl = createControlHandler({ connectionState, hooks: { onInterrupt }, logger });
+    onControl({
+      type: "control",
+      command: "interrupt",
+      targetConnectionUuid: "conn-1",
+      entityType: "task",
+      entityUuid: "task-9",
+    });
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+
+  // --- entity-field validation for interrupt/resume ---
+
+  it("ignores interrupt/resume missing entity fields + warns", () => {
+    const { onControl } = build("conn-1");
+    onControl({ type: "control", command: "interrupt", targetConnectionUuid: "conn-1" } as ControlEvent);
+    expect(onInterrupt).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("missing entityType/entityUuid"));
+  });
+
+  // --- forward-compatibility + non-control guards ---
+
+  it("ignores an unknown command + warns (forward-compatible)", () => {
+    const { onControl } = build("conn-1");
+    onControl({ type: "control", command: "explode", targetConnectionUuid: "conn-1" } as ControlEvent);
+    noHookCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('"explode" not supported'));
+  });
+
+  it("ignores a non-control event + warns", () => {
+    const { onControl } = build("conn-1");
+    onControl({ type: "new_notification" } as ControlEvent);
+    noHookCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("non-control event"));
+  });
+
+  // --- non-throwing backstop: a hook that throws must not escape ---
+
+  it("never throws even when a behavior hook throws (logs instead)", () => {
+    const { onControl } = build("conn-1", {
+      onInterrupt: () => {
+        throw new Error("boom");
+      },
+    });
+    expect(() =>
+      onControl({
+        type: "control",
+        command: "interrupt",
+        targetConnectionUuid: "conn-1",
+        entityType: "task",
+        entityUuid: "task-9",
+      }),
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("interrupt hook failed"));
+  });
+
+  it("never throws when getConnectionUuid itself throws (error backstop)", () => {
+    const throwingState = {
+      getConnectionUuid: () => {
+        throw new Error("state boom");
+      },
+    };
+    const onControl = createControlHandler({
+      connectionState: throwingState,
+      hooks: { onInterrupt },
+      logger,
+    });
+    expect(() =>
+      onControl({
+        type: "control",
+        command: "interrupt",
+        targetConnectionUuid: "conn-1",
+        entityType: "task",
+        entityUuid: "task-9",
+      }),
+    ).not.toThrow();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("control-handler unexpected error"));
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/openclaw-plugin/src/__tests__/daemon-client.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/daemon-client.test.ts
@@ -1,0 +1,559 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  OpenClawDaemonClient,
+  extractBlockReplyText,
+  deriveSessionId,
+  deriveSessionKey,
+  entityOf,
+  type WakeRunContext,
+  type WakeRequest,
+} from "../daemon-client.js";
+import type { DaemonRestClient, DaemonPendingTurn } from "../daemon-rest-client.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+/** Flush the fire-and-forget promise chain. */
+async function flush() {
+  for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+/** A rest-client fake recording every call; reads are configurable. */
+function makeRestClient(over: Partial<DaemonRestClient> = {}) {
+  const turnAdvance = vi.fn(async () => ({ ok: true, status: 200 }));
+  const transcript = vi.fn(async () => ({ ok: true, status: 200 }));
+  const executionState = vi.fn(async () => ({ ok: true, status: 200 }));
+  const reportInterrupt = vi.fn(async () => ({ ok: true, status: 200 }));
+  const readPendingTurns = vi.fn(async () => ({ ok: true, status: 200, data: { turns: [] as DaemonPendingTurn[] } }));
+  const client: DaemonRestClient = {
+    turnAdvance,
+    transcript,
+    executionState,
+    reportInterrupt,
+    readPendingTurns,
+    ...over,
+  };
+  return { client, turnAdvance, transcript, executionState, reportInterrupt, readPendingTurns };
+}
+
+/**
+ * A runtime.agent fake whose runEmbeddedAgent invokes the streaming callbacks the
+ * test supplies, then resolves/rejects per the test's directive. Records the params.
+ */
+function makeRunContext(opts: {
+  runEmbeddedAgent: ReturnType<typeof vi.fn>;
+  getSessionEntry?: ReturnType<typeof vi.fn>;
+}): WakeRunContext {
+  const getSessionEntry =
+    opts.getSessionEntry ?? vi.fn(() => ({ sessionId: "sid-existing", sessionFile: "f.jsonl" }));
+  const resolveSessionFilePath = vi.fn(() => "/ws/sessions/f.jsonl");
+  return {
+    agent: {
+      runEmbeddedAgent: opts.runEmbeddedAgent as never,
+      resolveAgentDir: vi.fn(() => "/ws/agent"),
+      resolveAgentWorkspaceDir: vi.fn(() => "/ws"),
+      resolveAgentTimeoutMs: vi.fn(() => 120000),
+      session: { getSessionEntry: getSessionEntry as never, resolveSessionFilePath: resolveSessionFilePath as never },
+    } as never,
+    sessionKey: "agent:main:main",
+    agentId: "main",
+    config: { fake: true },
+    workspaceDir: "/ws",
+    agentDir: "/ws/agent",
+    timeoutMs: 120000,
+    modelRef: { provider: "amazon-bedrock", model: "claude-sonnet-4-6" },
+  };
+}
+
+function build(over: {
+  rest?: ReturnType<typeof makeRestClient>;
+  runContext?: WakeRunContext | null;
+  redispatch?: ReturnType<typeof vi.fn>;
+  buildTurnPrompt?: (t: DaemonPendingTurn) => string;
+} = {}) {
+  const rest = over.rest ?? makeRestClient();
+  const logger = makeLogger();
+  const redispatch = over.redispatch ?? vi.fn();
+  const client = new OpenClawDaemonClient({
+    restClient: rest.client,
+    resolveRunContext: () => (over.runContext === undefined ? makeRunContext({ runEmbeddedAgent: vi.fn(async () => ({ meta: {} })) }) : over.runContext),
+    redispatch,
+    buildTurnPrompt: over.buildTurnPrompt ?? ((t) => `PROMPT:${t.promptText ?? ""}`),
+    logger,
+  });
+  return { client, rest, logger, redispatch };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("pure helpers", () => {
+  it("deriveSessionId prefers directIdeaUuid, falls back to entityUuid", () => {
+    expect(deriveSessionId({ directIdeaUuid: "idea-1", entityUuid: "task-1" })).toBe("idea-1");
+    expect(deriveSessionId({ directIdeaUuid: null, entityUuid: "task-1" })).toBe("task-1");
+    expect(deriveSessionId({ entityUuid: null })).toBeNull();
+  });
+
+  it("deriveSessionKey is deterministic from the business key + main session key", () => {
+    expect(deriveSessionKey("idea-1", "agent:main:main")).toBe("agent:main:main:chorus:idea-1");
+    // Same business key → SAME OpenClaw session key (resume continuity).
+    expect(deriveSessionKey("idea-1", "agent:main:main")).toBe(deriveSessionKey("idea-1", "agent:main:main"));
+    // Different business key → different lane.
+    expect(deriveSessionKey("idea-2", "agent:main:main")).not.toBe(deriveSessionKey("idea-1", "agent:main:main"));
+  });
+
+  it("entityOf accepts recognized resource kinds only", () => {
+    expect(entityOf({ entityType: "task", entityUuid: "t" })).toEqual({ entityType: "task", entityUuid: "t" });
+    expect(entityOf({ entityType: "daemon_session", entityUuid: "s" })).toEqual({ entityType: "daemon_session", entityUuid: "s" });
+    expect(entityOf({ entityType: "bogus", entityUuid: "x" })).toBeNull();
+    expect(entityOf({ entityType: "task", entityUuid: "" })).toBeNull();
+    expect(entityOf({ entityType: "task" })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC: Transcript filtering (only finalized assistant visible text)
+// ---------------------------------------------------------------------------
+
+describe("extractBlockReplyText — transcript content filter", () => {
+  it("keeps finalized assistant text", () => {
+    expect(extractBlockReplyText({ text: "Hello world" })).toEqual({ role: "assistant", text: "Hello world" });
+  });
+  it("drops reasoning/thinking blocks (isReasoning)", () => {
+    expect(extractBlockReplyText({ text: "let me think...", isReasoning: true })).toBeNull();
+  });
+  it("drops empty / whitespace-only text", () => {
+    expect(extractBlockReplyText({ text: "   " })).toBeNull();
+    expect(extractBlockReplyText({})).toBeNull();
+    expect(extractBlockReplyText(null)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC #1: lifecycle reporting (running→ended + execution snapshot)
+// ---------------------------------------------------------------------------
+
+describe("runWake — lifecycle reporting", () => {
+  it("reports turn-advance running then ended, with sessionId=directIdeaUuid", async () => {
+    const rest = makeRestClient();
+    const runEmbeddedAgent = vi.fn(async () => ({ meta: {} }));
+    const { client } = build({ rest, runContext: makeRunContext({ runEmbeddedAgent }) });
+
+    await client.runWake({
+      prompt: "do the task",
+      contextKey: "chorus:task_assigned:task-3",
+      entityType: "task",
+      entityUuid: "task-3",
+      directIdeaUuid: "idea-9",
+      rootIdeaUuid: "idea-root",
+    });
+
+    // running before the run, ended after.
+    expect(rest.turnAdvance).toHaveBeenNthCalledWith(1, {
+      sessionId: "idea-9",
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-3",
+    });
+    expect(rest.turnAdvance).toHaveBeenNthCalledWith(2, {
+      sessionId: "idea-9",
+      status: "ended",
+      entityType: "task",
+      entityUuid: "task-3",
+    });
+  });
+
+  it("publishes an execution snapshot with rootIdeaUuid + startedAt while running, then empty when ended", async () => {
+    const rest = makeRestClient();
+    let snapshotWhileRunning: unknown;
+    const runEmbeddedAgent = vi.fn(async () => {
+      // capture the snapshot emitted at the running transition
+      const calls = rest.executionState.mock.calls;
+      snapshotWhileRunning = calls[calls.length - 1]?.[0];
+      return { meta: {} };
+    });
+    const { client } = build({ rest, runContext: makeRunContext({ runEmbeddedAgent }) });
+
+    await client.runWake({
+      prompt: "p",
+      contextKey: "ctx",
+      entityType: "task",
+      entityUuid: "task-3",
+      directIdeaUuid: "idea-9",
+      rootIdeaUuid: "idea-root",
+    });
+
+    expect(snapshotWhileRunning).toEqual({
+      executions: [
+        expect.objectContaining({
+          entityType: "task",
+          entityUuid: "task-3",
+          rootIdeaUuid: "idea-root",
+          status: "running",
+          startedAt: expect.any(String),
+        }),
+      ],
+    });
+    // Last snapshot after the run finishes is empty (absence == ended server-side).
+    const last = rest.executionState.mock.calls[rest.executionState.mock.calls.length - 1][0];
+    expect(last).toEqual({ executions: [] });
+  });
+
+  it("uses entityUuid as the sessionId when there is no direct idea", async () => {
+    const rest = makeRestClient();
+    const runEmbeddedAgent = vi.fn(async () => ({ meta: {} }));
+    const { client } = build({ rest, runContext: makeRunContext({ runEmbeddedAgent }) });
+    await client.runWake({ prompt: "p", contextKey: "ctx", entityType: "task", entityUuid: "task-3", directIdeaUuid: null });
+    expect(rest.turnAdvance).toHaveBeenNthCalledWith(1, expect.objectContaining({ sessionId: "task-3", status: "running" }));
+  });
+
+  it("DROPS the wake (no reports) when the host run-context is unavailable", async () => {
+    const rest = makeRestClient();
+    const { client, logger } = build({ rest, runContext: null });
+    await client.runWake({ prompt: "p", contextKey: "ctx", entityType: "task", entityUuid: "task-3" });
+    expect(rest.turnAdvance).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("no resolvable session/agent runtime"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC #2: transcript streams from inline callbacks
+// ---------------------------------------------------------------------------
+
+describe("runWake — streaming transcript", () => {
+  it("posts only finalized assistant text from onBlockReply; never reasoning/tool internals", async () => {
+    const rest = makeRestClient();
+    const runEmbeddedAgent = vi.fn(async (params: Record<string, unknown>) => {
+      const onBlockReply = params.onBlockReply as (p: unknown) => void;
+      const onToolResult = params.onToolResult as ((p: unknown) => void) | undefined;
+      const onReasoningStream = params.onReasoningStream as ((p: unknown) => void) | undefined;
+      // visible text → posted
+      onBlockReply({ text: "Here is the answer." });
+      // reasoning block → dropped
+      onBlockReply({ text: "thinking out loud", isReasoning: true });
+      // tool result → never posted as transcript (client does not pass onToolResult,
+      // so even if a host called it, nothing would be posted). Assert it's absent.
+      expect(onToolResult).toBeUndefined();
+      // reasoning stream callback also not wired by the client → never posted.
+      expect(onReasoningStream).toBeUndefined();
+      return { meta: {} };
+    });
+    const { client } = build({ rest, runContext: makeRunContext({ runEmbeddedAgent }) });
+
+    await client.runWake({ prompt: "p", contextKey: "ctx", entityType: "task", entityUuid: "task-3", directIdeaUuid: "idea-9" });
+    await flush();
+
+    expect(rest.transcript).toHaveBeenCalledTimes(1);
+    expect(rest.transcript).toHaveBeenCalledWith({ sessionId: "idea-9", messages: [{ role: "assistant", text: "Here is the answer." }] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC #3: abort=user vs crash + controller deregistration
+// ---------------------------------------------------------------------------
+
+describe("runWake — interrupt (user) vs crash + controller lifecycle", () => {
+  it("an authorized interrupt aborts the in-flight run and reports reason=user", async () => {
+    const rest = makeRestClient();
+    let resolveRun!: (v: unknown) => void;
+    const runEmbeddedAgent = vi.fn((params: Record<string, unknown>) => {
+      const signal = params.abortSignal as AbortSignal;
+      return new Promise((resolve) => {
+        resolveRun = resolve;
+        // Simulate a cooperative abort: when the signal fires, resolve with meta.aborted.
+        signal.addEventListener("abort", () => resolve({ meta: { aborted: true } }));
+      });
+    });
+    const { client } = build({ rest, runContext: makeRunContext({ runEmbeddedAgent }) });
+
+    const runP = client.runWake({ prompt: "p", contextKey: "ctx", entityType: "task", entityUuid: "task-3", directIdeaUuid: "idea-9" });
+    await flush();
+
+    // While running, the entity is interruptible.
+    expect(client.controlHooks.isEntityRunning("task", "task-3")).toBe(true);
+    // Fire the interrupt.
+    client.controlHooks.onInterrupt("task", "task-3");
+    await runP;
+
+    expect(rest.reportInterrupt).toHaveBeenCalledWith({ entityType: "task", entityUuid: "task-3", reason: "user" });
+    // Controller deregistered after the run settled.
+    expect(client.controlHooks.isEntityRunning("task", "task-3")).toBe(false);
+    void resolveRun; // referenced to satisfy noUnusedLocals
+  });
+
+  it("a run rejection WITHOUT an interrupt reports reason=crash", async () => {
+    const rest = makeRestClient();
+    const runEmbeddedAgent = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const { client } = build({ rest, runContext: makeRunContext({ runEmbeddedAgent }) });
+
+    await client.runWake({ prompt: "p", contextKey: "ctx", entityType: "task", entityUuid: "task-3", directIdeaUuid: "idea-9" });
+
+    expect(rest.reportInterrupt).toHaveBeenCalledWith({ entityType: "task", entityUuid: "task-3", reason: "crash" });
+    // Still advances the turn to ended despite the crash.
+    expect(rest.turnAdvance).toHaveBeenCalledWith(expect.objectContaining({ status: "ended" }));
+  });
+
+  it("a clean completion reports NO interrupt", async () => {
+    const rest = makeRestClient();
+    const runEmbeddedAgent = vi.fn(async () => ({ meta: {} }));
+    const { client } = build({ rest, runContext: makeRunContext({ runEmbeddedAgent }) });
+    await client.runWake({ prompt: "p", contextKey: "ctx", entityType: "task", entityUuid: "task-3", directIdeaUuid: "idea-9" });
+    expect(rest.reportInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("interrupt for an entity with no in-flight run is a safe no-op (deregistered)", async () => {
+    const { client, rest } = build();
+    expect(client.controlHooks.isEntityRunning("task", "task-99")).toBe(false);
+    client.controlHooks.onInterrupt("task", "task-99");
+    expect(rest.reportInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("a stale controller cannot abort a later run for the same entity", async () => {
+    const rest = makeRestClient();
+    // First run completes cleanly.
+    const first = vi.fn(async () => ({ meta: {} }));
+    const ctx1 = makeRunContext({ runEmbeddedAgent: first });
+    let runContext: WakeRunContext = ctx1;
+    const client = new OpenClawDaemonClient({
+      restClient: rest.client,
+      resolveRunContext: () => runContext,
+      redispatch: vi.fn(),
+      buildTurnPrompt: () => "p",
+      logger: makeLogger(),
+    });
+    await client.runWake({ prompt: "p", contextKey: "ctx", entityType: "task", entityUuid: "task-3", directIdeaUuid: "idea-9" });
+    expect(client.controlHooks.isEntityRunning("task", "task-3")).toBe(false);
+
+    // Second run is in-flight; an interrupt now targets a FRESH controller, not the
+    // settled first one.
+    let resolve2!: (v: unknown) => void;
+    const secondSignals: AbortSignal[] = [];
+    const second = vi.fn((params: Record<string, unknown>) => {
+      secondSignals.push(params.abortSignal as AbortSignal);
+      return new Promise((r) => {
+        resolve2 = r;
+      });
+    });
+    runContext = makeRunContext({ runEmbeddedAgent: second });
+    const run2 = client.runWake({ prompt: "p2", contextKey: "ctx2", entityType: "task", entityUuid: "task-3", directIdeaUuid: "idea-9" });
+    await flush();
+    expect(secondSignals[0].aborted).toBe(false);
+    resolve2({ meta: {} });
+    await run2;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC #4: session-key continuity (resume / deliver_turn reuse the same session)
+// ---------------------------------------------------------------------------
+
+describe("session-key continuity", () => {
+  it("runWake derives the same sessionKey for the same business key, resolving the existing entry", async () => {
+    const rest = makeRestClient();
+    const getSessionEntry = vi.fn(() => ({ sessionId: "sid-existing", sessionFile: "f.jsonl" }));
+    const runEmbeddedAgent = vi.fn(async () => ({ meta: {} }));
+    const ctx = makeRunContext({ runEmbeddedAgent, getSessionEntry });
+    const { client } = build({ rest, runContext: ctx });
+
+    await client.runWake({ prompt: "p", contextKey: "ctx", entityType: "idea", entityUuid: "idea-9", directIdeaUuid: "idea-9" });
+
+    const expectedKey = deriveSessionKey("idea-9", "agent:main:main");
+    expect(getSessionEntry).toHaveBeenCalledWith({ sessionKey: expectedKey, agentId: "main" });
+    // The run reuses the existing sessionId returned by getSessionEntry (NOT a fresh one).
+    expect(runEmbeddedAgent.mock.calls[0][0].sessionId).toBe("sid-existing");
+    expect(runEmbeddedAgent.mock.calls[0][0].sessionKey).toBe(expectedKey);
+  });
+
+  it("opens a NEW session with a SAFE session id (the business key) when getSessionEntry returns none", async () => {
+    // Regression for a defect surfaced by a live OpenClaw gateway run (T5): when no
+    // OpenClaw session exists yet for the derived key, the fallback session id MUST be
+    // a valid OpenClaw session id. OpenClaw's resolveSessionFilePath enforces
+    // SAFE_SESSION_ID_RE (`^[a-z0-9][a-z0-9._-]{0,127}$`) — NO colons. The old fallback
+    // used the run id (`chorus-wake-N-chorus:deliver_turn:<uuid>`), which contains
+    // colons and was rejected with "Invalid session ID", dropping every fresh wake.
+    const SAFE_SESSION_ID_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
+    const rest = makeRestClient();
+    const getSessionEntry = vi.fn(() => undefined); // no existing session
+    const resolveSessionFilePath = vi.fn((sessionId: string) => {
+      if (!SAFE_SESSION_ID_RE.test(sessionId)) {
+        throw new Error(`Invalid session ID: ${sessionId}`);
+      }
+      return `/ws/sessions/${sessionId}.jsonl`;
+    });
+    const runEmbeddedAgent = vi.fn(async () => ({ meta: {} }));
+    const ctx = makeRunContext({ runEmbeddedAgent, getSessionEntry });
+    (ctx.agent as { session: { resolveSessionFilePath: unknown } }).session.resolveSessionFilePath =
+      resolveSessionFilePath as never;
+    const { client, logger } = build({ rest, runContext: ctx });
+
+    // A fresh ad-hoc business key (a uuid) — safe per the regex.
+    const businessKey = "bc4b0a8c-2f6c-47c2-9275-27e062d704ed";
+    await client.runWake({
+      prompt: "p",
+      contextKey: "chorus:deliver_turn:c44fd333-435d-44fa-be21-1569979e9d44",
+      entityType: "daemon_session",
+      entityUuid: businessKey,
+      directIdeaUuid: null,
+    });
+
+    // The wake was NOT dropped (no "session resolution failed" log).
+    const warnMsgs = (logger.warn as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(warnMsgs.some((w) => w.includes("session resolution failed"))).toBe(false);
+    // The run opened a NEW session whose id is the business key (a SAFE id), NOT a runId.
+    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+    const usedSessionId = runEmbeddedAgent.mock.calls[0][0].sessionId as string;
+    expect(usedSessionId).toBe(businessKey);
+    expect(SAFE_SESSION_ID_RE.test(usedSessionId)).toBe(true);
+    expect(usedSessionId).not.toContain(":");
+    // The run id (which DOES embed the colon-laden contextKey) is passed separately and
+    // is never used as the session id.
+    expect(runEmbeddedAgent.mock.calls[0][0].runId).toContain(":");
+  });
+
+  it("onResume re-dispatches a wake for the entity (continues the same session via redispatch)", () => {
+    const redispatch = vi.fn();
+    const { client } = build({ redispatch });
+    client.controlHooks.onResume("idea", "idea-9");
+    expect(redispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "idea", entityUuid: "idea-9", contextKey: "chorus:resume:idea-9" }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC #5: pending-turns backfill + at-most-once (live + backfill dedup)
+// ---------------------------------------------------------------------------
+
+describe("pending-turns backfill — at-most-once", () => {
+  const TURN: DaemonPendingTurn = {
+    turnUuid: "turn-7",
+    sessionId: "idea-9",
+    directIdeaUuid: "idea-9",
+    trigger: "human_instruction",
+    promptText: "please do X",
+  };
+
+  function withTurns(turns: DaemonPendingTurn[]) {
+    return makeRestClient({ readPendingTurns: vi.fn(async () => ({ ok: true, status: 200, data: { turns } })) });
+  }
+
+  it("deliverTurn(turnUuid) runs ONLY the named turn", async () => {
+    const other: DaemonPendingTurn = { ...TURN, turnUuid: "turn-OTHER", promptText: "other" };
+    const rest = withTurns([TURN, other]);
+    const redispatch = vi.fn();
+    const { client } = build({ rest, redispatch });
+
+    await client.deliverTurn("turn-7");
+
+    expect(redispatch).toHaveBeenCalledTimes(1);
+    expect(redispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        turnUuid: "turn-7",
+        // An idea-anchored turn reports its execution against the real idea so the
+        // delivered run is visible + interruptible (entityType MUST be set).
+        entityType: "idea",
+        directIdeaUuid: "idea-9",
+        entityUuid: "idea-9",
+        contextKey: "chorus:deliver_turn:turn-7",
+        prompt: "PROMPT:please do X",
+      }),
+    );
+  });
+
+  it("an ad-hoc turn (no directIdeaUuid) reports against daemon_session, not entity-less", async () => {
+    // Regression: deliverTurn used to omit entityType for ad-hoc turns, so entityOf()
+    // returned null → no execution row + no AbortController → the delivered run was
+    // invisible in the UI and uninterruptible. Mirror cli/event-router.mjs which sets
+    // entityType=daemon_session, entityUuid=sessionId for a directIdeaUuid-less turn.
+    const adhoc: DaemonPendingTurn = {
+      turnUuid: "turn-adhoc",
+      sessionId: "sess-abc",
+      directIdeaUuid: null,
+      trigger: "human_instruction",
+      promptText: "ad-hoc work",
+    };
+    const rest = withTurns([adhoc]);
+    const redispatch = vi.fn();
+    const { client } = build({ rest, redispatch });
+
+    await client.deliverTurn("turn-adhoc");
+
+    expect(redispatch).toHaveBeenCalledTimes(1);
+    const req = redispatch.mock.calls[0][0];
+    expect(req).toEqual(
+      expect.objectContaining({
+        turnUuid: "turn-adhoc",
+        entityType: "daemon_session",
+        entityUuid: "sess-abc",
+        directIdeaUuid: null,
+      }),
+    );
+    // entityOf must now resolve a real entity (was null before the fix) so the run
+    // reports an execution row and registers an interruptible AbortController.
+    expect(entityOf(req)).toEqual({ entityType: "daemon_session", entityUuid: "sess-abc" });
+  });
+
+  it("onReconnect sweeps ALL pending turns", async () => {
+    const t2: DaemonPendingTurn = { ...TURN, turnUuid: "turn-8" };
+    const rest = withTurns([TURN, t2]);
+    const redispatch = vi.fn();
+    const { client } = build({ rest, redispatch });
+    await client.onReconnect();
+    expect(redispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("a turn delivered live is NOT re-run by a later backfill (shared seen-set)", async () => {
+    const rest = withTurns([TURN]);
+    const redispatch = vi.fn();
+    const { client } = build({ rest, redispatch });
+
+    await client.deliverTurn("turn-7"); // live
+    await client.onReconnect(); // backfill sees the same turn
+
+    expect(redispatch).toHaveBeenCalledTimes(1); // at most once
+  });
+
+  it("a turn swept on reconnect is NOT re-run by a later live deliver_turn (shared seen-set)", async () => {
+    const rest = withTurns([TURN]);
+    const redispatch = vi.fn();
+    const { client } = build({ rest, redispatch });
+
+    await client.onReconnect(); // backfill first
+    await client.deliverTurn("turn-7"); // live ping for the same turn
+
+    expect(redispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failed pending-turns read dispatches nothing (logged, not crashing)", async () => {
+    const rest = makeRestClient({ readPendingTurns: vi.fn(async () => ({ ok: false, status: 500 })) });
+    const redispatch = vi.fn();
+    const { client } = build({ rest, redispatch });
+    await client.onReconnect();
+    expect(redispatch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// controlHooks integration with the T3 control handler shape
+// ---------------------------------------------------------------------------
+
+describe("controlHooks shape", () => {
+  let hooks: OpenClawDaemonClient["controlHooks"];
+  beforeEach(() => {
+    hooks = build().client.controlHooks;
+  });
+  it("exposes isEntityRunning / onInterrupt / onResume / onDeliverTurn", () => {
+    expect(typeof hooks.isEntityRunning).toBe("function");
+    expect(typeof hooks.onInterrupt).toBe("function");
+    expect(typeof hooks.onResume).toBe("function");
+    expect(typeof hooks.onDeliverTurn).toBe("function");
+  });
+});
+
+// Keep WakeRequest import meaningful for type-coverage of the test file.
+const _typecheck: WakeRequest = { prompt: "x", contextKey: "y" };
+void _typecheck;

--- a/packages/openclaw-plugin/src/__tests__/daemon-loop.e2e.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/daemon-loop.e2e.test.ts
@@ -1,0 +1,548 @@
+// packages/openclaw-plugin/src/__tests__/daemon-loop.e2e.test.ts
+//
+// TIER-2 LIVE INTEGRATION TEST (T5 integration checkpoint).
+//
+// Drives the REAL plugin daemon modules — `ChorusSseListener`, `ConnectionState`,
+// `createControlHandler`, `OpenClawDaemonClient`, `createDaemonRestClient` — wired
+// together EXACTLY as `src/index.ts` wires them, against a LIVE local Chorus server
+// over real HTTP. The ONLY thing replaced is the OpenClaw SDK
+// `runtime.agent.runEmbeddedAgent` call (we cannot run a real LLM in this sandbox);
+// everything else is the REAL wire protocol hitting the REAL server + DB:
+//   • SSE handshake → real `connection_registered` (our online DaemonConnection)
+//   • POST /api/daemon/turn-advance (running→ended) — real DaemonSessionTurn advance
+//   • POST /api/daemon/transcript — real DaemonTranscriptMessage append
+//   • POST /api/daemon/execution-state — real DaemonExecution reconcile
+//   • POST /api/daemon/report-interrupt — real interrupted/reason=user flip
+//   • the server's `control:{connectionUuid}` interrupt/resume/deliver_turn events
+//   • GET  /api/daemon/pending-turns — real reconnect backfill source
+//   • GET  /api/daemon/executions, GET /api/daemon-sessions/{uuid} — read-back verify
+//
+// GATED on `CHORUS_E2E_BASE_URL` + `CHORUS_E2E_PASSWORD`. When unset the whole suite
+// is SKIPPED, so committing this file never breaks CI on a machine with no server.
+// It self-provisions its own agent + API key + ad-hoc session via the live server's
+// real endpoints, so it is hermetic given only a running server.
+//
+// The ad-hoc `daemon_session` entity is used as the execution/control target: it is a
+// first-class EXECUTION_ENTITY_TYPE / CONTROL_ENTITY_TYPE validated server-side against
+// DaemonSession.sessionId, so the whole loop runs without needing a content entity.
+//
+// AC mapping:
+//   AC1  wake → turn-advance(running→ended) + execution row + readable transcript
+//   AC2  interrupt stops the in-flight run → execution interrupted reason=user;
+//        resume re-dispatches and continues the SAME session
+//   AC3  live deliver_turn runs a human_instruction once; a turn created during a
+//        disconnect is recovered by pending-turns backfill and runs at most once
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { ConnectionState } from "../connection-state.js";
+import { createControlHandler, type ControlBehaviorHooks } from "../control-handler.js";
+import { createDaemonRestClient, type DaemonPendingTurn } from "../daemon-rest-client.js";
+import { OpenClawDaemonClient, type WakeRequest } from "../daemon-client.js";
+import { ChorusSseListener, type SseControlEvent } from "../sse-listener.js";
+import type {
+  OpenClawRuntimeAgent,
+  RunEmbeddedAgentParams,
+  EmbeddedAgentRunResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+const BASE_URL = process.env.CHORUS_E2E_BASE_URL;
+const ADMIN_EMAIL = process.env.CHORUS_E2E_EMAIL ?? "admin@chorus.local";
+const ADMIN_PASSWORD = process.env.CHORUS_E2E_PASSWORD ?? "";
+const RUN = !!BASE_URL && !!ADMIN_PASSWORD;
+
+// --- live REST helpers (cookie jar for user session, bearer for agent key) ---
+
+let userCookie = "";
+
+async function adminLogin(): Promise<{ companyUuid: string; userUuid: string }> {
+  const res = await fetch(`${BASE_URL}/api/auth/default-login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+  });
+  if (!res.ok) throw new Error(`default-login failed: ${res.status} ${await res.text()}`);
+  const setCookie = res.headers.get("set-cookie") ?? "";
+  const m = /user_session=([^;]+)/.exec(setCookie);
+  if (!m) throw new Error("no user_session cookie returned");
+  userCookie = `user_session=${m[1]}`;
+  const body = (await res.json()) as { data: { user: { uuid: string; companyUuid: string } } };
+  return { companyUuid: body.data.user.companyUuid, userUuid: body.data.user.uuid };
+}
+
+async function userPost<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: userCookie },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`POST ${path} -> ${res.status}: ${text}`);
+  return JSON.parse(text).data as T;
+}
+
+async function userGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, { headers: { Cookie: userCookie } });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`GET ${path} -> ${res.status}: ${text}`);
+  return JSON.parse(text).data as T;
+}
+
+async function agentGet<T>(path: string, apiKey: string): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, { headers: { Authorization: `Bearer ${apiKey}` } });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`GET(agent) ${path} -> ${res.status}: ${text}`);
+  return JSON.parse(text).data as T;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function waitFor<T>(
+  fn: () => Promise<T | null | undefined>,
+  timeoutMs = 8000,
+  intervalMs = 150,
+): Promise<T | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v) return v;
+    await sleep(intervalMs);
+  }
+  return null;
+}
+
+type ExecRow = {
+  entityType: string;
+  entityUuid: string;
+  status: string;
+  interruptedReason?: string | null;
+};
+
+async function findExecution(
+  apiKey: string,
+  entityUuid: string,
+  predicate: (e: ExecRow) => boolean,
+): Promise<ExecRow | null> {
+  const { executions } = await agentGet<{ executions: ExecRow[] }>(
+    `/api/daemon/executions`,
+    apiKey,
+  );
+  return executions.find((e) => e.entityUuid === entityUuid && predicate(e)) ?? null;
+}
+
+// --- controllable fake for `runtime.agent` (the ONLY mocked seam) ---
+
+interface FakeRunHandle {
+  params: RunEmbeddedAgentParams;
+  finish: (visibleText?: string) => void;
+}
+
+function makeFakeAgent() {
+  const runs: FakeRunHandle[] = [];
+  let invocationCount = 0;
+
+  const agent: OpenClawRuntimeAgent = {
+    runEmbeddedAgent: (params: RunEmbeddedAgentParams): Promise<EmbeddedAgentRunResult> => {
+      invocationCount += 1;
+      return new Promise<EmbeddedAgentRunResult>((resolve) => {
+        let settled = false;
+        const settle = (aborted: boolean, visibleText?: string) => {
+          if (settled) return;
+          settled = true;
+          resolve({
+            meta: {
+              durationMs: 1,
+              aborted,
+              ...(visibleText ? { finalAssistantVisibleText: visibleText } : {}),
+            },
+          });
+        };
+        // Real abort relay — the daemon client's AbortController.abort() lands here.
+        if (params.abortSignal) {
+          if (params.abortSignal.aborted) settle(true);
+          else params.abortSignal.addEventListener("abort", () => settle(true), { once: true });
+        }
+        runs.push({
+          params,
+          finish: (visibleText = "fake-assistant-reply") => {
+            void (params.onBlockReply?.({ text: visibleText, isReasoning: false }) as
+              | Promise<void>
+              | void);
+            setTimeout(() => settle(false, visibleText), 60);
+          },
+        });
+      });
+    },
+    resolveAgentDir: () => "/tmp/fake-agent-dir",
+    resolveAgentWorkspaceDir: () => "/tmp/fake-workspace",
+    resolveAgentTimeoutMs: () => 60_000,
+    session: {
+      getSessionEntry: ({ sessionKey }) => ({
+        sessionId: `oc-${sessionKey}`,
+        sessionFile: `/tmp/sessions/${sessionKey}.jsonl`,
+      }),
+      resolveSessionFilePath: (sessionId) => `/tmp/sessions/${sessionId}.jsonl`,
+    },
+  };
+
+  return { agent, runs, invocations: () => invocationCount };
+}
+
+function makeLogger() {
+  const lines: string[] = [];
+  return {
+    lines,
+    info: (m: string) => lines.push(`INFO  ${m}`),
+    warn: (m: string) => lines.push(`WARN  ${m}`),
+    error: (m: string) => lines.push(`ERROR ${m}`),
+  };
+}
+
+// --- harness: wire the plugin exactly like src/index.ts, live, with the fake agent ---
+
+interface Harness {
+  connectionState: ConnectionState;
+  daemonClient: OpenClawDaemonClient;
+  onControl: (e: SseControlEvent) => void;
+  sse: ChorusSseListener;
+  fake: ReturnType<typeof makeFakeAgent>;
+  logger: ReturnType<typeof makeLogger>;
+  connectionUuid: () => string | null;
+  /** Drop live control events (simulates a lost SSE ping) while true. */
+  setControlDeaf: (deaf: boolean) => void;
+}
+
+async function buildHarness(apiKey: string): Promise<Harness> {
+  const logger = makeLogger();
+  const connectionState = new ConnectionState();
+  const fake = makeFakeAgent();
+
+  const restClient = createDaemonRestClient({
+    url: BASE_URL!,
+    apiKey,
+    getConnectionUuid: () => connectionState.getConnectionUuid(),
+    logger,
+  });
+
+  let daemonClient: OpenClawDaemonClient;
+  const redispatch = (req: WakeRequest): void => {
+    void daemonClient.runWake(req);
+  };
+  daemonClient = new OpenClawDaemonClient({
+    restClient,
+    resolveRunContext: () => ({
+      agent: fake.agent,
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      config: {},
+      workspaceDir: "/tmp/fake-workspace",
+      timeoutMs: 60_000,
+      modelRef: null,
+    }),
+    redispatch,
+    buildTurnPrompt: (turn: DaemonPendingTurn) =>
+      turn.promptText && turn.promptText.trim()
+        ? `[Chorus] instruction:\n\n${turn.promptText}`
+        : `[Chorus] new instruction in session ${turn.sessionId}`,
+    logger,
+  });
+
+  const controlHooks: ControlBehaviorHooks = daemonClient.controlHooks;
+  const realOnControl = createControlHandler({ connectionState, hooks: controlHooks, logger });
+  // A deaf toggle that drops live control events — the faithful simulation of a LOST
+  // deliver_turn SSE ping (the connection stays online server-side; the daemon simply
+  // never observed the ping). The persisted pending turn is then recovered by the
+  // reconnect-backfill, NOT by the live path.
+  let controlDeaf = false;
+  const onControl = (e: SseControlEvent): void => {
+    if (controlDeaf) {
+      logger.info(`[test] dropped live control event (deaf): ${e.command ?? e.type}`);
+      return;
+    }
+    realOnControl(e);
+  };
+
+  const sse = new ChorusSseListener({
+    chorusUrl: BASE_URL!,
+    apiKey,
+    logger,
+    onEvent: () => {},
+    onConnectionId: (uuid) => connectionState.setConnectionUuid(uuid),
+    onControl,
+    onReconnect: async () => {
+      await daemonClient.onReconnect();
+    },
+  });
+
+  await sse.connect();
+  const got = await waitFor(async () => connectionState.getConnectionUuid(), 8000, 100);
+  if (!got) throw new Error("never received connection_registered from server");
+
+  return {
+    connectionState,
+    daemonClient,
+    onControl,
+    sse,
+    fake,
+    logger,
+    connectionUuid: () => connectionState.getConnectionUuid(),
+    setControlDeaf: (deaf: boolean) => {
+      controlDeaf = deaf;
+    },
+  };
+}
+
+// Create an ad-hoc daemon session pinned to `connUuid`, returning its ids. The first
+// human_instruction turn it creates is consumed by the first runWake's turn-advance.
+async function createAdHocSession(
+  agentUuid: string,
+  connUuid: string,
+  instructionText: string,
+): Promise<{ sessionUuid: string; sessionId: string }> {
+  const { session } = await userPost<{ session: { uuid: string; sessionId: string } }>(
+    `/api/daemon-sessions/ad-hoc`,
+    { agentUuid, connectionUuid: connUuid, instructionText },
+  );
+  return { sessionUuid: session.uuid, sessionId: session.sessionId };
+}
+
+interface Provisioned {
+  companyUuid: string;
+  userUuid: string;
+  agentUuid: string;
+  apiKey: string;
+}
+
+let prov: Provisioned;
+
+describe.skipIf(!RUN)("OpenClaw daemon loop — live integration against local Chorus", () => {
+  beforeAll(async () => {
+    const { companyUuid, userUuid } = await adminLogin();
+    // admin_agent → carries `task:admin`. The daemon reports its OWN interrupt/resume
+    // with its agent key, and the reverse-control authz rule (daemon-control.service
+    // `authorizeConnectionControl`) requires `actorUuid === agent.ownerUuid` OR
+    // `task:admin`. The agent's owner is the human user (not the agent itself), so a
+    // daemon agent MUST hold `task:admin` to record its own interrupt outcome. This is
+    // a real protocol requirement surfaced by this integration test.
+    const agent = await userPost<{ uuid: string }>("/api/agents", {
+      name: `OpenClaw E2E ${Date.now()}`,
+      roles: ["admin_agent"],
+    });
+    const key = await userPost<{ key: string }>("/api/api-keys", {
+      agentUuid: agent.uuid,
+      name: "e2e",
+    });
+    prov = { companyUuid, userUuid, agentUuid: agent.uuid, apiKey: key.key };
+  }, 30_000);
+
+  // ---- AC1 ----------------------------------------------------------------
+  it("AC1: wake reports running→ended, surfaces an execution row, and a readable transcript", async () => {
+    const h = await buildHarness(prov.apiKey);
+    try {
+      const connUuid = h.connectionUuid()!;
+      expect(connUuid).toMatch(/[0-9a-f-]{36}/);
+
+      // Real ad-hoc session creation: server creates a DaemonSession (origin = our
+      // connection) + a pending human_instruction turn (and fires a deliver_turn ping
+      // we ignore for this AC — we drive the wake explicitly for determinism).
+      const { sessionUuid, sessionId } = await createAdHocSession(
+        prov.agentUuid,
+        connUuid,
+        "ac1 setup",
+      );
+
+      // Drive a real wake. The daemon client POSTs (all to the LIVE server):
+      //   turn-advance(running) → advances the pending turn
+      //   execution-state → upserts a running DaemonExecution (daemon_session/sessionId)
+      //   transcript (onBlockReply) → appends assistant text
+      //   turn-advance(ended) on completion
+      const runP = h.daemonClient.runWake({
+        prompt: "do the thing",
+        contextKey: "ac1",
+        entityType: "daemon_session",
+        entityUuid: sessionId,
+        directIdeaUuid: null,
+      });
+
+      const running = await waitFor(() =>
+        findExecution(prov.apiKey, sessionId, (e) => e.status === "running"),
+      );
+      expect(running, `running execution row for daemon_session ${sessionId}`).toBeTruthy();
+
+      // Finish the run (emits a finalized assistant block first).
+      await waitFor(async () => (h.fake.runs.length > 0 ? true : null));
+      h.fake.runs[0].finish("hello from the fake agent");
+      await runP;
+
+      // Transcript readable via the REAL server (daemon-session detail read).
+      const detail = await waitFor(async () => {
+        const d = await userGet<{
+          turns: Array<{ messages: Array<{ role: string; text: string }> }>;
+        }>(`/api/daemon-sessions/${sessionUuid}`);
+        const hit = d.turns.some((t) =>
+          t.messages.some((m) => m.role === "assistant" && m.text.includes("hello from the fake")),
+        );
+        return hit ? d : null;
+      });
+      expect(detail, "assistant transcript readable via server").toBeTruthy();
+
+      // After completion the active row is gone (ended via reconcile) — verify it is no
+      // longer reported as running.
+      const stillRunning = await findExecution(
+        prov.apiKey,
+        sessionId,
+        (e) => e.status === "running",
+      );
+      expect(stillRunning, "execution no longer running after ended").toBeNull();
+    } finally {
+      h.sse.disconnect();
+    }
+  }, 45_000);
+
+  // ---- AC2 ----------------------------------------------------------------
+  it("AC2: control interrupt stops the in-flight run (interrupted reason=user); resume continues the SAME session", async () => {
+    const h = await buildHarness(prov.apiKey);
+    try {
+      const connUuid = h.connectionUuid()!;
+      const { sessionId } = await createAdHocSession(prov.agentUuid, connUuid, "ac2 setup");
+
+      // Start a long-running wake — the fake run only ends on abort.
+      const runP = h.daemonClient.runWake({
+        prompt: "long task",
+        contextKey: "ac2",
+        entityType: "daemon_session",
+        entityUuid: sessionId,
+        directIdeaUuid: null,
+      });
+
+      const running = await waitFor(() =>
+        findExecution(prov.apiKey, sessionId, (e) => e.status === "running"),
+      );
+      expect(running, "run is in-flight (server shows running)").toBeTruthy();
+      await waitFor(async () => (h.fake.runs.length > 0 ? true : null));
+      const firstSessionKey = h.fake.runs[0].params.sessionKey;
+
+      // REAL interrupt via the server (the UI "Stop" path; admin user owns the agent).
+      // Server publishes control:{connUuid} → our SSE → control-handler double-check →
+      // daemon client aborts the in-flight run → report-interrupt(reason=user).
+      await userPost(`/api/daemon/control`, {
+        command: "interrupt",
+        targetConnectionUuid: connUuid,
+        entityType: "daemon_session",
+        entityUuid: sessionId,
+      });
+
+      // The in-flight run must actually stop (resolves because the abort fired).
+      await runP;
+
+      const interrupted = await waitFor(() =>
+        findExecution(
+          prov.apiKey,
+          sessionId,
+          (e) => e.status === "interrupted" && e.interruptedReason === "user",
+        ),
+      );
+      expect(interrupted, "execution interrupted with reason=user (server-side)").toBeTruthy();
+
+      // RESUME via the server. resumeExecution requires an interrupted/user row (just
+      // verified). It flips the row back to running and emits a resume control event →
+      // control-handler → re-dispatch → a NEW run on the SAME session key (continuity).
+      const runsBefore = h.fake.runs.length;
+      await userPost(`/api/daemon/resume`, {
+        connectionUuid: connUuid,
+        entityType: "daemon_session",
+        entityUuid: sessionId,
+      });
+
+      const resumed = await waitFor(
+        async () => (h.fake.runs.length > runsBefore ? true : null),
+        10_000,
+      );
+      expect(resumed, "resume re-dispatched a new run").toBeTruthy();
+      const resumeRun = h.fake.runs[h.fake.runs.length - 1];
+      // Same-session continuity: the resumed run derives the SAME sessionKey as the
+      // original (both come from the same business key → deriveSessionKey is stable).
+      expect(resumeRun.params.sessionKey).toBe(firstSessionKey);
+      resumeRun.finish("resumed-ok");
+    } finally {
+      h.sse.disconnect();
+    }
+  }, 60_000);
+
+  // ---- AC3 ----------------------------------------------------------------
+  it("AC3: live deliver_turn runs an instruction once; a turn created during disconnect is recovered by backfill at most once", async () => {
+    const h = await buildHarness(prov.apiKey);
+    try {
+      const connUuid = h.connectionUuid()!;
+      // Ad-hoc create ALSO fires a deliver_turn ping for its first turn — so creating
+      // the session is itself the first live-delivery event. Wait for it to run once.
+      const invStart = h.fake.invocations();
+      const { sessionUuid } = await createAdHocSession(
+        prov.agentUuid,
+        connUuid,
+        "first live instruction",
+      );
+
+      const ranLive = await waitFor(
+        async () => (h.fake.invocations() > invStart ? true : null),
+        10_000,
+      );
+      expect(ranLive, "live deliver_turn ran the first instruction").toBeTruthy();
+      const invAfterLive = h.fake.invocations();
+      for (const r of h.fake.runs) r.finish("ack");
+      await sleep(200);
+
+      // At-most-once across a reconnect backfill: the already-run turn is no longer
+      // pending server-side AND the daemon's seen-set blocks a re-run. Trigger the
+      // reconnect backfill path directly and assert no new invocation.
+      await h.daemonClient.onReconnect();
+      await sleep(600);
+      expect(
+        h.fake.invocations(),
+        "backfill did not re-run the already-delivered turn",
+      ).toBe(invAfterLive);
+
+      // Recovery of a turn whose LIVE deliver_turn ping was LOST:
+      //  (1) go "control-deaf" — the SSE stays connected and the connection stays
+      //      ONLINE server-side (so the instruction is accepted), but the live
+      //      deliver_turn control ping is dropped, exactly as a lost SSE frame would be.
+      //  (2) send a new instruction → server persists a pending turn + fires a ping the
+      //      deaf listener drops → the turn is NEVER run by the live path.
+      //  (3) run the reconnect-backfill (onReconnect) → reads pending-turns (origin-
+      //      pinned to our SAME connection) → runs the missed turn.
+      //  (4) exactly once.
+      h.setControlDeaf(true);
+      const invBeforeMissed = h.fake.invocations();
+      await userPost(`/api/daemon-sessions/${sessionUuid}/instruction`, {
+        instructionText: "instruction whose live ping is lost",
+      });
+      // Give the (dropped) live ping time to NOT run it.
+      await sleep(800);
+      expect(
+        h.fake.invocations(),
+        "lost-ping instruction was NOT run live (ping dropped)",
+      ).toBe(invBeforeMissed);
+
+      // Backfill recovery (re-enable control first so a recovered run can settle).
+      h.setControlDeaf(false);
+      await h.daemonClient.onReconnect();
+      const recovered = await waitFor(
+        async () => (h.fake.invocations() > invBeforeMissed ? true : null),
+        10_000,
+      );
+      expect(recovered, "reconnect-backfill recovered the missed (lost-ping) turn").toBeTruthy();
+      const invAfterRecover = h.fake.invocations();
+      for (const r of h.fake.runs) r.finish("ack2");
+
+      // At-most-once: a second backfill sweep must NOT re-run it (shared seen-set +
+      // server no longer lists it as pending).
+      await h.daemonClient.onReconnect();
+      await sleep(600);
+      expect(h.fake.invocations(), "backfill is at-most-once on re-sweep").toBe(
+        invAfterRecover,
+      );
+    } finally {
+      h.sse.disconnect();
+    }
+  }, 75_000);
+});

--- a/packages/openclaw-plugin/src/__tests__/daemon-rest-client.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/daemon-rest-client.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from "vitest";
+import { createDaemonRestClient } from "../daemon-rest-client.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+/** A fetch fake that records calls and returns a configurable response. */
+function makeFetch(impl?: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    if (impl) return impl(url, init);
+    return new Response(JSON.stringify({ success: true }), { status: 200 });
+  });
+  return { fetchImpl: fetchImpl as unknown as typeof fetch, calls };
+}
+
+const BASE = { url: "https://chorus.example.com/", apiKey: "cho_test" };
+
+describe("createDaemonRestClient — payload shapes (single source of truth)", () => {
+  it("turnAdvance POSTs { connectionUuid, sessionId, status } + entity link + Bearer auth", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = createDaemonRestClient({
+      ...BASE,
+      getConnectionUuid: () => "conn-1",
+      fetchImpl,
+      logger: makeLogger(),
+    });
+    const res = await client.turnAdvance({
+      sessionId: "idea-9",
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-3",
+    });
+    expect(res.ok).toBe(true);
+    expect(calls[0].url).toBe("https://chorus.example.com/api/daemon/turn-advance");
+    expect((calls[0].init as RequestInit).method).toBe("POST");
+    const headers = (calls[0].init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer cho_test");
+    expect(JSON.parse((calls[0].init as RequestInit).body as string)).toEqual({
+      connectionUuid: "conn-1",
+      sessionId: "idea-9",
+      status: "running",
+      entityType: "task",
+      entityUuid: "task-3",
+    });
+  });
+
+  it("turnAdvance omits the entity link when either field is missing", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "conn-1", fetchImpl });
+    await client.turnAdvance({ sessionId: "s", status: "ended" });
+    expect(JSON.parse((calls[0].init as RequestInit).body as string)).toEqual({
+      connectionUuid: "conn-1",
+      sessionId: "s",
+      status: "ended",
+    });
+  });
+
+  it("transcript POSTs { sessionId, messages } and needs no connectionUuid", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => null, fetchImpl });
+    const res = await client.transcript({
+      sessionId: "idea-9",
+      messages: [{ role: "assistant", text: "hi" }],
+    });
+    expect(res.ok).toBe(true);
+    expect(calls[0].url).toBe("https://chorus.example.com/api/daemon/transcript");
+    expect(JSON.parse((calls[0].init as RequestInit).body as string)).toEqual({
+      sessionId: "idea-9",
+      messages: [{ role: "assistant", text: "hi" }],
+    });
+  });
+
+  it("executionState POSTs { connectionUuid, executions } in the server row shape", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "conn-1", fetchImpl });
+    await client.executionState({
+      executions: [
+        { entityType: "task", entityUuid: "task-3", rootIdeaUuid: "idea-root", status: "running", startedAt: "2026-06-20T00:00:00Z" },
+      ],
+    });
+    expect(calls[0].url).toBe("https://chorus.example.com/api/daemon/execution-state");
+    expect(JSON.parse((calls[0].init as RequestInit).body as string)).toEqual({
+      connectionUuid: "conn-1",
+      executions: [
+        { entityType: "task", entityUuid: "task-3", rootIdeaUuid: "idea-root", status: "running", startedAt: "2026-06-20T00:00:00Z" },
+      ],
+    });
+  });
+
+  it("reportInterrupt POSTs { connectionUuid, entityType, entityUuid, reason }", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "conn-1", fetchImpl });
+    await client.reportInterrupt({ entityType: "task", entityUuid: "task-3", reason: "user" });
+    expect(calls[0].url).toBe("https://chorus.example.com/api/daemon/report-interrupt");
+    expect(JSON.parse((calls[0].init as RequestInit).body as string)).toEqual({
+      connectionUuid: "conn-1",
+      entityType: "task",
+      entityUuid: "task-3",
+      reason: "user",
+    });
+  });
+
+  it("readPendingTurns GETs ?connectionUuid=… and unwraps { data: { turns } }", async () => {
+    const { fetchImpl, calls } = makeFetch(() =>
+      new Response(JSON.stringify({ success: true, data: { turns: [{ turnUuid: "t1", sessionId: "s", directIdeaUuid: null, trigger: "human_instruction", promptText: "do it" }] } }), { status: 200 }),
+    );
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "conn-1", fetchImpl });
+    const res = await client.readPendingTurns();
+    expect(res.ok).toBe(true);
+    expect(calls[0].url).toBe("https://chorus.example.com/api/daemon/pending-turns?connectionUuid=conn-1");
+    expect(res.data?.turns[0].turnUuid).toBe("t1");
+  });
+});
+
+describe("createDaemonRestClient — no-silent-errors + connectionUuid guard", () => {
+  it("skips connection-scoped ops (and logs turnAdvance/reportInterrupt) when no connection uuid", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const logger = makeLogger();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => null, fetchImpl, logger });
+
+    const ta = await client.turnAdvance({ sessionId: "s", status: "running" });
+    const es = await client.executionState({ executions: [] });
+    const ri = await client.reportInterrupt({ entityType: "task", entityUuid: "t", reason: "crash" });
+    const pt = await client.readPendingTurns();
+
+    expect(ta.skipped).toBe(true);
+    expect(es.skipped).toBe(true);
+    expect(ri.skipped).toBe(true);
+    expect(pt.skipped).toBe(true);
+    expect(calls.length).toBe(0); // no HTTP issued
+    // turnAdvance + reportInterrupt log their skip (an unexpected absence); executionState
+    // + readPendingTurns skip silently (a normal early state).
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("no connection uuid yet"));
+  });
+
+  it("surfaces a non-2xx with status (logged, not swallowed) and never rejects", async () => {
+    const { fetchImpl } = makeFetch(() => new Response("nope", { status: 500 }));
+    const logger = makeLogger();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "c", fetchImpl, logger });
+    const res = await client.turnAdvance({ sessionId: "s", status: "running" });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(500);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("turn-advance returned 500"));
+  });
+
+  it("surfaces a network error with cause (logged) and never rejects", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const logger = makeLogger();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "c", fetchImpl, logger });
+    const res = await client.transcript({ sessionId: "s", messages: [{ role: "user", text: "x" }] });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("transcript upload request failed"));
+  });
+
+  it("surfaces a missing turns array as a failure (no silent empty success)", async () => {
+    const { fetchImpl } = makeFetch(() => new Response(JSON.stringify({ success: true, data: {} }), { status: 200 }));
+    const logger = makeLogger();
+    const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "c", fetchImpl, logger });
+    const res = await client.readPendingTurns();
+    expect(res.ok).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("no turns array"));
+  });
+});

--- a/packages/openclaw-plugin/src/__tests__/event-router.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/event-router.test.ts
@@ -56,6 +56,22 @@ describe("ChorusEventRouter.dispatch", () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('"count_update" ignored'));
   });
 
+  it("drops connection_registered SILENTLY (no wake, never logged as ignored)", () => {
+    const { router } = build({});
+    // Defense-in-depth: even if the listener fork were bypassed, the router must
+    // not treat connection_registered as an unhandled/ignored event.
+    router.dispatch({ type: "connection_registered", connectionUuid: "c1" } as unknown as SseNotificationEvent);
+    expect(wake).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("ignored"));
+  });
+
+  it("drops a type:control event SILENTLY (no wake, never logged as ignored)", () => {
+    const { router } = build({});
+    router.dispatch({ type: "control", command: "interrupt" } as unknown as SseNotificationEvent);
+    expect(wake).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("ignored"));
+  });
+
   it("warns and skips when notificationUuid is missing", () => {
     const { router } = build({});
     router.dispatch({ type: "new_notification" } as SseNotificationEvent);
@@ -127,5 +143,63 @@ describe("ChorusEventRouter.dispatch", () => {
     await flush();
     expect(wake).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Could not fetch notifications"));
+  });
+});
+
+describe("ChorusEventRouter — wake attribution (daemon parity)", () => {
+  let wake: ReturnType<typeof vi.fn>;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(() => {
+    wake = vi.fn();
+    logger = makeLogger();
+  });
+
+  function build(responses: Record<string, unknown>, lineage?: { resolve: ReturnType<typeof vi.fn> }) {
+    const mcpClient = makeMcpClient(responses) as never;
+    const router = new ChorusEventRouter({ mcpClient, wake, logger, lineage: lineage as never });
+    return { router };
+  }
+
+  it("resolves lineage and threads { entity*, rootIdeaUuid, directIdeaUuid } as the wake attribution", async () => {
+    const resolve = vi.fn(async () => ({ rootIdeaUuid: "root-1", directIdeaUuid: "direct-1" }));
+    const { router } = build(
+      { chorus_get_notifications: { notifications: [makeNotification()] } },
+      { resolve },
+    );
+    router.dispatch({ type: "new_notification", notificationUuid: "n1" } as SseNotificationEvent);
+    await flush();
+
+    expect(resolve).toHaveBeenCalledWith(expect.objectContaining({ entityType: "task", entityUuid: "task-1" }));
+    const attribution = wake.mock.calls[0][2];
+    expect(attribution).toEqual({
+      entityType: "task",
+      entityUuid: "task-1",
+      rootIdeaUuid: "root-1",
+      directIdeaUuid: "direct-1",
+    });
+  });
+
+  it("falls back to entity-only attribution when lineage resolve throws (wake not lost)", async () => {
+    const resolve = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const { router } = build(
+      { chorus_get_notifications: { notifications: [makeNotification()] } },
+      { resolve },
+    );
+    router.dispatch({ type: "new_notification", notificationUuid: "n1" } as SseNotificationEvent);
+    await flush();
+
+    expect(wake).toHaveBeenCalledOnce();
+    expect(wake.mock.calls[0][2]).toEqual({ entityType: "task", entityUuid: "task-1" });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Lineage resolve failed"));
+  });
+
+  it("threads entity-only attribution when no lineage resolver is wired", async () => {
+    const { router } = build({ chorus_get_notifications: { notifications: [makeNotification()] } });
+    router.dispatch({ type: "new_notification", notificationUuid: "n1" } as SseNotificationEvent);
+    await flush();
+    expect(wake.mock.calls[0][2]).toEqual({ entityType: "task", entityUuid: "task-1" });
   });
 });

--- a/packages/openclaw-plugin/src/__tests__/lineage.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/lineage.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { LineageResolver } from "../lineage.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeFetch(impl: (url: string) => Response | Promise<Response>) {
+  const calls: string[] = [];
+  const fetchImpl = vi.fn(async (url: string) => {
+    calls.push(url);
+    return impl(url);
+  });
+  return { fetchImpl: fetchImpl as unknown as typeof fetch, calls };
+}
+
+describe("LineageResolver", () => {
+  it("resolves { rootIdeaUuid, directIdeaUuid } from the root-idea endpoint with Bearer auth", async () => {
+    const { fetchImpl, calls } = makeFetch(() =>
+      new Response(JSON.stringify({ success: true, data: { rootIdeaUuid: "root-1", directIdeaUuid: "direct-1", resolvedVia: "task" } }), { status: 200 }),
+    );
+    const r = new LineageResolver({ url: "https://chorus.example.com/", apiKey: "cho_x", fetchImpl });
+    const out = await r.resolve({ entityType: "task", entityUuid: "task-9" });
+    expect(out).toEqual({ rootIdeaUuid: "root-1", directIdeaUuid: "direct-1" });
+    expect(calls[0]).toBe("https://chorus.example.com/api/entities/task/task-9/root-idea");
+  });
+
+  it("caches per entity (single-flights repeats)", async () => {
+    const { fetchImpl, calls } = makeFetch(() =>
+      new Response(JSON.stringify({ success: true, data: { rootIdeaUuid: "root-1", directIdeaUuid: "direct-1" } }), { status: 200 }),
+    );
+    const r = new LineageResolver({ url: "https://x", apiKey: "k", fetchImpl });
+    await r.resolve({ entityType: "task", entityUuid: "t" });
+    await r.resolve({ entityType: "task", entityUuid: "t" });
+    expect(calls.length).toBe(1);
+  });
+
+  it("short-circuits daemon_session (no idea ancestor) without a round-trip", async () => {
+    const { fetchImpl, calls } = makeFetch(() => new Response("{}", { status: 200 }));
+    const r = new LineageResolver({ url: "https://x", apiKey: "k", fetchImpl });
+    const out = await r.resolve({ entityType: "daemon_session", entityUuid: "s-1" });
+    expect(out).toEqual({ rootIdeaUuid: null, directIdeaUuid: null });
+    expect(calls.length).toBe(0);
+  });
+
+  it("returns both null on a non-2xx (caller falls back to a per-entity key)", async () => {
+    const logger = makeLogger();
+    const { fetchImpl } = makeFetch(() => new Response("err", { status: 500 }));
+    const r = new LineageResolver({ url: "https://x", apiKey: "k", fetchImpl, logger });
+    const out = await r.resolve({ entityType: "task", entityUuid: "t" });
+    expect(out).toEqual({ rootIdeaUuid: null, directIdeaUuid: null });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("server returned 500"));
+  });
+
+  it("tolerates a missing directIdeaUuid (older server) as null", async () => {
+    const { fetchImpl } = makeFetch(() =>
+      new Response(JSON.stringify({ success: true, data: { rootIdeaUuid: "root-1" } }), { status: 200 }),
+    );
+    const r = new LineageResolver({ url: "https://x", apiKey: "k", fetchImpl });
+    expect(await r.resolve({ entityType: "task", entityUuid: "t" })).toEqual({
+      rootIdeaUuid: "root-1",
+      directIdeaUuid: null,
+    });
+  });
+});

--- a/packages/openclaw-plugin/src/__tests__/sse-listener.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/sse-listener.test.ts
@@ -173,6 +173,135 @@ describe("ChorusSseListener", () => {
     listener.disconnect();
   });
 
+  it("forks connection_registered to onConnectionId and NOT to onEvent", async () => {
+    const events: unknown[] = [];
+    const connIds: string[] = [];
+    const payload = JSON.stringify({ type: "connection_registered", connectionUuid: "conn-42" });
+    vi.stubGlobal("fetch", vi.fn(async () => streamingResponse([`data: ${payload}\n\n`])));
+
+    const listener = new ChorusSseListener({
+      chorusUrl: "https://c.example.com",
+      apiKey: "cho_x",
+      logger: makeLogger(),
+      onEvent: (e) => events.push(e),
+      onConnectionId: (id) => connIds.push(id),
+      onReconnect: async () => {},
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(connIds).toEqual(["conn-42"]);
+    // connection_registered MUST NOT enter the wake path.
+    expect(events).toEqual([]);
+    listener.disconnect();
+  });
+
+  it("refreshes the connectionUuid on reconnect (new connection_registered overwrites)", async () => {
+    vi.useFakeTimers();
+    const connIds: string[] = [];
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        call++;
+        const uuid = call === 1 ? "conn-old" : "conn-new";
+        // First stream ends (triggers reconnect); second stream gives a new uuid.
+        return streamingResponse([`data: ${JSON.stringify({ type: "connection_registered", connectionUuid: uuid })}\n\n`]);
+      }),
+    );
+
+    const listener = new ChorusSseListener({
+      chorusUrl: "https://c.example.com",
+      apiKey: "cho_x",
+      logger: makeLogger(),
+      onEvent: () => {},
+      onConnectionId: (id) => connIds.push(id),
+      onReconnect: async () => {},
+    });
+    await listener.connect(); // first stream → conn-old, then ends → schedule reconnect
+    await vi.advanceTimersByTimeAsync(0); // flush stream microtasks
+    await vi.advanceTimersByTimeAsync(1000); // backoff fires reconnect → conn-new
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(connIds).toEqual(["conn-old", "conn-new"]);
+    listener.disconnect();
+  });
+
+  it("forks a type:control event to onControl and NOT to onEvent (never a wake)", async () => {
+    const events: unknown[] = [];
+    const controls: unknown[] = [];
+    const payload = JSON.stringify({
+      type: "control",
+      command: "interrupt",
+      targetConnectionUuid: "conn-42",
+      entityType: "task",
+      entityUuid: "task-1",
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => streamingResponse([`data: ${payload}\n\n`])));
+
+    const listener = new ChorusSseListener({
+      chorusUrl: "https://c.example.com",
+      apiKey: "cho_x",
+      logger: makeLogger(),
+      onEvent: (e) => events.push(e),
+      onControl: (e) => controls.push(e),
+      onReconnect: async () => {},
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(controls).toHaveLength(1);
+    expect((controls[0] as { command: string }).command).toBe("interrupt");
+    // The control event MUST NOT fall through to the wake path.
+    expect(events).toEqual([]);
+    listener.disconnect();
+  });
+
+  it("a control event forked while a new_notification arrives keeps the notification on onEvent", async () => {
+    const events: unknown[] = [];
+    const controls: unknown[] = [];
+    const control = JSON.stringify({ type: "control", command: "resume", targetConnectionUuid: "c", entityType: "idea", entityUuid: "i" });
+    const notif = JSON.stringify({ type: "new_notification", notificationUuid: "n1" });
+    vi.stubGlobal("fetch", vi.fn(async () => streamingResponse([`data: ${control}\n\n`, `data: ${notif}\n\n`])));
+
+    const listener = new ChorusSseListener({
+      chorusUrl: "https://c.example.com",
+      apiKey: "cho_x",
+      logger: makeLogger(),
+      onEvent: (e) => events.push(e),
+      onControl: (e) => controls.push(e),
+      onReconnect: async () => {},
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(controls).toHaveLength(1);
+    expect(events).toEqual([{ type: "new_notification", notificationUuid: "n1" }]);
+    listener.disconnect();
+  });
+
+  it("an onControl callback that throws is caught and warned (never crashes the stream)", async () => {
+    const logger = makeLogger();
+    const payload = JSON.stringify({ type: "control", command: "interrupt", targetConnectionUuid: "c" });
+    vi.stubGlobal("fetch", vi.fn(async () => streamingResponse([`data: ${payload}\n\n`])));
+
+    const listener = new ChorusSseListener({
+      chorusUrl: "https://c.example.com",
+      apiKey: "cho_x",
+      logger,
+      onEvent: () => {},
+      onControl: () => {
+        throw new Error("handler boom");
+      },
+      onReconnect: async () => {},
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("onControl callback error"));
+    listener.disconnect();
+  });
+
   it("re-sends the same self-report params on reconnect", async () => {
     vi.useFakeTimers();
     let call = 0;

--- a/packages/openclaw-plugin/src/connection-state.ts
+++ b/packages/openclaw-plugin/src/connection-state.ts
@@ -1,0 +1,66 @@
+// packages/openclaw-plugin/src/connection-state.ts
+// Holds the live DaemonConnection identity for this OpenClaw plugin process —
+// the `connectionUuid` the server assigns post-handshake and reports via the
+// `connection_registered` SSE data event (see api/events/notifications/route.ts).
+//
+// WHY A DEDICATED MODULE: the connectionUuid is captured in ONE place (the SSE
+// listener, via onConnectionId) but READ in several (the daemon REST client to
+// attribute execution-state / turn-advance, and the control handler to do its
+// `targetConnectionUuid === my uuid` double-check). Threading it through every
+// constructor would couple those modules to the listener's lifecycle; instead
+// the listener writes it here and the consumers read it through a stable
+// `getConnectionUuid()` accessor — the same accessor shape the shared
+// `daemon-rest-client` already expects (`getConnectionUuid?: () => string|null`).
+//
+// The value is refreshed on every `connection_registered` (so a reconnect that
+// registers a NEW DaemonConnection overwrites the stale uuid), and is the single
+// source of truth for "which connection am I" across the plugin.
+//
+// This mirrors the CLI host's `SseListener.connectionUuid` field
+// (cli/sse-listener.mjs), lifted into a module so the OpenClaw plugin's separate
+// modules can share one identity without a circular import on the listener.
+
+/**
+ * A read accessor for the live connection identity. This is the exact shape the
+ * shared `daemon-rest-client` (`getConnectionUuid?: () => string|null`) and the
+ * control handler consume, so a single `ConnectionState` instance can be passed
+ * to both.
+ */
+export interface ConnectionStateReader {
+  /** The connection uuid this stream registered as, or null before handshake. */
+  getConnectionUuid: () => string | null;
+}
+
+/**
+ * Mutable connection identity. One instance per plugin process; the SSE
+ * listener's `onConnectionId` writes it, the rest client + control handler read
+ * it. Not a singleton export — the entry owns the instance and injects it — so
+ * tests can construct an isolated state per case.
+ */
+export class ConnectionState implements ConnectionStateReader {
+  private connectionUuid: string | null = null;
+
+  /** The current connection identity, or null before the first handshake. */
+  getConnectionUuid(): string | null {
+    return this.connectionUuid;
+  }
+
+  /**
+   * Record (or refresh) the connection identity. Called from the SSE listener's
+   * `onConnectionId` on every `connection_registered` event, so a reconnect that
+   * registers a new DaemonConnection overwrites the previous uuid rather than
+   * leaving a stale one that could mis-route a control command.
+   */
+  setConnectionUuid(connectionUuid: string): void {
+    this.connectionUuid = connectionUuid;
+  }
+
+  /**
+   * Forget the connection identity (e.g. on a clean disconnect). After this,
+   * `getConnectionUuid()` returns null so the control handler's double-check
+   * treats every command as "not ours" until a fresh handshake re-registers.
+   */
+  clear(): void {
+    this.connectionUuid = null;
+  }
+}

--- a/packages/openclaw-plugin/src/control-handler.ts
+++ b/packages/openclaw-plugin/src/control-handler.ts
@@ -1,0 +1,219 @@
+// packages/openclaw-plugin/src/control-handler.ts
+// OpenClaw-host handler for reverse (server→daemon) control commands — the
+// in-process analog of cli/control-handler.mjs. The SSE listener forks a
+// `type:"control"` SSE event here (NOT to the wake router — see sse-listener.ts),
+// so a control command can NEVER spawn a new embedded-agent run for the control
+// event itself. This module is the ROUTING + DOUBLE-CHECK layer only; the actual
+// abort / re-dispatch / pending-turns-sweep BEHAVIORS are injected (filled by the
+// openclaw-daemon-client task, T4).
+//
+// The single safety property this module enforces is the DOUBLE-CHECK, identical
+// to the CLI host (cli/control-handler.mjs): act ONLY when —
+//   Check 1 (every command): event.targetConnectionUuid === this plugin's OWN
+//            registered connectionUuid (from connection-state). On mismatch — a
+//            stale/recycled uuid, another connection's command, or a handshake not
+//            yet complete — IGNORE + LOG. This is what stops a recycled connection
+//            uuid from aborting the wrong run (Tech Design "Risks": mis-kill after
+//            a reconnect).
+//   Check 2 (interrupt only): the injected `isEntityRunning(entityType, entityUuid)`
+//            predicate returns true — i.e. this plugin currently holds a running
+//            embedded-agent run for that entity. (In the CLI host this is "the
+//            execution registry holds a running child"; here it is an injected
+//            predicate the daemon client backs with its AbortController registry.)
+//            On mismatch — only queued, never ran, or already finished — IGNORE + LOG.
+//
+// `resume` and `deliver_turn` carry NO running-entity requirement (mirroring the
+// CLI host): the run for a resumed entity is already gone, and a `deliver_turn`
+// resolves its turn by uuid from the persisted turn table. They only require
+// Check 1.
+//
+// The three verbs route to injected behavior hooks (the seams T4 plugs into):
+//   - interrupt    → onInterrupt(entityType, entityUuid)
+//   - resume       → onResume(entityType, entityUuid)
+//   - deliver_turn → onDeliverTurn(turnUuid?)   (turnUuid present = precise single
+//                    turn; absent = older server, full connection sweep fallback)
+//
+// Non-throwing: a control event must NEVER crash the SSE loop, so the whole body
+// is wrapped in a try/catch backstop and the hooks' own throws are caught + logged
+// (memory: no-silent-errors — every ignore/failure is logged, never swallowed).
+
+import type { ConnectionStateReader } from "./connection-state.js";
+
+/**
+ * The control event shape the server publishes on `control:{connectionUuid}` and
+ * forwards verbatim as a `type:"control"` SSE data event. Mirrors the server's
+ * `ControlEvent` (src/lib/event-bus.ts). `entityType`/`entityUuid` are present for
+ * `interrupt`/`resume`; `turnUuid` is present only for `deliver_turn`.
+ */
+export interface ControlEvent {
+  // `string` (not the `"control"` literal) because this is the raw forked SSE
+  // event — the handler re-validates `type === "control"` and the command enum at
+  // runtime before acting. Matches the listener's `SseControlEvent` shape so the
+  // listener can pass its parsed event straight through.
+  type: string;
+  command?: string;
+  targetConnectionUuid?: string;
+  entityType?: string;
+  entityUuid?: string;
+  turnUuid?: string;
+}
+
+/**
+ * Injected behavior hooks. These are the seams the openclaw-daemon-client task
+ * (T4) fills with the real abort / re-dispatch / pending-turns-sweep. This task
+ * (T3) only ROUTES verified commands to them — it does not implement the
+ * behaviors. All hooks are optional so a partially-wired host (or a test) can
+ * verify routing without every behavior present.
+ */
+export interface ControlBehaviorHooks {
+  /**
+   * Whether this plugin currently holds a RUNNING embedded-agent run for the
+   * entity — the OpenClaw analog of the CLI host's "execution registry holds a
+   * running child" check. Gates `interrupt` (Check 2). Defaults to "nothing is
+   * running" (always false) when absent, so an interrupt with no registry is a
+   * safe no-op rather than a blind abort.
+   */
+  isEntityRunning?: (entityType: string, entityUuid: string) => boolean;
+
+  /**
+   * Abort the matching in-flight run for the entity (true mid-run stop via the
+   * run's AbortController). Invoked only after BOTH checks pass. (T4)
+   */
+  onInterrupt?: (entityType: string, entityUuid: string) => void;
+
+  /**
+   * Re-dispatch the entity's wake to continue the same session — the synthetic
+   * "resume" wake. Invoked after Check 1 only (no running-entity requirement —
+   * the run is gone). (T4)
+   */
+  onResume?: (entityType: string, entityUuid: string) => void;
+
+  /**
+   * Run the connection-scoped pending turn(s). With a `turnUuid` (origin-only
+   * live delivery) run PRECISELY that one turn; without one (older server /
+   * reconnect) sweep all pending turns. Invoked after Check 1 only. (T4)
+   */
+  onDeliverTurn?: (turnUuid?: string) => void;
+}
+
+export interface ControlHandlerOptions {
+  /** Live connection identity (connection-state). Provides Check 1's "my uuid". */
+  connectionState: ConnectionStateReader;
+  /** Injected behavior hooks (filled by T4). */
+  hooks: ControlBehaviorHooks;
+  logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
+}
+
+/**
+ * Build the `onControl(event)` callback the SSE listener invokes for a
+ * `type:"control"` event. The returned function is synchronous and non-throwing:
+ * it performs the double-check and routes to the (injected) behavior hook,
+ * returning immediately so the SSE consumer never blocks.
+ *
+ * A control event NEVER enqueues a wake or spawns a run for the control event
+ * itself — that structural guarantee is owned by the SSE listener fork (the
+ * control event never reaches `onEvent` / the wake router) and reinforced here
+ * by routing ONLY to the abort/resume/deliver hooks, never to the wake path.
+ */
+export function createControlHandler(opts: ControlHandlerOptions): (event: ControlEvent) => void {
+  const { connectionState, hooks, logger } = opts;
+  const isEntityRunning = hooks.isEntityRunning ?? (() => false);
+
+  return function onControl(event: ControlEvent): void {
+    try {
+      if (!event || event.type !== "control") {
+        logger.warn(`[Chorus] control-handler received non-control event; ignoring`);
+        return;
+      }
+
+      if (
+        event.command !== "interrupt" &&
+        event.command !== "resume" &&
+        event.command !== "deliver_turn"
+      ) {
+        // Forward-compatible: the wire enum may grow. Unknown command → ignore + log.
+        logger.warn(`[Chorus] control command "${event.command}" not supported; ignoring`);
+        return;
+      }
+
+      const { command, targetConnectionUuid, entityType, entityUuid } = event;
+
+      // --- Check 1: connection-uuid match (applies to EVERY command) ---
+      const myConnectionUuid = connectionState.getConnectionUuid();
+      if (!myConnectionUuid || targetConnectionUuid !== myConnectionUuid) {
+        // Not ours (stale/recycled uuid, another connection, or handshake not yet
+        // complete). Ignore — never abort/resume/deliver for a command that isn't ours.
+        logger.info(
+          `[Chorus] control: ignoring ${command} for connection ${targetConnectionUuid} ` +
+            `(this plugin is ${myConnectionUuid ?? "<unregistered>"})`,
+        );
+        return;
+      }
+
+      // --- deliver_turn: origin-only live delivery. No entity on the wire (the
+      //     turn is read by uuid) and NO running-entity requirement (mirrors
+      //     resume). With a turnUuid, run PRECISELY that turn; without one (older
+      //     server), the hook falls back to a full connection sweep. ---
+      if (command === "deliver_turn") {
+        const turnUuid = typeof event.turnUuid === "string" ? event.turnUuid : undefined;
+        logger.info(
+          `[Chorus] control: deliver_turn for connection ${targetConnectionUuid} ` +
+            (turnUuid ? `(turn ${turnUuid})` : "(no turnUuid — full sweep fallback)"),
+        );
+        try {
+          hooks.onDeliverTurn?.(turnUuid);
+        } catch (err) {
+          logger.warn(`[Chorus] control: deliver_turn hook failed: ${err}`);
+        }
+        return;
+      }
+
+      // interrupt / resume both target a specific entity — require both fields.
+      if (typeof entityType !== "string" || typeof entityUuid !== "string") {
+        logger.warn(`[Chorus] control: ${command} missing entityType/entityUuid; ignoring`);
+        return;
+      }
+
+      // --- resume: re-dispatch the wake for this entity. No running-entity check —
+      //     the run is gone (it was interrupted); the wake path re-enters the same
+      //     session. Check 1 already passed. ---
+      if (command === "resume") {
+        logger.info(`[Chorus] control: resuming ${entityType}:${entityUuid} (re-dispatch wake)`);
+        try {
+          hooks.onResume?.(entityType, entityUuid);
+        } catch (err) {
+          logger.warn(
+            `[Chorus] control: resume re-dispatch failed for ${entityType}:${entityUuid}: ${err}`,
+          );
+        }
+        return;
+      }
+
+      // --- interrupt path: Check 2 — this plugin must hold a RUNNING run for the
+      //     entity. The injected predicate is backed by the daemon client's
+      //     AbortController registry (T4). ---
+      if (!isEntityRunning(entityType, entityUuid)) {
+        // Either we never ran this entity, it's only queued, or the run already
+        // finished (race: interrupt arrived after completion). Safe no-op.
+        logger.info(
+          `[Chorus] control: no running embedded-agent run for ${entityType}:${entityUuid} ` +
+            `on this plugin; ignoring interrupt`,
+        );
+        return;
+      }
+
+      // --- Both checks passed: route to the abort hook (true mid-run stop). ---
+      logger.info(`[Chorus] control: interrupting running run for ${entityType}:${entityUuid}`);
+      try {
+        hooks.onInterrupt?.(entityType, entityUuid);
+      } catch (err) {
+        logger.warn(
+          `[Chorus] control: interrupt hook failed for ${entityType}:${entityUuid}: ${err}`,
+        );
+      }
+    } catch (err) {
+      // Absolute backstop — a control event must never crash the SSE loop.
+      logger.error(`[Chorus] control-handler unexpected error: ${err}`);
+    }
+  };
+}

--- a/packages/openclaw-plugin/src/daemon-client.ts
+++ b/packages/openclaw-plugin/src/daemon-client.ts
@@ -1,0 +1,622 @@
+// packages/openclaw-plugin/src/daemon-client.ts
+// The OpenClaw in-process host's bidirectional daemon behavior — the in-process
+// analog of the chorus CLI host (cli/waker.mjs + cli/daemon.mjs), re-mapped from a
+// spawned `claude` subprocess to a single `runtime.agent.runEmbeddedAgent(...)` call.
+//
+// Re-mapping table (verified against ../openclaw, 2026-06-20):
+//   | Concern             | CLI host                       | this client                          |
+//   | run an agent        | spawn `claude` subprocess      | runEmbeddedAgent(params) in-process  |
+//   | observe messages    | parse stream-json lines        | onAssistantMessageStart/onBlockReply |
+//   |                     |                                | /onToolResult callbacks (params.ts)  |
+//   | mid-run interrupt   | SIGINT→SIGKILL the proc group  | AbortController.abort() → abortSignal |
+//   | crash vs user-abort | non-zero exit code             | promise rejects / result.meta.aborted|
+//   | resume same session | `claude --resume <directIdea>` | sessionKey from business key →        |
+//   |                     |                                | getSessionEntry resolves sessionId   |
+// The server-facing payloads are IDENTICAL across hosts (that is why they live in the
+// shared daemon-rest-client). This module owns only the host-side concerns: the
+// run wrapper, the abort/execution registries, the transcript content filter, the
+// session mapping, and the at-most-once turn dispatch.
+//
+// VERIFIED runEmbeddedAgent surface (../openclaw):
+//   - abortSignal?: AbortSignal                              params.ts:167
+//   - onAssistantMessageStart?: () => void|Promise<void>     params.ts:190 (ZERO-arg)
+//   - onBlockReply?: (BlockReplyPayload{text?,isReasoning?}) params.ts:191 / payloads.ts:1-11
+//   - onToolResult?: (ReplyPayload)                          params.ts:201 (tool internals — NOT transcript)
+//   - onReasoningStream?: (...)                              params.ts:195 (thinking — NOT transcript)
+//   - result.meta.aborted?: boolean                          types.ts:140 (user-abort marker)
+//   - getSessionEntry({sessionKey,agentId}) → SessionEntry?  store.ts:210
+//   - resolveSessionFilePath(sessionId, entry?, opts?)       paths.ts:267
+
+import type {
+  OpenClawRuntimeAgent,
+  OpenClawBlockReplyPayload,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  DaemonRestClient,
+  DaemonExecutionRow,
+  DaemonTranscriptMessage,
+  DaemonPendingTurn,
+} from "./daemon-rest-client.js";
+
+export interface DaemonClientLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+const NOOP_LOGGER: DaemonClientLogger = { info() {}, warn() {}, error() {} };
+
+/** Resource kinds the server's DaemonExecution accepts (mirrors waker.mjs). */
+const EXECUTION_ENTITY_TYPES = new Set(["task", "idea", "proposal", "document", "daemon_session"]);
+
+/**
+ * The host knobs the run needs, resolved per-wake by the entry/wake layer. These are
+ * the OpenClaw runtime-derived values (workspace dir, timeout, model, …) that wake.ts
+ * already knows how to resolve from `api.config`. The daemon client takes them as a
+ * resolver so it never reaches into `api` directly (keeps it host-API-agnostic + testable).
+ */
+export interface WakeRunContext {
+  /** The `runtime.agent` surface to run the turn with. */
+  agent: OpenClawRuntimeAgent;
+  /** The OpenClaw session key for this wake's main agent (e.g. `agent:main:main`). */
+  sessionKey: string;
+  /** The resolved default agent id (session/workspace resolvers are agent-scoped). */
+  agentId: string;
+  /** The opaque `api.config` snapshot passed through to runEmbeddedAgent. */
+  config: unknown;
+  /** Resolved agent workspace dir. */
+  workspaceDir: string;
+  /** Resolved agent dir (optional — omitted when the host has none). */
+  agentDir?: string;
+  /** Resolved per-agent timeout. */
+  timeoutMs: number;
+  /** Resolved `{ provider, model }` override, or null to use the host default. */
+  modelRef: { provider: string; model: string } | null;
+}
+
+/**
+ * Per-wake attribution + prompt. `entityType`/`entityUuid` identify the resource the
+ * execution row keys on; `directIdeaUuid`/`rootIdeaUuid` come from the lineage resolve
+ * (the two-id contract: directIdea = session anchor, rootIdea = snapshot attribution).
+ * `contextKey` is the router's dedupe/log key. `turnUuid` is set for a delivered turn.
+ */
+export interface WakeRequest {
+  prompt: string;
+  contextKey: string;
+  entityType?: string | null;
+  entityUuid?: string | null;
+  directIdeaUuid?: string | null;
+  rootIdeaUuid?: string | null;
+  /** When this wake runs a specific pending turn (deliver_turn / backfill). */
+  turnUuid?: string | null;
+}
+
+interface ExecutionEntry {
+  entityType: string;
+  entityUuid: string;
+  rootIdeaUuid: string | null;
+  status: "running" | "queued";
+  startedAt: string | null;
+}
+
+interface AbortEntry {
+  controller: AbortController;
+  /** Set when an authorized interrupt fired before the run settled → reason=user. */
+  interrupting: boolean;
+}
+
+export interface OpenClawDaemonClientOptions {
+  /** The shared REST client (turnAdvance/transcript/executionState/reportInterrupt/readPendingTurns). */
+  restClient: DaemonRestClient;
+  /**
+   * Resolve the host run context for a wake (workspace/timeout/model/agent/session
+   * key). Returns null when the wake must be DROPPED (no resolvable session/agent on
+   * this host) — mirrors wake.ts's graceful-drop. Errors thrown here are caught.
+   */
+  resolveRunContext: () => WakeRunContext | null;
+  /**
+   * Re-dispatch a wake for an entity (the synthetic resume / pending-turn path). Built
+   * by the entry from the router so a resume / delivered turn rides the SAME wake path
+   * (continuing the same session). Receives the full WakeRequest.
+   */
+  redispatch: (req: WakeRequest) => void;
+  /**
+   * Read this connection's unstarted (pending) turns and feed each to `redispatch`.
+   * The client owns the seen-set dedup + the optional single-turn filter; the entry
+   * just provides the prompt builder via `buildTurnPrompt`.
+   */
+  buildTurnPrompt: (turn: DaemonPendingTurn) => string;
+  logger?: DaemonClientLogger;
+}
+
+/**
+ * Extract finalized assistant VISIBLE text from an `onBlockReply` payload, or null to
+ * skip. Mirrors the CLI host's stream-json filter (upload-hooks.mjs
+ * `extractTranscriptText`): keep only finalized assistant text; DROP reasoning/thinking
+ * (`isReasoning`) — verified the flag exists at ../openclaw/src/agents/
+ * embedded-agent-payloads.ts:7 and is set true for reasoning blocks
+ * (embedded-agent-subscribe.handlers.messages.ts:915). Tool internals never reach here
+ * (they arrive on `onToolResult`, which the client does not post). Never throws.
+ */
+export function extractBlockReplyText(
+  payload: OpenClawBlockReplyPayload | undefined | null,
+): DaemonTranscriptMessage | null {
+  if (!payload || typeof payload !== "object") return null;
+  // Reasoning/thinking blocks are internal — not user-visible transcript.
+  if (payload.isReasoning) return null;
+  const text = typeof payload.text === "string" ? payload.text : "";
+  if (!text.trim()) return null;
+  return { role: "assistant", text };
+}
+
+/**
+ * The OpenClaw in-process daemon client. One instance per plugin process; the entry
+ * injects the shared REST client + the host run-context resolver + the re-dispatch
+ * hook, and wires this client's `controlHooks` into the control handler.
+ */
+export class OpenClawDaemonClient {
+  private readonly restClient: DaemonRestClient;
+  private readonly resolveRunContext: OpenClawDaemonClientOptions["resolveRunContext"];
+  private readonly redispatch: OpenClawDaemonClientOptions["redispatch"];
+  private readonly buildTurnPrompt: OpenClawDaemonClientOptions["buildTurnPrompt"];
+  private readonly logger: DaemonClientLogger;
+
+  /** AbortController per in-flight run, keyed `entityType:entityUuid`. */
+  private readonly aborts = new Map<string, AbortEntry>();
+  /** Execution snapshot source — one entry per running/queued resource. */
+  private readonly executions = new Map<string, ExecutionEntry>();
+  /**
+   * At-most-once turn dedup, keyed `turn:<uuid>`. Shared by the live deliver_turn
+   * path and the reconnect backfill so a turn observed by either runs at most once
+   * (mirrors the CLI host's `seen` set; backfill.mjs).
+   */
+  private readonly seenTurns = new Set<string>();
+
+  private runCounter = 0;
+
+  constructor(opts: OpenClawDaemonClientOptions) {
+    this.restClient = opts.restClient;
+    this.resolveRunContext = opts.resolveRunContext;
+    this.redispatch = opts.redispatch;
+    this.buildTurnPrompt = opts.buildTurnPrompt;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Control hooks — wired into the T3 control handler (ControlBehaviorHooks).
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The behavior hooks the control handler routes verified commands to. The handler
+   * owns the double-check (own connection + held entity); these implement the actual
+   * abort / re-dispatch / pending-turns-sweep.
+   */
+  get controlHooks(): {
+    isEntityRunning: (entityType: string, entityUuid: string) => boolean;
+    onInterrupt: (entityType: string, entityUuid: string) => void;
+    onResume: (entityType: string, entityUuid: string) => void;
+    onDeliverTurn: (turnUuid?: string) => void;
+  } {
+    return {
+      isEntityRunning: (entityType, entityUuid) => this.aborts.has(execKey(entityType, entityUuid)),
+      onInterrupt: (entityType, entityUuid) => this.interrupt(entityType, entityUuid),
+      onResume: (entityType, entityUuid) => this.resume(entityType, entityUuid),
+      onDeliverTurn: (turnUuid) => {
+        // Fire-and-forget: the control handler is synchronous; the sweep is async.
+        void this.deliverTurn(turnUuid);
+      },
+    };
+  }
+
+  /**
+   * Abort the matching in-flight run (true mid-run stop via abortSignal) and mark it
+   * `interrupting` so the run's settle path reports reason=user (not crash). No-op when
+   * no run is registered (the handler's Check 2 already gates this, but we re-check so a
+   * direct caller is safe). Never throws.
+   */
+  interrupt(entityType: string, entityUuid: string): void {
+    const key = execKey(entityType, entityUuid);
+    const entry = this.aborts.get(key);
+    if (!entry) {
+      this.logger.info(`[Chorus] interrupt: no in-flight run for ${key}; ignoring`);
+      return;
+    }
+    entry.interrupting = true;
+    try {
+      entry.controller.abort();
+      this.logger.info(`[Chorus] interrupt: aborted in-flight run for ${key}`);
+    } catch (err) {
+      this.logger.warn(`[Chorus] interrupt: abort() failed for ${key}: ${err}`);
+    }
+  }
+
+  /**
+   * Re-dispatch a wake for the entity to continue the SAME session (the run is gone;
+   * resolveRunContext re-derives the same sessionKey → getSessionEntry resolves the
+   * existing sessionId). The control handler has no prompt; we synthesize a minimal
+   * resume prompt. Continues under the same business key (directIdea/entity).
+   */
+  resume(entityType: string, entityUuid: string): void {
+    this.logger.info(`[Chorus] resume: re-dispatching wake for ${entityType}:${entityUuid}`);
+    this.redispatch({
+      prompt:
+        `[Chorus] Your previous run for this ${entityType} was interrupted by a human and is now being resumed. ` +
+        `Continue where you left off (entityType: ${entityType}, entityUuid: ${entityUuid}).`,
+      contextKey: `chorus:resume:${entityUuid}`,
+      entityType,
+      entityUuid,
+    });
+  }
+
+  /**
+   * Read connection-scoped pending turns and run the unstarted human_instruction turn.
+   * With a `turnUuid` run PRECISELY that one (live deliver_turn); without one sweep all
+   * (reconnect backfill). Idempotent via the shared `seenTurns` set keyed `turn:<uuid>`.
+   * Never throws into the caller. Mirrors backfill.mjs `backfillPendingTurns`.
+   */
+  async deliverTurn(onlyTurnUuid?: string): Promise<void> {
+    const result = await this.restClient.readPendingTurns();
+    if (!result.ok || !result.data) {
+      // Nothing to read yet (skipped) or a logged failure — nothing to dispatch.
+      return;
+    }
+    let dispatched = 0;
+    for (const turn of result.data.turns) {
+      if (!turn || typeof turn.turnUuid !== "string") continue;
+      // Single-turn precision: when a uuid was announced, run ONLY it.
+      if (onlyTurnUuid && turn.turnUuid !== onlyTurnUuid) continue;
+      const seenKey = `turn:${turn.turnUuid}`;
+      if (this.seenTurns.has(seenKey)) continue;
+      this.seenTurns.add(seenKey);
+      dispatched++;
+      // Reconstruct the execution entity DIRECTLY from the turn's own ids (mirrors
+      // cli/event-router.mjs dispatchPendingTurn): an idea-anchored conversation
+      // reports against the real idea (`idea:<directIdeaUuid>`), an ad-hoc conversation
+      // against itself (`daemon_session:<sessionId>`). entityType MUST be set — without
+      // it entityOf() returns null, so the run reports no execution row (invisible in
+      // the UI) and registers no AbortController (uninterruptible). entityUuid aligns
+      // with the session business key so the report anchor, the OpenClaw session, and
+      // the per-session UI match key are all the same value.
+      const directIdeaUuid =
+        typeof turn.directIdeaUuid === "string" ? turn.directIdeaUuid : null;
+      this.redispatch({
+        prompt: this.buildTurnPrompt(turn),
+        contextKey: `chorus:deliver_turn:${turn.turnUuid}`,
+        entityType: directIdeaUuid ? "idea" : "daemon_session",
+        entityUuid: directIdeaUuid ?? turn.sessionId,
+        directIdeaUuid,
+        turnUuid: turn.turnUuid,
+      });
+    }
+    if (dispatched > 0) {
+      const scope = onlyTurnUuid ? `turn ${onlyTurnUuid}` : `${dispatched} pending turn(s)`;
+      this.logger.info(`[Chorus] deliver: re-derived ${scope} from the turn table`);
+    }
+  }
+
+  /** Reconnect backfill: full connection-scoped pending-turns sweep (no single-turn filter). */
+  async onReconnect(): Promise<void> {
+    await this.deliverTurn();
+  }
+
+  // ---------------------------------------------------------------------------
+  // The wake run wrapper.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Run one wake via runEmbeddedAgent with full daemon reporting. Never throws — a
+   * wake failure is logged + reported (crash), never propagated (the SSE service must
+   * stay alive). Fire-and-forget from the caller's perspective; returns a promise the
+   * tests can await.
+   *
+   * Lifecycle (mirrors waker.mjs):
+   *   1. resolve run context (drop on null);
+   *   2. derive sessionKey from the business key → getSessionEntry → sessionId/sessionFile;
+   *   3. register the AbortController + mark the execution running → turnAdvance(running)
+   *      + execution-state snapshot;
+   *   4. run with transcript callbacks (onBlockReply → post {role:"assistant", text});
+   *   5. on settle → turnAdvance(ended) + snapshot; classify interrupt(user) vs crash;
+   *   6. finally → deregister the controller + drop the execution row + snapshot.
+   */
+  async runWake(req: WakeRequest): Promise<void> {
+    const { prompt, contextKey } = req;
+    const entity = entityOf(req);
+    const key = entity ? execKey(entity.entityType, entity.entityUuid) : null;
+    const rootIdeaUuid = req.rootIdeaUuid ?? null;
+    // Session anchor = the business key: directIdeaUuid when present, else the entity
+    // uuid (quick task / standalone doc / ad-hoc daemon_session). This is the `sessionId`
+    // used in ALL reports (turn-advance/transcript) — NOT the OpenClaw sessionKey, which
+    // is the agent's queue key. Two distinct identifiers (see deriveSessionId / sessionKey).
+    const reportSessionId = deriveSessionId(req);
+    if (!reportSessionId) {
+      this.logger.warn(
+        `[Chorus] Wake DROPPED — no session id (no directIdea/entity) for contextKey=${contextKey}`,
+      );
+      return;
+    }
+
+    let ctx: WakeRunContext | null;
+    try {
+      ctx = this.resolveRunContext();
+    } catch (err) {
+      this.logger.warn(`[Chorus] Wake DROPPED — run-context resolution failed (${contextKey}): ${err}`);
+      return;
+    }
+    if (!ctx) {
+      this.logger.warn(
+        `[Chorus] Wake DROPPED — no resolvable session/agent runtime on this host (${contextKey}).`,
+      );
+      return;
+    }
+
+    // Resolve the EXISTING session for the business key so the wake continues the same
+    // conversation (resume / deliver_turn re-enter it). The OpenClaw sessionKey is
+    // derived deterministically from the business key, so a later resume re-derives the
+    // same key and getSessionEntry returns the same sessionId/sessionFile.
+    const sessionKey = deriveSessionKey(reportSessionId, ctx.sessionKey);
+    let sessionId: string;
+    let sessionFile: string;
+    try {
+      const sessionEntry = ctx.agent.session.getSessionEntry({ sessionKey, agentId: ctx.agentId });
+      // No existing OpenClaw session for this key (the FIRST wake on the business key):
+      // open a NEW session whose id is the business key itself. The business key
+      // (directIdeaUuid / entityUuid / ad-hoc sessionId) is always a uuid, which
+      // satisfies OpenClaw's SAFE_SESSION_ID_RE (`^[a-z0-9][a-z0-9._-]{0,127}$`).
+      // The run id (`nextRunId`) is NOT a valid session id — it embeds the colon-laden
+      // contextKey, which `resolveSessionFilePath` rejects with "Invalid session ID" —
+      // so it must never be used as the session id. Reusing the business key here also
+      // keeps continuity: a later resume re-derives the SAME sessionKey, and once this
+      // first run has persisted the session, getSessionEntry returns this same id.
+      sessionId = sessionEntry?.sessionId ?? reportSessionId;
+      sessionFile = ctx.agent.session.resolveSessionFilePath(
+        sessionId,
+        sessionEntry?.sessionFile ? { sessionFile: sessionEntry.sessionFile } : undefined,
+        { agentId: ctx.agentId },
+      );
+    } catch (err) {
+      this.logger.warn(`[Chorus] Wake DROPPED — session resolution failed (${contextKey}): ${err}`);
+      return;
+    }
+
+    const controller = new AbortController();
+    const abortEntry: AbortEntry = { controller, interrupting: false };
+    if (key) this.aborts.set(key, abortEntry);
+
+    // Mark RUNNING + report turn-advance(running) + execution snapshot.
+    if (entity && key) {
+      this.executions.set(key, {
+        entityType: entity.entityType,
+        entityUuid: entity.entityUuid,
+        rootIdeaUuid,
+        status: "running",
+        startedAt: new Date().toISOString(),
+      });
+      this.emitExecutionSnapshot();
+    }
+    let advancedToRunning = false;
+    await this.advanceTurn(reportSessionId, "running", entity);
+    advancedToRunning = true;
+
+    const runId = this.nextRunId(contextKey);
+    this.logger.info(
+      `[Chorus] Waking agent via embedded run (sessionKey=${sessionKey}, sessionId=${reportSessionId}, ` +
+        `model=${ctx.modelRef ? `${ctx.modelRef.provider}/${ctx.modelRef.model}` : "host-default"}, contextKey=${contextKey})`,
+    );
+
+    let aborted = false;
+    let crashed = false;
+    try {
+      const result = await ctx.agent.runEmbeddedAgent({
+        sessionId,
+        sessionKey,
+        agentId: ctx.agentId,
+        trigger: "manual",
+        sessionFile,
+        ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+        workspaceDir: ctx.workspaceDir,
+        config: ctx.config,
+        prompt,
+        timeoutMs: ctx.timeoutMs,
+        runId,
+        disableMessageTool: true,
+        abortSignal: controller.signal,
+        // Streaming transcript: post ONLY finalized assistant visible text. Reasoning
+        // (onReasoningStream / isReasoning blocks) and tool internals (onToolResult) are
+        // intentionally NOT posted (match the CLI host's stream-json filter).
+        onBlockReply: (payload) => {
+          const msg = extractBlockReplyText(payload);
+          if (msg) void this.postTranscript(reportSessionId, [msg]);
+        },
+        ...(ctx.modelRef ? { provider: ctx.modelRef.provider, model: ctx.modelRef.model } : {}),
+      });
+      // result.meta.aborted distinguishes a clean abort from a normal completion
+      // (types.ts:140). An abort flagged here OR an interrupt requested → user-abort.
+      aborted = result?.meta?.aborted === true || abortEntry.interrupting;
+    } catch (err) {
+      // The run rejected. If an interrupt was requested, it's a user abort; otherwise
+      // it's an unexpected crash.
+      if (abortEntry.interrupting || controller.signal.aborted) {
+        aborted = true;
+      } else {
+        crashed = true;
+      }
+      this.logger.warn(
+        `[Chorus] Wake turn ${crashed ? "crashed" : "aborted"} (sessionId=${reportSessionId}, ${contextKey}): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      // Deregister FIRST so a stale controller can never abort a later run for the
+      // same entity (spec: "A settled run deregisters its controller").
+      if (key) this.aborts.delete(key);
+    }
+
+    // Turn lifecycle: advance running→ended regardless of outcome (a turn ends whether
+    // clean, aborted, or crashed). Guarded on advancedToRunning so a never-started wake
+    // never attempts an illegal pending→ended transition.
+    if (advancedToRunning) {
+      await this.advanceTurn(reportSessionId, "ended", entity);
+    }
+
+    // Interrupt-vs-crash reporting (entity-keyed — only for a reportable resource).
+    if (entity) {
+      if (aborted) {
+        await this.report(entity, "user");
+      } else if (crashed) {
+        await this.report(entity, "crash");
+      }
+      // A clean completion reports nothing (mirrors waker.mjs).
+    }
+
+    // Drop the execution row + emit a fresh snapshot (absence == ended server-side).
+    if (key && this.executions.delete(key)) {
+      this.emitExecutionSnapshot();
+    }
+
+    this.logger.info(
+      `[Chorus] Wake complete (sessionId=${reportSessionId}, contextKey=${contextKey}, ` +
+        `outcome=${aborted ? "interrupted" : crashed ? "crashed" : "completed"})`,
+    );
+  }
+
+  /**
+   * Mark a resource QUEUED and emit a snapshot. Called before a wake actually runs
+   * (e.g. when it sits behind a same-session run) so the server sees it waiting. The
+   * running transition in `runWake` overwrites it. Never throws.
+   */
+  markQueued(req: WakeRequest): void {
+    const entity = entityOf(req);
+    if (!entity) return;
+    const key = execKey(entity.entityType, entity.entityUuid);
+    const existing = this.executions.get(key);
+    // Don't downgrade a running resource to queued if a duplicate dispatch arrives.
+    if (existing && existing.status === "running") return;
+    this.executions.set(key, {
+      entityType: entity.entityType,
+      entityUuid: entity.entityUuid,
+      rootIdeaUuid: req.rootIdeaUuid ?? null,
+      status: "queued",
+      startedAt: existing?.startedAt ?? null,
+    });
+    this.emitExecutionSnapshot();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal reporting helpers — never throw into the wake path.
+  // ---------------------------------------------------------------------------
+
+  private buildExecutionSnapshot(): DaemonExecutionRow[] {
+    return [...this.executions.values()].map((e) => ({
+      entityType: e.entityType,
+      entityUuid: e.entityUuid,
+      rootIdeaUuid: e.rootIdeaUuid,
+      status: e.status,
+      startedAt: e.startedAt,
+    }));
+  }
+
+  /** Fire-and-forget execution-state snapshot. Never throws. */
+  private emitExecutionSnapshot(): void {
+    void this.restClient.executionState({ executions: this.buildExecutionSnapshot() });
+  }
+
+  private async advanceTurn(
+    sessionId: string,
+    status: "running" | "ended",
+    entity: { entityType: string; entityUuid: string } | null,
+  ): Promise<void> {
+    try {
+      await this.restClient.turnAdvance({
+        sessionId,
+        status,
+        entityType: entity?.entityType ?? null,
+        entityUuid: entity?.entityUuid ?? null,
+      });
+    } catch (err) {
+      this.logger.warn(`[Chorus] advanceTurn failed for session ${sessionId} → ${status}: ${err}`);
+    }
+  }
+
+  private async postTranscript(sessionId: string, messages: DaemonTranscriptMessage[]): Promise<void> {
+    try {
+      await this.restClient.transcript({ sessionId, messages });
+    } catch (err) {
+      this.logger.warn(`[Chorus] transcript post failed for session ${sessionId}: ${err}`);
+    }
+  }
+
+  private async report(
+    entity: { entityType: string; entityUuid: string },
+    reason: "user" | "crash",
+  ): Promise<void> {
+    try {
+      await this.restClient.reportInterrupt({
+        entityType: entity.entityType,
+        entityUuid: entity.entityUuid,
+        reason,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `[Chorus] reportInterrupt failed for ${entity.entityType}:${entity.entityUuid} (${reason}): ${err}`,
+      );
+    }
+  }
+
+  private nextRunId(contextKey: string): string {
+    this.runCounter += 1;
+    return `chorus-wake-${this.runCounter}-${contextKey}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit testing).
+// ---------------------------------------------------------------------------
+
+/** Registry key for an entity. */
+export function execKey(entityType: string, entityUuid: string): string {
+  return `${entityType}:${entityUuid}`;
+}
+
+/**
+ * The reportable resource for a wake — `{ entityType, entityUuid }` — or null when it
+ * has no recognized target (mirrors waker.mjs `#entityOf`).
+ */
+export function entityOf(req: {
+  entityType?: string | null;
+  entityUuid?: string | null;
+}): { entityType: string; entityUuid: string } | null {
+  const { entityType, entityUuid } = req;
+  if (
+    typeof entityType === "string" &&
+    typeof entityUuid === "string" &&
+    entityUuid.length > 0 &&
+    EXECUTION_ENTITY_TYPES.has(entityType)
+  ) {
+    return { entityType, entityUuid };
+  }
+  return null;
+}
+
+/**
+ * The session BUSINESS KEY used in all reports (turn-advance/transcript): the
+ * directIdeaUuid when the entity has an idea ancestor, else the entity uuid. Mirrors
+ * the CLI host's `sessionId = directIdeaUuid ?? notification.entityUuid` (waker.mjs:286).
+ */
+export function deriveSessionId(req: {
+  directIdeaUuid?: string | null;
+  entityUuid?: string | null;
+}): string | null {
+  return req.directIdeaUuid ?? req.entityUuid ?? null;
+}
+
+/**
+ * Derive the deterministic OpenClaw `sessionKey` for a wake from its business key. The
+ * OpenClaw session store is keyed by `sessionKey` (the agent queue key), NOT by the
+ * Chorus business id — so to make `resume`/`deliver_turn` continue the SAME OpenClaw
+ * session we must derive the SAME key from the SAME business id every time. We namespace
+ * the business id under the host's main-agent key so a Chorus wake gets its own stable
+ * lane that re-resolves identically across runs (the in-process analog of
+ * `claude --resume <directIdeaUuid>`, where the disk transcript is the stable anchor).
+ */
+export function deriveSessionKey(businessKey: string, mainSessionKey: string): string {
+  return `${mainSessionKey}:chorus:${businessKey}`;
+}

--- a/packages/openclaw-plugin/src/daemon-rest-client.ts
+++ b/packages/openclaw-plugin/src/daemon-rest-client.ts
@@ -1,0 +1,312 @@
+// packages/openclaw-plugin/src/daemon-rest-client.ts
+// TypeScript mirror of the shared, host-agnostic pure-REST client for the Chorus
+// daemon → server reporting surface (`/api/daemon/*`).
+//
+// WHY A MIRROR (not an import): the single-source-of-truth implementation is
+// `cli/daemon-rest-client.mjs`, consumed verbatim by the chorus CLI daemon. The
+// OpenClaw plugin, however, is a SEPARATELY-PUBLISHED npm package
+// (`@chorus-aidlc/chorus-openclaw-plugin`, `files: ["src", "dist", ...]`) whose
+// TS build has `rootDir: "src"`. Importing a file under `cli/` (outside both the
+// package boundary AND rootDir) is rejected by `tsc` and would not be present in
+// the published tarball. So we mirror the EXACT same factory + payload shapes here
+// — this is NOT a fork of the wire contract: every payload below is byte-for-byte
+// the shape `cli/daemon-rest-client.mjs` sends (and the server already accepts).
+// The two files are kept in lock-step by the spec's "single source of truth for
+// the payload shapes" requirement; a drift would be caught by T5 (live e2e).
+//
+// The five operations and their EXACT server payload shapes (verified against
+// cli/daemon-rest-client.mjs + src/app/api/daemon/*/route.ts — server unchanged):
+//   turnAdvance      → POST /api/daemon/turn-advance
+//                      { connectionUuid, sessionId, status, entityType?, entityUuid? }
+//   transcript       → POST /api/daemon/transcript
+//                      { sessionId, messages: [{ role, text }] }
+//   executionState   → POST /api/daemon/execution-state
+//                      { connectionUuid, executions: [{ entityType, entityUuid,
+//                                                       rootIdeaUuid|null, status,
+//                                                       startedAt|null }] }
+//   reportInterrupt  → POST /api/daemon/report-interrupt
+//                      { connectionUuid, entityType, entityUuid, reason }
+//   readPendingTurns → GET  /api/daemon/pending-turns?connectionUuid=…
+//                      → { turns: [{ turnUuid, sessionId, directIdeaUuid, trigger,
+//                                    promptText }] }
+//
+// HARD CONSTRAINTS (identical to the CLI client):
+//   • ZERO daemon-host coupling — no child_process, no OpenClaw SDK import. Its only
+//     outbound effect is HTTP via the injected `fetchImpl` (global fetch on Node 18+).
+//     Adds NO new npm dependency (CLAUDE.md pitfall #9).
+//   • Bearer-only auth: every request carries `Authorization: Bearer <apiKey>`.
+//   • NO SILENT ERRORS (project policy): a network error, a non-2xx response, or a
+//     bad/empty body is LOGGED WITH ITS CAUSE and SURFACED via a structured result —
+//     never swallowed into a silent success.
+//   • A failed report NEVER rejects: every method RESOLVES with `{ ok: false, ... }`
+//     so a fire-and-forget caller can `await` it safely.
+
+export interface DaemonRestLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+const NOOP_LOGGER: DaemonRestLogger = { info() {}, warn() {}, error() {} };
+
+/** A single transcript message — only `role` + visible `text` (no internals). */
+export interface DaemonTranscriptMessage {
+  role: "user" | "assistant";
+  text: string;
+}
+
+/** One execution-snapshot row, in the server's exact `execution-state` shape. */
+export interface DaemonExecutionRow {
+  entityType: string;
+  entityUuid: string;
+  rootIdeaUuid: string | null;
+  status: "running" | "queued";
+  startedAt: string | null;
+}
+
+/** One unstarted (pending) turn read back from the turn table. */
+export interface DaemonPendingTurn {
+  turnUuid: string;
+  sessionId: string;
+  directIdeaUuid: string | null;
+  trigger: string;
+  promptText: string | null;
+}
+
+/**
+ * Structured result of every client call. Mirrors the CLI client's
+ * `DaemonRestResult`: `ok` is true only on a 2xx (and, for reads, a well-formed
+ * body); `error` carries the (also-logged) failure cause; `skipped` marks an
+ * intentional non-call (e.g. no connection uuid yet); `data` holds parsed read
+ * payloads.
+ */
+export interface DaemonRestResult<TData = unknown> {
+  ok: boolean;
+  status: number | null;
+  error?: string;
+  skipped?: boolean;
+  data?: TData;
+}
+
+export interface CreateDaemonRestClientOptions {
+  /** Chorus base URL (a trailing slash is normalized away). */
+  url: string;
+  /** `cho_` agent API key for Bearer auth. */
+  apiKey: string;
+  /**
+   * The daemon's registered connection uuid (learned from the SSE handshake),
+   * read LAZILY on every call so construction order does not matter. The
+   * connection-scoped operations (turnAdvance, executionState, reportInterrupt,
+   * readPendingTurns) require it; a null value skips the call (logged where the
+   * skip is unexpected, silent where it is a normal early state).
+   */
+  getConnectionUuid?: () => string | null;
+  /** Injectable for tests (defaults to global fetch). */
+  fetchImpl?: typeof fetch;
+  logger?: DaemonRestLogger;
+}
+
+export interface DaemonRestClient {
+  turnAdvance(p: {
+    sessionId: string;
+    status: "running" | "ended";
+    entityType?: string | null;
+    entityUuid?: string | null;
+  }): Promise<DaemonRestResult>;
+  transcript(p: {
+    sessionId: string;
+    messages: DaemonTranscriptMessage[];
+  }): Promise<DaemonRestResult>;
+  executionState(p: { executions: DaemonExecutionRow[] }): Promise<DaemonRestResult>;
+  reportInterrupt(p: {
+    entityType: string;
+    entityUuid: string;
+    reason: "user" | "crash";
+  }): Promise<DaemonRestResult>;
+  readPendingTurns(): Promise<DaemonRestResult<{ turns: DaemonPendingTurn[] }>>;
+}
+
+/**
+ * Build the shared daemon REST client. Inputs are entirely host-agnostic, which is
+ * exactly why the same surface serves both daemon hosts.
+ */
+export function createDaemonRestClient(opts: CreateDaemonRestClientOptions): DaemonRestClient {
+  const url = opts.url.replace(/\/$/, "");
+  const apiKey = opts.apiKey;
+  const getConnectionUuid = opts.getConnectionUuid ?? (() => null);
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const logger = opts.logger ?? NOOP_LOGGER;
+
+  const jsonHeaders = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+
+  /**
+   * Issue one daemon report. Owns the transport + the no-silent-errors contract
+   * IDENTICAL across all four POST endpoints; only the `op` label and the path
+   * differ. Never throws — returns a structured {@link DaemonRestResult}.
+   */
+  async function post(
+    op: string,
+    path: string,
+    body: unknown,
+    successLog?: string,
+    context = "",
+  ): Promise<DaemonRestResult> {
+    let response: Response;
+    try {
+      response = await fetchImpl(`${url}${path}`, {
+        method: "POST",
+        headers: jsonHeaders,
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      // Network-level failure (DNS, connection refused, abort, …). Surface WITH cause.
+      const error = `${op} request failed${context}: ${err}`;
+      logger.warn(`[Chorus] ${error}`);
+      return { ok: false, status: null, error };
+    }
+    if (!response.ok) {
+      // Non-2xx. Surface WITH the status so a 4xx/5xx is debuggable.
+      const error = `${op} returned ${response.status}${context}`;
+      logger.warn(`[Chorus] ${error}`);
+      return { ok: false, status: response.status, error };
+    }
+    if (successLog) logger.info(`[Chorus] ${successLog}`);
+    return { ok: true, status: response.status };
+  }
+
+  return {
+    /**
+     * POST /api/daemon/turn-advance — advance a wake's DaemonSessionTurn lifecycle.
+     * The server resolves the turn by the session BUSINESS KEY (`sessionId`); the
+     * optional `entityType`/`entityUuid` stamp the weak executionUuid link. Requires
+     * the connectionUuid.
+     */
+    async turnAdvance({ sessionId, status, entityType, entityUuid }) {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        const error = `cannot advance turn for session ${sessionId} → ${status} — no connection uuid yet`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: null, error, skipped: true };
+      }
+      const body = {
+        connectionUuid,
+        sessionId,
+        status,
+        // Only sent when BOTH are present, so the server never gets a partial linkage.
+        ...(entityType && entityUuid ? { entityType, entityUuid } : {}),
+      };
+      return post(
+        "turn-advance",
+        "/api/daemon/turn-advance",
+        body,
+        `advanced turn for session ${sessionId} → ${status}`,
+      );
+    },
+
+    /**
+     * POST /api/daemon/transcript — append finalized user/assistant text to the
+     * current turn, targeted by the session BUSINESS KEY. The caller owns the content
+     * filter (only `{ role, text }`) and any batching. No connectionUuid needed.
+     */
+    async transcript({ sessionId, messages }) {
+      return post(
+        "transcript upload",
+        "/api/daemon/transcript",
+        { sessionId, messages },
+        `transcript uploaded (${messages.length} msg) for session ${sessionId}`,
+      );
+    },
+
+    /**
+     * POST /api/daemon/execution-state — publish the connection's running/queued
+     * execution snapshot (caller supplies the already-built `executions` array).
+     * Requires the connectionUuid; a null uuid is a normal early state (silent skip).
+     */
+    async executionState({ executions }) {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        return { ok: false, status: null, skipped: true };
+      }
+      return post(
+        "execution-state upload",
+        "/api/daemon/execution-state",
+        { connectionUuid, executions },
+        `execution-state uploaded (${executions.length} active)`,
+      );
+    },
+
+    /**
+     * POST /api/daemon/report-interrupt — record a wake's `interrupted` outcome
+     * (reason = "user" | "crash") on the execution row keyed by connection + entity.
+     */
+    async reportInterrupt({ entityType, entityUuid, reason }) {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        const error = `cannot report interrupt for ${entityType}:${entityUuid} — no connection uuid yet`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: null, error, skipped: true };
+      }
+      return post(
+        "report-interrupt",
+        "/api/daemon/report-interrupt",
+        { connectionUuid, entityType, entityUuid, reason },
+        `reported ${entityType}:${entityUuid} interrupted (reason=${reason})`,
+        ` for ${entityType}:${entityUuid}`,
+      );
+    },
+
+    /**
+     * GET /api/daemon/pending-turns?connectionUuid=… — read this connection's
+     * unstarted (pending) turns. Returns the parsed `{ turns: [...] }` data on
+     * success; a network error / non-2xx / bad body / missing array is logged with
+     * cause and surfaced as a failure result — never a silent empty success.
+     */
+    async readPendingTurns() {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        return { ok: false, status: null, skipped: true };
+      }
+      const endpoint = `${url}/api/daemon/pending-turns?connectionUuid=${encodeURIComponent(connectionUuid)}`;
+      let response: Response;
+      try {
+        response = await fetchImpl(endpoint, {
+          headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+        });
+      } catch (err) {
+        const error = `pending-turns backfill request failed: ${err}`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: null, error };
+      }
+      if (!response.ok) {
+        const error = `pending-turns backfill returned ${response.status}`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: response.status, error };
+      }
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch (err) {
+        const error = `pending-turns backfill: bad JSON: ${err}`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: response.status, error };
+      }
+      // API envelope: { success: true, data: { turns: [...] } }.
+      const data =
+        parsed && typeof parsed === "object"
+          ? (parsed as { data?: unknown }).data
+          : undefined;
+      const turns =
+        data && typeof data === "object" ? (data as { turns?: unknown }).turns : undefined;
+      if (!Array.isArray(turns)) {
+        const error = "pending-turns backfill: no turns array in response";
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: response.status, error };
+      }
+      return { ok: true, status: response.status, data: { turns: turns as DaemonPendingTurn[] } };
+    },
+  };
+}

--- a/packages/openclaw-plugin/src/event-router.ts
+++ b/packages/openclaw-plugin/src/event-router.ts
@@ -1,21 +1,50 @@
 import type { ChorusMcpClient } from "./mcp-client.js";
 import type { SseNotificationEvent } from "./sse-listener.js";
+import type { LineageResolver } from "./lineage.js";
+
+/**
+ * Per-wake attribution the router resolves and threads to the wake. Carries the
+ * reportable resource (`entityType`/`entityUuid`) and the lineage ids (the two-id
+ * contract: `directIdeaUuid` = session anchor, `rootIdeaUuid` = snapshot attribution).
+ * All optional so a host wired WITHOUT the daemon client (no lineage) still wakes —
+ * the daemon-reporting fields are simply absent and the run is a plain wake.
+ */
+export interface WakeAttribution {
+  entityType?: string | null;
+  entityUuid?: string | null;
+  directIdeaUuid?: string | null;
+  rootIdeaUuid?: string | null;
+}
 
 /**
  * Wake callback injected by the entry. Runs an embedded agent turn on the main
- * agent's session with `message` as the prompt (see `wake.ts` → createWake,
- * which calls `api.runtime.agent.runEmbeddedAgent`).
+ * agent's session with `message` as the prompt (see `wake.ts` / daemon-client.ts,
+ * which call `api.runtime.agent.runEmbeddedAgent`).
  *
  * `contextKey` identifies the originating Chorus action+entity (e.g.
- * `chorus:mentioned:<uuid>`); it is used for the run id / logging. The wake
- * resolves the main agent session + model and DROPS (logs + returns) when it
- * cannot run — it never throws, so the SSE service stays alive.
+ * `chorus:mentioned:<uuid>`); it is used for the run id / logging. `attribution`
+ * (when present) lets the daemon client report turn-advance / execution-state /
+ * interrupt for the wake and anchor the session on the business key. The wake
+ * resolves the main agent session + model and DROPS (logs + returns) when it cannot
+ * run — it never throws, so the SSE service stays alive.
  */
-export type ChorusWakeFn = (message: string, contextKey: string) => void;
+export type ChorusWakeFn = (
+  message: string,
+  contextKey: string,
+  attribution?: WakeAttribution,
+) => void;
 
 export interface ChorusEventRouterOptions {
   mcpClient: ChorusMcpClient;
   wake: ChorusWakeFn;
+  /**
+   * Optional lineage resolver (daemon parity). When present, the router resolves each
+   * notification's `{ rootIdeaUuid, directIdeaUuid }` via the root-idea REST endpoint
+   * before waking, so the daemon client can anchor the session on the direct idea and
+   * report the root idea in its execution snapshot. When absent (a host with no daemon
+   * reporting), wakes carry only the entity fields the notification already provides.
+   */
+  lineage?: LineageResolver;
   logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
 }
 
@@ -39,11 +68,13 @@ interface NotificationDetail {
 export class ChorusEventRouter {
   private readonly mcpClient: ChorusMcpClient;
   private readonly wake: ChorusWakeFn;
+  private readonly lineage?: LineageResolver;
   private readonly logger: ChorusEventRouterOptions["logger"];
 
   constructor(opts: ChorusEventRouterOptions) {
     this.mcpClient = opts.mcpClient;
     this.wake = opts.wake;
+    this.lineage = opts.lineage;
     this.logger = opts.logger;
   }
 
@@ -52,6 +83,16 @@ export class ChorusEventRouter {
    * Never throws — all errors are caught and logged internally.
    */
   dispatch(event: SseNotificationEvent): void {
+    // The bidirectional daemon events `connection_registered` and `control` are
+    // forked upstream by the SSE listener (onConnectionId / onControl) and never
+    // reach the wake path. If one ever does arrive here (defense-in-depth), drop
+    // it SILENTLY — it is a known, handled-elsewhere event, NOT an unhandled one,
+    // so logging it as "ignored" would be misleading noise (and the spec requires
+    // connection_registered never be logged as ignored).
+    if (event.type === "connection_registered" || event.type === "control") {
+      return;
+    }
+
     // Only handle new_notification events (ignore count_update, etc.)
     if (event.type !== "new_notification") {
       this.logger.info(`SSE event type "${event.type}" ignored`);
@@ -103,35 +144,55 @@ export class ChorusEventRouter {
       return;
     }
 
+    // Resolve the wake attribution ONCE per notification (daemon parity). The lineage
+    // resolver returns { rootIdeaUuid, directIdeaUuid } via the root-idea REST endpoint;
+    // both null when there's no idea ancestor or no resolver is wired. The entity
+    // fields always come straight off the notification. This threads through to the
+    // daemon client so it reports/anchors against the right session + resource.
+    let attribution: WakeAttribution = {
+      entityType: notification.entityType,
+      entityUuid: notification.entityUuid,
+    };
+    if (this.lineage) {
+      try {
+        const { rootIdeaUuid, directIdeaUuid } = await this.lineage.resolve(notification);
+        attribution = { ...attribution, rootIdeaUuid, directIdeaUuid };
+      } catch (err) {
+        // A lineage failure must not lose the wake — fall back to the entity-only
+        // attribution (the daemon client then anchors on the entity uuid). Logged.
+        this.logger.warn(`Lineage resolve failed for ${notification.entityType}:${notification.entityUuid}: ${err}`);
+      }
+    }
+
     // Route based on action (which corresponds to notificationType)
     try {
       switch (notification.action) {
         case "task_assigned":
-          this.handleTaskAssigned(notification);
+          this.handleTaskAssigned(notification, attribution);
           break;
         case "mentioned":
-          this.handleMentioned(notification);
+          this.handleMentioned(notification, attribution);
           break;
         case "elaboration_requested":
-          this.handleElaborationRequested(notification);
+          this.handleElaborationRequested(notification, attribution);
           break;
         case "elaboration_answered":
-          this.handleElaborationAnswered(notification);
+          this.handleElaborationAnswered(notification, attribution);
           break;
         case "proposal_rejected":
-          this.handleProposalRejected(notification);
+          this.handleProposalRejected(notification, attribution);
           break;
         case "proposal_approved":
-          this.handleProposalApproved(notification);
+          this.handleProposalApproved(notification, attribution);
           break;
         case "idea_claimed":
-          this.handleIdeaClaimed(notification);
+          this.handleIdeaClaimed(notification, attribution);
           break;
         case "task_verified":
-          this.handleTaskVerified(notification);
+          this.handleTaskVerified(notification, attribution);
           break;
         case "task_reopened":
-          this.handleTaskReopened(notification);
+          this.handleTaskReopened(notification, attribution);
           break;
         default:
           this.logger.info(`Unhandled notification action: "${notification.action}"`);
@@ -153,34 +214,37 @@ export class ChorusEventRouter {
     );
   }
 
-  private handleTaskAssigned(n: NotificationDetail): void {
+  private handleTaskAssigned(n: NotificationDetail, attr: WakeAttribution): void {
     const mentionGuidance = this.buildMentionGuidance(n, "task");
 
     this.wake(
       `[Chorus] Task assigned: ${n.entityTitle}. Task UUID: ${n.entityUuid}, Project UUID: ${n.projectUuid}. Use chorus_get_task to review the task, then chorus_claim_task to start work.\n${mentionGuidance}`,
-      this.contextKeyFor("task_assigned", n.entityUuid)
+      this.contextKeyFor("task_assigned", n.entityUuid),
+      attr
     );
   }
 
-  private handleMentioned(n: NotificationDetail): void {
+  private handleMentioned(n: NotificationDetail, attr: WakeAttribution): void {
     const mentionGuidance = this.buildMentionGuidance(n, n.entityType);
 
     this.wake(
       `[Chorus] You were @mentioned in ${n.entityType} '${n.entityTitle}' (entityType: ${n.entityType}, entityUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}): ${n.message}\n` +
       `Review the ${n.entityType} content and use chorus_get_comments (targetType: "${n.entityType}", targetUuid: "${n.entityUuid}") to see the full conversation, then respond.\n` +
       mentionGuidance,
-      this.contextKeyFor("mentioned", n.entityUuid)
+      this.contextKeyFor("mentioned", n.entityUuid),
+      attr
     );
   }
 
-  private handleElaborationRequested(n: NotificationDetail): void {
+  private handleElaborationRequested(n: NotificationDetail, attr: WakeAttribution): void {
     this.wake(
       `[Chorus] Elaboration requested for idea '${n.entityTitle}' (ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). Use chorus_get_elaboration to review questions.`,
-      this.contextKeyFor("elaboration_requested", n.entityUuid)
+      this.contextKeyFor("elaboration_requested", n.entityUuid),
+      attr
     );
   }
 
-  private handleProposalRejected(n: NotificationDetail): void {
+  private handleProposalRejected(n: NotificationDetail, attr: WakeAttribution): void {
     const mentionGuidance = this.buildMentionGuidance(n, "proposal");
 
     this.wake(
@@ -188,11 +252,12 @@ export class ChorusEventRouter {
       `Use chorus_get_proposal to review the proposal, then fix issues with chorus_update_task_draft / chorus_update_document_draft. ` +
       `After fixing, call chorus_validate_proposal then chorus_submit_proposal to resubmit.\n` +
       mentionGuidance,
-      this.contextKeyFor("proposal_rejected", n.entityUuid)
+      this.contextKeyFor("proposal_rejected", n.entityUuid),
+      attr
     );
   }
 
-  private handleProposalApproved(n: NotificationDetail): void {
+  private handleProposalApproved(n: NotificationDetail, attr: WakeAttribution): void {
     const mentionGuidance = this.buildMentionGuidance(n, "proposal");
 
     const reviewInfo = n.message.includes("Note: ") ? ` Review note: "${n.message.split("Note: ").pop()}"` : "";
@@ -200,40 +265,44 @@ export class ChorusEventRouter {
       `[Chorus] Proposal '${n.entityTitle}' was APPROVED (proposalUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid})!${reviewInfo} Documents and tasks have been created. ` +
       `Use chorus_get_available_tasks with projectUuid: "${n.projectUuid}" to see the new tasks ready for work.\n` +
       mentionGuidance,
-      this.contextKeyFor("proposal_approved", n.entityUuid)
+      this.contextKeyFor("proposal_approved", n.entityUuid),
+      attr
     );
   }
 
-  private handleIdeaClaimed(n: NotificationDetail): void {
+  private handleIdeaClaimed(n: NotificationDetail, attr: WakeAttribution): void {
     const mentionGuidance = this.buildMentionGuidance(n, "idea");
 
     this.wake(
       `[Chorus] Idea '${n.entityTitle}' has been assigned to you (ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). ` +
       `Use chorus_get_idea to review the idea, then chorus_claim_idea to start elaboration.\n` +
       mentionGuidance,
-      this.contextKeyFor("idea_claimed", n.entityUuid)
+      this.contextKeyFor("idea_claimed", n.entityUuid),
+      attr
     );
   }
 
-  private handleTaskVerified(n: NotificationDetail): void {
+  private handleTaskVerified(n: NotificationDetail, attr: WakeAttribution): void {
     this.wake(
       `[Chorus] Task '${n.entityTitle}' has been verified and is now done (taskUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). ` +
       `Check if this unblocks other tasks: use chorus_get_unblocked_tasks with projectUuid "${n.projectUuid}" to find tasks that are now ready to start.`,
-      this.contextKeyFor("task_verified", n.entityUuid)
+      this.contextKeyFor("task_verified", n.entityUuid),
+      attr
     );
   }
 
-  private handleTaskReopened(n: NotificationDetail): void {
+  private handleTaskReopened(n: NotificationDetail, attr: WakeAttribution): void {
     const mentionGuidance = this.buildMentionGuidance(n, "task");
 
     this.wake(
       `[Chorus] Task '${n.entityTitle}' has been reopened and needs rework (taskUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). ` +
       `Use chorus_get_task to review the task and chorus_get_comments to see verification feedback, then fix the issues.\n${mentionGuidance}`,
-      this.contextKeyFor("task_reopened", n.entityUuid)
+      this.contextKeyFor("task_reopened", n.entityUuid),
+      attr
     );
   }
 
-  private handleElaborationAnswered(n: NotificationDetail): void {
+  private handleElaborationAnswered(n: NotificationDetail, attr: WakeAttribution): void {
     const mentionGuidance = this.buildMentionGuidance(n, "idea");
 
     this.wake(
@@ -243,7 +312,8 @@ export class ChorusEventRouter {
       `- Call chorus_validate_elaboration with issues + followUpQuestions for another round\n\n` +
       `After reviewing, @mention the answerer to ask if they have any further questions before you proceed.\n` +
       mentionGuidance,
-      this.contextKeyFor("elaboration_answered", n.entityUuid)
+      this.contextKeyFor("elaboration_answered", n.entityUuid),
+      attr
     );
   }
 }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -5,9 +5,15 @@ import { resolveConfig, validateConfigWithWarnings } from "./config.js";
 import { ensureChorusMcpServer } from "./mcp-registration.js";
 import { ChorusMcpClient } from "./mcp-client.js";
 import { ChorusSseListener } from "./sse-listener.js";
-import { ChorusEventRouter } from "./event-router.js";
-import { createWake } from "./wake.js";
+import { ChorusEventRouter, type WakeAttribution } from "./event-router.js";
+import { resolveWakeRunContext } from "./wake.js";
 import { registerChorusCommands } from "./commands.js";
+import { ConnectionState } from "./connection-state.js";
+import { createControlHandler, type ControlBehaviorHooks } from "./control-handler.js";
+import { createDaemonRestClient } from "./daemon-rest-client.js";
+import { LineageResolver } from "./lineage.js";
+import { OpenClawDaemonClient, type WakeRequest } from "./daemon-client.js";
+import type { DaemonPendingTurn } from "./daemon-rest-client.js";
 
 /**
  * JSON-Schema config contract for the Chorus plugin.
@@ -70,15 +76,97 @@ export default definePluginEntry({
     //    assignments, notifications back-fill).
     const mcpClient = new ChorusMcpClient({ chorusUrl, apiKey, logger });
 
-    // 5. Event router. Wakes the agent in-process by running an embedded agent
-    //    turn via `api.runtime.agent.runEmbeddedAgent` (see wake.ts). `createWake`
-    //    resolves the main agent session + configured model on each wake and
-    //    gracefully DROPS (logs + returns) when it cannot run — it never throws,
-    //    so the SSE service stays alive even on a host that exposes no session.
+    // 4b. Connection identity + reverse control channel + daemon reporting (parity).
+    //     `connectionState` holds the DaemonConnection uuid the server reports
+    //     post-handshake (captured by the listener's onConnectionId); it is the
+    //     single source of truth for "which connection am I", read by the control
+    //     handler's double-check AND the daemon REST reporter (lazily, so order
+    //     doesn't matter — both predate the handshake).
+    const connectionState = new ConnectionState();
+
+    //     The shared pure-REST daemon client owns the `/api/daemon/*` payload shapes
+    //     (turn-advance / transcript / execution-state / report-interrupt /
+    //     pending-turns). It reads the connectionUuid lazily from connectionState.
+    const restClient = createDaemonRestClient({
+      url: chorusUrl,
+      apiKey,
+      getConnectionUuid: () => connectionState.getConnectionUuid(),
+      logger,
+    });
+
+    //     Lineage resolver: per-notification { rootIdeaUuid, directIdeaUuid } via the
+    //     root-idea REST endpoint, so the daemon client anchors the session on the
+    //     DIRECT idea (resume/deliver_turn continuity) and reports the ROOT idea in
+    //     its execution snapshot (the two-id contract).
+    const lineage = new LineageResolver({ url: chorusUrl, apiKey, logger });
+
+    //     The in-process daemon client wraps runEmbeddedAgent with full reporting,
+    //     the AbortController registry (real mid-run interrupt), the execution
+    //     snapshot source, deterministic session-key mapping, and the at-most-once
+    //     pending-turns backfill. `resolveRunContext` is the ONE place that reaches
+    //     into api.config/api.runtime (kept out of the client so it stays testable).
+    //     `redispatch` resolves lineage for a synthetic resume so it continues the
+    //     SAME session, then runs the wake; a delivered turn already carries its ids.
+    let daemonClient: OpenClawDaemonClient;
+    const redispatch = (req: WakeRequest): void => {
+      void (async () => {
+        let enriched = req;
+        // A resume only knows the entity — resolve its lineage so the wake anchors on
+        // the same business key (direct idea) the original run used. A delivered turn
+        // already carries directIdeaUuid, so we skip the round-trip when present.
+        if (req.directIdeaUuid == null && req.entityType && req.entityUuid) {
+          try {
+            const { rootIdeaUuid, directIdeaUuid } = await lineage.resolve({
+              entityType: req.entityType,
+              entityUuid: req.entityUuid,
+            });
+            enriched = { ...req, rootIdeaUuid, directIdeaUuid };
+          } catch (err) {
+            logger.warn(`[Chorus] resume lineage resolve failed: ${err}`);
+          }
+        }
+        await daemonClient.runWake(enriched);
+      })();
+    };
+    daemonClient = new OpenClawDaemonClient({
+      restClient,
+      resolveRunContext: () => resolveWakeRunContext(api, logger),
+      redispatch,
+      // Build the prompt for a delivered human_instruction turn. The free-text body
+      // lives only on the turn (promptText); fall back to a generic nudge if absent.
+      buildTurnPrompt: (turn: DaemonPendingTurn) =>
+        turn.promptText && turn.promptText.trim()
+          ? `[Chorus] A human sent you an instruction in this conversation:\n\n${turn.promptText}`
+          : `[Chorus] A human sent you a new instruction in this conversation (session ${turn.sessionId}). Review the latest comments and respond.`,
+      logger,
+    });
+
+    //     The control handler ROUTES verified control commands to the daemon client's
+    //     behavior hooks (real abort / resume re-dispatch / pending-turns sweep),
+    //     after its own double-check (own connection + held entity).
+    const controlHooks: ControlBehaviorHooks = daemonClient.controlHooks;
+    const onControl = createControlHandler({ connectionState, hooks: controlHooks, logger });
+
+    // 5. Event router. Wakes the agent in-process by running an embedded agent turn
+    //    via the daemon client (which calls api.runtime.agent.runEmbeddedAgent and
+    //    reports lifecycle/transcript). The router resolves each notification's
+    //    lineage, then the daemon client's runWake gracefully DROPS (logs + returns)
+    //    when it cannot run — it never throws, so the SSE service stays alive.
+    const wakeFn = (message: string, contextKey: string, attribution?: WakeAttribution): void => {
+      void daemonClient.runWake({
+        prompt: message,
+        contextKey,
+        entityType: attribution?.entityType,
+        entityUuid: attribution?.entityUuid,
+        directIdeaUuid: attribution?.directIdeaUuid,
+        rootIdeaUuid: attribution?.rootIdeaUuid,
+      });
+    };
     const eventRouter = new ChorusEventRouter({
       mcpClient,
       logger,
-      wake: createWake(api, logger),
+      lineage,
+      wake: wakeFn,
     });
 
     // 6. Background SSE service. The SSE socket opens only inside start(), which
@@ -92,7 +180,23 @@ export default definePluginEntry({
           apiKey,
           logger,
           onEvent: (event) => eventRouter.dispatch(event),
+          // Capture (and refresh on reconnect) the DaemonConnection identity the
+          // server reports post-handshake. NOT a wake — forked by the listener.
+          onConnectionId: (connectionUuid) => {
+            connectionState.setConnectionUuid(connectionUuid);
+            logger.info(`[Chorus] registered as daemon connection ${connectionUuid}`);
+          },
+          // Reverse control channel. The handler does the double-check and routes
+          // to the behavior hooks — NEVER the wake path.
+          onControl,
           onReconnect: async () => {
+            // (1) Notification backfill — re-pull unread notifications missed during
+            //     the gap (autonomous wakes). (2) Pending-turns backfill — re-derive
+            //     this connection's unstarted human_instruction turns from the turn
+            //     table and run each (the lost-deliver_turn-ping safety net). The two
+            //     share the daemon client's seen-set so a turn is run at most once
+            //     across live delivery + backfill. Each swallows its own errors so one
+            //     failing source never aborts the other.
             try {
               const result = (await mcpClient.callTool("chorus_get_notifications", {
                 status: "unread",
@@ -105,6 +209,7 @@ export default definePluginEntry({
             } catch (err) {
               logger.warn(`Failed to back-fill notifications: ${err}`);
             }
+            await daemonClient.onReconnect();
           },
         });
         await sseListener.connect();

--- a/packages/openclaw-plugin/src/lineage.ts
+++ b/packages/openclaw-plugin/src/lineage.ts
@@ -1,0 +1,157 @@
+// packages/openclaw-plugin/src/lineage.ts
+// Resolves any inbound Chorus notification/entity to its idea attribution, so the
+// OpenClaw daemon client can anchor ONE embedded-agent session per DIRECT idea (the
+// in-process analog of `claude --resume <directIdeaUuid>`) while reporting the ROOT
+// idea in its execution snapshot for observability.
+//
+// TS mirror of `cli/lineage.mjs` (`LineageResolver`) — same single-source-of-truth
+// REST contract, re-stated in TS because the plugin publishes standalone (it cannot
+// import a file under `cli/`; see daemon-rest-client.ts for the same rationale).
+//
+// Resolution is fully SERVER-SIDE: every entity is resolved by a single call to the
+// standalone REST endpoint
+//   GET /api/entities/{type}/{uuid}/root-idea   (Bearer <cho_ agent key>)
+// which returns BOTH `rootIdeaUuid` (topmost ancestor) and `directIdeaUuid` (the
+// first idea node on the lineage). There is intentionally NO client-side lineage
+// walk. On any failure (unreachable server, non-2xx, malformed body) it returns both
+// ids as null so the caller falls back to a per-entity session key — "no idea
+// ancestor" is a normal, non-fatal outcome. Uses global fetch (Node 18+) → no new dep.
+
+export interface LineageLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+const NOOP_LOGGER: LineageLogger = { info() {}, warn() {}, error() {} };
+
+/** The idea attribution of an entity. Both null when there's no idea ancestor. */
+export interface LineageAttribution {
+  rootIdeaUuid: string | null;
+  directIdeaUuid: string | null;
+}
+
+const NONE: LineageAttribution = { rootIdeaUuid: null, directIdeaUuid: null };
+
+export interface LineageResolverOptions {
+  /** Chorus base URL. */
+  url: string;
+  /** `cho_` agent API key. */
+  apiKey: string;
+  logger?: LineageLogger;
+  /** Injectable for tests (defaults to global fetch). */
+  fetchImpl?: typeof fetch;
+}
+
+export class LineageResolver {
+  private readonly url: string;
+  private readonly apiKey: string;
+  private readonly logger: LineageLogger;
+  private readonly fetchImpl: typeof fetch;
+  /** Per-run cache keyed by `${type}:${uuid}` so repeats single-flight. */
+  private readonly cache = new Map<string, LineageAttribution>();
+
+  constructor(opts: LineageResolverOptions) {
+    this.url = opts.url.replace(/\/$/, "");
+    this.apiKey = opts.apiKey;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  }
+
+  /**
+   * Resolve an entity to its idea attribution `{ rootIdeaUuid, directIdeaUuid }`.
+   * One REST call per entity; the cache single-flights repeats. On any failure both
+   * ids are null (caller falls back to a per-entity key). Never throws.
+   */
+  async resolve(event: {
+    entityType?: string;
+    entityUuid?: string;
+  }): Promise<LineageAttribution> {
+    const entityType = event?.entityType;
+    const entityUuid = event?.entityUuid;
+    if (!entityType || !entityUuid) {
+      this.logger.warn("[Chorus] lineage: event missing entityType/entityUuid");
+      return NONE;
+    }
+    // An ad-hoc conversation (`daemon_session`) has NO idea ancestor by definition,
+    // and the root-idea endpoint does not accept it (it would 400). Short-circuit to
+    // the null attribution the caller would fall back to anyway — avoiding a
+    // guaranteed-failing round-trip + a spurious warn on every ad-hoc resume. The
+    // caller then anchors the session on the entity uuid (= the ad-hoc sessionId).
+    if (entityType === "daemon_session") {
+      return NONE;
+    }
+    const cacheKey = `${entityType}:${entityUuid}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
+    const result = await this.resolveViaServer(entityType, entityUuid);
+    this.cache.set(cacheKey, result);
+    return result;
+  }
+
+  /**
+   * Call GET /api/entities/{type}/{uuid}/root-idea and return
+   * `{ rootIdeaUuid, directIdeaUuid }` (each string | null). Returns both null on any
+   * error so the caller degrades to a per-entity session key — never throws.
+   */
+  private async resolveViaServer(
+    entityType: string,
+    entityUuid: string,
+  ): Promise<LineageAttribution> {
+    const endpoint =
+      `${this.url}/api/entities/${encodeURIComponent(entityType)}/` +
+      `${encodeURIComponent(entityUuid)}/root-idea`;
+    let response: Response;
+    try {
+      response = await this.fetchImpl(endpoint, {
+        headers: { Authorization: `Bearer ${this.apiKey}`, Accept: "application/json" },
+      });
+    } catch (err) {
+      this.logger.warn(`[Chorus] lineage: request failed for ${entityType}:${entityUuid}: ${err}`);
+      return NONE;
+    }
+    if (!response.ok) {
+      this.logger.warn(
+        `[Chorus] lineage: server returned ${response.status} for ${entityType}:${entityUuid}`,
+      );
+      return NONE;
+    }
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (err) {
+      this.logger.warn(`[Chorus] lineage: bad JSON for ${entityType}:${entityUuid}: ${err}`);
+      return NONE;
+    }
+    // API envelope: { success: true, data: { rootIdeaUuid, directIdeaUuid, ... } }.
+    const data =
+      body && typeof body === "object" ? (body as { data?: unknown }).data : undefined;
+    if (!data || typeof data !== "object" || !("rootIdeaUuid" in data)) {
+      this.logger.warn(
+        `[Chorus] lineage: unexpected response shape for ${entityType}:${entityUuid}`,
+      );
+      return NONE;
+    }
+    const root = (data as { rootIdeaUuid: unknown }).rootIdeaUuid;
+    if (root !== null && typeof root !== "string") {
+      this.logger.warn(`[Chorus] lineage: non-string rootIdeaUuid for ${entityType}:${entityUuid}`);
+      return NONE;
+    }
+    // directIdeaUuid is the session anchor. Older servers may omit it: treat a
+    // missing/non-string value as null so the caller falls back to a per-entity key.
+    const directRaw = (data as { directIdeaUuid?: unknown }).directIdeaUuid;
+    const direct = typeof directRaw === "string" ? directRaw : null;
+    if (directRaw !== undefined && directRaw !== null && typeof directRaw !== "string") {
+      this.logger.warn(
+        `[Chorus] lineage: non-string directIdeaUuid for ${entityType}:${entityUuid}`,
+      );
+    }
+    const resolvedVia = (data as { resolvedVia?: unknown }).resolvedVia;
+    this.logger.info(
+      `[Chorus] lineage: ${entityType}:${entityUuid} → root ${root ?? "none"}, direct ${direct ?? "none"}` +
+        (typeof resolvedVia === "string" ? ` (${resolvedVia})` : ""),
+    );
+    return { rootIdeaUuid: root, directIdeaUuid: direct };
+  }
+}

--- a/packages/openclaw-plugin/src/mcp-registration.ts
+++ b/packages/openclaw-plugin/src/mcp-registration.ts
@@ -86,25 +86,12 @@ export async function ensureChorusMcpServer(
   const desired = buildDesiredEntry(cfg.chorusUrl!, cfg.apiKey!);
 
   try {
-    // `api.runtime` is permissively typed via the SDK shim; narrow to the
-    // config surface we use (current() + mutateConfigFile). At runtime the host
-    // provides the real `PluginRuntimeCore.config` API
-    // (../openclaw/src/plugins/runtime/types-core.ts:145).
-    const runtimeConfig = (
-      api.runtime as
-        | {
-            config?: {
-              current?: () => { mcp?: { servers?: Record<string, unknown> } } | undefined;
-              mutateConfigFile?: (params: {
-                afterWrite: { mode: "auto" };
-                mutate: (draft: {
-                  mcp?: { servers?: Record<string, unknown> };
-                }) => void;
-              }) => Promise<unknown>;
-            };
-          }
-        | undefined
-    )?.config;
+    // `api.runtime` is now typed (`OpenClawPluginRuntime`) via the SDK shim; its
+    // `config` slice mirrors the real `PluginRuntimeCore.config` API
+    // (../openclaw/src/plugins/runtime/types-core.ts:145) — `current()` reads the
+    // live snapshot, `mutateConfigFile(...)` writes the `mcp.servers.chorus`
+    // entry. No `unknown` cast needed.
+    const runtimeConfig = api.runtime?.config;
 
     if (!runtimeConfig?.mutateConfigFile) {
       logger.error(

--- a/packages/openclaw-plugin/src/openclaw-sdk.d.ts
+++ b/packages/openclaw-plugin/src/openclaw-sdk.d.ts
@@ -42,11 +42,236 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
     jsonSchema?: Record<string, unknown>;
   };
 
+  // ===========================================================================
+  // Runtime SDK surface (`api.runtime`) — typed against the REAL ../openclaw
+  // source so the daemon call sites are compile-time checked rather than
+  // `unknown`-cast. We declare ONLY the minimal slice the plugin consumes; the
+  // full `PluginRuntime` graph (subagent/nodes/channel/media/...) is not pulled
+  // in. Every shape below was verified field-by-field against the real source
+  // (file:line citations inline) — NOT from memory.
+  //
+  // WHY HAND-DECLARED (not imported from `openclaw/plugin-sdk`): the real
+  // package exports `./plugin-sdk` (package.json exports map) but NOT the
+  // `./plugin-sdk/plugin-entry` subpath this plugin imports, and the `openclaw`
+  // build resolvable in this workspace is an older 2026.3.x that lacks both.
+  // Importing the real defs would also couple this separately-published package
+  // to the full `openclaw` type graph (llm-core, markdown-core, …) and turn the
+  // peer into a build-time hard dependency. The plugin must build/pack
+  // standalone (peerDependencies.openclaw only), so we mirror the minimal slice.
+  // ===========================================================================
+
+  /**
+   * `BlockReplyPayload` — payload for the `onBlockReply` streaming callback.
+   * Verified: ../openclaw/src/agents/embedded-agent-payloads.ts:1-11.
+   * The plugin's transcript reporter reads only `.text`.
+   */
+  export type OpenClawBlockReplyPayload = {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+    trustedLocalMedia?: boolean;
+    sensitiveMedia?: boolean;
+    isReasoning?: boolean;
+    replyToId?: string;
+    replyToTag?: boolean;
+    replyToCurrent?: boolean;
+  };
+
+  /**
+   * `ReplyPayload` (subset) — payload for the `onToolResult` streaming callback.
+   * Verified: ../openclaw/src/auto-reply/reply-payload.ts:7-60 (only the fields
+   * the plugin may read are declared; the rest of the large union is omitted via
+   * the index signature).
+   */
+  export type OpenClawReplyPayload = {
+    text?: string;
+    mediaUrl?: string;
+    mediaUrls?: string[];
+    isError?: boolean;
+    isReasoning?: boolean;
+    isReasoningSnapshot?: boolean;
+    channelData?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+
+  /**
+   * What initiated an embedded run.
+   * Verified: ../openclaw/src/agents/embedded-agent-runner/run/params.ts:32
+   * (`EmbeddedRunTrigger`).
+   */
+  export type OpenClawEmbeddedRunTrigger =
+    | "cron"
+    | "heartbeat"
+    | "manual"
+    | "memory"
+    | "overflow"
+    | "user";
+
+  /**
+   * Params for `runtime.agent.runEmbeddedAgent`.
+   *
+   * The real `RunEmbeddedAgentParams` has ~100 fields, almost all optional;
+   * verified against ../openclaw/src/agents/embedded-agent-runner/run/params.ts.
+   * We declare exactly the fields the plugin passes/uses (required ones with
+   * their real required/optional-ness) plus the daemon-parity fields
+   * (`abortSignal` + per-message streaming callbacks) the dependent tasks
+   * consume, and keep an index signature for the untouched remainder so the
+   * type stays a faithful subset rather than a closed shape.
+   *
+   * Required-field cites (params.ts): sessionId:40, sessionFile:104,
+   * workspaceDir:105, prompt:111, timeoutMs:155, runId:166.
+   * Optional-field cites: sessionKey:41, agentId:46, trigger:51, agentDir:108,
+   * config:109, provider:122, model:123, disableMessageTool:91,
+   * runTimeoutOverrideMs:165, abortSignal:167, onAssistantMessageStart:190,
+   * onBlockReply:191, onReasoningStream:195-199, onToolResult:201.
+   */
+  export type RunEmbeddedAgentParams = {
+    sessionId: string;
+    sessionFile: string;
+    workspaceDir: string;
+    prompt: string;
+    timeoutMs: number;
+    runId: string;
+    sessionKey?: string;
+    agentId?: string;
+    trigger?: OpenClawEmbeddedRunTrigger;
+    agentDir?: string;
+    // The real type is `OpenClawConfig`; the plugin passes through the opaque
+    // `api.config` snapshot, so `unknown` keeps it pass-through-safe.
+    config?: unknown;
+    provider?: string;
+    model?: string;
+    disableMessageTool?: boolean;
+    runTimeoutOverrideMs?: number;
+    /** Cooperative mid-run interrupt; relayed through the whole run. (params.ts:167) */
+    abortSignal?: AbortSignal;
+    /** Fires when the assistant begins a message. (params.ts:190) */
+    onAssistantMessageStart?: () => void | Promise<void>;
+    /** Fires per finalized assistant text block — the transcript source. (params.ts:191) */
+    onBlockReply?: (payload: OpenClawBlockReplyPayload) => void | Promise<void>;
+    /** Fires for reasoning/thinking deltas; NOT posted to the transcript. (params.ts:195) */
+    onReasoningStream?: (payload: {
+      text?: string;
+      mediaUrls?: string[];
+      isReasoningSnapshot?: boolean;
+    }) => void | Promise<void>;
+    /** Fires per tool result. (params.ts:201) */
+    onToolResult?: (payload: OpenClawReplyPayload) => void | Promise<void>;
+    // The real type carries many more optional fields; allow them without
+    // re-declaring the full graph.
+    [key: string]: unknown;
+  };
+
+  /**
+   * Result of `runtime.agent.runEmbeddedAgent`.
+   * Verified: ../openclaw/src/agents/embedded-agent-runner/types.ts:179-212
+   * (`EmbeddedAgentRunResult`) and its `meta: EmbeddedAgentRunMeta` at :137-177.
+   * The plugin reads `meta.aborted` to distinguish a user-abort from a crash.
+   */
+  export type EmbeddedAgentRunMeta = {
+    durationMs: number;
+    /** True when the run was aborted via `abortSignal`. (types.ts:140) */
+    aborted?: boolean;
+    finalAssistantVisibleText?: string;
+    stopReason?: string;
+    [key: string]: unknown;
+  };
+  export type EmbeddedAgentRunResult = {
+    meta: EmbeddedAgentRunMeta;
+    payloads?: Array<{ text?: string; isError?: boolean; isReasoning?: boolean }>;
+    [key: string]: unknown;
+  };
+
+  /**
+   * Session store entry (subset).
+   * Verified: ../openclaw/src/config/sessions/types.ts — `sessionId:254`,
+   * `sessionFile?:256`. Returned by `getSessionEntry`.
+   */
+  export type OpenClawSessionEntry = {
+    sessionId: string;
+    sessionFile?: string;
+    [key: string]: unknown;
+  };
+
+  /**
+   * The `runtime.agent` slice the plugin consumes.
+   * Verified: ../openclaw/src/plugins/runtime/types-core.ts:180-221
+   * (`PluginRuntimeCore.agent`). Each member's signature confirmed at its real
+   * definition site (cited per member).
+   */
+  export type OpenClawRuntimeAgent = {
+    /** params.ts/run.ts:458 — `(params) => Promise<EmbeddedAgentRunResult>`. */
+    runEmbeddedAgent: (params: RunEmbeddedAgentParams) => Promise<EmbeddedAgentRunResult>;
+    /** agent-scope-config.ts:195 — positional `(cfg, agentId)`, returns the agent dir. */
+    resolveAgentDir: (cfg: unknown, agentId: string) => string;
+    /** agent-scope-config.ts:170 — positional `(cfg, agentId)`, returns the workspace dir. */
+    resolveAgentWorkspaceDir: (cfg: unknown, agentId: string) => string;
+    /** timeout.ts:15 — options-object `({ cfg }) => number`. */
+    resolveAgentTimeoutMs: (opts: {
+      cfg?: unknown;
+      overrideMs?: number | null;
+      overrideSeconds?: number | null;
+      minMs?: number;
+    }) => number;
+    session: {
+      /** store.ts:210 — `({ sessionKey, agentId? }) => SessionEntry | undefined`. */
+      getSessionEntry: (options: {
+        sessionKey: string;
+        agentId?: string;
+        env?: NodeJS.ProcessEnv;
+        storePath?: string;
+      }) => OpenClawSessionEntry | undefined;
+      /** paths.ts:267 — `(sessionId, entry?, opts?) => string`. */
+      resolveSessionFilePath: (
+        sessionId: string,
+        entry?: { sessionFile?: string },
+        opts?: { agentId?: string; sessionsDir?: string },
+      ) => string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+
+  /**
+   * The `runtime.config` slice the plugin consumes (MCP-server registration).
+   * Verified: ../openclaw/src/plugins/runtime/types-core.ts:145-178
+   * (`PluginRuntimeCore.config`). The plugin uses `current()` to read the live
+   * config snapshot and `mutateConfigFile(...)` to write the `mcp.servers.chorus`
+   * entry; the real `mutateConfigFile` is generic — `mutate(draft)` mutates a
+   * `DeepReadonly`-cloned draft in place. We narrow `draft`/return to the MCP
+   * slice the plugin touches.
+   */
+  export type OpenClawRuntimeConfig = {
+    current?: () => { mcp?: { servers?: Record<string, unknown> } } | undefined;
+    mutateConfigFile?: (params: {
+      afterWrite: { mode: "auto" };
+      mutate: (draft: { mcp?: { servers?: Record<string, unknown> } }) => void;
+    }) => Promise<unknown>;
+    [key: string]: unknown;
+  };
+
+  /**
+   * The slice of `PluginRuntime` (`api.runtime`) the plugin consumes.
+   * Verified: ../openclaw/src/plugins/types.ts:2600 (`runtime: PluginRuntime`)
+   * → ../openclaw/src/plugins/runtime/types.ts (PluginRuntime = PluginRuntimeCore
+   * & …) → ../openclaw/src/plugins/runtime/types-core.ts (`agent` :180,
+   * `config` :145). The reverse control channel is NOT part of this runtime
+   * surface — it arrives over the SSE stream (`type: "control"`), handled in
+   * `sse-listener.ts` / the control handler, not via `api.runtime`. Confirmed:
+   * no `control`/`connection` member exists on `PluginRuntimeCore`.
+   */
+  export type OpenClawPluginRuntime = {
+    agent: OpenClawRuntimeAgent;
+    config: OpenClawRuntimeConfig;
+    [key: string]: unknown;
+  };
+
   /**
    * Permissive subset of `OpenClawPluginApi` used by this plugin's entry.
    *
    * Only the members this plugin touches are typed; the index signature keeps
    * the rest of the (large) host API accessible without importing it.
+   * Verified: ../openclaw/src/plugins/types.ts:2584-2600 (`OpenClawPluginApi`).
    */
   export type OpenClawPluginApi = {
     registrationMode: PluginRegistrationMode;
@@ -68,7 +293,13 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
     }) => void;
     registerCommand: (command: unknown) => void;
     registerTool: (tool: unknown, opts?: unknown) => void;
-    runtime?: unknown;
+    /**
+     * In-process runtime helpers. Typed to the minimal slice the plugin uses
+     * (`agent`, `config`) — no longer bare `unknown`. Optional because the
+     * narrow registration modes (discovery/cli-metadata) may not expose it; the
+     * plugin guards `api.runtime` before use.
+     */
+    runtime?: OpenClawPluginRuntime;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
   };

--- a/packages/openclaw-plugin/src/sse-listener.ts
+++ b/packages/openclaw-plugin/src/sse-listener.ts
@@ -13,10 +13,42 @@ export interface SseNotificationEvent {
   [key: string]: unknown;
 }
 
+/**
+ * The server's post-handshake `connection_registered` data event (carrying the
+ * DaemonConnection uuid this stream registered as). Forked to `onConnectionId`,
+ * NEVER to the wake path. See api/events/notifications/route.ts.
+ */
+export interface SseControlEvent {
+  type: string; // "control" | "connection_registered"
+  command?: string; // interrupt | resume | deliver_turn (control only)
+  connectionUuid?: string; // connection_registered only
+  targetConnectionUuid?: string; // control only
+  entityType?: string;
+  entityUuid?: string;
+  turnUuid?: string;
+  [key: string]: unknown;
+}
+
 export interface ChorusSseListenerOptions {
   chorusUrl: string;
   apiKey: string;
   onEvent: (event: SseNotificationEvent) => void;
+  /**
+   * Called once the server reports which DaemonConnection this stream registered
+   * as (the `connection_registered` data event). Stored as the connection
+   * identity (connection-state) and refreshed on every reconnect. This event is
+   * NOT a wake — it is forked here BEFORE `onEvent`, so the router never sees it.
+   */
+  onConnectionId?: (connectionUuid: string) => void;
+  /**
+   * Called for a `type:"control"` data event (the reverse control channel). This
+   * is NOT a wake: the control event is forked here BEFORE `onEvent`, so the
+   * router / wake path never sees it and it can never spawn a new embedded-agent
+   * run for the control event itself. The handler verifies the target connection
+   * (+ entity, for interrupt) and routes to the behavior hooks — see
+   * control-handler.ts.
+   */
+  onControl?: (event: SseControlEvent) => void;
   onReconnect: () => Promise<void>;
   logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
 }
@@ -52,6 +84,8 @@ const PROCESS_STARTED_AT = new Date();
 
 export class ChorusSseListener {
   private readonly opts: ChorusSseListenerOptions;
+  private readonly onConnectionId: (connectionUuid: string) => void;
+  private readonly onControl: (event: SseControlEvent) => void;
   private readonly endpoint: string;
   private _status: SseListenerStatus = "disconnected";
   private abortController: AbortController | null = null;
@@ -60,6 +94,10 @@ export class ChorusSseListener {
 
   constructor(opts: ChorusSseListenerOptions) {
     this.opts = opts;
+    // Default the optional bidirectional callbacks to no-ops so a caller that
+    // only wants the wake path (no daemon reporting) still works unchanged.
+    this.onConnectionId = opts.onConnectionId ?? (() => {});
+    this.onControl = opts.onControl ?? (() => {});
 
     // Build the self-reporting endpoint URL once and reuse it across every
     // (re)connect, so the reconnect path always re-sends the same params. The
@@ -194,12 +232,43 @@ export class ChorusSseListener {
       // Data lines
       if (line.startsWith("data: ")) {
         const jsonStr = line.slice(6);
+        let event: SseNotificationEvent;
         try {
-          const event: SseNotificationEvent = JSON.parse(jsonStr);
-          this.opts.onEvent(event);
+          event = JSON.parse(jsonStr);
         } catch (err) {
           this.opts.logger.warn(`SSE JSON parse error: ${err} — raw: ${jsonStr}`);
+          continue;
         }
+
+        // The server's post-handshake `connection_registered` data event tells us
+        // which DaemonConnection this stream registered as. Capture it (the
+        // connection identity used to attribute reports + double-check control
+        // commands) and do NOT forward it to the wake path — it isn't a
+        // notification. Forked here so the router never logs it as ignored.
+        if (event.type === "connection_registered" && typeof event.connectionUuid === "string") {
+          try {
+            this.onConnectionId(event.connectionUuid);
+          } catch (err) {
+            this.opts.logger.warn(`onConnectionId callback error: ${err}`);
+          }
+          continue;
+        }
+
+        // Reverse control channel: a `type:"control"` event is NOT a wake. Fork it
+        // to onControl and `continue` — it MUST NEVER fall through to onEvent (the
+        // router / wake path), or a control command could be mistaken for a wake and
+        // spawn a new embedded-agent run. This is the structural guarantee the spec
+        // requires.
+        if (event.type === "control") {
+          try {
+            this.onControl(event as SseControlEvent);
+          } catch (err) {
+            this.opts.logger.warn(`onControl callback error: ${err}`);
+          }
+          continue;
+        }
+
+        this.opts.onEvent(event);
       }
     }
   }

--- a/packages/openclaw-plugin/src/wake.ts
+++ b/packages/openclaw-plugin/src/wake.ts
@@ -1,4 +1,8 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  OpenClawPluginApi,
+  OpenClawRuntimeAgent,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { WakeRunContext } from "./daemon-client.js";
 
 /**
  * Wake mechanism for the Chorus plugin.
@@ -142,34 +146,21 @@ export function resolveModelRef(
 }
 
 /**
- * Narrowed view of the `api.runtime.agent` surface we use to run a turn. Only
- * the members this plugin touches are typed; the host provides the full
- * `PluginRuntimeCore.agent` at runtime (types-core.ts:180-221).
+ * Resolve the `api.runtime.agent` surface we use to run a turn, returning null
+ * when the host does not expose it (narrow registration modes / older hosts).
+ *
+ * `api.runtime` is now typed (`OpenClawPluginRuntime`) via the SDK shim — the
+ * `agent` slice mirrors `PluginRuntimeCore.agent` (types-core.ts:180-221). We
+ * still runtime-check each function we call (the declared type is a structural
+ * promise the host fulfills; a real host that drops a member must degrade
+ * gracefully, not throw).
  */
-interface SessionEntryLike {
-  sessionId: string;
-  sessionFile?: string;
-}
-interface RuntimeAgentSlice {
-  runEmbeddedAgent: (params: Record<string, unknown>) => Promise<unknown>;
-  resolveAgentDir: (cfg: unknown, agentId: string) => string;
-  resolveAgentWorkspaceDir: (cfg: unknown, agentId: string) => string;
-  resolveAgentTimeoutMs: (opts: { cfg?: unknown }) => number;
-  session: {
-    getSessionEntry: (options: { sessionKey: string; agentId?: string }) => SessionEntryLike | undefined;
-    resolveSessionFilePath: (
-      sessionId: string,
-      entry?: { sessionFile?: string },
-      opts?: { agentId?: string },
-    ) => string;
-  };
-}
-
-function getRuntimeAgent(api: OpenClawPluginApi): RuntimeAgentSlice | null {
-  const agent = (api.runtime as { agent?: Partial<RuntimeAgentSlice> } | undefined)?.agent;
+function getRuntimeAgent(api: OpenClawPluginApi): OpenClawRuntimeAgent | null {
+  const agent = api.runtime?.agent as Partial<OpenClawRuntimeAgent> | undefined;
   if (
     !agent ||
     typeof agent.runEmbeddedAgent !== "function" ||
+    typeof agent.resolveAgentDir !== "function" ||
     typeof agent.resolveAgentWorkspaceDir !== "function" ||
     typeof agent.resolveAgentTimeoutMs !== "function" ||
     typeof agent.session?.getSessionEntry !== "function" ||
@@ -177,7 +168,7 @@ function getRuntimeAgent(api: OpenClawPluginApi): RuntimeAgentSlice | null {
   ) {
     return null;
   }
-  return agent as RuntimeAgentSlice;
+  return agent as OpenClawRuntimeAgent;
 }
 
 /**
@@ -189,6 +180,58 @@ let wakeCounter = 0;
 function nextRunId(contextKey: string): string {
   wakeCounter += 1;
   return `chorus-wake-${wakeCounter}-${contextKey}`;
+}
+
+/**
+ * Resolve the host run context the daemon client needs to run a wake via
+ * `runEmbeddedAgent` — the main-agent session key + agent id + workspace/timeout +
+ * model override + the typed `runtime.agent` surface. Returns null when the wake must
+ * be DROPPED (no resolvable session key, or the host does not expose the agent
+ * runtime / a required session helper). This is the SINGLE place that reaches into
+ * `api.config` / `api.runtime`, so the daemon client stays host-API-agnostic and
+ * unit-testable with a plain context object.
+ *
+ * NOTE: this resolves only the host-derived knobs (the agent's main-session lane,
+ * workspace, model). The per-wake session ANCHOR (the Chorus business key →
+ * deterministic sessionKey → getSessionEntry) is owned by the daemon client, so a
+ * resume continues the same session regardless of when the context was resolved.
+ */
+export function resolveWakeRunContext(
+  api: OpenClawPluginApi,
+  logger: { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void },
+): WakeRunContext | null {
+  const sessionKey = resolveSessionKey(api);
+  if (!sessionKey) {
+    logger.warn("[Chorus] Wake run-context unavailable — could not resolve a main agent session key.");
+    return null;
+  }
+  const agent = getRuntimeAgent(api);
+  if (!agent) {
+    logger.warn(
+      "[Chorus] Wake run-context unavailable — api.runtime.agent.runEmbeddedAgent (or a required session helper) is not exposed on this host.",
+    );
+    return null;
+  }
+  const cfg = api.config;
+  const agentId = resolveAgentId(api);
+  let workspaceDir: string;
+  let agentDir: string | undefined;
+  let timeoutMs: number;
+  try {
+    workspaceDir = agent.resolveAgentWorkspaceDir(cfg, agentId);
+    agentDir = agent.resolveAgentDir(cfg, agentId);
+    timeoutMs = agent.resolveAgentTimeoutMs({ cfg });
+  } catch (err) {
+    logger.warn(`[Chorus] Wake run-context unavailable — workspace/timeout resolution failed: ${err}`);
+    return null;
+  }
+  const modelRef = resolveModelRef(api);
+  if (!modelRef) {
+    logger.warn(
+      "[Chorus] No agents.defaults.model configured — wake turns will use the host default model, which may be unavailable.",
+    );
+  }
+  return { agent, sessionKey, agentId, config: cfg, workspaceDir, agentDir, timeoutMs, modelRef };
 }
 
 /**


### PR DESCRIPTION
## Summary

Brings the **OpenClaw plugin** to the same bidirectional daemon protocol the chorus CLI host already implements, re-mapped onto the in-process `runEmbeddedAgent` host. **The server side is unchanged** — every `/api/daemon/*` endpoint and the `control:{connectionUuid}` channel already existed; this makes the second daemon host speak the same protocol. Implements idea `adfd0b31` (OpenSpec change `align-openclaw-daemon-parity`).

Before: the OpenClaw plugin was single-direction (receive notification → wake agent) and a black box in the UI. After: it captures its `connectionUuid`, subscribes the reverse control channel, reports turn lifecycle + execution-state + streaming transcript + report-interrupt, supports real mid-run interrupt + resume, and recovers missed instructions via pending-turns backfill.

## What changed

- **Shared `daemon-rest-client`** — single source of truth for the 5 `/api/daemon/*` payload shapes; `cli/daemon.mjs` reporters refactored onto it (behavior-preserving — CLI suite unchanged & green). The plugin carries a byte-faithful TS mirror because it publishes standalone (no cross-package import).
- **Real SDK typing** — replaced the opaque `runtime: unknown` shim so `runEmbeddedAgent`'s `abortSignal` + per-message streaming callbacks + session helpers are compile-time checked (verified against real `../openclaw` source).
- **connection_registered + control channel** — `onConnectionId` captures the uuid; `onControl` forks `type:"control"` to a handler with the connection+entity double-check; control never enters the wake path.
- **In-process daemon client** — turn-advance / execution-state / streaming transcript reporting; real mid-run interrupt via per-run `AbortController` (user vs crash); deterministic session-key mapping (resume/deliver_turn re-enter the same session); pending-turns backfill with at-most-once dedup.

## Two real bugs caught during review & fixed (with regression tests)

| Bug | Found by | Fix |
|-----|----------|-----|
| Fresh-wake session-id fell back to a colon-laden runId, violating OpenClaw's `SAFE_SESSION_ID_RE` → wake dropped | live OpenClaw-gateway e2e | fall back to the business-key uuid (preserves resume continuity) |
| Delivered/backfilled **ad-hoc** turns omitted `entityType` → no execution row + no AbortController → run invisible in UI & uninterruptible (the `task:<sessionId>` trap the CLI comment warns about) | holistic full-diff code review | anchor on `daemon_session:<sessionId>` (idea-anchored → `idea:<directIdeaUuid>`) |

## Test plan

- [x] Plugin suite: 139 passed / 3 skipped (e2e CI-gated); `tsc --noEmit` clean
- [x] CLI behavior-preservation oracle: 272 passed (existing reporter assertions unchanged)
- [x] **e2e Tier 1**: real OpenClaw gateway + real Bedrock LLM wake → transcript readable; deterministic live-HTTP test covers interrupt→interrupted(user)→resume + deliver_turn + pending-turns backfill at-most-once
- [x] Each task independently reviewed (`chorus:task-reviewer`) + a holistic `/code-review` of the full diff

## Notes

- `docs/design.pen` intentionally untouched — no user-facing surface changed (existing Agent Connections UI renders any daemon host's reports).
- Out of scope: the dispatch concurrency model (sibling idea `6fab91cd`).
- Follow-up (low severity, not blocking): the long-lived plugin's `aborts`/`executions`/`seenTurns`/lineage Maps clear on the normal path but have no TTL/cap — add LRU if a long session shows memory creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)