### PR TITLE
feat(daemon-chat): add "Copy session ID" button to transcript header

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1493,7 +1493,9 @@
     "detailsHostUnknown": "Unknown host",
     "detailUptime": "Uptime",
     "detailHost": "Host",
-    "detailStarted": "Started"
+    "detailStarted": "Started",
+    "copySessionId": "Copy session ID",
+    "sessionIdCopied": "Copied!"
   },
   "agentPresence": {
     "online": "online",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1494,7 +1494,9 @@
     "detailsHostUnknown": "未知主机",
     "detailUptime": "运行时长",
     "detailHost": "主机",
-    "detailStarted": "启动于"
+    "detailStarted": "启动于",
+    "copySessionId": "复制 session ID",
+    "sessionIdCopied": "已复制!"
   },
   "agentPresence": {
     "online": "在线",

--- a/src/components/agent-presence/__tests__/copy-session-id-button.test.tsx
+++ b/src/components/agent-presence/__tests__/copy-session-id-button.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+//
+// "Copy session ID" button (daemon chat transcript header). Two layers:
+//
+//   1. CopySessionIdButton in isolation — the copy interaction itself: a click
+//      writes the BARE session id to the clipboard (no `claude --resume`, no cwd),
+//      flips to the "Copied!" state, and resets after 2s (fake timers). A clipboard
+//      that rejects is swallowed (no throw, no false "Copied!" state).
+//   2. The button mounted inside the real TranscriptView header — placement next to
+//      the "Connection details" trigger, render-gating on `session != null`, and that
+//      BOTH session kinds (idea-anchored where sessionId === directIdeaUuid, and
+//      ad-hoc where it doesn't) surface the button copying their own sessionId.
+//
+// next-intl resolves real en.json strings so a missing key would surface as its
+// dotted path and fail the text assertions (same harness as send-instruction-box).
+// The footer ConversationReplyBox is stubbed so the header tests don't drag in
+// authFetch / sonner / the realtime context.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+
+// next-intl: resolve real en strings so a missing key surfaces as its dotted path.
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    let node: unknown = en;
+    for (const p of fullKey.split(".")) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations:
+      (namespace = "") =>
+      (key: string, params?: Record<string, string | number>) => {
+        let s = resolve(namespace, key);
+        if (params) {
+          for (const [k, v] of Object.entries(params)) {
+            s = s.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          }
+        }
+        return s;
+      },
+  };
+});
+
+vi.mock("@/lib/logger-client", () => ({
+  clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// The footer reply composer is irrelevant to the copy button — stub it so the
+// full-header render stays free of its data/context dependencies.
+vi.mock("../send-instruction-box", () => ({
+  ConversationReplyBox: () => null,
+}));
+
+import { clientLogger } from "@/lib/logger-client";
+import {
+  CopySessionIdButton,
+  TranscriptView,
+} from "@/components/agent-presence/chat/transcript-view";
+import type { SessionView } from "@/services/daemon-session.service";
+
+const NOW = "2026-06-22T03:00:00.000Z";
+
+function sessionView(overrides: Partial<SessionView> = {}): SessionView {
+  return {
+    uuid: "sess-1",
+    agentUuid: "agent-1",
+    sessionId: "8974ee58-1111-2222-3333-444455556666",
+    directIdeaUuid: "8974ee58-1111-2222-3333-444455556666", // idea-anchored: equals sessionId
+    originConnectionUuid: "conn-1",
+    status: "active",
+    title: "Refactor auth",
+    lastTurnAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+// Install a clipboard whose writeText is observable. Returns the spy.
+function installClipboard(impl?: (text: string) => Promise<void>) {
+  const writeText = vi.fn<(text: string) => Promise<void>>(
+    impl ?? (() => Promise.resolve()),
+  );
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+  return writeText;
+}
+
+function transcriptProps(session: SessionView | null) {
+  return {
+    session,
+    turns: [],
+    title: session?.title ?? "Conversation",
+    loading: false,
+    error: false,
+    originConnection: null,
+    originOnline: false,
+    sessionExecutions: [],
+    executionsByUuid: new Map(),
+    hasMoreEarlier: false,
+    loadingEarlier: false,
+    onLoadEarlier: () => {},
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // jsdom doesn't implement scrollIntoView; TranscriptView's auto-scroll effect
+  // calls it on mount. Stub it so the full-header render tests don't throw.
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("CopySessionIdButton — copy interaction", () => {
+  it("copies the bare session id (no `claude --resume`, no cwd) on click", async () => {
+    const writeText = installClipboard();
+    render(<CopySessionIdButton sessionId="sid-abc-123" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy session ID" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText).toHaveBeenCalledWith("sid-abc-123");
+    // Exactly the id — never a command form.
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toBe("sid-abc-123");
+    expect(copied).not.toContain("claude --resume");
+    expect(copied).not.toContain("cd ");
+  });
+
+  it("flips to the Copied! state then resets after 2s", async () => {
+    vi.useFakeTimers();
+    installClipboard();
+    render(<CopySessionIdButton sessionId="sid-abc-123" />);
+
+    // Drive the async click + the timer under fake timers.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy session ID" }));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByRole("button", { name: "Copied!" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Copy session ID" })).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.getByRole("button", { name: "Copy session ID" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Copied!" })).toBeNull();
+  });
+
+  it("swallows a clipboard rejection — no throw, stays in the un-copied state", async () => {
+    const writeText = installClipboard(() =>
+      Promise.reject(new Error("denied")),
+    );
+    render(<CopySessionIdButton sessionId="sid-abc-123" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy session ID" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    // It logged but did NOT flip to Copied! (the label stays "Copy session ID").
+    await waitFor(() => expect(clientLogger.error).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: "Copy session ID" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Copied!" })).toBeNull();
+  });
+
+  it("does not throw when the Clipboard API is unavailable (insecure context)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    render(<CopySessionIdButton sessionId="sid-abc-123" />);
+    // The optional-chained writeText is a no-op (awaiting `undefined`); clicking
+    // must not throw. The state flip that follows is flushed inside act().
+    await act(async () => {
+      expect(() =>
+        fireEvent.click(screen.getByRole("button", { name: "Copy session ID" })),
+      ).not.toThrow();
+      await Promise.resolve();
+    });
+  });
+});
+
+describe("CopySessionIdButton — inside the TranscriptView header", () => {
+  it("renders the button for an idea-anchored session and copies its sessionId", async () => {
+    const writeText = installClipboard();
+    const session = sessionView(); // sessionId === directIdeaUuid
+    render(<TranscriptView {...transcriptProps(session)} />);
+
+    const btn = screen.getByRole("button", { name: "Copy session ID" });
+    fireEvent.click(btn);
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(session.sessionId));
+  });
+
+  it("renders the button for an ad-hoc session (sessionId !== directIdeaUuid)", async () => {
+    const writeText = installClipboard();
+    const session = sessionView({
+      sessionId: "adhoc-server-generated-uuid",
+      directIdeaUuid: null,
+    });
+    render(<TranscriptView {...transcriptProps(session)} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy session ID" }));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("adhoc-server-generated-uuid"),
+    );
+  });
+
+  it("does NOT render the button when there is no session", () => {
+    installClipboard();
+    render(<TranscriptView {...transcriptProps(null)} />);
+    expect(screen.queryByRole("button", { name: "Copy session ID" })).toBeNull();
+  });
+});

--- a/src/components/agent-presence/__tests__/copy-session-id-button.test.tsx
+++ b/src/components/agent-presence/__tests__/copy-session-id-button.test.tsx
@@ -207,6 +207,59 @@ describe("CopySessionIdButton — copy interaction", () => {
   });
 });
 
+describe("CopySessionIdButton — responsive label (mobile icon-only)", () => {
+  // The visible label <span> is space-saving on mobile: hidden at rest
+  // (`hidden lg:inline` → icon-only), shown on copy (`inline` → the transient
+  // "Copied!" confirmation) and always shown on desktop. The accessible name
+  // (aria-label) is present at every breakpoint regardless.
+  function labelSpan(button: HTMLElement, text: string) {
+    return Array.from(button.querySelectorAll("span")).find(
+      (s) => s.textContent === text,
+    ) as HTMLElement | undefined;
+  }
+
+  it("hides the label on mobile at rest but keeps the accessible name (icon-only)", () => {
+    installClipboard();
+    render(<CopySessionIdButton sessionId="sid-abc-123" />);
+    const btn = screen.getByRole("button", { name: "Copy session ID" });
+    // Icon-only on mobile: the label span is `hidden` until the `lg` breakpoint.
+    const span = labelSpan(btn, "Copy session ID");
+    expect(span).toBeTruthy();
+    expect(span!.className).toContain("hidden");
+    expect(span!.className).toContain("lg:inline");
+    // a11y name still resolves (button is queryable by it) even while visually hidden.
+  });
+
+  it("reveals the confirmation label on copy (visible on mobile too), then collapses", async () => {
+    vi.useFakeTimers();
+    installClipboard();
+    render(<CopySessionIdButton sessionId="sid-abc-123" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy session ID" }));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    // After copy: the "Copied!" label is unconditionally `inline` (shown on mobile
+    // as the requested post-copy hint, not hidden behind the lg breakpoint).
+    const copiedBtn = screen.getByRole("button", { name: "Copied!" });
+    const copiedSpan = labelSpan(copiedBtn, "Copied!");
+    expect(copiedSpan).toBeTruthy();
+    expect(copiedSpan!.className).toContain("inline");
+    expect(copiedSpan!.className).not.toContain("hidden");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    // Back to rest → icon-only again on mobile.
+    const restSpan = labelSpan(
+      screen.getByRole("button", { name: "Copy session ID" }),
+      "Copy session ID",
+    );
+    expect(restSpan!.className).toContain("hidden");
+    expect(restSpan!.className).toContain("lg:inline");
+  });
+});
+
 describe("CopySessionIdButton — inside the TranscriptView header", () => {
   it("renders the button for an idea-anchored session and copies its sessionId", async () => {
     const writeText = installClipboard();

--- a/src/components/agent-presence/chat/transcript-view.tsx
+++ b/src/components/agent-presence/chat/transcript-view.tsx
@@ -24,9 +24,18 @@
 // Live updates are owned by the container (daemon-chat); this pane is presentational
 // over the already-patched `turns`.
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import { ChevronDown, ChevronUp, Info, Loader2, Lock, WifiOff } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  Info,
+  Loader2,
+  Lock,
+  WifiOff,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -36,6 +45,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { clientLogger } from "@/lib/logger-client";
 import { IdentityBlock } from "../identity-block";
 import { ConversationReplyBox } from "../send-instruction-box";
 import {
@@ -72,6 +82,48 @@ function DetailField({
         {value}
       </div>
     </div>
+  );
+}
+
+// A one-click "copy this conversation's session id" button for the header. The
+// session id IS the `claude --resume` anchor (daemon spawns idea-anchored sessions
+// with `--session-id = <idea uuid>`, and ad-hoc sessions carry a server-generated
+// uuid) — so copying it lets a human take the conversation over locally. We copy
+// the BARE id (not a `claude --resume <id>` command and not a `cd <dir> && …`): cwd
+// isn't reported yet, so a full command can't be assembled here. Mirrors the copy
+// idiom from `daemon-connect-cta.tsx` (guarded clipboard + 2s Copy→Check + a11y).
+export function CopySessionIdButton({ sessionId }: { sessionId: string }) {
+  const t = useTranslations("daemonChat");
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      // Optional-chain so an unavailable Clipboard API (insecure context, etc.)
+      // degrades gracefully — the button just no-ops instead of throwing.
+      await navigator.clipboard?.writeText(sessionId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      clientLogger.error("Failed to copy session id:", error);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={copy}
+      aria-label={copied ? t("sessionIdCopied") : t("copySessionId")}
+      aria-live="polite"
+      className="inline-flex h-auto items-center gap-1.5 px-1.5 py-0.5 text-[12px] font-medium text-[#6B6B6B] hover:bg-transparent hover:text-[#2C2C2C]"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-green-600" aria-hidden />
+      ) : (
+        <Copy className="h-3.5 w-3.5" aria-hidden />
+      )}
+      {copied ? t("sessionIdCopied") : t("copySessionId")}
+    </Button>
   );
 }
 
@@ -228,20 +280,32 @@ export function TranscriptView({
                 )}
               </span>
             )}
-            {/* Connection details — DEMOTED to a collapsible disclosure that shares the
-                status line. Its trigger sits inline with the badges; the content (host /
-                version / uptime / started via the reused IdentityBlock + formatters)
-                expands below the line. A subtle leading separator divides it from the
-                status when both render on the same line. */}
-            {originConnection && (
-              <CollapsibleTrigger className="group ml-auto inline-flex items-center gap-1.5 text-[12px] font-medium text-[#6B6B6B] hover:text-[#2C2C2C]">
-                <Info className="h-3.5 w-3.5" aria-hidden />
-                {t("detailsLabel")}
-                <ChevronDown
-                  className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180"
-                  aria-hidden
-                />
-              </CollapsibleTrigger>
+            {/* Right-aligned action group — the "Copy session ID" button and the
+                "Connection details" disclosure trigger sit ADJACENT at the end of the
+                status line. `ml-auto` lives on this wrapper (not on the trigger) so the
+                two stay grouped together rather than splitting to opposite ends. The
+                copy button is gated on `session` (an offline conversation can still be
+                resumed locally, so its id is still worth copying); the details trigger
+                is gated on `originConnection` (there's nothing to disclose without it). */}
+            {(session || originConnection) && (
+              <div className="ml-auto flex items-center gap-1">
+                {session && (
+                  <CopySessionIdButton sessionId={session.sessionId} />
+                )}
+                {/* Connection details — DEMOTED to a collapsible disclosure that shares
+                    the status line. The content (host / version / uptime / started via
+                    the reused IdentityBlock + formatters) expands below the line. */}
+                {originConnection && (
+                  <CollapsibleTrigger className="group inline-flex items-center gap-1.5 text-[12px] font-medium text-[#6B6B6B] hover:text-[#2C2C2C]">
+                    <Info className="h-3.5 w-3.5" aria-hidden />
+                    {t("detailsLabel")}
+                    <ChevronDown
+                      className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180"
+                      aria-hidden
+                    />
+                  </CollapsibleTrigger>
+                )}
+              </div>
             )}
           </div>
           {originConnection && (

--- a/src/components/agent-presence/chat/transcript-view.tsx
+++ b/src/components/agent-presence/chat/transcript-view.tsx
@@ -92,9 +92,16 @@ function DetailField({
 // the BARE id (not a `claude --resume <id>` command and not a `cd <dir> && …`): cwd
 // isn't reported yet, so a full command can't be assembled here. Mirrors the copy
 // idiom from `daemon-connect-cta.tsx` (guarded clipboard + 2s Copy→Check + a11y).
+//
+// Responsive label: on mobile the header is cramped, so at rest the button is
+// ICON-ONLY (label hidden) to save space; the moment it's copied it briefly
+// reveals the "Copied!" confirmation text (then collapses back after 2s). On
+// desktop (≥lg) the label is always shown. `aria-label` + `aria-live` keep it
+// accessible at every breakpoint, even while the visible label is hidden.
 export function CopySessionIdButton({ sessionId }: { sessionId: string }) {
   const t = useTranslations("daemonChat");
   const [copied, setCopied] = useState(false);
+  const label = copied ? t("sessionIdCopied") : t("copySessionId");
 
   const copy = async () => {
     try {
@@ -113,7 +120,8 @@ export function CopySessionIdButton({ sessionId }: { sessionId: string }) {
       variant="ghost"
       size="sm"
       onClick={copy}
-      aria-label={copied ? t("sessionIdCopied") : t("copySessionId")}
+      title={label}
+      aria-label={label}
       aria-live="polite"
       className="inline-flex h-auto items-center gap-1.5 px-1.5 py-0.5 text-[12px] font-medium text-[#6B6B6B] hover:bg-transparent hover:text-[#2C2C2C]"
     >
@@ -122,7 +130,9 @@ export function CopySessionIdButton({ sessionId }: { sessionId: string }) {
       ) : (
         <Copy className="h-3.5 w-3.5" aria-hidden />
       )}
-      {copied ? t("sessionIdCopied") : t("copySessionId")}
+      {/* Hidden on mobile at rest (icon-only, space-saving); revealed on copy as
+          the transient confirmation, and always shown on desktop (≥lg). */}
+      <span className={copied ? "inline" : "hidden lg:inline"}>{label}</span>
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a **Copy session ID** button to the daemon chat transcript header. The session id is the `claude --resume` anchor, so copying it lets a human take a daemon conversation over locally.
- Copies the **bare session id** (no `claude --resume` command, no `cd` — cwd isn't reported yet; deferred to idea `3a8b6be6`). Shows for both idea-anchored and ad-hoc sessions.
- **Responsive (mobile)**: at rest on mobile the button is **icon-only** (label hidden below `lg`) to save space in the cramped header; on copy it briefly reveals the "Copied!" confirmation (on mobile too), then collapses back after 2s. Desktop is unchanged (icon + label always). `aria-label`/`aria-live` keep it accessible at every breakpoint.
- Pure frontend — zero server/DB/API/service change (`session.sessionId` is already on the client).
- Implements idea `16044294` (task `2b149ddc`), elaboration: Q1=A copy bare id, Q2=B no directory hint, Q3=A header placement grouped with "Connection details".

## Changed files
| File | Change |
|------|--------|
| `src/components/agent-presence/chat/transcript-view.tsx` | New exported `CopySessionIdButton` (reuses the `daemon-connect-cta` copy idiom: guarded `clipboard?.writeText` + 2s Copy→Check + `aria-label`/`aria-live`); responsive label (`hidden lg:inline` at rest, `inline` on copy); mounted in the header with `ml-auto` on a wrapper `<div>` so the button and the "Connection details" trigger sit adjacent at the line end |
| `messages/en.json`, `messages/zh.json` | `daemonChat.copySessionId` / `sessionIdCopied` in both locales |
| `src/components/agent-presence/__tests__/copy-session-id-button.test.tsx` | New — 9 cases (incl. mobile icon-only / post-copy reveal) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` green, incl. the new 9-case file: click→`writeText(sessionId)` once, 2s reset, `session==null` no-render, clipboard reject/undefined graceful degrade, both session kinds, header placement, **mobile icon-only at rest + post-copy label reveal**
- [x] Reviewed by `chorus:task-reviewer` → PASS WITH NOTES (no blockers)
- [ ] `docs/design.pen` update deferred — Pencil MCP can't run in the headless daemon session that authored this; tracked as a follow-up

Generated with [Claude Code](https://claude.com/claude-code)