### PR TITLE
feat(dashboard): render project description as collapsible markdown

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -13,6 +13,8 @@
     "copied": "Copied!",
     "back": "Back",
     "viewAll": "View all",
+    "showMore": "Show more",
+    "showLess": "Show less",
     "signOut": "Sign out",
     "optional": "Optional",
     "unassigned": "Unassigned",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -13,6 +13,8 @@
     "copied": "已复制!",
     "back": "返回",
     "viewAll": "查看全部",
+    "showMore": "展开",
+    "showLess": "收起",
     "signOut": "退出登录",
     "optional": "可选",
     "unassigned": "未分配",

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
@@ -5,6 +5,7 @@ import { getTranslations } from "next-intl/server";
 import { getDashboardData } from "./dashboard-data";
 import { ProjectSettingsModal } from "./project-settings-modal";
 import { IdeaTracker } from "./idea-tracker";
+import { CollapsibleMarkdown } from "@/components/collapsible-markdown";
 
 interface DashboardContentProps {
   projectUuid: string;
@@ -21,9 +22,14 @@ export async function DashboardContent({ projectUuid, initialSelectedIdeaUuid }:
         <div className="min-w-0">
           <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-[#A8A39B]">{t("ideaTracker.overview")}</p>
           <h1 className="mt-1 truncate text-2xl font-semibold tracking-tight text-[#2C2C2A]">{project.name}</h1>
-          <p className="mt-1 text-[13px] text-[#5F5E5A]">
-            {project.description?.trim() ? project.description : t("ideaTracker.overviewSubtitle")}
-          </p>
+          {project.description?.trim() ? (
+            <CollapsibleMarkdown
+              content={project.description}
+              className="mt-1 text-[13px] leading-relaxed text-[#5F5E5A] max-w-none"
+            />
+          ) : (
+            <p className="mt-1 text-[13px] text-[#5F5E5A]">{t("ideaTracker.overviewSubtitle")}</p>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-3">
           <ProjectSettingsModal projectUuid={projectUuid} projectName={project.name} projectDescription={project.description ?? null} />

--- a/src/components/collapsible-markdown.tsx
+++ b/src/components/collapsible-markdown.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { MarkdownContent } from "@/components/markdown-content";
+
+const COLLAPSED_MAX_HEIGHT = 80; // px — roughly 3-4 lines of compact body text
+
+interface CollapsibleMarkdownProps {
+  content: string;
+  /** Extra classes applied to the outer wrapper (spacing, typography). */
+  className?: string;
+}
+
+/**
+ * Renders markdown content with an expand/collapse toggle for long content.
+ *
+ * Unlike the character-slicing approach used for plain comments, this clamps
+ * the *rendered* height so markdown syntax (headings, lists, code) is never cut
+ * mid-token. The collapsed clamp is applied from first paint (no flash), and the
+ * "Show more" toggle only appears when the content actually overflows.
+ */
+export function CollapsibleMarkdown({ content, className }: CollapsibleMarkdownProps) {
+  const t = useTranslations();
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+
+    const measure = () =>
+      setOverflowing(el.scrollHeight > COLLAPSED_MAX_HEIGHT + 1);
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [content]);
+
+  return (
+    <div className={className}>
+      <div
+        ref={contentRef}
+        className="overflow-hidden [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:mt-2 [&_h1]:mb-1 [&_h2]:text-[13px] [&_h2]:font-semibold [&_h2]:mt-2 [&_h2]:mb-1 [&_h3]:text-[13px] [&_h3]:font-semibold [&_h3]:mt-1.5 [&_h3]:mb-0.5 [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0"
+        style={expanded ? undefined : { maxHeight: COLLAPSED_MAX_HEIGHT }}
+      >
+        <MarkdownContent>{content}</MarkdownContent>
+      </div>
+      {overflowing && (
+        <Button
+          variant="link"
+          size="sm"
+          onClick={() => setExpanded((value) => !value)}
+          className="h-auto p-0 text-[#E07A5F] text-xs font-medium mt-1"
+        >
+          {expanded ? t("common.showLess") : t("common.showMore")}
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- The project dashboard rendered `project.description` as a plain `<p>` — two problems: (1) no markdown rendering, (2) long descriptions were never truncated.
- Added a reusable `CollapsibleMarkdown` component that renders the description through the existing `MarkdownContent` (Streamdown) pipeline and adds a **Show more / Show less** toggle, mirroring the comment expand/collapse UX.
- Clamps by **rendered height** (`max-height: 80px`) via a `ResizeObserver` rather than char-slicing the raw string — so markdown syntax (headings, lists, code blocks) is never cut mid-token, and the toggle only shows when content actually overflows.

## Changed files
| File | Change |
|------|--------|
| `src/components/collapsible-markdown.tsx` | New reusable markdown + expand/collapse component |
| `src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx` | Render description via `CollapsibleMarkdown` when present; keep plain fallback subtitle when empty |
| `messages/en.json` / `messages/zh.json` | Add `common.showMore` / `common.showLess` |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] JSON locale files valid
- [x] Manual browser verification: created a project with a rich markdown description; confirmed collapsed state (clamped + "Show more"), expanded state (headings, lists, inline code, link, emphasis, syntax-highlighted code block, blockquote + "Show less"), and that short descriptions show no toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)