### PR TITLE
docs: update design.pen with daemon chat + agent presence screens

### DIFF
--- a/docs/design.pen
+++ b/docs/design.pen
@@ -90404,18 +90404,18 @@
     },
     {
       "type": "frame",
-      "id": "d5VzQU",
+      "id": "iVp8a",
       "x": 0,
-      "y": 23941,
-      "name": "Chorus - Agent Connections",
+      "y": 24126,
+      "name": "Chorus - Daemon Conversations (Modal)",
       "clip": true,
       "width": 1440,
-      "height": 900,
+      "height": 940,
       "fill": "#FAF8F4",
       "children": [
         {
           "type": "frame",
-          "id": "jHY4L",
+          "id": "stAgZ",
           "name": "Sidebar",
           "width": 220,
           "height": "fill_container",
@@ -90435,7 +90435,7 @@
           "children": [
             {
               "type": "frame",
-              "id": "m1YjQ",
+              "id": "YWD4V",
               "name": "Sidebar Top",
               "width": "fill_container",
               "layout": "vertical",
@@ -90443,7 +90443,7 @@
               "children": [
                 {
                   "type": "frame",
-                  "id": "VAKjB",
+                  "id": "D07bF1",
                   "name": "Logo",
                   "gap": 10,
                   "alignItems": "center",
@@ -90451,7 +90451,7 @@
                     {
                       "type": "rectangle",
                       "cornerRadius": 4,
-                      "id": "UHtV5",
+                      "id": "fNjsu",
                       "name": "logoMark",
                       "fill": "#C67A52",
                       "width": 28,
@@ -90459,7 +90459,7 @@
                     },
                     {
                       "type": "text",
-                      "id": "CbLvO",
+                      "id": "wVOaS",
                       "name": "logoText",
                       "fill": "#2C2C2C",
                       "content": "Chorus",
@@ -90471,7 +90471,7 @@
                 },
                 {
                   "type": "frame",
-                  "id": "JPEOI",
+                  "id": "E4PKFn",
                   "name": "Navigation",
                   "width": "fill_container",
                   "layout": "vertical",
@@ -90479,7 +90479,7 @@
                   "children": [
                     {
                       "type": "frame",
-                      "id": "m37zG5",
+                      "id": "B6zTm7",
                       "name": "navProjects",
                       "width": "fill_container",
                       "cornerRadius": 8,
@@ -90491,7 +90491,7 @@
                       "children": [
                         {
                           "type": "icon",
-                          "id": "YzkaN",
+                          "id": "M4DEvE",
                           "name": "ProjectsIcon",
                           "width": 16,
                           "height": 16,
@@ -90501,7 +90501,7 @@
                         },
                         {
                           "type": "text",
-                          "id": "K5bMY",
+                          "id": "g6a3E",
                           "name": "ProjectsText",
                           "fill": "#6B6B6B",
                           "content": "Projects",
@@ -90513,7 +90513,7 @@
                     },
                     {
                       "type": "frame",
-                      "id": "vndUQ",
+                      "id": "NLh3m",
                       "name": "navActivity",
                       "width": "fill_container",
                       "cornerRadius": 8,
@@ -90525,7 +90525,7 @@
                       "children": [
                         {
                           "type": "icon",
-                          "id": "PRTiK",
+                          "id": "f6A7mg",
                           "name": "ActivityIcon",
                           "width": 16,
                           "height": 16,
@@ -90535,7 +90535,7 @@
                         },
                         {
                           "type": "text",
-                          "id": "k4oVFY",
+                          "id": "Ye9Yt",
                           "name": "ActivityText",
                           "fill": "#6B6B6B",
                           "content": "Activity",
@@ -90547,7 +90547,7 @@
                     },
                     {
                       "type": "frame",
-                      "id": "NEdvD",
+                      "id": "s6vQt",
                       "name": "navDaemons",
                       "width": "fill_container",
                       "fill": "#F5F2EC",
@@ -90560,7 +90560,7 @@
                       "children": [
                         {
                           "type": "icon",
-                          "id": "N22W0T",
+                          "id": "lpwaI",
                           "name": "DaemonsIcon",
                           "width": 16,
                           "height": 16,
@@ -90570,7 +90570,7 @@
                         },
                         {
                           "type": "text",
-                          "id": "IoTx8",
+                          "id": "NvjhZ",
                           "name": "DaemonsText",
                           "fill": "#2C2C2C",
                           "content": "Agent Connections",
@@ -90582,7 +90582,7 @@
                     },
                     {
                       "type": "frame",
-                      "id": "pAJrY",
+                      "id": "TW62D",
                       "name": "navSettings",
                       "width": "fill_container",
                       "cornerRadius": 8,
@@ -90594,7 +90594,7 @@
                       "children": [
                         {
                           "type": "icon",
-                          "id": "qSOnX",
+                          "id": "z0S72",
                           "name": "SettingsIcon",
                           "width": 16,
                           "height": 16,
@@ -90604,7 +90604,7 @@
                         },
                         {
                           "type": "text",
-                          "id": "cQdk8",
+                          "id": "nL4zP",
                           "name": "SettingsText",
                           "fill": "#6B6B6B",
                           "content": "Settings",
@@ -90620,7 +90620,7 @@
             },
             {
               "type": "frame",
-              "id": "zWmjp",
+              "id": "aPiJA",
               "name": "Sidebar Bottom",
               "width": "fill_container",
               "layout": "vertical",
@@ -90628,7 +90628,7 @@
               "children": [
                 {
                   "type": "frame",
-                  "id": "V0pVit",
+                  "id": "gRI82",
                   "name": "userProfile",
                   "width": "fill_container",
                   "gap": 8,
@@ -90636,7 +90636,7 @@
                   "children": [
                     {
                       "type": "frame",
-                      "id": "ULsFc",
+                      "id": "ZXna8",
                       "name": "avatar",
                       "width": 36,
                       "height": 36,
@@ -90647,7 +90647,7 @@
                       "children": [
                         {
                           "type": "text",
-                          "id": "BtBJK",
+                          "id": "GlMl8",
                           "name": "avatarText",
                           "fill": "#FFFFFF",
                           "content": "A",
@@ -90659,14 +90659,14 @@
                     },
                     {
                       "type": "frame",
-                      "id": "YX94S",
+                      "id": "Den5N",
                       "name": "userInfo",
                       "layout": "vertical",
                       "gap": 2,
                       "children": [
                         {
                           "type": "text",
-                          "id": "ncuYG",
+                          "id": "LQnu1",
                           "name": "userName",
                           "fill": "#2C2C2C",
                           "content": "Alice Chen",
@@ -90676,7 +90676,7 @@
                         },
                         {
                           "type": "text",
-                          "id": "bocbx",
+                          "id": "OCVyQ",
                           "name": "userRole",
                           "fill": "#6B6B6B",
                           "content": "Tech Lead",
@@ -90694,12 +90694,12 @@
         },
         {
           "type": "frame",
-          "id": "Afv27",
+          "id": "v8OsA3",
           "name": "Main Content",
           "width": "fill_container",
           "height": "fill_container",
           "layout": "vertical",
-          "gap": 24,
+          "gap": 22,
           "padding": [
             24,
             32
@@ -90707,7 +90707,7 @@
           "children": [
             {
               "type": "frame",
-              "id": "m2s8K",
+              "id": "Am0iP",
               "name": "Top Bar",
               "width": "fill_container",
               "justifyContent": "space_between",
@@ -90715,24 +90715,24 @@
               "children": [
                 {
                   "type": "text",
-                  "id": "O4RL3",
+                  "id": "BNnAD",
                   "name": "breadcrumb",
                   "fill": "#9A9A9A",
-                  "content": "Chorus / Agent Connections",
+                  "content": "Chorus / Projects",
                   "fontFamily": "IBM Plex Sans",
                   "fontSize": 12,
                   "fontWeight": "normal"
                 },
                 {
                   "type": "frame",
-                  "id": "srbXd",
+                  "id": "lKvqh",
                   "name": "topActions",
                   "gap": 16,
                   "alignItems": "center",
                   "children": [
                     {
                       "type": "icon",
-                      "id": "pZkxS",
+                      "id": "DliGC",
                       "name": "searchIcon",
                       "width": 16,
                       "height": 16,
@@ -90742,7 +90742,7 @@
                     },
                     {
                       "type": "icon",
-                      "id": "gTbEh",
+                      "id": "v99akO",
                       "name": "bellIcon",
                       "width": 16,
                       "height": 16,
@@ -90756,544 +90756,1108 @@
             },
             {
               "type": "frame",
-              "id": "O4I50G",
-              "name": "Title Row",
+              "id": "VW32X",
+              "name": "Title Section",
+              "width": 680,
+              "layout": "vertical",
+              "gap": 5,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rtLFx",
+                  "name": "pageTitle",
+                  "fill": "#2C2C2C",
+                  "content": "Projects",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 24,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "ZguXj",
+                  "name": "pageSubtitle",
+                  "fill": "#6B6B6B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Your active projects and recent work.",
+                  "lineHeight": 1.4,
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "u4ppYL",
+              "name": "projGridBehind",
               "width": "fill_container",
-              "justifyContent": "space_between",
+              "layout": "vertical",
+              "gap": 12,
               "children": [
                 {
                   "type": "frame",
-                  "id": "FDNMg",
-                  "name": "Title Section",
-                  "width": 620,
+                  "id": "mocCH",
+                  "name": "proj Chorus 0.11.0",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "b2aQRj",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZVWZo",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "Chorus 0.11.0",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "A2ZYfF",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "12 ideas · 3 in progress",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "zyY59",
+                      "name": "arr",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "cwDUn",
+                  "name": "proj MCS 1.3.0",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "atBiC",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "m3BFr",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "MCS 1.3.0",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "FV5Nd",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "1 idea · awaiting conduct",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "gnTb0",
+                      "name": "arr",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "b1noG",
+                  "name": "proj Data Engine Demo",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Q4cV2l",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "n59Rm",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "Data Engine Demo",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "fSX5a",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "1 idea · in progress",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "oS3o1",
+                      "name": "arr",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "EJmvG",
+                  "name": "proj OpenSpec Mirror",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LlOdS",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qKOPA",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "OpenSpec Mirror",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "TPY7z",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "5 ideas",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "SdGyV",
+                      "name": "arr",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "ecJjk",
+          "layoutPosition": "absolute",
+          "x": 0,
+          "y": 0,
+          "name": "Scrim",
+          "fill": "#1A14108f",
+          "width": 1440,
+          "height": 940
+        },
+        {
+          "type": "frame",
+          "id": "AkdzG",
+          "layoutPosition": "absolute",
+          "x": 120,
+          "y": 80,
+          "name": "Dialog",
+          "clip": true,
+          "width": 1200,
+          "height": 780,
+          "fill": "#FAF8F4",
+          "cornerRadius": 16,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#1A141055",
+            "offset": {
+              "x": 0,
+              "y": 24
+            },
+            "blur": 60
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "D1oCPc",
+              "name": "dialogHeader",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "padding": [
+                18,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "m9AcZm",
+                  "name": "headLeft",
+                  "width": "fill_container",
                   "layout": "vertical",
-                  "gap": 5,
+                  "gap": 4,
                   "children": [
                     {
                       "type": "text",
-                      "id": "K7sPQX",
-                      "name": "pageTitle",
+                      "id": "hIekM",
+                      "name": "dTitle",
                       "fill": "#2C2C2C",
-                      "content": "Agent Connections",
+                      "content": "Conversations",
                       "fontFamily": "IBM Plex Sans",
-                      "fontSize": 24,
+                      "fontSize": 18,
                       "fontWeight": "600"
                     },
                     {
                       "type": "text",
-                      "id": "nN7FO",
-                      "name": "pageSubtitle",
+                      "id": "JcSQS",
+                      "name": "dSub",
                       "fill": "#6B6B6B",
-                      "textGrowth": "fixed-width",
-                      "width": "fill_container",
-                      "content": "Local agents connected to Chorus on your behalf, in real time. Showing your own connections only.",
-                      "lineHeight": 1.4,
+                      "content": "Read what your agents did, turn by turn. Continue or interrupt a conversation inline.",
                       "fontFamily": "IBM Plex Sans",
-                      "fontSize": 13,
+                      "fontSize": 12.5,
                       "fontWeight": "normal"
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "t9VJYG",
-                  "name": "Summary",
-                  "fill": "#FFFFFF",
-                  "cornerRadius": 999,
-                  "stroke": "#E5E0D8",
-                  "strokeWidth": 1,
-                  "strokeAlignment": "inner",
-                  "gap": 8,
-                  "padding": [
-                    8,
-                    14
-                  ],
+                  "id": "aFPTg",
+                  "name": "closeBtn",
+                  "width": 32,
+                  "height": 32,
+                  "fill": "#F5F2EC",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "frame",
-                      "id": "IHZYr",
-                      "name": "sumDotWrap",
-                      "width": 14,
-                      "height": 14,
-                      "layout": "none",
-                      "children": [
-                        {
-                          "type": "ellipse",
-                          "id": "h14zfd",
-                          "x": 2,
-                          "y": 2,
-                          "name": "halo",
-                          "fill": "#22C55E26",
-                          "width": 10,
-                          "height": 10
-                        },
-                        {
-                          "type": "ellipse",
-                          "id": "EIIAd",
-                          "x": 4,
-                          "y": 4,
-                          "name": "dot",
-                          "fill": "#22C55E",
-                          "width": 6,
-                          "height": 6
-                        }
-                      ]
-                    },
-                    {
-                      "type": "text",
-                      "id": "Fs0sK",
-                      "name": "sumLabel",
-                      "fill": "#2C2C2C",
-                      "content": "2 / 3 online",
-                      "fontFamily": "IBM Plex Sans",
-                      "fontSize": 13,
-                      "fontWeight": "500"
+                      "type": "icon",
+                      "id": "qdSWB",
+                      "name": "xIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "x",
+                      "library": "lucide",
+                      "fill": "#6B6B6B"
                     }
                   ]
                 }
               ]
             },
             {
+              "type": "rectangle",
+              "id": "y5RsHO",
+              "name": "dialogDivider",
+              "fill": "#EFEBE4",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
               "type": "frame",
-              "id": "CCaTD",
-              "name": "Body",
+              "id": "UlXLK",
+              "name": "dialogBody",
               "width": "fill_container",
               "height": "fill_container",
-              "gap": 20,
+              "gap": 18,
+              "padding": [
+                18,
+                22
+              ],
               "children": [
                 {
                   "type": "frame",
-                  "id": "G6tvx4",
-                  "name": "Connection Rail",
-                  "clip": true,
+                  "id": "Q4Yr2",
+                  "name": "Left Column",
                   "width": 340,
                   "height": "fill_container",
-                  "fill": "#FFFFFF",
-                  "cornerRadius": 14,
-                  "stroke": "#E5E0D8",
-                  "strokeWidth": 1,
-                  "strokeAlignment": "inner",
                   "layout": "vertical",
+                  "gap": 14,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "yIJXG",
-                      "name": "railHeader",
+                      "id": "ClCmK",
+                      "name": "Agent Select",
                       "width": "fill_container",
-                      "padding": [
-                        16,
-                        18
-                      ],
-                      "justifyContent": "space_between",
-                      "alignItems": "center",
+                      "layout": "vertical",
+                      "gap": 6,
                       "children": [
                         {
                           "type": "text",
-                          "id": "J68Rr",
-                          "name": "railTitle",
+                          "id": "ahvo7",
+                          "name": "label",
                           "fill": "#9A9A9A",
-                          "content": "CONNECTIONS",
+                          "content": "AGENT",
                           "fontFamily": "IBM Plex Mono",
                           "fontSize": 11,
                           "fontWeight": "500",
-                          "letterSpacing": 1
+                          "letterSpacing": 0.6
                         },
                         {
-                          "type": "text",
-                          "id": "gowl4",
-                          "name": "railCount",
-                          "fill": "#9A9A9A",
-                          "content": "3",
-                          "fontFamily": "IBM Plex Mono",
-                          "fontSize": 11,
-                          "fontWeight": "500"
+                          "type": "frame",
+                          "id": "flKQk",
+                          "name": "SelectTrigger",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": "#E5E0D8",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            9,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "J9ginM",
+                              "name": "selLeft",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "y5dAp",
+                                  "name": "avatar",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "#C67A52",
+                                  "cornerRadius": 10,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "e9ySiC",
+                                      "name": "botIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "bot",
+                                      "library": "lucide",
+                                      "fill": "#FFFFFF"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "slVD8",
+                                  "name": "selValue",
+                                  "fill": "#2C2C2C",
+                                  "content": "Admin Claude",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon",
+                              "id": "RitP4",
+                              "name": "chev",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "chevron-down",
+                              "library": "lucide",
+                              "fill": "#9A9A9A"
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "type": "rectangle",
-                      "id": "UtOkF",
-                      "name": "railDivider",
-                      "fill": "#EFEBE4",
+                      "type": "frame",
+                      "id": "fUXx1",
+                      "name": "New Conversation Button",
                       "width": "fill_container",
-                      "height": 1
+                      "height": 36,
+                      "fill": "#C67A52",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "KsmVK",
+                          "name": "plusIcon",
+                          "width": 15,
+                          "height": 15,
+                          "icon": "message-circle-plus",
+                          "library": "lucide",
+                          "fill": "#FFFFFF"
+                        },
+                        {
+                          "type": "text",
+                          "id": "BabUo",
+                          "name": "newLabel",
+                          "fill": "#FFFFFF",
+                          "content": "New conversation",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
                     },
                     {
                       "type": "frame",
-                      "id": "E1ITOd",
-                      "name": "rows",
+                      "id": "t1l4gh",
+                      "name": "Conversations Card",
+                      "clip": true,
                       "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 14,
+                      "stroke": "#E5E0D8",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "children": [
                         {
                           "type": "frame",
-                          "id": "y6HFqd",
-                          "name": "row claude_code-1",
+                          "id": "HVVBZ",
+                          "name": "listHeader",
                           "width": "fill_container",
-                          "fill": "#FBF4EF",
-                          "gap": 12,
                           "padding": [
-                            14,
-                            18
+                            12,
+                            16
                           ],
+                          "justifyContent": "space_between",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "rectangle",
-                              "id": "urigg",
-                              "layoutPosition": "absolute",
-                              "x": 0,
-                              "y": 0,
-                              "name": "selBar",
-                              "fill": "#C67A52",
-                              "width": 3,
-                              "height": 64
-                            },
-                            {
-                              "type": "frame",
-                              "id": "gl6F6",
-                              "name": "dotWrap",
-                              "width": 12,
-                              "height": 12,
-                              "layout": "none",
-                              "children": [
-                                {
-                                  "type": "ellipse",
-                                  "id": "NYUw6",
-                                  "x": 0,
-                                  "y": 0,
-                                  "name": "halo",
-                                  "fill": "#22C55E26",
-                                  "width": 12,
-                                  "height": 12
-                                },
-                                {
-                                  "type": "ellipse",
-                                  "id": "CGGKs",
-                                  "x": 3,
-                                  "y": 3,
-                                  "name": "dot",
-                                  "fill": "#22C55E",
-                                  "width": 6,
-                                  "height": 6
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "hbh5Y",
-                              "name": "txt",
-                              "width": "fill_container",
-                              "layout": "vertical",
-                              "gap": 3,
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "ojlnG",
-                                  "name": "client",
-                                  "fill": "#2C2C2C",
-                                  "content": "Admin Claude",
-                                  "fontFamily": "IBM Plex Sans",
-                                  "fontSize": 14,
-                                  "fontWeight": "600"
-                                },
-                                {
-                                  "type": "frame",
-                                  "id": "znxnF",
-                                  "name": "subRow",
-                                  "width": "fill_container",
-                                  "gap": 7,
-                                  "alignItems": "center",
-                                  "children": [
-                                    {
-                                      "type": "frame",
-                                      "id": "PwtXC",
-                                      "name": "typeBadge",
-                                      "fill": "#F0EDE8",
-                                      "cornerRadius": 5,
-                                      "padding": [
-                                        2,
-                                        6
-                                      ],
-                                      "children": [
-                                        {
-                                          "type": "text",
-                                          "id": "ohUUf",
-                                          "name": "typeText",
-                                          "fill": "#6B6B6B",
-                                          "content": "Claude Code",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 10,
-                                          "fontWeight": "500"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "i7vM0r",
-                                      "name": "host",
-                                      "fill": "#9A9A9A",
-                                      "content": "· laptop-01",
-                                      "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 11,
-                                      "fontWeight": "normal"
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
                               "type": "text",
-                              "id": "jgvpy",
-                              "name": "meta",
-                              "fill": "#15803D",
-                              "content": "now",
-                              "fontFamily": "IBM Plex Sans",
-                              "fontSize": 11,
-                              "fontWeight": "500"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "rectangle",
-                          "id": "EowTz",
-                          "name": "rowDiv1",
-                          "fill": "#F2EEE7",
-                          "width": "fill_container",
-                          "height": 1
-                        },
-                        {
-                          "type": "frame",
-                          "id": "l77KNw",
-                          "name": "row claude_code-2",
-                          "width": "fill_container",
-                          "fill": "#FFFFFF",
-                          "gap": 12,
-                          "padding": [
-                            14,
-                            18
-                          ],
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "frame",
-                              "id": "LdtK6",
-                              "name": "dotWrap",
-                              "width": 12,
-                              "height": 12,
-                              "layout": "none",
-                              "children": [
-                                {
-                                  "type": "ellipse",
-                                  "id": "mEieh",
-                                  "x": 0,
-                                  "y": 0,
-                                  "name": "halo",
-                                  "fill": "#22C55E26",
-                                  "width": 12,
-                                  "height": 12
-                                },
-                                {
-                                  "type": "ellipse",
-                                  "id": "OubcI",
-                                  "x": 3,
-                                  "y": 3,
-                                  "name": "dot",
-                                  "fill": "#22C55E",
-                                  "width": 6,
-                                  "height": 6
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "nJ5GE",
-                              "name": "txt",
-                              "width": "fill_container",
-                              "layout": "vertical",
-                              "gap": 3,
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "lpKKH",
-                                  "name": "client",
-                                  "fill": "#2C2C2C",
-                                  "content": "Backend Dev",
-                                  "fontFamily": "IBM Plex Sans",
-                                  "fontSize": 14,
-                                  "fontWeight": "600"
-                                },
-                                {
-                                  "type": "frame",
-                                  "id": "J3n4Wp",
-                                  "name": "subRow",
-                                  "width": "fill_container",
-                                  "gap": 7,
-                                  "alignItems": "center",
-                                  "children": [
-                                    {
-                                      "type": "frame",
-                                      "id": "ms05w",
-                                      "name": "typeBadge",
-                                      "fill": "#F0EDE8",
-                                      "cornerRadius": 5,
-                                      "padding": [
-                                        2,
-                                        6
-                                      ],
-                                      "children": [
-                                        {
-                                          "type": "text",
-                                          "id": "eI2Xt",
-                                          "name": "typeText",
-                                          "fill": "#6B6B6B",
-                                          "content": "Claude Code",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 10,
-                                          "fontWeight": "500"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "z2SWE",
-                                      "name": "host",
-                                      "fill": "#9A9A9A",
-                                      "content": "· devbox.local",
-                                      "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 11,
-                                      "fontWeight": "normal"
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "text",
-                              "id": "O5YiD",
-                              "name": "meta",
-                              "fill": "#15803D",
-                              "content": "4s",
-                              "fontFamily": "IBM Plex Sans",
-                              "fontSize": 11,
-                              "fontWeight": "500"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "rectangle",
-                          "id": "FNy1s",
-                          "name": "rowDiv2",
-                          "fill": "#F2EEE7",
-                          "width": "fill_container",
-                          "height": 1
-                        },
-                        {
-                          "type": "frame",
-                          "id": "a5o2t0",
-                          "name": "row openclaw-1",
-                          "width": "fill_container",
-                          "fill": "#FFFFFF",
-                          "gap": 12,
-                          "padding": [
-                            14,
-                            18
-                          ],
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "frame",
-                              "id": "d4OUk",
-                              "name": "dotWrap",
-                              "width": 12,
-                              "height": 12,
-                              "layout": "none",
-                              "children": [
-                                {
-                                  "type": "ellipse",
-                                  "id": "S2d1b",
-                                  "x": 3,
-                                  "y": 3,
-                                  "name": "dot",
-                                  "fill": "#C4BEB4",
-                                  "width": 6,
-                                  "height": 6
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "gAEfw",
-                              "name": "txt",
-                              "width": "fill_container",
-                              "layout": "vertical",
-                              "gap": 3,
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "R1MtF",
-                                  "name": "client",
-                                  "fill": "#2C2C2C",
-                                  "content": "Release Bot",
-                                  "fontFamily": "IBM Plex Sans",
-                                  "fontSize": 14,
-                                  "fontWeight": "600"
-                                },
-                                {
-                                  "type": "frame",
-                                  "id": "INzT7",
-                                  "name": "subRow",
-                                  "width": "fill_container",
-                                  "gap": 7,
-                                  "alignItems": "center",
-                                  "children": [
-                                    {
-                                      "type": "frame",
-                                      "id": "vrFZH",
-                                      "name": "typeBadge",
-                                      "fill": "#F4F1EC",
-                                      "cornerRadius": 5,
-                                      "padding": [
-                                        2,
-                                        6
-                                      ],
-                                      "children": [
-                                        {
-                                          "type": "text",
-                                          "id": "eWGvx",
-                                          "name": "typeText",
-                                          "fill": "#A39C90",
-                                          "content": "OpenClaw",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 10,
-                                          "fontWeight": "500"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "ht6Nq",
-                                      "name": "host",
-                                      "fill": "#9A9A9A",
-                                      "content": "· ci-runner-2",
-                                      "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 11,
-                                      "fontWeight": "normal"
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "text",
-                              "id": "OxVMw",
-                              "name": "meta",
+                              "id": "xFdFD",
+                              "name": "headLabel",
                               "fill": "#9A9A9A",
-                              "content": "16h",
-                              "fontFamily": "IBM Plex Sans",
+                              "content": "CONVERSATIONS",
+                              "fontFamily": "IBM Plex Mono",
                               "fontSize": 11,
-                              "fontWeight": "500"
+                              "fontWeight": "500",
+                              "letterSpacing": 0.6
+                            },
+                            {
+                              "type": "text",
+                              "id": "i2MeC",
+                              "name": "count",
+                              "fill": "#9A9A9A",
+                              "content": "4",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "zXVh4",
+                          "name": "divider",
+                          "fill": "#EFEBE4",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "RdPg6",
+                          "name": "rows",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "GWqgm",
+                              "name": "Row Pluggable data-engine layer",
+                              "width": "fill_container",
+                              "fill": "#FBF4EF",
+                              "stroke": "#F2EEE7",
+                              "strokeWidth": {
+                                "bottom": 1
+                              },
+                              "strokeAlignment": "inner",
+                              "gap": 11,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "ttjZw",
+                                  "name": "indicator",
+                                  "width": 14,
+                                  "padding": [
+                                    3,
+                                    0
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "RZs0Q",
+                                      "name": "dotWrap",
+                                      "width": 12,
+                                      "height": 12,
+                                      "layout": "none",
+                                      "children": [
+                                        {
+                                          "type": "ellipse",
+                                          "id": "rUaJX",
+                                          "x": 0,
+                                          "y": 0,
+                                          "name": "halo",
+                                          "fill": "#C67A5233",
+                                          "width": 12,
+                                          "height": 12
+                                        },
+                                        {
+                                          "type": "ellipse",
+                                          "id": "u9asvj",
+                                          "x": 3,
+                                          "y": 3,
+                                          "name": "dot",
+                                          "fill": "#C67A52",
+                                          "width": 6,
+                                          "height": 6
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "KcelS",
+                                  "name": "content",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 3,
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "gcZOo",
+                                      "name": "titleRow",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "VVLLr",
+                                          "name": "ideaBadge",
+                                          "fill": "#F3ECFB",
+                                          "cornerRadius": 5,
+                                          "gap": 3,
+                                          "padding": [
+                                            2,
+                                            6
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon",
+                                              "id": "L0zAx",
+                                              "name": "sparkIcon",
+                                              "width": 10,
+                                              "height": 10,
+                                              "icon": "sparkles",
+                                              "library": "lucide",
+                                              "fill": "#7C5BC0"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "HZzzZ",
+                                              "name": "badgeTxt",
+                                              "fill": "#7C5BC0",
+                                              "content": "Idea",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 10,
+                                              "fontWeight": "600"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "bnFV3",
+                                          "name": "title",
+                                          "fill": "#2C2C2C",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Pluggable data-engine layer",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 14,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "L0k5dk",
+                                      "name": "meta",
+                                      "gap": 8,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "X9PF5g",
+                                          "name": "statusLbl",
+                                          "fill": "#C67A52",
+                                          "content": "RUNNING",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 0.5
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "A9KLB",
+                                          "name": "time",
+                                          "fill": "#9A9A9A",
+                                          "content": "just now",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "rectangle",
+                                  "id": "JuqTy",
+                                  "layoutPosition": "absolute",
+                                  "x": 0,
+                                  "y": 8,
+                                  "name": "selSpine",
+                                  "fill": "#C67A52",
+                                  "width": 3,
+                                  "height": 52
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "THa4c",
+                              "name": "Row Ad-hoc: refactor auth context",
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "stroke": "#F2EEE7",
+                              "strokeWidth": {
+                                "bottom": 1
+                              },
+                              "strokeAlignment": "inner",
+                              "gap": 11,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "lTA6d",
+                                  "name": "indicator",
+                                  "width": 14,
+                                  "padding": [
+                                    3,
+                                    0
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "ellipse",
+                                      "id": "g2XxBP",
+                                      "name": "idleDot",
+                                      "fill": "#D7D2C9",
+                                      "width": 6,
+                                      "height": 6
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Tm5u7",
+                                  "name": "content",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 3,
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "PqoFH",
+                                      "name": "titleRow",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "YSqSQ",
+                                          "name": "title",
+                                          "fill": "#2C2C2C",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Ad-hoc: refactor auth context",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 14,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Him9J",
+                                      "name": "meta",
+                                      "gap": 8,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "F7UvLa",
+                                          "name": "time",
+                                          "fill": "#9A9A9A",
+                                          "content": "2h ago",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "l320Z",
+                              "name": "Row Daemon parallel/serial model",
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "stroke": "#F2EEE7",
+                              "strokeWidth": {
+                                "bottom": 1
+                              },
+                              "strokeAlignment": "inner",
+                              "gap": 11,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "u7iuvB",
+                                  "name": "indicator",
+                                  "width": 14,
+                                  "padding": [
+                                    3,
+                                    0
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "h7JGly",
+                                      "name": "stIcon",
+                                      "width": 13,
+                                      "height": 13,
+                                      "icon": "circle-pause",
+                                      "library": "lucide",
+                                      "fill": "#B45309"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "tvFIB",
+                                  "name": "content",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 3,
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "k2GBvr",
+                                      "name": "titleRow",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "G83b8c",
+                                          "name": "ideaBadge",
+                                          "fill": "#F3ECFB",
+                                          "cornerRadius": 5,
+                                          "gap": 3,
+                                          "padding": [
+                                            2,
+                                            6
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon",
+                                              "id": "yftmF",
+                                              "name": "sparkIcon",
+                                              "width": 10,
+                                              "height": 10,
+                                              "icon": "sparkles",
+                                              "library": "lucide",
+                                              "fill": "#7C5BC0"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "yy7Hy",
+                                              "name": "badgeTxt",
+                                              "fill": "#7C5BC0",
+                                              "content": "Idea",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 10,
+                                              "fontWeight": "600"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "s6MBFK",
+                                          "name": "title",
+                                          "fill": "#2C2C2C",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Daemon parallel/serial model",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 14,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "B1kuSE",
+                                      "name": "meta",
+                                      "gap": 8,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "xeGi5",
+                                          "name": "statusLbl",
+                                          "fill": "#B45309",
+                                          "content": "INTERRUPTED",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 0.5
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "JocIP",
+                                          "name": "time",
+                                          "fill": "#9A9A9A",
+                                          "content": "5h ago",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "YRh4U",
+                              "name": "Row Ad-hoc: tidy CHANGELOG",
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "gap": 11,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "ZEAUM",
+                                  "name": "indicator",
+                                  "width": 14,
+                                  "padding": [
+                                    3,
+                                    0
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "DJsmQ",
+                                      "name": "stIcon",
+                                      "width": 13,
+                                      "height": 13,
+                                      "icon": "triangle-alert",
+                                      "library": "lucide",
+                                      "fill": "#DC2626"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "etsrI",
+                                  "name": "content",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 3,
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "zzkzQ",
+                                      "name": "titleRow",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "g1HiwI",
+                                          "name": "title",
+                                          "fill": "#2C2C2C",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Ad-hoc: tidy CHANGELOG",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 14,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "iYPbW",
+                                      "name": "meta",
+                                      "gap": 8,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "M1DDoe",
+                                          "name": "statusLbl",
+                                          "fill": "#DC2626",
+                                          "content": "ERROR",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 0.5
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "NggDd",
+                                          "name": "time",
+                                          "fill": "#9A9A9A",
+                                          "content": "yesterday",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
                             }
                           ]
                         }
@@ -91303,7 +91867,7 @@
                 },
                 {
                   "type": "frame",
-                  "id": "zrAm0",
+                  "id": "ShWZD",
                   "name": "Detail Panel",
                   "clip": true,
                   "width": "fill_container",
@@ -91317,87 +91881,318 @@
                   "children": [
                     {
                       "type": "frame",
-                      "id": "cD4N8",
-                      "name": "detailHeader",
+                      "id": "azEBq",
+                      "name": "transcriptHeader",
                       "width": "fill_container",
-                      "gap": 14,
+                      "layout": "vertical",
+                      "gap": 12,
                       "padding": [
-                        22,
+                        20,
                         24
                       ],
-                      "justifyContent": "space_between",
                       "children": [
                         {
                           "type": "frame",
-                          "id": "Xz8FA",
-                          "name": "headLeft",
+                          "id": "NND87",
+                          "name": "headTopRow",
+                          "width": "fill_container",
                           "gap": 14,
-                          "alignItems": "center",
+                          "justifyContent": "space_between",
                           "children": [
                             {
                               "type": "frame",
-                              "id": "bhuWK",
-                              "name": "iconWrap",
-                              "width": 44,
-                              "height": 44,
-                              "fill": "#C67A5214",
-                              "cornerRadius": 10,
-                              "justifyContent": "center",
-                              "alignItems": "center",
+                              "id": "xPDBD",
+                              "name": "titleWrap",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 6,
                               "children": [
                                 {
-                                  "type": "icon",
-                                  "id": "YYTlz",
-                                  "name": "clientIcon",
-                                  "width": 22,
-                                  "height": 22,
-                                  "icon": "bot",
-                                  "library": "lucide",
-                                  "fill": "#C67A52"
+                                  "type": "frame",
+                                  "id": "mt3yy",
+                                  "name": "tline",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "WXaHC",
+                                      "name": "ideaBadge",
+                                      "fill": "#F3ECFB",
+                                      "cornerRadius": 5,
+                                      "gap": 3,
+                                      "padding": [
+                                        2,
+                                        7
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon",
+                                          "id": "mEaFs",
+                                          "name": "sp",
+                                          "width": 11,
+                                          "height": 11,
+                                          "icon": "sparkles",
+                                          "library": "lucide",
+                                          "fill": "#7C5BC0"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "b4Bzpd",
+                                          "name": "t",
+                                          "fill": "#7C5BC0",
+                                          "content": "Idea",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 10,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "MCB4J",
+                                      "name": "convTitle",
+                                      "fill": "#2C2C2C",
+                                      "content": "Pluggable data-engine layer",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 17,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "TQxsb",
+                                  "name": "detailsToggle",
+                                  "gap": 6,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "XdOii",
+                                      "name": "chev",
+                                      "width": 14,
+                                      "height": 14,
+                                      "icon": "chevron-down",
+                                      "library": "lucide",
+                                      "fill": "#9A9A9A"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "Le3qb",
+                                      "name": "detLbl",
+                                      "fill": "#9A9A9A",
+                                      "content": "Connection details",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "xiABy",
+                                      "name": "detMeta",
+                                      "fill": "#B6B0A6",
+                                      "content": "·  Laptop-Q3  ·  Uptime 00:07:42  ·  Started 14:21",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
                                 }
                               ]
                             },
                             {
                               "type": "frame",
-                              "id": "GX7wL",
-                              "name": "idCol",
+                              "id": "HSm3t",
+                              "name": "runningBadge",
+                              "fill": "#FBF0E8",
+                              "cornerRadius": 999,
+                              "gap": 6,
+                              "padding": [
+                                5,
+                                11
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "t3jFY5",
+                                  "name": "loader",
+                                  "width": 12,
+                                  "height": 12,
+                                  "icon": "loader",
+                                  "library": "lucide",
+                                  "fill": "#C67A52"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "UrOg4",
+                                  "name": "runTxt",
+                                  "fill": "#C67A52",
+                                  "content": "Running",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "zaNjr",
+                      "name": "headDivider",
+                      "fill": "#EFEBE4",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CVjcD",
+                      "name": "transcriptBody",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "#FCFBF8",
+                      "layout": "vertical",
+                      "gap": 18,
+                      "padding": [
+                        20,
+                        24
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mvj0Z",
+                          "name": "loadEarlier",
+                          "fill": "#C67A52",
+                          "content": "Load earlier messages",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nC8RD",
+                          "name": "Turn 1",
+                          "width": "fill_container",
+                          "gap": 14,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "O1gfGu",
+                              "name": "spine",
+                              "width": 3,
+                              "height": "fill_container",
+                              "fill": "#EFEBE4",
+                              "cornerRadius": 2
+                            },
+                            {
+                              "type": "frame",
+                              "id": "V5Bjy",
+                              "name": "col",
+                              "width": "fill_container",
                               "layout": "vertical",
-                              "gap": 4,
+                              "gap": 11,
                               "children": [
                                 {
                                   "type": "frame",
-                                  "id": "B2x7r",
-                                  "name": "nameRow",
-                                  "gap": 8,
+                                  "id": "XmG1E",
+                                  "name": "eyebrow",
+                                  "width": "fill_container",
+                                  "gap": 10,
                                   "alignItems": "center",
                                   "children": [
                                     {
+                                      "type": "frame",
+                                      "id": "vpln2",
+                                      "name": "trigger",
+                                      "gap": 5,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon",
+                                          "id": "ZGcxv",
+                                          "name": "tIcon",
+                                          "width": 14,
+                                          "height": 14,
+                                          "icon": "sparkles",
+                                          "library": "lucide",
+                                          "fill": "#6B6B6B"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "UZBIC",
+                                          "name": "tLbl",
+                                          "fill": "#6B6B6B",
+                                          "content": "Elaboration",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 12,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
                                       "type": "text",
-                                      "id": "WeZsu",
-                                      "name": "clientName",
-                                      "fill": "#2C2C2C",
-                                      "content": "Admin Claude",
-                                      "fontFamily": "IBM Plex Sans",
-                                      "fontSize": 18,
-                                      "fontWeight": "600"
+                                      "id": "vsrfY",
+                                      "name": "seq",
+                                      "fill": "#B6B0A6",
+                                      "content": "Turn 1",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "qYycq",
-                                      "name": "typeBadgeD",
+                                      "id": "D8Xicd",
+                                      "name": "statusBadge",
                                       "fill": "#F0EDE8",
-                                      "cornerRadius": 6,
+                                      "cornerRadius": 999,
+                                      "gap": 5,
                                       "padding": [
                                         3,
                                         8
                                       ],
+                                      "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "m4OIa4",
-                                          "name": "typeTextD",
+                                          "id": "ohIUu",
+                                          "name": "sbt",
                                           "fill": "#6B6B6B",
-                                          "content": "Claude Code",
+                                          "content": "Ended",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 10,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "E54GR6",
+                                      "name": "openLink",
+                                      "gap": 4,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon",
+                                          "id": "t8NCSw",
+                                          "name": "ext",
+                                          "width": 11,
+                                          "height": 11,
+                                          "icon": "external-link",
+                                          "library": "lucide",
+                                          "fill": "#C67A52"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "Hvcir",
+                                          "name": "lkt",
+                                          "fill": "#C67A52",
+                                          "content": "Open idea",
                                           "fontFamily": "IBM Plex Sans",
                                           "fontSize": 11,
                                           "fontWeight": "500"
@@ -91407,13 +92202,1869 @@
                                   ]
                                 },
                                 {
+                                  "type": "frame",
+                                  "id": "uljkc",
+                                  "name": "messages",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 12,
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "At6fn",
+                                      "name": "msg You",
+                                      "width": "fill_container",
+                                      "layout": "vertical",
+                                      "gap": 5,
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "RfBBN",
+                                          "name": "msgHead",
+                                          "gap": 7,
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "frame",
+                                              "id": "vsWdZ",
+                                              "name": "roleAvatar",
+                                              "width": 18,
+                                              "height": 18,
+                                              "fill": "#E7E1D7",
+                                              "cornerRadius": 9,
+                                              "justifyContent": "center",
+                                              "alignItems": "center",
+                                              "children": [
+                                                {
+                                                  "type": "icon",
+                                                  "id": "dfwSA",
+                                                  "name": "ic",
+                                                  "width": 11,
+                                                  "height": 11,
+                                                  "icon": "user",
+                                                  "library": "lucide",
+                                                  "fill": "#6B6B6B"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "u7ags",
+                                              "name": "role",
+                                              "fill": "#2C2C2C",
+                                              "content": "You",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 12,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "OJ1Pi",
+                                              "name": "time",
+                                              "fill": "#9A9A9A",
+                                              "content": "14:21",
+                                              "fontFamily": "IBM Plex Mono",
+                                              "fontSize": 10,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "S8tVJY",
+                                          "name": "bubble",
+                                          "width": "fill_container",
+                                          "fill": "#F4EFE8",
+                                          "cornerRadius": 10,
+                                          "stroke": "#EFEBE4",
+                                          "strokeWidth": 1,
+                                          "strokeAlignment": "inner",
+                                          "padding": [
+                                            10,
+                                            13
+                                          ],
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "BznJi",
+                                              "name": "txt",
+                                              "fill": "#2C2C2C",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "Verified the elaboration — please write the proposal: document drafts plus a task DAG.",
+                                              "lineHeight": 1.5,
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 13,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Mq7ed",
+                                      "name": "msg Agent",
+                                      "width": "fill_container",
+                                      "layout": "vertical",
+                                      "gap": 5,
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "REEtz",
+                                          "name": "msgHead",
+                                          "gap": 7,
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "frame",
+                                              "id": "tRsD8",
+                                              "name": "roleAvatar",
+                                              "width": 18,
+                                              "height": 18,
+                                              "fill": "#C67A52",
+                                              "cornerRadius": 9,
+                                              "justifyContent": "center",
+                                              "alignItems": "center",
+                                              "children": [
+                                                {
+                                                  "type": "icon",
+                                                  "id": "Nxvo5",
+                                                  "name": "ic",
+                                                  "width": 11,
+                                                  "height": 11,
+                                                  "icon": "bot",
+                                                  "library": "lucide",
+                                                  "fill": "#FFFFFF"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "fI9aH",
+                                              "name": "role",
+                                              "fill": "#2C2C2C",
+                                              "content": "Agent",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 12,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "B4TKUW",
+                                              "name": "time",
+                                              "fill": "#9A9A9A",
+                                              "content": "14:22",
+                                              "fontFamily": "IBM Plex Mono",
+                                              "fontSize": 10,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "AZ9zz",
+                                          "name": "bubble",
+                                          "width": "fill_container",
+                                          "fill": "#FFFFFF",
+                                          "cornerRadius": 10,
+                                          "stroke": "#EFEBE4",
+                                          "strokeWidth": 1,
+                                          "strokeAlignment": "inner",
+                                          "padding": [
+                                            10,
+                                            13
+                                          ],
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "kK2Yp",
+                                              "name": "txt",
+                                              "fill": "#2C2C2C",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "Got it. Drafting a PRD for the pluggable engine layer and breaking it into 6 tasks with dependencies.",
+                                              "lineHeight": 1.5,
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 13,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZUXD8",
+                          "name": "Turn 2",
+                          "width": "fill_container",
+                          "gap": 14,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "qCZ4I",
+                              "name": "spine",
+                              "width": 3,
+                              "height": "fill_container",
+                              "fill": "#C67A52",
+                              "cornerRadius": 2
+                            },
+                            {
+                              "type": "frame",
+                              "id": "U6e8s",
+                              "name": "col",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 11,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "iBatL",
+                                  "name": "eyebrow",
+                                  "width": "fill_container",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "BGQ9c",
+                                      "name": "trigger",
+                                      "gap": 5,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon",
+                                          "id": "EJ4y7",
+                                          "name": "tIcon",
+                                          "width": 14,
+                                          "height": 14,
+                                          "icon": "pen-line",
+                                          "library": "lucide",
+                                          "fill": "#6B6B6B"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "S5E7X",
+                                          "name": "tLbl",
+                                          "fill": "#6B6B6B",
+                                          "content": "Instruction",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 12,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "i0d5S",
+                                      "name": "seq",
+                                      "fill": "#B6B0A6",
+                                      "content": "Turn 2",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ptxYk",
+                                      "name": "statusBadge",
+                                      "fill": "#FBF0E8",
+                                      "cornerRadius": 999,
+                                      "gap": 5,
+                                      "padding": [
+                                        3,
+                                        8
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon",
+                                          "id": "AMmnr",
+                                          "name": "sl",
+                                          "width": 11,
+                                          "height": 11,
+                                          "icon": "loader",
+                                          "library": "lucide",
+                                          "fill": "#C67A52"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "GHrUT",
+                                          "name": "sbt",
+                                          "fill": "#C67A52",
+                                          "content": "Running",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 10,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "LYcPA",
+                                  "name": "messages",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 12,
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "aoTGd",
+                                      "name": "msg You",
+                                      "width": "fill_container",
+                                      "layout": "vertical",
+                                      "gap": 5,
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "vTZqI",
+                                          "name": "msgHead",
+                                          "gap": 7,
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "frame",
+                                              "id": "Hie5Z",
+                                              "name": "roleAvatar",
+                                              "width": 18,
+                                              "height": 18,
+                                              "fill": "#E7E1D7",
+                                              "cornerRadius": 9,
+                                              "justifyContent": "center",
+                                              "alignItems": "center",
+                                              "children": [
+                                                {
+                                                  "type": "icon",
+                                                  "id": "E2rdri",
+                                                  "name": "ic",
+                                                  "width": 11,
+                                                  "height": 11,
+                                                  "icon": "user",
+                                                  "library": "lucide",
+                                                  "fill": "#6B6B6B"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "vLlvy",
+                                              "name": "role",
+                                              "fill": "#2C2C2C",
+                                              "content": "You",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 12,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "CWu1Z",
+                                              "name": "time",
+                                              "fill": "#9A9A9A",
+                                              "content": "15:03",
+                                              "fontFamily": "IBM Plex Mono",
+                                              "fontSize": 10,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "xaRCK",
+                                          "name": "bubble",
+                                          "width": "fill_container",
+                                          "fill": "#F4EFE8",
+                                          "cornerRadius": 10,
+                                          "stroke": "#EFEBE4",
+                                          "strokeWidth": 1,
+                                          "strokeAlignment": "inner",
+                                          "padding": [
+                                            10,
+                                            13
+                                          ],
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "njNXW",
+                                              "name": "txt",
+                                              "fill": "#2C2C2C",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "Add Athena as the first concrete adapter and note the config schema.",
+                                              "lineHeight": 1.5,
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 13,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "OZQ2I",
+                                      "name": "msg Agent",
+                                      "width": "fill_container",
+                                      "layout": "vertical",
+                                      "gap": 5,
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "yp4ML",
+                                          "name": "msgHead",
+                                          "gap": 7,
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "frame",
+                                              "id": "XufzE",
+                                              "name": "roleAvatar",
+                                              "width": 18,
+                                              "height": 18,
+                                              "fill": "#C67A52",
+                                              "cornerRadius": 9,
+                                              "justifyContent": "center",
+                                              "alignItems": "center",
+                                              "children": [
+                                                {
+                                                  "type": "icon",
+                                                  "id": "p3N8wk",
+                                                  "name": "ic",
+                                                  "width": 11,
+                                                  "height": 11,
+                                                  "icon": "bot",
+                                                  "library": "lucide",
+                                                  "fill": "#FFFFFF"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "eBVxt",
+                                              "name": "role",
+                                              "fill": "#2C2C2C",
+                                              "content": "Agent",
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 12,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "LnHo5",
+                                              "name": "time",
+                                              "fill": "#9A9A9A",
+                                              "content": "15:03",
+                                              "fontFamily": "IBM Plex Mono",
+                                              "fontSize": 10,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "iN36Y",
+                                          "name": "bubble",
+                                          "width": "fill_container",
+                                          "fill": "#FFFFFF",
+                                          "cornerRadius": 10,
+                                          "stroke": "#EFEBE4",
+                                          "strokeWidth": 1,
+                                          "strokeAlignment": "inner",
+                                          "padding": [
+                                            10,
+                                            13
+                                          ],
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "vRw4A",
+                                              "name": "txt",
+                                              "fill": "#2C2C2C",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "Working on it — adding the AthenaAdapter and a JSON-schema for connection config now…",
+                                              "lineHeight": 1.5,
+                                              "fontFamily": "IBM Plex Sans",
+                                              "fontSize": 13,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "kswpX",
+                      "name": "footDivider",
+                      "fill": "#EFEBE4",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gi42a",
+                      "name": "composer",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF",
+                      "gap": 10,
+                      "padding": [
+                        16,
+                        24
+                      ],
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "PpItx",
+                          "name": "textarea",
+                          "width": "fill_container",
+                          "height": 56,
+                          "fill": "#FCFBF8",
+                          "cornerRadius": 10,
+                          "stroke": "#E5E0D8",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            11,
+                            13
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "zs1cX",
+                              "name": "placeholder",
+                              "fill": "#A8A29A",
+                              "content": "Reply in this conversation…",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Y6FBto",
+                          "name": "sendBtn",
+                          "height": 38,
+                          "fill": "#C67A52",
+                          "cornerRadius": 9,
+                          "gap": 7,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "FrRrc",
+                              "name": "sendIcon",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "send",
+                              "library": "lucide",
+                              "fill": "#FFFFFF"
+                            },
+                            {
+                              "type": "text",
+                              "id": "g9ptP",
+                              "name": "sendTxt",
+                              "fill": "#FFFFFF",
+                              "content": "Send",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "BjCWC",
+                          "name": "interruptBtn",
+                          "height": 38,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 9,
+                          "stroke": "#EBD9C4",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "gap": 7,
+                          "padding": [
+                            0,
+                            15
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "SDzRD",
+                              "name": "intIcon",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "octagon-x",
+                              "library": "lucide",
+                              "fill": "#B45309"
+                            },
+                            {
+                              "type": "text",
+                              "id": "aUVWO",
+                              "name": "intTxt",
+                              "fill": "#B45309",
+                              "content": "Interrupt",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "a3aZRC",
+      "x": 3812,
+      "y": 24126,
+      "name": "Mobile - Daemon Conversations (List)",
+      "clip": true,
+      "width": 390,
+      "height": 844,
+      "fill": "#FAF8F4",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "bx60z",
+          "name": "statusbar",
+          "width": "fill_container",
+          "height": 44,
+          "fill": "#FAF8F4",
+          "padding": [
+            0,
+            20
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "Q4ZEqT",
+              "name": "time",
+              "fill": "#2C2C2C",
+              "content": "9:41",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "icon",
+              "id": "IIu8a",
+              "name": "sig",
+              "width": 18,
+              "height": 18,
+              "icon": "signal-high",
+              "library": "lucide",
+              "fill": "#2C2C2C"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "w8m9A0",
+          "name": "topbar",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#EFEBE4",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            12,
+            18
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "D5nUW",
+              "name": "title",
+              "fill": "#2C2C2C",
+              "content": "Conversations",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 18,
+              "fontWeight": "600"
+            },
+            {
+              "type": "icon",
+              "id": "cpJZt",
+              "name": "close",
+              "width": 20,
+              "height": 20,
+              "icon": "x",
+              "library": "lucide",
+              "fill": "#6B6B6B"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "p1Aijz",
+          "name": "controls",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 10,
+          "padding": [
+            14,
+            18
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "vJDyS",
+              "name": "SelectTrigger",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 9,
+              "stroke": "#E5E0D8",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "padding": [
+                10,
+                12
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Xb5xH",
+                  "name": "selLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hDX4C",
+                      "name": "av",
+                      "width": 22,
+                      "height": 22,
+                      "fill": "#C67A52",
+                      "cornerRadius": 11,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "VpJqP",
+                          "name": "b",
+                          "width": 13,
+                          "height": 13,
+                          "icon": "bot",
+                          "library": "lucide",
+                          "fill": "#FFFFFF"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "fzzHZ",
+                      "name": "v",
+                      "fill": "#2C2C2C",
+                      "content": "Admin Claude",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "icon",
+                  "id": "yYUPx",
+                  "name": "c",
+                  "width": 17,
+                  "height": 17,
+                  "icon": "chevron-down",
+                  "library": "lucide",
+                  "fill": "#9A9A9A"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cz1eU",
+              "name": "New Conversation Button",
+              "width": "fill_container",
+              "height": 42,
+              "fill": "#C67A52",
+              "cornerRadius": 9,
+              "gap": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "qPAe6",
+                  "name": "p",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "message-circle-plus",
+                  "library": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "XqcGW",
+                  "name": "l",
+                  "fill": "#FFFFFF",
+                  "content": "New conversation",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "MkKif",
+          "name": "listHeader",
+          "width": "fill_container",
+          "padding": [
+            10,
+            18
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "xR2bZ",
+              "name": "hl",
+              "fill": "#9A9A9A",
+              "content": "CONVERSATIONS",
+              "fontFamily": "IBM Plex Mono",
+              "fontSize": 11,
+              "fontWeight": "normal",
+              "letterSpacing": 0.6
+            },
+            {
+              "type": "text",
+              "id": "Y6k66",
+              "name": "ct",
+              "fill": "#9A9A9A",
+              "content": "4",
+              "fontFamily": "IBM Plex Mono",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "M5jpDP",
+          "name": "rows",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "gON8a",
+              "name": "Row Pluggable data-engine layer",
+              "width": "fill_container",
+              "fill": "#FBF4EF",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "gap": 12,
+              "padding": [
+                15,
+                18
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Qvm1q",
+                  "name": "indicator",
+                  "width": 14,
+                  "padding": [
+                    3,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zv81J",
+                      "name": "dotWrap",
+                      "width": 12,
+                      "height": 12,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "H3yN6",
+                          "x": 0,
+                          "y": 0,
+                          "name": "halo",
+                          "fill": "#C67A5233",
+                          "width": 12,
+                          "height": 12
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "e46z4S",
+                          "x": 3,
+                          "y": 3,
+                          "name": "dot",
+                          "fill": "#C67A52",
+                          "width": 6,
+                          "height": 6
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "l5lgv9",
+                  "name": "content",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "KUVOK",
+                      "name": "titleRow",
+                      "width": "fill_container",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "b1O67",
+                          "name": "ideaBadge",
+                          "fill": "#F3ECFB",
+                          "cornerRadius": 5,
+                          "gap": 3,
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "zQCMj",
+                              "name": "s",
+                              "width": 10,
+                              "height": 10,
+                              "icon": "sparkles",
+                              "library": "lucide",
+                              "fill": "#7C5BC0"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hW4JM",
+                              "name": "t",
+                              "fill": "#7C5BC0",
+                              "content": "Idea",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "E7s2L",
+                          "name": "title",
+                          "fill": "#2C2C2C",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Pluggable data-engine layer",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14.5,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "T0Skr",
+                      "name": "meta",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "u09Xi",
+                          "name": "sl",
+                          "fill": "#C67A52",
+                          "content": "RUNNING",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "text",
+                          "id": "Jll6F",
+                          "name": "tm",
+                          "fill": "#9A9A9A",
+                          "content": "just now",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "icon",
+                  "id": "mENh3",
+                  "name": "chev",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "chevron-right",
+                  "library": "lucide",
+                  "fill": "#C7C1B7"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "M7h22l",
+                  "layoutPosition": "absolute",
+                  "x": 0,
+                  "y": 10,
+                  "name": "selSpine",
+                  "fill": "#C67A52",
+                  "width": 3,
+                  "height": 54
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ggbg0",
+              "name": "Row Ad-hoc: refactor auth context",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "gap": 12,
+              "padding": [
+                15,
+                18
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "eD0ii",
+                  "name": "indicator",
+                  "width": 14,
+                  "padding": [
+                    3,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "ih7yM",
+                      "name": "idle",
+                      "fill": "#D7D2C9",
+                      "width": 6,
+                      "height": 6
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JO28O",
+                  "name": "content",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c0QvsQ",
+                      "name": "titleRow",
+                      "width": "fill_container",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "gbDrb",
+                          "name": "title",
+                          "fill": "#2C2C2C",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Ad-hoc: refactor auth context",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14.5,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FjUwt",
+                      "name": "meta",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "OVPoO",
+                          "name": "tm",
+                          "fill": "#9A9A9A",
+                          "content": "2h ago",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "icon",
+                  "id": "PV1MS",
+                  "name": "chev",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "chevron-right",
+                  "library": "lucide",
+                  "fill": "#C7C1B7"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "x3H2qZ",
+              "name": "Row Daemon parallel/serial model",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "gap": 12,
+              "padding": [
+                15,
+                18
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Nyd5I",
+                  "name": "indicator",
+                  "width": 14,
+                  "padding": [
+                    3,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "fumzq",
+                      "name": "st",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "circle-pause",
+                      "library": "lucide",
+                      "fill": "#B45309"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "EOW2n",
+                  "name": "content",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "difmC",
+                      "name": "titleRow",
+                      "width": "fill_container",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "G254u",
+                          "name": "ideaBadge",
+                          "fill": "#F3ECFB",
+                          "cornerRadius": 5,
+                          "gap": 3,
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "Hlv2r",
+                              "name": "s",
+                              "width": 10,
+                              "height": 10,
+                              "icon": "sparkles",
+                              "library": "lucide",
+                              "fill": "#7C5BC0"
+                            },
+                            {
+                              "type": "text",
+                              "id": "KXZsB",
+                              "name": "t",
+                              "fill": "#7C5BC0",
+                              "content": "Idea",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "rdplZ",
+                          "name": "title",
+                          "fill": "#2C2C2C",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Daemon parallel/serial model",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14.5,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "d6oDk",
+                      "name": "meta",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "MyXfz",
+                          "name": "sl",
+                          "fill": "#B45309",
+                          "content": "INTERRUPTED",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "text",
+                          "id": "CtO3T",
+                          "name": "tm",
+                          "fill": "#9A9A9A",
+                          "content": "5h ago",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "icon",
+                  "id": "pE7IO",
+                  "name": "chev",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "chevron-right",
+                  "library": "lucide",
+                  "fill": "#C7C1B7"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "FvNi7",
+              "name": "Row Ad-hoc: tidy CHANGELOG",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": "#F2EEE7",
+              "strokeAlignment": "inner",
+              "gap": 12,
+              "padding": [
+                15,
+                18
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Jo5F7",
+                  "name": "indicator",
+                  "width": 14,
+                  "padding": [
+                    3,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "y5BjNL",
+                      "name": "st",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "triangle-alert",
+                      "library": "lucide",
+                      "fill": "#DC2626"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "DXWMU",
+                  "name": "content",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ZcER7",
+                      "name": "titleRow",
+                      "width": "fill_container",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WWjpG",
+                          "name": "title",
+                          "fill": "#2C2C2C",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Ad-hoc: tidy CHANGELOG",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 14.5,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "X0G9W",
+                      "name": "meta",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RsJQT",
+                          "name": "sl",
+                          "fill": "#DC2626",
+                          "content": "ERROR",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "text",
+                          "id": "S28tjd",
+                          "name": "tm",
+                          "fill": "#9A9A9A",
+                          "content": "yesterday",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "icon",
+                  "id": "ymSVI",
+                  "name": "chev",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "chevron-right",
+                  "library": "lucide",
+                  "fill": "#C7C1B7"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "OYbTA",
+      "x": 4302,
+      "y": 24126,
+      "name": "Mobile - Daemon Transcript (Drill-down)",
+      "clip": true,
+      "width": 390,
+      "height": 844,
+      "fill": "#FCFBF8",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "o6r1zs",
+          "name": "statusbar",
+          "width": "fill_container",
+          "height": 44,
+          "fill": "#FFFFFF",
+          "padding": [
+            0,
+            20
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "S4dvf",
+              "name": "time",
+              "fill": "#2C2C2C",
+              "content": "9:41",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "icon",
+              "id": "SsuWw",
+              "name": "sig",
+              "width": 18,
+              "height": 18,
+              "icon": "signal-high",
+              "library": "lucide",
+              "fill": "#2C2C2C"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Qinel",
+          "name": "backHeader",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#EFEBE4",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "strokeAlignment": "inner",
+          "gap": 6,
+          "padding": [
+            12,
+            14
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon",
+              "id": "Monoc",
+              "name": "chev",
+              "width": 20,
+              "height": 20,
+              "icon": "chevron-left",
+              "library": "lucide",
+              "fill": "#C67A52"
+            },
+            {
+              "type": "text",
+              "id": "j84TR",
+              "name": "bt",
+              "fill": "#C67A52",
+              "content": "Conversations",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 14,
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "r4C5R",
+          "name": "transcriptHead",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#EFEBE4",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 9,
+          "padding": [
+            14,
+            18
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Ck7VL",
+              "name": "tl",
+              "width": "fill_container",
+              "gap": 7,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "P0PqoD",
+                  "name": "ideaBadge",
+                  "fill": "#F3ECFB",
+                  "cornerRadius": 5,
+                  "gap": 3,
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "osUah",
+                      "name": "s",
+                      "width": 10,
+                      "height": 10,
+                      "icon": "sparkles",
+                      "library": "lucide",
+                      "fill": "#7C5BC0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "aJX2m",
+                      "name": "t",
+                      "fill": "#7C5BC0",
+                      "content": "Idea",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "tWzxw",
+                  "name": "ct",
+                  "fill": "#2C2C2C",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Pluggable data-engine layer",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 15.5,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QLyuK",
+              "name": "badgeRow",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "I2aZmp",
+                  "name": "runningBadge",
+                  "fill": "#FBF0E8",
+                  "cornerRadius": 999,
+                  "gap": 5,
+                  "padding": [
+                    4,
+                    9
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "yZhCK",
+                      "name": "ld",
+                      "width": 11,
+                      "height": 11,
+                      "icon": "loader",
+                      "library": "lucide",
+                      "fill": "#C67A52"
+                    },
+                    {
+                      "type": "text",
+                      "id": "iSTP8",
+                      "name": "rt",
+                      "fill": "#C67A52",
+                      "content": "Running",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "KXCYL",
+                  "name": "dm",
+                  "fill": "#B6B0A6",
+                  "content": "Laptop-Q3 · 00:07:42",
+                  "fontFamily": "IBM Plex Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ji8Vl",
+          "name": "transcriptBody",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#FCFBF8",
+          "layout": "vertical",
+          "gap": 14,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "Pb7RS",
+              "name": "Turn 1",
+              "width": "fill_container",
+              "gap": 11,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RAj5e",
+                  "name": "spine",
+                  "width": 3,
+                  "height": "fill_container",
+                  "fill": "#EFEBE4",
+                  "cornerRadius": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "PG1u6",
+                  "name": "col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 9,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "R8utcG",
+                      "name": "eyebrow",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ti2Ah",
+                          "name": "trigger",
+                          "gap": 5,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "R0cr4j",
+                              "name": "ti",
+                              "width": 13,
+                              "height": 13,
+                              "icon": "sparkles",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "cglgX",
+                              "name": "tl",
+                              "fill": "#6B6B6B",
+                              "content": "Elaboration",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "QoiY6",
+                          "name": "sq",
+                          "fill": "#B6B0A6",
+                          "content": "Turn 1",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "aMQZN",
+                          "name": "sbadge",
+                          "fill": "#F0EDE8",
+                          "cornerRadius": 999,
+                          "gap": 4,
+                          "padding": [
+                            2,
+                            7
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NB7r6",
+                              "name": "sbt",
+                              "fill": "#6B6B6B",
+                              "content": "Ended",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Dbtta",
+                      "name": "messages",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "P49Xn",
+                          "name": "msg You",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 5,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "FpcA1",
+                              "name": "msgHead",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "Y8pnE",
+                                  "name": "av",
+                                  "width": 17,
+                                  "height": 17,
+                                  "fill": "#E7E1D7",
+                                  "cornerRadius": 9,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "dKH3w",
+                                      "name": "ic",
+                                      "width": 10,
+                                      "height": 10,
+                                      "icon": "user",
+                                      "library": "lucide",
+                                      "fill": "#6B6B6B"
+                                    }
+                                  ]
+                                },
+                                {
                                   "type": "text",
-                                  "id": "MRsIb",
-                                  "name": "clientHost",
-                                  "fill": "#9A9A9A",
-                                  "content": "v0.11.0 · laptop-01",
-                                  "fontFamily": "IBM Plex Mono",
+                                  "id": "MeeKj",
+                                  "name": "role",
+                                  "fill": "#2C2C2C",
+                                  "content": "You",
+                                  "fontFamily": "IBM Plex Sans",
                                   "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "HGphy",
+                                  "name": "time",
+                                  "fill": "#9A9A9A",
+                                  "content": "14:21",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "pIiGk",
+                              "name": "bubble",
+                              "width": "fill_container",
+                              "fill": "#F4EFE8",
+                              "cornerRadius": 10,
+                              "stroke": "#EFEBE4",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "padding": [
+                                9,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "S7ceRL",
+                                  "name": "txt",
+                                  "fill": "#2C2C2C",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Verified the elaboration — please write the proposal.",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
                                   "fontWeight": "normal"
                                 }
                               ]
@@ -91422,339 +94073,305 @@
                         },
                         {
                           "type": "frame",
-                          "id": "z9U63",
-                          "name": "statusBadge",
-                          "fill": "#DCFCE7",
-                          "cornerRadius": 999,
-                          "gap": 7,
-                          "padding": [
-                            7,
-                            12
-                          ],
-                          "alignItems": "center",
+                          "id": "vK2Gt",
+                          "name": "msg Agent",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 5,
                           "children": [
                             {
                               "type": "frame",
-                              "id": "K3OZ4x",
-                              "name": "sbDotWrap",
-                              "width": 10,
-                              "height": 10,
-                              "layout": "none",
+                              "id": "y66Ose",
+                              "name": "msgHead",
+                              "gap": 6,
+                              "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "ellipse",
-                                  "id": "yPzNf",
-                                  "x": 0,
-                                  "y": 0,
-                                  "name": "halo",
-                                  "fill": "#22C55E40",
-                                  "width": 10,
-                                  "height": 10
+                                  "type": "frame",
+                                  "id": "IEbSY",
+                                  "name": "av",
+                                  "width": 17,
+                                  "height": 17,
+                                  "fill": "#C67A52",
+                                  "cornerRadius": 9,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "TLoar",
+                                      "name": "ic",
+                                      "width": 10,
+                                      "height": 10,
+                                      "icon": "bot",
+                                      "library": "lucide",
+                                      "fill": "#FFFFFF"
+                                    }
+                                  ]
                                 },
                                 {
-                                  "type": "ellipse",
-                                  "id": "HcQFd",
-                                  "x": 2,
-                                  "y": 2,
-                                  "name": "dot",
-                                  "fill": "#22C55E",
-                                  "width": 6,
-                                  "height": 6
+                                  "type": "text",
+                                  "id": "AEs1Z",
+                                  "name": "role",
+                                  "fill": "#2C2C2C",
+                                  "content": "Agent",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Yltds",
+                                  "name": "time",
+                                  "fill": "#9A9A9A",
+                                  "content": "14:22",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
                                 }
                               ]
                             },
                             {
+                              "type": "frame",
+                              "id": "ZMg5f",
+                              "name": "bubble",
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "cornerRadius": 10,
+                              "stroke": "#EFEBE4",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "padding": [
+                                9,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "trpD0",
+                                  "name": "txt",
+                                  "fill": "#2C2C2C",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Drafting a PRD and breaking it into 6 tasks with dependencies.",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wcqzo",
+              "name": "Turn 2",
+              "width": "fill_container",
+              "gap": 11,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "q4iI3",
+                  "name": "spine",
+                  "width": 3,
+                  "height": "fill_container",
+                  "fill": "#C67A52",
+                  "cornerRadius": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "ki50i",
+                  "name": "col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 9,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sZodn",
+                      "name": "eyebrow",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "guPq9",
+                          "name": "trigger",
+                          "gap": 5,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "NJ5sW",
+                              "name": "ti",
+                              "width": 13,
+                              "height": 13,
+                              "icon": "pen-line",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
                               "type": "text",
-                              "id": "pPJc6",
-                              "name": "sbText",
-                              "fill": "#15803D",
-                              "content": "ONLINE",
+                              "id": "lhA0t",
+                              "name": "tl",
+                              "fill": "#6B6B6B",
+                              "content": "Instruction",
                               "fontFamily": "IBM Plex Sans",
-                              "fontSize": 11,
-                              "fontWeight": "600",
-                              "letterSpacing": 0.5
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "h5ESvi",
+                          "name": "sq",
+                          "fill": "#B6B0A6",
+                          "content": "Turn 2",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "V0hfGq",
+                          "name": "sbadge",
+                          "fill": "#FBF0E8",
+                          "cornerRadius": 999,
+                          "gap": 4,
+                          "padding": [
+                            2,
+                            7
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "rDRzi",
+                              "name": "sl",
+                              "width": 10,
+                              "height": 10,
+                              "icon": "loader",
+                              "library": "lucide",
+                              "fill": "#C67A52"
+                            },
+                            {
+                              "type": "text",
+                              "id": "E2sMhq",
+                              "name": "sbt",
+                              "fill": "#C67A52",
+                              "content": "Running",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "600"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "type": "rectangle",
-                      "id": "NjYWU",
-                      "name": "headDivider",
-                      "fill": "#EFEBE4",
-                      "width": "fill_container",
-                      "height": 1
-                    },
-                    {
                       "type": "frame",
-                      "id": "yJijD",
-                      "name": "detailBody",
+                      "id": "AMKFh",
+                      "name": "messages",
                       "width": "fill_container",
-                      "height": "fill_container",
                       "layout": "vertical",
-                      "gap": 24,
-                      "padding": 24,
+                      "gap": 10,
                       "children": [
                         {
                           "type": "frame",
-                          "id": "OprqN",
-                          "name": "statGrid",
+                          "id": "Ngjao",
+                          "name": "msg You",
                           "width": "fill_container",
                           "layout": "vertical",
-                          "gap": 14,
+                          "gap": 5,
                           "children": [
                             {
                               "type": "frame",
-                              "id": "EtHGo",
-                              "name": "gridRow1",
-                              "width": "fill_container",
-                              "gap": 14,
+                              "id": "dF77E",
+                              "name": "msgHead",
+                              "gap": 6,
+                              "alignItems": "center",
                               "children": [
                                 {
                                   "type": "frame",
-                                  "id": "sDg2a",
-                                  "name": "tile Uptime",
-                                  "width": "fill_container",
-                                  "fill": "#FAF8F4",
-                                  "cornerRadius": 12,
-                                  "stroke": "#EFEBE4",
-                                  "strokeWidth": 1,
-                                  "strokeAlignment": "inner",
-                                  "layout": "vertical",
-                                  "gap": 8,
-                                  "padding": [
-                                    16,
-                                    18
-                                  ],
+                                  "id": "X01GJb",
+                                  "name": "av",
+                                  "width": 17,
+                                  "height": 17,
+                                  "fill": "#E7E1D7",
+                                  "cornerRadius": 9,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "frame",
-                                      "id": "Xk8xG",
-                                      "name": "labelRow",
-                                      "gap": 7,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "icon",
-                                          "id": "Xmp4D",
-                                          "name": "ic",
-                                          "width": 14,
-                                          "height": 14,
-                                          "icon": "timer",
-                                          "library": "lucide",
-                                          "fill": "#C67A52"
-                                        },
-                                        {
-                                          "type": "text",
-                                          "id": "RDYhS",
-                                          "name": "lbl",
-                                          "fill": "#9A9A9A",
-                                          "content": "Uptime",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 12,
-                                          "fontWeight": "500",
-                                          "letterSpacing": 0.3
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "MHyvZ",
-                                      "name": "val",
-                                      "fill": "#2C2C2C",
-                                      "content": "00:07:42",
-                                      "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 22,
-                                      "fontWeight": "500"
+                                      "type": "icon",
+                                      "id": "KEGKB",
+                                      "name": "ic",
+                                      "width": 10,
+                                      "height": 10,
+                                      "icon": "user",
+                                      "library": "lucide",
+                                      "fill": "#6B6B6B"
                                     }
                                   ]
                                 },
                                 {
-                                  "type": "frame",
-                                  "id": "o2djc",
-                                  "name": "tile Last active",
-                                  "width": "fill_container",
-                                  "fill": "#FAF8F4",
-                                  "cornerRadius": 12,
-                                  "stroke": "#EFEBE4",
-                                  "strokeWidth": 1,
-                                  "strokeAlignment": "inner",
-                                  "layout": "vertical",
-                                  "gap": 8,
-                                  "padding": [
-                                    16,
-                                    18
-                                  ],
-                                  "children": [
-                                    {
-                                      "type": "frame",
-                                      "id": "ZDPat",
-                                      "name": "labelRow",
-                                      "gap": 7,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "icon",
-                                          "id": "hdaMs",
-                                          "name": "ic",
-                                          "width": 14,
-                                          "height": 14,
-                                          "icon": "activity",
-                                          "library": "lucide",
-                                          "fill": "#C67A52"
-                                        },
-                                        {
-                                          "type": "text",
-                                          "id": "mRoUm",
-                                          "name": "lbl",
-                                          "fill": "#9A9A9A",
-                                          "content": "Last active",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 12,
-                                          "fontWeight": "500",
-                                          "letterSpacing": 0.3
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "bXBkL",
-                                      "name": "val",
-                                      "fill": "#2C2C2C",
-                                      "content": "just now",
-                                      "fontFamily": "IBM Plex Sans",
-                                      "fontSize": 16,
-                                      "fontWeight": "500"
-                                    }
-                                  ]
+                                  "type": "text",
+                                  "id": "FAj7V",
+                                  "name": "role",
+                                  "fill": "#2C2C2C",
+                                  "content": "You",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "JrHqG",
+                                  "name": "time",
+                                  "fill": "#9A9A9A",
+                                  "content": "15:03",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
                                 }
                               ]
                             },
                             {
                               "type": "frame",
-                              "id": "zYG0n",
-                              "name": "gridRow2",
+                              "id": "htZGg",
+                              "name": "bubble",
                               "width": "fill_container",
-                              "gap": 14,
+                              "fill": "#F4EFE8",
+                              "cornerRadius": 10,
+                              "stroke": "#EFEBE4",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "padding": [
+                                9,
+                                12
+                              ],
                               "children": [
                                 {
-                                  "type": "frame",
-                                  "id": "NY9MK",
-                                  "name": "tile Started",
+                                  "type": "text",
+                                  "id": "X9ntw",
+                                  "name": "txt",
+                                  "fill": "#2C2C2C",
+                                  "textGrowth": "fixed-width",
                                   "width": "fill_container",
-                                  "fill": "#FAF8F4",
-                                  "cornerRadius": 12,
-                                  "stroke": "#EFEBE4",
-                                  "strokeWidth": 1,
-                                  "strokeAlignment": "inner",
-                                  "layout": "vertical",
-                                  "gap": 8,
-                                  "padding": [
-                                    16,
-                                    18
-                                  ],
-                                  "children": [
-                                    {
-                                      "type": "frame",
-                                      "id": "WmxZ5",
-                                      "name": "labelRow",
-                                      "gap": 7,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "icon",
-                                          "id": "iw6BK",
-                                          "name": "ic",
-                                          "width": 14,
-                                          "height": 14,
-                                          "icon": "calendar-clock",
-                                          "library": "lucide",
-                                          "fill": "#C67A52"
-                                        },
-                                        {
-                                          "type": "text",
-                                          "id": "GLw7c",
-                                          "name": "lbl",
-                                          "fill": "#9A9A9A",
-                                          "content": "Started",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 12,
-                                          "fontWeight": "500",
-                                          "letterSpacing": 0.3
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "idOlR",
-                                      "name": "val",
-                                      "fill": "#2C2C2C",
-                                      "content": "2 days ago",
-                                      "fontFamily": "IBM Plex Sans",
-                                      "fontSize": 16,
-                                      "fontWeight": "500"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "frame",
-                                  "id": "rQutX",
-                                  "name": "tile Host",
-                                  "width": "fill_container",
-                                  "fill": "#FAF8F4",
-                                  "cornerRadius": 12,
-                                  "stroke": "#EFEBE4",
-                                  "strokeWidth": 1,
-                                  "strokeAlignment": "inner",
-                                  "layout": "vertical",
-                                  "gap": 8,
-                                  "padding": [
-                                    16,
-                                    18
-                                  ],
-                                  "children": [
-                                    {
-                                      "type": "frame",
-                                      "id": "Q2DEzx",
-                                      "name": "labelRow",
-                                      "gap": 7,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "icon",
-                                          "id": "xEp5J",
-                                          "name": "ic",
-                                          "width": 14,
-                                          "height": 14,
-                                          "icon": "server",
-                                          "library": "lucide",
-                                          "fill": "#C67A52"
-                                        },
-                                        {
-                                          "type": "text",
-                                          "id": "fQmhO",
-                                          "name": "lbl",
-                                          "fill": "#9A9A9A",
-                                          "content": "Host",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 12,
-                                          "fontWeight": "500",
-                                          "letterSpacing": 0.3
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "h10NN",
-                                      "name": "val",
-                                      "fill": "#2C2C2C",
-                                      "content": "laptop-01",
-                                      "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 16,
-                                      "fontWeight": "500"
-                                    }
-                                  ]
+                                  "content": "Add Athena as the first concrete adapter.",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
                                 }
                               ]
                             }
@@ -91762,288 +94379,227 @@
                         },
                         {
                           "type": "frame",
-                          "id": "x4XANg",
-                          "name": "Executions",
+                          "id": "e6OUj",
+                          "name": "msg Agent",
                           "width": "fill_container",
-                          "height": "fill_container",
-                          "fill": "#FCFBF8",
-                          "cornerRadius": 12,
-                          "stroke": "#EFEBE4",
-                          "strokeWidth": 1,
-                          "strokeAlignment": "inner",
                           "layout": "vertical",
-                          "gap": 14,
-                          "padding": 20,
+                          "gap": 5,
                           "children": [
                             {
                               "type": "frame",
-                              "id": "fs9bF",
-                              "name": "execHead",
-                              "width": "fill_container",
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "uC6jj",
-                                  "name": "execTitle",
-                                  "fill": "#9A9A9A",
-                                  "content": "RUNNING & QUEUED",
-                                  "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 11,
-                                  "fontWeight": "500",
-                                  "letterSpacing": 1
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "qP4Wg",
-                                  "name": "execCount",
-                                  "fill": "#9A9A9A",
-                                  "content": "1 running · 1 queued",
-                                  "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 11,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "e9Asa",
-                              "name": "runningRow",
-                              "width": "fill_container",
-                              "fill": "#FFFFFF",
-                              "cornerRadius": 10,
-                              "stroke": "#EFEBE4",
-                              "strokeWidth": 1,
-                              "strokeAlignment": "inner",
-                              "gap": 12,
-                              "padding": [
-                                12,
-                                14
-                              ],
-                              "justifyContent": "space_between",
+                              "id": "Tppxy",
+                              "name": "msgHead",
+                              "gap": 6,
                               "alignItems": "center",
                               "children": [
                                 {
                                   "type": "frame",
-                                  "id": "SNllA",
-                                  "name": "runInfo",
-                                  "layout": "vertical",
-                                  "gap": 5,
-                                  "children": [
-                                    {
-                                      "type": "text",
-                                      "id": "gv7ic",
-                                      "name": "runTitle",
-                                      "fill": "#2C2C2C",
-                                      "content": "Implement auth module",
-                                      "fontFamily": "IBM Plex Sans",
-                                      "fontSize": 14,
-                                      "fontWeight": "600"
-                                    },
-                                    {
-                                      "type": "frame",
-                                      "id": "w3Shn1",
-                                      "name": "runMeta",
-                                      "gap": 8,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "frame",
-                                          "id": "gAqfU",
-                                          "name": "runBadge",
-                                          "fill": "#DCFCE7",
-                                          "cornerRadius": 999,
-                                          "gap": 6,
-                                          "padding": [
-                                            4,
-                                            9
-                                          ],
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "ellipse",
-                                              "id": "XOJUe",
-                                              "name": "runDot",
-                                              "fill": "#22C55E",
-                                              "width": 6,
-                                              "height": 6
-                                            },
-                                            {
-                                              "type": "text",
-                                              "id": "bNft0",
-                                              "name": "runBadgeTxt",
-                                              "fill": "#15803D",
-                                              "content": "running 3m",
-                                              "fontFamily": "IBM Plex Sans",
-                                              "fontSize": 11,
-                                              "fontWeight": "500"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "text",
-                                          "id": "UOcCb",
-                                          "name": "runRoot",
-                                          "fill": "#9A9A9A",
-                                          "content": "root idea: Auth revamp",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 12,
-                                          "fontWeight": "normal"
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "frame",
-                                  "id": "vDxDd",
-                                  "name": "interruptBtn",
-                                  "fill": "#FFFFFF",
-                                  "cornerRadius": 8,
-                                  "stroke": "#E5C2C2",
-                                  "strokeWidth": 1,
-                                  "strokeAlignment": "inner",
-                                  "gap": 6,
-                                  "padding": [
-                                    8,
-                                    14
-                                  ],
+                                  "id": "GgCvH",
+                                  "name": "av",
+                                  "width": 17,
+                                  "height": 17,
+                                  "fill": "#C67A52",
+                                  "cornerRadius": 9,
+                                  "justifyContent": "center",
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "icon",
-                                      "id": "INv8N",
-                                      "name": "interruptIcon",
-                                      "width": 14,
-                                      "height": 14,
-                                      "icon": "square",
+                                      "id": "q6cMLF",
+                                      "name": "ic",
+                                      "width": 10,
+                                      "height": 10,
+                                      "icon": "bot",
                                       "library": "lucide",
-                                      "fill": "#DC2626"
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "b35Jcv",
-                                      "name": "interruptTxt",
-                                      "fill": "#DC2626",
-                                      "content": "Interrupt",
-                                      "fontFamily": "IBM Plex Sans",
-                                      "fontSize": 13,
-                                      "fontWeight": "500"
+                                      "fill": "#FFFFFF"
                                     }
                                   ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "PesGj",
+                                  "name": "role",
+                                  "fill": "#2C2C2C",
+                                  "content": "Agent",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "ZNO4C",
+                                  "name": "time",
+                                  "fill": "#9A9A9A",
+                                  "content": "15:03",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
                                 }
                               ]
                             },
                             {
                               "type": "frame",
-                              "id": "v3Py7G",
-                              "name": "queuedRow",
+                              "id": "NTvYg",
+                              "name": "bubble",
                               "width": "fill_container",
                               "fill": "#FFFFFF",
                               "cornerRadius": 10,
                               "stroke": "#EFEBE4",
                               "strokeWidth": 1,
                               "strokeAlignment": "inner",
-                              "gap": 12,
                               "padding": [
-                                12,
-                                14
+                                9,
+                                12
                               ],
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "frame",
-                                  "id": "ZBhYz",
-                                  "name": "qInfo",
-                                  "layout": "vertical",
-                                  "gap": 5,
-                                  "children": [
-                                    {
-                                      "type": "text",
-                                      "id": "J1iBO",
-                                      "name": "qTitle",
-                                      "fill": "#2C2C2C",
-                                      "content": "Write integration tests",
-                                      "fontFamily": "IBM Plex Sans",
-                                      "fontSize": 14,
-                                      "fontWeight": "600"
-                                    },
-                                    {
-                                      "type": "frame",
-                                      "id": "u61Xj",
-                                      "name": "qMeta",
-                                      "gap": 8,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "frame",
-                                          "id": "Fgg7U",
-                                          "name": "qBadge",
-                                          "fill": "#F5F2EC",
-                                          "cornerRadius": 999,
-                                          "gap": 6,
-                                          "padding": [
-                                            4,
-                                            9
-                                          ],
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "icon",
-                                              "id": "A7ZXV",
-                                              "name": "qIcon",
-                                              "width": 12,
-                                              "height": 12,
-                                              "icon": "clock",
-                                              "library": "lucide",
-                                              "fill": "#9A9A9A"
-                                            },
-                                            {
-                                              "type": "text",
-                                              "id": "R07L0",
-                                              "name": "qBadgeTxt",
-                                              "fill": "#6B6B6B",
-                                              "content": "queued",
-                                              "fontFamily": "IBM Plex Sans",
-                                              "fontSize": 11,
-                                              "fontWeight": "500"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "text",
-                                          "id": "IwJcD",
-                                          "name": "qRoot",
-                                          "fill": "#9A9A9A",
-                                          "content": "waiting for a slot",
-                                          "fontFamily": "IBM Plex Sans",
-                                          "fontSize": 12,
-                                          "fontWeight": "normal"
-                                        }
-                                      ]
-                                    }
-                                  ]
+                                  "type": "text",
+                                  "id": "t9KIxb",
+                                  "name": "txt",
+                                  "fill": "#2C2C2C",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Working on it — adding the AthenaAdapter now…",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
                                 }
                               ]
-                            },
-                            {
-                              "type": "text",
-                              "id": "Evy4x",
-                              "name": "execHint",
-                              "fill": "#9A9A9A",
-                              "textGrowth": "fixed-width",
-                              "width": "fill_container",
-                              "content": "Only your own connections expose an Interrupt action. Two-stage SIGINT then force-kill; the task moves to Interrupted.",
-                              "lineHeight": 1.5,
-                              "fontFamily": "IBM Plex Sans",
-                              "fontSize": 12,
-                              "fontWeight": "normal"
                             }
                           ]
                         }
                       ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "J3mTy",
+          "name": "composer",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#EFEBE4",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 10,
+          "padding": [
+            12,
+            16,
+            16,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "dpAt7",
+              "name": "textarea",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "#FCFBF8",
+              "cornerRadius": 10,
+              "stroke": "#E5E0D8",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "padding": [
+                11,
+                13
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "b1nPS",
+                  "name": "ph",
+                  "fill": "#A8A29A",
+                  "content": "Reply in this conversation…",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UeX2M",
+              "name": "btnRow",
+              "width": "fill_container",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ki1qQ",
+                  "name": "sendBtn",
+                  "width": "fill_container",
+                  "height": 42,
+                  "fill": "#C67A52",
+                  "cornerRadius": 9,
+                  "gap": 7,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Sfn91",
+                      "name": "si",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "send",
+                      "library": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "v64c7a",
+                      "name": "st",
+                      "fill": "#FFFFFF",
+                      "content": "Send",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "nWd79",
+                  "name": "interruptBtn",
+                  "width": "fill_container",
+                  "height": 42,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 9,
+                  "stroke": "#EBD9C4",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "gap": 7,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "DB4UK",
+                      "name": "ii",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "octagon-x",
+                      "library": "lucide",
+                      "fill": "#B45309"
+                    },
+                    {
+                      "type": "text",
+                      "id": "RSjDU",
+                      "name": "it",
+                      "fill": "#B45309",
+                      "content": "Interrupt",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "600"
                     }
                   ]
                 }
@@ -92055,65 +94611,358 @@
     },
     {
       "type": "frame",
-      "id": "Mul8X",
-      "x": 1493,
-      "y": 23941,
-      "name": "Agent Connections - Mobile (List)",
+      "id": "O1m13A",
+      "x": 1580,
+      "y": 24126,
+      "name": "Chorus - Agent Presence Popover",
       "clip": true,
-      "width": 390,
-      "height": 844,
+      "width": 1440,
+      "height": 940,
       "fill": "#FAF8F4",
-      "layout": "vertical",
       "children": [
         {
           "type": "frame",
-          "id": "z91I0q",
-          "name": "statusBar",
-          "width": "fill_container",
-          "height": 44,
+          "id": "LtoBc",
+          "name": "Sidebar",
+          "width": 220,
+          "height": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#E5E2DC",
+          "strokeWidth": {
+            "right": 1
+          },
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 32,
           "padding": [
-            0,
-            24
+            24,
+            20
           ],
           "justifyContent": "space_between",
-          "alignItems": "center",
           "children": [
             {
-              "type": "text",
-              "id": "diEIw",
-              "name": "time",
-              "fill": "#2C2C2C",
-              "content": "9:41",
-              "fontFamily": "IBM Plex Sans",
-              "fontSize": 14,
-              "fontWeight": "600"
+              "type": "frame",
+              "id": "S1S94R",
+              "name": "Sidebar Top",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 32,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KltGW",
+                  "name": "Logo",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 4,
+                      "id": "xbIHi",
+                      "name": "logoMark",
+                      "fill": "#C67A52",
+                      "width": 28,
+                      "height": 28
+                    },
+                    {
+                      "type": "text",
+                      "id": "r3Tmp",
+                      "name": "logoText",
+                      "fill": "#2C2C2C",
+                      "content": "Chorus",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "fBnKu",
+                  "name": "Navigation",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "X2NAHD",
+                      "name": "navProjects",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "TGPok",
+                          "name": "ProjectsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "folder",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "elp46",
+                          "name": "ProjectsText",
+                          "fill": "#6B6B6B",
+                          "content": "Projects",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fH7z5",
+                      "name": "navActivity",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "J26Xm7",
+                          "name": "ActivityIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "activity",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Y8T0OC",
+                          "name": "ActivityText",
+                          "fill": "#6B6B6B",
+                          "content": "Activity",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "q8iWJ",
+                      "name": "navDaemons",
+                      "width": "fill_container",
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "snSQz",
+                          "name": "DaemonsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "radio-tower",
+                          "library": "lucide",
+                          "fill": "#2C2C2C"
+                        },
+                        {
+                          "type": "text",
+                          "id": "UbncE",
+                          "name": "DaemonsText",
+                          "fill": "#2C2C2C",
+                          "content": "Agent Connections",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DNLnG",
+                      "name": "navSettings",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "L0XVO",
+                          "name": "SettingsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "settings",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "SUBhc",
+                          "name": "SettingsText",
+                          "fill": "#6B6B6B",
+                          "content": "Settings",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "frame",
-              "id": "n26GQk",
-              "name": "statusRight",
-              "gap": 6,
-              "alignItems": "center",
+              "id": "A8KUYL",
+              "name": "Sidebar Bottom",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
               "children": [
                 {
-                  "type": "icon",
-                  "id": "gbf4Z",
-                  "name": "signal",
-                  "width": 16,
-                  "height": 16,
-                  "icon": "signal-high",
-                  "library": "lucide",
-                  "fill": "#2C2C2C"
+                  "type": "frame",
+                  "id": "fENdJ",
+                  "name": "Agent Presence Pill",
+                  "width": "fill_container",
+                  "fill": "#FCFBF8",
+                  "cornerRadius": 12,
+                  "stroke": "#E7E1D7",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "gap": 9,
+                  "padding": [
+                    9,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Mgk6v",
+                      "name": "dotWrap",
+                      "width": 12,
+                      "height": 12,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "UyX1f",
+                          "x": 0,
+                          "y": 0,
+                          "name": "halo",
+                          "fill": "#15803D33",
+                          "width": 12,
+                          "height": 12
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "ao5Mu",
+                          "x": 3,
+                          "y": 3,
+                          "name": "dot",
+                          "fill": "#15803D",
+                          "width": 6,
+                          "height": 6
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "J5xVSl",
+                      "name": "count",
+                      "fill": "#15803D",
+                      "content": "2",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "A6Qau",
+                      "name": "unit",
+                      "fill": "#4B7A57",
+                      "content": "agents online",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
                 },
                 {
-                  "type": "icon",
-                  "id": "EsH11",
-                  "name": "battery",
-                  "width": 18,
-                  "height": 18,
-                  "icon": "battery-medium",
-                  "library": "lucide",
-                  "fill": "#2C2C2C"
+                  "type": "frame",
+                  "id": "TGPvL",
+                  "name": "userProfile",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "m55owe",
+                      "name": "avatar",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#C67A52",
+                      "cornerRadius": 18,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qy6y9",
+                          "name": "avatarText",
+                          "fill": "#FFFFFF",
+                          "content": "A",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tD19j",
+                      "name": "userInfo",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "BHsr4",
+                          "name": "userName",
+                          "fill": "#2C2C2C",
+                          "content": "Alice Chen",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "S9CHMl",
+                          "name": "userRole",
+                          "fill": "#6B6B6B",
+                          "content": "Tech Lead",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -92121,816 +94970,792 @@
         },
         {
           "type": "frame",
-          "id": "RxdfQ",
-          "name": "mHeader",
+          "id": "eeM96",
+          "name": "Main Content",
           "width": "fill_container",
+          "height": "fill_container",
           "layout": "vertical",
-          "gap": 12,
+          "gap": 22,
           "padding": [
-            16,
-            20
+            24,
+            32
           ],
           "children": [
             {
               "type": "frame",
-              "id": "icDG1",
-              "name": "mTitleRow",
+              "id": "JtPNP",
+              "name": "Top Bar",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
               "children": [
                 {
                   "type": "text",
-                  "id": "eMi4p",
-                  "name": "mTitle",
-                  "fill": "#2C2C2C",
-                  "content": "Agent Connections",
+                  "id": "C4qd6",
+                  "name": "bc",
+                  "fill": "#9A9A9A",
+                  "content": "Chorus / Projects",
                   "fontFamily": "IBM Plex Sans",
-                  "fontSize": 22,
-                  "fontWeight": "600"
+                  "fontSize": 12,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "frame",
-                  "id": "mtaw6",
-                  "name": "mSum",
-                  "fill": "#FFFFFF",
-                  "cornerRadius": 999,
-                  "stroke": "#E5E0D8",
-                  "strokeWidth": 1,
-                  "strokeAlignment": "inner",
-                  "gap": 7,
-                  "padding": [
-                    6,
-                    11
-                  ],
+                  "id": "RfQT9",
+                  "name": "acts",
+                  "gap": 16,
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "frame",
-                      "id": "Fjorr",
-                      "name": "dotWrap",
-                      "width": 10,
-                      "height": 10,
-                      "layout": "none",
-                      "children": [
-                        {
-                          "type": "ellipse",
-                          "id": "y80S5w",
-                          "x": 0,
-                          "y": 0,
-                          "name": "halo",
-                          "fill": "#22C55E26",
-                          "width": 10,
-                          "height": 10
-                        },
-                        {
-                          "type": "ellipse",
-                          "id": "RcbIA",
-                          "x": 2,
-                          "y": 2,
-                          "name": "dot",
-                          "fill": "#22C55E",
-                          "width": 6,
-                          "height": 6
-                        }
-                      ]
+                      "type": "icon",
+                      "id": "MwSyV",
+                      "name": "s",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "search",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
                     },
                     {
-                      "type": "text",
-                      "id": "Y541dV",
-                      "name": "mSumLbl",
-                      "fill": "#2C2C2C",
-                      "content": "2/3",
-                      "fontFamily": "IBM Plex Sans",
-                      "fontSize": 12,
-                      "fontWeight": "600"
+                      "type": "icon",
+                      "id": "RFKfw",
+                      "name": "b",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "bell",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
                     }
                   ]
                 }
               ]
             },
             {
-              "type": "text",
-              "id": "mnvWb",
-              "name": "mSub",
-              "fill": "#6B6B6B",
-              "textGrowth": "fixed-width",
+              "type": "frame",
+              "id": "dC6Bp",
+              "name": "Title Section",
+              "width": 680,
+              "layout": "vertical",
+              "gap": 5,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "x1PtQL",
+                  "name": "pt",
+                  "fill": "#2C2C2C",
+                  "content": "Projects",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 24,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "uPs3a",
+                  "name": "ps",
+                  "fill": "#6B6B6B",
+                  "content": "Your active projects and recent work.",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "i1LXD",
+              "name": "projGrid",
               "width": "fill_container",
-              "content": "Local agents connected on your behalf, in real time.",
-              "lineHeight": 1.4,
-              "fontFamily": "IBM Plex Sans",
-              "fontSize": 13,
-              "fontWeight": "normal"
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ATlgf",
+                  "name": "proj Chorus 0.11.0",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "J61Cp",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pgNC6",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "Chorus 0.11.0",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eCUDG",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "12 ideas · 3 in progress",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "pAr8m",
+                      "name": "ar",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "woztj",
+                  "name": "proj MCS 1.3.0",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hFxES",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zyJjG",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "MCS 1.3.0",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "X7uUE3",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "1 idea · awaiting conduct",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "c341r",
+                      "name": "ar",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "M8KSgm",
+                  "name": "proj Data Engine Demo",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QEA2c",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NqDay",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "Data Engine Demo",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "oXtow",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "1 idea · in progress",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "nGzBY",
+                      "name": "ar",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "type": "frame",
-          "id": "sIDh3",
-          "name": "mList",
-          "width": "fill_container",
-          "height": "fill_container",
+          "id": "i6zGQ",
+          "layoutPosition": "absolute",
+          "x": 212,
+          "y": 262,
+          "name": "Presence Popover",
+          "width": 340,
+          "fill": "#FFFFFF",
+          "cornerRadius": 14,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#1A141033",
+            "offset": {
+              "x": 0,
+              "y": 16
+            },
+            "blur": 40
+          },
           "layout": "vertical",
-          "gap": 12,
-          "padding": [
-            4,
-            20,
-            20,
-            20
-          ],
           "children": [
             {
               "type": "frame",
-              "id": "O4Fjk4",
-              "name": "mCard Admin Claude",
+              "id": "Nx68p",
+              "name": "popHeader",
               "width": "fill_container",
-              "fill": "#FFFFFF",
-              "cornerRadius": 14,
-              "stroke": "#E5E0D8",
-              "strokeWidth": 1,
-              "strokeAlignment": "inner",
-              "layout": "vertical",
-              "gap": 14,
-              "padding": 16,
+              "padding": [
+                13,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
               "children": [
                 {
+                  "type": "text",
+                  "id": "y9VV0",
+                  "name": "pht",
+                  "fill": "#6B6B6B",
+                  "content": "ONLINE AGENTS",
+                  "fontFamily": "IBM Plex Mono",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.6
+                },
+                {
                   "type": "frame",
-                  "id": "MyhDc",
-                  "name": "top",
-                  "width": "fill_container",
-                  "gap": 12,
+                  "id": "J6T9t",
+                  "name": "summary",
+                  "gap": 6,
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "frame",
-                      "id": "alwXi",
-                      "name": "iconWrap",
-                      "width": 40,
-                      "height": 40,
-                      "fill": "#C67A5214",
-                      "cornerRadius": 10,
-                      "justifyContent": "center",
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "icon",
-                          "id": "FlmGJ",
-                          "name": "ic",
-                          "width": 20,
-                          "height": 20,
-                          "icon": "bot",
-                          "library": "lucide",
-                          "fill": "#C67A52"
-                        }
-                      ]
+                      "type": "ellipse",
+                      "id": "R7Vi0a",
+                      "name": "d",
+                      "fill": "#15803D",
+                      "width": 6,
+                      "height": 6
                     },
                     {
-                      "type": "frame",
-                      "id": "q95jzO",
-                      "name": "idc",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 4,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "k2Asfw",
-                          "name": "agent",
-                          "fill": "#2C2C2C",
-                          "content": "Admin Claude",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 16,
-                          "fontWeight": "600"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "TYdlT",
-                          "name": "sub",
-                          "gap": 7,
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "frame",
-                              "id": "ZUsI6",
-                              "name": "badge",
-                              "fill": "#F0EDE8",
-                              "cornerRadius": 5,
-                              "padding": [
-                                2,
-                                6
-                              ],
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "jpEoG",
-                                  "name": "bt",
-                                  "fill": "#6B6B6B",
-                                  "content": "Claude Code",
-                                  "fontFamily": "IBM Plex Sans",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "text",
-                              "id": "Wv0GH",
-                              "name": "host",
-                              "fill": "#9A9A9A",
-                              "content": "· laptop-01",
-                              "fontFamily": "IBM Plex Mono",
-                              "fontSize": 11,
-                              "fontWeight": "normal"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "jgTCu",
-                      "name": "statusBadge",
-                      "fill": "#DCFCE7",
-                      "cornerRadius": 999,
-                      "gap": 6,
-                      "padding": [
-                        6,
-                        10
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "frame",
-                          "id": "YGxdf",
-                          "name": "dotWrap",
-                          "width": 8,
-                          "height": 8,
-                          "layout": "none",
-                          "children": [
-                            {
-                              "type": "ellipse",
-                              "id": "v6UKcW",
-                              "x": 0,
-                              "y": 0,
-                              "name": "halo",
-                              "fill": "#22C55E40",
-                              "width": 8,
-                              "height": 8
-                            },
-                            {
-                              "type": "ellipse",
-                              "id": "JSZzV",
-                              "x": 1,
-                              "y": 1,
-                              "name": "dot",
-                              "fill": "#22C55E",
-                              "width": 6,
-                              "height": 6
-                            }
-                          ]
-                        },
-                        {
-                          "type": "text",
-                          "id": "t8v0Rn",
-                          "name": "st",
-                          "fill": "#15803D",
-                          "content": "Online",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "600"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "rectangle",
-                  "id": "ojhR3",
-                  "name": "cdiv",
-                  "fill": "#F2EEE7",
-                  "width": "fill_container",
-                  "height": 1
-                },
-                {
-                  "type": "frame",
-                  "id": "g2hefk",
-                  "name": "stats",
-                  "width": "fill_container",
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "oHbeS",
-                      "name": "stat Uptime",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 3,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "XzFvH",
-                          "name": "l",
-                          "fill": "#9A9A9A",
-                          "content": "Uptime",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "rURgj",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "00:07:42",
-                          "fontFamily": "IBM Plex Mono",
-                          "fontSize": 14,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "KgQxn",
-                      "name": "stat Last active",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 3,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "rZJOr",
-                          "name": "l",
-                          "fill": "#9A9A9A",
-                          "content": "Last active",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "BNKXA",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "just now",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 14,
-                          "fontWeight": "500"
-                        }
-                      ]
+                      "type": "text",
+                      "id": "Q7y4sL",
+                      "name": "t",
+                      "fill": "#9A9A9A",
+                      "content": "2 / 3",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
                     }
                   ]
                 }
               ]
             },
             {
-              "type": "frame",
-              "id": "U9Enj4",
-              "name": "mCard Backend Dev",
+              "type": "rectangle",
+              "id": "pIIsI",
+              "name": "div",
+              "fill": "#EFEBE4",
               "width": "fill_container",
-              "fill": "#FFFFFF",
-              "cornerRadius": 14,
-              "stroke": "#E5E0D8",
-              "strokeWidth": 1,
-              "strokeAlignment": "inner",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "uszAf",
+              "name": "connList",
+              "width": "fill_container",
               "layout": "vertical",
-              "gap": 14,
-              "padding": 16,
               "children": [
                 {
                   "type": "frame",
-                  "id": "UMuuY",
-                  "name": "top",
+                  "id": "dWL8z",
+                  "name": "conn Admin Claude",
                   "width": "fill_container",
-                  "gap": 12,
-                  "alignItems": "center",
+                  "stroke": "#F2EEE7",
+                  "strokeWidth": {
+                    "bottom": 1
+                  },
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "gap": 9,
+                  "padding": [
+                    13,
+                    16
+                  ],
                   "children": [
                     {
                       "type": "frame",
-                      "id": "w0idQ",
-                      "name": "iconWrap",
-                      "width": 40,
-                      "height": 40,
-                      "fill": "#C67A5214",
-                      "cornerRadius": 10,
-                      "justifyContent": "center",
+                      "id": "S0s22",
+                      "name": "identity",
+                      "width": "fill_container",
+                      "gap": 9,
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon",
-                          "id": "EidW2",
-                          "name": "ic",
-                          "width": 20,
-                          "height": 20,
-                          "icon": "bot",
-                          "library": "lucide",
-                          "fill": "#C67A52"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "DPuaU",
-                      "name": "idc",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 4,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "y5U6A",
-                          "name": "agent",
-                          "fill": "#2C2C2C",
-                          "content": "Backend Dev",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 16,
-                          "fontWeight": "600"
-                        },
-                        {
                           "type": "frame",
-                          "id": "xMCyr",
-                          "name": "sub",
-                          "gap": 7,
+                          "id": "M4t2vG",
+                          "name": "av",
+                          "width": 26,
+                          "height": 26,
+                          "fill": "#C67A52",
+                          "cornerRadius": 13,
+                          "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "frame",
-                              "id": "g97zWs",
-                              "name": "badge",
-                              "fill": "#F0EDE8",
-                              "cornerRadius": 5,
-                              "padding": [
-                                2,
-                                6
-                              ],
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "g1fMxD",
-                                  "name": "bt",
-                                  "fill": "#6B6B6B",
-                                  "content": "Claude Code",
-                                  "fontFamily": "IBM Plex Sans",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
+                              "type": "icon",
+                              "id": "zi5NY",
+                              "name": "b",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "bot",
+                              "library": "lucide",
+                              "fill": "#FFFFFF"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "huwmB",
+                          "name": "nm",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 1,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "D3tfv",
+                              "name": "an",
+                              "fill": "#2C2C2C",
+                              "content": "Admin Claude",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13.5,
+                              "fontWeight": "600"
                             },
                             {
                               "type": "text",
-                              "id": "hrsK7",
+                              "id": "I39hD",
                               "name": "host",
                               "fill": "#9A9A9A",
-                              "content": "· devbox.local",
-                              "fontFamily": "IBM Plex Mono",
+                              "content": "Laptop-Q3",
+                              "fontFamily": "IBM Plex Sans",
                               "fontSize": 11,
                               "fontWeight": "normal"
                             }
                           ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "x9QGu",
+                          "name": "clientBadge",
+                          "fill": "#F5F2EC",
+                          "cornerRadius": 5,
+                          "padding": [
+                            2,
+                            7
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mNebr",
+                              "name": "cbt",
+                              "fill": "#6B6B6B",
+                              "content": "Claude Code",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "500"
+                            }
+                          ]
                         }
                       ]
                     },
                     {
                       "type": "frame",
-                      "id": "B9n4b",
-                      "name": "statusBadge",
-                      "fill": "#DCFCE7",
-                      "cornerRadius": 999,
-                      "gap": 6,
-                      "padding": [
-                        6,
-                        10
-                      ],
-                      "alignItems": "center",
+                      "id": "d8d0Rq",
+                      "name": "runSec",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
                       "children": [
                         {
                           "type": "frame",
-                          "id": "zxMSw",
-                          "name": "dotWrap",
-                          "width": 8,
-                          "height": 8,
-                          "layout": "none",
+                          "id": "upDR6",
+                          "name": "secHead",
+                          "gap": 5,
+                          "alignItems": "center",
                           "children": [
                             {
-                              "type": "ellipse",
-                              "id": "y0XXEv",
-                              "x": 0,
-                              "y": 0,
-                              "name": "halo",
-                              "fill": "#22C55E40",
-                              "width": 8,
-                              "height": 8
+                              "type": "icon",
+                              "id": "Dy5OY",
+                              "name": "pi",
+                              "width": 11,
+                              "height": 11,
+                              "icon": "play",
+                              "library": "lucide",
+                              "fill": "#C67A52"
                             },
                             {
-                              "type": "ellipse",
-                              "id": "Cw8nv",
-                              "x": 1,
-                              "y": 1,
-                              "name": "dot",
-                              "fill": "#22C55E",
-                              "width": 6,
-                              "height": 6
+                              "type": "text",
+                              "id": "Y98qo",
+                              "name": "sht",
+                              "fill": "#C67A52",
+                              "content": "RUNNING",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "600",
+                              "letterSpacing": 0.5
                             }
                           ]
                         },
                         {
-                          "type": "text",
-                          "id": "OFwy8",
-                          "name": "st",
-                          "fill": "#15803D",
-                          "content": "Online",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "600"
+                          "type": "frame",
+                          "id": "ahoD6",
+                          "name": "exec Pluggable data-engine layer",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            7,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "v3qYeM",
+                              "name": "ei",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "sparkles",
+                              "library": "lucide",
+                              "fill": "#7C5BC0"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Awoy7",
+                              "name": "et",
+                              "fill": "#2C2C2C",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Pluggable data-engine layer",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12.5,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "cDYno",
+                              "name": "tm",
+                              "fill": "#9A9A9A",
+                              "content": "01:42",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 10.5,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TkmPp",
+                          "name": "qHead",
+                          "gap": 5,
+                          "padding": [
+                            6,
+                            0,
+                            0,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "f6ehz",
+                              "name": "qi",
+                              "width": 11,
+                              "height": 11,
+                              "icon": "list-checks",
+                              "library": "lucide",
+                              "fill": "#9A8C7E"
+                            },
+                            {
+                              "type": "text",
+                              "id": "kOCdu",
+                              "name": "qt",
+                              "fill": "#9A8C7E",
+                              "content": "QUEUED",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "600",
+                              "letterSpacing": 0.5
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "g3sed",
+                          "name": "exec Add Athena adapter",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            7,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "KLVb9",
+                              "name": "ei",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "list-checks",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "h0Jka7",
+                              "name": "et",
+                              "fill": "#2C2C2C",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Add Athena adapter",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12.5,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dA6mh",
+                              "name": "tm",
+                              "fill": "#9A9A9A",
+                              "content": "—",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 10.5,
+                              "fontWeight": "normal"
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "type": "rectangle",
-                  "id": "NlPX0",
-                  "name": "cdiv",
-                  "fill": "#F2EEE7",
-                  "width": "fill_container",
-                  "height": 1
-                },
-                {
                   "type": "frame",
-                  "id": "poQm4",
-                  "name": "stats",
+                  "id": "Xqi21",
+                  "name": "conn PM Agent",
                   "width": "fill_container",
+                  "stroke": "#F2EEE7",
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "gap": 9,
+                  "padding": [
+                    13,
+                    16
+                  ],
                   "children": [
                     {
                       "type": "frame",
-                      "id": "M78rk",
-                      "name": "stat Uptime",
+                      "id": "nxSDa",
+                      "name": "identity",
                       "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 3,
+                      "gap": 9,
+                      "alignItems": "center",
                       "children": [
                         {
-                          "type": "text",
-                          "id": "LmUtN",
-                          "name": "l",
-                          "fill": "#9A9A9A",
-                          "content": "Uptime",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "500"
+                          "type": "frame",
+                          "id": "GHSKC",
+                          "name": "av",
+                          "width": 26,
+                          "height": 26,
+                          "fill": "#C67A52",
+                          "cornerRadius": 13,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "RUENA",
+                              "name": "b",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "bot",
+                              "library": "lucide",
+                              "fill": "#FFFFFF"
+                            }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "tvDYk",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "03:11:08",
-                          "fontFamily": "IBM Plex Mono",
-                          "fontSize": 14,
-                          "fontWeight": "500"
+                          "type": "frame",
+                          "id": "VT83w",
+                          "name": "nm",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 1,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hBN6G",
+                              "name": "an",
+                              "fill": "#2C2C2C",
+                              "content": "PM Agent",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13.5,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "glX19",
+                              "name": "host",
+                              "fill": "#9A9A9A",
+                              "content": "ci-runner-02",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "p5ARPC",
+                          "name": "clientBadge",
+                          "fill": "#F5F2EC",
+                          "cornerRadius": 5,
+                          "padding": [
+                            2,
+                            7
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "eBqSe",
+                              "name": "cbt",
+                              "fill": "#6B6B6B",
+                              "content": "OpenClaw",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 10,
+                              "fontWeight": "500"
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "type": "frame",
-                      "id": "otROu",
-                      "name": "stat Last active",
+                      "type": "text",
+                      "id": "f8vAsW",
+                      "name": "idle",
+                      "fill": "#9A9A9A",
+                      "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 3,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "A9XOE",
-                          "name": "l",
-                          "fill": "#9A9A9A",
-                          "content": "Last active",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "erWk1",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "4s ago",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 14,
-                          "fontWeight": "500"
-                        }
-                      ]
+                      "content": "Idle — no running or queued work.",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
                     }
                   ]
                 }
               ]
             },
             {
-              "type": "frame",
-              "id": "YoHW1",
-              "name": "mCard Release Bot",
+              "type": "rectangle",
+              "id": "tYWGn",
+              "name": "div2",
+              "fill": "#EFEBE4",
               "width": "fill_container",
-              "fill": "#FFFFFF",
-              "cornerRadius": 14,
-              "stroke": "#E5E0D8",
-              "strokeWidth": 1,
-              "strokeAlignment": "inner",
-              "layout": "vertical",
-              "gap": 14,
-              "padding": 16,
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "tY5De",
+              "name": "viewAll",
+              "width": "fill_container",
+              "padding": [
+                12,
+                0
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
               "children": [
                 {
-                  "type": "frame",
-                  "id": "Syhi7",
-                  "name": "top",
-                  "width": "fill_container",
-                  "gap": 12,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "Y0sYWO",
-                      "name": "iconWrap",
-                      "width": 40,
-                      "height": 40,
-                      "fill": "#9A9A9A14",
-                      "cornerRadius": 10,
-                      "justifyContent": "center",
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "icon",
-                          "id": "U5BB6",
-                          "name": "ic",
-                          "width": 20,
-                          "height": 20,
-                          "icon": "clock-3",
-                          "library": "lucide",
-                          "fill": "#9A9A9A"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "b23kQ8",
-                      "name": "idc",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 4,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "a7bM0S",
-                          "name": "agent",
-                          "fill": "#2C2C2C",
-                          "content": "Release Bot",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 16,
-                          "fontWeight": "600"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "wKyTF",
-                          "name": "sub",
-                          "gap": 7,
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "frame",
-                              "id": "YuQQP",
-                              "name": "badge",
-                              "fill": "#F4F1EC",
-                              "cornerRadius": 5,
-                              "padding": [
-                                2,
-                                6
-                              ],
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "H6B9Yh",
-                                  "name": "bt",
-                                  "fill": "#A39C90",
-                                  "content": "OpenClaw",
-                                  "fontFamily": "IBM Plex Sans",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "text",
-                              "id": "uzkiX",
-                              "name": "host",
-                              "fill": "#9A9A9A",
-                              "content": "· ci-runner-2",
-                              "fontFamily": "IBM Plex Mono",
-                              "fontSize": 11,
-                              "fontWeight": "normal"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "hesAT",
-                      "name": "statusBadge",
-                      "fill": "#F0EDE8",
-                      "cornerRadius": 999,
-                      "gap": 6,
-                      "padding": [
-                        6,
-                        10
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "frame",
-                          "id": "AiJiP",
-                          "name": "dotWrap",
-                          "width": 8,
-                          "height": 8,
-                          "layout": "none",
-                          "children": [
-                            {
-                              "type": "ellipse",
-                              "id": "QAnzC",
-                              "x": 1,
-                              "y": 1,
-                              "name": "dot",
-                              "fill": "#9A9A9A",
-                              "width": 6,
-                              "height": 6
-                            }
-                          ]
-                        },
-                        {
-                          "type": "text",
-                          "id": "g3RoJk",
-                          "name": "st",
-                          "fill": "#6B6B6B",
-                          "content": "Offline",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "600"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "rectangle",
-                  "id": "Rma3W",
-                  "name": "cdiv",
-                  "fill": "#F2EEE7",
-                  "width": "fill_container",
-                  "height": 1
-                },
-                {
-                  "type": "frame",
-                  "id": "t3y6pr",
-                  "name": "stats",
-                  "width": "fill_container",
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "i93cy4",
-                      "name": "uptime placeholder",
-                      "width": "fill_container",
-                      "height": "fit_content(0)",
-                      "layout": "vertical",
-                      "gap": 3
-                    },
-                    {
-                      "type": "frame",
-                      "id": "SIPLW",
-                      "name": "stat Last active",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 3,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "c6MAd",
-                          "name": "l",
-                          "fill": "#9A9A9A",
-                          "content": "Last active",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 11,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "M6AFeF",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "16h ago",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 14,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "text",
+                  "id": "Z6deNG",
+                  "name": "vat",
+                  "fill": "#C67A52",
+                  "content": "View all",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12.5,
+                  "fontWeight": "600"
                 }
               ]
             }
@@ -92940,108 +95765,139 @@
     },
     {
       "type": "frame",
-      "id": "rIbgl",
-      "x": 1955,
-      "y": 23941,
-      "name": "Agent Connections - Mobile (Detail)",
-      "clip": true,
-      "width": 390,
-      "height": 844,
-      "fill": "#FAF8F4",
+      "id": "d5BN6F",
+      "x": 3140,
+      "y": 24126,
+      "name": "Component - Daemon Connect CTA (Prominent)",
+      "width": 520,
+      "fill": "#FFFFFF",
+      "cornerRadius": 16,
+      "stroke": "#E5E0D8",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
       "layout": "vertical",
+      "gap": 16,
+      "padding": [
+        28,
+        28,
+        30,
+        28
+      ],
       "children": [
         {
           "type": "frame",
-          "id": "RMI9v",
-          "name": "statusBar",
+          "id": "eU1xQ",
+          "name": "head",
           "width": "fill_container",
-          "height": 44,
+          "gap": 11,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "mxQhB",
+              "name": "iconWrap",
+              "width": 38,
+              "height": 38,
+              "fill": "#FBF4EF",
+              "cornerRadius": 10,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "p83jkL",
+                  "name": "term",
+                  "width": 19,
+                  "height": 19,
+                  "icon": "terminal",
+                  "library": "lucide",
+                  "fill": "#C67A52"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "XVJ9q",
+              "name": "headline",
+              "fill": "#2C2C2C",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Next step: keep your agent online",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 16,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "V5y0z",
+          "name": "body",
+          "fill": "#6B6B6B",
+          "textGrowth": "fixed-width",
+          "width": "fill_container",
+          "content": "Installing a plugin sets up a one-shot connection — it doesn't keep an agent online. Run a long-lived daemon in your terminal so your agent stays connected and automatically receives dispatched work.",
+          "lineHeight": 1.55,
+          "fontFamily": "IBM Plex Sans",
+          "fontSize": 13,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "tdvD7",
+          "name": "commandBox",
+          "width": "fill_container",
+          "fill": "#2C2722",
+          "cornerRadius": 10,
           "padding": [
-            0,
-            24
+            13,
+            15
           ],
           "justifyContent": "space_between",
           "alignItems": "center",
           "children": [
             {
               "type": "text",
-              "id": "L3qhOP",
-              "name": "time",
-              "fill": "#2C2C2C",
-              "content": "9:41",
-              "fontFamily": "IBM Plex Sans",
-              "fontSize": 14,
-              "fontWeight": "600"
+              "id": "klOHn",
+              "name": "cmdTxt",
+              "fill": "#F0E9DF",
+              "content": "npx @chorus-aidlc/chorus daemon",
+              "fontFamily": "IBM Plex Mono",
+              "fontSize": 13,
+              "fontWeight": "normal"
             },
             {
               "type": "frame",
-              "id": "k2XSj",
-              "name": "statusRight",
-              "gap": 6,
+              "id": "HTr1F",
+              "name": "copyBtn",
+              "fill": "#3D362E",
+              "cornerRadius": 7,
+              "gap": 5,
+              "padding": [
+                5,
+                9
+              ],
               "alignItems": "center",
               "children": [
                 {
                   "type": "icon",
-                  "id": "YaFEG",
-                  "name": "signal",
-                  "width": 16,
-                  "height": 16,
-                  "icon": "signal-high",
+                  "id": "Z7XGz",
+                  "name": "ci",
+                  "width": 13,
+                  "height": 13,
+                  "icon": "copy",
                   "library": "lucide",
-                  "fill": "#2C2C2C"
-                },
-                {
-                  "type": "icon",
-                  "id": "HzI9W",
-                  "name": "battery",
-                  "width": 18,
-                  "height": 18,
-                  "icon": "battery-medium",
-                  "library": "lucide",
-                  "fill": "#2C2C2C"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "I1ctCp",
-          "name": "navBar",
-          "width": "fill_container",
-          "gap": 8,
-          "padding": [
-            10,
-            16
-          ],
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "frame",
-              "id": "pwHQ2",
-              "name": "back",
-              "gap": 4,
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "icon",
-                  "id": "uFLjF",
-                  "name": "chev",
-                  "width": 20,
-                  "height": 20,
-                  "icon": "chevron-left",
-                  "library": "lucide",
-                  "fill": "#C67A52"
+                  "fill": "#C9C1B5"
                 },
                 {
                   "type": "text",
-                  "id": "h8cTr2",
-                  "name": "backText",
-                  "fill": "#C67A52",
-                  "content": "Connections",
+                  "id": "Y42qoN",
+                  "name": "ct",
+                  "fill": "#C9C1B5",
+                  "content": "Copy",
                   "fontFamily": "IBM Plex Sans",
-                  "fontSize": 15,
-                  "fontWeight": "normal"
+                  "fontSize": 12,
+                  "fontWeight": "500"
                 }
               ]
             }
@@ -93049,114 +95905,417 @@
         },
         {
           "type": "frame",
-          "id": "cTMX8",
-          "name": "mdBody",
+          "id": "oJLPU",
+          "name": "loginNote",
+          "width": "fill_container",
+          "gap": 6,
+          "children": [
+            {
+              "type": "icon",
+              "id": "WXEsm",
+              "name": "info",
+              "width": 14,
+              "height": 14,
+              "icon": "info",
+              "library": "lucide",
+              "fill": "#9A9A9A"
+            },
+            {
+              "type": "text",
+              "id": "H7EIOC",
+              "name": "nt",
+              "fill": "#9A9A9A",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "First time? Sign in once with npx @chorus-aidlc/chorus login.",
+              "lineHeight": 1.45,
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "RGMeJ",
+          "name": "learnMore",
+          "gap": 5,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "OkmKV",
+              "name": "lmt",
+              "fill": "#C67A52",
+              "content": "Learn more about connecting an agent",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 12.5,
+              "fontWeight": "500"
+            },
+            {
+              "type": "icon",
+              "id": "ld5bH",
+              "name": "arr",
+              "width": 13,
+              "height": 13,
+              "icon": "arrow-right",
+              "library": "lucide",
+              "fill": "#C67A52"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Moiwv",
+      "x": 1560,
+      "y": 18704,
+      "name": "Idea Tracker - Verify Elaborate (ready)",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#F7F6F3",
+      "children": [
+        {
+          "type": "frame",
+          "id": "a0NsVL",
+          "name": "Content Area",
+          "clip": true,
           "width": "fill_container",
           "height": "fill_container",
-          "layout": "vertical",
-          "gap": 18,
-          "padding": [
-            8,
-            20,
-            20,
-            20
-          ],
+          "fill": "#FAF8F4",
           "children": [
             {
               "type": "frame",
-              "id": "EGM42",
-              "name": "idBlock",
-              "width": "fill_container",
+              "id": "MDij7",
+              "name": "Sidebar",
+              "width": 240,
+              "height": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": "#E5E0D8",
+              "strokeWidth": {
+                "right": 1
+              },
+              "strokeAlignment": "inner",
               "layout": "vertical",
-              "gap": 14,
+              "gap": 48,
+              "padding": [
+                32,
+                24
+              ],
+              "justifyContent": "space_between",
               "children": [
                 {
                   "type": "frame",
-                  "id": "g8q2o",
-                  "name": "idTop",
+                  "id": "R6qhMg",
+                  "name": "Sidebar Top",
                   "width": "fill_container",
-                  "gap": 14,
-                  "alignItems": "center",
+                  "layout": "vertical",
+                  "gap": 48,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "hkk5y",
-                      "name": "iconWrap",
-                      "width": 48,
-                      "height": 48,
-                      "fill": "#C67A5214",
-                      "cornerRadius": 12,
-                      "justifyContent": "center",
+                      "id": "Vp4EQ",
+                      "name": "Logo",
+                      "width": "fill_container",
+                      "gap": 12,
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon",
-                          "id": "tHG7J",
-                          "name": "ic",
+                          "type": "rectangle",
+                          "cornerRadius": 4,
+                          "id": "yxQX7",
+                          "name": "logoMark",
+                          "fill": "#C67A52",
                           "width": 24,
-                          "height": 24,
-                          "icon": "bot",
-                          "library": "lucide",
-                          "fill": "#C67A52"
+                          "height": 24
+                        },
+                        {
+                          "type": "text",
+                          "id": "XO5jU",
+                          "name": "logoTxt",
+                          "fill": "#2C2C2C",
+                          "content": "Chorus",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 18,
+                          "fontWeight": "600"
                         }
                       ]
                     },
                     {
                       "type": "frame",
-                      "id": "dB4C0",
-                      "name": "idc",
+                      "id": "RwNrS",
+                      "name": "Navigation",
                       "width": "fill_container",
                       "layout": "vertical",
-                      "gap": 5,
+                      "gap": 8,
                       "children": [
                         {
-                          "type": "text",
-                          "id": "KjqjH",
-                          "name": "agent",
-                          "fill": "#2C2C2C",
-                          "content": "Admin Claude",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 20,
-                          "fontWeight": "600"
-                        },
-                        {
                           "type": "frame",
-                          "id": "TgL2u",
-                          "name": "sub",
-                          "gap": 7,
+                          "id": "Q8JkX",
+                          "name": "Back to Projects",
+                          "width": "fill_container",
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            0
+                          ],
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "frame",
-                              "id": "Zoexc",
-                              "name": "badge",
-                              "fill": "#F0EDE8",
-                              "cornerRadius": 6,
-                              "padding": [
-                                3,
-                                8
-                              ],
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "o5AYEP",
-                                  "name": "bt",
-                                  "fill": "#6B6B6B",
-                                  "content": "Claude Code",
-                                  "fontFamily": "IBM Plex Sans",
-                                  "fontSize": 11,
-                                  "fontWeight": "500"
-                                }
-                              ]
+                              "type": "icon",
+                              "id": "wT99w",
+                              "name": "backIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "arrow-left",
+                              "library": "lucide",
+                              "fill": "#9A9A9A"
                             },
                             {
                               "type": "text",
-                              "id": "Ms7Xv",
-                              "name": "vh",
+                              "id": "wZOIv",
+                              "name": "backTxt",
                               "fill": "#9A9A9A",
-                              "content": "v0.11.0 · laptop-01",
-                              "fontFamily": "IBM Plex Mono",
-                              "fontSize": 11,
+                              "content": "Projects",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "sE8pn",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "padding": [
+                            12,
+                            0,
+                            6,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "oyj26",
+                              "name": "projName",
+                              "fill": "#2C2C2C",
+                              "content": "Project Alpha",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "mowec",
+                          "name": "Nav Overview",
+                          "width": "fill_container",
+                          "fill": "#F5F2EC",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "TZfRN",
+                              "name": "ovIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "layout-dashboard",
+                              "library": "lucide",
+                              "fill": "#C67A52"
+                            },
+                            {
+                              "type": "text",
+                              "id": "lHyem",
+                              "name": "ovTxt",
+                              "fill": "#C67A52",
+                              "content": "Overview",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "X6r5sc",
+                          "name": "Nav Ideas",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "pthTZ",
+                              "name": "ideasIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "lightbulb",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dnCu1",
+                              "name": "ideasTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Ideas",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "g9mcZQ",
+                          "name": "Nav Documents",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "C2IHe",
+                              "name": "docsIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "file-text",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "VTFnh",
+                              "name": "docsTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Documents",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fsqEU",
+                          "name": "Nav Proposals",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "X8oAO",
+                              "name": "propIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "git-pull-request",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "g3Jiw",
+                              "name": "propTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Proposals",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "aKyZS",
+                          "name": "Nav Tasks",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "p5zrm",
+                              "name": "tasksIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "square-check",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "LtMPR",
+                              "name": "tasksTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Tasks",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "KfZ6b",
+                          "name": "Nav Activity",
+                          "width": "fill_container",
+                          "cornerRadius": 8,
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "uz5VW",
+                              "name": "actIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "activity",
+                              "library": "lucide",
+                              "fill": "#6B6B6B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "U2RKkP",
+                              "name": "actTxt",
+                              "fill": "#6B6B6B",
+                              "content": "Activity",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
                               "fontWeight": "normal"
                             }
                           ]
@@ -93167,57 +96326,39 @@
                 },
                 {
                   "type": "frame",
-                  "id": "ZE8qL",
-                  "name": "statusBadge",
-                  "fill": "#DCFCE7",
-                  "cornerRadius": 999,
-                  "gap": 7,
-                  "padding": [
-                    8,
-                    13
-                  ],
-                  "alignItems": "center",
+                  "id": "Jsq6G",
+                  "name": "Sidebar Bottom",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 24,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "fNoRr",
-                      "name": "dotWrap",
-                      "width": 10,
-                      "height": 10,
-                      "layout": "none",
+                      "id": "ABbX2",
+                      "name": "User Profile",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
                       "children": [
                         {
                           "type": "ellipse",
-                          "id": "YLowR",
-                          "x": 0,
-                          "y": 0,
-                          "name": "halo",
-                          "fill": "#22C55E40",
-                          "width": 10,
-                          "height": 10
+                          "id": "uC6Mz",
+                          "name": "avatar",
+                          "fill": "#E5E0D8",
+                          "width": 32,
+                          "height": 32
                         },
                         {
-                          "type": "ellipse",
-                          "id": "S4RuHr",
-                          "x": 2,
-                          "y": 2,
-                          "name": "dot",
-                          "fill": "#22C55E",
-                          "width": 6,
-                          "height": 6
+                          "type": "text",
+                          "id": "JsKOx",
+                          "name": "userName",
+                          "fill": "#2C2C2C",
+                          "content": "John Doe",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "id": "P4r8F8",
-                      "name": "st",
-                      "fill": "#15803D",
-                      "content": "ONLINE",
-                      "fontFamily": "IBM Plex Sans",
-                      "fontSize": 11,
-                      "fontWeight": "600",
-                      "letterSpacing": 0.5
                     }
                   ]
                 }
@@ -93225,71 +96366,69 @@
             },
             {
               "type": "frame",
-              "id": "QDjpt",
-              "name": "statGrid",
+              "id": "xYtzO",
+              "name": "Main Content",
               "width": "fill_container",
+              "height": "fill_container",
               "layout": "vertical",
-              "gap": 12,
+              "gap": 20,
+              "padding": [
+                20,
+                24
+              ],
               "children": [
                 {
                   "type": "frame",
-                  "id": "qfdVU",
-                  "name": "r1",
+                  "id": "Q1rWR0",
+                  "name": "Top Bar",
                   "width": "fill_container",
-                  "gap": 12,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
                   "children": [
                     {
+                      "type": "text",
+                      "id": "f3zxdR",
+                      "name": "breadcrumb",
+                      "fill": "#888780",
+                      "content": "Project Alpha / Overview",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
                       "type": "frame",
-                      "id": "qkuLI",
-                      "name": "tile Uptime",
-                      "width": "fill_container",
-                      "fill": "#FFFFFF",
-                      "cornerRadius": 12,
-                      "stroke": "#E5E0D8",
-                      "strokeWidth": 1,
-                      "strokeAlignment": "inner",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "padding": 16,
+                      "id": "c6VTC",
+                      "name": "topActions",
+                      "gap": 16,
+                      "alignItems": "center",
                       "children": [
                         {
-                          "type": "frame",
-                          "id": "h7mwy8",
-                          "name": "lr",
-                          "gap": 7,
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "icon",
-                              "id": "UvPbh",
-                              "name": "ic",
-                              "width": 14,
-                              "height": 14,
-                              "icon": "timer",
-                              "library": "lucide",
-                              "fill": "#C67A52"
-                            },
-                            {
-                              "type": "text",
-                              "id": "fZMIo",
-                              "name": "l",
-                              "fill": "#9A9A9A",
-                              "content": "Uptime",
-                              "fontFamily": "IBM Plex Sans",
-                              "fontSize": 12,
-                              "fontWeight": "500"
-                            }
-                          ]
+                          "type": "icon",
+                          "id": "Travb",
+                          "name": "searchIcon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "search",
+                          "library": "lucide",
+                          "fill": "#888780"
                         },
                         {
-                          "type": "text",
-                          "id": "bZlDu",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "00:07:42",
-                          "fontFamily": "IBM Plex Mono",
-                          "fontSize": 22,
-                          "fontWeight": "500"
+                          "type": "icon",
+                          "id": "w8URq",
+                          "name": "bellIcon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "bell",
+                          "library": "lucide",
+                          "fill": "#888780"
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "PczfT",
+                          "name": "topAvatar",
+                          "fill": "#E5E0D8",
+                          "width": 32,
+                          "height": 32
                         }
                       ]
                     }
@@ -93297,310 +96436,1547 @@
                 },
                 {
                   "type": "frame",
-                  "id": "OVC7C",
-                  "name": "r2",
-                  "width": "fill_container",
-                  "gap": 12,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "aEmMb",
-                      "name": "tile Last active",
-                      "width": "fill_container",
-                      "fill": "#FFFFFF",
-                      "cornerRadius": 12,
-                      "stroke": "#E5E0D8",
-                      "strokeWidth": 1,
-                      "strokeAlignment": "inner",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "padding": 16,
-                      "children": [
-                        {
-                          "type": "frame",
-                          "id": "d8QQXA",
-                          "name": "lr",
-                          "gap": 7,
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "icon",
-                              "id": "j39GdE",
-                              "name": "ic",
-                              "width": 14,
-                              "height": 14,
-                              "icon": "activity",
-                              "library": "lucide",
-                              "fill": "#C67A52"
-                            },
-                            {
-                              "type": "text",
-                              "id": "vEvOe",
-                              "name": "l",
-                              "fill": "#9A9A9A",
-                              "content": "Last active",
-                              "fontFamily": "IBM Plex Sans",
-                              "fontSize": 12,
-                              "fontWeight": "500"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "text",
-                          "id": "gVg62",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "just now",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 16,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "K7tw3e",
-                      "name": "tile Started",
-                      "width": "fill_container",
-                      "fill": "#FFFFFF",
-                      "cornerRadius": 12,
-                      "stroke": "#E5E0D8",
-                      "strokeWidth": 1,
-                      "strokeAlignment": "inner",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "padding": 16,
-                      "children": [
-                        {
-                          "type": "frame",
-                          "id": "rG6RP",
-                          "name": "lr",
-                          "gap": 7,
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "icon",
-                              "id": "hrgzr",
-                              "name": "ic",
-                              "width": 14,
-                              "height": 14,
-                              "icon": "calendar-clock",
-                              "library": "lucide",
-                              "fill": "#C67A52"
-                            },
-                            {
-                              "type": "text",
-                              "id": "fcUAq",
-                              "name": "l",
-                              "fill": "#9A9A9A",
-                              "content": "Started",
-                              "fontFamily": "IBM Plex Sans",
-                              "fontSize": 12,
-                              "fontWeight": "500"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "text",
-                          "id": "u1C13",
-                          "name": "v",
-                          "fill": "#2C2C2C",
-                          "content": "2d ago",
-                          "fontFamily": "IBM Plex Sans",
-                          "fontSize": 16,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "ErTmN",
-              "name": "comingSoon",
-              "width": "fill_container",
-              "height": "fill_container",
-              "fill": "#FCFBF8",
-              "cornerRadius": 12,
-              "stroke": "#EFEBE4",
-              "strokeWidth": 1,
-              "strokeAlignment": "inner",
-              "layout": "vertical",
-              "gap": 12,
-              "padding": 18,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "V4ulfc",
-                  "name": "sh",
+                  "id": "GwL6b",
+                  "name": "Title Section",
                   "width": "fill_container",
                   "justifyContent": "space_between",
                   "alignItems": "center",
                   "children": [
                     {
                       "type": "frame",
-                      "id": "HCpXl",
-                      "name": "shl",
-                      "gap": 9,
-                      "alignItems": "center",
+                      "id": "pD5xI",
+                      "name": "titleLeft",
+                      "layout": "vertical",
+                      "gap": 4,
                       "children": [
                         {
-                          "type": "icon",
-                          "id": "hodrr",
-                          "name": "si",
-                          "width": 16,
-                          "height": 16,
-                          "icon": "messages-square",
-                          "library": "lucide",
-                          "fill": "#C67A52"
+                          "type": "text",
+                          "id": "WVpgG",
+                          "name": "titleTxt",
+                          "fill": "#2C2C2A",
+                          "content": "Overview",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 20,
+                          "fontWeight": "500"
                         },
                         {
                           "type": "text",
-                          "id": "gijQ3",
-                          "name": "st",
-                          "fill": "#2C2C2C",
-                          "content": "Sessions & Transcript",
+                          "id": "AxoGZ",
+                          "name": "subtitleTxt",
+                          "fill": "#5F5E5A",
+                          "content": "Track ideas, proposals, and tasks at a glance",
                           "fontFamily": "IBM Plex Sans",
-                          "fontSize": 14,
-                          "fontWeight": "600"
+                          "fontSize": 13,
+                          "fontWeight": "normal"
                         }
                       ]
                     },
                     {
                       "type": "frame",
-                      "id": "CFog1",
-                      "name": "sp",
-                      "fill": "#F0EDE8",
-                      "cornerRadius": 999,
-                      "padding": [
-                        4,
-                        9
-                      ],
+                      "id": "PERdE",
+                      "name": "titleActions",
+                      "fill": "#d9d9d9ff",
+                      "gap": 12,
+                      "alignItems": "center",
                       "children": [
                         {
-                          "type": "text",
-                          "id": "TTsa4",
-                          "name": "spt",
-                          "fill": "#9A8C7E",
-                          "content": "SOON",
-                          "fontFamily": "IBM Plex Mono",
-                          "fontSize": 10,
-                          "fontWeight": "500",
-                          "letterSpacing": 0.5
+                          "type": "frame",
+                          "id": "CxjjP",
+                          "name": "newIdeaBtn",
+                          "fill": "#c67a52",
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "aYL2h",
+                              "name": "newIdeaIcon",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "plus",
+                              "library": "lucide",
+                              "fill": "#FFFFFF"
+                            },
+                            {
+                              "type": "text",
+                              "id": "z2QyPh",
+                              "name": "newIdeaTxt",
+                              "fill": "#FFFFFF",
+                              "content": "New Idea",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "type": "text",
-                  "id": "aXTiM",
-                  "name": "sb",
-                  "fill": "#9A9A9A",
-                  "textGrowth": "fixed-width",
-                  "width": "fill_container",
-                  "content": "Tap into live root-idea sessions and a streaming transcript of what this agent is doing.",
-                  "lineHeight": 1.5,
-                  "fontFamily": "IBM Plex Sans",
-                  "fontSize": 13,
-                  "fontWeight": "normal"
-                },
-                {
                   "type": "frame",
-                  "id": "L2JSfI",
-                  "name": "ghost",
+                  "id": "L6WAs",
+                  "name": "Ideas Area",
                   "width": "fill_container",
                   "height": "fill_container",
                   "layout": "vertical",
-                  "gap": 10,
-                  "justifyContent": "center",
+                  "gap": 16,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "a6cfSD",
-                      "name": "gr",
+                      "id": "z3y9aI",
+                      "name": "In Review Group",
                       "width": "fill_container",
-                      "gap": 10,
-                      "alignItems": "center",
+                      "layout": "vertical",
+                      "gap": 6,
                       "children": [
                         {
-                          "type": "ellipse",
-                          "id": "qyg08",
-                          "name": "gd",
-                          "fill": "#E3DDD3",
-                          "width": 8,
-                          "height": 8
+                          "type": "frame",
+                          "id": "C9gFf",
+                          "name": "h1",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "y6i3as",
+                              "name": "a5",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "chevron-down",
+                              "library": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "e0Y8ef",
+                              "fill": "#7F77DD",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "IpTJZ",
+                              "fill": "#5F5E5A",
+                              "content": "In Review",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "FWH9k",
+                              "fill": "#888780",
+                              "content": "2",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
                         },
                         {
-                          "type": "rectangle",
-                          "cornerRadius": 4,
-                          "id": "QJj5D",
-                          "name": "gb",
-                          "fill": "#EFEBE4",
-                          "width": 200,
-                          "height": 9
+                          "type": "frame",
+                          "id": "x5OiL",
+                          "name": "b1",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "emc0F",
+                              "name": "r1",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "V4XHec",
+                                  "name": "r1l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Svypd",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-5",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "rclyr",
+                                      "fill": "#2C2C2A",
+                                      "content": "CLI 工具重构",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "MxdAT",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "U6m46W",
+                                          "fill": "#888780",
+                                          "content": "Proposal",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "x8l8TV",
+                                  "fill": "#888780",
+                                  "content": "Mar 13",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "DLEQo",
+                              "fill": "#F0EEEA",
+                              "width": "fill_container",
+                              "height": 1
+                            },
+                            {
+                              "type": "frame",
+                              "id": "qgcR1",
+                              "name": "r2",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "bn6a1",
+                                  "name": "r2l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Y1biLh",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-3",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "l0ipOr",
+                                      "fill": "#2C2C2A",
+                                      "content": "新建 quick-dev skill",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "lNZkz",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "l3bKku",
+                                          "fill": "#888780",
+                                          "content": "Work done",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "e1uWG",
+                                  "fill": "#888780",
+                                  "content": "Mar 13",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
                         }
                       ]
                     },
                     {
                       "type": "frame",
-                      "id": "OfeCA",
-                      "name": "gr",
+                      "id": "fke7h",
+                      "name": "In Progress Group",
                       "width": "fill_container",
-                      "gap": 10,
-                      "alignItems": "center",
+                      "layout": "vertical",
+                      "gap": 6,
                       "children": [
                         {
-                          "type": "ellipse",
-                          "id": "IMNWy",
-                          "name": "gd",
-                          "fill": "#E3DDD3",
-                          "width": 8,
-                          "height": 8
+                          "type": "frame",
+                          "id": "p3R4eP",
+                          "name": "h2",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "Q0X7Tf",
+                              "name": "a6",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "chevron-down",
+                              "library": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "RGoMx",
+                              "fill": "#378ADD",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "vrCVw",
+                              "fill": "#5F5E5A",
+                              "content": "In Progress",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "U4bBq",
+                              "fill": "#888780",
+                              "content": "1",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
                         },
                         {
-                          "type": "rectangle",
-                          "cornerRadius": 4,
-                          "id": "i4E0cm",
-                          "name": "gb",
-                          "fill": "#EFEBE4",
-                          "width": 150,
-                          "height": 9
+                          "type": "frame",
+                          "id": "YAK4A",
+                          "name": "b2",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "a1sTe",
+                              "name": "r3",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "aq4rx",
+                                  "name": "r3l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "nzJ0U",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-24",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "pE6wE",
+                                      "fill": "#2C2C2A",
+                                      "content": "T5: 测试验证",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "QRv6l",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "dcD0T",
+                                          "fill": "#888780",
+                                          "content": "Working",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "kTSOg",
+                                  "fill": "#888780",
+                                  "content": "Mar 13",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
                         }
                       ]
                     },
                     {
                       "type": "frame",
-                      "id": "kOW9t",
-                      "name": "gr",
+                      "id": "G5eAW",
+                      "name": "Todo Group",
                       "width": "fill_container",
-                      "gap": 10,
-                      "alignItems": "center",
+                      "layout": "vertical",
+                      "gap": 6,
                       "children": [
                         {
-                          "type": "ellipse",
-                          "id": "Jqlx8",
-                          "name": "gd",
-                          "fill": "#E3DDD3",
-                          "width": 8,
-                          "height": 8
+                          "type": "frame",
+                          "id": "TTyzU",
+                          "name": "h3",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "dXJ5I",
+                              "name": "a7",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "chevron-down",
+                              "library": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "c8p7lY",
+                              "width": 8,
+                              "height": 8,
+                              "stroke": "#888780",
+                              "strokeWidth": 1.5,
+                              "strokeAlignment": "inner"
+                            },
+                            {
+                              "type": "text",
+                              "id": "jL1Ow",
+                              "fill": "#5F5E5A",
+                              "content": "Todo",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "VoM1K",
+                              "fill": "#888780",
+                              "content": "6",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
                         },
                         {
-                          "type": "rectangle",
-                          "cornerRadius": 4,
-                          "id": "efbJ0",
-                          "name": "gb",
-                          "fill": "#EFEBE4",
-                          "width": 230,
-                          "height": 9
+                          "type": "frame",
+                          "id": "litvd",
+                          "name": "b3",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "iRGyr",
+                              "name": "r4",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "V3p81",
+                                  "name": "r4l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "J76Ud",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-7",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "KTIiq",
+                                      "fill": "#2C2C2A",
+                                      "content": "优化错误提示信息",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "yTKuB",
+                                  "fill": "#888780",
+                                  "content": "Jan 17",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "diK2W",
+                              "fill": "#F0EEEA",
+                              "width": "fill_container",
+                              "height": 1
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ViFcj",
+                              "name": "r5",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "JQ2st",
+                                  "name": "r5l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "q17Vs",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-1",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "V6XJgW",
+                                      "fill": "#2C2C2A",
+                                      "content": "Get familiar with Linear",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "UMg7q",
+                                  "fill": "#888780",
+                                  "content": "Jan 17",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "f7A0W",
+                      "name": "Done Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FI41g",
+                          "name": "dh1",
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            0,
+                            4,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "Wb8XO",
+                              "name": "a8",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "chevron-down",
+                              "library": "lucide",
+                              "fill": "#888780"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "X4gjZ",
+                              "fill": "#1D9E75",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "NAEO8",
+                              "fill": "#5F5E5A",
+                              "content": "Done",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "gk267",
+                              "fill": "#888780",
+                              "content": "1",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "d5F7Q",
+                          "name": "db1",
+                          "width": "fill_container",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "gF3I9",
+                              "name": "dr1",
+                              "width": "fill_container",
+                              "padding": [
+                                12,
+                                14
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "dI32W",
+                                  "name": "dr1l",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "aWcvl",
+                                      "fill": "#B4B2A9",
+                                      "content": "IDEA-2",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "cPTXL",
+                                      "fill": "#2C2C2A",
+                                      "content": "OpenClaw Plugin 工具迁移",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "DVr3Q",
+                                      "fill": "#F0EEEA",
+                                      "cornerRadius": 4,
+                                      "padding": [
+                                        2,
+                                        6
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "V7IaJ",
+                                          "fill": "#1D9E75",
+                                          "content": "Completed",
+                                          "fontFamily": "IBM Plex Sans",
+                                          "fontSize": 11,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "bH48m",
+                                  "fill": "#888780",
+                                  "content": "Mar 10",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
                 }
               ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "DFUlM",
+          "name": "Detail Panel",
+          "width": 460,
+          "height": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#E5E0D8",
+          "strokeWidth": {
+            "left": 1
+          },
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 20,
+          "padding": [
+            28,
+            24
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Q6VFz",
+              "name": "dpHead",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "C2qZTY",
+                  "name": "dpClose",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "x",
+                  "library": "lucide",
+                  "fill": "#9A9A9A"
+                },
+                {
+                  "type": "frame",
+                  "id": "UQZ6j",
+                  "name": "dpRight",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "k2jWY",
+                      "name": "dpId",
+                      "fill": "#9A9A9A",
+                      "content": "IDEA-6",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xgiZe",
+                      "name": "dpBadge",
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 4,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "m8IURQ",
+                          "name": "dpBadgeTxt",
+                          "fill": "#C67A52",
+                          "content": "In Progress",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zBTAX",
+              "name": "dpTitle",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "n0IYg",
+                  "name": "dpTitleTxt",
+                  "fill": "#2C2C2C",
+                  "content": "支持多语言文档生成",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 16,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "yZreI",
+                  "name": "dpDesc",
+                  "fill": "#6B6B6B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "自动生成多语言版本的文档，支持中英日韩等主要语言",
+                  "lineHeight": 1.5,
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "V82bht",
+              "name": "dpSectionLabel",
+              "fill": "#9A9A9A",
+              "content": "ELABORATION QUESTIONS (3/3)",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "Ds9Ym",
+              "name": "Questions",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Z9whHh",
+                  "name": "Q1 Answered",
+                  "width": "fill_container",
+                  "fill": "#F7F6F3",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 14,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "VS7LR",
+                      "name": "q1h",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "G1NEyi",
+                          "name": "q1icon",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "circle-check",
+                          "library": "lucide",
+                          "fill": "#888780"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ecsyz",
+                          "name": "q1num",
+                          "fill": "#2C2C2C",
+                          "content": "1  Scope",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "tUiRt",
+                      "name": "q1q",
+                      "fill": "#6B6B6B",
+                      "content": "需要支持哪些语言？",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "soekj",
+                      "name": "q1a",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 6,
+                      "stroke": "#E5E0D8",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rTHVh",
+                          "name": "q1aTxt",
+                          "fill": "#2C2C2C",
+                          "content": "中英日韩",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tbaom",
+                  "name": "Q2 Current",
+                  "width": "fill_container",
+                  "fill": "#F7F6F3",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 14,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "WvXDx",
+                      "name": "q2h",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "svNd1",
+                          "name": "q2dot",
+                          "fill": "#E8A849",
+                          "width": 14,
+                          "height": 14
+                        },
+                        {
+                          "type": "text",
+                          "id": "z5ShP",
+                          "name": "q2num",
+                          "fill": "#2C2C2C",
+                          "content": "2  Integration",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "jBIdG",
+                      "name": "q2q",
+                      "fill": "#6B6B6B",
+                      "content": "翻译服务如何集成？",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZcQXv",
+                      "name": "q2opts",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF",
+                      "stroke": "#FFFFFF",
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "QT5eM",
+                          "name": "opt1",
+                          "width": "fill_container",
+                          "gap": 10,
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "c04kx",
+                              "name": "badge1",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "#F0EEEA",
+                              "cornerRadius": 6,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "mR3An",
+                                  "x": 10,
+                                  "y": 6,
+                                  "name": "num1",
+                                  "fill": "#5F5E5A",
+                                  "content": "1",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "hjGEQ",
+                              "name": "txt1",
+                              "fill": "#2C2C2A",
+                              "content": "使用 OpenAI API",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "Q39a2",
+                          "name": "div1",
+                          "fill": "#F0EEEA",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NCVEz",
+                          "name": "opt2",
+                          "width": "fill_container",
+                          "gap": 10,
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zOSt3",
+                              "name": "badge2",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "#F0EEEA",
+                              "cornerRadius": 6,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "yoHE7",
+                                  "x": 10,
+                                  "y": 6,
+                                  "name": "num2",
+                                  "fill": "#5F5E5A",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "ycxjL",
+                              "name": "txt2",
+                              "fill": "#2C2C2A",
+                              "content": "使用 Google Translate",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "OQDMr",
+                          "name": "div2",
+                          "fill": "#F0EEEA",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fJmh1",
+                          "name": "opt3-selected",
+                          "width": "fill_container",
+                          "fill": "#F0EEEA",
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "wn1Bj",
+                              "name": "left3",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "Rj4Es",
+                                  "name": "badge3",
+                                  "width": 28,
+                                  "height": 28,
+                                  "fill": "#E5E0D8",
+                                  "cornerRadius": 6,
+                                  "layout": "none",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "o1iZNy",
+                                      "x": 10,
+                                      "y": 6,
+                                      "name": "num3",
+                                      "fill": "#5F5E5A",
+                                      "content": "3",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "jHqGd",
+                                  "name": "txt3",
+                                  "fill": "#2C2C2A",
+                                  "content": "支持多种翻译服务可切换",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon",
+                              "id": "FMU0j",
+                              "name": "arrow3",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "arrow-right",
+                              "library": "lucide",
+                              "fill": "#888780"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "xeZMm",
+                          "name": "div3",
+                          "fill": "#F0EEEA",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "A57Np",
+                          "name": "opt4",
+                          "width": "fill_container",
+                          "gap": 10,
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zRLy0",
+                              "name": "badge4",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "#F0EEEA",
+                              "cornerRadius": 6,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "W5ORH7",
+                                  "x": 10,
+                                  "y": 6,
+                                  "name": "num4",
+                                  "fill": "#5F5E5A",
+                                  "content": "4",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "X95THu",
+                              "name": "txt4",
+                              "fill": "#2C2C2A",
+                              "content": "本地模型离线翻译",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "cr0xC",
+                          "name": "div4",
+                          "fill": "#F0EEEA",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "yQRNA",
+                          "name": "bottomRow",
+                          "width": "fill_container",
+                          "padding": [
+                            12,
+                            14
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "dQ2Pi",
+                              "name": "leftBot",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "y9Y8k",
+                                  "name": "penIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "icon": "pencil",
+                                  "library": "lucide",
+                                  "fill": "#B4B2A9"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "havE1",
+                                  "name": "someTxt",
+                                  "fill": "#B4B2A9",
+                                  "content": "Something else",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal",
+                                  "fontStyle": "italic"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Dc8uI",
+                              "name": "skipBtn",
+                              "cornerRadius": 6,
+                              "stroke": "#E5E0D8",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "padding": [
+                                6,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "x833w",
+                                  "name": "skipTxt",
+                                  "fill": "#5F5E5A",
+                                  "content": "Skip",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "H5TAJh",
+                  "name": "Q3 Pending",
+                  "width": "fill_container",
+                  "fill": "#F7F6F3",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 14,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OTNuQ",
+                      "name": "q3h",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "IDAic",
+                          "name": "q3dot",
+                          "width": 14,
+                          "height": 14,
+                          "stroke": "#CCCCCC",
+                          "strokeWidth": 1.5,
+                          "strokeAlignment": "inner"
+                        },
+                        {
+                          "type": "text",
+                          "id": "oPsDw",
+                          "name": "q3num",
+                          "fill": "#9A9A9A",
+                          "content": "3  Output",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Du4V7",
+                      "name": "q3q",
+                      "fill": "#6B6B6B",
+                      "content": "生成的多语言文档如何组织？",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "X9DZF",
+                      "name": "q3p",
+                      "fill": "#2C2C2C",
+                      "content": "组织结构：按 /docs/<lang>/ 目录分语言存放",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "C6oNC",
+              "name": "Agent Status",
+              "width": "fill_container",
+              "fill": "#EAF4EC",
+              "cornerRadius": 8,
+              "gap": 8,
+              "padding": [
+                10,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "P1O7h",
+                  "name": "agentAv",
+                  "width": 22,
+                  "height": 22,
+                  "fill": "#E5E0D8",
+                  "cornerRadius": 11,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "V3Asa",
+                      "x": 4,
+                      "y": 5,
+                      "name": "agentAvTxt",
+                      "fill": "#6B6B6B",
+                      "content": "PM",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 7,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "zVpvu",
+                  "name": "agentMsg",
+                  "fill": "#3F7A4E",
+                  "content": "All questions answered — ready to verify.",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KcAsg",
+              "name": "Footer Button",
+              "width": "fill_container",
+              "fill": "#C67A52",
+              "cornerRadius": 8,
+              "gap": 8,
+              "padding": [
+                10,
+                16
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "thLG8",
+                  "name": "verifyIcon",
+                  "width": 15,
+                  "height": 15,
+                  "icon": "circle-check",
+                  "library": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "h5MN0S",
+                  "name": "footerTxt",
+                  "fill": "#FFFFFF",
+                  "content": "Verify Elaborate",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "b4g5NY",
+              "name": "queuedHint",
+              "fill": "#9A9A9A",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "After verifying, the agent will write the proposal when it's available.",
+              "lineHeight": 1.45,
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 11,
+              "fontWeight": "normal"
             }
           ]
         }


### PR DESCRIPTION
## Summary
Brings `docs/design.pen` current with the **June daemon / agent-presence UI cluster** (PRs #327–#343) — the dominant UI work that landed since the last design.pen commit (`c915423`, 2026-06-18).

The new daemon UI is a **floating modal (浮窗)**, a different design from the old standalone Agent Connections page, so those outdated screens were removed.

## Screens added
| Frame | What it shows |
|------|------|
| **Daemon Conversations (Modal)** | Floating chat-style overlay over a dimmed Projects page: agent dropdown + "New conversation" + conversation list (running pulse / interrupted / error states, Idea badges, selection spine) on the left; turn-band transcript (trigger eyebrows, You/Agent bubbles, status badges) + inline Send/Interrupt composer on the right |
| **Mobile - Daemon Conversations (List)** | Fullscreen sheet, list view with drill-down |
| **Mobile - Daemon Transcript (Drill-down)** | Back header → transcript → stacked Send/Interrupt composer |
| **Agent Presence Popover** | Sidebar "2 agents online" pill + open popover (online agents w/ running/queued executions, "View all") |
| **Component - Daemon Connect CTA (Prominent)** | Empty-state: `npx @chorus-aidlc/chorus daemon` command card + copy, login note, learn-more |
| **Idea Tracker - Verify Elaborate (ready)** | Elaboration panel in all-answered state with the active "Verify Elaborate" button + queued hint |

## Screens removed
- `Chorus - Agent Connections` (standalone desktop page)
- `Agent Connections - Mobile (List)`
- `Agent Connections - Mobile (Detail)`

## Notes
- Matched existing design language (terracotta `#C67A52`, warm `#FAF8F4` canvas, `#E5E0D8` hairlines, IBM Plex type) and used real i18n strings + lucide icons from the codebase.
- Every screen verified by rendering via Pencil `export_nodes` (PNG).

## Test plan
- [x] All new frames render correctly (verified via PNG export)
- [x] Old Agent Connections screens removed; no stray nodes
- [ ] Design review by maintainer

Generated with [Claude Code](https://claude.com/claude-code)