### PR TITLE
feat(daemon-chat): vertical-space optimization for the conversation surface

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1450,6 +1450,7 @@
     "conversationIdea": "Idea {id}",
     "badgeIdea": "Idea",
     "running": "Running",
+    "runningElapsedLabel": "Elapsed since this run started",
     "statusActive": "Active",
     "statusEnded": "Ended",
     "statusInterrupted": "Interrupted",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1451,6 +1451,7 @@
     "conversationIdea": "想法 {id}",
     "badgeIdea": "想法",
     "running": "运行中",
+    "runningElapsedLabel": "本次运行已用时",
     "statusActive": "进行中",
     "statusEnded": "已结束",
     "statusInterrupted": "已打断",

--- a/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/README.md
+++ b/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/README.md
@@ -1,0 +1,3 @@
+# optimize-daemon-chat-vertical-space
+
+Daemon chat window vertical-space optimization: drop redundant subtitle, top-align content, fold interrupt/resume/send into the input box

--- a/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/design.md
+++ b/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/design.md
@@ -1,0 +1,112 @@
+# Design: Daemon chat window vertical-space optimization
+
+## Overview
+
+A front-end-only refinement of the daemon chat surface (`DaemonChat` + `TranscriptView` + the `ComposeField`/`ConversationReplyBox` composer). Three changes, one theme — reclaim vertical space by cutting chrome:
+
+1. Drop the redundant visible header subtitle; tighten outer padding/gap so content top-aligns.
+2. Move the running-status (running marker + elapsed time) into the transcript header; remove the standalone footer `ExecutionRow` card.
+3. Fold Interrupt / Resume / Send into one bottom-right action row on the input box, and stop disabling the textarea while a turn runs.
+
+No backend, schema, endpoint, or permission change. Everything reuses the shipped daemon-session pipeline: the instruction endpoint, the `/api/daemon/control` interrupt + `/api/daemon/resume` resume endpoints, the execution snapshot, and the transcript SSE.
+
+## Key decisions (from elaboration)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| Q1 | **Send-while-running: input stays usable; Send always present, Interrupt appears beside it while running, Resume after a user-interrupt.** (option b) | Owner choice. Chat-like — the user can type a follow-up/correction mid-run. Cost is up to two buttons in the corner at once (Send + Interrupt), accepted. |
+| Q2 | **Running status (running marker + elapsed time) moves into the transcript header.** (option b) | Owner choice. Frees the footer to be purely input + actions, maximizing transcript height. The header already shows a running pulse — extend it with elapsed time. |
+| Q3 | **No deep-link in the status.** (option b) | Owner choice. The header conversation title (with its Idea badge) already identifies the conversation and is the jump-off point; the status stays minimal. |
+| Q4 | **Mobile (`< lg`) syncs the same layout.** (option a) | Owner choice. Mobile vertical space is tighter still; same "drop card, fold actions into input" via the composer's `stacked` variant. |
+| — | **Interrupt keeps its confirmation `AlertDialog`.** (hard constraint) | Destructive op; a misclick must never silently kill a running agent. Non-negotiable regardless of layout. |
+| — | **Running-state visibility is preserved, not dropped.** (hard constraint) | Removing the card must not lose "what's running / how long" — Q2 gives it a home in the header. |
+
+## Architecture
+
+### Current layout (what changes)
+
+```
+DaemonChat (daemon-chat.tsx)
+ └ outer container: px-4 py-5 … lg:py-7, gap-6
+    ├ <header>  <h2>title</h2>  <p>subtitle</p>        ← subtitle removed; py/gap tightened
+    └ two-pane body
+        └ TranscriptView (right pane)
+            ├ header: title + status badge + "running" pulse   ← add elapsed time here (Q2)
+            │         + collapsible connection details (unchanged)
+            ├ body: turn bands (ScrollArea)                     (unchanged)
+            └ footer:
+                ├ controllableExecutions.map(ExecutionRow)      ← standalone card REMOVED
+                └ ConversationReplyBox (Textarea + Send)         ← gains action row (Q1)
+```
+
+### Target layout
+
+```
+DaemonChat
+ └ outer container: tightened py/gap (content top-aligned)
+    ├ <header>  <h2>title</h2>                               (single line — no subtitle)
+    └ two-pane body
+        └ TranscriptView
+            ├ header: title + status badge + running pulse + ELAPSED TIME   (Q2)
+            ├ body: turn bands                                              (unchanged)
+            └ footer: ConversationReplyBox ONLY
+                 └ ComposeField
+                     ├ Textarea (NOT disabled while running — Q1)
+                     └ action row (bottom-right):
+                         Send  [+ Interrupt while running] [+ Resume if user-interrupted]
+```
+
+### Running-status home (Q2)
+
+`TranscriptView` already derives `currentTurn` (the running turn, else the newest) and renders a "running" pulse when `currentTurn.status === "running"`. It also already computes `controllableExecutions` from `sessionExecutions`. To carry elapsed time in the header:
+
+- Pick the conversation's running execution (the `running` entry already in `controllableExecutions`, running-first).
+- In the header's status line, when running, render the existing pulse **plus** the elapsed time using the existing `useElapsedMono()` / `nowMs` formatter (the same one `ExecutionRow` uses today) off that execution's `startedAt`.
+- No deep link (Q3): the elapsed time is plain text beside the pulse; the `<h3>` title above it is the only navigational affordance.
+
+This keeps the "how long has it been running" signal that the card used to provide, in a lighter single-line form, satisfying the hard constraint.
+
+### Consolidated action row (Q1)
+
+`ComposeField` currently renders a footer with a disabled-reason on the left and a single Send button on the right. Generalize the right side into an **action row** that can host additional state-driven controls before Send:
+
+- The composer is told this conversation's controllable execution (the `running` or user-`interrupted` one), if any.
+- **Running** → render the Interrupt control (the existing `InterruptButton`, with its `AlertDialog`) to the left of Send.
+- **User-interrupted** → render the Resume control (the existing `ResumeButton`) to the left of Send.
+- **Crash-interrupted** → no Resume; the "auto-recovers" hint stays (today it lives on the card; it moves to a minimal inline hint or the header — kept visible, never silently dropped).
+- **Send** is always present and independently gated (empty/pending), exactly as today.
+
+**Textarea enable (send-while-running):** today `ComposeField` disables the textarea via `disabled || pending`. The hard-`disabled` path (origin offline) is unchanged. The change is that a *running turn* no longer disables it — there is no "running disables input" coupling to add; the composer simply isn't told to disable on run. The existing Enter-to-send + `isImeComposing` guard is preserved.
+
+**Reusing the controls:** `InterruptButton` and `ResumeButton` are currently file-private to `execution-row.tsx`. Export them (or extract to a small shared module) so the composer renders the **same** controls — same `AlertDialog` confirmation, same `/api/daemon/control` + `/api/daemon/resume` calls, same toasts/`entityType`/`entityUuid` wiring. No behavioral divergence; only the mount point moves.
+
+### Layout variants (Q4)
+
+`ComposeField` already takes `layout: "inline" | "stacked"`. Desktop two-pane uses `inline` (action row on the same line as the footer); mobile drill-down uses `stacked` (action row drops below the textarea). The consolidated action row honors both: inline keeps Send + Interrupt/Resume on the footer's right; stacked stacks them under the textarea. Mobile thus gets the same "no card, actions in the input" outcome with no separate code path.
+
+### Top-align (improvements 1 & 2)
+
+Purely Tailwind spacing in `daemon-chat.tsx`:
+
+- Header becomes a single line (subtitle `<p>` removed), so the header's intrinsic height drops.
+- Reduce the outer container's vertical padding (`py-5`/`md:py-6`/`lg:py-7`) and the header→body `gap-6` to a tighter scale so the two-pane content's top edge sits near the modal top. Exact values are a visual-tuning detail for the implementer; the AC asserts the *outcome* (content top-aligned, no visible subtitle), not specific pixel values.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Deleting the subtitle accidentally breaks the Radix Dialog a11y "described-by". | The hidden `DialogDescription` in `connections-modal.tsx` is a **separate** node that also reads `t("subtitle")`; we delete only the visible `<p>` in `daemon-chat.tsx` and **keep the i18n key**. AC explicitly asserts the a11y description still resolves. |
+| Interrupt loses its confirmation when moved into the input row. | Reuse the existing `InterruptButton` component verbatim — the `AlertDialog` travels with it. AC asserts the confirm dialog still appears. |
+| Running state disappears with the card. | Q2 moves running + elapsed into the header. AC asserts running indication + elapsed time remain visible after the card is removed. |
+| Two buttons (Send + Interrupt) crowd the corner, especially on mobile. | The `stacked` layout drops actions below the textarea on mobile; inline has room on desktop. Visual check on both widths. |
+| Send-while-running implies a backend change. | It does not — the instruction endpoint already appends a `human_instruction` turn irrespective of run state. The change is only un-disabling the textarea. AC notes no backend change. |
+| `InterruptButton`/`ResumeButton` were file-private; exporting them risks regressing the connection-deck/popover. | They are presentational + prop-driven already; export without changing their internals. The standalone `ExecutionRow` and its other call sites are untouched. |
+
+## Implementation order
+
+1. **Header chrome + top-align** (`daemon-chat.tsx`) — remove visible subtitle, tighten py/gap (desktop + mobile). Independently shippable; lowest risk.
+2. **Running status into header** (`transcript-view.tsx`) — add elapsed time to the header status line from the running execution.
+3. **Composer action row** (`send-instruction-box.tsx` + export controls from `execution-row.tsx`) — Send always present; Interrupt/Resume state-driven beside it; textarea no longer disabled while running; honor inline/stacked.
+4. **Remove the standalone footer card** (`transcript-view.tsx`) — drop `controllableExecutions.map(ExecutionRow)` from the footer once (3) hosts the controls; feed the controllable execution into the composer instead.
+5. **i18n + design.pen** — any new key in en+zh; update the daemon chat mock(s).
+6. **Integration checkpoint** — desktop + mobile, idle/running/user-interrupted/crash/offline states verified end to end in a real browser.

--- a/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/proposal.md
+++ b/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: Daemon chat window vertical-space optimization
+
+## Why
+
+The daemon "conversation" window — the chat-style two-pane surface inside the agent-presence "View all" modal (`DaemonChat`) — wastes **vertical space**, most visibly on desktop. Three concrete complaints from use:
+
+1. **Content does not top-align on desktop.** The right (transcript) pane's top edge sits well below the modal top. The outer container spends `lg:py-7` + `gap-6`, and a two-line `<header>` (title **plus** subtitle) eats height before any conversation shows. The transcript — the thing the user opened the window to read — starts too low.
+
+2. **The header subtitle is redundant.** Once you are *inside* the conversation surface, the line "逐回合查看智能体做了什么。可在对话内继续发送或中断。" (`daemonChat.subtitle`) is stating the obvious. It is pure chrome competing with the conversation for vertical space.
+
+3. **The standalone running-task card crowds the conversation.** After a send/dispatch, the footer stacks a standalone `ExecutionRow` card (running/interrupted state + Interrupt/Resume) **above** the reply box — two separate blocks, each taking a row, squeezing the transcript. The interrupt/resume/send actions are scattered instead of living together where the user's hands already are.
+
+The fix is one theme: **let the conversation breathe vertically by cutting chrome** — drop the redundant subtitle, pull content to the top, and fold the Interrupt / Resume / Send actions into a single action row at the bottom-right of the input box, so the standalone task card disappears.
+
+Two hard constraints (PM, non-negotiable):
+
+- **Interrupt is destructive — it MUST keep its confirmation dialog** even after moving into the input action row, so a misclick never silently kills a running agent.
+- **Running-state visibility MUST NOT be lost with the card.** "Which agent is running / how long it's been running" needs a new, lighter home — it cannot just vanish when the card does.
+
+## What Changes
+
+- **Remove the visible header subtitle.** Delete the visible `<p>{t("subtitle")}</p>` from `DaemonChat`'s header (desktop + mobile). The `daemonChat.subtitle` i18n **key is kept** — it is independently referenced by the hidden `DialogDescription` in `connections-modal.tsx` (the Radix Dialog accessibility "described-by"), which is a *separate* node from the visible subtitle and is **not** touched. So accessibility is unaffected; only the on-screen redundant line goes away.
+
+- **Top-align the content.** Tighten the outer container's vertical padding and the header→body gap (`py-7`/`py-6`/`py-5` and `gap-6`) so the two-pane content sits close to the modal top, reclaiming the space the subtitle freed. The visible `<h2>` title is **kept** (it is the surface's heading); only its spacing and the now-single-line header shrink.
+
+- **Move the running status into the transcript header (Q2=b).** The transcript header already shows a "running" pulse for the current turn; extend it to also carry the **elapsed run time** of this conversation's running execution. The standalone footer `ExecutionRow` card is then **removed** from the footer. The status carries **no** deep-link to the task/idea (Q3=b) — the header conversation title remains the jump-off point.
+
+- **Consolidate Interrupt / Resume / Send into the input action row (Q1=b).** The reply composer (`ConversationReplyBox` / `ComposeField`) renders a single bottom-right action area:
+  - **Send** is always present.
+  - When this conversation has a **running** execution, **Interrupt** appears beside Send (keeping its `AlertDialog` confirmation).
+  - When this conversation has a **user-interrupted** execution, **Resume** appears.
+  - A **crash**-interrupted execution shows the existing "auto-recovers" hint (no Resume) — unchanged semantics.
+  - **Input stays usable while running (send-while-running):** the textarea is NOT disabled during a running turn, so the user can type and send a follow-up/correcting instruction mid-run. This reuses the existing `POST /api/daemon-sessions/{uuid}/instruction` endpoint, which already appends a `human_instruction` turn regardless of run state — **no backend change**. (Origin-offline still hard-disables the composer with its visible read-only reason, unchanged.)
+
+- **Apply to mobile too (Q4=a).** The mobile (`< lg`) drill-down footer gets the same treatment — standalone task card removed, actions folded into the input's action row — using the composer's existing `stacked` layout variant. Running status likewise reads from the transcript header.
+
+- **i18n.** Any new user-facing string (e.g. an elapsed-time label in the header, if not already present) is added to **both** `messages/en.json` and `messages/zh.json`. No hardcoded text. The `daemonChat.subtitle` key is retained (still used for a11y).
+
+- **design.pen.** Update the daemon chat window mock(s) to reflect: no visible subtitle, top-aligned content, header-carried running status, and the consolidated input action row (desktop + mobile).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `daemon-session-transcript-read`: The existing "Chat-style conversation surface" and mobile-fullscreen requirements describe the two-pane chat UI and an inline send/interrupt footer. This change adds three **refinement** requirements to the same capability: (1) minimized header chrome + top-aligned content, (2) running status carried in the transcript header instead of a standalone footer card, (3) Interrupt/Resume/Send consolidated into the reply input's action row with send-while-running. These are additive `## ADDED Requirements` — they refine, and do not contradict, the existing high-level surface requirement (which only states the right pane "SHALL offer inline send-instruction and interrupt controls," without dictating their layout).
+
+## Impact
+
+- **Schema**: none. No migration, no model change.
+- **Backend code**: none. "Send while running" reuses the existing instruction endpoint as-is; running/interrupt/resume all reuse the existing `/api/daemon/control` + `/api/daemon/resume` + execution-snapshot machinery.
+- **Frontend code**:
+  - `src/components/agent-presence/chat/daemon-chat.tsx` — remove the visible subtitle `<p>`; tighten outer `py`/`gap` for top-align (desktop + mobile branches).
+  - `src/components/agent-presence/chat/transcript-view.tsx` — header gains the running elapsed time; footer drops the standalone `ExecutionRow` list and instead feeds the running/interrupted execution into the composer's action row.
+  - `src/components/agent-presence/send-instruction-box.tsx` — `ComposeField` / `ConversationReplyBox` grow an action-row API that hosts Send plus a state-driven Interrupt/Resume control; the textarea is no longer disabled merely because a turn is running.
+  - `src/components/agent-presence/execution-row.tsx` — the `InterruptButton` (with its `AlertDialog`) and `ResumeButton` are extracted/reused as embeddable controls so the composer action row can render them byte-identically to today (same confirm dialog, same endpoints). The standalone `ExecutionRow` card itself remains available for other surfaces (popover/connection deck) — only the daemon-chat footer stops using it.
+  - `messages/en.json` + `messages/zh.json` — any new key (elapsed-time label etc.); `daemonChat.subtitle` retained.
+- **a11y**: the hidden `DialogDescription` in `connections-modal.tsx` is unchanged; removing the *visible* subtitle has no accessibility impact.
+- **Docs**: `docs/design.pen` updated. No MCP tool change → `docs/MCP_TOOLS.md` and skill docs unchanged.
+- **Runtime**: no new dependencies, no migration, no new permission bit.
+- **Backward compat**: fully additive UI refinement. Interrupt keeps its confirmation; offline gating, crash auto-recovery, resume semantics, and the transcript/SSE pipeline are all unchanged. Other surfaces that render `ExecutionRow` (sidebar popover, connection deck) are not modified.
+
+## Out of Scope
+
+- Removing the visible `<h2>` header **title** — only the subtitle is redundant; the title stays.
+- Any change to *when* a running agent consumes a mid-run instruction — that is daemon runtime behavior, out of this UI idea's scope. The UI only re-enables the composer; the existing turn pipeline handles the rest.
+- Backend changes to the instruction / control / resume endpoints — all reused unchanged.
+- Changing `ExecutionRow` usage on other surfaces (popover, Agent Connections deck) — they keep the standalone card.
+- The connection-details collapsible disclosure (host/version/uptime) in the transcript header — unchanged.

--- a/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/specs/daemon-session-transcript-read/spec.md
@@ -1,0 +1,88 @@
+# daemon-session-transcript-read Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: The daemon conversation surface SHALL minimize header chrome and top-align content
+
+The daemon conversation surface ("View all" chat modal) SHALL NOT render a visible header subtitle describing the surface; the surface's visible heading (title) SHALL be retained, but the explanatory subtitle line SHALL be removed so it does not consume vertical space inside the conversation view. The conversation content (the two-pane layout on desktop, the list/drill-down on mobile) SHALL be top-aligned — its top edge SHALL sit close to the modal's top edge, without the excess vertical padding/gap that previously pushed it down. Removing the visible subtitle SHALL NOT remove the modal's accessibility description: the hidden Radix `DialogDescription` used to satisfy the dialog's "described-by" requirement SHALL continue to resolve a localized string, independent of the visible header.
+
+#### Scenario: No visible subtitle in the conversation header
+
+- **WHEN** the daemon conversation surface renders (desktop or mobile)
+- **THEN** the visible heading (title) MUST be present
+- **AND** no visible explanatory subtitle line MUST be shown beneath it
+
+#### Scenario: Content is top-aligned on desktop
+
+- **WHEN** the surface renders on a desktop-width (`lg`+) viewport
+- **THEN** the two-pane conversation content's top edge MUST sit near the modal's top edge, with no large empty band above it
+
+#### Scenario: The dialog accessibility description is preserved
+
+- **WHEN** the conversation modal mounts after the visible subtitle is removed
+- **THEN** the modal MUST still provide an accessibility description (a hidden `DialogDescription`) that resolves a localized string
+- **AND** that description MUST be a separate node from the (now removed) visible subtitle
+
+### Requirement: Running status SHALL be carried in the transcript header rather than a standalone footer card
+
+The conversation's running status — a running indicator plus the elapsed run time of the conversation's running execution — SHALL be presented in the transcript header (alongside the existing running marker), and the standalone running/interrupted execution card SHALL NOT occupy a separate row in the conversation footer. The elapsed time SHALL update live (using the same monotonic elapsed formatter the execution rows use) and SHALL respect reduced-motion for any animated indicator. The running status in the header SHALL NOT include a deep-link to the underlying task/idea; the conversation's header title remains the navigational affordance. Removing the standalone footer card SHALL NOT remove the visibility of which work is running and for how long.
+
+#### Scenario: Elapsed run time appears in the header while running
+
+- **WHEN** the open conversation has a running execution
+- **THEN** the transcript header MUST show a running indicator and the elapsed run time
+- **AND** the elapsed time MUST advance live without a manual refresh
+
+#### Scenario: No standalone running card in the footer
+
+- **WHEN** the open conversation has a running or interrupted execution
+- **THEN** the footer MUST NOT render a standalone execution card on its own row above the input
+- **AND** the running-state information MUST instead be available in the header (running + elapsed)
+
+#### Scenario: The header running status carries no deep link
+
+- **WHEN** the running status renders in the header
+- **THEN** it MUST show only the running indicator and elapsed time (no separate link to the task/idea)
+- **AND** the conversation header title MUST remain the navigational affordance
+
+### Requirement: Interrupt, Resume, and Send SHALL be consolidated into the reply input's action row
+
+The reply composer SHALL present a single action area at the bottom-right of the input box that hosts the conversation's controls together: Send SHALL always be present; when the conversation has a running execution, an Interrupt control SHALL appear alongside Send; when the conversation has a user-interrupted execution, a Resume control SHALL appear; a crash-interrupted execution SHALL show no Resume control (the existing "auto-recovers" hint is retained and remains visible). The Interrupt control SHALL retain its confirmation dialog (a destructive-action confirm) wherever it is rendered. The Interrupt and Resume controls SHALL issue the same control/resume requests they do today (no change to the `/api/daemon/control` interrupt or `/api/daemon/resume` resume behavior). While a turn is running, the input textarea SHALL remain usable so the user can compose and send a follow-up instruction mid-run (reusing the existing instruction endpoint, which appends a `human_instruction` turn regardless of run state); this send-while-running SHALL require no backend change. When the conversation's origin connection is offline, the composer SHALL remain hard-disabled with its visible read-only reason, unchanged. This consolidated layout SHALL apply on both desktop (inline action row) and mobile (stacked action row beneath the textarea).
+
+#### Scenario: Send is always present; Interrupt joins it while running
+
+- **WHEN** the open conversation has a running execution and its origin is online
+- **THEN** the input action row MUST show Send and, beside it, an Interrupt control
+- **AND** the input textarea MUST remain usable (not disabled by the running state)
+
+#### Scenario: Interrupt keeps its confirmation dialog
+
+- **WHEN** the user activates the Interrupt control in the input action row
+- **THEN** a confirmation dialog MUST be shown before any interrupt request is issued
+- **AND** confirming MUST issue the same interrupt request as the prior standalone control
+
+#### Scenario: Resume appears for a user-interrupted conversation; crash shows no Resume
+
+- **WHEN** the open conversation's execution is interrupted with reason `user`
+- **THEN** the input action row MUST show a Resume control
+- **WHEN** instead the execution is interrupted with reason `crash`
+- **THEN** no Resume control MUST be shown, and the existing "auto-recovers" hint MUST remain visible
+
+#### Scenario: Sending a follow-up while a turn is running
+
+- **GIVEN** the open conversation has a running execution and its origin is online
+- **WHEN** the user types an instruction and sends it
+- **THEN** the instruction MUST be submitted via the existing session instruction endpoint (appending a `human_instruction` turn)
+- **AND** no backend change MUST be required for this to work
+
+#### Scenario: Offline origin still hard-disables the composer
+
+- **WHEN** the open conversation's origin connection is offline
+- **THEN** the composer MUST be disabled with its visible localized read-only reason
+- **AND** Send MUST NOT issue a request
+
+#### Scenario: Consolidated controls on mobile use the stacked layout
+
+- **WHEN** the conversation footer renders on a mobile (`< lg`) drill-down
+- **THEN** the standalone execution card MUST NOT be present
+- **AND** Send plus any Interrupt/Resume control MUST render in the stacked action area beneath the textarea

--- a/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/tasks.md
+++ b/openspec/changes/archive/2026-06-21-optimize-daemon-chat-vertical-space/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: optimize-daemon-chat-vertical-space
+
+## 1. Header chrome + top-align
+- [ ] 1.1 `daemon-chat.tsx`: remove the visible `<p>{t("subtitle")}</p>` from the header (desktop + mobile branches); keep the `<h2>` title
+- [ ] 1.2 `daemon-chat.tsx`: tighten outer container vertical padding (`py-5`/`md:py-6`/`lg:py-7`) and header→body `gap-6` so two-pane content top-aligns
+- [ ] 1.3 Verify `connections-modal.tsx` hidden `DialogDescription` still resolves `t("subtitle")` (a11y intact) — `daemonChat.subtitle` key retained in both locales
+
+## 2. Running status into transcript header
+- [ ] 2.1 `transcript-view.tsx`: in the header status line, render the running execution's live elapsed time beside the existing running pulse (reuse `useElapsedMono()`/`nowMs`); no deep-link
+- [ ] 2.2 Reduced-motion respected for the pulse (already `motion-safe`); elapsed updates live
+
+## 3. Composer action row (Interrupt/Resume/Send) + send-while-running
+- [ ] 3.1 `execution-row.tsx`: export `InterruptButton` (with its `AlertDialog`) and `ResumeButton` as reusable controls (no behavior change; standalone `ExecutionRow` and other call sites untouched)
+- [ ] 3.2 `send-instruction-box.tsx`: generalize `ComposeField` right side into an action row — Send always present; accept an optional controllable execution and render Interrupt (running) / Resume (user-interrupted) beside Send; crash → keep "auto-recovers" hint
+- [ ] 3.3 `send-instruction-box.tsx`: stop disabling the textarea on running state (keep hard-disable only for origin offline); preserve Enter-to-send + `isImeComposing` guard
+- [ ] 3.4 `send-instruction-box.tsx`: honor `inline` (desktop) vs `stacked` (mobile) layout for the action row
+
+## 4. Remove standalone footer card
+- [ ] 4.1 `transcript-view.tsx`: drop the `controllableExecutions.map(ExecutionRow)` block from the footer; feed the controllable execution into `ConversationReplyBox` instead so its action row hosts Interrupt/Resume
+
+## 5. i18n + design
+- [ ] 5.1 Add any new user-facing string (e.g. header elapsed-time label) to `messages/en.json` + `messages/zh.json`; confirm no hardcoded text; `daemonChat.subtitle` retained
+- [ ] 5.2 Update `docs/design.pen` daemon chat mock(s): no visible subtitle, top-aligned content, header running status, consolidated input action row (desktop + mobile)
+
+## 6. Integration checkpoint
+- [ ] 6.1 E2E (real browser, desktop + mobile widths): idle → Send only; running → Send + Interrupt (confirm dialog fires) + header elapsed; user-interrupt → Resume; crash → auto-recovers hint, no Resume; offline → composer disabled with reason; send-while-running appends a turn; content top-aligned, no visible subtitle

--- a/openspec/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/specs/daemon-session-transcript-read/spec.md
@@ -269,3 +269,88 @@ SHALL NOT be persisted and SHALL NOT require any schema or message-role change.
   or a live event that also references the same turn
 - **THEN** the slot is de-duplicated by its stable uuid and is not rendered twice
 
+### Requirement: The daemon conversation surface SHALL minimize header chrome and top-align content
+
+The daemon conversation surface ("View all" chat modal) SHALL NOT render a visible header subtitle describing the surface; the surface's visible heading (title) SHALL be retained, but the explanatory subtitle line SHALL be removed so it does not consume vertical space inside the conversation view. The conversation content (the two-pane layout on desktop, the list/drill-down on mobile) SHALL be top-aligned — its top edge SHALL sit close to the modal's top edge, without the excess vertical padding/gap that previously pushed it down. Removing the visible subtitle SHALL NOT remove the modal's accessibility description: the hidden Radix `DialogDescription` used to satisfy the dialog's "described-by" requirement SHALL continue to resolve a localized string, independent of the visible header.
+
+#### Scenario: No visible subtitle in the conversation header
+
+- **WHEN** the daemon conversation surface renders (desktop or mobile)
+- **THEN** the visible heading (title) MUST be present
+- **AND** no visible explanatory subtitle line MUST be shown beneath it
+
+#### Scenario: Content is top-aligned on desktop
+
+- **WHEN** the surface renders on a desktop-width (`lg`+) viewport
+- **THEN** the two-pane conversation content's top edge MUST sit near the modal's top edge, with no large empty band above it
+
+#### Scenario: The dialog accessibility description is preserved
+
+- **WHEN** the conversation modal mounts after the visible subtitle is removed
+- **THEN** the modal MUST still provide an accessibility description (a hidden `DialogDescription`) that resolves a localized string
+- **AND** that description MUST be a separate node from the (now removed) visible subtitle
+
+### Requirement: Running status SHALL be carried in the transcript header rather than a standalone footer card
+
+The conversation's running status — a running indicator plus the elapsed run time of the conversation's running execution — SHALL be presented in the transcript header (alongside the existing running marker), and the standalone running/interrupted execution card SHALL NOT occupy a separate row in the conversation footer. The elapsed time SHALL update live (using the same monotonic elapsed formatter the execution rows use) and SHALL respect reduced-motion for any animated indicator. The running status in the header SHALL NOT include a deep-link to the underlying task/idea; the conversation's header title remains the navigational affordance. Removing the standalone footer card SHALL NOT remove the visibility of which work is running and for how long.
+
+#### Scenario: Elapsed run time appears in the header while running
+
+- **WHEN** the open conversation has a running execution
+- **THEN** the transcript header MUST show a running indicator and the elapsed run time
+- **AND** the elapsed time MUST advance live without a manual refresh
+
+#### Scenario: No standalone running card in the footer
+
+- **WHEN** the open conversation has a running or interrupted execution
+- **THEN** the footer MUST NOT render a standalone execution card on its own row above the input
+- **AND** the running-state information MUST instead be available in the header (running + elapsed)
+
+#### Scenario: The header running status carries no deep link
+
+- **WHEN** the running status renders in the header
+- **THEN** it MUST show only the running indicator and elapsed time (no separate link to the task/idea)
+- **AND** the conversation header title MUST remain the navigational affordance
+
+### Requirement: Interrupt, Resume, and Send SHALL be consolidated into the reply input's action row
+
+The reply composer SHALL present a single action area at the bottom-right of the input box that hosts the conversation's controls together: Send SHALL always be present; when the conversation has a running execution, an Interrupt control SHALL appear alongside Send; when the conversation has a user-interrupted execution, a Resume control SHALL appear; a crash-interrupted execution SHALL show no Resume control (the existing "auto-recovers" hint is retained and remains visible). The Interrupt control SHALL retain its confirmation dialog (a destructive-action confirm) wherever it is rendered. The Interrupt and Resume controls SHALL issue the same control/resume requests they do today (no change to the `/api/daemon/control` interrupt or `/api/daemon/resume` resume behavior). While a turn is running, the input textarea SHALL remain usable so the user can compose and send a follow-up instruction mid-run (reusing the existing instruction endpoint, which appends a `human_instruction` turn regardless of run state); this send-while-running SHALL require no backend change. When the conversation's origin connection is offline, the composer SHALL remain hard-disabled with its visible read-only reason, unchanged. This consolidated layout SHALL apply on both desktop (inline action row) and mobile (stacked action row beneath the textarea).
+
+#### Scenario: Send is always present; Interrupt joins it while running
+
+- **WHEN** the open conversation has a running execution and its origin is online
+- **THEN** the input action row MUST show Send and, beside it, an Interrupt control
+- **AND** the input textarea MUST remain usable (not disabled by the running state)
+
+#### Scenario: Interrupt keeps its confirmation dialog
+
+- **WHEN** the user activates the Interrupt control in the input action row
+- **THEN** a confirmation dialog MUST be shown before any interrupt request is issued
+- **AND** confirming MUST issue the same interrupt request as the prior standalone control
+
+#### Scenario: Resume appears for a user-interrupted conversation; crash shows no Resume
+
+- **WHEN** the open conversation's execution is interrupted with reason `user`
+- **THEN** the input action row MUST show a Resume control
+- **WHEN** instead the execution is interrupted with reason `crash`
+- **THEN** no Resume control MUST be shown, and the existing "auto-recovers" hint MUST remain visible
+
+#### Scenario: Sending a follow-up while a turn is running
+
+- **GIVEN** the open conversation has a running execution and its origin is online
+- **WHEN** the user types an instruction and sends it
+- **THEN** the instruction MUST be submitted via the existing session instruction endpoint (appending a `human_instruction` turn)
+- **AND** no backend change MUST be required for this to work
+
+#### Scenario: Offline origin still hard-disables the composer
+
+- **WHEN** the open conversation's origin connection is offline
+- **THEN** the composer MUST be disabled with its visible localized read-only reason
+- **AND** Send MUST NOT issue a request
+
+#### Scenario: Consolidated controls on mobile use the stacked layout
+
+- **WHEN** the conversation footer renders on a mobile (`< lg`) drill-down
+- **THEN** the standalone execution card MUST NOT be present
+- **AND** Send plus any Interrupt/Resume control MUST render in the stacked action area beneath the textarea
+

--- a/src/components/agent-presence/__tests__/connections-modal.test.tsx
+++ b/src/components/agent-presence/__tests__/connections-modal.test.tsx
@@ -75,6 +75,13 @@ vi.mock("@/lib/logger-client", () => ({
   clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
+// sonner: the reply composer + Interrupt/Resume controls toast on success/error.
+// Stub it so a send-while-running / interrupt test doesn't depend on a mounted
+// <Toaster> (and so we never touch the real notification stack in jsdom).
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
 import { Button } from "@/components/ui/button";
 import {
   AgentPresenceProvider,
@@ -596,6 +603,80 @@ describe("Daemon chat modal — opening + conversation list", () => {
     await waitFor(() =>
       expect(screen.getAllByRole("button", { name: /resume/i }).length).toBeGreaterThan(0),
     );
+  });
+
+  // ===== Consolidated action row (this task) =====
+  // The standalone footer ExecutionRow card is gone — Interrupt/Resume now live in the
+  // reply input's action row. The control coexists WITH the reply composer (the
+  // placeholder + Send), not as a separate card above an otherwise-disabled box.
+
+  it("hosts Interrupt in the reply action row beside Send (no standalone card), with the textarea usable while running", async () => {
+    await openShipLogin({ turnStatus: "running", executionUuid: null, executions: [adHocExec()] });
+    // The reply composer renders (placeholder + Send) AND Interrupt — together, in one
+    // action row. The control is not a separate card above a disabled box.
+    const textarea = (await screen.findAllByPlaceholderText(
+      "Reply in this conversation…",
+    ))[0] as HTMLTextAreaElement;
+    expect(screen.getAllByRole("button", { name: /interrupt/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Send" }).length).toBeGreaterThan(0);
+    // Send-while-running: the textarea is NOT disabled merely because a turn is running
+    // (only origin-offline hard-disables it). The user can type a mid-run follow-up.
+    expect(textarea.disabled).toBe(false);
+  });
+
+  it("sends a follow-up while running via the existing instruction endpoint (no backend change)", async () => {
+    const user = await openShipLogin({
+      turnStatus: "running",
+      executionUuid: null,
+      executions: [adHocExec()],
+    });
+    const textarea = (await screen.findAllByPlaceholderText(
+      "Reply in this conversation…",
+    ))[0] as HTMLTextAreaElement;
+    await user.type(textarea, "also update the README");
+    await user.click(screen.getAllByRole("button", { name: "Send" })[0]);
+    // The follow-up POSTs to the SAME session instruction endpoint, regardless of run state.
+    await waitFor(() => {
+      const call = mockAuthFetch.mock.calls.find(
+        (c) =>
+          typeof c[0] === "string" &&
+          c[0] === "/api/daemon-sessions/s1/instruction" &&
+          (c[1] as RequestInit | undefined)?.method === "POST",
+      );
+      expect(call).toBeTruthy();
+      const body = JSON.parse((call![1] as RequestInit).body as string);
+      expect(body).toEqual({ instructionText: "also update the README" });
+    });
+  });
+
+  it("shows the crash 'auto-recovers' hint (no Resume) for a crash-interrupted conversation", async () => {
+    await openShipLogin({
+      turnStatus: "ended",
+      executions: [adHocExec({ status: "interrupted", interruptedReason: "crash" })],
+    });
+    await waitFor(() =>
+      expect(screen.getAllByText("Auto-recovers").length).toBeGreaterThan(0),
+    );
+    // Crash recovers via reconnect-backfill — no manual Resume affordance.
+    expect(screen.queryByRole("button", { name: /resume/i })).toBeNull();
+  });
+
+  it("opening Interrupt in the action row shows its confirmation dialog before any request", async () => {
+    const user = await openShipLogin({
+      turnStatus: "running",
+      executionUuid: null,
+      executions: [adHocExec()],
+    });
+    await user.click((await screen.findAllByRole("button", { name: /interrupt/i }))[0]);
+    // The destructive confirm AlertDialog appears; no control POST has fired yet.
+    await waitFor(() =>
+      expect(screen.getByText("Interrupt this execution?")).toBeTruthy(),
+    );
+    expect(
+      mockAuthFetch.mock.calls.some(
+        (c) => typeof c[0] === "string" && c[0] === "/api/daemon/control",
+      ),
+    ).toBe(false);
   });
 
   it("does NOT show another conversation's execution in this conversation's footer (per-session scope)", async () => {

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -615,7 +615,11 @@ export function DaemonChat() {
     listStatus === "ok" && sessions.length === 0;
   const noAgentsAtAll = noConversations && agents.length === 0;
 
-  const transcriptPane = (
+  // The transcript pane is reused on both breakpoints, differing ONLY in the reply
+  // composer's action-row geometry: desktop two-pane keeps it inline (actions on the
+  // footer line), mobile drill-down stacks it beneath the textarea (`footerLayout`).
+  // Everything else is identical, so it's a thin factory over the shared prop set.
+  const renderTranscript = (footerLayout: "inline" | "stacked") => (
     <TranscriptView
       session={detail?.session ?? null}
       turns={turns}
@@ -626,11 +630,13 @@ export function DaemonChat() {
       originOnline={originOnline}
       sessionExecutions={sessionExecutions}
       executionsByUuid={executionsByUuid}
+      footerLayout={footerLayout}
       hasMoreEarlier={hasMoreEarlier}
       loadingEarlier={loadingEarlier}
       onLoadEarlier={loadEarlier}
     />
   );
+  const transcriptPane = renderTranscript("inline");
 
   // The default right pane (nothing selected) — a new-conversation composer, not a
   // passive prompt. Also the mobile drill-down body for "New conversation".
@@ -645,7 +651,11 @@ export function DaemonChat() {
 
   // Mobile drill-down shows EITHER the selected transcript OR (when nothing is
   // selected but the drill-down was opened via "New conversation") the composer.
-  const mobileDrillContent = selectedSession ? transcriptPane : newConversationPane;
+  // The mobile transcript stacks its reply action row beneath the textarea (the
+  // narrow drill-down has no room for an inline footer line), per Q4=mobile-syncs.
+  const mobileDrillContent = selectedSession
+    ? renderTranscript("stacked")
+    : newConversationPane;
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#FAF8F4]">
@@ -675,16 +685,17 @@ export function DaemonChat() {
       <div
         className={`${
           mobileDetailOpen ? "hidden lg:flex" : "flex"
-        } h-full min-h-0 flex-col gap-6 overflow-y-auto px-4 py-5 lg:overflow-hidden md:px-8 md:py-6 lg:gap-6 lg:px-8 lg:py-7`}
+        } h-full min-h-0 flex-col gap-3 overflow-y-auto px-4 py-3 lg:overflow-hidden md:px-8 md:py-4 lg:gap-3 lg:px-8 lg:py-4`}
       >
-        {/* Header */}
-        <header className="flex flex-col gap-1.5">
+        {/* Header — title only. The descriptive subtitle is intentionally dropped
+            from the VISIBLE chrome to reclaim vertical space so the two-pane content
+            top-aligns near the modal top; the `daemonChat.subtitle` key is retained
+            and still feeds the hidden DialogDescription in connections-modal.tsx for
+            the Radix dialog's accessibility description. */}
+        <header className="flex flex-col">
           <h2 className="text-[22px] font-semibold text-[#2C2C2C] lg:text-[24px]">
             {t("title")}
           </h2>
-          <p className="max-w-[640px] text-[13px] leading-relaxed text-[#6B6B6B]">
-            {t("subtitle")}
-          </p>
         </header>
 
         {/* Body */}

--- a/src/components/agent-presence/chat/transcript-view.tsx
+++ b/src/components/agent-presence/chat/transcript-view.tsx
@@ -10,12 +10,13 @@
 //     is a secondary disclosure, per the design brief.
 //   - Body: the turn bands in a ScrollArea, auto-scrolled to the newest turn. The
 //     turn band is the signature element (see turn-band.tsx).
-//   - Footer: the reused SendInstructionBox (direct-send to the open session +
-//     ad-hoc), and — for a running turn whose live execution resolves — the reused
-//     ExecutionRow, which carries the shipped Interrupt control. Both are gated on
-//     origin-online exactly as the connections deck gates them (the send box does
-//     it internally via `originOnline`; the interrupt row only renders when the
-//     execution is in the live snapshot, which requires the origin daemon online).
+//   - Footer: input + actions ONLY — the reused ConversationReplyBox, whose
+//     bottom-right action row now HOSTS this conversation's Interrupt / Resume
+//     control (no standalone ExecutionRow card stacked above it any more). The
+//     running marker + elapsed time live in the HEADER (prior task). Send is gated
+//     on origin-online internally (`originOnline`); Interrupt/Resume reuse the
+//     shipped controls and only resolve when the execution is in the live snapshot
+//     (which requires the origin daemon online).
 //   - States: a distinct error card on read failure (never a silent empty), a
 //     loading state during the first fetch, and a read-only note when the origin is
 //     offline.
@@ -36,9 +37,9 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { IdentityBlock } from "../identity-block";
-import { ExecutionRow } from "../execution-row";
 import { ConversationReplyBox } from "../send-instruction-box";
 import {
+  useElapsedMono,
   useNowTick,
   useRelativeTime,
   useUptimeMono,
@@ -87,13 +88,19 @@ export function TranscriptView({
   originOnline,
   // THIS conversation's CURRENT live executions (running / interrupted), already
   // filtered to the open session by the container (idea:<directIdeaUuid> or
-  // daemon_session:<sessionId>). Rendered with the reused ExecutionRow so its shipped
-  // Interrupt + Resume controls appear inline — and ONLY for this conversation's work,
-  // so unrelated task cards never crowd the reply box. Does not depend on a per-turn
-  // `executionUuid` back-link (which the daemon does not always populate).
+  // daemon_session:<sessionId>). The single relevant one is threaded into the reply
+  // composer's action row so its shipped Interrupt / Resume control appears beside
+  // Send — and ONLY for this conversation's work, so unrelated task cards never crowd
+  // the reply box. Does not depend on a per-turn `executionUuid` back-link (which the
+  // daemon does not always populate).
   sessionExecutions,
   // Matched by `turn.executionUuid` so an entity-bearing turn can show its deep link.
   executionsByUuid,
+  // The reply composer's action-row geometry: "inline" (desktop two-pane — actions on
+  // the footer line) vs "stacked" (mobile drill-down — actions beneath the textarea).
+  // A single TranscriptView instance is reused across breakpoints, so the container
+  // passes the right value per surface rather than this pane sniffing the viewport.
+  footerLayout = "inline",
   // Older-page pagination: `hasMoreEarlier` shows a "load earlier" affordance at the
   // TOP of the transcript; `onLoadEarlier` fetches+prepends the previous page; while
   // `loadingEarlier` the control shows a spinner. The newest page loads first, so a
@@ -111,6 +118,7 @@ export function TranscriptView({
   originOnline: boolean;
   sessionExecutions: ExecutionView[];
   executionsByUuid: Map<string, ExecutionView>;
+  footerLayout?: "inline" | "stacked";
   hasMoreEarlier: boolean;
   loadingEarlier: boolean;
   onLoadEarlier: () => void;
@@ -119,6 +127,7 @@ export function TranscriptView({
   const nowMs = useNowTick();
   const formatRelative = useRelativeTime();
   const formatUptime = useUptimeMono();
+  const formatElapsed = useElapsedMono();
 
   const agentName =
     originConnection?.agentName?.trim() || t("roleAgent");
@@ -130,24 +139,36 @@ export function TranscriptView({
     return running ?? turns[turns.length - 1] ?? null;
   }, [turns]);
 
-  // The conversation's controllable executions — its origin connection's CURRENT
-  // running / user-interrupted work. ExecutionRow renders the shipped Interrupt
-  // (running) and Resume (user-interrupted) controls; we surface these directly off
-  // the connection's live slice rather than the per-turn `executionUuid` link, which
-  // the daemon does not reliably populate (so the control would otherwise never
-  // appear even while the conversation is plainly running). Ordered running-first.
-  const controllableExecutions = useMemo(
+  // The conversation's single composer-hosted execution — its origin connection's
+  // CURRENT in-flight work that the reply box's action row reflects. Priority:
+  // running (→ Interrupt) > user-interrupted (→ Resume) > crash-interrupted (→ the
+  // "auto-recovers" hint, no Resume). We surface this directly off the connection's
+  // live slice rather than the per-turn `executionUuid` link, which the daemon does
+  // not reliably populate (so the control would otherwise never appear even while the
+  // conversation is plainly running). Null when the conversation is idle (just Send).
+  const composerExecution = useMemo(() => {
+    const running = sessionExecutions.find((e) => e.status === "running");
+    if (running) return running;
+    const userInterrupted = sessionExecutions.find(
+      (e) => e.status === "interrupted" && e.interruptedReason === "user",
+    );
+    if (userInterrupted) return userInterrupted;
+    const crashInterrupted = sessionExecutions.find(
+      (e) => e.status === "interrupted" && e.interruptedReason === "crash",
+    );
+    return crashInterrupted ?? null;
+  }, [sessionExecutions]);
+
+  // The conversation's CURRENTLY-running execution. Its `startedAt` feeds the live
+  // elapsed timer beside the header pulse — same `useElapsedMono()` / `nowMs`
+  // formatter the execution rows use, so the header time and the composer's
+  // Interrupt control reflect the same run.
+  const runningExecution = useMemo(
     () =>
-      sessionExecutions
-        .filter(
-          (e) =>
-            e.status === "running" ||
-            (e.status === "interrupted" && e.interruptedReason === "user"),
-        )
-        .sort((a, b) =>
-          a.status === b.status ? 0 : a.status === "running" ? -1 : 1,
-        ),
-    [sessionExecutions],
+      composerExecution && composerExecution.status === "running"
+        ? composerExecution
+        : null,
+    [composerExecution],
   );
 
   // Auto-scroll the transcript to the newest turn when the turn list grows or
@@ -165,50 +186,65 @@ export function TranscriptView({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Header */}
-      <div className="flex flex-col gap-3 px-6 py-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            <h3 className="truncate text-[17px] font-semibold text-[#2C2C2C]">
-              {title}
-            </h3>
-            <div className="mt-1 flex flex-wrap items-center gap-2">
-              <Badge
-                variant="secondary"
-                className={`border-0 px-2 py-0.5 text-[10px] font-medium ${
-                  sessionEnded
-                    ? "bg-[#F0EDE8] text-[#6B6B6B]"
-                    : "bg-[#DCFCE7] text-[#15803D]"
-                }`}
-              >
-                {sessionEnded ? t("statusEnded") : t("statusActive")}
-              </Badge>
-              {currentTurn && currentTurn.status === "running" && (
-                <span className="inline-flex items-center gap-1 text-[11px] font-medium text-[#C67A52]">
-                  <span className="relative inline-flex h-2 w-2 items-center justify-center">
-                    <span className="absolute inline-flex h-full w-full rounded-full bg-[#C67A52] opacity-40 motion-safe:animate-ping" />
-                    <span className="relative inline-flex h-1 w-1 rounded-full bg-[#C67A52]" />
-                  </span>
-                  {t("running")}
+      {/* Header — the <h3> title on its own line, then a SINGLE flex-wrap line that
+          carries the status badges (active/ended + running pulse + elapsed) AND the
+          'Connection details' disclosure trigger together (wrapping only if truly
+          unavoidable), saving a vertical row. The collapsible CONTENT still expands
+          below the whole line on click. The Collapsible wraps both the inline trigger
+          and the content so Radix open/close state binds correctly. */}
+      <div className="flex flex-col gap-2 px-6 py-2.5 lg:gap-3 lg:py-4">
+        <h3 className="truncate text-[17px] font-semibold text-[#2C2C2C]">
+          {title}
+        </h3>
+        <Collapsible>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant="secondary"
+              className={`border-0 px-2 py-0.5 text-[10px] font-medium ${
+                sessionEnded
+                  ? "bg-[#F0EDE8] text-[#6B6B6B]"
+                  : "bg-[#DCFCE7] text-[#15803D]"
+              }`}
+            >
+              {sessionEnded ? t("statusEnded") : t("statusActive")}
+            </Badge>
+            {currentTurn && currentTurn.status === "running" && (
+              <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-[#C67A52]">
+                <span className="relative inline-flex h-2 w-2 items-center justify-center">
+                  <span className="absolute inline-flex h-full w-full rounded-full bg-[#C67A52] opacity-40 motion-safe:animate-ping" />
+                  <span className="relative inline-flex h-1 w-1 rounded-full bg-[#C67A52]" />
                 </span>
-              )}
-            </div>
+                {t("running")}
+                {/* Live elapsed run time of the conversation's running execution —
+                    ticks every second off `useNowTick()` (no deep-link; the <h3>
+                    header title stays the only navigational affordance). */}
+                {runningExecution?.startedAt && (
+                  <span
+                    className="font-mono tabular-nums text-[#C67A52]"
+                    title={t("runningElapsedLabel")}
+                  >
+                    {formatElapsed(runningExecution.startedAt, nowMs)}
+                  </span>
+                )}
+              </span>
+            )}
+            {/* Connection details — DEMOTED to a collapsible disclosure that shares the
+                status line. Its trigger sits inline with the badges; the content (host /
+                version / uptime / started via the reused IdentityBlock + formatters)
+                expands below the line. A subtle leading separator divides it from the
+                status when both render on the same line. */}
+            {originConnection && (
+              <CollapsibleTrigger className="group ml-auto inline-flex items-center gap-1.5 text-[12px] font-medium text-[#6B6B6B] hover:text-[#2C2C2C]">
+                <Info className="h-3.5 w-3.5" aria-hidden />
+                {t("detailsLabel")}
+                <ChevronDown
+                  className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180"
+                  aria-hidden
+                />
+              </CollapsibleTrigger>
+            )}
           </div>
-        </div>
-
-        {/* Connection details — DEMOTED to a collapsible disclosure, not the
-            headline. Holds host / version / uptime / started via the reused
-            IdentityBlock + formatters. */}
-        {originConnection && (
-          <Collapsible>
-            <CollapsibleTrigger className="group inline-flex items-center gap-1.5 text-[12px] font-medium text-[#6B6B6B] hover:text-[#2C2C2C]">
-              <Info className="h-3.5 w-3.5" aria-hidden />
-              {t("detailsLabel")}
-              <ChevronDown
-                className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180"
-                aria-hidden
-              />
-            </CollapsibleTrigger>
+          {originConnection && (
             <CollapsibleContent>
               <div className="mt-3 flex flex-col gap-3 rounded-xl border border-[#EFEBE4] bg-[#FCFBF8] p-4">
                 <IdentityBlock connection={originConnection} size="sm" />
@@ -238,8 +274,8 @@ export function TranscriptView({
                 </div>
               </div>
             </CollapsibleContent>
-          </Collapsible>
-        )}
+          )}
+        </Collapsible>
       </div>
       <div className="h-px w-full bg-[#EFEBE4]" />
 
@@ -285,7 +321,7 @@ export function TranscriptView({
               `daemon-transcript-scroll` rule in globals.css); without that override
               this alone is insufficient, since the viewport child is `display:table`
               and sizes to content regardless of `min-w-0`. */}
-          <div className="flex w-full min-w-0 flex-col gap-5 px-6 py-5">
+          <div className="flex w-full min-w-0 flex-col gap-3 px-6 py-3 lg:gap-5 lg:py-5">
             {/* Privacy note — once per pane: the transcript is daemon-self-reported. */}
             <p className="flex items-start gap-1.5 text-[11px] leading-relaxed text-[#9A9A9A]">
               <Lock className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
@@ -329,29 +365,20 @@ export function TranscriptView({
         </ScrollArea>
       )}
 
-      {/* Footer — the live Interrupt/Resume control(s) for this conversation's
-          in-flight work + a PLAIN reply composer (new-conversation/agent/connection
-          targeting all live in the left list, so the footer is just "reply here").
-          The reply box self-gates on origin-online and shows the read-only reason
-          when the daemon is offline. */}
+      {/* Footer — input + actions ONLY. The reply composer's bottom-right action row
+          hosts this conversation's Interrupt / Resume control (running / interrupted);
+          there is no standalone ExecutionRow card stacked above it any more (the
+          running marker + elapsed time live in the header). New-conversation / agent /
+          connection targeting all live in the left list, so the footer is just "reply
+          here". The reply box self-gates on origin-online and shows the read-only
+          reason when the daemon is offline; while running the textarea stays usable. */}
       {!error && session && (
-        <div className="flex flex-col gap-3 border-t border-[#EFEBE4] bg-[#FAF8F4] px-6 py-4">
-          {controllableExecutions.length > 0 && (
-            <ul className="flex flex-col gap-2">
-              {controllableExecutions.map((exec) => (
-                <ExecutionRow
-                  key={exec.uuid}
-                  exec={exec}
-                  nowMs={nowMs}
-                  layout="inline"
-                />
-              ))}
-            </ul>
-          )}
+        <div className="flex flex-col gap-3 border-t border-[#EFEBE4] bg-[#FAF8F4] px-6 py-2.5 lg:py-4">
           <ConversationReplyBox
             sessionUuid={session.uuid}
             originOnline={originOnline}
-            layout="inline"
+            layout={footerLayout}
+            controllableExecution={composerExecution}
           />
         </div>
       )}

--- a/src/components/agent-presence/execution-row.tsx
+++ b/src/components/agent-presence/execution-row.tsx
@@ -59,7 +59,14 @@ import { execHref, useElapsedMono, useEntityTypeLabel } from "./hooks";
 // returns without waiting for the kill (the daemon reports the resulting
 // `interrupted` task state asynchronously; the row simply drops out of the next
 // execution snapshot). Errors surface via a toast with a localized fallback.
-function InterruptButton({ exec }: { exec: ExecutionView }) {
+//
+// Exported (alongside ResumeButton) so the daemon-chat reply composer can mount
+// the SAME control byte-identically — same AlertDialog confirm, same endpoint,
+// same toasts/entityType/entityUuid wiring (see send-instruction-box.tsx). Its
+// internals are prop-driven and surface-agnostic; the standalone ExecutionRow
+// and its other call sites (sidebar popover, Agent Connections deck) keep using
+// it unchanged.
+export function InterruptButton({ exec }: { exec: ExecutionView }) {
   const t = useTranslations("agentConnections");
   const tc = useTranslations("common");
   const [open, setOpen] = useState(false);
@@ -158,7 +165,11 @@ function InterruptButton({ exec }: { exec: ExecutionView }) {
 // the server records the transition + dispatches a `resume` control command, and the
 // row re-appears as running via the next execution snapshot. No confirm dialog —
 // resume is non-destructive, unlike interrupt.
-function ResumeButton({ exec }: { exec: ExecutionView }) {
+//
+// Exported (alongside InterruptButton) so the daemon-chat reply composer can mount
+// the SAME control byte-identically — same /api/daemon/resume endpoint, same
+// toasts/entityType/entityUuid wiring. Internals unchanged.
+export function ResumeButton({ exec }: { exec: ExecutionView }) {
   const t = useTranslations("agentConnections");
   const [pending, setPending] = useState(false);
 

--- a/src/components/agent-presence/send-instruction-box.tsx
+++ b/src/components/agent-presence/send-instruction-box.tsx
@@ -45,7 +45,8 @@ import { authFetch } from "@/lib/auth-client";
 import { clientLogger } from "@/lib/logger-client";
 import { isImeComposing } from "@/lib/ime";
 import { useClientTypeLabel } from "./hooks";
-import type { ConnectionView } from "./types";
+import { InterruptButton, ResumeButton } from "./execution-row";
+import type { ConnectionView, ExecutionView } from "./types";
 import type { SessionView } from "@/services/daemon-session.service";
 
 // Mirror of the server-side `MAX_INSTRUCTION_CHARS` (daemon-instruction.service.ts)
@@ -72,10 +73,23 @@ export interface SessionTarget {
 }
 
 // =====================================================================
-// Shared compose surface — a Textarea + a labeled footer (char counter +
-// disabled-reason + trailing Send button). Geometry is layout-aware so the
-// narrow mobile drill-down stacks the footer while the wide desktop pane keeps
-// it inline, matching the ExecutionRow inline/stacked convention.
+// Shared compose surface — a Textarea whose ACTION GROUP (an optional state-driven
+// control — Interrupt / Resume / a crash "auto-recovers" hint — beside the
+// always-present Send) is OVERLAID in the input's bottom-right corner rather than
+// sitting on a separate row beneath it. The textarea carries enough bottom padding
+// (`pb-12`) that typed text never runs under the controls. This in-box overlay is
+// the shared treatment for BOTH layouts (the `layout` prop is retained for call-site
+// compatibility but no longer branches geometry — the corner overlay reads cleanly
+// on the wide desktop pane and the narrow mobile drill-down alike).
+//
+// The origin-offline read-only reason (when `disabled`) stays VISIBLE — it renders
+// ABOVE the input as a labeled line, never a tooltip — so the gate is never silent.
+//
+// Send-while-running: a RUNNING controllable execution does NOT disable the
+// textarea — the user can type + send a follow-up instruction mid-run (the
+// existing instruction endpoint appends a `human_instruction` turn regardless of
+// run state). Only the hard `disabled` path (origin offline) makes the textarea
+// inert, with its visible read-only reason.
 // =====================================================================
 
 function ComposeField({
@@ -88,6 +102,7 @@ function ComposeField({
   placeholder,
   sendLabel,
   layout,
+  controllableExecution,
 }: {
   value: string;
   onChange: (next: string) => void;
@@ -101,7 +116,15 @@ function ComposeField({
   placeholder: string;
   sendLabel: string;
   layout: "inline" | "stacked";
+  // THIS conversation's in-flight execution, if any — a `running` one (→ Interrupt
+  // beside Send) or a `user`-interrupted one (→ Resume). A `crash`-interrupted one is
+  // also accepted and renders the static "auto-recovers" hint (no Resume). The
+  // Interrupt/Resume controls are the SAME shipped components the connection deck
+  // renders — same AlertDialog confirm, same endpoints, same wiring. Null/undefined
+  // when the conversation is idle (just Send).
+  controllableExecution?: ExecutionView | null;
 }) {
+  const tc = useTranslations("agentConnections");
   const empty = value.trim().length === 0;
   // The Send control is inert only when hard-disabled, mid-flight, or empty. There is
   // no client-side char cap UI — the server cap stays authoritative and a rejected
@@ -137,41 +160,72 @@ function ComposeField({
     </Button>
   );
 
-  // Only a hard-disabled reason (no online origin) is shown — it must be visible
-  // (not just a tooltip) so the gate is never silent. Otherwise the footer is empty.
-  const footerLeft = disabled ? (
-    <div className="flex min-w-0 flex-1 items-center gap-2">
-      <span className="inline-flex items-center gap-1.5 text-[12px] font-medium text-[#B45309]">
-        <WifiOff className="h-3.5 w-3.5 shrink-0" aria-hidden />
-        <span className="min-w-0">{disabledReason}</span>
-      </span>
+  // The state-driven control that joins Send in the action row, mirroring the
+  // standalone ExecutionRow's trailing controls byte-for-byte:
+  //   running                       → Interrupt (with its AlertDialog confirm)
+  //   interrupted + reason === user → Resume
+  //   interrupted + reason === crash → a static "auto-recovers" hint (no Resume),
+  //                                    since a crash recovers via reconnect-backfill.
+  const exec = controllableExecution ?? null;
+  const execControl = exec
+    ? exec.status === "running"
+      ? <InterruptButton exec={exec} />
+      : exec.status === "interrupted" && exec.interruptedReason === "user"
+        ? <ResumeButton exec={exec} />
+        : exec.status === "interrupted" && exec.interruptedReason === "crash"
+          ? (
+              <span className="text-[11px] font-medium text-[#9A8C7E]">
+                {tc("execCrashAutoRecovers")}
+              </span>
+            )
+          : null
+    : null;
+
+  // Action group: the state-driven control (if any) beside the always-present
+  // Send. OVERLAID in the input's bottom-right corner (see the return) — the same
+  // group regardless of `layout`.
+  const actionGroup = (
+    <div className="absolute bottom-2 right-2 z-10 flex shrink-0 items-center gap-2">
+      {execControl}
+      {sendButton}
     </div>
-  ) : (
-    <div className="min-w-0 flex-1" />
   );
+
+  // Only a hard-disabled reason (no online origin) is shown — it must be visible
+  // (not just a tooltip) so the gate is never silent. It renders ABOVE the input.
+  const offlineReason = disabled ? (
+    <span className="inline-flex items-center gap-1.5 text-[12px] font-medium text-[#B45309]">
+      <WifiOff className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0">{disabledReason}</span>
+    </span>
+  ) : null;
+
+  // `layout` is retained for call-site compatibility but no longer branches the
+  // geometry: the in-box overlay is the single shared treatment. Reference it so a
+  // future divergence is a one-line change and lint stays clean.
+  void layout;
 
   return (
     <div className="flex flex-col gap-2.5">
-      <Textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        onKeyDown={handleKeyDown}
-        disabled={disabled || pending}
-        placeholder={placeholder}
-        rows={3}
-        className="min-h-[76px] resize-none rounded-xl border-[#E5E0D8] bg-white text-[14px] text-[#2C2C2C] placeholder:text-[#9A9A9A] focus-visible:border-[#C67A52] focus-visible:ring-[#C67A52]/30"
-      />
-      {layout === "stacked" ? (
-        <div className="flex flex-col gap-2">
-          {disabled && footerLeft}
-          {sendButton}
-        </div>
-      ) : (
-        <div className="flex items-center justify-between gap-3">
-          {footerLeft}
-          {sendButton}
-        </div>
-      )}
+      {/* Origin-offline read-only reason — VISIBLE above the input, never a tooltip. */}
+      {offlineReason}
+      {/* Relative wrapper so the action group can overlay the input's bottom-right.
+          The textarea's `pb-12` reserves room so typed text never sits under the
+          controls. */}
+      <div className="relative">
+        <Textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          // Hard-disable ONLY for origin-offline (or mid-flight). A running turn does
+          // NOT disable the textarea — send-while-running is intentional.
+          disabled={disabled || pending}
+          placeholder={placeholder}
+          rows={3}
+          className="min-h-[76px] resize-none rounded-xl border-[#E5E0D8] bg-white pb-12 text-[14px] text-[#2C2C2C] placeholder:text-[#9A9A9A] focus-visible:border-[#C67A52] focus-visible:ring-[#C67A52]/30"
+        />
+        {actionGroup}
+      </div>
     </div>
   );
 }
@@ -187,12 +241,20 @@ function ComposeField({
 // Gating: sending is allowed only while the session's origin daemon is online
 // (the server re-checks and 409s otherwise); when offline the box is disabled
 // with the localized read-only reason, never silently inert.
+//
+// Action row (子 — daemon chat refinement): the footer no longer stacks a
+// standalone ExecutionRow card above this box. Instead this conversation's
+// in-flight execution (running / user-interrupted / crash) is threaded into
+// ComposeField, which hosts the matching Interrupt / Resume / auto-recovers hint
+// beside Send. While running the textarea stays usable (send-while-running);
+// only origin-offline hard-disables it.
 // =====================================================================
 
 export function ConversationReplyBox({
   sessionUuid,
   originOnline,
   layout = "inline",
+  controllableExecution,
 }: {
   // The open conversation's uuid — replies POST to its `/instruction` endpoint.
   sessionUuid: string;
@@ -200,6 +262,9 @@ export function ConversationReplyBox({
   // server re-checks on POST).
   originOnline: boolean;
   layout?: "inline" | "stacked";
+  // THIS conversation's controllable execution (running or user/crash-interrupted),
+  // if any — hosted in the composer's action row (Interrupt / Resume / hint).
+  controllableExecution?: ExecutionView | null;
 }) {
   const t = useTranslations("agentConnections");
   const tc = useTranslations("daemonChat");
@@ -245,6 +310,7 @@ export function ConversationReplyBox({
       placeholder={tc("replyPlaceholder")}
       sendLabel={t("send")}
       layout={layout}
+      controllableExecution={controllableExecution}
     />
   );
 }


### PR DESCRIPTION
## Summary
Reclaim vertical space in the daemon "View all" chat modal (idea `ab1b46f1`), across desktop two-pane and mobile drill-down:
- Remove the redundant visible header subtitle (hidden a11y `DialogDescription` retained) and top-align content.
- Carry running status (running marker + live elapsed) in the transcript header; remove the standalone footer execution card.
- Consolidate **Interrupt / Resume / Send** into one action group overlaid in the input box's bottom-right, with **send-while-running** (textarea stays usable during a running turn). Interrupt keeps its confirmation `AlertDialog`; origin-offline still hard-disables the composer with a visible reason.
- Put the header status badges and the "Connection details" disclosure trigger on one line; tighten mobile (`<lg`) header/body/footer vertical padding.

Frontend-only — reuses the existing `/api/daemon/control`, `/api/daemon/resume`, and `/api/daemon-sessions/{uuid}/instruction` endpoints. **No backend, schema, or permission change.** `InterruptButton`/`ResumeButton` are exported from `execution-row` and reused unchanged; other `ExecutionRow` call sites (sidebar popover, Agent Connections deck) are untouched.

## Changed files
| File | Change |
|------|--------|
| `src/components/agent-presence/chat/daemon-chat.tsx` | Remove visible subtitle; top-align; pass footer layout |
| `src/components/agent-presence/chat/transcript-view.tsx` | Running status + elapsed in header; one-line header+details; drop footer card; mobile padding |
| `src/components/agent-presence/send-instruction-box.tsx` | In-box action row (Send + Interrupt/Resume/crash-hint); send-while-running; visible offline reason |
| `src/components/agent-presence/execution-row.tsx` | Export `InterruptButton`/`ResumeButton` (internals unchanged) |
| `src/components/agent-presence/__tests__/connections-modal.test.tsx` | Behavioral tests for the action row, send-while-running, interrupt-confirm, crash hint |
| `messages/en.json`, `messages/zh.json` | `daemonChat.runningElapsedLabel` (both locales) |
| `openspec/specs/daemon-session-transcript-read/spec.md` + archived change | OpenSpec spec delta merged + archived change folder |

## Test plan
- [x] `npx tsc --noEmit` — exit 0
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run src/components/agent-presence/` — 71/71 pass
- [x] Independent code review (fresh-context agent, re-ran gates) — PASS
- [x] Deployed to the live environment and verified `/login` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)