### PR TITLE
feat(agent-presence): daemon-connect CTA on empty states (run npx chorus daemon)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1383,8 +1383,7 @@
     "execEmptyTitle": "Nothing running",
     "execEmptyBody": "This connection has no running or queued work right now. Dispatched work will appear here as the daemon picks it up.",
     "empty": {
-      "title": "No agent connections yet",
-      "body": "Start a daemon to connect an agent to Chorus. Run `chorus daemon` from your terminal, or enable the OpenClaw plugin, then this page will show it here."
+      "title": "No agent connections yet"
     },
     "loadErrorTitle": "Couldn't load connections",
     "loadErrorBody": "We couldn't reach the connection service. This is a loading problem, not an empty list — your agents may still be online. Retrying automatically.",
@@ -1503,9 +1502,17 @@
     "unavailable": "Agents unavailable",
     "pillAria": "Online agents — open details",
     "popoverTitle": "Online agents",
-    "popoverEmpty": "No agents are online right now.",
     "connectionIdle": "Idle — no running or queued work.",
     "viewAll": "View all"
+  },
+  "daemonConnectCta": {
+    "headline": "Next step: keep your agent online",
+    "body": "Run a long-lived daemon so your agent stays online and picks up dispatched work.",
+    "bodyLong": "Installing a plugin sets up a one-shot connection — it doesn't keep an agent online. Run a long-lived daemon in your terminal so your agent stays connected and automatically receives dispatched work.",
+    "loginNote": "First time? Sign in once with {command}.",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "learnMore": "Learn more about connecting an agent"
   },
   "mention": {
     "online": "Online",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1384,8 +1384,7 @@
     "execEmptyTitle": "暂无运行中的任务",
     "execEmptyBody": "该连接当前没有正在处理或排队的工作。派发的工作会在 daemon 接手时显示在这里。",
     "empty": {
-      "title": "暂无智能体连接",
-      "body": "启动一个守护进程以将智能体连接到 Chorus。在终端运行 `chorus daemon`，或启用 OpenClaw 插件，连接成功后即可在此页面看到。"
+      "title": "暂无智能体连接"
     },
     "loadErrorTitle": "无法加载连接",
     "loadErrorBody": "无法连接到连接服务。这是加载失败，并非列表为空——你的智能体可能仍在线。正在自动重试。",
@@ -1504,9 +1503,17 @@
     "unavailable": "智能体不可用",
     "pillAria": "在线智能体 — 打开详情",
     "popoverTitle": "在线智能体",
-    "popoverEmpty": "当前没有在线的智能体。",
     "connectionIdle": "空闲 — 没有正在运行或排队的工作。",
     "viewAll": "查看全部"
+  },
+  "daemonConnectCta": {
+    "headline": "下一步：让你的智能体保持在线",
+    "body": "运行一个常驻守护进程，让你的智能体保持在线并自动接收派发的工作。",
+    "bodyLong": "安装插件只是建立一次性连接，并不能让智能体常驻在线。在终端运行一个常驻守护进程，智能体才会保持连接并自动接收派发的工作。",
+    "loginNote": "首次使用？先用 {command} 登录一次。",
+    "copy": "复制",
+    "copied": "已复制！",
+    "learnMore": "了解如何连接智能体"
   },
   "mention": {
     "online": "在线",

--- a/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/README.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/README.md
@@ -1,0 +1,3 @@
+# add-daemon-connect-onboarding-cta
+
+Empty-state CTAs guiding users to run the chorus daemon (npx form) so their agents stay online

--- a/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/design.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/design.md
@@ -1,0 +1,78 @@
+# Technical Design: Daemon-connect empty-state CTA
+
+## Overview
+
+A purely-presentational shared component, `DaemonConnectCta`, is added to the agent-presence vocabulary and rendered in three empty-state surfaces. There is no data fetching, no backend, no schema work. The only "logic" is: render the CTA when there are 0 online connections (the two presence surfaces already know this from `useAgentPresence()`), and on the onboarding completion screen render it unconditionally as the next step.
+
+## Architecture
+
+### Single source of truth for the command
+
+The command shown to users is the `npx` zero-install form. It is defined **once** as an exported constant, not inlined at each call site:
+
+```ts
+// src/components/agent-presence/daemon-connect-cta.tsx (or a small co-located consts module)
+export const DAEMON_NPX_PACKAGE = "@chorus-aidlc/chorus";
+export const DAEMON_START_COMMAND = `npx ${DAEMON_NPX_PACKAGE} daemon`;
+export const DAEMON_LOGIN_COMMAND = `npx ${DAEMON_NPX_PACKAGE} login`;
+```
+
+Rationale (idea owner's instruction): the CLI will be published to npm; the target user has installed nothing, so `npx` is the most copy-paste-runnable. Verified against the current CLI: `chorus.mjs` declares bin `chorus` for package `@chorus-aidlc/chorus`, with subcommands exactly `daemon` and `login`; `daemon` resolves credentials by flag > env > `~/.chorus/daemon.json` (written by `login`) > plugin fallback. So a first-time user runs `login` then `daemon`.
+
+i18n messages carry **only** the surrounding prose (headline, body, button labels, link text) — never the command literal. A future package/bin rename changes one constant and all three surfaces follow.
+
+### `DaemonConnectCta` component contract
+
+```ts
+type DaemonConnectCtaVariant = "compact" | "prominent";
+
+function DaemonConnectCta({ variant }: { variant: DaemonConnectCtaVariant }): JSX.Element
+```
+
+- `compact` — used in the sidebar pill popover (narrow, ~360px). Tighter spacing, single primary command (`DAEMON_START_COMMAND`) with a copy button; the `login`-first note and "Learn more" link are condensed.
+- `prominent` — used in the onboarding completion screen (and acceptable in the wider Agent Connections modal). A framed "Next step" card with headline, body emphasizing "plugin installed ≠ resident online," the command + copy, the first-run `login` note, and the "Learn more" link.
+
+The component:
+- renders the command inside a monospace, copyable surface. **Reuse** the existing copy affordance pattern. The onboarding flow already has `src/components/install-guide/CodeBlock.tsx` (renders fenced code via `MarkdownContent`) — but it has no explicit copy button. For an explicit one-click copy with a "Copied" confirmation, add a small copy button using the browser Clipboard API (`navigator.clipboard.writeText`) with a transient copied state, consistent with how the codebase already triggers clipboard writes. Use shadcn `Button` + a lucide `Copy` / `Check` icon swap.
+- exposes the "Learn more" link to the onboarding install guide. On the completion screen this routes within the onboarding flow; on the pill/modal (dashboard shell) it links to the onboarding install guide route. Use the existing onboarding route already used by the wizard rather than inventing a new path; if no standalone install-guide route exists, link to `/onboarding` (or the settings agent-key area that embeds `AgentInstallGuide`).
+- is `"use client"` (uses `useTranslations` + clipboard + local copied state) and fetches nothing.
+
+### Surface wiring
+
+1. **Pill popover** (`agent-presence-pill.tsx`, `PopoverBody`): the `onlineConnections.length === 0` branch currently returns `<p>{t("popoverEmpty")}</p>`. Replace with `<DaemonConnectCta variant="compact" />`. The popover already only renders online connections, so this branch *is* the 0-online state; nothing else gates it. The pill trigger itself stays unchanged (it must remain visible at 0 online per the existing no-silent-error rule).
+
+2. **Onboarding completion** (`CompletionStep.tsx`): insert a `DaemonConnectCta variant="prominent"` block between the summary card and the action buttons. The existing "Go to projects / settings" buttons remain. This is the only surface where the CTA shows regardless of connection state (the user just finished onboarding and by definition has nothing connected yet).
+
+3. **Agent Connections modal empty state** (`connections-view.tsx`): the `connections.length === 0` branch currently renders a `Card` with `RadioTower` icon + `empty.title` + `empty.body`. Keep the card framing/icon/title; replace the hand-written `empty.body` command sentence with `<DaemonConnectCta variant="prominent" />` (or fold the body into the shared CTA). The distinct **error** state (`showError`) is untouched — no-silent-error contract preserved.
+
+### Why a shared component, not three copies
+
+The Agent Connections empty state already ships a near-identical sentence. Three independent copies drift (one says "Run `chorus daemon`", another might say "run the daemon", a third the npx form). One component + one command constant guarantees the three surfaces stay byte-identical in command and consistent in prose, and a command change is a one-line edit.
+
+## Data Model
+
+None. No Prisma/schema/migration changes.
+
+## API Design
+
+None. No new endpoints; no calls to existing ones. The CTA is static.
+
+## Module Contracts
+
+- **Command constants** (`DAEMON_START_COMMAND`, `DAEMON_LOGIN_COMMAND`, `DAEMON_NPX_PACKAGE`) are the single source of truth, exported from the CTA module and re-exported from the `src/components/agent-presence/index.ts` barrel if any other surface needs them.
+- **`DaemonConnectCta`** is exported from the `agent-presence` barrel (`index.ts`) alongside the other shared vocabulary (`StatusDot`, `IdentityBlock`, etc.), so all three call sites import from `@/components/agent-presence`. It takes only `{ variant }` and never reads `useAgentPresence()` itself — the *caller* decides whether to render it.
+- **i18n keys**: the CTA reads from a single namespace (extend `agentConnections` for the CTA prose, since it already owns the empty-state copy, OR a small new `daemonConnectCta` group — pick one and use it for all three surfaces). The completion-screen-specific framing ("plugin installed ≠ online") may be a separate key under `onboarding.completion` passed in as the `prominent` body, OR carried by the shared namespace; keep the command-bearing prose in the shared namespace either way. Every new key is added to **both** `en.json` and `zh.json`.
+- **Copy interaction + IME**: the copy button is a click affordance, not an Enter-submit handler, so the CLAUDE.md IME-composition guard does not apply. If any Enter-to-copy keyboard handler is added, route it through `isImeComposing` from `@/lib/ime`.
+
+## Implementation Plan
+
+1. Add `DaemonConnectCta` + the command constants; export from the barrel. Add i18n keys (en + zh). Reuse/extend the copy affordance.
+2. Wire the three surfaces (pill popover empty branch, completion screen block, connections-view empty branch); remove the now-redundant `popoverEmpty` usage and reconcile `agentConnections.empty.body`.
+3. Update `docs/design.pen` for the three mocks; verify in a real browser (e2e) that the pill popover at 0-online and the onboarding completion screen show the CTA with a working copy button, and the Agent Connections empty state matches.
+
+## Risks & Mitigations
+
+- **`npx` form correctness** — the package name / bin / subcommands were verified against `chorus.mjs` at design time, but the developer must re-verify against the CLI source at implementation time (don't trust LLM memory for the exact package string), since the npm publish name could change before release. Mitigation: the AC requires verifying the command against `chorus.mjs` / `package.json`.
+- **"Learn more" link target** — there may not be a standalone install-guide route outside the onboarding wizard. Mitigation: link to the existing onboarding route (`/onboarding`) or the settings surface that embeds `AgentInstallGuide`; the developer picks the real existing route rather than inventing one, and the AC calls this out.
+- **i18n namespace choice** — extending `agentConnections` vs. a new `daemonConnectCta` group is a judgment call; either is fine as long as **one** namespace is used across all three surfaces and both locales are updated. Mitigation: AC requires a single namespace + both locales.
+- **Clipboard API availability** — `navigator.clipboard` requires a secure context; in dev over plain HTTP on non-localhost it can be undefined. Mitigation: guard the write (no-throw) and still show the command text so copy failure degrades gracefully (no silent crash).

--- a/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/proposal.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/proposal.md
@@ -1,0 +1,50 @@
+# Proposal: Empty-state CTAs guiding users to run the `chorus daemon`
+
+## Why
+
+The parent idea (`f2fe9a7f` — Daemon connection observability) shipped the full "watch your connections" surface: the bottom-left agent-presence pill, its popover, the Agent Connections "View all" modal, and chat-style daemon sessions. But all of that is only populated **once a daemon is already connected**. For a user who has never run `chorus daemon`, the platform barely hints that they need to start a long-lived local daemon for an agent to actually be online and do work. That is a **discoverability gap**.
+
+Concretely, at the two moments a user is most likely to notice "I'm not connected," the UI is a dead end:
+
+1. **Bottom-left agent-presence pill, 0-online empty state** (`src/components/agent-presence-pill.tsx`). When no agent is online, opening the popover renders only `agentPresence.popoverEmpty` = "No agents are online right now." — a bare statement with **no guidance on how to bring an agent online**.
+
+2. **Onboarding completion screen** (`src/app/onboarding/components/CompletionStep.tsx`, the 6-step wizard's final step). It shows a success icon, an agent summary card, and two navigation buttons ("Go to projects" / "Go to settings"). The wizard's middle steps cover installing a plugin (`InstallGuideStep`) and testing a one-shot connection (`TestConnectionStep`), but the completion screen never explains that **installing a plugin ≠ a resident online agent — you must run `chorus daemon` to keep a long-lived connection so the agent auto-receives dispatched work**.
+
+A third surface, the **Agent Connections modal empty state** (`src/components/agent-presence/connections-view.tsx`), *already* carries guidance text (`agentConnections.empty.body`: "Start a daemon to connect an agent to Chorus. Run `chorus daemon`…"). So that surface is partially covered — the risk is text drift across three places that say almost-the-same thing differently.
+
+This change turns the two dead-end empty states into **calls to action**, and unifies the existing third one, by extracting one shared "connect-a-daemon" CTA fragment used in all three places.
+
+## What Changes
+
+- **New shared CTA component `DaemonConnectCta`.** A single presentational fragment (lives under `src/components/agent-presence/`) that renders: a short headline + body explaining that a long-lived `chorus daemon` keeps the agent online, the **exact command shown in `npx` form** with a one-click **copy** button, and a "Learn more" link to the onboarding install guide. It is prop-driven (a `variant`/size prop for compact vs. prominent) and fetches nothing.
+
+- **Command shown in `npx` form, sourced from one constant.** Per the idea owner: the CLI publishes to npm (package `@chorus-aidlc/chorus`, bin `chorus`), and the target user has installed nothing, so the most copy-paste-runnable command is the zero-install `npx` form. The keep-alive command is `npx @chorus-aidlc/chorus daemon`; first run is preceded by `npx @chorus-aidlc/chorus login` (writes `~/.chorus/daemon.json`; the daemon resolves credentials by flag > env > login-file > plugin fallback). The command string is a **single exported constant**, never hardcoded per call site, so a future package/bin change updates all three surfaces at once. i18n messages carry only the surrounding prose, not the command literal.
+
+- **Pill 0-online popover empty state → CTA.** In `agent-presence-pill.tsx`, the `popoverEmpty` line is replaced by the `DaemonConnectCta` (compact variant). It shows **only while 0 connections are online** and is **not dismissible** — once a daemon connects, the popover naturally renders the live connection list instead, so the CTA disappears on its own. No `localStorage`, no dismiss state (deferred as unnecessary complexity).
+
+- **Onboarding completion screen → prominent "Next step" block.** In `CompletionStep.tsx`, a prominent "Next step" block is added (above or alongside the existing action buttons) using the `DaemonConnectCta` (prominent variant), emphasizing "installing the plugin ≠ staying online — run `chorus daemon` so your agent auto-receives dispatched work."
+
+- **Agent Connections modal empty state → same shared CTA.** The hand-written `agentConnections.empty.body` block in `connections-view.tsx` is replaced by the shared `DaemonConnectCta`, so all three surfaces stay consistent and cannot drift. The existing `empty` i18n keys are reconciled into the shared CTA's keys.
+
+- **i18n.** New keys for the CTA prose (headline, body, completion-screen "next step" framing, copy button label + copied state, "Learn more" link) added to **both** `messages/en.json` and `messages/zh.json`. The redundant `agentConnections.empty.body` command sentence is folded into the shared keys.
+
+- **design.pen.** Update the pill popover empty-state, the onboarding completion screen, and the Agent Connections empty-state mocks to show the CTA.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-connect-cta`: The shared empty-state call-to-action that guides a user with no online daemon connection to run `chorus daemon` (npx form) — the single command constant, the three surfaces it appears on (pill popover empty state, onboarding completion screen, Agent Connections modal empty state), the copy + "Learn more" affordances, the non-dismissible "show only while 0 online" behavior, and the i18n + design.pen scope.
+
+## Impact
+
+- **Frontend only.** No daemon protocol change, no observability/session/transcript backend change (those belong to the parent and sibling ideas). No "detect whether the CLI is installed / daemon is running" probing — the CTA renders purely from the already-known "no online connection" state.
+- **Affected files:** new `src/components/agent-presence/daemon-connect-cta.tsx` (+ barrel export); edits to `agent-presence-pill.tsx`, `connections-view.tsx`, `CompletionStep.tsx`; `messages/en.json` + `messages/zh.json`; `docs/design.pen`.
+- **No DB / schema / migration impact. No new dependencies** (reuse existing shadcn/ui + lucide; copy-to-clipboard via the browser Clipboard API as elsewhere).
+
+## Out of Scope
+
+- Changing the daemon protocol, connection/session/transcript backend, or the SSE/presence provider data flow.
+- Detecting local CLI/daemon presence; the CTA is static guidance gated only on "0 online connections."
+- A dismissible / `localStorage`-remembered variant of the pill CTA.
+- Touching the generic install-guide wizard steps (`InstallGuideStep`, `TestConnectionStep`) beyond linking to them.

--- a/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/specs/daemon-connect-cta/spec.md
+++ b/openspec/changes/archive/2026-06-21-add-daemon-connect-onboarding-cta/specs/daemon-connect-cta/spec.md
@@ -1,0 +1,78 @@
+# Daemon-connect CTA — delta spec
+
+## ADDED Requirements
+
+### Requirement: Shared daemon-connect call-to-action component
+
+The system SHALL provide a single shared, presentational call-to-action component that guides a user with no online daemon connection to start a long-lived `chorus daemon`. The component SHALL be prop-driven (a size/emphasis variant), SHALL fetch no data, and SHALL be the only implementation of this guidance — the three empty-state surfaces (sidebar pill popover, onboarding completion screen, Agent Connections modal) SHALL render this same component rather than hand-written copies.
+
+#### Scenario: Component renders command, copy, and learn-more
+
+- **WHEN** the daemon-connect CTA component is rendered
+- **THEN** it displays prose explaining that a long-lived `chorus daemon` keeps the agent online, the exact start command, a one-click copy control for that command, and a "Learn more" link to the onboarding install guide
+
+#### Scenario: All three surfaces use the one component
+
+- **WHEN** the daemon-connect guidance appears in the sidebar pill popover empty state, the onboarding completion screen, or the Agent Connections modal empty state
+- **THEN** each surface renders the same shared component, so the command and prose cannot drift between surfaces
+
+### Requirement: Command shown in npx form from a single constant
+
+The CTA SHALL show the daemon command in the zero-install `npx` form, sourced from a single exported constant rather than a per-call-site literal. The start command SHALL be `npx @chorus-aidlc/chorus daemon`, and the CTA SHALL also surface the first-run login command `npx @chorus-aidlc/chorus login`. i18n message strings SHALL carry only the surrounding prose and SHALL NOT embed the command literal, so a future package or bin rename is a one-line constant change.
+
+#### Scenario: Start command is the npx form
+
+- **WHEN** a user views the daemon-connect CTA
+- **THEN** the copyable command is `npx @chorus-aidlc/chorus daemon` (not a bare `chorus daemon`)
+- **AND** the first-run login command `npx @chorus-aidlc/chorus login` is surfaced as the prerequisite step
+
+#### Scenario: Command literal is not duplicated in i18n or per call site
+
+- **WHEN** the command string must change (e.g. the published package name changes)
+- **THEN** editing the single command constant updates all three surfaces
+- **AND** no locale message file and no call site contains the command literal
+
+#### Scenario: Copy control copies the command
+
+- **WHEN** the user activates the copy control on the CTA
+- **THEN** the start command is written to the clipboard and the control shows a transient confirmation
+- **AND** if the clipboard write is unavailable, the command text remains visible and no error crashes the surface
+
+### Requirement: Pill popover 0-online empty state shows the CTA, non-dismissible
+
+The sidebar agent-presence pill popover SHALL render the daemon-connect CTA in place of a bare "no agents online" statement whenever zero connections are online. The CTA SHALL NOT be dismissible and SHALL NOT persist a dismissed preference; it SHALL disappear naturally once at least one daemon connection is online (the popover then renders the live connection list).
+
+#### Scenario: Zero online agents
+
+- **WHEN** the user opens the agent-presence pill popover and no connections are online
+- **THEN** the popover shows the daemon-connect CTA (with command + copy + learn-more) instead of only a "no agents online" sentence
+
+#### Scenario: An agent comes online
+
+- **WHEN** at least one daemon connection becomes online
+- **THEN** the popover renders the live connection list and the CTA is no longer shown, with no dismiss action required
+
+#### Scenario: The resident pill remains visible
+
+- **WHEN** zero connections are online
+- **THEN** the pill trigger itself remains visible in the sidebar (the CTA lives inside the popover, not in place of the pill)
+
+### Requirement: Onboarding completion screen shows a prominent next-step CTA
+
+The onboarding completion screen SHALL display the daemon-connect CTA as a prominent "next step" block, in addition to the existing summary card and navigation buttons. The block SHALL emphasize that installing a plugin does not by itself keep an agent online and that running `chorus daemon` is required for the agent to auto-receive dispatched work. The existing "Go to projects" / "Go to settings" actions SHALL be preserved.
+
+#### Scenario: Completion screen guides toward the daemon
+
+- **WHEN** a user reaches the final onboarding completion step
+- **THEN** a prominent next-step block shows the daemon-connect CTA emphasizing "installed plugin ≠ resident online — run the daemon"
+- **AND** the existing "Go to projects" and "Go to settings" buttons are still present
+
+### Requirement: i18n coverage in both locales
+
+All user-facing strings introduced by the CTA (headline, body, completion-screen framing, copy button label and copied state, and learn-more link text) SHALL exist in both the English and Chinese locale files, under a single namespace used by all three surfaces. The previously hand-written Agent Connections empty-state command sentence SHALL be reconciled into the shared CTA so no duplicate command-bearing copy remains.
+
+#### Scenario: Keys present in both locales
+
+- **WHEN** the CTA renders in either the English or Chinese locale
+- **THEN** every CTA string resolves from a translation key present in both `messages/en.json` and `messages/zh.json`
+- **AND** no CTA string is hardcoded in JSX

--- a/openspec/specs/daemon-connect-cta/spec.md
+++ b/openspec/specs/daemon-connect-cta/spec.md
@@ -1,0 +1,80 @@
+# daemon-connect-cta Specification
+
+## Purpose
+TBD - created by archiving change add-daemon-connect-onboarding-cta. Update Purpose after archive.
+## Requirements
+### Requirement: Shared daemon-connect call-to-action component
+
+The system SHALL provide a single shared, presentational call-to-action component that guides a user with no online daemon connection to start a long-lived `chorus daemon`. The component SHALL be prop-driven (a size/emphasis variant), SHALL fetch no data, and SHALL be the only implementation of this guidance — the three empty-state surfaces (sidebar pill popover, onboarding completion screen, Agent Connections modal) SHALL render this same component rather than hand-written copies.
+
+#### Scenario: Component renders command, copy, and learn-more
+
+- **WHEN** the daemon-connect CTA component is rendered
+- **THEN** it displays prose explaining that a long-lived `chorus daemon` keeps the agent online, the exact start command, a one-click copy control for that command, and a "Learn more" link to the onboarding install guide
+
+#### Scenario: All three surfaces use the one component
+
+- **WHEN** the daemon-connect guidance appears in the sidebar pill popover empty state, the onboarding completion screen, or the Agent Connections modal empty state
+- **THEN** each surface renders the same shared component, so the command and prose cannot drift between surfaces
+
+### Requirement: Command shown in npx form from a single constant
+
+The CTA SHALL show the daemon command in the zero-install `npx` form, sourced from a single exported constant rather than a per-call-site literal. The start command SHALL be `npx @chorus-aidlc/chorus daemon`, and the CTA SHALL also surface the first-run login command `npx @chorus-aidlc/chorus login`. i18n message strings SHALL carry only the surrounding prose and SHALL NOT embed the command literal, so a future package or bin rename is a one-line constant change.
+
+#### Scenario: Start command is the npx form
+
+- **WHEN** a user views the daemon-connect CTA
+- **THEN** the copyable command is `npx @chorus-aidlc/chorus daemon` (not a bare `chorus daemon`)
+- **AND** the first-run login command `npx @chorus-aidlc/chorus login` is surfaced as the prerequisite step
+
+#### Scenario: Command literal is not duplicated in i18n or per call site
+
+- **WHEN** the command string must change (e.g. the published package name changes)
+- **THEN** editing the single command constant updates all three surfaces
+- **AND** no locale message file and no call site contains the command literal
+
+#### Scenario: Copy control copies the command
+
+- **WHEN** the user activates the copy control on the CTA
+- **THEN** the start command is written to the clipboard and the control shows a transient confirmation
+- **AND** if the clipboard write is unavailable, the command text remains visible and no error crashes the surface
+
+### Requirement: Pill popover 0-online empty state shows the CTA, non-dismissible
+
+The sidebar agent-presence pill popover SHALL render the daemon-connect CTA in place of a bare "no agents online" statement whenever zero connections are online. The CTA SHALL NOT be dismissible and SHALL NOT persist a dismissed preference; it SHALL disappear naturally once at least one daemon connection is online (the popover then renders the live connection list).
+
+#### Scenario: Zero online agents
+
+- **WHEN** the user opens the agent-presence pill popover and no connections are online
+- **THEN** the popover shows the daemon-connect CTA (with command + copy + learn-more) instead of only a "no agents online" sentence
+
+#### Scenario: An agent comes online
+
+- **WHEN** at least one daemon connection becomes online
+- **THEN** the popover renders the live connection list and the CTA is no longer shown, with no dismiss action required
+
+#### Scenario: The resident pill remains visible
+
+- **WHEN** zero connections are online
+- **THEN** the pill trigger itself remains visible in the sidebar (the CTA lives inside the popover, not in place of the pill)
+
+### Requirement: Onboarding completion screen shows a prominent next-step CTA
+
+The onboarding completion screen SHALL display the daemon-connect CTA as a prominent "next step" block, in addition to the existing summary card and navigation buttons. The block SHALL emphasize that installing a plugin does not by itself keep an agent online and that running `chorus daemon` is required for the agent to auto-receive dispatched work. The existing "Go to projects" / "Go to settings" actions SHALL be preserved.
+
+#### Scenario: Completion screen guides toward the daemon
+
+- **WHEN** a user reaches the final onboarding completion step
+- **THEN** a prominent next-step block shows the daemon-connect CTA emphasizing "installed plugin ≠ resident online — run the daemon"
+- **AND** the existing "Go to projects" and "Go to settings" buttons are still present
+
+### Requirement: i18n coverage in both locales
+
+All user-facing strings introduced by the CTA (headline, body, completion-screen framing, copy button label and copied state, and learn-more link text) SHALL exist in both the English and Chinese locale files, under a single namespace used by all three surfaces. The previously hand-written Agent Connections empty-state command sentence SHALL be reconciled into the shared CTA so no duplicate command-bearing copy remains.
+
+#### Scenario: Keys present in both locales
+
+- **WHEN** the CTA renders in either the English or Chinese locale
+- **THEN** every CTA string resolves from a translation key present in both `messages/en.json` and `messages/zh.json`
+- **AND** no CTA string is hardcoded in JSX
+

--- a/src/app/onboarding/components/CompletionStep.tsx
+++ b/src/app/onboarding/components/CompletionStep.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { CheckCircle2, FolderKanban, Settings } from "lucide-react";
 import { motion } from "framer-motion";
 import { fadeInUp } from "@/lib/animation";
+import { DaemonConnectCta } from "@/components/agent-presence";
 
 interface CompletionStepProps {
   createdAgent: {
@@ -90,6 +91,12 @@ export function CompletionStep({ createdAgent }: CompletionStepProps) {
           </CardContent>
         </Card>
       )}
+
+      {/* Next step: keep the agent online. Installing a plugin only configures a
+          one-shot connection — a resident agent that auto-receives dispatched
+          work needs a long-lived `chorus daemon`. This is the discoverability
+          nudge the completion screen was missing. */}
+      <DaemonConnectCta variant="prominent" />
 
       {/* Action buttons */}
       <div className="flex w-full max-w-xs flex-col gap-3">

--- a/src/components/__tests__/agent-presence-pill.test.tsx
+++ b/src/components/__tests__/agent-presence-pill.test.tsx
@@ -29,6 +29,9 @@ import type {
   ConnectionView,
   ExecutionView,
 } from "@/components/agent-presence";
+// Real en strings for asserting CTA prose by value (kept in sync with the
+// next-intl mock below, which resolves from the same file).
+import enMessages from "../../../messages/en.json";
 
 // next-intl: resolve real en strings (mirrors the sibling agent-connections tests).
 vi.mock("next-intl", async () => {
@@ -333,7 +336,7 @@ describe("AgentPresencePill — popover content", () => {
     expect(setModalOpen).toHaveBeenCalledWith(true);
   });
 
-  it("popover renders empty-state when no connections are online", async () => {
+  it("popover 0-online empty state shows the daemon-connect CTA (command + copy), not a dead-end sentence", async () => {
     setPresence({
       status: "ok",
       onlineCount: 0,
@@ -345,8 +348,18 @@ describe("AgentPresencePill — popover content", () => {
     render(<AgentPresencePill />);
     await user.click(screen.getByRole("button", { name: TRIGGER_LABEL }));
 
+    // The dead-end "No agents are online right now." statement is replaced by an
+    // actionable CTA: the npx start command (verbatim from the single constant)
+    // plus a copy control. Asserting the command text guards against the literal
+    // being moved into i18n by mistake.
     expect(
-      await screen.findByText("No agents are online right now."),
+      await screen.findByText("npx @chorus-aidlc/chorus daemon"),
+    ).toBeTruthy();
+    // The compact CTA body prose resolves from the shared daemonConnectCta
+    // namespace (a renamed/missing key would surface as its dotted path).
+    expect(screen.getByText(enMessages.daemonConnectCta.body)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: enMessages.daemonConnectCta.copy }),
     ).toBeTruthy();
   });
 });

--- a/src/components/agent-presence-pill.tsx
+++ b/src/components/agent-presence-pill.tsx
@@ -26,6 +26,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useAgentPresence } from "@/contexts/agent-presence-context";
 import {
+  DaemonConnectCta,
   ExecutionRow,
   ExecutionSection,
   IdentityBlock,
@@ -81,10 +82,12 @@ function PopoverBody({
   const t = useTranslations("agentPresence");
   const ta = useTranslations("agentConnections");
 
+  // 0-online empty state: no longer a dead-end "nobody online" sentence — show
+  // the daemon-connect CTA (compact) so the user knows HOW to bring an agent
+  // online. Not dismissible: once a daemon connects, this branch is replaced by
+  // the live connection list below, so the CTA disappears on its own.
   if (onlineConnections.length === 0) {
-    return (
-      <p className="px-1 py-2 text-[13px] text-[#9A9A9A]">{t("popoverEmpty")}</p>
-    );
+    return <DaemonConnectCta variant="compact" />;
   }
 
   return (

--- a/src/components/agent-presence/__tests__/connections-modal.test.tsx
+++ b/src/components/agent-presence/__tests__/connections-modal.test.tsx
@@ -341,6 +341,13 @@ describe("Daemon chat modal — opening + conversation list", () => {
       expect(screen.queryByText("No conversations yet")).toBeTruthy(),
     );
     expect(screen.queryAllByRole("button", { name: "Start session" }).length).toBe(0);
+    // The dead-end card now carries the shared daemon-connect CTA so this surface
+    // matches the pill popover + onboarding completion screen: the npx start
+    // command (verbatim from the single constant) plus a copy control.
+    expect(screen.getByText("npx @chorus-aidlc/chorus daemon")).toBeTruthy();
+    expect(
+      screen.getAllByRole("button", { name: "Copy" }).length,
+    ).toBeGreaterThan(0);
   });
 
   it("names an ad-hoc conversation by its first human instruction (not type+uuid)", async () => {

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -53,6 +53,7 @@ import {
 import { TranscriptView } from "./transcript-view";
 import { NewConversationPane } from "./new-conversation-pane";
 import { executionsForSession, sessionExecStatus } from "./session-execution";
+import { DaemonConnectCta } from "../daemon-connect-cta";
 
 const PAGE_SIZE = 12;
 
@@ -716,7 +717,7 @@ export function DaemonChat() {
         ) : noAgentsAtAll ? (
           // The ONLY remaining dead-end: no agent connected AND no history — there is
           // nothing to talk to, so a calm "connect a daemon" card (no composer).
-          <Card className="items-center gap-3 rounded-2xl border-[#E5E0D8] bg-white p-8 text-center shadow-none md:p-12">
+          <Card className="items-center gap-4 rounded-2xl border-[#E5E0D8] bg-white p-8 text-center shadow-none md:p-12">
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#C67A5215]">
               <MessagesSquare className="h-6 w-6 text-[#C67A52]" />
             </div>
@@ -726,6 +727,12 @@ export function DaemonChat() {
             <p className="max-w-md text-[13px] leading-relaxed text-[#6B6B6B]">
               {t("noAgents.body")}
             </p>
+            {/* Actionable CTA for the only remaining dead-end (no connected agent
+                AND no history): the shared daemon-connect block, consistent with
+                the pill popover + onboarding completion screen. */}
+            <div className="w-full max-w-md text-left">
+              <DaemonConnectCta variant="prominent" />
+            </div>
           </Card>
         ) : (
           <>

--- a/src/components/agent-presence/connections-view.tsx
+++ b/src/components/agent-presence/connections-view.tsx
@@ -55,6 +55,7 @@ import { authFetch } from "@/lib/auth-client";
 import { clientLogger } from "@/lib/logger-client";
 import { useAgentPresence } from "@/contexts/agent-presence-context";
 import {
+  DaemonConnectCta,
   ExecutionRow,
   ExecutionSection,
   IdentityBlock,
@@ -692,16 +693,20 @@ export function AgentConnectionsView() {
             </p>
           </Card>
         ) : connections.length === 0 ? (
-          <Card className="items-center gap-3 rounded-2xl border-[#E5E0D8] bg-white p-8 text-center shadow-none md:p-12">
+          <Card className="items-center gap-4 rounded-2xl border-[#E5E0D8] bg-white p-8 text-center shadow-none md:p-12">
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#C67A5215]">
               <RadioTower className="h-6 w-6 text-[#C67A52]" />
             </div>
             <h3 className="text-base font-semibold text-[#2C2C2C]">
               {t("empty.title")}
             </h3>
-            <p className="max-w-md text-[13px] leading-relaxed text-[#6B6B6B]">
-              {t("empty.body")}
-            </p>
+            {/* The hand-written "run chorus daemon" sentence is replaced by the
+                shared daemon-connect CTA so this surface stays consistent with
+                the pill popover + onboarding completion screen and the command
+                can never drift. */}
+            <div className="w-full max-w-md text-left">
+              <DaemonConnectCta variant="prominent" />
+            </div>
           </Card>
         ) : (
           <>

--- a/src/components/agent-presence/daemon-connect-cta.tsx
+++ b/src/components/agent-presence/daemon-connect-cta.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+// Shared "connect a daemon" call-to-action for the daemon-discoverability empty
+// states. Rendered in three places — all of which mean "you have no online agent
+// connection right now, here is how to get one":
+//   - the sidebar agent-presence pill popover, when 0 connections are online
+//     (compact variant),
+//   - the onboarding completion screen, as the prominent "next step" block,
+//   - the Agent Connections "View all" modal empty state.
+//
+// One component + one command constant so the three surfaces can never drift in
+// the exact command they show. The component is purely presentational and
+// prop-driven — it fetches nothing and never reads useAgentPresence(); the CALLER
+// decides whether to render it (e.g. the pill only renders it on its 0-online
+// branch). The command literal lives in the constants below, NOT in any i18n
+// message, so a future package/bin rename is a one-line change here.
+
+import { useState } from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Check, Copy, Terminal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { clientLogger } from "@/lib/logger-client";
+
+// ---------------------------------------------------------------------------
+// Single source of truth for the daemon command.
+//
+// The CLI publishes to npm (package `@chorus-aidlc/chorus`, bin `chorus`), and
+// the target user of this CTA has installed nothing — so the most
+// copy-paste-runnable form is the zero-install `npx` form. Verified against the
+// live CLI: `chorus.mjs` declares bin `chorus` for package `@chorus-aidlc/chorus`
+// with subcommands exactly `daemon` and `login`; `daemon` resolves credentials by
+// flag > env > ~/.chorus/daemon.json (written by `login`) > plugin fallback, so a
+// first-time user runs `login` then `daemon`.
+// ---------------------------------------------------------------------------
+export const DAEMON_NPX_PACKAGE = "@chorus-aidlc/chorus";
+export const DAEMON_START_COMMAND = `npx ${DAEMON_NPX_PACKAGE} daemon`;
+export const DAEMON_LOGIN_COMMAND = `npx ${DAEMON_NPX_PACKAGE} login`;
+
+// Where "Learn more" points: the onboarding wizard (which includes the
+// multi-agent install guide as one of its steps) is the stable, always-available
+// route covering how to connect an agent. We link to the wizard rather than
+// inventing a new standalone route; it opens at the start of the flow.
+const LEARN_MORE_HREF = "/onboarding";
+
+export type DaemonConnectCtaVariant = "compact" | "prominent";
+
+// A monospace command line with a one-click copy button. The copy is guarded so
+// an unavailable Clipboard API (insecure context, etc.) degrades gracefully — the
+// command text stays visible and nothing throws.
+function CommandLine({ command }: { command: string }) {
+  const t = useTranslations("daemonConnectCta");
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard?.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      clientLogger.error("Failed to copy daemon command:", error);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <code className="flex-1 overflow-x-auto rounded-md bg-foreground px-3 py-2 font-mono text-[12.5px] leading-relaxed text-background">
+        {command}
+      </code>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={copy}
+        aria-label={copied ? t("copied") : t("copy")}
+        aria-live="polite"
+        className="shrink-0"
+      >
+        {copied ? (
+          <>
+            <Check className="mr-1 h-4 w-4 text-green-500" />
+            {t("copied")}
+          </>
+        ) : (
+          <>
+            <Copy className="mr-1 h-4 w-4" />
+            {t("copy")}
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}
+
+export function DaemonConnectCta({ variant }: { variant: DaemonConnectCtaVariant }) {
+  const t = useTranslations("daemonConnectCta");
+
+  if (variant === "compact") {
+    // Narrow surface (sidebar pill popover ~360px): tight spacing, the primary
+    // start command + copy, and a condensed login note + learn-more link.
+    return (
+      <div className="flex flex-col gap-2.5 px-1 py-1.5">
+        <div className="flex items-start gap-2">
+          <Terminal className="mt-0.5 h-4 w-4 shrink-0 text-[#C67A52]" aria-hidden />
+          <p className="text-[12.5px] leading-relaxed text-[#6B6B6B]">
+            {t("body")}
+          </p>
+        </div>
+        <CommandLine command={DAEMON_START_COMMAND} />
+        <p className="text-[11.5px] leading-relaxed text-[#9A9A9A]">
+          {t("loginNote", { command: DAEMON_LOGIN_COMMAND })}
+        </p>
+        <Link
+          href={LEARN_MORE_HREF}
+          className="text-[12px] font-medium text-[#C67A52] hover:text-[#A65F3C] hover:underline"
+        >
+          {t("learnMore")}
+        </Link>
+      </div>
+    );
+  }
+
+  // Prominent surface (onboarding completion screen, also fine in the wider
+  // Agent Connections modal): a framed "next step" card with headline, the
+  // "installed plugin ≠ resident online" body, command + copy, login note, and
+  // the learn-more link.
+  return (
+    <div className="flex w-full flex-col gap-3 rounded-xl border border-[#EFEBE4] bg-[#FCFBF8] p-5 text-left">
+      <div className="flex items-center gap-2">
+        <Terminal className="h-4 w-4 text-[#C67A52]" aria-hidden />
+        <h3 className="text-[14px] font-semibold text-[#2C2C2C]">
+          {t("headline")}
+        </h3>
+      </div>
+      <p className="text-[13px] leading-relaxed text-[#6B6B6B]">{t("bodyLong")}</p>
+      <CommandLine command={DAEMON_START_COMMAND} />
+      <p className="text-[12px] leading-relaxed text-[#9A9A9A]">
+        {t("loginNote", { command: DAEMON_LOGIN_COMMAND })}
+      </p>
+      <Link
+        href={LEARN_MORE_HREF}
+        className="text-[12.5px] font-medium text-[#C67A52] hover:text-[#A65F3C] hover:underline"
+      >
+        {t("learnMore")}
+      </Link>
+    </div>
+  );
+}

--- a/src/components/agent-presence/index.ts
+++ b/src/components/agent-presence/index.ts
@@ -26,3 +26,10 @@ export { ExecutionRow, ExecutionSection } from "./execution-row";
 export { SendInstructionBox, type SessionTarget } from "./send-instruction-box";
 export { AgentConnectionsView } from "./connections-view";
 export { AgentConnectionsModal } from "./connections-modal";
+export {
+  DaemonConnectCta,
+  type DaemonConnectCtaVariant,
+  DAEMON_NPX_PACKAGE,
+  DAEMON_START_COMMAND,
+  DAEMON_LOGIN_COMMAND,
+} from "./daemon-connect-cta";


### PR DESCRIPTION
## Summary
Turns three previously dead-end empty states — where a user has no online daemon connection — into an actionable call-to-action that shows the zero-install `npx @chorus-aidlc/chorus daemon` command, a one-click copy button, a first-run `login` note, and a "Learn more" link. Frontend + i18n only; no backend, schema, or daemon-protocol change.

The three live surfaces:
- sidebar agent-presence **pill popover** (0 online),
- **onboarding completion** screen (prominent "next step" block),
- the live **"View all" conversations modal** no-agent card (`DaemonChat`).

The command is a **single exported constant** in `npx` form — never duplicated per call site, never embedded in an i18n message — so a future package/bin rename is a one-line change. Verified against `package.json` (`@chorus-aidlc/chorus`) + `chorus.mjs` (subcommands `daemon`/`login`).

## Changed files
| File | Change |
|------|--------|
| `src/components/agent-presence/daemon-connect-cta.tsx` | **New** shared `DaemonConnectCta` (compact/prominent) + command constants |
| `src/components/agent-presence/index.ts` | Barrel export |
| `src/components/agent-presence-pill.tsx` | Pill popover 0-online branch → compact CTA |
| `src/app/onboarding/components/CompletionStep.tsx` | Prominent next-step CTA block (nav buttons preserved) |
| `src/components/agent-presence/chat/daemon-chat.tsx` | Live "View all" no-agent card → CTA |
| `src/components/agent-presence/connections-view.tsx` | Empty branch → CTA (legacy surface, test-covered) |
| `messages/en.json`, `messages/zh.json` | New `daemonConnectCta` namespace; removed `popoverEmpty` + folded `empty.body` |
| `*/__tests__/*.test.tsx` | Updated pill + connections-modal tests to assert the CTA |
| `openspec/changes/archive/...`, `openspec/specs/daemon-connect-cta/` | Archived OpenSpec change + cumulative spec |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` clean on touched files (2 pre-existing errors in an untouched openclaw test remain repo-wide)
- [x] `pnpm test` — 170 files, 2822 passed, 1 skipped
- [x] Independent review agent → PASS WITH NOTES (no blockers); polish applied
- [x] Real-browser e2e: pill popover + onboarding completion verified (copy → "Copied!"); third surface covered by deterministic test
- [ ] design.pen mocks (owner-waived for this pure-copy change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)