### PR TITLE
fix(dashboard): sync idea panel to URL on soft navigation

### DIFF
--- a/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/README.md
+++ b/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/README.md
@@ -1,0 +1,3 @@
+# fix-idea-panel-softnav-sync
+
+Fix idea side-panel not switching on soft navigation (usePanelUrl ignores useSearchParams)

--- a/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/design.md
+++ b/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/design.md
@@ -1,0 +1,68 @@
+# Technical Design: Idea panel URL sync on soft navigation
+
+## Overview
+
+The Dashboard renders the idea detail panel from a single piece of client state, `selectedId`, owned by the `usePanelUrl` hook. The panel is opened/switched by reflecting `?panel=<ideaUuid>` into the URL. Today `selectedId` is a local `useState` that only re-syncs on `popstate`; App Router soft navigation does not fire `popstate`, so external `router.push('?panel=…')` links change the URL but not `selectedId`.
+
+The fix makes the URL the source of truth for the selection by reading `useSearchParams()`, which the App Router updates reactively on every navigation kind. The hook's imperative API (`openPanel` / `closePanel` / `switchTab`) is preserved so in-app callers are unaffected.
+
+## Root cause (verified against code)
+
+`src/hooks/use-panel-url.ts`:
+- `const [selectedId, setSelectedId] = useState(initialSelectedId ?? null)` — `initialSelectedId` (from the server `page.tsx` reading `searchParams.panel`) is a `useState` **initializer**; it is ignored on every render after the first mount. So while already on the Dashboard, changing `?panel=` never updates `selectedId`.
+- The only post-mount sync path is a `popstate` listener (browser back/forward). `router.push` / `<Link>` soft navigation updates the URL via the App Router without dispatching `popstate`, so the listener never runs.
+
+The four external entry points all build `/projects/{p}/dashboard?panel={ideaUuid}` and navigate via soft nav, so all four hit the same dead path:
+- `src/components/notification-popup.tsx` → `getEntityPath()` + `router.push` (`handleClickNotification`).
+- `src/contexts/notification-context.tsx` → toast action `router.push(getEntityPath(...))`.
+- `src/components/global-search.tsx` → `navigateToResult` `router.push`.
+- `src/components/agent-presence/hooks.ts` `execHref()` → consumed by `execution-row.tsx` and `chat/turn-band.tsx` (rendered as links/anchors → soft nav).
+
+The in-app callers already work because they call the hook's `openPanel` directly (e.g. `idea-tracker.tsx` `onIdeaClick={openPanel}`, `IdeaDetailPanel onNavigate={openPanel}`), which updates local state. The bug is exclusively on the URL→state direction for soft nav.
+
+## Approach (chosen: A — derive from useSearchParams)
+
+Rewrite `usePanelUrl` so the URL drives the state:
+
+1. Read the live params with `const searchParams = useSearchParams()`.
+2. Derive selection directly: `const selectedId = searchParams.get("panel")` and `const selectedTab = searchParams.get("tab")`. No `useState` mirror for these (eliminates the stale-initializer and dual-source-of-truth classes of bug at once).
+3. `openPanel(id, tab?)` / `closePanel()` / `switchTab(tab)` continue to update the URL. They should push the change through the router so `useSearchParams()` re-renders the subtree:
+   - Use `router.replace(buildUrl(...))` (App Router) so the param change is observable to `useSearchParams()` while keeping a single history entry (matching the current `history.replaceState` semantics — these are programmatic panel toggles, not new history destinations).
+   - `buildUrl` keeps preserving unrelated query params (filters, etc.), unchanged from today.
+4. Drop the manual `popstate` listener — `useSearchParams()` already reflects back/forward, so the listener becomes redundant (and removing it avoids double-handling).
+
+Rationale for A over B/C (from elaboration):
+- **B (controlled initial prop):** relies on the RSC re-render delivering a new prop on every `?panel=` change and introduces an `openPanel`-vs-prop race; more moving parts than reading the param directly.
+- **C (fix each entry):** would touch 4 call sites and require a new cross-component channel to reach `openPanel`; largest blast radius for a one-line-root-cause bug.
+
+## Suspense boundary (Next 15 requirement)
+
+`useSearchParams()` must be under a `<Suspense>` boundary, or Next 15 opts the whole route into client-side rendering and emits a build-time warning. `IdeaTracker` is the component that owns `usePanelUrl`, mounted by `dashboard-content.tsx`. Wrap the `<IdeaTracker .../>` element in `<Suspense fallback={…}>`:
+- The fallback should be a lightweight skeleton/empty placeholder matching the tracker's container so there is no layout jump (the real content hydrates immediately on the client).
+- Keep the boundary as tight as practical (around `IdeaTracker`, not the whole page header) so the static header still streams.
+
+## No-remount invariant (must preserve)
+
+The hook file header documents why `?panel=` uses query params rather than path segments: App Router intercepts **pathname** changes and remounts, but **query-param** changes do not remount. The fix keeps navigation on the same `pathname` and only mutates the query string, so:
+- The `IdeaTracker` subtree is **not** remounted on panel switch — list scroll position, view mode (ideas/lineage/stats), and other transient state survive.
+- `?tab=` keeps working alongside `?panel=` (both derived from the same `searchParams`).
+
+A regression check on this invariant: switching `?panel=` must not reset the segmented view control or list scroll.
+
+## Module contracts
+
+`usePanelUrl(basePath, initialSelectedId?)` keeps its return shape exactly: `{ selectedId, selectedTab, openPanel, closePanel, switchTab }`. `initialSelectedId` becomes advisory (the SSR-rendered first paint can still use it if needed) but is no longer the long-lived source of truth — `useSearchParams()` is. Callers (`idea-tracker.tsx`) need no signature changes.
+
+## Implementation plan
+
+1. Rewrite `usePanelUrl` to derive `selectedId` / `selectedTab` from `useSearchParams()`; route `openPanel` / `closePanel` / `switchTab` through `router.replace` (preserving unrelated params via `buildUrl`); remove the `popstate` listener.
+2. Add a `<Suspense>` boundary around `IdeaTracker` in `dashboard-content.tsx` with a no-layout-jump fallback.
+3. Manually verify all four soft-nav entry points switch the panel while already on the Dashboard.
+4. Add a unit test for `usePanelUrl` (URL change → selection change) and an e2e regression (notification idea link → panel switches).
+
+## Risks & Mitigations
+
+- **Risk:** `router.replace` triggers an RSC round-trip (more work than a bare `history.replaceState`), adding latency or a flash on panel toggle. **Mitigation:** the page is already mounted and the panel fetches its own data client-side; query-only nav does not remount. If a perceptible delay appears, fall back to `window.history.replaceState` for the write path while still reading from `useSearchParams()` for the read path (the read path is what fixes the bug; the write path can stay imperative).
+- **Risk:** Missing/incorrect `<Suspense>` placement degrades the route to CSR. **Mitigation:** verify with `pnpm build` (no `useSearchParams` CSR-bailout warning) and confirm the header still SSRs.
+- **Risk:** Removing `popstate` regresses back/forward. **Mitigation:** the e2e/manual check includes browser back/forward; `useSearchParams()` is documented to update on back/forward.
+- **Risk:** Deriving `selectedId` without local state changes referential identity each render. **Mitigation:** `selectedId` is a primitive string compared by value downstream; no memo dependency relies on a stable object identity here.

--- a/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/proposal.md
+++ b/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+On the project Dashboard (Idea Tracker), clicking an idea link from a notification, the SSE toast, global search, or an agent-presence row changes the URL to `?panel=<ideaUuid>` but the right-hand idea detail panel does **not** open or switch. The URL and the visible UI fall out of sync, so the deep link silently appears broken.
+
+The root cause is a single hook: `usePanelUrl` keeps the selected idea in local `useState` and only re-syncs it on the `popstate` event. App Router soft navigation (`router.push`) changes the URL **without** firing `popstate`, so the hook never learns the URL changed. The server-passed `initialSelectedIdeaUuid` only seeds `useState` on first mount, so navigating between `?panel=` values while already on the Dashboard never updates the panel.
+
+## What Changes
+
+- Make `usePanelUrl` derive its selected-panel / selected-tab state from Next.js `useSearchParams()` (the App Router source of truth that updates reactively on soft navigation), instead of from `popstate`-only local state.
+- Wrap the `IdeaTracker` subtree in a `<Suspense>` boundary, as required by Next 15 for components that read `useSearchParams()` (otherwise the route opts into full client-side rendering and emits a build warning).
+- Preserve the existing design intent: query-param navigation MUST NOT remount the `IdeaTracker` subtree (scroll/tab state survives), and the `?tab=` param continues to work alongside `?panel=`.
+- One root fix repairs **all four** soft-navigation entry points that build `?panel=` links — notification popup, SSE notification toast, global search, and agent-presence rows/turn-band — not just the reported notification popup.
+- Add regression coverage: a unit test that `usePanelUrl` updates the selection when `searchParams` change, plus an e2e test for "stay on Dashboard → click a notification idea link → the panel switches to the new idea" (today's `notification-popup.test` only asserts the pushed URL, never that the panel actually switched).
+
+No API, schema, or data-model changes. No breaking changes — `openPanel` / `closePanel` / `switchTab` keep their existing signatures.
+
+## Capabilities
+
+### New Capabilities
+
+- `idea-panel-url-sync`: The Dashboard idea side-panel selection (`?panel=` / `?tab=`) stays in sync with the browser URL across all navigation kinds — soft navigation (`router.push` / `<Link>`), back/forward, and direct load — without remounting the tracker subtree.
+
+### Modified Capabilities
+
+<!-- None. `idea-list-removal` covers routing/redirects to ?panel= addresses; this change concerns the reactive in-page sync of the panel to that URL, which no existing capability specifies. -->
+
+## Impact
+
+- **Code (changed):**
+  - `src/hooks/use-panel-url.ts` — derive `selectedId` / `selectedTab` from `useSearchParams()`; keep `openPanel` / `closePanel` / `switchTab` updating the URL.
+  - `src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx` (or `idea-tracker.tsx`) — add the `<Suspense>` boundary around `IdeaTracker`.
+- **Code (verified fixed, no change needed):** the four `?panel=` link builders — `src/components/notification-popup.tsx`, `src/contexts/notification-context.tsx`, `src/components/global-search.tsx`, `src/components/agent-presence/hooks.ts` (consumed by `execution-row.tsx` and `chat/turn-band.tsx`).
+- **Tests:** new unit test for `usePanelUrl`; new e2e regression for the notification → panel-switch flow.
+- **Dependencies / APIs / data model:** none.

--- a/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/specs/idea-panel-url-sync/spec.md
+++ b/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/specs/idea-panel-url-sync/spec.md
@@ -1,0 +1,56 @@
+# idea-panel-url-sync Specification
+
+## ADDED Requirements
+
+### Requirement: Dashboard idea panel reflects the URL on soft navigation
+
+The Dashboard idea detail panel selection SHALL be derived from the browser URL query parameter `panel` as its source of truth. When the URL changes to `?panel=<ideaUuid>` via App Router soft navigation (`router.push`, `router.replace`, or `<Link>`) while the Dashboard is already mounted, the panel SHALL open or switch to that idea without requiring a full page reload or a `popstate` event.
+
+#### Scenario: Clicking a notification idea link switches the panel in place
+
+- **WHEN** a user is already on `/projects/{projectUuid}/dashboard` and opens a notification whose target is an idea, then clicks it
+- **THEN** the URL becomes `/projects/{projectUuid}/dashboard?panel={ideaUuid}`
+- **AND** the right-hand idea detail panel opens (or switches) to `{ideaUuid}` without a full page reload
+
+#### Scenario: Switching between two ideas while the panel is open
+
+- **WHEN** the panel is open for idea A and the user soft-navigates to `?panel={ideaB}` (e.g. from search, the SSE toast, or an agent-presence row)
+- **THEN** the panel switches to idea B
+
+#### Scenario: Closing the panel clears the selection
+
+- **WHEN** the URL transitions from `?panel={ideaUuid}` to a URL with no `panel` parameter
+- **THEN** the idea detail panel closes
+
+### Requirement: All soft-navigation idea entry points open the panel
+
+Every in-app navigation that targets an idea by building a `?panel={ideaUuid}` Dashboard URL SHALL result in the panel opening when the user is already on the Dashboard. This applies uniformly to the notification popup, the real-time notification toast, global search, and agent-presence execution rows / chat turn-band links.
+
+#### Scenario: Global search opens the panel in place
+
+- **WHEN** a user already on the Dashboard selects an idea result in global search
+- **THEN** the panel opens to that idea (the URL change alone is not sufficient — the panel must visibly switch)
+
+#### Scenario: Agent-presence idea link opens the panel in place
+
+- **WHEN** a user already on the Dashboard clicks an idea-anchored agent-presence execution row or chat turn-band "Open idea" link
+- **THEN** the panel opens to that idea
+
+### Requirement: Panel navigation preserves tracker state and back/forward
+
+Synchronizing the panel to the URL SHALL NOT remount the Idea Tracker subtree, and SHALL keep browser back/forward and the `tab` parameter working.
+
+#### Scenario: Switching the panel does not reset the tracker view
+
+- **WHEN** the user has selected a tracker view (ideas / lineage / stats) or scrolled the list, then soft-navigates to a different `?panel={ideaUuid}`
+- **THEN** the selected view and list state are preserved (the tracker subtree is not remounted)
+
+#### Scenario: The tab parameter continues to work alongside panel
+
+- **WHEN** the URL is `?panel={ideaUuid}&tab=overview`
+- **THEN** the panel opens to that idea with the `overview` tab selected
+
+#### Scenario: Browser back and forward update the panel
+
+- **WHEN** the user navigates between panel states and then presses the browser Back or Forward button
+- **THEN** the panel selection updates to match the restored URL

--- a/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/tasks.md
+++ b/openspec/changes/archive/2026-06-21-fix-idea-panel-softnav-sync/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+## 1. Fix panel-URL sync + Suspense + regression tests
+
+- [ ] 1.1 Rewrite `usePanelUrl` to derive `selectedId` / `selectedTab` from `useSearchParams()`; route `openPanel` / `closePanel` / `switchTab` through `router.replace` (preserving unrelated query params); remove the redundant `popstate` listener.
+- [ ] 1.2 Wrap `IdeaTracker` in a `<Suspense>` boundary in `dashboard-content.tsx` with a no-layout-jump fallback.
+- [ ] 1.3 Verify all four soft-nav entry points (notification popup, SSE toast, global search, agent-presence rows/turn-band) open/switch the panel while already on the Dashboard, and that back/forward + `?tab=` still work and the tracker view is not reset.
+- [ ] 1.4 Add a unit test for `usePanelUrl` (searchParams change → selection change) and an e2e regression for "stay on Dashboard → click a notification idea link → panel switches".
+- [ ] 1.5 `pnpm build` shows no `useSearchParams` CSR-bailout warning; `pnpm lint`, `npx tsc --noEmit`, and `pnpm test` pass.

--- a/openspec/specs/idea-panel-url-sync/spec.md
+++ b/openspec/specs/idea-panel-url-sync/spec.md
@@ -1,0 +1,58 @@
+# idea-panel-url-sync Specification
+
+## Purpose
+TBD - created by archiving change fix-idea-panel-softnav-sync. Update Purpose after archive.
+## Requirements
+### Requirement: Dashboard idea panel reflects the URL on soft navigation
+
+The Dashboard idea detail panel selection SHALL be derived from the browser URL query parameter `panel` as its source of truth. When the URL changes to `?panel=<ideaUuid>` via App Router soft navigation (`router.push`, `router.replace`, or `<Link>`) while the Dashboard is already mounted, the panel SHALL open or switch to that idea without requiring a full page reload or a `popstate` event.
+
+#### Scenario: Clicking a notification idea link switches the panel in place
+
+- **WHEN** a user is already on `/projects/{projectUuid}/dashboard` and opens a notification whose target is an idea, then clicks it
+- **THEN** the URL becomes `/projects/{projectUuid}/dashboard?panel={ideaUuid}`
+- **AND** the right-hand idea detail panel opens (or switches) to `{ideaUuid}` without a full page reload
+
+#### Scenario: Switching between two ideas while the panel is open
+
+- **WHEN** the panel is open for idea A and the user soft-navigates to `?panel={ideaB}` (e.g. from search, the SSE toast, or an agent-presence row)
+- **THEN** the panel switches to idea B
+
+#### Scenario: Closing the panel clears the selection
+
+- **WHEN** the URL transitions from `?panel={ideaUuid}` to a URL with no `panel` parameter
+- **THEN** the idea detail panel closes
+
+### Requirement: All soft-navigation idea entry points open the panel
+
+Every in-app navigation that targets an idea by building a `?panel={ideaUuid}` Dashboard URL SHALL result in the panel opening when the user is already on the Dashboard. This applies uniformly to the notification popup, the real-time notification toast, global search, and agent-presence execution rows / chat turn-band links.
+
+#### Scenario: Global search opens the panel in place
+
+- **WHEN** a user already on the Dashboard selects an idea result in global search
+- **THEN** the panel opens to that idea (the URL change alone is not sufficient — the panel must visibly switch)
+
+#### Scenario: Agent-presence idea link opens the panel in place
+
+- **WHEN** a user already on the Dashboard clicks an idea-anchored agent-presence execution row or chat turn-band "Open idea" link
+- **THEN** the panel opens to that idea
+
+### Requirement: Panel navigation preserves tracker state and back/forward
+
+Synchronizing the panel to the URL SHALL NOT remount the Idea Tracker subtree, and SHALL keep browser back/forward and the `tab` parameter working.
+
+#### Scenario: Switching the panel does not reset the tracker view
+
+- **WHEN** the user has selected a tracker view (ideas / lineage / stats) or scrolled the list, then soft-navigates to a different `?panel={ideaUuid}`
+- **THEN** the selected view and list state are preserved (the tracker subtree is not remounted)
+
+#### Scenario: The tab parameter continues to work alongside panel
+
+- **WHEN** the URL is `?panel={ideaUuid}&tab=overview`
+- **THEN** the panel opens to that idea with the `overview` tab selected
+
+#### Scenario: Browser back and forward update the panel
+
+- **WHEN** the user navigates between panel states and then presses the browser Back or Forward button
+- **THEN** the panel selection updates to match the restored URL
+

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-tracker-panel-softnav.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-tracker-panel-softnav.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+//
+// Regression for the reported bug: "stay on the Dashboard → follow an idea link
+// (notification / search / toast / agent-presence) → URL changes to ?panel=<id>
+// but the right-hand idea detail panel does not open/switch."
+//
+// This drives the REAL usePanelUrl hook (only useSearchParams is mocked, exactly
+// as Next re-renders consumers on soft navigation) through IdeaTracker, and
+// asserts the IdeaDetailPanel renders for the idea named in the URL — and
+// switches when the URL changes. The pre-fix hook ignored useSearchParams, so
+// the panel marker never appeared / never switched.
+
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IdeaTracker } from "../idea-tracker";
+import type { TrackerGroupsResult, TrackerIdeaItem } from "@/services/idea.service";
+
+// Controllable URL query string standing in for the live address bar that
+// useSearchParams() reflects. Tests mutate it, then re-render the tree.
+let mockParams = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockParams,
+}));
+
+vi.mock("@/contexts/realtime-context", () => ({
+  useRealtimeEntityTypeEvent: () => {},
+}));
+
+// IdeaDetailPanel is the thing the bug failed to render/switch. Stub it to a
+// marker that echoes the ideaUuid prop so we can assert which idea is open.
+vi.mock("../panels/idea-detail-panel", () => ({
+  IdeaDetailPanel: ({ ideaUuid }: { ideaUuid: string }) => (
+    <div data-testid="detail-panel">{ideaUuid}</div>
+  ),
+}));
+
+vi.mock("../idea-tracker-stats", () => ({
+  IdeaTrackerStats: () => <div data-testid="stats-view" />,
+}));
+vi.mock("../idea-status-group", () => ({
+  IdeaStatusGroup: ({ status, ideas }: { status: string; ideas: unknown[] }) => (
+    <div data-testid="status-group">{`${status}:${ideas.length}`}</div>
+  ),
+}));
+vi.mock("../idea-lineage-tree", () => ({
+  IdeaLineageTree: ({ ideas }: { ideas: unknown[] }) => (
+    <div data-testid="lineage-tree">{ideas.length}</div>
+  ),
+}));
+vi.mock("../new-idea-dialog", () => ({ NewIdeaDialog: () => null }));
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolveKey(ns: string, key: string): string {
+    const path = ns ? `${ns}.${key}`.split(".") : key.split(".");
+    let node: unknown = en;
+    for (const p of path) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return `${ns ? ns + "." : ""}${key}`;
+      }
+    }
+    return typeof node === "string" ? node : `${ns ? ns + "." : ""}${key}`;
+  }
+  return {
+    useTranslations: (ns?: string) => (key: string) => resolveKey(ns ?? "", key),
+  };
+});
+
+const PROJECT = "11111111-1111-4111-8111-111111111111";
+
+function idea(over: Partial<TrackerIdeaItem> = {}): TrackerIdeaItem {
+  return {
+    uuid: "i1",
+    title: "First idea",
+    status: "todo",
+    derivedStatus: "todo",
+    badgeHint: null,
+    createdAt: "2026-06-14T00:00:00.000Z",
+    parentUuid: null,
+    childCount: 0,
+    ...over,
+  };
+}
+
+const flatTracker: TrackerGroupsResult = { groups: { todo: [idea()] }, counts: { todo: 1 } };
+
+const baseProps = {
+  projectUuid: PROJECT,
+  currentUserUuid: "u1",
+  initialTrackerData: flatTracker,
+  initialStatsData: {
+    stats: {
+      ideas: { total: 1, open: 1 },
+      tasks: { total: 0, inProgress: 0, todo: 0, toVerify: 0, done: 0 },
+      proposals: { total: 0, pending: 0 },
+      documents: { total: 0 },
+    },
+    recentActivities: [],
+  },
+};
+
+beforeEach(() => {
+  mockParams = new URLSearchParams();
+  window.history.replaceState(null, "", `/projects/${PROJECT}/dashboard`);
+});
+
+describe("Dashboard idea panel — soft navigation sync (regression)", () => {
+  it("opens the detail panel for the idea named in ?panel= on the current URL", () => {
+    mockParams = new URLSearchParams("panel=idea-A");
+    render(<IdeaTracker {...baseProps} />);
+    expect(screen.getByTestId("detail-panel").textContent).toBe("idea-A");
+  });
+
+  it("switches the open panel when the URL changes to a different ?panel= (soft nav)", () => {
+    mockParams = new URLSearchParams("panel=idea-A");
+    const { rerender } = render(<IdeaTracker {...baseProps} />);
+    expect(screen.getByTestId("detail-panel").textContent).toBe("idea-A");
+
+    // Simulate a soft-nav idea link (notification / search / toast / presence):
+    // the URL changes and Next re-renders useSearchParams consumers.
+    mockParams = new URLSearchParams("panel=idea-B");
+    rerender(<IdeaTracker {...baseProps} />);
+    expect(screen.getByTestId("detail-panel").textContent).toBe("idea-B");
+  });
+
+  it("closes the panel when the URL loses its ?panel= param", () => {
+    mockParams = new URLSearchParams("panel=idea-A");
+    const { rerender } = render(<IdeaTracker {...baseProps} />);
+    expect(screen.queryByTestId("detail-panel")).not.toBeNull();
+
+    mockParams = new URLSearchParams("");
+    rerender(<IdeaTracker {...baseProps} />);
+    expect(screen.queryByTestId("detail-panel")).toBeNull();
+  });
+
+  it("does not open a panel when no ?panel= param is present", () => {
+    mockParams = new URLSearchParams("");
+    render(<IdeaTracker {...baseProps} />);
+    expect(screen.queryByTestId("detail-panel")).toBeNull();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
@@ -1,5 +1,6 @@
 // Shared Server Component for /dashboard and /dashboard/[ideaUuid]
 
+import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { getDashboardData } from "./dashboard-data";
 import { ProjectSettingsModal } from "./project-settings-modal";
@@ -29,13 +30,21 @@ export async function DashboardContent({ projectUuid, initialSelectedIdeaUuid }:
         </div>
       </div>
       <div className="min-h-0 flex-1">
-        <IdeaTracker
-          projectUuid={projectUuid}
-          currentUserUuid={currentUserUuid}
-          initialTrackerData={trackerData}
-          initialStatsData={{ stats, recentActivities: activities }}
-          initialSelectedIdeaUuid={initialSelectedIdeaUuid}
-        />
+        {/* IdeaTracker reads useSearchParams() (via usePanelUrl) so the idea
+            side-panel selection tracks the URL on soft navigation. Next 15
+            requires a Suspense boundary above any useSearchParams() consumer,
+            else the whole route opts into client-side rendering (+ build
+            warning). The fallback fills the same flex cell so the static header
+            above streams with no layout jump. */}
+        <Suspense fallback={<div className="h-full" />}>
+          <IdeaTracker
+            projectUuid={projectUuid}
+            currentUserUuid={currentUserUuid}
+            initialTrackerData={trackerData}
+            initialStatsData={{ stats, recentActivities: activities }}
+            initialSelectedIdeaUuid={initialSelectedIdeaUuid}
+          />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/hooks/__tests__/use-panel-url.test.tsx
+++ b/src/hooks/__tests__/use-panel-url.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+//
+// Regression guard for the "URL changes but the panel doesn't switch" bug.
+//
+// Root cause (pre-fix): usePanelUrl kept `selectedId` in local useState seeded
+// once from `initialSelectedId`, and only re-synced on `popstate`. App Router
+// soft navigation (router.push / <Link>) changes the URL WITHOUT firing
+// popstate, so external `?panel=<id>` links updated the address bar but never
+// the panel. The fix makes `useSearchParams()` the source of truth so any URL
+// change — soft nav, back/forward, or direct load — drives the selection.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePanelUrl } from "../use-panel-url";
+
+// Controllable stand-in for the live URL query string that useSearchParams()
+// reflects. Each test sets it, then rerender() re-reads it — mirroring how Next
+// re-renders consumers of useSearchParams() on navigation.
+let mockParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockParams,
+}));
+
+function setUrl(search: string) {
+  mockParams = new URLSearchParams(search);
+  // Keep window.location.search aligned so the openPanel/closePanel writers,
+  // which read window.location.search to preserve unrelated params, see the
+  // same state the reader derives from.
+  window.history.replaceState(null, "", search ? `/base?${search}` : "/base");
+}
+
+beforeEach(() => {
+  setUrl("");
+});
+
+describe("usePanelUrl", () => {
+  it("derives selectedId from the panel search param", () => {
+    setUrl("panel=idea-1");
+    const { result } = renderHook(() => usePanelUrl("/base"));
+    expect(result.current.selectedId).toBe("idea-1");
+  });
+
+  it("derives selectedTab from the tab search param", () => {
+    setUrl("panel=idea-1&tab=overview");
+    const { result } = renderHook(() => usePanelUrl("/base"));
+    expect(result.current.selectedTab).toBe("overview");
+  });
+
+  it("returns null selectedId when no panel param is present", () => {
+    setUrl("");
+    const { result } = renderHook(() => usePanelUrl("/base"));
+    expect(result.current.selectedId).toBeNull();
+  });
+
+  // THE regression: a soft-nav URL change (new searchParams) must update the
+  // selection on rerender. The pre-fix hook ignored useSearchParams entirely,
+  // so selectedId stayed at its initial value here.
+  it("updates selectedId when the search params change (soft navigation)", () => {
+    setUrl("panel=idea-1");
+    const { result, rerender } = renderHook(() => usePanelUrl("/base"));
+    expect(result.current.selectedId).toBe("idea-1");
+
+    setUrl("panel=idea-2");
+    rerender();
+    expect(result.current.selectedId).toBe("idea-2");
+  });
+
+  it("clears the selection when the panel param is removed (soft navigation)", () => {
+    setUrl("panel=idea-1");
+    const { result, rerender } = renderHook(() => usePanelUrl("/base"));
+    expect(result.current.selectedId).toBe("idea-1");
+
+    setUrl("");
+    rerender();
+    expect(result.current.selectedId).toBeNull();
+  });
+
+  it("openPanel writes ?panel= to the URL, preserving unrelated params", () => {
+    setUrl("filter=open");
+    const { result } = renderHook(() => usePanelUrl("/base"));
+    act(() => {
+      result.current.openPanel("idea-9");
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("panel")).toBe("idea-9");
+    expect(params.get("filter")).toBe("open");
+  });
+
+  it("openPanel with a tab writes both ?panel= and ?tab=", () => {
+    setUrl("");
+    const { result } = renderHook(() => usePanelUrl("/base"));
+    act(() => {
+      result.current.openPanel("idea-9", "overview");
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("panel")).toBe("idea-9");
+    expect(params.get("tab")).toBe("overview");
+  });
+
+  it("closePanel removes panel and tab while preserving unrelated params", () => {
+    setUrl("panel=idea-1&tab=overview&filter=open");
+    const { result } = renderHook(() => usePanelUrl("/base"));
+    act(() => {
+      result.current.closePanel();
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("panel")).toBeNull();
+    expect(params.get("tab")).toBeNull();
+    expect(params.get("filter")).toBe("open");
+  });
+
+  // Regression: a deep-linked panel (server seeds initialSelectedId from
+  // ?panel=) MUST close. If the initialSelectedId fallback leaks past the first
+  // paint, removing the panel param resolves back to the seed and the panel
+  // re-sticks open — the close button would never work.
+  it("does not re-stick a deep-linked panel open after the param is removed", () => {
+    setUrl("panel=idea-X");
+    const { result, rerender } = renderHook(() => usePanelUrl("/base", "idea-X"));
+    expect(result.current.selectedId).toBe("idea-X");
+
+    // User closes the panel → ?panel= removed from the URL.
+    setUrl("");
+    rerender();
+    expect(result.current.selectedId).toBeNull();
+  });
+
+  it("clears a deep-linked selection when soft-navigating to a panel-less URL", () => {
+    setUrl("panel=idea-X");
+    const { result, rerender } = renderHook(() => usePanelUrl("/base", "idea-X"));
+    expect(result.current.selectedId).toBe("idea-X");
+
+    // Soft navigation to a URL with other params but no panel.
+    setUrl("filter=open");
+    rerender();
+    expect(result.current.selectedId).toBeNull();
+  });
+});

--- a/src/hooks/use-panel-url.ts
+++ b/src/hooks/use-panel-url.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 
 /**
  * Manages browser URL for side-panel navigation using History API.
@@ -10,17 +11,51 @@ import { useState, useEffect, useCallback, useRef } from "react";
  * and triggers soft navigation, which remounts components and resets state.
  * Query param changes do NOT trigger soft navigation.
  *
+ * The selected panel/tab is derived from `useSearchParams()` — the App Router's
+ * reactive source of truth for the query string. It updates on every navigation
+ * kind: soft navigation (router.push / <Link>), browser back/forward, and direct
+ * load. This is what makes an external `?panel={id}` link (notifications, search,
+ * toast, agent-presence) actually open/switch the panel: those use soft navigation,
+ * which changes the URL WITHOUT firing `popstate`, so a popstate-only listener
+ * never saw them.
+ *
  * - openPanel(id, tab?): replaceState with ?panel={id}&tab={tab}
  * - closePanel(): replaceState removing panel & tab params
- * - popstate: syncs React state from query params
+ * - switchTab(tab): replaceState updating only ?tab=
  * - Preserves other query params (filters, etc.)
+ *
+ * `initialSelectedId` is retained for API compatibility but is no longer the
+ * source of truth — `useSearchParams()` supersedes it. It seeds ONLY the very
+ * first render (server prerender, where `useSearchParams()` is empty), then is
+ * dropped: after that, `useSearchParams()` is authoritative. The fallback must
+ * not leak past first paint — otherwise closing a deep-linked panel (server
+ * seeded `initialSelectedId` from `?panel=`) would resolve `null ?? seed` back
+ * to the seed and re-stick the panel open, breaking the close button. A
+ * `<Suspense>` boundary above this hook is required by Next.js so the rest of
+ * the route can still be statically prerendered.
+ *
+ * Writes use `window.history.replaceState` (not router.replace): per the Next.js
+ * App Router docs, this updates `useSearchParams()` reactively WITHOUT a soft
+ * navigation / RSC round-trip, so the subtree is not remounted and transient
+ * state (scroll, view mode) survives — preserving the query-param design above.
  */
 export function usePanelUrl(basePath: string, initialSelectedId?: string | null) {
-  const [selectedId, setSelectedId] = useState<string | null>(initialSelectedId ?? null);
-  const [selectedTab, setSelectedTab] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return new URLSearchParams(window.location.search).get("tab");
-  });
+  const searchParams = useSearchParams();
+
+  // The server-provided seed applies only to the first render frame (prerender,
+  // where useSearchParams() is empty). Once the client has rendered once,
+  // useSearchParams() is the sole source of truth — so we never fall back to the
+  // seed again. Without this gate the fallback leaks into every render: after a
+  // deep-linked `?panel=X` close, `get("panel")` is null and `null ?? "X"` would
+  // re-open the panel.
+  const hasRenderedRef = useRef(false);
+  const useSeed = !hasRenderedRef.current;
+  hasRenderedRef.current = true;
+
+  // Derive selection straight from the URL (the tab has no SSR seed and simply
+  // starts unselected).
+  const selectedId = searchParams.get("panel") ?? (useSeed ? initialSelectedId ?? null : null);
+  const selectedTab = searchParams.get("tab");
 
   /** Build URL with query params, preserving existing non-panel/tab params */
   const buildUrl = useCallback(
@@ -44,48 +79,22 @@ export function usePanelUrl(basePath: string, initialSelectedId?: string | null)
 
   const openPanel = useCallback(
     (id: string, tab?: string) => {
-      const newUrl = buildUrl(id, tab);
-      window.history.replaceState(null, "", newUrl);
-      setSelectedId(id);
-      setSelectedTab(tab ?? null);
+      window.history.replaceState(null, "", buildUrl(id, tab));
     },
     [buildUrl]
   );
 
   const closePanel = useCallback(() => {
-    const newUrl = buildUrl(null);
-    window.history.replaceState(null, "", newUrl);
-    setSelectedId(null);
-    setSelectedTab(null);
+    window.history.replaceState(null, "", buildUrl(null));
   }, [buildUrl]);
 
   const switchTab = useCallback(
     (tab: string) => {
       if (!selectedId) return;
-      const newUrl = buildUrl(selectedId, tab);
-      window.history.replaceState(null, "", newUrl);
-      setSelectedTab(tab);
+      window.history.replaceState(null, "", buildUrl(selectedId, tab));
     },
     [buildUrl, selectedId]
   );
-
-  // Listen for popstate (browser back/forward)
-  useEffect(() => {
-    function handlePopState() {
-      const params = new URLSearchParams(window.location.search);
-      const id = params.get("panel");
-      if (id) {
-        setSelectedId(id);
-        setSelectedTab(params.get("tab"));
-      } else {
-        setSelectedId(null);
-        setSelectedTab(null);
-      }
-    }
-
-    window.addEventListener("popstate", handlePopState);
-    return () => window.removeEventListener("popstate", handlePopState);
-  }, []);
 
   return { selectedId, selectedTab, openPanel, closePanel, switchTab };
 }


### PR DESCRIPTION
## Summary
On the project Dashboard, following an idea link via App Router soft navigation (`router.push('?panel=<ideaUuid>')`) changed the URL but did **not** open/switch the right-hand idea detail panel. Root cause: `usePanelUrl` kept `selectedId` in local `useState` (seeded once) and only re-synced on `popstate`; soft nav doesn't fire `popstate`.

Fix (approach A): derive `selectedId`/`selectedTab` from `useSearchParams()` — the App Router's reactive source of truth. One root fix repairs all four entry points: notification popup, SSE toast, global search, agent-presence rows/turn-band (all unchanged — they already build the right `?panel=` URL).

Source idea: `a2fdbc86` (Chorus 0.11.0). Already verified end-to-end on the local dev server and deployed to the live env.

## Key decisions
- **Seed gated to first render** (`hasRenderedRef`): the server-passed `initialSelectedId` seeds only the prerender frame. Without the gate, closing a deep-linked `?panel=X` panel resolves `null ?? "X"` back to the seed and re-sticks it open — a regression caught by both the dev-server e2e pass and an independent code-review agent, now fixed + guarded by tests.
- **Write path keeps `window.history.replaceState`** (not `router.replace`): per Next.js docs it updates `useSearchParams()` reactively without an RSC round-trip, so the tracker subtree is not remounted (scroll/view state survive). Removed the now-redundant `popstate` listener (App Router instruments back/forward → `useSearchParams()` already reflects them).
- **`<Suspense>` boundary** added around `IdeaTracker` (Next 15 requirement for `useSearchParams()` consumers).

## Changed files
| File | Change |
|------|--------|
| `src/hooks/use-panel-url.ts` | Derive selection from `useSearchParams()`; gate seed to first render; keep `replaceState` writes; drop popstate listener |
| `src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx` | Wrap `IdeaTracker` in `<Suspense>` |
| `src/hooks/__tests__/use-panel-url.test.tsx` | New — 10 unit tests incl. deep-link-close regression |
| `src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-tracker-panel-softnav.test.tsx` | New — integration test driving the real hook through IdeaTracker |
| `openspec/...` | OpenSpec change (archived) + cumulative `idea-panel-url-sync` capability spec |

## Test plan
- [x] `pnpm test` — 170 files / 2807 pass
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` clean on touched files
- [x] Clean `pnpm build` — 54/54 static pages, no `useSearchParams` CSR-bailout warning
- [x] Real-browser e2e (local dev): soft-nav switch works; deep-link close works; browser Back restores prior panel; view tab not reset (no remount)
- [x] Deployed to live env; prod `/login` 200

Generated with [Claude Code](https://claude.com/claude-code)