### PR TITLE
feat(daemon): headless interaction guard — no AskUserQuestion, route to Chorus

### DIFF
--- a/cli/__tests__/claude-spawner.test.mjs
+++ b/cli/__tests__/claude-spawner.test.mjs
@@ -281,6 +281,61 @@ describe("ClaudeSpawner.wake", () => {
   });
 });
 
+// add-daemon-headless-interaction-guard: the spawned child is marked with
+// CHORUS_DAEMON_HEADLESS=1 (merged over inherited env) as a machine-checkable headless
+// signal. buildArgs stays free of --append-system-prompt (the rule rides the wake prompt).
+describe("ClaudeSpawner.wake — CHORUS_DAEMON_HEADLESS env signal", () => {
+  async function spawnAndGetOpts(permissionMode) {
+    const child = makeFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const spawner = new ClaudeSpawner({
+      claudePath: "/usr/bin/claude",
+      spawnImpl,
+      logger: silent,
+      platform: "linux",
+      ...(permissionMode ? { permissionMode } : {}),
+    });
+    const p = spawner.wake({ prompt: "go", sessionId: SID, isNew: true, mcpConfigPath: "/m.json" });
+    child.emit("close", 0);
+    await p;
+    return spawnImpl.mock.calls[0][2]; // spawn options
+  }
+
+  it("sets CHORUS_DAEMON_HEADLESS=1 in the spawned child env (default chorus mode)", async () => {
+    const opts = await spawnAndGetOpts();
+    expect(opts.env).toBeDefined();
+    expect(opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+  });
+
+  it("sets CHORUS_DAEMON_HEADLESS=1 in yolo mode too (unconditional)", async () => {
+    const opts = await spawnAndGetOpts("yolo");
+    expect(opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+  });
+
+  it("merges over inherited process.env — a pre-existing var survives", async () => {
+    const sentinel = "__CHORUS_TEST_SENTINEL__";
+    process.env[sentinel] = "keep-me";
+    try {
+      const opts = await spawnAndGetOpts();
+      expect(opts.env[sentinel]).toBe("keep-me"); // inherited var preserved
+      expect(opts.env.CHORUS_DAEMON_HEADLESS).toBe("1"); // and ours added
+      // PATH (always present) is inherited too — sanity that we didn't replace env wholesale.
+      expect(opts.env.PATH).toBe(process.env.PATH);
+    } finally {
+      delete process.env[sentinel];
+    }
+  });
+
+  it("buildArgs output never contains --append-system-prompt (q1=C: rule rides the wake prompt, not the system prompt)", () => {
+    for (const mode of [undefined, "yolo"]) {
+      for (const isNew of [true, false]) {
+        const args = buildArgs({ sessionId: SID, isNew, mcpConfigPath: "/m.json", permissionMode: mode });
+        expect(args).not.toContain("--append-system-prompt");
+      }
+    }
+  });
+});
+
 // 子3 — daemon-interrupt-resume: detached POSIX spawn (process-group leader) so the
 // interrupt path can group-kill the tree, plus the onChild handle hand-off. These
 // MUST NOT regress stdin prompt delivery or stream-json parsing.

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -3,11 +3,13 @@
 // failure isolation, and the no-op upload hooks (cli-daemon spec
 // "Task-dispatch wake" + "Reserved upload hooks").
 import { describe, it, expect, vi } from "vitest";
-import { buildPrompt, WAKE_ACTIONS } from "../prompts.mjs";
+import { buildPrompt, WAKE_ACTIONS, HEADLESS_PREAMBLE } from "../prompts.mjs";
 import { createNoopUploadHooks } from "../upload-hooks.mjs";
 import { Waker } from "../waker.mjs";
 import { EventRouter } from "../event-router.mjs";
 import { WakeQueue } from "../wake-queue.mjs";
+import { ClaudeSpawner } from "../claude-spawner.mjs";
+import { EventEmitter } from "node:events";
 
 const silent = { info() {}, warn() {}, error() {} };
 
@@ -126,6 +128,63 @@ describe("buildPrompt", () => {
     ]) {
       expect(WAKE_ACTIONS.has(a), `expected ${a} NOT to wake`).toBe(false);
     }
+  });
+});
+
+// add-daemon-headless-interaction-guard: every wake prompt carries the headless preamble
+// so a daemon-woken (no-human-at-terminal) session never calls AskUserQuestion and routes
+// human-decision points through Chorus instead.
+describe("HEADLESS_PREAMBLE (daemon headless interaction guard)", () => {
+  it("the preamble declares headlessness, the env signal, the AskUserQuestion prohibition, the Chorus route, and the async hand-off", () => {
+    // (1) identity + no-human + env signal
+    expect(HEADLESS_PREAMBLE).toContain("headless");
+    expect(HEADLESS_PREAMBLE.toLowerCase()).toContain("no human at the terminal");
+    expect(HEADLESS_PREAMBLE).toContain("CHORUS_DAEMON_HEADLESS=1");
+    // (2) prohibition — literal tool name
+    expect(HEADLESS_PREAMBLE).toContain("AskUserQuestion");
+    // (3) general route-through-Chorus rule
+    expect(HEADLESS_PREAMBLE).toContain("chorus_add_comment");
+    expect(HEADLESS_PREAMBLE.toLowerCase()).toContain("elaboration");
+    // (5) async hand-off — post then end the turn, don't block
+    expect(HEADLESS_PREAMBLE.toLowerCase()).toContain("end the turn");
+    expect(HEADLESS_PREAMBLE.toLowerCase()).toContain("pending");
+  });
+
+  it("does NOT embed the answer-questions tool names — keeps the elaboration_verified contract intact even though it rides every wake", () => {
+    // The preamble is prepended to EVERY wake, including elaboration_verified
+    // (write-the-proposal), whose contract forbids the answer-questions tools. Routing
+    // guidance therefore uses chorus_add_comment + prose, not these literals.
+    expect(HEADLESS_PREAMBLE).not.toContain("chorus_pm_start_elaboration");
+    expect(HEADLESS_PREAMBLE).not.toContain("chorus_pm_validate_elaboration");
+  });
+
+  it("every WAKE_ACTIONS prompt is prefixed with the preamble while preserving the per-action body + @mention guidance", () => {
+    for (const action of WAKE_ACTIONS) {
+      const extra = action === "human_instruction" ? { instructionText: "please rebase onto main" } : {};
+      const p = buildPrompt({ ...TASK_NOTIF, action, ...extra });
+      expect(p, `WAKE_ACTIONS "${action}" must produce a prompt`).not.toBeNull();
+      // preamble first, original body after it
+      expect(p.startsWith(HEADLESS_PREAMBLE), `"${action}" prompt must start with the preamble`).toBe(true);
+      expect(p).toContain("AskUserQuestion");
+      expect(p.toLowerCase()).toContain("end the turn");
+      // the per-action body still follows the preamble (e.g. the [Chorus] marker)
+      expect(p.slice(HEADLESS_PREAMBLE.length)).toContain("[Chorus]");
+    }
+  });
+
+  it("preserves the per-action @mention guidance after the preamble (task_assigned)", () => {
+    const p = buildPrompt(TASK_NOTIF);
+    expect(p.startsWith(HEADLESS_PREAMBLE)).toBe(true);
+    expect(p).toContain("chorus_claim_task"); // body intact
+    expect(p).toContain("@[Alice](user:user-1)"); // mention guidance intact
+  });
+
+  it("a null body stays null after the wrapper — no preamble-only prompt is produced", () => {
+    // unknown action
+    expect(buildPrompt({ ...TASK_NOTIF, action: "count_update" })).toBeNull();
+    // empty human_instruction (no body to act on)
+    expect(buildPrompt({ ...TASK_NOTIF, action: "human_instruction", instructionText: "   " })).toBeNull();
+    expect(buildPrompt({ ...TASK_NOTIF, action: "human_instruction" })).toBeNull();
   });
 });
 
@@ -517,5 +576,94 @@ describe("EventRouter dispatch", () => {
 
     expect(spawner.wake).toHaveBeenCalledTimes(2);
     expect(maxConcurrent).toBe(1); // same direct idea → never concurrent
+  });
+});
+
+// add-daemon-headless-interaction-guard — integration checkpoint: the convergence of
+// BOTH changes (preamble in prompts.mjs + env signal in claude-spawner.mjs) on the real
+// wake chain. Uses the REAL ClaudeSpawner (not the mocked one above) wired to a fake
+// child, driven by a real Waker, so we assert the whole flow in one place:
+// notification → buildPrompt(preamble+body) → spawn with CHORUS_DAEMON_HEADLESS=1 →
+// prompt over stdin → NDJSON parsed → clean exit.
+describe("headless guard — end-to-end wake flow (real Waker + real ClaudeSpawner)", () => {
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    const stdin = new EventEmitter();
+    stdin.writes = [];
+    stdin.write = (c) => stdin.writes.push(String(c));
+    stdin.end = vi.fn();
+    child.stdin = stdin;
+    child.stdout = new EventEmitter();
+    child.stdout.setEncoding = () => {};
+    child.stderr = new EventEmitter();
+    child.stderr.setEncoding = () => {};
+    return child;
+  }
+
+  it("preamble+body reaches stdin AND CHORUS_DAEMON_HEADLESS=1 reaches the spawn env, in one flow", async () => {
+    const child = makeFakeChild();
+    // Drive the child reactively the moment it's spawned: Waker.wake awaits several
+    // steps (lineage, writeMcpConfig, onSessionStart) BEFORE spawning, so emitting
+    // synchronously from the test body would fire before any listener is attached.
+    const spawnImpl = vi.fn(() => {
+      queueMicrotask(() => {
+        child.stdout.emit("data", `{"type":"system","session_id":"${DIRECT_IDEA}"}\n`);
+        child.emit("close", 0);
+      });
+      return child;
+    });
+    const spawner = new ClaudeSpawner({
+      claudePath: "/usr/bin/claude",
+      spawnImpl,
+      logger: silent,
+      platform: "linux",
+    });
+    const waker = new Waker({
+      creds: { url: "https://c", apiKey: "cho_x" },
+      lineage: { resolve: async () => ({ rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA }) },
+      spawner, // the REAL spawner
+      cwd: "/work/dir",
+      hooks: createNoopUploadHooks(),
+      logger: silent,
+      writeMcpConfigFn: vi.fn(() => ({ path: "/tmp/m.json", cleanup: vi.fn() })),
+      isNewSessionFn: vi.fn(() => true),
+    });
+
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    const [, argv, opts] = spawnImpl.mock.calls[0];
+    // env signal present (task 2)
+    expect(opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+    // argv carries the session id, never the prompt
+    expect(argv).toContain("--session-id");
+    expect(argv).toContain(DIRECT_IDEA);
+    // the prompt that reached stdin is preamble + the task_assigned body (task 1)
+    const stdinPrompt = child.stdin.writes.join("");
+    expect(stdinPrompt.startsWith(HEADLESS_PREAMBLE)).toBe(true);
+    expect(stdinPrompt).toContain("AskUserQuestion"); // headless guard text
+    expect(stdinPrompt).toContain("task-1"); // per-action body intact
+    expect(stdinPrompt).toContain("chorus_claim_task");
+    expect(child.stdin.end).toHaveBeenCalled();
+  });
+
+  it("a null-prompt action (count_update) never spawns a subprocess", async () => {
+    const spawnImpl = vi.fn();
+    const spawner = new ClaudeSpawner({ claudePath: "/usr/bin/claude", spawnImpl, logger: silent, platform: "linux" });
+    const waker = new Waker({
+      creds: { url: "https://c", apiKey: "cho_x" },
+      lineage: { resolve: async () => ({ rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA }) },
+      spawner,
+      cwd: "/work/dir",
+      hooks: createNoopUploadHooks(),
+      logger: silent,
+      writeMcpConfigFn: vi.fn(() => ({ path: "/tmp/m.json", cleanup: vi.fn() })),
+      isNewSessionFn: vi.fn(() => true),
+    });
+    const notif = { ...TASK_NOTIF, action: "count_update" };
+    const resolved = await waker.keyFor(notif);
+    await waker.wake(notif, resolved.key, resolved);
+    expect(spawnImpl).not.toHaveBeenCalled(); // no contentless spawn
   });
 });

--- a/cli/claude-spawner.mjs
+++ b/cli/claude-spawner.mjs
@@ -15,6 +15,12 @@
 //
 // The flag list lives in ONE place (buildArgs) so a CLI flag change is a
 // single-line edit.
+//
+// HEADLESS SIGNAL (add-daemon-headless-interaction-guard): wake() spawns the child
+// with CHORUS_DAEMON_HEADLESS=1 merged over the inherited env — a machine-checkable
+// marker that this is a daemon-woken, no-human-at-the-terminal run. buildArgs is
+// deliberately NOT changed (no --append-system-prompt): the headless behavior rule is
+// carried per-turn by the wake-prompt preamble in prompts.mjs, not at the system level.
 
 import { spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
@@ -315,6 +321,14 @@ export class ClaudeSpawner {
         child = this.spawnImpl(command, argv, {
           cwd: cwd ?? process.cwd(),
           stdio: ["pipe", "pipe", "pipe"],
+          // Mark the child as a headless daemon-woken session (add-daemon-headless-
+          // interaction-guard). Merged OVER the inherited env so PATH, the Bedrock /
+          // credential vars, CLAUDE_CONFIG_DIR, etc. all survive — only this one var is
+          // added. It is a machine-checkable signal (the wake prompt also states it in
+          // text); this change only LAYS IT DOWN — no code here reads it back. Set
+          // unconditionally: the spawner only ever runs headless daemon wakes, so both
+          // "chorus" and "yolo" permission modes get it.
+          env: { ...process.env, CHORUS_DAEMON_HEADLESS: "1" },
           // No shell:true — command is either the real executable or cmd.exe
           // with the script as an argv element. Avoids shell word-splitting /
           // injection; .cmd is handled explicitly via cmd.exe above.

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -3,6 +3,15 @@
 // event-router wake messages. The spawned Claude is headless and acts only
 // through the chorus_* MCP tools — these prompts tell it what happened and
 // which tools to use.
+//
+// HEADLESS GUARD (add-daemon-headless-interaction-guard): a daemon-woken session
+// has NO human at the terminal, so it must never call AskUserQuestion or any
+// blocking terminal prompt — that would hang or be silently dropped. buildPrompt
+// prepends HEADLESS_PREAMBLE (below) to EVERY non-null wake body so the rule rides
+// every turn, new or --resume (the daemon rebuilds the prompt on each wake, so a
+// per-turn prefix persists across resumes without touching the spawn argv — there
+// is deliberately no --append-system-prompt; see claude-spawner.mjs). The preamble
+// also names the CHORUS_DAEMON_HEADLESS=1 env signal the spawner sets.
 
 /**
  * @typedef {Object} NotificationDetail
@@ -32,12 +41,64 @@ function mentionGuidance(n, entityType) {
 }
 
 /**
+ * Shared headless preamble prepended to EVERY wake prompt (add-daemon-headless-
+ * interaction-guard). A daemon-woken session is a headless `claude -p` run with no
+ * human at the terminal, so AskUserQuestion (and any blocking terminal prompt) reaches
+ * no one — it hangs or is dropped, stalling the agent or forcing a unilateral decision.
+ * This block tells the agent that fact and routes every human-decision point through
+ * Chorus's async channels instead.
+ *
+ * Wording note: the re-routing guidance names `chorus_add_comment` and describes the
+ * elaboration panel in prose ON PURPOSE — it must NOT embed the literal
+ * `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` tool names, because
+ * this preamble rides EVERY wake including `elaboration_verified` (write-the-proposal),
+ * whose contract is that it never mentions the answer-questions tools. Keep it that way.
+ *
+ * Kept compact: it is paid on every wake, so each line costs tokens per wake.
+ */
+export const HEADLESS_PREAMBLE = [
+  "[Headless daemon session] You are a headless `claude -p` session woken by the Chorus",
+  "daemon. There is NO human at the terminal, and the environment variable",
+  "CHORUS_DAEMON_HEADLESS=1 is set.",
+  "",
+  "Do NOT call AskUserQuestion or any interactive / blocking terminal prompt — it reaches",
+  "no one and will hang or be silently dropped. Whenever you would ask the human something,",
+  "route it through Chorus instead: post a comment with chorus_add_comment and @mention the",
+  "requester, and/or open an elaboration round the human answers in the Chorus UI panel.",
+  "",
+  "A few examples (not exhaustive): when a skill says to present elaboration questions via",
+  "AskUserQuestion, open an elaboration round and @mention the requester in a comment so they",
+  "answer in the UI; when a skill says to ask permission before skipping a step, do not skip",
+  "silently — record the reason in a Chorus comment; when a skill offers to write a report,",
+  "create it directly or skip it, never prompt for it.",
+  "",
+  "After you post something that needs a human decision, END THE TURN and leave the work",
+  "pending — do not poll or wait for a synchronous reply. The human's later comment or",
+  "elaboration answer wakes a fresh turn that continues the work.",
+].join("\n");
+
+/**
  * Build the wake prompt for a notification, or null if the action has no
- * wake (caller ignores those). Mirrors the OpenClaw event-router handlers.
+ * wake (caller ignores those). Prepends HEADLESS_PREAMBLE to every non-null body
+ * (a null body — unknown action / empty human_instruction — stays null so the router
+ * still skips it and no contentless subprocess is spawned). The per-action body is
+ * produced by buildPromptBody below.
  * @param {NotificationDetail} n
  * @returns {string | null}
  */
 export function buildPrompt(n) {
+  const body = buildPromptBody(n);
+  if (body == null) return null;
+  return `${HEADLESS_PREAMBLE}\n\n${body}`;
+}
+
+/**
+ * The per-action wake body (without the headless preamble). Mirrors the OpenClaw
+ * event-router handlers; returns null for actions that have no wake.
+ * @param {NotificationDetail} n
+ * @returns {string | null}
+ */
+function buildPromptBody(n) {
   switch (n.action) {
     case "task_assigned":
       return (

--- a/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/README.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/README.md
@@ -1,0 +1,3 @@
+# add-daemon-headless-interaction-guard
+
+Daemon-woken headless Claude avoids AskUserQuestion; routes human interaction to Chorus via wake-prompt preamble + CHORUS_DAEMON_HEADLESS env signal

--- a/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/design.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/design.md
@@ -1,0 +1,72 @@
+# Design: Daemon headless interaction guard
+
+## Context
+
+The daemon's wake path is: SSE notification → `event-router` resolves lineage → `WakeQueue` serializes per direct-idea → `Waker.wake()` → `buildPrompt(notification)` (`cli/prompts.mjs`) produces the user-message prompt → `ClaudeSpawner.wake()` (`cli/claude-spawner.mjs`) spawns headless `claude -p`, writes the prompt to **stdin**, parses NDJSON stdout.
+
+Two insertion points, both already single-responsibility and daemon-only:
+
+1. **`cli/prompts.mjs#buildPrompt(n)`** — the one function that builds every wake user-message. Imported only by `cli/waker.mjs` and tests; never by interactive Claude Code. A preamble here reaches every wake and nothing else.
+2. **`cli/claude-spawner.mjs#ClaudeSpawner.wake()`** — the one place that calls `spawnImpl(command, argv, opts)`. Today `opts` has **no `env` key**, so the child inherits `process.env` wholesale. Adding `env` is the single point to inject `CHORUS_DAEMON_HEADLESS=1`.
+
+The elaboration answers (human-verified) fix the design choices; this document records the *how* and the non-obvious edge cases.
+
+## Decisions
+
+### D1 — Per-turn wake-prompt preamble, NOT `--append-system-prompt` (q1=C, q2=A)
+
+The rule lives in a single exported constant `HEADLESS_PREAMBLE` in `cli/prompts.mjs`. `buildPrompt()` prepends it to every **non-null** wake body.
+
+- **Why per-turn works across `--resume`:** the daemon builds a fresh prompt for *every* wake (new session or resume) — see `Waker.wake()` calling `buildPrompt(notification)` unconditionally before each `spawner.wake()`. So the preamble is present on turn 1 and every resumed turn. There is no turn that skips `buildPrompt`. This is the property that made the owner pick C over the `--append-system-prompt` option: we get cross-resume persistence without touching the spawn argv contract.
+- **Why not `--append-system-prompt`:** rejected by the owner. It would change `buildArgs()` (the deliberately single-line-edit flag list) and add a second injection channel to keep coherent with the prompt. Re-injecting one preamble per turn is simpler and equally persistent given the daemon's build-every-wake behavior.
+- **Soft only:** the preamble is guidance text. No deny-list, no argv change to strip tools, no runtime interception (q2=A).
+
+### D2 — `CHORUS_DAEMON_HEADLESS=1` child env (q3=A)
+
+`ClaudeSpawner.wake()` builds the spawn options with:
+
+```js
+env: { ...process.env, CHORUS_DAEMON_HEADLESS: "1" }
+```
+
+- Merged over `process.env` so the child keeps PATH, the Bedrock/credential vars, `CLAUDE_CONFIG_DIR`, etc. — only the one var is added.
+- Set unconditionally for the daemon spawn (the spawner exists only to run headless daemon wakes; both `chorus` and `yolo` permission modes are headless).
+- The preamble *states* the variable so the agent is aware of it. In default `chorus` permission mode the agent has only `mcp__chorus__*` tools (no Bash), so it cannot literally `echo $CHORUS_DAEMON_HEADLESS` — awareness comes from the prompt text. The env var's value is forward-looking: a future skill/hook (out of scope here) can branch on it. **No code in this change reads it back** — laying down the signal is the deliverable.
+- Default `chorus` mode already can't call `AskUserQuestion` (it's not an `mcp__chorus__*` tool, so it's auto-denied). The guard's real bite is in `yolo`/`--dangerously-skip-permissions` mode (the verified live session above), where every tool is allowed and `AskUserQuestion` *would* fire — there the preamble is what stops it.
+
+### D3 — Preamble content (q6=C — general rule + a few examples)
+
+`HEADLESS_PREAMBLE` is a compact block (kept short — it rides every wake, so every token is paid per wake). It contains, in order:
+
+1. **Identity + fact:** "You are a headless `claude -p` session woken by the Chorus daemon. There is no human at the terminal. `CHORUS_DAEMON_HEADLESS=1` is set."
+2. **Prohibition:** "Do NOT call `AskUserQuestion` or any interactive/blocking terminal prompt — it reaches no one and will hang or be dropped."
+3. **General rule:** "Route every point that needs human input or confirmation through Chorus: post a comment with an `@mention`, or open an elaboration round the human answers in the UI."
+4. **A few examples (illustrative, not exhaustive):**
+   - skill says "present elaboration questions via `AskUserQuestion`" → open an elaboration round (described in prose) the human answers in the Chorus UI panel + a comment `@mention`.
+   - skill says "ask the user before skipping elaboration" → don't silently skip; record the reason in a Chorus comment.
+   - skill says "invite a report via `AskUserQuestion`" → create the report directly or skip it; don't prompt.
+5. **Async hand-off (q7=A):** "After posting a question to Chorus, end the turn and leave the work pending. Do not poll or wait for a synchronous reply — the human's reply wakes a fresh turn that continues."
+
+The block is delimited so it reads as a framing preamble, then the existing per-action text follows (`[Chorus] …`).
+
+> **Wording constraint (discovered during implementation).** The preamble rides **every** wake, including `elaboration_verified` — and a prior change (`add-elaboration-verify-wake`) established an invariant, asserted in `wake-orchestration.test.mjs`, that the `elaboration_verified` "write the proposal" prompt MUST NOT contain the answer-questions tool names `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration`. So the preamble's re-routing guidance names **`chorus_add_comment`** and describes the elaboration panel **in prose**, and deliberately does NOT embed those two literal tool names. This satisfies q6=C (general rule + a few examples) while preserving the sibling invariant — no existing test needed editing.
+
+### D4 — Null-prompt actions stay null
+
+`buildPrompt()` returns `null` for unknown actions and for an empty `human_instruction` (no body to act on). The wrapper prepends the preamble **only when the underlying body is non-null** — a null stays null so the router still skips the wake (no contentless spawn). Implementation: compute the body first, `if (body == null) return null;` then return `HEADLESS_PREAMBLE + "\n\n" + body`.
+
+### D5 — Surface scope: daemon-only, skills untouched (q4=C + q5=A reconciled)
+
+q4=C says keep the rule in the wake prompt, not in skill bodies. q5=A says keep the 4 skill surfaces in sync. These only *appear* to conflict: since the rule lives entirely in `cli/` (the daemon, effectively the Claude Code surface — the only one with a spawner) and **no skill markdown is edited**, there is nothing to fan out, so all four surfaces stay byte-identical-as-before = "in sync." The reconciliation was put to the owner explicitly and verified. Net: this change touches `cli/prompts.mjs`, `cli/claude-spawner.mjs`, and `cli/__tests__/` only.
+
+## Risks / Trade-offs
+
+- **Per-wake token cost.** The preamble is added to every wake prompt. Mitigation: keep it compact (a handful of lines); it is far cheaper than a stalled or wrongly-auto-decided turn.
+- **Soft guidance is not a guarantee.** A model could still emit `AskUserQuestion` despite the preamble. Accepted (q2=A); the env var is laid down so a hard block or hook-based enforcement can be added later without re-plumbing.
+- **`yolo` vs `chorus` mode asymmetry.** In `chorus` mode `AskUserQuestion` is already auto-denied (not an allowed tool); the preamble is belt-and-braces there and load-bearing in `yolo` mode. Documented in D2 so a future reader doesn't think the preamble is redundant.
+
+## Test Plan
+
+- `cli/prompts.mjs`: assert every action in `WAKE_ACTIONS` yields a prompt that **starts with / contains** the headless preamble and the literal `AskUserQuestion` prohibition; assert unknown action and empty `human_instruction` still return `null` (preamble did not resurrect them); assert the existing per-action `[Chorus] …` text and `@mention` guidance are still present after the preamble.
+- `cli/claude-spawner.mjs`: with an injected `spawnImpl`, assert the spawn options' `env.CHORUS_DAEMON_HEADLESS === "1"` and that an inherited var (e.g. a sentinel set on `process.env`) survives in the merged env; assert `buildArgs(...)` output does **not** include `--append-system-prompt` (locks in q1=C).
+- Existing daemon integration / wake-orchestration tests continue to pass (the prompt is longer but structurally unchanged; argv is unchanged).

--- a/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/proposal.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/proposal.md
@@ -1,0 +1,69 @@
+# Proposal: Daemon-woken headless Claude SHALL avoid AskUserQuestion and route human interaction through Chorus
+
+## Why
+
+The 0.11.0 daemon (root idea `9b76ccd7`) spawns a **headless `claude -p` subprocess** to do work when a notification arrives. Verified against the live process tree, a woken session runs as:
+
+```
+claude -p --output-format stream-json --verbose --session-id <idea-uuid> --dangerously-skip-permissions
+```
+
+There is **no human at the terminal**. Yet the woken agent still follows skills that mandate terminal-interactive prompts:
+
+- `idea/SKILL.md` — "MUST ask the user for permission first via `AskUserQuestion`" before skipping elaboration; "MUST use `AskUserQuestion`" to present elaboration questions; "Use `AskUserQuestion` for all interactive questions — never plain text."
+- `brainstorm/SKILL.md` — the whole loop is one `AskUserQuestion` per round.
+- `develop/SKILL.md` — invites a completion report via `AskUserQuestion`.
+
+When a headless session calls `AskUserQuestion`, the call either **hangs waiting for input that never arrives**, or is silently dropped by the host — so the agent **stalls** or **makes a unilateral decision** a human should have made. Meanwhile the real human *is* reachable, asynchronously, through the Chorus UI (comments, the elaboration question panel) — channels built for exactly this.
+
+Two facts make the gap concrete (verified 2026-06-21):
+
+1. **No daemon-specific context reaches the woken Claude.** `cli/claude-spawner.mjs#buildArgs()` runs headless with no `--append-system-prompt`; the only channel that injects daemon context is the wake prompt (`cli/prompts.mjs#buildPrompt()`). The prompts' file-header comment *claims* "The spawned Claude is headless," but **no actual wake prompt tells Claude that** — so Claude does not know.
+2. **No machine-checkable headless signal exists.** `CHORUS_DAEMON_HEADLESS` is unset; nothing marks a daemon-woken process as headless.
+
+This change closes the behavior gap so a daemon-woken session never blocks on a terminal prompt and always routes human-decision points to Chorus.
+
+> Provenance: derived from daemon root idea `9b76ccd7`; idea `aa1b1dcc` (this proposal's input). The idea was elaborated and **human-verified** (Round 1, 7 questions) — the design below encodes those verified answers. The elaboration itself dogfooded the target behavior: it was conducted from a headless session that routed its questions to the Chorus elaboration panel + a comment instead of calling `AskUserQuestion`.
+
+## What Changes
+
+- **Wake-prompt headless preamble (q1=C, per-turn injection).** `cli/prompts.mjs` gains a shared `HEADLESS_PREAMBLE` block that `buildPrompt()` prepends to **every** non-null wake prompt (all `WAKE_ACTIONS`). It declares: you are a headless `claude -p` session; there is no human at the terminal; `CHORUS_DAEMON_HEADLESS=1` is set; do NOT call `AskUserQuestion` or any blocking terminal prompt. Because every wake — new **or** `--resume` — carries a freshly built prompt, the rule rides every turn (this is why a per-turn wake-prefix, not `--append-system-prompt`, satisfies cross-resume persistence).
+
+- **Machine-checkable headless env signal (q3=A).** `cli/claude-spawner.mjs#wake()` sets `CHORUS_DAEMON_HEADLESS=1` in the spawned child's environment (merged over inherited `process.env`). The preamble also states the variable in-prompt, so the agent is aware of it even though, in default `chorus` permission mode, it cannot run a shell to read it.
+
+- **Chorus-channel re-routing guidance (q6=C, general rule + a few examples).** The preamble gives a general rule plus a short illustrative mapping (not an exhaustive table): present elaboration questions → `chorus_pm_start_elaboration` (human answers in the UI panel); need a decision/confirmation → `chorus_add_comment` with an `@mention`; never silently skip a step that needs human input — record it in Chorus and stop.
+
+- **Async hand-off behavior (q7=A).** The preamble instructs: when a point genuinely needs a human decision, post it to Chorus, then **end the turn and leave the work pending** — do not block waiting for a synchronous reply. The human's later comment / elaboration answer wakes a fresh turn that continues.
+
+- **Soft guidance only (q2=A).** No tool-layer hard block of `AskUserQuestion`, no permission-deny, no runtime interceptor. The wake prompt + env signal guide behavior; revisiting a hard block is deferred unless guidance proves insufficient.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-headless-interaction-guard`: the behavioral contract for a daemon-woken headless session — the wake-prompt preamble (headless declaration + `AskUserQuestion` prohibition), the `CHORUS_DAEMON_HEADLESS=1` environment signal, the skill-instruction → Chorus-channel re-routing guidance, the post-to-Chorus-then-end-turn async hand-off, and the explicit injection-layer scope guard (wake-prompt only — not the system prompt, not a tool-layer block, not skill bodies).
+
+### Modified Capabilities
+
+- None. This change is purely additive. The existing `cli-daemon` spawn and wake requirements are unchanged — the spawn argv is byte-for-byte the same except for the added child env var, which is a new requirement in the new capability rather than a rewrite of the cross-platform-spawn requirement.
+
+## Impact
+
+- **Schema**: none. No migration, no model, no enum.
+- **Daemon client code** (in-repo, `cli/`):
+  - `cli/prompts.mjs` — add `HEADLESS_PREAMBLE`; wrap `buildPrompt()` to prepend it to every non-null wake body (null-returning actions — empty `human_instruction`, unknown actions — stay null, so no spurious spawn). Update the file-header comment to stop merely *claiming* headlessness and point at the preamble.
+  - `cli/claude-spawner.mjs` — `wake()` passes `env: { ...process.env, CHORUS_DAEMON_HEADLESS: "1" }` to the spawn; `buildArgs()` is unchanged (explicitly **no** `--append-system-prompt`). Update the header comment.
+  - `cli/__tests__/` — unit tests for the preamble (every wake action carries it; non-wake actions still null) and the env signal (child env contains the var, inherited env preserved, `buildArgs` excludes `--append-system-prompt`).
+- **Skill docs**: **none.** Reconciling the two verified scope answers — q4=C (keep the rule in the wake prompt only; do **not** add `if headless` branches to skill bodies) and q5=A (keep the 4 skill surfaces in sync) — the net is that **no skill body changes**, so there is nothing to fan out across the Claude Code / Codex / standalone / OpenClaw surfaces; "in sync" is satisfied by leaving them all untouched.
+- **MCP tools / `docs/MCP_TOOLS.md`**: unchanged — no new tool.
+- **`docs/design.pen`**: not applicable — this is a daemon CLI behavior change with no user-facing screen or component.
+- **Runtime**: no new dependencies, no new permission bit, no protocol change.
+- **Backward compat**: fully additive. Interactive (human-at-terminal) Claude Code sessions never go through `cli/prompts.mjs` or `cli/claude-spawner.mjs`, so they are entirely unaffected — the preamble and env var exist only on the daemon spawn path.
+
+## Out of Scope
+
+- **Editing skill bodies.** No `if headless` conditional is added to `idea` / `brainstorm` / `develop` / `proposal` / `yolo` (q4=C). The `AskUserQuestion` interactive path stays intact for human-at-terminal runs; it is only soft-bypassed in headless via the wake prompt.
+- **A tool-layer hard block** of `AskUserQuestion` (deny / strip / runtime interceptor) — deferred (q2=A); revisit only if soft guidance proves insufficient.
+- **`--append-system-prompt` / system-level injection** — explicitly rejected (q1=C). Persistence across `--resume` is achieved by re-injecting the preamble in each per-turn wake prompt.
+- **A skill/hook consumer of `CHORUS_DAEMON_HEADLESS`.** The env var is laid down now as a forward-looking, machine-checkable signal (and stated in the prompt for the agent's awareness), but wiring skills or hooks to programmatically branch on it is deferred (follows from q4=C). No code in this change reads the variable back.
+- Daemon protocol, concurrency/queue model, transcript, and connection observability — owned by sibling ideas.

--- a/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/specs/daemon-headless-interaction-guard/spec.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/specs/daemon-headless-interaction-guard/spec.md
@@ -1,0 +1,83 @@
+# daemon-headless-interaction-guard Specification
+
+## ADDED Requirements
+
+### Requirement: Wake prompts SHALL declare the headless, no-human-at-terminal context
+
+Every wake prompt the daemon sends to a spawned headless Claude session (`cli/prompts.mjs#buildPrompt`) SHALL be prefixed with a shared headless preamble. The preamble SHALL state that the session is a headless `claude -p` run woken by the Chorus daemon, that there is no human at the terminal, and that `CHORUS_DAEMON_HEADLESS=1` is set. The preamble SHALL be prepended to the prompt body for **every** wake action that produces a prompt, regardless of action type and regardless of whether the spawn is a new session or a `--resume` continuation.
+
+#### Scenario: Every wake action carries the headless preamble
+
+- **WHEN** `buildPrompt` is called for any action in `WAKE_ACTIONS` (e.g. `task_assigned`, `mentioned`, `elaboration_verified`, `human_instruction` with body, …)
+- **THEN** the returned prompt contains the shared headless preamble text declaring "headless", "no human at the terminal", and `CHORUS_DAEMON_HEADLESS=1`
+- **AND** the original per-action body (the `[Chorus] …` text and any `@mention` guidance) is still present after the preamble
+
+#### Scenario: The preamble rides every turn including resumes
+
+- **WHEN** the daemon resumes an existing session and builds a fresh wake prompt for the new turn
+- **THEN** that prompt also carries the headless preamble
+- **AND** the spawn argv does NOT use `--append-system-prompt` to inject the rule
+
+### Requirement: Wake prompts SHALL prohibit AskUserQuestion and route human interaction through Chorus
+
+The headless preamble SHALL instruct the woken agent not to call `AskUserQuestion` or any interactive/blocking terminal prompt, and SHALL direct it to route every point that needs human input or confirmation through Chorus async channels — posting a comment with an `@mention` and/or opening an elaboration round the human answers in the UI. The preamble SHALL include a small number of illustrative skill-instruction → Chorus-channel mappings (general rule plus examples, not an exhaustive table). The preamble SHALL instruct the agent that, after posting a question to Chorus, it ends the turn and leaves the work pending rather than blocking on a synchronous reply.
+
+#### Scenario: The prohibition and re-routing rule are present
+
+- **WHEN** any wake prompt is built
+- **THEN** it contains an explicit instruction not to use `AskUserQuestion` / blocking terminal prompts
+- **AND** it contains the general rule to route human-decision points through Chorus — posting a comment with `chorus_add_comment` (`@mention`) and/or opening an elaboration round the human answers in the UI
+- **AND** it contains the async hand-off instruction: post to Chorus, then end the turn and leave the work pending (do not poll/wait)
+- **AND** the preamble does NOT embed the literal answer-questions tool names `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` (it rides every wake, including the `elaboration_verified` write-the-proposal wake whose contract forbids them)
+
+#### Scenario: Guidance is soft, not a tool-layer block
+
+- **WHEN** this change is applied
+- **THEN** no tool-layer deny, strip, or runtime interception of `AskUserQuestion` is added
+- **AND** the spawn allowed-tools / permission-mode behavior is unchanged from before this change
+
+### Requirement: Null wake bodies SHALL remain null after the preamble is applied
+
+Prepending the headless preamble SHALL NOT turn a non-wake notification into a wake. Actions for which `buildPrompt` returns `null` (an unknown action, or a `human_instruction` whose instruction body is empty) SHALL still return `null`, so the router continues to skip them and no contentless subprocess is spawned.
+
+#### Scenario: Unknown action stays null
+
+- **WHEN** `buildPrompt` is called with an action not in `WAKE_ACTIONS`
+- **THEN** it returns `null`
+- **AND** no preamble-only prompt is produced
+
+#### Scenario: Empty human_instruction stays null
+
+- **WHEN** `buildPrompt` is called for a `human_instruction` action whose `instructionText` is missing or blank
+- **THEN** it returns `null`
+
+### Requirement: The spawner SHALL mark headless daemon sessions with an environment signal
+
+`ClaudeSpawner.wake()` SHALL spawn the headless Claude subprocess with `CHORUS_DAEMON_HEADLESS` set to `"1"` in the child process environment. The variable SHALL be added on top of the inherited environment so all other inherited variables (PATH, credential/Bedrock vars, `CLAUDE_CONFIG_DIR`, etc.) are preserved. This change in this proposal SHALL NOT add any code that reads the variable back — it is a forward-looking, machine-checkable signal.
+
+#### Scenario: Spawned child environment carries the signal
+
+- **WHEN** the daemon spawns a headless wake via `ClaudeSpawner.wake()`
+- **THEN** the child process environment contains `CHORUS_DAEMON_HEADLESS=1`
+- **AND** environment variables inherited from the daemon process are still present in the child environment
+
+#### Scenario: The signal is independent of permission mode
+
+- **WHEN** the spawner runs in either `chorus` (allowed-tools) or `yolo` (`--dangerously-skip-permissions`) permission mode
+- **THEN** the child environment carries `CHORUS_DAEMON_HEADLESS=1` in both cases
+
+### Requirement: The interaction guard SHALL NOT modify skill bodies or the spawn argv contract
+
+The headless interaction guard SHALL be implemented entirely on the daemon path — the wake-prompt builder and the spawner. It SHALL NOT add a conditional `AskUserQuestion`/headless branch to any skill body (`idea`, `brainstorm`, `develop`, `proposal`, `yolo`) on any of the four skill surfaces, and SHALL NOT change `buildArgs()` to add `--append-system-prompt`. Interactive (human-at-terminal) Claude Code sessions, which never traverse the daemon wake path, SHALL be unaffected.
+
+#### Scenario: Skill bodies are untouched and stay in sync
+
+- **WHEN** the change is applied
+- **THEN** no skill markdown file is modified to add a headless conditional
+- **AND** the four skill surfaces (Claude Code plugin, Codex plugin, standalone `public/skill/`, OpenClaw) remain consistent with each other (unchanged)
+
+#### Scenario: Interactive sessions are unaffected
+
+- **WHEN** a human runs Claude Code interactively (not via the daemon)
+- **THEN** the headless preamble and `CHORUS_DAEMON_HEADLESS` env var are absent
+- **AND** `AskUserQuestion` continues to work as before

--- a/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/tasks.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: add-daemon-headless-interaction-guard
+
+## 1. Wake-prompt headless preamble (`cli/prompts.mjs`)
+- [ ] 1.1 Add exported `HEADLESS_PREAMBLE` constant: headless + no-human-at-terminal + `CHORUS_DAEMON_HEADLESS=1` declaration; `AskUserQuestion`/blocking-prompt prohibition; general route-through-Chorus rule; a few illustrative skill→Chorus mappings (q6=C); async hand-off (post to Chorus, end turn, leave pending — q7=A)
+- [ ] 1.2 Wrap `buildPrompt(n)` so it computes the per-action body first, returns `null` unchanged when the body is null (unknown action / empty `human_instruction`), and otherwise returns `HEADLESS_PREAMBLE + body`
+- [ ] 1.3 Update the file-header comment to point at the preamble instead of merely asserting headlessness
+
+## 2. Headless env signal (`cli/claude-spawner.mjs`)
+- [ ] 2.1 In `ClaudeSpawner.wake()`, pass `env: { ...process.env, CHORUS_DAEMON_HEADLESS: "1" }` to the spawn options (merged over inherited env); leave `buildArgs()` unchanged — explicitly NO `--append-system-prompt`
+- [ ] 2.2 Update the header comment to document the env signal
+
+## 3. Tests (`cli/__tests__/`)
+- [ ] 3.1 prompts: every `WAKE_ACTIONS` entry yields a prompt containing the preamble + the `AskUserQuestion` prohibition + the async-hand-off line, with the original `[Chorus] …`/`@mention` body still present after it
+- [ ] 3.2 prompts: unknown action and empty `human_instruction` still return `null` (preamble did not resurrect them)
+- [ ] 3.3 spawner: injected `spawnImpl` receives `env.CHORUS_DAEMON_HEADLESS === "1"` and a sentinel inherited var survives the merge; assert in both `chorus` and `yolo` permission modes
+- [ ] 3.4 spawner: `buildArgs(...)` output does not contain `--append-system-prompt` (locks q1=C)
+
+## 4. Integration checkpoint
+- [ ] 4.1 Run the existing daemon suite green end-to-end — `cli/__tests__/wake-orchestration.test.mjs` (where the `buildPrompt` wake-prompt assertions live), `daemon-integration.test.mjs`, `claude-spawner.test.mjs` — the preamble lengthens prompts but argv and wake flow are structurally unchanged; confirm no existing assertion on exact prompt text breaks (update any that pin the full body)
+- [ ] 4.2 Verify the daemon-only scope guard manually (the spec's "no skill bodies modified" negative requirement has no automated test): confirm `git diff --stat` shows changes ONLY under `cli/` (`prompts.mjs`, `claude-spawner.mjs`, `__tests__/`) — no skill markdown under any of the four surfaces (Claude Code plugin, Codex plugin, `public/skill/`, OpenClaw) and no `--append-system-prompt` added to `buildArgs`

--- a/openspec/specs/daemon-headless-interaction-guard/spec.md
+++ b/openspec/specs/daemon-headless-interaction-guard/spec.md
@@ -1,0 +1,85 @@
+# daemon-headless-interaction-guard Specification
+
+## Purpose
+TBD - created by archiving change add-daemon-headless-interaction-guard. Update Purpose after archive.
+## Requirements
+### Requirement: Wake prompts SHALL declare the headless, no-human-at-terminal context
+
+Every wake prompt the daemon sends to a spawned headless Claude session (`cli/prompts.mjs#buildPrompt`) SHALL be prefixed with a shared headless preamble. The preamble SHALL state that the session is a headless `claude -p` run woken by the Chorus daemon, that there is no human at the terminal, and that `CHORUS_DAEMON_HEADLESS=1` is set. The preamble SHALL be prepended to the prompt body for **every** wake action that produces a prompt, regardless of action type and regardless of whether the spawn is a new session or a `--resume` continuation.
+
+#### Scenario: Every wake action carries the headless preamble
+
+- **WHEN** `buildPrompt` is called for any action in `WAKE_ACTIONS` (e.g. `task_assigned`, `mentioned`, `elaboration_verified`, `human_instruction` with body, …)
+- **THEN** the returned prompt contains the shared headless preamble text declaring "headless", "no human at the terminal", and `CHORUS_DAEMON_HEADLESS=1`
+- **AND** the original per-action body (the `[Chorus] …` text and any `@mention` guidance) is still present after the preamble
+
+#### Scenario: The preamble rides every turn including resumes
+
+- **WHEN** the daemon resumes an existing session and builds a fresh wake prompt for the new turn
+- **THEN** that prompt also carries the headless preamble
+- **AND** the spawn argv does NOT use `--append-system-prompt` to inject the rule
+
+### Requirement: Wake prompts SHALL prohibit AskUserQuestion and route human interaction through Chorus
+
+The headless preamble SHALL instruct the woken agent not to call `AskUserQuestion` or any interactive/blocking terminal prompt, and SHALL direct it to route every point that needs human input or confirmation through Chorus async channels — posting a comment with an `@mention` and/or opening an elaboration round the human answers in the UI. The preamble SHALL include a small number of illustrative skill-instruction → Chorus-channel mappings (general rule plus examples, not an exhaustive table). The preamble SHALL instruct the agent that, after posting a question to Chorus, it ends the turn and leaves the work pending rather than blocking on a synchronous reply.
+
+#### Scenario: The prohibition and re-routing rule are present
+
+- **WHEN** any wake prompt is built
+- **THEN** it contains an explicit instruction not to use `AskUserQuestion` / blocking terminal prompts
+- **AND** it contains the general rule to route human-decision points through Chorus — posting a comment with `chorus_add_comment` (`@mention`) and/or opening an elaboration round the human answers in the UI
+- **AND** it contains the async hand-off instruction: post to Chorus, then end the turn and leave the work pending (do not poll/wait)
+- **AND** the preamble does NOT embed the literal answer-questions tool names `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` (it rides every wake, including the `elaboration_verified` write-the-proposal wake whose contract forbids them)
+
+#### Scenario: Guidance is soft, not a tool-layer block
+
+- **WHEN** this change is applied
+- **THEN** no tool-layer deny, strip, or runtime interception of `AskUserQuestion` is added
+- **AND** the spawn allowed-tools / permission-mode behavior is unchanged from before this change
+
+### Requirement: Null wake bodies SHALL remain null after the preamble is applied
+
+Prepending the headless preamble SHALL NOT turn a non-wake notification into a wake. Actions for which `buildPrompt` returns `null` (an unknown action, or a `human_instruction` whose instruction body is empty) SHALL still return `null`, so the router continues to skip them and no contentless subprocess is spawned.
+
+#### Scenario: Unknown action stays null
+
+- **WHEN** `buildPrompt` is called with an action not in `WAKE_ACTIONS`
+- **THEN** it returns `null`
+- **AND** no preamble-only prompt is produced
+
+#### Scenario: Empty human_instruction stays null
+
+- **WHEN** `buildPrompt` is called for a `human_instruction` action whose `instructionText` is missing or blank
+- **THEN** it returns `null`
+
+### Requirement: The spawner SHALL mark headless daemon sessions with an environment signal
+
+`ClaudeSpawner.wake()` SHALL spawn the headless Claude subprocess with `CHORUS_DAEMON_HEADLESS` set to `"1"` in the child process environment. The variable SHALL be added on top of the inherited environment so all other inherited variables (PATH, credential/Bedrock vars, `CLAUDE_CONFIG_DIR`, etc.) are preserved. This change in this proposal SHALL NOT add any code that reads the variable back — it is a forward-looking, machine-checkable signal.
+
+#### Scenario: Spawned child environment carries the signal
+
+- **WHEN** the daemon spawns a headless wake via `ClaudeSpawner.wake()`
+- **THEN** the child process environment contains `CHORUS_DAEMON_HEADLESS=1`
+- **AND** environment variables inherited from the daemon process are still present in the child environment
+
+#### Scenario: The signal is independent of permission mode
+
+- **WHEN** the spawner runs in either `chorus` (allowed-tools) or `yolo` (`--dangerously-skip-permissions`) permission mode
+- **THEN** the child environment carries `CHORUS_DAEMON_HEADLESS=1` in both cases
+
+### Requirement: The interaction guard SHALL NOT modify skill bodies or the spawn argv contract
+
+The headless interaction guard SHALL be implemented entirely on the daemon path — the wake-prompt builder and the spawner. It SHALL NOT add a conditional `AskUserQuestion`/headless branch to any skill body (`idea`, `brainstorm`, `develop`, `proposal`, `yolo`) on any of the four skill surfaces, and SHALL NOT change `buildArgs()` to add `--append-system-prompt`. Interactive (human-at-terminal) Claude Code sessions, which never traverse the daemon wake path, SHALL be unaffected.
+
+#### Scenario: Skill bodies are untouched and stay in sync
+
+- **WHEN** the change is applied
+- **THEN** no skill markdown file is modified to add a headless conditional
+- **AND** the four skill surfaces (Claude Code plugin, Codex plugin, standalone `public/skill/`, OpenClaw) remain consistent with each other (unchanged)
+
+#### Scenario: Interactive sessions are unaffected
+
+- **WHEN** a human runs Claude Code interactively (not via the daemon)
+- **THEN** the headless preamble and `CHORUS_DAEMON_HEADLESS` env var are absent
+- **AND** `AskUserQuestion` continues to work as before
+


### PR DESCRIPTION
## Summary
A daemon-woken headless `claude -p` session has no human at the terminal, so any `AskUserQuestion` (or other blocking terminal prompt) hangs or is silently dropped — stalling the agent or forcing a unilateral decision. This guards against it entirely on the daemon path, routing human-decision points to Chorus instead.

- **`cli/prompts.mjs`** — new exported `HEADLESS_PREAMBLE` prepended to every non-null wake prompt (`buildPrompt` now wraps an internal `buildPromptBody`). It declares the headless / no-human context + `CHORUS_DAEMON_HEADLESS=1`, forbids `AskUserQuestion`, routes human-decision points through Chorus (comment `@mention` / elaboration panel), and gives an async hand-off (post → end the turn → leave pending). Null bodies stay null (no contentless spawn).
- **`cli/claude-spawner.mjs`** — `ClaudeSpawner.wake()` spawns the child with `CHORUS_DAEMON_HEADLESS=1` merged over inherited env. `buildArgs()` unchanged — no `--append-system-prompt`.

Implements the human-verified elaboration of idea `aa1b1dcc` (Chorus 0.11.0): q1=C per-turn wake-prompt prefix, q2=A soft guidance, q3=A env signal, q4=C no skill-body edits, q5=A four surfaces stay in sync (untouched), q6=C general rule + a few examples, q7=A async hand-off.

## Design notes
- **Per-turn prefix, not `--append-system-prompt`**: the daemon rebuilds the prompt on every wake (new and `--resume`), so a per-turn prefix persists across resumes without touching the spawn argv contract.
- **Preamble omits `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` literals on purpose**: it rides every wake including `elaboration_verified`, whose existing contract (asserted in `wake-orchestration.test.mjs`) forbids those tokens. Using `chorus_add_comment` + prose for the panel keeps that invariant intact — no pre-existing assertion was edited.
- **Soft guard**: no tool-layer block; the env var is a write-only signal (nothing reads it back yet). Both deferred by explicit owner decision.

## Changed files
| File | Change |
|------|--------|
| `cli/prompts.mjs` | `HEADLESS_PREAMBLE` + `buildPrompt`/`buildPromptBody` wrapper |
| `cli/claude-spawner.mjs` | `CHORUS_DAEMON_HEADLESS=1` in spawn env; `buildArgs` untouched |
| `cli/__tests__/wake-orchestration.test.mjs` | preamble unit tests + real-spawner end-to-end wake test |
| `cli/__tests__/claude-spawner.test.mjs` | env-signal unit tests (both permission modes, inherited-var survival, no `--append-system-prompt`) |
| `openspec/changes/archive/2026-06-21-add-daemon-headless-interaction-guard/` | archived OpenSpec change (proposal/design/spec/tasks) |
| `openspec/specs/daemon-headless-interaction-guard/spec.md` | emitted long-term capability spec |

## Test plan
- [x] `npx vitest run cli/__tests__/` — full daemon suite green (287 tests incl. cross-cutting `elaboration-verify-wake` integration test)
- [x] No pre-existing assertion weakened; `elaboration_verified` no-answer-tools invariant preserved
- [x] Scope guard: only `cli/` source changed; no skill markdown on any of the 4 surfaces; no `--append-system-prompt` in argv
- [x] Independent adversarial code review: APPROVE, no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)