### PR TITLE
feat(mention): rank online agents to the top of @mention candidates

### DIFF
--- a/src/services/__tests__/mention.service.pure.test.ts
+++ b/src/services/__tests__/mention.service.pure.test.ts
@@ -1,5 +1,82 @@
 import { describe, it, expect } from "vitest";
-import { parseMentions } from "@/services/mention.service";
+import {
+  parseMentions,
+  compareMentionables,
+  type Mentionable,
+} from "@/services/mention.service";
+
+// ===== Test helpers =====
+
+function onlineAgent(name: string, activeCount: number): Mentionable {
+  return { type: "agent", uuid: `${name}-uuid`, name, online: true, activeCount };
+}
+function offlineAgent(name: string): Mentionable {
+  return { type: "agent", uuid: `${name}-uuid`, name, online: false, activeCount: 0 };
+}
+function user(name: string): Mentionable {
+  return { type: "user", uuid: `${name}-uuid`, name };
+}
+
+// ===== compareMentionables (pure comparator) =====
+
+describe("compareMentionables", () => {
+  it("ranks an online agent before a user", () => {
+    expect(compareMentionables(onlineAgent("Bot", 0), user("Alice"))).toBeLessThan(0);
+    expect(compareMentionables(user("Alice"), onlineAgent("Bot", 0))).toBeGreaterThan(0);
+  });
+
+  it("ranks an online agent before an offline agent", () => {
+    expect(compareMentionables(onlineAgent("Bot", 0), offlineAgent("Idle"))).toBeLessThan(0);
+    expect(compareMentionables(offlineAgent("Idle"), onlineAgent("Bot", 0))).toBeGreaterThan(0);
+  });
+
+  it("ranks an offline agent before a user", () => {
+    expect(compareMentionables(offlineAgent("Idle"), user("Alice"))).toBeLessThan(0);
+    expect(compareMentionables(user("Alice"), offlineAgent("Idle"))).toBeGreaterThan(0);
+  });
+
+  it("orders two online agents by activeCount ascending (idle first)", () => {
+    expect(compareMentionables(onlineAgent("Busy", 2), onlineAgent("Free", 0))).toBeGreaterThan(0);
+    expect(compareMentionables(onlineAgent("Free", 0), onlineAgent("Busy", 2))).toBeLessThan(0);
+  });
+
+  it("tie-breaks two online agents with equal activeCount by name (localeCompare asc)", () => {
+    expect(compareMentionables(onlineAgent("Bravo", 1), onlineAgent("Alpha", 1))).toBeGreaterThan(0);
+    expect(compareMentionables(onlineAgent("Alpha", 1), onlineAgent("Bravo", 1))).toBeLessThan(0);
+  });
+
+  it("treats missing activeCount on an online agent as 0", () => {
+    const noCount: Mentionable = { type: "agent", uuid: "x", name: "X", online: true };
+    // noCount (0) should precede an agent with activeCount 1
+    expect(compareMentionables(noCount, onlineAgent("Y", 1))).toBeLessThan(0);
+  });
+
+  it("returns 0 for two offline agents (same rank → stable order preserved)", () => {
+    expect(compareMentionables(offlineAgent("A"), offlineAgent("B"))).toBe(0);
+  });
+
+  it("returns 0 for two users (same rank → stable order preserved)", () => {
+    expect(compareMentionables(user("A"), user("B"))).toBe(0);
+  });
+
+  it("sorts a mixed list online-first, then offline agents, then users", () => {
+    const list: Mentionable[] = [
+      user("Zoe"),
+      offlineAgent("OffBot"),
+      onlineAgent("BusyBot", 3),
+      user("Amy"),
+      onlineAgent("IdleBot", 0),
+    ];
+    const sorted = [...list].sort(compareMentionables);
+    expect(sorted.map((m) => m.name)).toEqual([
+      "IdleBot", // online, activeCount 0
+      "BusyBot", // online, activeCount 3
+      "OffBot", // offline agent
+      "Zoe", // user (stable: came before Amy)
+      "Amy",
+    ]);
+  });
+});
 
 // ===== parseMentions =====
 

--- a/src/services/__tests__/mention.service.test.ts
+++ b/src/services/__tests__/mention.service.test.ts
@@ -257,18 +257,21 @@ describe("searchMentionables", () => {
     });
 
     expect(results).toHaveLength(2);
+    // Online-first ordering: agents (even offline, rank 1) sort ahead of users
+    // (rank 2). AliceBot has no online connection in this test, so it is an
+    // offline agent and still ranks above the user.
     expect(results[0]).toEqual(
-      expect.objectContaining({
-        type: "user",
-        uuid: USER_UUID,
-        name: "Alice",
-      })
-    );
-    expect(results[1]).toEqual(
       expect.objectContaining({
         type: "agent",
         uuid: AGENT_UUID,
         name: "AliceBot",
+      })
+    );
+    expect(results[1]).toEqual(
+      expect.objectContaining({
+        type: "user",
+        uuid: USER_UUID,
+        name: "Alice",
       })
     );
 
@@ -475,5 +478,208 @@ describe("searchMentionables — agent liveness enrichment", () => {
     // Cheap empty path: zero agent candidates ⇒ no liveness/count query at all.
     expect(mockPrisma.daemonConnection.findMany).not.toHaveBeenCalled();
     expect(mockPrisma.daemonExecution.groupBy).not.toHaveBeenCalled();
+  });
+});
+
+describe("searchMentionables — online-first ordering", () => {
+  const FRESH = new Date(); // within STALE_THRESHOLD_MS
+
+  // Distinct, valid hex UUIDs for multi-candidate scenarios.
+  const A1 = "a1a1a1a1-0000-0000-0000-000000000001";
+  const A2 = "a2a2a2a2-0000-0000-0000-000000000002";
+  const A3 = "a3a3a3a3-0000-0000-0000-000000000003";
+  const U1 = "b1b1b1b1-0000-0000-0000-000000000001";
+  const U2 = "b2b2b2b2-0000-0000-0000-000000000002";
+  const U3 = "b3b3b3b3-0000-0000-0000-000000000003";
+  const U4 = "b4b4b4b4-0000-0000-0000-000000000004";
+  const U5 = "b5b5b5b5-0000-0000-0000-000000000005";
+
+  // Scenario 1 (§5.1): online agent on top of an offline agent and a user.
+  it("places an online agent above an offline agent and a user", async () => {
+    // DB returns users first, then agents (current insertion order).
+    mockPrisma.user.findMany.mockResolvedValue([
+      { uuid: U1, name: "Carol", email: "carol@example.com", avatarUrl: null },
+    ]);
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: A1, name: "OnlineBot", roles: [] },
+      { uuid: A2, name: "OfflineBot", roles: [] },
+    ]);
+    // Only A1 has a fresh online connection.
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: A1, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "o",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    expect(results.map((r) => ({ type: r.type, uuid: r.uuid }))).toEqual([
+      { type: "agent", uuid: A1 }, // online agent
+      { type: "agent", uuid: A2 }, // offline agent
+      { type: "user", uuid: U1 }, // user last
+    ]);
+  });
+
+  // Scenario 2 (§5.2): among online agents, idle (lower activeCount) first.
+  it("orders online agents by activeCount ascending (idle first)", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    // Busy agent returned BEFORE the idle one by the DB.
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: A1, name: "BusyBot", roles: [] },
+      { uuid: A2, name: "IdleBot", roles: [] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: A1, status: "online", lastSeenAt: FRESH },
+      { agentUuid: A2, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([
+      { agentUuid: A1, _count: { _all: 2 } }, // busy
+      // A2 has no active executions → activeCount 0
+    ]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "bot",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    expect(results.map((r) => r.uuid)).toEqual([A2, A1]); // idle (0) before busy (2)
+    expect(results[0].activeCount).toBe(0);
+    expect(results[1].activeCount).toBe(2);
+  });
+
+  // Scenario 3 (§5.3): equal activeCount → name ascending tie-break.
+  it("tie-breaks online agents with equal activeCount by name ascending", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    // DB returns Zeta before Alpha; both idle.
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: A1, name: "Zeta", roles: [] },
+      { uuid: A2, name: "Alpha", roles: [] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: A1, status: "online", lastSeenAt: FRESH },
+      { agentUuid: A2, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "a",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    expect(results.map((r) => r.name)).toEqual(["Alpha", "Zeta"]);
+  });
+
+  // Scenario 4 (§5.4) — CORE REGRESSION: reserved slot for online agent.
+  // limit=2, 5 matching users (returned first by DB) + 1 online agent.
+  // The online agent must SURVIVE the slice and sit at index 0.
+  it("keeps an online agent at index 0 even when many users match and limit is small", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      { uuid: U1, name: "User1", email: "u1@example.com", avatarUrl: null },
+      { uuid: U2, name: "User2", email: "u2@example.com", avatarUrl: null },
+      { uuid: U3, name: "User3", email: "u3@example.com", avatarUrl: null },
+      { uuid: U4, name: "User4", email: "u4@example.com", avatarUrl: null },
+      { uuid: U5, name: "User5", email: "u5@example.com", avatarUrl: null },
+    ]);
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: A1, name: "OnlineBot", roles: [] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: A1, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "user",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+      limit: 2,
+    });
+
+    expect(results).toHaveLength(2);
+    // Online agent reserved the top slot despite 5 users matching first.
+    expect(results[0]).toEqual(
+      expect.objectContaining({ type: "agent", uuid: A1, online: true })
+    );
+    expect(results.some((r) => r.type === "agent" && r.uuid === A1)).toBe(true);
+    // Agent candidate pool is widened to effectiveLimit (not effectiveLimit - users.length).
+    expect(mockPrisma.agent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 2 })
+    );
+  });
+
+  // Scenario 5 (§5.5): empty-query branch — an online agent that is NOT the most
+  // recently created still gets surfaced to the top of the display.
+  it("surfaces an online agent in the empty-query branch even if it is not newest", async () => {
+    // orderBy createdAt desc → newest first. Newest two are offline; the online
+    // one (A3) is older and would previously have been at the bottom / cut.
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: A1, name: "NewestBot", roles: [] },
+      { uuid: A2, name: "MiddleBot", roles: [] },
+      { uuid: A3, name: "OlderOnlineBot", roles: [] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: A3, status: "online", lastSeenAt: FRESH },
+    ]);
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    // Empty-query is agent-only; online agent climbs to the front.
+    expect(results[0]).toEqual(
+      expect.objectContaining({ type: "agent", uuid: A3, online: true })
+    );
+    // Offline agents keep their DB (createdAt desc) order after the online one.
+    expect(results.map((r) => r.uuid)).toEqual([A3, A1, A2]);
+    // Candidate pool was widened to effectiveLimit so a non-newest online agent
+    // can be considered (default limit 10 here).
+    expect(mockPrisma.agent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 10 })
+    );
+  });
+
+  // Scenario 6 (§5.6): same-rank stability — offline agents and users keep
+  // their original relative order (stable sort regression).
+  it("preserves stable order among same-rank offline agents and among users", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      { uuid: U1, name: "Ursula", email: "u1@example.com", avatarUrl: null },
+      { uuid: U2, name: "Aaron", email: "u2@example.com", avatarUrl: null },
+    ]);
+    // Two offline agents, neither online → both rank 1, keep DB order.
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: A1, name: "ZebraBot", roles: [] },
+      { uuid: A2, name: "AntBot", roles: [] },
+    ]);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]); // all offline
+    mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
+
+    const results = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "a",
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+    });
+
+    // Offline agents (rank 1) come before users (rank 2); within each rank the
+    // DB / match insertion order is preserved (no name reordering off-rank).
+    expect(results.map((r) => ({ type: r.type, uuid: r.uuid }))).toEqual([
+      { type: "agent", uuid: A1 }, // ZebraBot kept before AntBot (stable)
+      { type: "agent", uuid: A2 },
+      { type: "user", uuid: U1 }, // Ursula kept before Aaron (stable)
+      { type: "user", uuid: U2 },
+    ]);
   });
 });

--- a/src/services/mention.service.ts
+++ b/src/services/mention.service.ts
@@ -217,6 +217,41 @@ export async function createMentions(params: CreateMentionsParams): Promise<void
 const DEFAULT_EMPTY_QUERY_LIMIT = 5;
 
 /**
+ * Type rank for online-first ordering (ascending): online agent → offline agent → user.
+ * Reads the `online` field that enrichAgentLiveness populates, so this must run AFTER
+ * enrichment (a not-yet-enriched agent has `online === undefined`, ranking as offline).
+ */
+function rankMentionable(m: Mentionable): number {
+  if (m.type === "agent") return m.online ? 0 : 1;
+  return 2;
+}
+
+/**
+ * Pure comparator for the @mention candidate list. Sorts (ascending):
+ * 1. By type rank: online agent (0) → offline agent (1) → user (2).
+ * 2. Among online agents (rank 0): by `activeCount` ascending (idle first), then by
+ *    `name.localeCompare` ascending as a deterministic tie-break.
+ * 3. Otherwise (same rank: offline agents, or users) returns 0 — relies on
+ *    `Array.prototype.sort` stability (Node ≥11 / ES2019) to preserve insertion order.
+ *
+ * Exported as a pure function for unit testing without a prisma mock. Must be applied
+ * after enrichAgentLiveness, since it reads `online` / `activeCount`.
+ */
+export function compareMentionables(a: Mentionable, b: Mentionable): number {
+  const ra = rankMentionable(a);
+  const rb = rankMentionable(b);
+  if (ra !== rb) return ra - rb;
+  if (ra === 0) {
+    // Both online agents: idle first, then deterministic name tie-break.
+    const ca = a.activeCount ?? 0;
+    const cb = b.activeCount ?? 0;
+    if (ca !== cb) return ca - cb;
+    return a.name.localeCompare(b.name);
+  }
+  return 0; // offline agents / users: keep stable (insertion) order.
+}
+
+/**
  * Enrich agent candidates in place with daemon liveness: `online` + `activeCount`.
  *
  * Resolves both in BATCH over the given agent uuids (two queries total, both
@@ -322,7 +357,10 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
           roles: true,
         },
         orderBy: { createdAt: 'desc' },
-        take: Math.min(DEFAULT_EMPTY_QUERY_LIMIT, effectiveLimit),
+        // Widen the candidate pool to effectiveLimit (was min(5, effectiveLimit)):
+        // an online agent that is NOT among the most recently created few must
+        // still be eligible to climb to the top via the online-first sort below.
+        take: effectiveLimit,
       });
 
       for (const agent of agents) {
@@ -335,9 +373,11 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
       }
     }
 
-    // Enrich the (agent-only) empty-query results with liveness before returning.
+    // enrich → sort (online-first) → slice. Enrich the full agent candidate pool,
+    // then order online agents to the front, then trim to the display cap (≤5).
     await enrichAgentLiveness(companyUuid, results);
-    return results;
+    results.sort(compareMentionables);
+    return results.slice(0, Math.min(DEFAULT_EMPTY_QUERY_LIMIT, effectiveLimit));
   }
   // Search users (all company users are mentionable)
   const users = await prisma.user.findMany({
@@ -390,7 +430,10 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
       name: true,
       roles: true,
     },
-    take: effectiveLimit - results.length > 0 ? effectiveLimit - results.length : effectiveLimit,
+    // Take the full effectiveLimit (NOT effectiveLimit - results.length): the agent
+    // candidate pool must be large enough that online agents survive the slice even
+    // when many matching users were inserted first. Online-first sort happens below.
+    take: effectiveLimit,
   });
 
   for (const agent of agents) {
@@ -402,11 +445,12 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
     });
   }
 
-  const sliced = results.slice(0, effectiveLimit);
-  // Enrich only the agents that survive the slice (liveness queries are scoped to
-  // what we actually return).
-  await enrichAgentLiveness(companyUuid, sliced);
-  return sliced;
+  // enrich → sort → slice. Enrich the FULL candidate pool (so liveness is known for
+  // every agent), order online agents to the front, THEN trim to the display limit —
+  // this is what keeps online agents from being sliced out by a flood of users.
+  await enrichAgentLiveness(companyUuid, results);
+  results.sort(compareMentionables);
+  return results.slice(0, effectiveLimit);
 }
 
 /**


### PR DESCRIPTION
## Summary
- @mention dropdowns now surface **online agents at the very top** of the candidate list (idea `193a08f9`).
- Root fix: `searchMentionables` used to **slice to `limit` before computing liveness**, with users inserted first — so a flood of matching users could cut online agents out before they were known to be online, defeating any post-hoc sort. Reordered both branches to **enrich → sort → slice** and widened the agent candidate pool to `effectiveLimit`.
- Pure server-side change in `src/services/mention.service.ts`; **frontend unchanged** (renders in server order). Both entry points — `GET /api/mentionables` and MCP `chorus_search_mentionables` — benefit from the single server-side sort.

### Ordering rules
- `compareMentionables` rank: online agent (0) → offline agent (1) → user (2).
- Among online agents: `activeCount` ascending (idle first), then `name.localeCompare` ascending as a deterministic tie-break.
- Same-rank entries (offline agents, users) keep insertion order via ES2019 stable sort.
- Empty-query branch keeps its `<=5` display cap.

## Changed files
| File | Change |
|------|--------|
| `src/services/mention.service.ts` | New exported `compareMentionables`; both branches reordered to enrich→sort→slice; agent pool widened to `effectiveLimit` |
| `src/services/__tests__/mention.service.test.ts` | New "online-first ordering" suite (6 scenarios incl. reserved-slot regression: limit=2 + 5 users + 1 online agent → agent at index 0) |
| `src/services/__tests__/mention.service.pure.test.ts` | New `compareMentionables` direct unit cases |

## Not changed (constraints)
Liveness computation (`enrichAgentLiveness` / `STALE_THRESHOLD_MS` / `ACTIVE_EXECUTION_STATUSES`), auth/owner-scope, the 50 cap, return shape, frontend, i18n, design.pen.

## Test plan
- [x] `npx tsc --noEmit` → exit 0
- [x] `pnpm test mention.service.test.ts mention.service.pure.test.ts` → 45 passed
- [x] `npx eslint src/services/mention.service.ts` → 0 errors (full `pnpm lint`'s only 2 errors are pre-existing, in `packages/openclaw-plugin/`, untouched here)

Generated with [Claude Code](https://claude.com/claude-code)