### PR TITLE
feat(daemon): multi-path cwd support — promote cwd to connection identity

### DIFF
--- a/cli/__tests__/daemon-config.test.mjs
+++ b/cli/__tests__/daemon-config.test.mjs
@@ -3,7 +3,11 @@
 // spec "The timeout SHALL be resolvable through the daemon's layered configuration"):
 //   --sigint-timeout flag > CHORUS_DAEMON_SIGINT_TIMEOUT env > daemon.json > 10000.
 import { describe, it, expect, vi } from "vitest";
-import { resolveSigintTimeoutMs, DEFAULT_SIGINT_TIMEOUT_MS } from "../daemon-config.mjs";
+import {
+  resolveSigintTimeoutMs,
+  DEFAULT_SIGINT_TIMEOUT_MS,
+  resolveDaemonCwds,
+} from "../daemon-config.mjs";
 
 describe("resolveSigintTimeoutMs layered precedence", () => {
   it("defaults to 10000 when no source is present", () => {
@@ -57,5 +61,91 @@ describe("resolveSigintTimeoutMs layered precedence", () => {
   it("a malformed daemon.json (readJson returns null) falls through to the default", () => {
     const ms = resolveSigintTimeoutMs({}, { env: {}, readJson: () => null });
     expect(ms).toBe(10_000);
+  });
+});
+
+// ===== T3: resolveDaemonCwds — the SET of paths a single daemon serves =====
+// FR-5/FR-8, DEC-2/DEC-5: a daemon declares a LIST of cwds (each → one independent
+// connection). JUST a path list — no project binding. Layered precedence mirrors
+// resolveSigintTimeoutMs: --cwd flag(s) > CHORUS_DAEMON_CWDS env > daemon.json `cwds`
+// > [undefined] (single connection at the process cwd / HARD-1 single-path default).
+describe("resolveDaemonCwds layered precedence", () => {
+  const HOME = "/home/tester";
+
+  it("defaults to [undefined] (single process-cwd connection) when nothing is declared", () => {
+    const cwds = resolveDaemonCwds({}, { env: {}, readJson: () => null, home: HOME });
+    expect(cwds).toEqual([undefined]);
+  });
+
+  it("daemon.json `cwds` declares the SET, resolved to absolute paths + deduped", () => {
+    const readJson = vi.fn(() => ({ cwds: ["/dev/repo-a", "/dev/repo-b", "/dev/repo-a"] }));
+    const cwds = resolveDaemonCwds(
+      {},
+      { env: {}, readJson, loginPath: "/x/daemon.json", home: HOME },
+    );
+    expect(cwds).toEqual(["/dev/repo-a", "/dev/repo-b"]); // dup dropped, order preserved
+    expect(readJson).toHaveBeenCalledWith("/x/daemon.json");
+  });
+
+  it("env CHORUS_DAEMON_CWDS overrides daemon.json (comma OR colon separated)", () => {
+    const comma = resolveDaemonCwds(
+      {},
+      { env: { CHORUS_DAEMON_CWDS: "/a,/b" }, readJson: () => ({ cwds: ["/from-file"] }), home: HOME },
+    );
+    expect(comma).toEqual(["/a", "/b"]);
+    const colon = resolveDaemonCwds(
+      {},
+      { env: { CHORUS_DAEMON_CWDS: "/a:/b" }, readJson: () => null, home: HOME, delimiter: "" },
+    );
+    expect(colon).toEqual(["/a", "/b"]);
+  });
+
+  it("the --cwd flag list wins over env and file (highest precedence), repeatable", () => {
+    const cwds = resolveDaemonCwds(
+      { cwd: ["/flag-a", "/flag-b"] },
+      { env: { CHORUS_DAEMON_CWDS: "/env" }, readJson: () => ({ cwds: ["/file"] }), home: HOME },
+    );
+    expect(cwds).toEqual(["/flag-a", "/flag-b"]);
+  });
+
+  it("accepts a single --cwd as a string too", () => {
+    const cwds = resolveDaemonCwds({ cwd: "/only" }, { env: {}, readJson: () => null, home: HOME });
+    expect(cwds).toEqual(["/only"]);
+  });
+
+  it("expands a leading ~ to the home dir", () => {
+    const cwds = resolveDaemonCwds(
+      { cwd: ["~/dev/x", "~"] },
+      { env: {}, readJson: () => null, home: HOME },
+    );
+    expect(cwds).toEqual([`${HOME}/dev/x`, HOME]);
+  });
+
+  it("resolves a relative path to absolute (against process cwd)", () => {
+    const cwds = resolveDaemonCwds({ cwd: ["sub/dir"] }, { env: {}, readJson: () => null, home: HOME });
+    expect(cwds).toEqual([`${process.cwd()}/sub/dir`]);
+  });
+
+  it("drops blank / whitespace-only entries and falls through when all blank", () => {
+    // All-blank flag list → fall through to env → file → default.
+    const cwds = resolveDaemonCwds(
+      { cwd: ["", "   "] },
+      { env: {}, readJson: () => null, home: HOME },
+    );
+    expect(cwds).toEqual([undefined]);
+  });
+
+  it("a malformed daemon.json (no `cwds` array) falls through to the default", () => {
+    const cwds = resolveDaemonCwds({}, { env: {}, readJson: () => ({ url: "x" }), home: HOME });
+    expect(cwds).toEqual([undefined]);
+  });
+
+  it("the declaration is JUST paths — it never reads or returns any project binding", () => {
+    // Even if a config carried an (ignored) project field, only the path set is used.
+    const readJson = vi.fn(() => ({ cwds: ["/dev/repo-a"], projectUuid: "should-be-ignored" }));
+    const cwds = resolveDaemonCwds({}, { env: {}, readJson, home: HOME });
+    expect(cwds).toEqual(["/dev/repo-a"]);
+    // The result is a flat array of strings — no project info threaded anywhere.
+    expect(cwds.every((c) => typeof c === "string")).toBe(true);
   });
 });

--- a/cli/__tests__/daemon-multipath.test.mjs
+++ b/cli/__tests__/daemon-multipath.test.mjs
@@ -1,0 +1,389 @@
+// cli/__tests__/daemon-multipath.test.mjs
+// T3 — 单 daemon 多路径引擎. Covers the engine core:
+//   • AC#1 unified cwd source of truth: Waker.resolveCwd() drives BOTH the transcript
+//     probe and the spawn; process-level cwd is only the unspecified fallback.
+//   • AC#2 multi-path registration: one daemon process serving a SET of cwds builds one
+//     independent connection per path, each self-reporting its own cwd.
+//   • AC#3 per-spawn cwd: each spawned child uses its connection-bound cwd; the daemon
+//     process cwd never changes; the same session's repeated wakes land the same cwd.
+//   • AC#6 HARD-1: an unspecified cwd (old daemon) degrades to the process default cwd
+//     for both spawn and self-report — behaves exactly as before.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildDaemon } from "../daemon.mjs";
+import { Waker } from "../waker.mjs";
+import { transcriptPath } from "../claude-spawner.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+
+const DIRECT_IDEA = "11111111-1111-4111-8111-111111111111";
+const ROOT_IDEA = "99999999-9999-4999-8999-999999999999";
+
+const TASK_NOTIF = {
+  uuid: "notif-1",
+  projectUuid: "proj-1",
+  entityType: "task",
+  entityUuid: "task-1",
+  entityTitle: "Build the thing",
+  action: "task_assigned",
+  message: "",
+  actorType: "user",
+  actorUuid: "user-1",
+  actorName: "Alice",
+};
+
+function mockMcp() {
+  return {
+    async callTool(name) {
+      return name === "chorus_get_notifications" ? { notifications: [TASK_NOTIF] } : null;
+    },
+    async disconnect() {},
+  };
+}
+
+function lineageFetch() {
+  return async (url) => ({
+    ok: true,
+    status: 200,
+    async json() {
+      if (String(url).includes("/api/entities/task/task-1/root-idea")) {
+        return {
+          success: true,
+          data: { rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA, lineage: [], resolvedVia: "via_proposal" },
+        };
+      }
+      return { success: true, data: { rootIdeaUuid: null, directIdeaUuid: null, lineage: [], resolvedVia: "not_found" } };
+    },
+  });
+}
+
+/** A mock SSE listener mirroring the real fork; records the cwd it was constructed with. */
+class MockSse {
+  constructor(opts) {
+    this.opts = opts;
+    // Mirror the real SseListener: an unspecified cwd self-reports the process cwd
+    // (HARD-1). So `this.cwd` is the value actually sent to the server.
+    this.cwd = opts.cwd ?? process.cwd();
+    this.connected = false;
+  }
+  async connect() {
+    this.connected = true;
+  }
+  disconnect() {
+    this.connected = false;
+  }
+  deliver(event) {
+    if (event?.type === "connection_registered") return this.opts.onConnectionId?.(event.connectionUuid);
+    if (event?.type === "control") return this.opts.onControl?.(event);
+    this.opts.onEvent(event);
+  }
+}
+
+// ===== AC#1 — Waker.resolveCwd() is the single cwd source of truth =====
+describe("AC#1 unified cwd source of truth (Waker.resolveCwd)", () => {
+  it("resolveCwd returns the connection-bound cwd when one is declared", () => {
+    const waker = new Waker({ creds: {}, lineage: {}, spawner: {}, cwd: "/dev/repo-a", logger: silent });
+    expect(waker.resolveCwd()).toBe("/dev/repo-a");
+  });
+
+  it("resolveCwd degrades to the process cwd when cwd is unspecified (HARD-1 fallback)", () => {
+    const waker = new Waker({ creds: {}, lineage: {}, spawner: {}, logger: silent });
+    expect(waker.cwd).toBeUndefined(); // stored raw — no process.cwd() baked at construction
+    expect(waker.resolveCwd()).toBe(process.cwd());
+  });
+
+  it("the transcript probe AND the spawn both receive the SAME resolved cwd", async () => {
+    const probeCwds = [];
+    const spawnCwds = [];
+    const waker = new Waker({
+      creds: { url: "u", apiKey: "k" },
+      lineage: { resolve: async () => ({ rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA }) },
+      isNewSessionFn: (_id, cwd) => {
+        probeCwds.push(cwd);
+        return true;
+      },
+      writeMcpConfigFn: () => ({ path: "/tmp/mcp.json", cleanup() {} }),
+      spawner: {
+        wake: vi.fn(async (params) => {
+          spawnCwds.push(params.cwd);
+          return { sessionId: params.sessionId, exitCode: 0, isNew: params.isNew };
+        }),
+      },
+      cwd: "/dev/repo-bound",
+      logger: silent,
+    });
+    await waker.wake(TASK_NOTIF, `idea:${DIRECT_IDEA}`, { rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA });
+    // One probe, one spawn, both at the connection-bound cwd — never process.cwd().
+    expect(probeCwds).toEqual(["/dev/repo-bound"]);
+    expect(spawnCwds).toEqual(["/dev/repo-bound"]);
+  });
+});
+
+// ===== AC#2 / AC#3 — single daemon, multiple paths =====
+describe("AC#2/#3 single daemon serving a SET of cwds", () => {
+  it("builds one independent connection per declared cwd, each self-reporting its own cwd", async () => {
+    const created = [];
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner: { wake: vi.fn(async (p) => ({ sessionId: p.sessionId, exitCode: 0, isNew: p.isNew })) },
+        cwds: ["/dev/repo-a", "/dev/repo-b"],
+        makeSseListener: (o) => {
+          const sse = new MockSse(o);
+          created.push(sse);
+          return sse;
+        },
+      }
+    );
+    // Two connections, each with its own Waker bound to a distinct cwd.
+    expect(daemon.connections).toHaveLength(2);
+    expect(daemon.connections.map((c) => c.cwd)).toEqual(["/dev/repo-a", "/dev/repo-b"]);
+    expect(daemon.connections[0].waker.resolveCwd()).toBe("/dev/repo-a");
+    expect(daemon.connections[1].waker.resolveCwd()).toBe("/dev/repo-b");
+    // Each connection's SSE listener self-reports ITS cwd → distinct registry rows.
+    await daemon.start();
+    expect(created.map((s) => s.cwd)).toEqual(["/dev/repo-a", "/dev/repo-b"]);
+    expect(created.every((s) => s.connected)).toBe(true);
+    await daemon.stop();
+    expect(created.every((s) => !s.connected)).toBe(true);
+  });
+
+  it("a wake delivered to the repo-b connection spawns in repo-b; the daemon process cwd is untouched", async () => {
+    const spawnCalls = [];
+    const procCwdBefore = process.cwd();
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner: {
+          wake: vi.fn(async (p) => {
+            spawnCalls.push({ cwd: p.cwd, sessionId: p.sessionId });
+            p.onMessage?.({ type: "system", session_id: p.sessionId });
+            return { sessionId: p.sessionId, exitCode: 0, isNew: p.isNew };
+          }),
+        },
+        cwds: ["/dev/repo-a", "/dev/repo-b"],
+        makeSseListener: (o) => new MockSse(o),
+      }
+    );
+    await daemon.start();
+    // Drive a wake only on connection #2 (repo-b).
+    daemon.connections[1].sseListener.deliver({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cwd).toBe("/dev/repo-b"); // per-spawn cwd = the connection's cwd
+    expect(spawnCalls[0].sessionId).toBe(DIRECT_IDEA);
+    // NFR-3: the daemon's OWN process cwd never changed.
+    expect(process.cwd()).toBe(procCwdBefore);
+    await daemon.stop();
+  });
+
+  it("the same session's repeated wakes on a connection always land that connection's cwd", async () => {
+    const spawnCwds = [];
+    // Two DISTINCT notifications, both targeting task-1 → same DIRECT_IDEA session. The
+    // realistic "repeated wakes on one session" path (a single notif uuid is deduped by
+    // the router's `seen` set, which is correct — a session continues across wakes).
+    const mcp = {
+      async callTool(name) {
+        return name === "chorus_get_notifications"
+          ? { notifications: [TASK_NOTIF, { ...TASK_NOTIF, uuid: "notif-2" }] }
+          : null;
+      },
+      async disconnect() {},
+    };
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mcp,
+        fetchImpl: lineageFetch(),
+        spawner: {
+          wake: vi.fn(async (p) => {
+            spawnCwds.push(p.cwd);
+            return { sessionId: p.sessionId, exitCode: 0, isNew: p.isNew };
+          }),
+        },
+        cwds: ["/dev/repo-a"],
+        makeSseListener: (o) => new MockSse(o),
+      }
+    );
+    await daemon.start();
+    const conn = daemon.connections[0];
+    conn.sseListener.deliver({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 30));
+    conn.sseListener.deliver({ type: "new_notification", notificationUuid: "notif-2" });
+    await new Promise((r) => setTimeout(r, 30));
+    // Both wakes for the same session landed the same (connection-bound) cwd.
+    expect(spawnCwds).toEqual(["/dev/repo-a", "/dev/repo-a"]);
+    await daemon.stop();
+  });
+
+  it("connections do not share a connectionUuid box (independent registration)", async () => {
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner: { wake: vi.fn(async (p) => ({ sessionId: p.sessionId, exitCode: 0, isNew: p.isNew })) },
+        cwds: ["/dev/repo-a", "/dev/repo-b"],
+        makeSseListener: (o) => new MockSse(o),
+      }
+    );
+    await daemon.start();
+    daemon.connections[0].sseListener.deliver({ type: "connection_registered", connectionUuid: "conn-A" });
+    daemon.connections[1].sseListener.deliver({ type: "connection_registered", connectionUuid: "conn-B" });
+    expect(daemon.connections[0].connectionState.connectionUuid).toBe("conn-A");
+    expect(daemon.connections[1].connectionState.connectionUuid).toBe("conn-B");
+    await daemon.stop();
+  });
+});
+
+// ===== AC#6 — HARD-1: old daemon / unspecified cwd =====
+describe("AC#6 HARD-1: an unspecified cwd degrades to the process default", () => {
+  it("a single-path daemon (no cwds) builds one connection whose cwd is undefined → self-reports process.cwd()", async () => {
+    let captured;
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner: { wake: vi.fn(async (p) => ({ sessionId: p.sessionId, exitCode: 0, isNew: p.isNew })) },
+        // no `cwds` and no `cwd` → the default single connection
+        makeSseListener: (o) => (captured = new MockSse(o)),
+      }
+    );
+    expect(daemon.connections).toHaveLength(1);
+    expect(daemon.connections[0].cwd).toBeUndefined(); // raw — unspecified
+    // resolveCwd() and the self-reported cwd both degrade to the process cwd.
+    expect(daemon.connections[0].waker.resolveCwd()).toBe(process.cwd());
+    await daemon.start();
+    expect(captured.cwd).toBe(process.cwd()); // SSE self-report = process cwd (HARD-1)
+    await daemon.stop();
+  });
+
+  it("an old-daemon wake (undefined cwd) still spawns — at the process default cwd", async () => {
+    const spawnCalls = [];
+    let captured;
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner: {
+          wake: vi.fn(async (p) => {
+            spawnCalls.push(p.cwd);
+            p.onMessage?.({ type: "system", session_id: p.sessionId });
+            return { sessionId: p.sessionId, exitCode: 0, isNew: p.isNew };
+          }),
+        },
+        // explicitly model the OLD daemon: cwds = [undefined] (what resolveDaemonCwds
+        // returns when nothing is declared).
+        cwds: [undefined],
+        makeSseListener: (o) => (captured = new MockSse(o)),
+      }
+    );
+    await daemon.start();
+    captured.deliver({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]).toBe(process.cwd()); // degraded to process default (HARD-1)
+    await daemon.stop();
+  });
+});
+
+// ===== AC#3/#4 — real on-disk transcript isolation per cwd =====
+// Uses the REAL isNewSession/transcriptPath probe against a sandboxed CLAUDE_CONFIG_DIR.
+// Proves: a session run in cwd-A creates its transcript under cwd-A's escaped projects
+// dir, and the SAME session id probed in cwd-B is still "new" (the cwd-A transcript is
+// invisible there) — i.e. resume is cwd-bound, so a cross-cwd route would `No conversation
+// found`. This is exactly why resume must route back to the session's ORIGINAL cwd.
+describe("AC#3/#4 real transcript isolation across cwds (resume is cwd-bound)", () => {
+  let configDir;
+  const SESSION = "11111111-1111-4111-8111-111111111111";
+
+  afterEach(() => {
+    if (configDir) rmSync(configDir, { recursive: true, force: true });
+    configDir = undefined;
+    delete process.env.CLAUDE_CONFIG_DIR;
+  });
+
+  it("a Waker bound to cwd-A creates its transcript under cwd-A only; cwd-B's probe stays 'new'", async () => {
+    configDir = mkdtempSync(join(tmpdir(), "chorus-mp-cfg-"));
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const cwdA = mkdtempSync(join(tmpdir(), "chorus-mp-a-"));
+    const cwdB = mkdtempSync(join(tmpdir(), "chorus-mp-b-"));
+
+    // A spawner that behaves like claude: writes the transcript at the REAL probed path
+    // for the cwd it is told to spawn in.
+    const spawner = {
+      wake: vi.fn(async ({ sessionId, cwd, isNew }) => {
+        const tpath = transcriptPath(sessionId, cwd, { env: process.env });
+        mkdirSync(tpath.slice(0, tpath.lastIndexOf("/")), { recursive: true });
+        writeFileSync(tpath, `{"type":"system","session_id":"${sessionId}"}\n`, { flag: "a" });
+        return { sessionId, exitCode: 0, isNew };
+      }),
+    };
+
+    // Waker bound to cwd-A (real probe + real spawn).
+    const wakerA = new Waker({
+      creds: { url: "u", apiKey: "k" },
+      lineage: { resolve: async () => ({ rootIdeaUuid: SESSION, directIdeaUuid: SESSION }) },
+      writeMcpConfigFn: () => ({ path: join(configDir, "mcp.json"), cleanup() {} }),
+      spawner,
+      cwd: cwdA,
+      logger: silent,
+    });
+
+    const notif = { ...TASK_NOTIF, entityUuid: SESSION };
+    await wakerA.wake(notif, `idea:${SESSION}`, { rootIdeaUuid: SESSION, directIdeaUuid: SESSION });
+
+    // The transcript now exists under cwd-A's escaped dir, NOT cwd-B's.
+    const pathA = transcriptPath(SESSION, cwdA, { env: process.env });
+    const pathB = transcriptPath(SESSION, cwdB, { env: process.env });
+    expect(existsSync(pathA)).toBe(true);
+    expect(existsSync(pathB)).toBe(false);
+    expect(pathA).not.toBe(pathB); // distinct escaped-cwd dirs → cwd-bound resume
+
+    // A Waker bound to cwd-B probing the SAME session id sees "new" (transcript invisible
+    // there) — proving a cross-cwd resume would start fresh / fail, hence resume MUST
+    // route back to the original cwd (the server's originConnectionUuid pin).
+    const wakerB = new Waker({ creds: {}, lineage: {}, spawner: {}, cwd: cwdB, logger: silent });
+    expect(wakerB.isNewSessionFn(SESSION, wakerB.resolveCwd())).toBe(true);
+    // While cwd-A correctly resumes (transcript present → not new).
+    expect(wakerA.isNewSessionFn(SESSION, wakerA.resolveCwd())).toBe(false);
+
+    rmSync(cwdA, { recursive: true, force: true });
+    rmSync(cwdB, { recursive: true, force: true });
+  });
+});
+
+// ===== Back-compat: deps.cwd single value still works (every existing test path) =====
+describe("back-compat: deps.cwd (single value) maps to a one-element cwd set", () => {
+  it("a daemon built with deps.cwd has one connection bound to that cwd, aliased onto daemon.waker", async () => {
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner: { wake: vi.fn(async (p) => ({ sessionId: p.sessionId, exitCode: 0, isNew: p.isNew })) },
+        cwd: "/legacy/single",
+        makeSseListener: (o) => new MockSse(o),
+      }
+    );
+    expect(daemon.connections).toHaveLength(1);
+    expect(daemon.waker).toBe(daemon.connections[0].waker); // primary alias
+    expect(daemon.waker.resolveCwd()).toBe("/legacy/single");
+  });
+});

--- a/cli/__tests__/sse-listener.test.mjs
+++ b/cli/__tests__/sse-listener.test.mjs
@@ -204,7 +204,7 @@ describe("SseListener self-report URL", () => {
     return { listener, fetchImpl };
   }
 
-  it("appends clientType=claude_code + version + host + startedAt", async () => {
+  it("appends clientType=claude_code + version + host + cwd + startedAt", async () => {
     const { listener, fetchImpl } = captureUrl();
     await listener.connect();
 
@@ -216,6 +216,10 @@ describe("SseListener self-report URL", () => {
     // Version is the CLI's real package version, not a hardcoded literal.
     expect(url.searchParams.get("clientVersion")).toBe(CLI_VERSION);
     expect(url.searchParams.get("host")).toBe(hostname());
+    // cwd is the working directory this connection serves — the CLI is single-cwd
+    // today so it reports process.cwd(). The server keys the registry on it so
+    // same agent + same host + different cwd no longer overwrite each other.
+    expect(url.searchParams.get("cwd")).toBe(process.cwd());
     // startedAt is a valid ISO-8601 timestamp.
     const startedAt = url.searchParams.get("startedAt");
     expect(startedAt).toBeTruthy();

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -28,10 +28,16 @@ export const KNOWN_AGENTS = new Set(["claude-code"]);
  * "false" (important for layered env/flag precedence downstream).
  *
  * @param {string[]} argv
+ * The new repeatable `--cwd <path>` (space + `=`) declares a working directory the
+ * daemon serves; repeating it (`--cwd a --cwd b`) declares the SET of paths for the
+ * single-daemon multi-path engine (T3). It is collected into a `cwd: string[]` array
+ * preserving order; absent ⇒ `cwd` is unset (the layered resolver then falls back to
+ * env / config / the process cwd). It is JUST a path list — no project binding.
+ *
  * @returns {{
  *   url?: string, apiKey?: string, yolo?: boolean, sigintTimeout?: string,
  *   agent?: string, chorusOnly?: boolean, verbose?: boolean, detach?: boolean,
- *   help?: boolean,
+ *   cwd?: string[], help?: boolean,
  * }}
  */
 export function parseClientFlags(argv) {
@@ -47,6 +53,11 @@ export function parseClientFlags(argv) {
     else if (a.startsWith("--sigint-timeout=")) out.sigintTimeout = a.slice("--sigint-timeout=".length);
     else if (a === "--agent") out.agent = argv[i + 1];
     else if (a.startsWith("--agent=")) out.agent = a.slice("--agent=".length);
+    else if (a === "--cwd" || a.startsWith("--cwd=")) {
+      // Repeatable: collect every --cwd into an ordered array (the cwd SET).
+      const value = a === "--cwd" ? argv[i + 1] : a.slice("--cwd=".length);
+      if (typeof value === "string") (out.cwd ??= []).push(value);
+    }
     else if (a === "--chorus-only") out.chorusOnly = true;
     else if (a === "--verbose") out.verbose = true;
     else if (a === "-d" || a === "--detach") out.detach = true;
@@ -103,6 +114,11 @@ OPTIONS
   --chorus-only            Restrict the woken agent to Chorus  (env: CHORUS_CHORUS_ONLY=1)
                            MCP tools only (no Bash / file edits) — reclaims the
                            safe posture from the default yolo.
+  --cwd <path>             A working directory the daemon serves. Repeatable —
+                           (env: CHORUS_DAEMON_CWDS) each --cwd registers an independent
+                           connection for that path, so one daemon can serve several
+                           local paths at once. Default: the directory it was launched
+                           from. (Also configurable as "cwds":[…] in ~/.chorus/daemon.json.)
   -d, --detach             Run detached in the background (pidfile + logfile)
   --verbose                More detailed per-wake logging
   --sigint-timeout <ms>    Grace window after SIGINT before a forceful kill

--- a/cli/daemon-config.mjs
+++ b/cli/daemon-config.mjs
@@ -13,6 +13,8 @@
 // IO (env / file read) is injectable so this is unit-testable without real disk.
 
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, resolve as resolvePath } from "node:path";
 import { loginFilePath } from "./credentials.mjs";
 
 /** Built-in default escalation window (ms) — matches the spec's 10 seconds. */
@@ -81,4 +83,120 @@ export function resolveSigintTimeoutMs(flags = {}, deps = {}) {
 
   // 4. Built-in default
   return DEFAULT_SIGINT_TIMEOUT_MS;
+}
+
+// ===== Multi-path cwd set (T3 — 单 daemon 多路径引擎, FR-5/FR-8, DEC-2) =====
+//
+// A daemon may declare a SET of local working directories (a cwd LIST) it serves.
+// Each declared path becomes one INDEPENDENT connection (own SSE self-report +
+// own Waker bound to that cwd), so the same agent on the same host driving several
+// paths registers as several distinct rows instead of one. This is JUST a set of
+// paths: per the human's cwd⟂project correction (DEC-5) it carries NO path↔project
+// binding and there is NO project→cwd routing — the daemon only declares which
+// directories it serves.
+//
+// Layered resolution, mirroring resolveSigintTimeoutMs's precedence — first defined
+// source wins (the WHOLE set comes from the first source that yields any path):
+//
+//   --cwd flag(s)  > CHORUS_DAEMON_CWDS env (comma/`os.delimiter`-separated)
+//                  > ~/.chorus/daemon.json `cwds: [...]`
+//                  > [undefined]  (single connection at the daemon's process cwd)
+//
+// The `[undefined]` fallback is the HARD-1 / single-path default: an unspecified
+// cwd set means "serve one path, the process default" — exactly today's behavior.
+// The Waker/SseListener treat an `undefined` entry as "use process.cwd()".
+
+/** Expand a leading `~` to the home dir and resolve to an absolute path. */
+function normalizeCwd(value, home) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  let expanded = trimmed;
+  if (expanded === "~") expanded = home;
+  else if (expanded.startsWith("~/")) expanded = resolvePath(home, expanded.slice(2));
+  // Resolve relative paths against the daemon's process cwd so the declared path is
+  // always absolute (claude --resume scopes transcripts to the ABSOLUTE cwd).
+  return isAbsolute(expanded) ? expanded : resolvePath(expanded);
+}
+
+/**
+ * De-duplicate a list of normalized paths preserving first-seen order, dropping
+ * blanks/undefined. Returns the cleaned array (possibly empty).
+ * @param {Array<unknown>} list @param {string} home
+ * @returns {string[]}
+ */
+function cleanCwdList(list, home) {
+  const seen = new Set();
+  const out = [];
+  for (const raw of Array.isArray(list) ? list : []) {
+    const norm = normalizeCwd(raw, home);
+    if (norm === undefined || seen.has(norm)) continue;
+    seen.add(norm);
+    out.push(norm);
+  }
+  return out;
+}
+
+/**
+ * Resolve the SET of working directories this daemon serves (FR-5). One entry per
+ * connection the daemon will register. Each entry is an absolute path, EXCEPT the
+ * single-element `[undefined]` fallback which means "serve the process default cwd"
+ * (the unspecified / single-path / HARD-1 default — identical to today's behavior).
+ *
+ * Layered precedence (first source that yields ANY path wins for the whole set):
+ *   1. flags.cwd      — a string or string[] from repeatable `--cwd` flags.
+ *   2. env            — CHORUS_DAEMON_CWDS, split on the platform path delimiter or
+ *                       a comma (whichever the user used; both are accepted).
+ *   3. login/config   — ~/.chorus/daemon.json `cwds` (array of strings).
+ *   4. default        — `[undefined]` (one connection at the process cwd).
+ *
+ * The declaration is purely a list of paths — it does NOT carry, store, or upload
+ * any path↔project binding (DEC-5: cwd ⟂ project).
+ *
+ * @param {{ cwd?: string|string[] }} [flags]  Explicit `--cwd` value(s).
+ * @param {{
+ *   env?: Record<string, string|undefined>,
+ *   readJson?: (path: string) => (Record<string, unknown>|null),
+ *   loginPath?: string,
+ *   home?: string,
+ *   delimiter?: string,
+ * }} [deps]
+ * @returns {Array<string|undefined>}  A non-empty list; `[undefined]` ⇒ process cwd.
+ */
+export function resolveDaemonCwds(flags = {}, deps = {}) {
+  const env = deps.env ?? process.env;
+  const readJson = deps.readJson ?? readJsonSafe;
+  const loginPath = deps.loginPath ?? loginFilePath();
+  const home = deps.home ?? homedir();
+  // Accept both the OS path delimiter (":" on POSIX, ";" on Windows) and a comma, so
+  // CHORUS_DAEMON_CWDS=/a:/b and CHORUS_DAEMON_CWDS=/a,/b both work cross-platform.
+  const delimiters = new RegExp(`[${deps.delimiter ?? ""},]|${process.platform === "win32" ? ";" : ":"}`);
+
+  // 1. Explicit --cwd flag(s) — a string or an array (repeatable flag).
+  const flagList = Array.isArray(flags.cwd)
+    ? flags.cwd
+    : typeof flags.cwd === "string"
+      ? [flags.cwd]
+      : [];
+  const fromFlags = cleanCwdList(flagList, home);
+  if (fromFlags.length > 0) return fromFlags;
+
+  // 2. Environment variable (delimiter- or comma-separated).
+  const envRaw = env.CHORUS_DAEMON_CWDS;
+  if (typeof envRaw === "string" && envRaw.trim()) {
+    const fromEnv = cleanCwdList(envRaw.split(delimiters), home);
+    if (fromEnv.length > 0) return fromEnv;
+  }
+
+  // 3. Login/config file (~/.chorus/daemon.json `cwds`).
+  const file = readJson(loginPath);
+  if (file && Array.isArray(file.cwds)) {
+    const fromFile = cleanCwdList(file.cwds, home);
+    if (fromFile.length > 0) return fromFile;
+  }
+
+  // 4. Built-in default: a single connection at the daemon's process cwd. `undefined`
+  //    is the "unspecified" sentinel the Waker/SseListener degrade to process.cwd()
+  //    for (HARD-1 / single-path — exactly today's behavior).
+  return [undefined];
 }

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -37,7 +37,7 @@ import { WAKE_ACTIONS } from "./prompts.mjs";
 import { createInterruptReporter } from "./interrupt-reporter.mjs";
 import { createTurnReporter } from "./turn-reporter.mjs";
 import { createControlHandler } from "./control-handler.mjs";
-import { resolveSigintTimeoutMs } from "./daemon-config.mjs";
+import { resolveSigintTimeoutMs, resolveDaemonCwds } from "./daemon-config.mjs";
 import {
   startBackground,
   stopDaemon,
@@ -81,7 +81,8 @@ function defaultLogger() {
  *   fetchImpl?: typeof fetch,
  *   sseListener?: any,
  *   spawner?: any,
- *   cwd?: string,
+ *   cwd?: string,   Single served path (back-compat); maps to a one-element cwd set.
+ *   cwds?: Array<string|undefined>,  The SET of paths this daemon serves (T3 多路径). Each entry registers one independent connection bound to that cwd; `undefined` ⇒ process cwd. Takes precedence over `cwd`.
  *   hooks?: any,
  *   makeSseListener?: (opts: any) => any,
  *   maxConcurrency?: number,
@@ -102,37 +103,8 @@ export function buildDaemon(creds, deps = {}) {
   // the layered resolver; falls back to the resolver's default here when not given,
   // so a daemon built directly (integration tests) still gets a sane value.
   const sigintTimeoutMs = deps.sigintTimeoutMs ?? resolveSigintTimeoutMs();
-  // Interrupt reporter (子3): REST POST with the daemon's Bearer key (zero new deps),
-  // injectable for tests. The waker calls it on an interrupted/crashed exit.
-  // connectionState holds the connection uuid learned from the SSE handshake;
-  // declared here so the reporter (which needs it to address the execution row)
-  // can read it lazily. It is assigned by onConnectionId below.
-  /** @type {{ connectionUuid: string|null }} */
-  const connectionState = { connectionUuid: null };
-  const reportInterrupt =
-    deps.reportInterrupt ??
-    createInterruptReporter({
-      url: creds.url,
-      apiKey: creds.apiKey,
-      getConnectionUuid: () => connectionState.connectionUuid,
-      logger,
-      fetchImpl: deps.fetchImpl,
-    });
-  // Turn-lifecycle reporter (子1 — daemon-session-conversation): REST POST with the
-  // daemon's Bearer key (zero new deps), injectable for tests. The waker calls it on a
-  // wake's spawn (→ running) and exit (→ ended) to advance the server-side
-  // DaemonSessionTurn the notification chokepoint created. Reads the connectionUuid
-  // lazily from the same box the SSE handshake fills.
-  const advanceTurn =
-    deps.advanceTurn ??
-    createTurnReporter({
-      url: creds.url,
-      apiKey: creds.apiKey,
-      getConnectionUuid: () => connectionState.connectionUuid,
-      logger,
-      fetchImpl: deps.fetchImpl,
-    });
-
+  // ===== Shared deps (one set per daemon process) =====
+  // These are process-wide — independent of how many paths (cwds) the daemon serves.
   const mcpClient =
     deps.mcpClient ?? new ChorusClient({ url: creds.url, apiKey: creds.apiKey, logger });
   // Lineage resolution is a plain REST call (Bearer agent key) per notification —
@@ -141,150 +113,202 @@ export function buildDaemon(creds, deps = {}) {
     deps.lineage ??
     new LineageResolver({ url: creds.url, apiKey: creds.apiKey, logger, fetchImpl: deps.fetchImpl });
   const spawner = deps.spawner ?? new ClaudeSpawner({ logger, permissionMode });
+  // The WakeQueue serializes per DIRECT idea (keyFor's key). It is shared across all
+  // path-connections: serialization-per-idea still holds, and maxConcurrency caps the
+  // whole process's in-flight wakes rather than per-cwd — the right global budget.
   const queue = new WakeQueue({ maxConcurrency: deps.maxConcurrency ?? 4, logger });
 
-  // `connectionState` (declared above, next to the reporter) is the mutable box the
-  // SSE handshake fills with this daemon's `connection_registered` uuid; the upload
-  // hooks, the reporter, and the control handler all read it lazily so construction
-  // order doesn't matter. `waker` is assigned just below; the snapshot closure reads
-  // it lazily so the hooks can predate it.
-  /** @type {Waker|undefined} */
-  let waker;
+  // ===== Multi-path: the SET of cwds this daemon serves (T3 — FR-5) =====
+  // Each declared path becomes one INDEPENDENT connection (own SSE self-report + own
+  // Waker bound to that cwd + own router/backfill/control). The daemon process's OWN
+  // cwd never changes (NFR-3). `undefined` ⇒ "serve the process default cwd" (single-
+  // path / HARD-1 default). `deps.cwds` (a list) takes precedence; `deps.cwd` (a single
+  // value, still injected by integration tests) maps to a one-element set; otherwise a
+  // single `[undefined]` connection at the process cwd — exactly today's behavior. This
+  // is JUST a list of paths; it carries NO path↔project binding (DEC-5: cwd ⟂ project).
+  const cwdSet =
+    Array.isArray(deps.cwds) && deps.cwds.length > 0
+      ? deps.cwds
+      : [deps.cwd];
 
-  // Execution-state upload hooks: POST the WakeQueue/waker-derived snapshot to
-  // the server on each lifecycle transition. `getSnapshot` reads the waker's
-  // per-task registry (which reuses the already-resolved root-idea lineage).
-  // Fire-and-forget; failures logged + non-fatal (see upload-hooks.mjs). The
-  // hooks share the daemon's existing creds + zero new deps (global fetch).
-  // Transcript upload hooks (子1 — daemon-session-conversation): the waker's
-  // stream-json consumer (onMessage) and pre-spawn (onSessionStart) feed these,
-  // which keep only user/assistant text and batch-POST it to /api/daemon/transcript
-  // for the current turn (resolved server-side by the session business key the waker
-  // already anchors on). Same zero-dep, fire-and-forget, warn-not-throw contract as
-  // the execution hooks; no connectionUuid needed (the agent key + sessionId suffice).
-  // The two hook sets are MERGED into the single object the waker takes:
-  // onSessionStart/onTranscriptMessage fan out to the transcript hooks,
-  // onExecutionChange to the execution hooks.
-  const hooks =
-    deps.hooks ??
-    mergeUploadHooks(
-      createExecutionUploadHooks({
+  /**
+   * Build ONE independent path-connection bound to `cwd` (one SSE stream → one
+   * DaemonConnection row, keyed by that cwd server-side). All per-connection state —
+   * its connectionUuid box, reporters, hooks, Waker(cwd), router, backfill, control
+   * handler, and SseListener(cwd) — lives in this closure so two connections never
+   * share a connectionUuid or a dedup set. `index` selects the per-connection injected
+   * test dep (sseListener/makeSseListener) when an array was supplied (a single value
+   * is reused for connection 0, mirroring the historical single-connection injection).
+   * @param {string|undefined} cwd
+   * @param {number} index
+   */
+  function buildConnection(cwd, index) {
+    // connectionState holds the connectionUuid learned from THIS stream's SSE handshake;
+    // the reporters, hooks, and control handler read it lazily so construction order
+    // doesn't matter. Per-connection so each path's wakes report against the right row.
+    /** @type {{ connectionUuid: string|null }} */
+    const connectionState = { connectionUuid: null };
+
+    // Interrupt reporter (子3): REST POST with the daemon's Bearer key. Injectable for
+    // tests (shared across connections when injected — tests use a single connection).
+    const reportInterrupt =
+      deps.reportInterrupt ??
+      createInterruptReporter({
         url: creds.url,
         apiKey: creds.apiKey,
         getConnectionUuid: () => connectionState.connectionUuid,
-        getSnapshot: () => waker?.buildExecutionSnapshot() ?? [],
         logger,
         fetchImpl: deps.fetchImpl,
-      }),
-      createTranscriptUploadHooks({
+      });
+    // Turn-lifecycle reporter (子1): advances the server-side DaemonSessionTurn on
+    // spawn (→ running) and exit (→ ended), reading the connectionUuid lazily.
+    const advanceTurn =
+      deps.advanceTurn ??
+      createTurnReporter({
         url: creds.url,
         apiKey: creds.apiKey,
+        getConnectionUuid: () => connectionState.connectionUuid,
         logger,
         fetchImpl: deps.fetchImpl,
-      }),
-      { logger }
-    );
+      });
 
-  // One dedup set shared by the router (live SSE path) and the reconnect
-  // backfill, so a notification handled live is never re-woken on reconnect.
-  const seen = new Set();
-  // cwd: the daemon spawns all wakes in one working directory; the waker uses it
-  // BOTH to probe the transcript (new-vs-resume) and to spawn, so they never diverge.
-  waker = new Waker({ creds, lineage, spawner, cwd: deps.cwd ?? process.cwd(), hooks, logger, reportInterrupt, advanceTurn, verbose });
-  const router = new EventRouter({ mcpClient, waker, queue, wakeActions: WAKE_ACTIONS, seen, logger });
+    /** @type {Waker|undefined} */
+    let waker;
 
-  // Reverse control channel (子3): the control handler verifies a control event
-  // against this daemon's own connectionUuid + the running child for the target
-  // entity (q1=a double-check), then interrupts the subprocess. It reads the
-  // connectionUuid lazily from the same mutable box the SSE handshake fills, so it
-  // works regardless of construction order.
-  // Resume re-dispatch (子3): a `command:"resume"` control event re-runs the wake
-  // for the target entity. It reuses the SAME router/queue path as a normal wake,
-  // so serialization-per-direct-idea holds and the spawner's on-disk transcript
-  // probe naturally selects `claude --resume` (the session already exists). The
-  // synthetic event mirrors the `new_notification` shape the router expects; we
-  // fetch the real notification detail lazily inside the router via MCP, so a
-  // minimal `{ action: "resource_resumed", entityType, entityUuid }` is enough to
-  // re-key and re-spawn. Because resume rides the control channel (not a persisted
-  // notification), there is no notificationUuid — the router tolerates a synthetic
-  // resume dispatch via the dedicated entrypoint below.
-  const redispatchResume = (entityType, entityUuid) => {
-    router.dispatchResume?.({ entityType, entityUuid });
-  };
-  // Origin-only live delivery (子2 — daemon-instruction-injection): a `deliver_turn`
-  // control event means the server pinged THIS connection that a SPECIFIC new pending
-  // `human_instruction` turn (`turnUuid`) awaits. The control handler forwards that uuid
-  // to the connection-scoped pending-turns sweep (exposed as `backfill.pendingTurnsOnly`)
-  // so ONLY that one turn is dispatched — never a connection-wide sweep that would also
-  // run every other still-pending turn. It shares the same `seen` set as reconnect
-  // backfill (a turn runs at most once). Read lazily so it tolerates the construction
-  // order (backfill is assigned just after).
-  const deliverTurn = (turnUuid) => backfill?.pendingTurnsOnly?.(turnUuid);
-  const onControl = createControlHandler({
-    waker,
-    getConnectionUuid: () => connectionState.connectionUuid,
-    sigintTimeoutMs,
-    redispatchResume,
-    deliverTurn,
-    logger,
-  });
+    // Execution + transcript upload hooks (子1), merged. Bound to THIS connection's
+    // connectionState + waker so snapshots attribute to the right connection row.
+    const hooks =
+      deps.hooks ??
+      mergeUploadHooks(
+        createExecutionUploadHooks({
+          url: creds.url,
+          apiKey: creds.apiKey,
+          getConnectionUuid: () => connectionState.connectionUuid,
+          getSnapshot: () => waker?.buildExecutionSnapshot() ?? [],
+          logger,
+          fetchImpl: deps.fetchImpl,
+        }),
+        createTranscriptUploadHooks({
+          url: creds.url,
+          apiKey: creds.apiKey,
+          logger,
+          fetchImpl: deps.fetchImpl,
+        }),
+        { logger }
+      );
 
-  // Reconnect backfill re-dispatches notifications missed during a gap, through
-  // the SAME router/queue (so serialization holds) and the SAME seen set (so
-  // already-handled notifications are skipped). The router marks seen at
-  // dispatch; backfill's own pre-check is a cheap early-out.
-  // `deliverTurn` (defined above) closes over `backfill` but only invokes it lazily,
-  // so a `const` initialized here is safe despite the earlier lexical reference.
-  const backfill = createBackfill({
-    mcpClient,
-    dispatch: (event) => router.dispatch(event),
-    seen,
-    logger,
-    // 子1 — pending-turn backfill: re-derive unstarted turns from the turn table (NOT
-    // notifications) for this connection's origin-pinned sessions, so a lost delivery
-    // ping never loses an instruction. Shares the same router (dispatchPendingTurn) +
-    // seen set so a turn handled live (or by an earlier backfill) is not re-run. Reads
-    // the connectionUuid lazily from the SSE-handshake box.
-    url: creds.url,
-    apiKey: creds.apiKey,
-    getConnectionUuid: () => connectionState.connectionUuid,
-    dispatchPendingTurn: (turn) => router.dispatchPendingTurn?.(turn),
-    fetchImpl: deps.fetchImpl,
-  });
+    // One dedup set per connection, shared by its router (live SSE) and its reconnect
+    // backfill, so a notification handled live is never re-woken on reconnect.
+    const seen = new Set();
+    // The Waker is bound to THIS connection's cwd: it uses cwd BOTH to probe the
+    // transcript (new-vs-resume) and to spawn, so they never diverge (Module Contract
+    // 1 — resolveCwd is the single source). `cwd` is `undefined` for the single-path /
+    // old-daemon default, which the Waker degrades to process.cwd() (HARD-1).
+    waker = new Waker({ creds, lineage, spawner, cwd, hooks, logger, reportInterrupt, advanceTurn, verbose });
+    const router = new EventRouter({ mcpClient, waker, queue, wakeActions: WAKE_ACTIONS, seen, logger });
 
-  const sseListener =
-    deps.sseListener ??
-    (deps.makeSseListener ?? ((o) => new SseListener(o)))({
-      url: creds.url,
-      apiKey: creds.apiKey,
-      onEvent: (event) => router.dispatch(event),
-      // Capture the connectionUuid the server reports for this stream so the
-      // execution-state upload hooks can attribute snapshots to it.
-      onConnectionId: (connectionUuid) => {
-        connectionState.connectionUuid = connectionUuid;
-        logger.info(`[Chorus] registered as connection ${connectionUuid}`);
-      },
-      // Reverse control channel: a `type:"control"` event is forked here, NEVER to
-      // onEvent/router/queue — so it can never spawn a wake (子3).
-      onControl,
-      onReconnect: backfill,
+    // Reverse control channel (子3) + resume re-dispatch + origin-only deliver_turn —
+    // all scoped to THIS connection's uuid/router/backfill (see the original wiring
+    // comments retained on the shared helpers). The control handler verifies a control
+    // event against this connection's own connectionUuid before acting.
+    const redispatchResume = (entityType, entityUuid) => {
+      router.dispatchResume?.({ entityType, entityUuid });
+    };
+    const deliverTurn = (turnUuid) => backfill?.pendingTurnsOnly?.(turnUuid);
+    const onControl = createControlHandler({
+      waker,
+      getConnectionUuid: () => connectionState.connectionUuid,
+      sigintTimeoutMs,
+      redispatchResume,
+      deliverTurn,
       logger,
     });
+
+    // Reconnect + pending-turn backfill, pinned to THIS connection's sessions (the
+    // server scopes getPendingTurnsForConnection by originConnectionUuid — i.e. the
+    // cwd this connection serves — so a multi-path daemon's backfill never re-runs
+    // another cwd's turns).
+    const backfill = createBackfill({
+      mcpClient,
+      dispatch: (event) => router.dispatch(event),
+      seen,
+      logger,
+      url: creds.url,
+      apiKey: creds.apiKey,
+      getConnectionUuid: () => connectionState.connectionUuid,
+      dispatchPendingTurn: (turn) => router.dispatchPendingTurn?.(turn),
+      fetchImpl: deps.fetchImpl,
+    });
+
+    // Per-connection SSE listener, self-reporting THIS connection's cwd so the server
+    // registers it as a distinct (agent, clientType, host, cwd) row. Test injection:
+    //  - `deps.sseListener` is a CONCRETE instance — there is only one, so it stands in
+    //    for connection 0 only (a single-path daemon, the historical injection shape).
+    //  - `deps.makeSseListener` is a FACTORY — it is invoked PER connection (so a
+    //    multi-path test gets one mock listener per cwd). An array form also works:
+    //    one factory/instance per connection by index.
+    const injectedListener = Array.isArray(deps.sseListener)
+      ? deps.sseListener[index]
+      : index === 0
+        ? deps.sseListener
+        : undefined;
+    const makeSse =
+      (Array.isArray(deps.makeSseListener) ? deps.makeSseListener[index] : deps.makeSseListener) ??
+      ((o) => new SseListener(o));
+    const sseListener =
+      injectedListener ??
+      makeSse({
+        url: creds.url,
+        apiKey: creds.apiKey,
+        // The working directory THIS connection serves (T3). `undefined` ⇒ the listener
+        // reports its process cwd (single-path / HARD-1). It is just the served path.
+        cwd,
+        onEvent: (event) => router.dispatch(event),
+        onConnectionId: (connectionUuid) => {
+          connectionState.connectionUuid = connectionUuid;
+          logger.info(
+            `[Chorus] registered as connection ${connectionUuid}` +
+              (cwd ? ` (cwd=${cwd})` : "")
+          );
+        },
+        onControl,
+        onReconnect: backfill,
+        logger,
+      });
+
+    return { cwd, connectionState, waker, router, backfill, sseListener, hooks };
+  }
+
+  // Build one connection per declared cwd. The order is the declaration order; the
+  // FIRST connection's pieces are aliased onto the returned object for backward
+  // compatibility (existing tests/inspection read daemon.waker / .router / .sseListener).
+  const connections = cwdSet.map((cwd, i) => buildConnection(cwd, i));
+  const primary = connections[0];
 
   return {
     mcpClient,
     lineage,
     spawner,
     queue,
-    waker,
-    router,
-    sseListener,
+    // Back-compat single-connection aliases (the common single-path case). The full
+    // set is exposed as `connections` for multi-path inspection/tests.
+    waker: primary.waker,
+    router: primary.router,
+    sseListener: primary.sseListener,
+    connections,
     async start() {
-      await hooks.onConnect?.({ host: creds.url });
-      await sseListener.connect();
+      // Connect every path-connection. Each fires its own onConnect hook + SSE connect;
+      // the daemon process cwd is untouched (NFR-3).
+      for (const c of connections) {
+        await c.hooks.onConnect?.({ host: creds.url });
+        await c.sseListener.connect();
+      }
     },
     async stop() {
-      sseListener.disconnect?.();
+      for (const c of connections) {
+        c.sseListener.disconnect?.();
+      }
+      // The MCP client is process-wide (shared) — disconnect it once.
       await mcpClient.disconnect?.();
     },
   };
@@ -358,6 +382,13 @@ export async function runDaemon(flags = {}, deps = {}) {
   //   --sigint-timeout flag > CHORUS_DAEMON_SIGINT_TIMEOUT env > ~/.chorus/daemon.json > 10000.
   const sigintTimeoutMs = resolveSigintTimeoutMs({ sigintTimeout: flags.sigintTimeout }, { env });
 
+  // The SET of working directories this daemon serves (T3 — 单 daemon 多路径引擎).
+  // Layered: --cwd flag(s) > CHORUS_DAEMON_CWDS env > ~/.chorus/daemon.json `cwds`
+  // > [undefined] (single connection at the process cwd). A single `[undefined]`
+  // is exactly today's single-path behavior. JUST a list of paths — no project
+  // binding (DEC-5: cwd ⟂ project). The daemon process's own cwd never changes.
+  const cwds = resolveDaemonCwds({ cwd: flags.cwd }, { env });
+
   // Foreground preflight: resolve/complete credentials + resolve the permission
   // posture (confirming yolo on a TTY). Reuses the same pfDeps bundle the detach
   // path uses. Returns a numeric exit code on failure, or
@@ -394,12 +425,22 @@ export async function runDaemon(flags = {}, deps = {}) {
     errLog(`[Chorus] ${yoloWarningLine()}`);
   }
 
+  // Surface the served paths so an operator sees a multi-path daemon at a glance.
+  // A single `[undefined]` (the default) prints the process cwd it falls back to.
+  const servedPaths = cwds.map((c) => c ?? process.cwd());
+  if (servedPaths.length > 1) {
+    log(`[Chorus] serving ${servedPaths.length} paths: ${servedPaths.join(", ")}`);
+  } else {
+    log(`[Chorus] serving path: ${servedPaths[0]}`);
+  }
+
   const daemon = build(creds, {
     logger: { info: log, warn: errLog, error: errLog },
     permissionMode,
     agentType,
     verbose,
     sigintTimeoutMs,
+    cwds,
   });
 
   // Graceful shutdown on signals.

--- a/cli/sse-listener.mjs
+++ b/cli/sse-listener.mjs
@@ -8,11 +8,19 @@
 // API key; data lines are `data: <json>\n\n`, heartbeats are `: ...` comments.
 //
 // Self-report: the listener appends ?clientType=claude_code&clientVersion=…&
-// host=…&startedAt=… to the endpoint so the server's DaemonConnection registry
-// (src/services/daemon-connection.service.ts → parseSelfReport) can record which
-// client is on the other end. The CLI reports clientType=claude_code (it only
-// drives a local Claude Code subprocess — not a generic "daemon"). These params
-// are display-only metadata; auth remains the unchanged Bearer header.
+// host=…&cwd=…&startedAt=… to the endpoint so the server's DaemonConnection
+// registry (src/services/daemon-connection.service.ts → parseSelfReport) can
+// record which client is on the other end. The CLI reports clientType=claude_code
+// (it only drives a local Claude Code subprocess — not a generic "daemon"). These
+// params are display-only metadata; auth remains the unchanged Bearer header.
+//
+// `cwd` is the working directory this daemon connection serves. Today the CLI
+// runs single-cwd (the directory it was launched from), so it reports
+// `process.cwd()`. The server keys the connection registry on
+// (agentUuid, clientType, host, cwd) — so the same agent on the same host driving
+// two different working directories registers as two independent connections
+// instead of overwriting each other. An *older* daemon that does not send `cwd`
+// registers as a `cwd=null` row (HARD-1: no error, behaves exactly as before).
 
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
@@ -91,6 +99,11 @@ export class SseListener {
       clientType: "claude_code",
       clientVersion: CLI_VERSION,
       host: hostname(),
+      // Working directory this connection serves. The CLI is single-cwd today
+      // (the dir it was launched from), so report process.cwd(). The server uses
+      // it as part of the registry's composite key so same agent + same host +
+      // different cwd no longer overwrite each other (the multi-path fix).
+      cwd: process.cwd(),
       startedAt: PROCESS_STARTED_AT.toISOString(),
     });
     this.endpoint = `${this.url}/api/events/notifications?${params.toString()}`;

--- a/cli/sse-listener.mjs
+++ b/cli/sse-listener.mjs
@@ -71,6 +71,12 @@ const PROCESS_STARTED_AT = new Date();
  *   connection + entity and interrupts the running subprocess (see control-handler.mjs).
  * @property {() => Promise<void>} [onReconnect]  Called after a reconnect so the
  *   caller can back-fill notifications missed during the gap.
+ * @property {string} [cwd]  The working directory THIS connection serves (T3 — 单
+ *   daemon 多路径). A multi-path daemon runs one SseListener per declared path, each
+ *   self-reporting its own cwd so the server registers them as distinct connections
+ *   (the registry key includes cwd). Omitted ⇒ the daemon's process cwd (single-path
+ *   / HARD-1 default — identical to today). It is JUST the served path; it carries no
+ *   project binding (DEC-5: cwd ⟂ project).
  * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
  * @property {typeof fetch} [fetchImpl]  Injectable for tests.
  * @property {number} [initialDelayMs]
@@ -95,15 +101,18 @@ export class SseListener {
 
     // Build the self-reporting endpoint URL once and reuse it across every
     // (re)connect, so the reconnect path always re-sends the same params.
+    // Working directory THIS connection serves. A multi-path daemon (T3) constructs
+    // one SseListener per declared path, each with its own `opts.cwd`, so the server's
+    // (agentUuid, clientType, host, cwd) registry key lands them as distinct rows —
+    // same agent + same host + different cwd no longer overwrite each other. When no
+    // cwd is supplied the daemon is single-path: report the process cwd (the directory
+    // it was launched from), identical to today / an old daemon (HARD-1).
+    this.cwd = opts.cwd ?? process.cwd();
     const params = new URLSearchParams({
       clientType: "claude_code",
       clientVersion: CLI_VERSION,
       host: hostname(),
-      // Working directory this connection serves. The CLI is single-cwd today
-      // (the dir it was launched from), so report process.cwd(). The server uses
-      // it as part of the registry's composite key so same agent + same host +
-      // different cwd no longer overwrite each other (the multi-path fix).
-      cwd: process.cwd(),
+      cwd: this.cwd,
       startedAt: PROCESS_STARTED_AT.toISOString(),
     });
     this.endpoint = `${this.url}/api/events/notifications?${params.toString()}`;

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -28,7 +28,7 @@ export class Waker {
    *   creds: { url: string, apiKey: string },
    *   lineage: { resolve: (event: any) => Promise<{ rootIdeaUuid: string|null, directIdeaUuid: string|null }> },
    *   spawner: { wake: (params: any) => Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }> },
-   *   cwd?: string,  Spawn working directory; used BOTH for the transcript probe and the spawn (default process.cwd()).
+   *   cwd?: string,  The connection/session-bound working directory this Waker serves; resolveCwd() is the single source the probe + spawn + resume use. `undefined` ⇒ the process default cwd (HARD-1 / single-path).
    *   hooks?: import("./upload-hooks.mjs").UploadHooks,
    *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
    *   writeMcpConfigFn?: typeof writeMcpConfig,
@@ -54,10 +54,14 @@ export class Waker {
     // line per lifecycle event (arrival / spawn new-vs-resume / completion).
     // When true, additional detail is emitted alongside those lines.
     this.verbose = opts.verbose ?? false;
-    // The daemon spawns in one fixed working directory; the transcript probe must
-    // use the SAME cwd as the spawn, or it would decide new-vs-resume against the
-    // wrong directory (claude scopes --resume to cwd).
-    this.cwd = opts.cwd ?? process.cwd();
+    // The connection/session-bound working directory this Waker serves (T3 — 单
+    // daemon 多路径引擎). A daemon process may run SEVERAL Wakers, one per declared
+    // path, each pinned to its own cwd; the daemon process's OWN cwd never changes
+    // (NFR-3). `opts.cwd` is that bound path; `undefined` (unspecified / old daemon /
+    // single-path default) degrades to the process cwd via resolveCwd(). Stored raw
+    // so resolveCwd() is the SINGLE place the process-default fallback is applied
+    // (Module Contract 1 — one cwd source of truth, no scattered process.cwd()).
+    this.cwd = opts.cwd;
     this.hooks = opts.hooks;
     this.logger = opts.logger ?? NOOP_LOGGER;
     this.writeMcpConfigFn = opts.writeMcpConfigFn ?? writeMcpConfig;
@@ -103,6 +107,25 @@ export class Waker {
     // `child` — the handle stays daemon-local and never leaks onto the wire.
     /** @type {Map<string, { entityType: string, entityUuid: string, rootIdeaUuid: string|null, status: "running"|"queued", startedAt: string|null, child: import("node:child_process").ChildProcess|null }>} */
     this.executions = new Map();
+  }
+
+  /**
+   * The SINGLE source of truth for this Waker's working directory (Module Contract
+   * 1 — 不变式安全 / cwd 事实源统一). transcript probing (new-vs-resume), spawn, and
+   * resume ALL resolve cwd through here, so they can never diverge — a divergence
+   * would make the on-disk transcript probe decide new-vs-resume against a different
+   * directory than the one we spawn in (`claude --resume` is cwd-bound).
+   *
+   * Returns the connection/session-bound cwd when one was declared, else the daemon
+   * process's own cwd. The process-default fallback lives ONLY here: `this.cwd` is
+   * stored raw (possibly `undefined`) and `process.cwd()` is read at exactly this one
+   * site — Module Contract 2's HARD-1 degrade path (an old daemon / unspecified cwd
+   * behaves exactly as today, spawning at the process default). No other code in the
+   * wake path reads `process.cwd()`.
+   * @returns {string}
+   */
+  resolveCwd() {
+    return this.cwd ?? process.cwd();
   }
 
   /**
@@ -295,7 +318,12 @@ export class Waker {
       // spawn in. The spawner re-validates the id is a lowercase UUID before
       // spawning, so a garbage id surfaces visibly rather than misanchoring.
       const sessionId = directIdeaUuid ?? notification.entityUuid ?? null;
-      const isNew = sessionId ? this.isNewSessionFn(sessionId, this.cwd) : true;
+      // Resolve the connection/session-bound cwd ONCE for this wake (Module Contract
+      // 1). The transcript probe and the spawn below BOTH use this same value, so a
+      // session's repeated wakes/probes always land the same cwd (NFR-3) — and a
+      // multi-path daemon's other Wakers (other cwds) never bleed in.
+      const cwd = this.resolveCwd();
+      const isNew = sessionId ? this.isNewSessionFn(sessionId, cwd) : true;
 
       // Lifecycle line 2 — spawn: new vs resume, plus the (otherwise hidden)
       // `claude --resume <id>` takeover hint so an operator can attach to the
@@ -305,7 +333,7 @@ export class Waker {
           (sessionId ? ` — take over with: claude --resume ${sessionId}` : "")
       );
       if (this.verbose) {
-        this.logger.info(`[Chorus]   cwd=${this.cwd} action=${notification.action} root=${rootIdeaUuid ?? "(none)"}`);
+        this.logger.info(`[Chorus]   cwd=${cwd} action=${notification.action} root=${rootIdeaUuid ?? "(none)"}`);
       }
 
       cfg = this.writeMcpConfigFn(this.creds);
@@ -331,7 +359,7 @@ export class Waker {
         prompt,
         sessionId,
         isNew,
-        cwd: this.cwd,
+        cwd,
         mcpConfigPath: cfg.path,
         // Capture the live child into the running execution entry the instant it
         // spawns (子3) so the control handler can interrupt it mid-wake. Guarded so

--- a/packages/openclaw-plugin/src/__tests__/sse-listener.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/sse-listener.test.ts
@@ -146,7 +146,7 @@ describe("ChorusSseListener", () => {
     listener.disconnect();
   });
 
-  it("appends clientType=openclaw + version + host + startedAt to the SSE URL", async () => {
+  it("appends clientType=openclaw + version + host + cwd + startedAt to the SSE URL", async () => {
     const fetchSpy = vi.fn(async () => streamingResponse([]));
     vi.stubGlobal("fetch", fetchSpy);
 
@@ -165,6 +165,8 @@ describe("ChorusSseListener", () => {
     // Version is the plugin's real package version, not a hardcoded literal.
     expect(url.searchParams.get("clientVersion")).toBe(PLUGIN_VERSION);
     expect(url.searchParams.get("host")).toBe(hostname());
+    // cwd is the working directory this connection serves (single-cwd today).
+    expect(url.searchParams.get("cwd")).toBe(process.cwd());
     const startedAt = url.searchParams.get("startedAt");
     expect(startedAt).toBeTruthy();
     expect(Number.isNaN(Date.parse(startedAt as string))).toBe(false);

--- a/packages/openclaw-plugin/src/sse-listener.ts
+++ b/packages/openclaw-plugin/src/sse-listener.ts
@@ -108,6 +108,11 @@ export class ChorusSseListener {
       clientType: "openclaw",
       clientVersion: PLUGIN_VERSION,
       host: hostname(),
+      // Working directory this connection serves. OpenClaw is single-cwd today
+      // (the dir it was launched from), so report process.cwd(). The server keys
+      // the connection registry on (agentUuid, clientType, host, cwd) so the same
+      // agent on the same host with different cwds no longer overwrite each other.
+      cwd: process.cwd(),
       startedAt: PROCESS_STARTED_AT.toISOString(),
     });
     this.endpoint = `${this.opts.chorusUrl.replace(/\/$/, "")}/api/events/notifications?${params.toString()}`;

--- a/prisma/migrations/20260622115159_add_daemon_connection_cwd/migration.sql
+++ b/prisma/migrations/20260622115159_add_daemon_connection_cwd/migration.sql
@@ -1,0 +1,9 @@
+-- DropIndex
+DROP INDEX "DaemonConnection_agentUuid_clientType_host_key";
+
+-- AlterTable
+ALTER TABLE "DaemonConnection" ADD COLUMN     "cwd" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DaemonConnection_agentUuid_clientType_host_cwd_key" ON "DaemonConnection"("agentUuid", "clientType", "host", "cwd");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -408,6 +408,23 @@ model DaemonConnection {
   // null as distinct (Prisma docs), which would let reconnects accumulate rows.
   // Defaulting to "" makes (agentUuid, clientType, host) a deterministic upsert key.
   host          String    @default("")
+  // Self-reported working directory this connection serves (display + identity).
+  // Nullable per the ratified migration decision (DEC/Q6=a): rows that exist at
+  // migration time get cwd=NULL as a sentinel and are backfilled on the next
+  // handshake — no forced backfill script. NOTE: unlike `host` (which defaults
+  // to "" to stay a deterministic dedup key), `cwd` is left nullable here.
+  // Postgres treats NULL as distinct in a UNIQUE index, so two
+  // (agentUuid, clientType, host, NULL) rows do NOT dedup; that is accepted for
+  // the migration era (old daemons are single-cwd, so independent null rows
+  // match the HARD-1 "behave exactly as today" requirement). Verified
+  // empirically (psql) + against Prisma docs. The real cwd self-report, the
+  // cwd-aware dedup, and the "reuse the migrated null row on reconnect"
+  // compatibility path all live in T2 — not this task. Because Prisma types a
+  // nullable column as non-null inside the compound-unique `where` input (NULL
+  // cannot be targeted there), T1's still-untouched registerConnection() upsert
+  // pins cwd to the "" sentinel to preserve today's deterministic dedup; T2
+  // reconciles the ""-vs-NULL sentinel when it wires real cwd self-report.
+  cwd           String?
   startedAt     DateTime? // self-reported daemon process start time
 
   status         String    @default("online") // online | offline
@@ -418,7 +435,7 @@ model DaemonConnection {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([agentUuid, clientType, host])
+  @@unique([agentUuid, clientType, host, cwd])
   @@index([companyUuid])
   @@index([agentUuid])
   @@index([status])

--- a/src/app/api/agent-connections/__tests__/route.test.ts
+++ b/src/app/api/agent-connections/__tests__/route.test.ts
@@ -36,6 +36,7 @@ const sampleConnections = [
     clientType: "claude_code",
     clientVersion: "0.11.0",
     host: "laptop",
+    cwd: "/Users/me/projects/alpha",
     startedAt: "2026-06-15T03:00:00.000Z",
     status: "online",
     effectiveStatus: "online",
@@ -52,6 +53,8 @@ const sampleConnections = [
     clientType: "openclaw",
     clientVersion: null,
     host: "",
+    // Old daemon (no cwd self-report) → cwd:null flows through verbatim.
+    cwd: null,
     startedAt: null,
     status: "offline",
     effectiveStatus: "offline",

--- a/src/components/__tests__/agent-presence-pill.test.tsx
+++ b/src/components/__tests__/agent-presence-pill.test.tsx
@@ -120,6 +120,7 @@ function makeConnection(over: Partial<ConnectionView> = {}): ConnectionView {
     clientType: "claude_code",
     clientVersion: "1.2.3",
     host: "macbook",
+    cwd: "/Users/me/projects/alpha",
     startedAt: "2026-06-18T09:00:00.000Z",
     status: "online",
     effectiveStatus: "online",

--- a/src/components/agent-presence/__tests__/connections-modal.test.tsx
+++ b/src/components/agent-presence/__tests__/connections-modal.test.tsx
@@ -118,6 +118,7 @@ type Conn = {
   clientType: string;
   clientVersion: string | null;
   host: string;
+  cwd: string | null;
   startedAt: string | null;
   status: string;
   effectiveStatus: "online" | "offline";
@@ -134,6 +135,7 @@ function conn(overrides: Partial<Conn> & { uuid: string }): Conn {
     clientType: "claude_code",
     clientVersion: "0.11.0",
     host: "host-" + overrides.uuid,
+    cwd: "/work/" + overrides.uuid,
     startedAt: now,
     status: "online",
     effectiveStatus: "online",

--- a/src/components/agent-presence/types.ts
+++ b/src/components/agent-presence/types.ts
@@ -11,6 +11,7 @@ export interface ConnectionView {
   clientType: string;
   clientVersion: string | null;
   host: string; // "" when host-less
+  cwd: string | null; // working directory this connection serves; null for an old daemon
   startedAt: string | null;
   status: string;
   effectiveStatus: "online" | "offline";

--- a/src/contexts/__tests__/agent-presence-context.test.tsx
+++ b/src/contexts/__tests__/agent-presence-context.test.tsx
@@ -73,6 +73,7 @@ function conn(uuid: string, effectiveStatus: "online" | "offline"): ConnectionVi
     clientType: "claude_code",
     clientVersion: null,
     host: "host",
+    cwd: null,
     startedAt: null,
     status: effectiveStatus,
     effectiveStatus,

--- a/src/services/__tests__/daemon-connection-registration.integration.test.ts
+++ b/src/services/__tests__/daemon-connection-registration.integration.test.ts
@@ -1,0 +1,275 @@
+// src/services/__tests__/daemon-connection-registration.integration.test.ts
+//
+// REAL-POSTGRES INTEGRATION TEST for T2 (握手自报 cwd + 注册按含 cwd 的键 upsert).
+//
+// Unlike the unit test (which mocks prisma and asserts the *call shapes*), this
+// test runs the REAL `registerConnection` service against a REAL PostgreSQL
+// instance, because the whole point of T2 is behavior that a mock cannot prove:
+//   - Postgres treats every NULL as DISTINCT in a UNIQUE index, so two
+//     (agent, clientType, host, NULL) rows do NOT collide; and
+//   - Prisma types the compound-unique `where` field as non-null, so a NULL cwd
+//     cannot be targeted in an upsert at all.
+// Both facts are exactly why the old-daemon (cwd=null) path is findFirst→update/
+// create rather than a compound-key upsert, and they are only observable against
+// a genuine database.
+//
+// It proves the four T2 acceptance scenarios end to end at the service layer:
+//   (1) a new daemon that reports cwd → one row carrying that cwd;
+//   (2) the SAME agent + SAME host with TWO DIFFERENT cwds → two INDEPENDENT
+//       rows, each with its own presence (the overwrite-bug fix);
+//   (3) an OLD daemon that does NOT report cwd → a single cwd=null row, and a
+//       reconnect REUSES that row (no null-row pileup), behaving as before;
+//   (4) a new daemon (with cwd) and an old daemon (cwd=null) under the SAME
+//       agent + host COEXIST as two distinct rows without interfering.
+//
+// HOW TO RUN (never touches the live store):
+//   docker run -d --name chorus-t2-pg -e POSTGRES_USER=t2 -e POSTGRES_PASSWORD=t2 \
+//     -e POSTGRES_DB=t2 -p 55433:5432 postgres:16-alpine
+//   DATABASE_URL="postgresql://t2:t2@127.0.0.1:55433/t2" npx prisma migrate deploy
+//   T2_REAL_DB_URL="postgresql://t2:t2@127.0.0.1:55433/t2" \
+//     npx vitest run src/services/__tests__/daemon-connection-registration.integration.test.ts
+//
+// When T2_REAL_DB_URL is NOT set (the default for `pnpm test` / CI), the whole
+// suite is skipped — so it never connects to a database it shouldn't, and in
+// particular never touches the live PGlite store (port 5433 / ~/.chorus-data).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+// Gate: only run when an explicit throwaway DB URL is provided.
+const REAL_DB_URL = process.env.T2_REAL_DB_URL;
+const describeReal = REAL_DB_URL ? describe : describe.skip;
+
+// The real generated Prisma client is imported by ABSOLUTE filesystem path so it
+// bypasses the vitest alias that points "@/generated/prisma/client" at a stub
+// (see vitest.config.ts). We deliberately want the REAL client here.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let realPrisma: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let pool: any;
+
+// Lazily-imported real service functions (imported AFTER the prisma mock is wired).
+type RegisterConnection = typeof import("@/services/daemon-connection.service")["registerConnection"];
+type ListConnectionsForAgent =
+  typeof import("@/services/daemon-connection.service")["listConnectionsForAgent"];
+type ParseSelfReport = typeof import("@/services/daemon-connection.service")["parseSelfReport"];
+let registerConnection: RegisterConnection;
+let listConnectionsForAgent: ListConnectionsForAgent;
+let parseSelfReport: ParseSelfReport;
+
+const companyUuid = "company-it-0000-0000-000000000001";
+const agentUuid = "agent-it-0000-0000-0000-00000000001";
+const otherAgentUuid = "agent-it-0000-0000-0000-00000000002";
+
+describeReal("registerConnection — REAL Postgres (cwd-aware registry)", () => {
+  beforeAll(async () => {
+    // Build a REAL PrismaClient pointed at the throwaway DB, then make the
+    // service's `@/lib/prisma` import resolve to it. The logger is silenced.
+    const { PrismaClient } = await import(
+      /* @vite-ignore */ "../../generated/prisma/client"
+    );
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const pg = (await import("pg")).default;
+
+    pool = new pg.Pool({ connectionString: REAL_DB_URL });
+    const adapter = new PrismaPg(pool);
+    realPrisma = new PrismaClient({ adapter });
+
+    vi.doMock("@/lib/prisma", () => ({ prisma: realPrisma }));
+    vi.doMock("@/lib/logger", () => ({
+      default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    }));
+
+    const svc = await import("@/services/daemon-connection.service");
+    registerConnection = svc.registerConnection;
+    listConnectionsForAgent = svc.listConnectionsForAgent;
+    parseSelfReport = svc.parseSelfReport;
+
+    // Seed the two Company + Agent rows the FK relations require. The schema uses
+    // relationMode="prisma" (no DB FKs), but the read projection joins agent.name,
+    // so the agent rows must exist for listConnectionsForAgent to resolve names.
+    await realPrisma.company.upsert({
+      where: { uuid: companyUuid },
+      create: { uuid: companyUuid, name: "IT Co" },
+      update: {},
+    });
+    for (const [uuid, name] of [
+      [agentUuid, "IT Agent"],
+      [otherAgentUuid, "IT Agent 2"],
+    ] as const) {
+      await realPrisma.agent.upsert({
+        where: { uuid },
+        create: { uuid, companyUuid, name, roles: [], permissions: [] },
+        update: {},
+      });
+    }
+  });
+
+  afterAll(async () => {
+    if (realPrisma) {
+      await realPrisma.daemonConnection.deleteMany({ where: { companyUuid } });
+      await realPrisma.agent.deleteMany({ where: { companyUuid } });
+      await realPrisma.company.deleteMany({ where: { uuid: companyUuid } });
+      await realPrisma.$disconnect();
+    }
+    if (pool) await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Each test starts from an empty connection table (scoped to our company).
+    await realPrisma.daemonConnection.deleteMany({ where: { companyUuid } });
+  });
+
+  // ---- Scenario 1: new daemon reports cwd → a cwd row ----
+  it("(1) a new daemon that reports cwd lands exactly one row carrying that cwd", async () => {
+    const report = parseSelfReport(
+      new URLSearchParams({
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/work/alpha",
+      }),
+    );
+    expect(report.cwd).toBe("/work/alpha");
+
+    const handle = await registerConnection(companyUuid, agentUuid, report);
+    expect(handle).not.toBeNull();
+
+    const rows = await realPrisma.daemonConnection.findMany({ where: { companyUuid, agentUuid } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cwd).toBe("/work/alpha");
+    expect(rows[0].host).toBe("mac.local");
+    expect(rows[0].status).toBe("online");
+  });
+
+  // ---- Scenario 2: two different cwds coexist (the overwrite-bug fix) ----
+  it("(2) SAME agent + SAME host + TWO DIFFERENT cwds → two independent rows, each its own presence", async () => {
+    const a = await registerConnection(
+      companyUuid,
+      agentUuid,
+      parseSelfReport(
+        new URLSearchParams({ clientType: "claude_code", host: "mac.local", cwd: "/work/a" }),
+      ),
+    );
+    const b = await registerConnection(
+      companyUuid,
+      agentUuid,
+      parseSelfReport(
+        new URLSearchParams({ clientType: "claude_code", host: "mac.local", cwd: "/work/b" }),
+      ),
+    );
+
+    // Two DISTINCT connection generations (different uuids) — neither overwrote
+    // the other. Before the fix, the second registration would have updated the
+    // first's single (agent, clientType, host) row.
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.uuid).not.toBe(b!.uuid);
+
+    const views = await listConnectionsForAgent(companyUuid, agentUuid);
+    expect(views).toHaveLength(2);
+    const byCwd = Object.fromEntries(views.map((v) => [v.cwd, v]));
+    // Each cwd has its own row with its own independent presence.
+    expect(byCwd["/work/a"]).toBeTruthy();
+    expect(byCwd["/work/b"]).toBeTruthy();
+    expect(byCwd["/work/a"].uuid).not.toBe(byCwd["/work/b"].uuid);
+    expect(byCwd["/work/a"].effectiveStatus).toBe("online");
+    expect(byCwd["/work/b"].effectiveStatus).toBe("online");
+
+    // Marking ONE cwd's row offline (via a direct status flip) does not touch the
+    // other — presence is genuinely independent per cwd.
+    await realPrisma.daemonConnection.update({
+      where: { uuid: byCwd["/work/a"].uuid },
+      data: { status: "offline", disconnectedAt: new Date() },
+    });
+    const after = await listConnectionsForAgent(companyUuid, agentUuid);
+    const afterByCwd = Object.fromEntries(after.map((v) => [v.cwd, v]));
+    expect(afterByCwd["/work/a"].effectiveStatus).toBe("offline");
+    expect(afterByCwd["/work/b"].effectiveStatus).toBe("online");
+  });
+
+  // ---- Scenario 3: old daemon (no cwd) → single null row; reconnect no pileup ----
+  it("(3) an OLD daemon (no cwd) lands a single cwd=null row, and reconnect REUSES it (no pileup)", async () => {
+    // No cwd param → an old daemon. parseSelfReport yields cwd:null.
+    const report = parseSelfReport(
+      new URLSearchParams({ clientType: "claude_code", host: "mac.local" }),
+    );
+    expect(report.cwd).toBeNull();
+
+    const first = await registerConnection(companyUuid, agentUuid, report);
+    expect(first).not.toBeNull();
+
+    let rows = await realPrisma.daemonConnection.findMany({ where: { companyUuid, agentUuid } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cwd).toBeNull();
+
+    // Reconnect three more times. A naive cwd=null upsert would ACCUMULATE a new
+    // NULL row each time (Postgres NULLs never collide). The compatibility path
+    // must REUSE the same row instead.
+    const second = await registerConnection(companyUuid, agentUuid, report);
+    const third = await registerConnection(companyUuid, agentUuid, report);
+    const fourth = await registerConnection(companyUuid, agentUuid, report);
+
+    rows = await realPrisma.daemonConnection.findMany({ where: { companyUuid, agentUuid } });
+    expect(rows).toHaveLength(1); // STILL one row — no null-row pileup.
+    // Same physical row reused across every reconnect.
+    expect(first!.uuid).toBe(second!.uuid);
+    expect(second!.uuid).toBe(third!.uuid);
+    expect(third!.uuid).toBe(fourth!.uuid);
+    expect(rows[0].uuid).toBe(first!.uuid);
+    expect(rows[0].status).toBe("online");
+  });
+
+  // Empirical confirmation of the FINDING that motivates the null-compat path:
+  // two raw NULL-cwd inserts do NOT collide on the composite unique index. This
+  // is the exact behavior the service code must work around.
+  it("(3b) [empirical] two raw cwd=NULL rows do NOT dedup on the composite unique index (Postgres NULL is distinct)", async () => {
+    const base = {
+      companyUuid,
+      agentUuid,
+      clientType: "claude_code",
+      host: "mac.local",
+      cwd: null,
+      status: "online",
+    };
+    await realPrisma.daemonConnection.create({ data: base });
+    // A SECOND identical (agent, clientType, host, NULL) row inserts WITHOUT a
+    // unique-constraint violation — proving NULL is treated as distinct.
+    await expect(
+      realPrisma.daemonConnection.create({ data: base }),
+    ).resolves.toBeTruthy();
+    const rows = await realPrisma.daemonConnection.findMany({ where: { companyUuid, agentUuid } });
+    expect(rows).toHaveLength(2);
+  });
+
+  // ---- Scenario 4: new + old daemons coexist under the same agent+host ----
+  it("(4) a new daemon (cwd) and an old daemon (cwd=null) under the SAME agent+host coexist without interfering", async () => {
+    const oldReport = parseSelfReport(
+      new URLSearchParams({ clientType: "claude_code", host: "mac.local" }),
+    );
+    const newReport = parseSelfReport(
+      new URLSearchParams({ clientType: "claude_code", host: "mac.local", cwd: "/work/new" }),
+    );
+
+    const oldHandle = await registerConnection(companyUuid, agentUuid, oldReport);
+    const newHandle = await registerConnection(companyUuid, agentUuid, newReport);
+
+    expect(oldHandle).not.toBeNull();
+    expect(newHandle).not.toBeNull();
+    expect(oldHandle!.uuid).not.toBe(newHandle!.uuid);
+
+    const views = await listConnectionsForAgent(companyUuid, agentUuid);
+    expect(views).toHaveLength(2);
+    // Order-independent: one row is the old daemon's null cwd, one is the new
+    // daemon's "/work/new" — they coexist as two distinct rows.
+    const cwds = views.map((v) => v.cwd);
+    expect(cwds).toContain(null);
+    expect(cwds).toContain("/work/new");
+
+    // Old daemon reconnecting does NOT disturb the new daemon's cwd row.
+    await registerConnection(companyUuid, agentUuid, oldReport);
+    const after = await listConnectionsForAgent(companyUuid, agentUuid);
+    expect(after).toHaveLength(2);
+    const afterCwds = after.map((v) => v.cwd);
+    expect(afterCwds).toContain(null);
+    expect(afterCwds).toContain("/work/new");
+  });
+});

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -6,6 +6,11 @@ const mockPrisma = vi.hoisted(() => ({
     upsert: vi.fn(),
     updateMany: vi.fn(),
     findMany: vi.fn(),
+    // The null-cwd (old-daemon) compatibility path does not use upsert (Prisma
+    // cannot target a NULL compound-key field); it does findFirst → update/create.
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
   },
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
@@ -56,27 +61,40 @@ describe("constants", () => {
 
 // ===== parseSelfReport =====
 describe("parseSelfReport", () => {
-  it("parses all params including a valid ISO-8601 startedAt", () => {
+  it("parses all params including cwd and a valid ISO-8601 startedAt", () => {
     const params = new URLSearchParams({
       clientType: "claude_code",
       clientVersion: "0.11.0",
       host: "mac.local",
+      cwd: "/Users/me/projects/alpha",
       startedAt: "2026-06-15T03:00:00.000Z",
     });
     const report = parseSelfReport(params);
     expect(report.clientType).toBe("claude_code");
     expect(report.clientVersion).toBe("0.11.0");
     expect(report.host).toBe("mac.local");
+    expect(report.cwd).toBe("/Users/me/projects/alpha");
     expect(report.startedAt).toBeInstanceOf(Date);
     expect(report.startedAt?.toISOString()).toBe("2026-06-15T03:00:00.000Z");
   });
 
-  it("defaults missing string params: clientType='' and nullable fields null", () => {
+  it("defaults missing string params: clientType='' and nullable fields null (cwd→null for an old daemon)", () => {
     const report = parseSelfReport(new URLSearchParams());
     expect(report.clientType).toBe("");
     expect(report.clientVersion).toBeNull();
     expect(report.host).toBeNull();
+    // HARD-1: a daemon that does not report cwd → cwd:null (NOT ""). This is the
+    // single representation of "unknown cwd".
+    expect(report.cwd).toBeNull();
     expect(report.startedAt).toBeNull();
+  });
+
+  it("parses cwd independently of host (a cwd with no host is honored)", () => {
+    const report = parseSelfReport(
+      new URLSearchParams({ clientType: "claude_code", cwd: "/srv/work" }),
+    );
+    expect(report.host).toBeNull();
+    expect(report.cwd).toBe("/srv/work");
   });
 
   it("parses an unparseable startedAt to null (no Invalid Date)", () => {
@@ -95,124 +113,255 @@ describe("parseSelfReport", () => {
 });
 
 // ===== registerConnection =====
+//
+// Two write paths to cover (Module Contract 3 — both upsert paths):
+//   - cwd PRESENT (current daemon) → a single compound-key `upsert` carrying the
+//     REAL cwd. This is what supersedes T1's `cwd=""` shim.
+//   - cwd NULL (old daemon, HARD-1) → findFirst → update/create (NOT upsert),
+//     because Prisma can't target NULL in the compound-unique where.
 describe("registerConnection", () => {
-  it("writes an online row for a daemon clientType and returns a {uuid, connectedAt} handle", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
-    const report: SelfReport = {
-      clientType: "claude_code",
-      clientVersion: "0.11.0",
-      host: "mac.local",
-      startedAt: new Date("2026-06-15T03:00:00.000Z"),
-    };
+  describe("cwd present (current daemon) → compound-key upsert on the REAL cwd", () => {
+    it("writes an online row keyed on (agent, clientType, host, cwd) and returns a {uuid, connectedAt} handle", async () => {
+      mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+      const report: SelfReport = {
+        clientType: "claude_code",
+        clientVersion: "0.11.0",
+        host: "mac.local",
+        cwd: "/Users/me/projects/alpha",
+        startedAt: new Date("2026-06-15T03:00:00.000Z"),
+      };
 
-    const result = await registerConnection(companyUuid, agentUuid, report);
+      const result = await registerConnection(companyUuid, agentUuid, report);
 
-    expect(result).toEqual({ uuid: connectionUuid, connectedAt });
-    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
-    const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
-    // Upsert key is the composite unique (agentUuid, clientType, host, cwd).
-    // T1 added cwd to the key; this path pins cwd to the "" sentinel so dedup
-    // stays deterministic (real cwd self-report is T2).
-    expect(arg.where).toEqual({
-      agentUuid_clientType_host_cwd: {
+      expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+      // The null-compat path must NOT be taken for a present cwd.
+      expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+      expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+      const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
+      // The composite unique key now carries the REAL cwd (no more "" shim).
+      expect(arg.where).toEqual({
+        agentUuid_clientType_host_cwd: {
+          agentUuid,
+          clientType: "claude_code",
+          host: "mac.local",
+          cwd: "/Users/me/projects/alpha",
+        },
+      });
+      expect(arg.create.cwd).toBe("/Users/me/projects/alpha");
+      expect(arg.create.status).toBe("online");
+      expect(arg.create.companyUuid).toBe(companyUuid);
+      expect(arg.create.host).toBe("mac.local");
+      expect(arg.create.connectedAt).toBeInstanceOf(Date);
+      expect(arg.create.lastSeenAt).toBeInstanceOf(Date);
+      // update branch flips back to online + clears disconnectedAt + refreshes
+      // connectedAt (the fencing token for an older generation's late calls).
+      expect(arg.update.status).toBe("online");
+      expect(arg.update.disconnectedAt).toBeNull();
+      expect(arg.update.connectedAt).toBeInstanceOf(Date);
+      expect(arg.update.companyUuid).toBe(companyUuid);
+      // The handle's connectedAt comes from the persisted row, not the local clock.
+      expect(arg.select).toEqual({ uuid: true, connectedAt: true });
+    });
+
+    it("registers an openclaw clientType", async () => {
+      mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "openclaw",
+        host: "linux-box",
+        cwd: "/srv/work",
+      });
+      expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+      expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+    });
+
+    it("upserts the same composite key on reconnect rather than inserting", async () => {
+      mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+      const report: SelfReport = {
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/w",
+      };
+
+      const first = await registerConnection(companyUuid, agentUuid, report);
+      const second = await registerConnection(companyUuid, agentUuid, report);
+
+      expect(first).toEqual({ uuid: connectionUuid, connectedAt });
+      expect(second).toEqual({ uuid: connectionUuid, connectedAt });
+      // Two upsert calls, both keyed on the same composite — never .create.
+      expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.daemonConnection.create).not.toHaveBeenCalled();
+      const firstWhere = mockPrisma.daemonConnection.upsert.mock.calls[0][0].where;
+      const secondWhere = mockPrisma.daemonConnection.upsert.mock.calls[1][0].where;
+      expect(firstWhere).toEqual(secondWhere);
+    });
+
+    it("the SAME agent+host with two DIFFERENT cwds upserts two DISTINCT composite keys (overwrite-bug fix)", async () => {
+      mockPrisma.daemonConnection.upsert
+        .mockResolvedValueOnce({ uuid: "conn-cwd-a", connectedAt })
+        .mockResolvedValueOnce({ uuid: "conn-cwd-b", connectedAt });
+
+      const a = await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/work/a",
+      });
+      const b = await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/work/b",
+      });
+
+      expect(a?.uuid).toBe("conn-cwd-a");
+      expect(b?.uuid).toBe("conn-cwd-b");
+      const whereA = mockPrisma.daemonConnection.upsert.mock.calls[0][0].where
+        .agentUuid_clientType_host_cwd;
+      const whereB = mockPrisma.daemonConnection.upsert.mock.calls[1][0].where
+        .agentUuid_clientType_host_cwd;
+      // Same agent + same host, but the cwd differs → the keys are NOT equal, so
+      // they target different rows (no overwrite). The real DB-level proof of two
+      // independent rows lives in the integration test.
+      expect(whereA.host).toBe(whereB.host);
+      expect(whereA.agentUuid).toBe(whereB.agentUuid);
+      expect(whereA.cwd).toBe("/work/a");
+      expect(whereB.cwd).toBe("/work/b");
+      expect(whereA).not.toEqual(whereB);
+    });
+
+    it("defaults a missing host to '' so the composite key stays deterministic", async () => {
+      mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+      await registerConnection(companyUuid, agentUuid, { clientType: "claude_code", cwd: "/w" });
+      const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
+      expect(arg.where.agentUuid_clientType_host_cwd.host).toBe("");
+      expect(arg.create.host).toBe("");
+    });
+
+    it("coerces missing clientVersion/startedAt to null", async () => {
+      mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+      await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "h",
+        cwd: "/w",
+      });
+      const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
+      expect(arg.create.clientVersion).toBeNull();
+      expect(arg.create.startedAt).toBeNull();
+    });
+
+    it("swallows + logs a persistence error and returns null (never throws)", async () => {
+      mockPrisma.daemonConnection.upsert.mockRejectedValue(new Error("db down"));
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/w",
+      });
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("cwd null (old daemon, HARD-1) → findFirst then update/create, NOT upsert", () => {
+    it("creates a cwd=null row on first connect (no existing null row)", async () => {
+      mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+      mockPrisma.daemonConnection.create.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+
+      // No cwd in the report → an old daemon. Must NOT throw / reject.
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "mac.local",
+      });
+
+      expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+      // The compound-key upsert must NOT be used for the NULL cwd path.
+      expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+      // Looked for an existing null row keyed on (agent, clientType, host, cwd:null).
+      expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.daemonConnection.findFirst.mock.calls[0][0].where).toEqual({
         agentUuid,
         clientType: "claude_code",
         host: "mac.local",
-        cwd: "",
-      },
+        cwd: null,
+      });
+      // Then created exactly one row with cwd:null.
+      expect(mockPrisma.daemonConnection.create).toHaveBeenCalledTimes(1);
+      const createArg = mockPrisma.daemonConnection.create.mock.calls[0][0];
+      expect(createArg.data.cwd).toBeNull();
+      expect(createArg.data.status).toBe("online");
+      expect(createArg.data.companyUuid).toBe(companyUuid);
     });
-    expect(arg.create.cwd).toBe("");
-    expect(arg.create.status).toBe("online");
-    expect(arg.create.companyUuid).toBe(companyUuid);
-    expect(arg.create.host).toBe("mac.local");
-    expect(arg.create.connectedAt).toBeInstanceOf(Date);
-    expect(arg.create.lastSeenAt).toBeInstanceOf(Date);
-    // update branch flips back to online + clears disconnectedAt + refreshes
-    // connectedAt (the fencing token for an older generation's late calls).
-    expect(arg.update.status).toBe("online");
-    expect(arg.update.disconnectedAt).toBeNull();
-    expect(arg.update.connectedAt).toBeInstanceOf(Date);
-    expect(arg.update.companyUuid).toBe(companyUuid);
-    // The handle's connectedAt comes from the persisted row, not the local clock.
-    expect(arg.select).toEqual({ uuid: true, connectedAt: true });
-  });
 
-  it("registers an openclaw clientType", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
-    const result = await registerConnection(companyUuid, agentUuid, {
-      clientType: "openclaw",
-      host: "linux-box",
+    it("REUSES the existing cwd=null row on reconnect (update by uuid) — no null-row pileup", async () => {
+      mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: connectionUuid });
+      mockPrisma.daemonConnection.update.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "mac.local",
+      });
+
+      expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+      expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+      // Crucially: it UPDATEs the found row by uuid — it does NOT create a second
+      // null row. This is the anti-pileup guarantee.
+      expect(mockPrisma.daemonConnection.create).not.toHaveBeenCalled();
+      expect(mockPrisma.daemonConnection.update).toHaveBeenCalledTimes(1);
+      const updateArg = mockPrisma.daemonConnection.update.mock.calls[0][0];
+      expect(updateArg.where).toEqual({ uuid: connectionUuid });
+      expect(updateArg.data.status).toBe("online");
+      expect(updateArg.data.disconnectedAt).toBeNull();
+      expect(updateArg.data.connectedAt).toBeInstanceOf(Date);
     });
-    expect(result).toEqual({ uuid: connectionUuid, connectedAt });
-    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
-  });
 
-  it("returns null and writes nothing for a non-daemon clientType (browser)", async () => {
-    const result = await registerConnection(companyUuid, agentUuid, {
-      clientType: "browser",
-      host: "mac.local",
+    it("treats an explicit cwd:null in the report the same as a missing cwd", async () => {
+      mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+      mockPrisma.daemonConnection.create.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+      await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: null,
+      });
+      expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
     });
-    expect(result).toBeNull();
-    expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
-  });
 
-  it("returns null and writes nothing for an unrecognized clientType", async () => {
-    const result = await registerConnection(companyUuid, agentUuid, {
-      clientType: "something-else",
+    it("swallows + logs a persistence error on the null path and returns null (never throws)", async () => {
+      mockPrisma.daemonConnection.findFirst.mockRejectedValue(new Error("db down"));
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "claude_code",
+        host: "mac.local",
+      });
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
     });
-    expect(result).toBeNull();
-    expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
   });
 
-  it("returns null and writes nothing for an empty clientType", async () => {
-    const result = await registerConnection(companyUuid, agentUuid, { clientType: "" });
-    expect(result).toBeNull();
-    expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
-  });
-
-  it("upserts the same (agentUuid, clientType, host) row on reconnect rather than inserting", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
-    const report: SelfReport = { clientType: "claude_code", host: "mac.local" };
-
-    const first = await registerConnection(companyUuid, agentUuid, report);
-    const second = await registerConnection(companyUuid, agentUuid, report);
-
-    expect(first).toEqual({ uuid: connectionUuid, connectedAt });
-    expect(second).toEqual({ uuid: connectionUuid, connectedAt });
-    // Two upsert calls, both keyed on the same composite — never .create.
-    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(2);
-    const firstWhere = mockPrisma.daemonConnection.upsert.mock.calls[0][0].where;
-    const secondWhere = mockPrisma.daemonConnection.upsert.mock.calls[1][0].where;
-    expect(firstWhere).toEqual(secondWhere);
-  });
-
-  it("defaults a missing host to '' so the composite key stays deterministic", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
-    await registerConnection(companyUuid, agentUuid, { clientType: "claude_code" });
-    const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
-    expect(arg.where.agentUuid_clientType_host_cwd.host).toBe("");
-    expect(arg.create.host).toBe("");
-  });
-
-  it("coerces missing clientVersion/startedAt to null", async () => {
-    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
-    await registerConnection(companyUuid, agentUuid, {
-      clientType: "claude_code",
-      host: "h",
+  describe("clientType gating (no write at all)", () => {
+    it("returns null and writes nothing for a non-daemon clientType (browser)", async () => {
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "browser",
+        host: "mac.local",
+        cwd: "/w",
+      });
+      expect(result).toBeNull();
+      expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+      expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+      expect(mockPrisma.daemonConnection.create).not.toHaveBeenCalled();
     });
-    const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
-    expect(arg.create.clientVersion).toBeNull();
-    expect(arg.create.startedAt).toBeNull();
-  });
 
-  it("swallows + logs a persistence error and returns null (never throws)", async () => {
-    mockPrisma.daemonConnection.upsert.mockRejectedValue(new Error("db down"));
-    const result = await registerConnection(companyUuid, agentUuid, {
-      clientType: "claude_code",
-      host: "mac.local",
+    it("returns null and writes nothing for an unrecognized clientType", async () => {
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "something-else",
+      });
+      expect(result).toBeNull();
+      expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+      expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
     });
-    expect(result).toBeNull();
-    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+
+    it("returns null and writes nothing for an empty clientType", async () => {
+      const result = await registerConnection(companyUuid, agentUuid, { clientType: "" });
+      expect(result).toBeNull();
+      expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+      expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -289,6 +438,7 @@ function makeRow(
     startedAt?: Date | null;
     clientVersion?: string | null;
     host?: string;
+    cwd?: string | null;
     disconnectedAt?: Date | null;
     agent?: { name: string } | null;
   } = {},
@@ -302,6 +452,7 @@ function makeRow(
     // is honored rather than falling through to the default.
     clientVersion: "clientVersion" in overrides ? overrides.clientVersion : "0.11.0",
     host: overrides.host ?? "mac.local",
+    cwd: "cwd" in overrides ? overrides.cwd : "/Users/me/projects/alpha",
     startedAt:
       "startedAt" in overrides ? overrides.startedAt : new Date("2026-06-15T03:00:00.000Z"),
     status: overrides.status ?? "online",
@@ -340,6 +491,7 @@ describe("listConnectionsForOwner", () => {
       clientType: "claude_code",
       clientVersion: "0.11.0",
       host: "mac.local",
+      cwd: "/Users/me/projects/alpha",
       startedAt: "2026-06-15T03:00:00.000Z",
       status: "online",
       effectiveStatus: "online",
@@ -349,15 +501,23 @@ describe("listConnectionsForOwner", () => {
     });
   });
 
-  it("maps null startedAt / clientVersion / disconnectedAt through as null", async () => {
+  it("maps null startedAt / clientVersion / disconnectedAt / cwd through as null (old daemon)", async () => {
     mockPrisma.daemonConnection.findMany.mockResolvedValue([
-      makeRow({ startedAt: null, clientVersion: null, disconnectedAt: null, host: "" }),
+      makeRow({ startedAt: null, clientVersion: null, disconnectedAt: null, host: "", cwd: null }),
     ]);
     const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
     expect(view.startedAt).toBeNull();
     expect(view.clientVersion).toBeNull();
     expect(view.disconnectedAt).toBeNull();
     expect(view.host).toBe("");
+    // An old daemon's null cwd projects through as null (not "").
+    expect(view.cwd).toBeNull();
+  });
+
+  it("projects a non-null cwd through to the view (the new identity dimension is observable)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([makeRow({ cwd: "/work/beta" })]);
+    const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
+    expect(view.cwd).toBe("/work/beta");
   });
 
   it("projects agentName: null (not throw) when the agent relation cannot be resolved", async () => {

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -110,14 +110,18 @@ describe("registerConnection", () => {
     expect(result).toEqual({ uuid: connectionUuid, connectedAt });
     expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
     const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
-    // Upsert key is the composite unique (agentUuid, clientType, host).
+    // Upsert key is the composite unique (agentUuid, clientType, host, cwd).
+    // T1 added cwd to the key; this path pins cwd to the "" sentinel so dedup
+    // stays deterministic (real cwd self-report is T2).
     expect(arg.where).toEqual({
-      agentUuid_clientType_host: {
+      agentUuid_clientType_host_cwd: {
         agentUuid,
         clientType: "claude_code",
         host: "mac.local",
+        cwd: "",
       },
     });
+    expect(arg.create.cwd).toBe("");
     expect(arg.create.status).toBe("online");
     expect(arg.create.companyUuid).toBe(companyUuid);
     expect(arg.create.host).toBe("mac.local");
@@ -186,7 +190,7 @@ describe("registerConnection", () => {
     mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
     await registerConnection(companyUuid, agentUuid, { clientType: "claude_code" });
     const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
-    expect(arg.where.agentUuid_clientType_host.host).toBe("");
+    expect(arg.where.agentUuid_clientType_host_cwd.host).toBe("");
     expect(arg.create.host).toBe("");
   });
 

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -581,6 +581,67 @@ describe("listConnectionsForAgent", () => {
   });
 });
 
+// ===== T3 — 派单选连接维度不变 (AC#5 / Module Contract 5) =====
+// Dispatch selects a connection by AGENT + ONLINE status only (the chokepoint takes the
+// FIRST online connection of the agent). Introducing multi-path (same agent, several cwd
+// rows) and null-cwd (old daemon) rows must NOT make that selection miss, error, or
+// collapse rows — and there is NO project→cwd inference. These tests model the exact read
+// the dispatch chokepoint runs (listConnectionsForAgent, then first-online) and prove it
+// behaves correctly across those new row shapes.
+describe("T3 dispatch selection across multi-cwd + null-cwd connections", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("surfaces EVERY same-agent cwd row (multi-path does not collapse/miss connections)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ uuid: "conn-a", cwd: "/dev/repo-a", status: "online", agoMs: 0 }),
+      makeRow({ uuid: "conn-b", cwd: "/dev/repo-b", status: "online", agoMs: 1000 }),
+      makeRow({ uuid: "conn-null", cwd: null, status: "online", agoMs: 2000 }),
+    ]);
+    const result = await listConnectionsForAgent(companyUuid, agentUuid);
+    // All three distinct connections are returned — none missed, none merged.
+    expect(result.map((v) => v.uuid).sort()).toEqual(["conn-a", "conn-b", "conn-null"]);
+    expect(result.map((v) => v.cwd).sort()).toEqual(["/dev/repo-a", "/dev/repo-b", null].sort());
+    // The query dimension is unchanged — agent + company, NO cwd / project filter.
+    expect(mockPrisma.daemonConnection.findMany.mock.calls[0][0].where).toEqual({
+      companyUuid,
+      agentUuid,
+    });
+  });
+
+  it("the dispatch chokepoint's 'first online' selection is unaffected by cwd (online-first sort)", async () => {
+    // One OFFLINE repo-a row + two ONLINE rows (repo-b, then null). The first-online pick
+    // must land an ONLINE connection regardless of cwd — selection is by online status,
+    // never by cwd or project.
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ uuid: "conn-a-offline", cwd: "/dev/repo-a", status: "offline", agoMs: 0 }),
+      makeRow({ uuid: "conn-b-online", cwd: "/dev/repo-b", status: "online", agoMs: 5000 }),
+      makeRow({ uuid: "conn-null-online", cwd: null, status: "online", agoMs: 1000 }),
+    ]);
+    const result = await listConnectionsForAgent(companyUuid, agentUuid);
+    // The chokepoint does exactly this: take the first effectiveStatus==="online" entry.
+    const origin = result.find((c) => c.effectiveStatus === "online");
+    expect(origin).toBeTruthy();
+    expect(origin!.effectiveStatus).toBe("online");
+    // Online-first, then lastSeenAt desc: the freshest online (null-cwd, agoMs 1000) leads
+    // the offline repo-a row — i.e. a null-cwd connection is fully selectable as origin.
+    expect(origin!.uuid).toBe("conn-null-online");
+  });
+
+  it("a null-cwd (old daemon) connection is selectable as the sole online connection (HARD-1)", async () => {
+    // Old daemon only: a single cwd=null online row. Dispatch must still select it.
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      makeRow({ uuid: "conn-old", cwd: null, status: "online", agoMs: 0 }),
+    ]);
+    const result = await listConnectionsForAgent(companyUuid, agentUuid);
+    const origin = result.find((c) => c.effectiveStatus === "online");
+    expect(origin?.uuid).toBe("conn-old");
+    expect(origin?.cwd).toBeNull();
+  });
+});
+
 describe("effectiveStatus derivation", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/services/__tests__/daemon-multipath-e2e.integration.test.ts
+++ b/src/services/__tests__/daemon-multipath-e2e.integration.test.ts
@@ -1,0 +1,641 @@
+// src/services/__tests__/daemon-multipath-e2e.integration.test.ts
+//
+// T4 — INTEGRATION CHECKPOINT (the DAG convergence point) for the daemon
+// multi-path-cwd engine. This is the END-TO-END verification that T1–T3 work
+// TOGETHER as combined scenarios — NOT a re-run of the per-task unit tests.
+//
+// Unlike the per-layer suites (each of which mocks prisma or a single seam), this
+// test wires the REAL composition of every layer against ONE real PostgreSQL
+// instance, so each function reads exactly what the previous one wrote — the thing
+// a mock cannot prove:
+//
+//   registerConnection / listConnectionsForAgent   (T1+T2 registry — composite key
+//                                                    (agent, clientType, host, cwd),
+//                                                    two write paths, effectiveStatus)
+//     → maybeCreateTurnForWakeNotification          (the wake/DISPATCH chokepoint —
+//                                                    selects the origin connection by
+//                                                    (company, agent) only, online-first;
+//                                                    NO cwd filter, NO project→cwd infer)
+//       → resolveOrCreateSession + createPendingTurn (T3 session — stamps
+//                                                     originConnectionUuid write-once)
+//   assertContinuable                               (T3 resume — pins continuation to
+//                                                    the session's ORIGIN connection;
+//                                                    a different cwd is a different row
+//                                                    and is NEVER routed to → cross-cwd
+//                                                    resume is refused, not mis-routed)
+//   escapeCwd / transcriptPath                      (T3 on-disk transcript naming —
+//                                                    the ~/.claude/projects/<escaped-cwd>
+//                                                    rule that makes resume cwd-bound)
+//
+// Only lineage (directIdeaUuid resolution) is faked at its module boundary, because
+// it walks idea ancestry that is orthogonal to this slice; everything else — the
+// registry writes, the connection selection, the session/turn writes, the resume
+// assertion — runs for real against the database.
+//
+// The five AC are proven as COMBINED scenarios (mapped to the tech design's 验证要点):
+//   (AC1) same agent + same host + two DIFFERENT real cwds → two registry rows coexist,
+//         each presence online INDEPENDENTLY, end-to-end through registerConnection +
+//         listConnectionsForAgent (effectiveStatus).
+//   (AC2) resume ALWAYS returns to the session's original cwd; a scenario constructed
+//         to route to a DIFFERENT cwd is REFUSED (SessionReadOnlyError) rather than
+//         mis-routed — backed by a REAL on-disk transcript that exists only under the
+//         origin cwd's escaped dir (so a cross-cwd `claude --resume` would
+//         `No conversation found`).
+//   (AC3) the DISPATCH connection-selection is not broken: same agent with multiple cwd
+//         connections + a null-cwd connection coexisting → the existing selection picks
+//         correctly (online-first), no miss, no error; and NO project→cwd inference is
+//         introduced (the selection input is purely (company, agent)).
+//   (AC4) HARD-1 end-to-end: a fully cwd-less OLD daemon registers (null row) / receives
+//         dispatch (agent-based selection) / its session resumes (origin connection, not
+//         blocked by the cwd check); new + old daemon coexist without interfering.
+//   (AC5) MIGRATION BACKFILL: an existing cwd=null row (the migration-era state), after
+//         the daemon upgrades and self-reports a real cwd, results in a row carrying that
+//         cwd, and functionality never regresses across the transition.
+//
+// HOW TO RUN (never touches the live store — see the gate below):
+//   docker run -d --name chorus-t4-pg -e POSTGRES_USER=t4 -e POSTGRES_PASSWORD=t4 \
+//     -e POSTGRES_DB=t4 -p 127.0.0.1:55444:5432 postgres:16-alpine
+//   DATABASE_URL="postgresql://t4:t4@127.0.0.1:55444/t4" npx prisma migrate deploy
+//   T4_REAL_DB_URL="postgresql://t4:t4@127.0.0.1:55444/t4" \
+//     npx vitest run src/services/__tests__/daemon-multipath-e2e.integration.test.ts
+//
+// When T4_REAL_DB_URL is NOT set (the default for `pnpm test` / CI), the WHOLE suite is
+// skipped — so it never connects to a database it shouldn't, and in particular NEVER
+// touches the live PGlite store (port 5433 / ~/.chorus-data).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Gate: only run when an explicit throwaway DB URL is provided.
+const REAL_DB_URL = process.env.T4_REAL_DB_URL;
+const describeReal = REAL_DB_URL ? describe : describe.skip;
+
+// The real generated Prisma client is imported by ABSOLUTE filesystem path so it
+// bypasses the vitest alias that points "@/generated/prisma/client" at a stub
+// (see vitest.config.ts). We deliberately want the REAL client here.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let realPrisma: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let pool: any;
+
+// Lazily-imported real service functions (imported AFTER the prisma mock is wired).
+type RegisterConnection = typeof import("@/services/daemon-connection.service")["registerConnection"];
+type ListConnectionsForAgent =
+  typeof import("@/services/daemon-connection.service")["listConnectionsForAgent"];
+type ParseSelfReport = typeof import("@/services/daemon-connection.service")["parseSelfReport"];
+type MaybeCreateTurn =
+  typeof import("@/services/notification-turn")["maybeCreateTurnForWakeNotification"];
+type AssertContinuable = typeof import("@/services/daemon-session.service")["assertContinuable"];
+type SessionReadOnlyErrorT = typeof import("@/services/daemon-session.service")["SessionReadOnlyError"];
+type StaleThreshold = typeof import("@/services/daemon-connection.service")["STALE_THRESHOLD_MS"];
+
+let registerConnection: RegisterConnection;
+let listConnectionsForAgent: ListConnectionsForAgent;
+let parseSelfReport: ParseSelfReport;
+let maybeCreateTurnForWakeNotification: MaybeCreateTurn;
+let assertContinuable: AssertContinuable;
+let SessionReadOnlyError: SessionReadOnlyErrorT;
+let STALE_THRESHOLD_MS: StaleThreshold;
+
+// The CLI transcript-path helpers — the SAME functions the daemon uses on disk to
+// decide --session-id vs --resume. We exercise the REAL implementation so the resume
+// scenario proves the actual ~/.claude/projects/<escaped-cwd> naming, not a guess.
+type TranscriptPath = typeof import("../../../cli/claude-spawner.mjs")["transcriptPath"];
+type IsNewSession = typeof import("../../../cli/claude-spawner.mjs")["isNewSession"];
+type EscapeCwd = typeof import("../../../cli/claude-spawner.mjs")["escapeCwd"];
+let transcriptPath: TranscriptPath;
+let isNewSession: IsNewSession;
+let escapeCwd: EscapeCwd;
+
+const companyUuid = "company-t4-0000-0000-000000000001";
+const agentUuid = "agent-t4-0000-0000-0000-00000000001"; // the "new" multi-path agent
+const oldAgentUuid = "agent-t4-0000-0000-0000-00000000002"; // a purely cwd-less OLD daemon agent
+const HOST = "mac.local";
+
+// A wake-notification context for the dispatch chokepoint. entityType "task" is
+// lineage-walkable, so the session id is derived from the (faked) directIdeaUuid.
+function wakeCtx(overrides: Partial<Parameters<MaybeCreateTurn>[0]> = {}) {
+  return {
+    companyUuid,
+    recipientType: "agent",
+    recipientUuid: agentUuid,
+    entityType: "task",
+    entityUuid: "task-e2e-1",
+    action: "task_assigned",
+    ...overrides,
+  };
+}
+
+describeReal("daemon multi-path E2E — REAL Postgres (T4 integration checkpoint)", () => {
+  // A single faked direct-idea so the session key is deterministic. Tests that want a
+  // distinct session set DIRECT_IDEA before driving the chokepoint.
+  let DIRECT_IDEA = "idea-e2e-0000-0000-0000-00000000001";
+
+  beforeAll(async () => {
+    // Build a REAL PrismaClient pointed at the throwaway DB, then make the services'
+    // `@/lib/prisma` import resolve to it. The logger is silenced. lineage is faked
+    // (directIdeaUuid resolution is orthogonal to this slice).
+    const { PrismaClient } = await import(
+      /* @vite-ignore */ "../../generated/prisma/client"
+    );
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const pg = (await import("pg")).default;
+
+    pool = new pg.Pool({ connectionString: REAL_DB_URL });
+    const adapter = new PrismaPg(pool);
+    realPrisma = new PrismaClient({ adapter });
+
+    vi.doMock("@/lib/prisma", () => ({ prisma: realPrisma }));
+    vi.doMock("@/lib/logger", () => {
+      const fn = () => {};
+      const stub = { error: fn, warn: fn, info: fn, debug: fn, child: () => stub };
+      return { default: stub };
+    });
+    // Fake ONLY lineage: the chokepoint asks for the entity's direct idea. We resolve
+    // it to DIRECT_IDEA (so the session key is the idea), or null for ad-hoc.
+    vi.doMock("@/services/lineage.service", () => ({
+      resolveRootIdea: async () => ({
+        rootIdeaUuid: DIRECT_IDEA,
+        directIdeaUuid: DIRECT_IDEA,
+        lineage: [],
+        resolvedVia: "via_proposal",
+      }),
+    }));
+
+    const connSvc = await import("@/services/daemon-connection.service");
+    registerConnection = connSvc.registerConnection;
+    listConnectionsForAgent = connSvc.listConnectionsForAgent;
+    parseSelfReport = connSvc.parseSelfReport;
+    STALE_THRESHOLD_MS = connSvc.STALE_THRESHOLD_MS;
+
+    const bridge = await import("@/services/notification-turn");
+    maybeCreateTurnForWakeNotification = bridge.maybeCreateTurnForWakeNotification;
+
+    const sessSvc = await import("@/services/daemon-session.service");
+    assertContinuable = sessSvc.assertContinuable;
+    SessionReadOnlyError = sessSvc.SessionReadOnlyError;
+
+    const spawner = await import(/* @vite-ignore */ "../../../cli/claude-spawner.mjs");
+    transcriptPath = spawner.transcriptPath;
+    isNewSession = spawner.isNewSession;
+    escapeCwd = spawner.escapeCwd;
+
+    // Seed the Company + Agent rows the read projection joins on (agent.name). The
+    // schema uses relationMode="prisma" (no DB FKs), but listConnectionsForAgent joins
+    // the agent name, so the agent rows must exist.
+    await realPrisma.company.upsert({
+      where: { uuid: companyUuid },
+      create: { uuid: companyUuid, name: "T4 Co" },
+      update: {},
+    });
+    for (const [uuid, name] of [
+      [agentUuid, "T4 Multi-path Agent"],
+      [oldAgentUuid, "T4 Old Daemon Agent"],
+    ] as const) {
+      await realPrisma.agent.upsert({
+        where: { uuid },
+        create: { uuid, companyUuid, name, roles: [], permissions: [] },
+        update: {},
+      });
+    }
+  });
+
+  afterAll(async () => {
+    if (realPrisma) {
+      // Order matters under relationMode="prisma" (no cascade at DB level here).
+      await realPrisma.daemonSessionTurn.deleteMany({}).catch(() => {});
+      await realPrisma.daemonSession.deleteMany({ where: { companyUuid } });
+      await realPrisma.daemonConnection.deleteMany({ where: { companyUuid } });
+      await realPrisma.agent.deleteMany({ where: { companyUuid } });
+      await realPrisma.company.deleteMany({ where: { uuid: companyUuid } });
+      await realPrisma.$disconnect();
+    }
+    if (pool) await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Each test starts from an empty session/turn/connection table (scoped to our company).
+    // Turns reference sessions by sessionUuid (not companyUuid), so clear them first.
+    const sessions = await realPrisma.daemonSession.findMany({
+      where: { companyUuid },
+      select: { uuid: true },
+    });
+    const sessionUuids = sessions.map((s: { uuid: string }) => s.uuid);
+    if (sessionUuids.length) {
+      await realPrisma.daemonSessionTurn.deleteMany({
+        where: { sessionUuid: { in: sessionUuids } },
+      });
+    }
+    await realPrisma.daemonSession.deleteMany({ where: { companyUuid } });
+    await realPrisma.daemonConnection.deleteMany({ where: { companyUuid } });
+    DIRECT_IDEA = "idea-e2e-0000-0000-0000-00000000001";
+  });
+
+  // Helper: register a connection the way the SSE route does — parse a self-report off
+  // query params, then registerConnection. Returns the ConnectionHandle.
+  async function register(
+    agent: string,
+    params: { host?: string; cwd?: string },
+  ) {
+    const sp = new URLSearchParams({ clientType: "claude_code" });
+    if (params.host !== undefined) sp.set("host", params.host);
+    if (params.cwd !== undefined) sp.set("cwd", params.cwd);
+    const report = parseSelfReport(sp);
+    return registerConnection(companyUuid, agent, report);
+  }
+
+  // Helper: directly age a connection's lastSeenAt so its effectiveStatus computes to
+  // offline (the registry's staleness rule), without touching status. Mirrors a daemon
+  // whose heartbeat stopped — the exact condition assertContinuable refuses resume on.
+  async function makeStale(connUuid: string) {
+    await realPrisma.daemonConnection.update({
+      where: { uuid: connUuid },
+      data: { lastSeenAt: new Date(Date.now() - STALE_THRESHOLD_MS - 60_000) },
+    });
+  }
+
+  // =========================================================================
+  // AC1 — same agent + same host + two DIFFERENT real cwds → two rows coexist,
+  //       each presence online independently (end-to-end through the registry).
+  // =========================================================================
+  describe("AC1: same agent + same host + two different cwds coexist, presence independent", () => {
+    it("registers two independent rows for two real cwds; each is online; flipping one does not touch the other", async () => {
+      const cwdA = "/work/alpha";
+      const cwdB = "/work/beta";
+
+      const a = await register(agentUuid, { host: HOST, cwd: cwdA });
+      const b = await register(agentUuid, { host: HOST, cwd: cwdB });
+      expect(a).not.toBeNull();
+      expect(b).not.toBeNull();
+      // Two DISTINCT rows — neither overwrote the other (the overwrite bug is fixed).
+      expect(a!.uuid).not.toBe(b!.uuid);
+
+      const views = await listConnectionsForAgent(companyUuid, agentUuid);
+      expect(views).toHaveLength(2);
+      const byCwd = Object.fromEntries(views.map((v) => [v.cwd, v]));
+      expect(byCwd[cwdA]).toBeTruthy();
+      expect(byCwd[cwdB]).toBeTruthy();
+      // Each cwd row carries the SAME agent + host but is its own connection identity.
+      expect(byCwd[cwdA].host).toBe(HOST);
+      expect(byCwd[cwdB].host).toBe(HOST);
+      expect(byCwd[cwdA].agentUuid).toBe(agentUuid);
+      expect(byCwd[cwdB].agentUuid).toBe(agentUuid);
+      // Presence is computed independently per row.
+      expect(byCwd[cwdA].effectiveStatus).toBe("online");
+      expect(byCwd[cwdB].effectiveStatus).toBe("online");
+
+      // Take cwdA offline (stale heartbeat). cwdB stays online — genuinely independent.
+      await makeStale(byCwd[cwdA].uuid);
+      const after = await listConnectionsForAgent(companyUuid, agentUuid);
+      const afterByCwd = Object.fromEntries(after.map((v) => [v.cwd, v]));
+      expect(afterByCwd[cwdA].effectiveStatus).toBe("offline");
+      expect(afterByCwd[cwdB].effectiveStatus).toBe("online");
+    });
+  });
+
+  // =========================================================================
+  // AC2 — resume always returns to the original cwd; a cross-cwd route is REFUSED
+  //       (not mis-routed to "No conversation found"). Backed by a REAL on-disk
+  //       transcript that lives only under the origin cwd's escaped dir.
+  // =========================================================================
+  describe("AC2: resume returns to origin cwd; cross-cwd route refused (not mis-routed)", () => {
+    let configDir: string;
+    let cwdA: string;
+    let cwdB: string;
+
+    beforeEach(() => {
+      // A sandboxed CLAUDE_CONFIG_DIR + two real on-disk cwds. Real escapeCwd naming.
+      configDir = mkdtempSync(join(tmpdir(), "chorus-t4-cfg-"));
+      process.env.CLAUDE_CONFIG_DIR = configDir;
+      cwdA = mkdtempSync(join(tmpdir(), "chorus-t4-cwdA-"));
+      cwdB = mkdtempSync(join(tmpdir(), "chorus-t4-cwdB-"));
+    });
+
+    afterEach(() => {
+      for (const d of [configDir, cwdA, cwdB]) {
+        if (d) rmSync(d, { recursive: true, force: true });
+      }
+      delete process.env.CLAUDE_CONFIG_DIR;
+    });
+
+    it("the session pins origin to the cwd it was created on; an online origin resumes there; a cross-cwd connection is never the resume target", async () => {
+      // Two connections of the SAME agent on the SAME host, different cwds.
+      const connA = await register(agentUuid, { host: HOST, cwd: cwdA });
+      const connB = await register(agentUuid, { host: HOST, cwd: cwdB });
+      expect(connA).not.toBeNull();
+      expect(connB).not.toBeNull();
+
+      // listConnectionsForAgent sorts online-first then lastSeenAt desc. connB was
+      // registered last, so it is the freshest → the dispatch chokepoint would pin a
+      // NEW session to connB. To make the test deterministic about WHICH cwd is the
+      // origin, age connB slightly so connA is the freshest online row, pinning origin
+      // to cwdA. (This is the realistic case: the session began on cwdA.)
+      await realPrisma.daemonConnection.update({
+        where: { uuid: connB!.uuid },
+        data: { lastSeenAt: new Date(Date.now() - 5_000) },
+      });
+
+      // Drive the REAL dispatch chokepoint: it selects the origin connection by
+      // (company, agent) only and stamps it on the session. The session id = DIRECT_IDEA.
+      const turn = await maybeCreateTurnForWakeNotification(wakeCtx());
+      expect(turn).not.toBeNull();
+
+      // The session was pinned to cwdA's connection (the freshest online row).
+      const session = await realPrisma.daemonSession.findFirst({
+        where: { companyUuid, agentUuid, sessionId: DIRECT_IDEA },
+        select: { uuid: true, originConnectionUuid: true },
+      });
+      expect(session).not.toBeNull();
+      expect(session.originConnectionUuid).toBe(connA!.uuid);
+
+      // Simulate the daemon having run claude in cwdA: a REAL transcript file exists
+      // only under cwdA's escaped projects dir, NOT cwdB's. This is exactly why a
+      // cross-cwd resume would `No conversation found`.
+      const tPathA = transcriptPath(DIRECT_IDEA, cwdA, { env: process.env });
+      const tPathB = transcriptPath(DIRECT_IDEA, cwdB, { env: process.env });
+      mkdirSync(tPathA.slice(0, tPathA.lastIndexOf("/")), { recursive: true });
+      writeFileSync(tPathA, `{"type":"system","session_id":"${DIRECT_IDEA}"}\n`);
+      expect(tPathA).not.toBe(tPathB); // distinct escaped-cwd dirs → cwd-bound resume
+      expect(existsSync(tPathA)).toBe(true);
+      expect(existsSync(tPathB)).toBe(false);
+      // A probe in cwdA resumes (transcript present → not new); a probe in cwdB is
+      // "new" (the cwdA transcript is invisible there) — i.e. a cross-cwd `--resume`
+      // would start fresh / fail. This is the disk truth behind the server refusal.
+      expect(isNewSession(DIRECT_IDEA, cwdA, { env: process.env })).toBe(false);
+      expect(isNewSession(DIRECT_IDEA, cwdB, { env: process.env })).toBe(true);
+
+      // While the origin (cwdA) is online, resume routes back to it — the ORIGINAL cwd.
+      const target = await assertContinuable(companyUuid, session.uuid);
+      expect(target).toBe(connA!.uuid); // resume returns to origin cwd, never connB.
+
+      // Now take the origin (cwdA) offline while the OTHER cwd (connB) is still online.
+      // A naive "route to any online connection of the agent" would pick connB and
+      // resume against the WRONG cwd (No conversation found). The real code REFUSES:
+      // it never falls back to a different cwd.
+      await makeStale(connA!.uuid);
+      // sanity: connB IS still effectively online (the tempting wrong target).
+      const live = await listConnectionsForAgent(companyUuid, agentUuid);
+      const connBView = live.find((v) => v.uuid === connB!.uuid);
+      expect(connBView?.effectiveStatus).toBe("online");
+
+      let thrown: unknown;
+      try {
+        await assertContinuable(companyUuid, session.uuid);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(SessionReadOnlyError);
+      // The error names the ORIGIN connection (cwdA) — it did not silently switch cwd.
+      expect((thrown as InstanceType<SessionReadOnlyErrorT>).originConnectionUuid).toBe(
+        connA!.uuid,
+      );
+      // escapeCwd is the real ~/.claude/projects naming rule (load-bearing for resume).
+      expect(tPathA).toContain(join("projects", escapeCwd(cwdA)));
+      expect(tPathB).toContain(join("projects", escapeCwd(cwdB)));
+    });
+  });
+
+  // =========================================================================
+  // AC3 — dispatch connection-selection NOT broken by multi-cwd + null-cwd coexistence;
+  //       online-first selection still works; no project→cwd inference introduced.
+  // =========================================================================
+  describe("AC3: dispatch selection survives multi-cwd + null-cwd coexistence (no project→cwd infer)", () => {
+    it("with two cwd connections + one null-cwd connection, the chokepoint selects an online connection of the agent (input is purely (company, agent)) and pins a valid origin", async () => {
+      // Mixed registry for ONE agent: two real cwds + one old-daemon null row, all online.
+      const c1 = await register(agentUuid, { host: HOST, cwd: "/work/one" });
+      const c2 = await register(agentUuid, { host: HOST, cwd: "/work/two" });
+      const cNull = await register(agentUuid, { host: HOST }); // no cwd → null row (old daemon)
+      expect(c1).not.toBeNull();
+      expect(c2).not.toBeNull();
+      expect(cNull).not.toBeNull();
+
+      const views = await listConnectionsForAgent(companyUuid, agentUuid);
+      expect(views).toHaveLength(3);
+      // The null-cwd row coexists alongside the two cwd rows — no miss, no merge.
+      // (Order-independent: JS Array.sort() would place null last, so compare as a set.)
+      const cwds = views.map((v) => v.cwd);
+      expect(cwds).toContain(null);
+      expect(cwds).toContain("/work/one");
+      expect(cwds).toContain("/work/two");
+      expect(views.every((v) => v.effectiveStatus === "online")).toBe(true);
+
+      // Drive the dispatch chokepoint. It must pick SOME online connection of the agent
+      // and pin it — without erroring and without missing the agent's daemon. The
+      // selection input is purely (company, agent); cwd does not participate.
+      const turn = await maybeCreateTurnForWakeNotification(wakeCtx());
+      expect(turn).not.toBeNull();
+
+      const session = await realPrisma.daemonSession.findFirst({
+        where: { companyUuid, agentUuid, sessionId: DIRECT_IDEA },
+        select: { originConnectionUuid: true },
+      });
+      expect(session).not.toBeNull();
+      // The chosen origin is one of the agent's real connections (deterministically the
+      // freshest online one) — never a fabricated / project-derived target.
+      const validUuids = [c1!.uuid, c2!.uuid, cNull!.uuid];
+      expect(validUuids).toContain(session.originConnectionUuid);
+      // It is the LAST-registered (freshest) online row, confirming the online-first +
+      // lastSeenAt-desc selection still holds with mixed cwd/null rows present.
+      expect(session.originConnectionUuid).toBe(cNull!.uuid);
+
+      // Structural guard against project→cwd inference: the chokepoint's selection input
+      // never references a project; the Project model carries no cwd. We assert the
+      // negative by confirming the selection ran purely off (company, agent) — there is
+      // no projectUuid in the wake context, yet selection succeeds. (The absence of any
+      // project↔cwd mapping in the codebase is verified separately in the work report.)
+      expect("projectUuid" in wakeCtx()).toBe(false);
+    });
+
+    it("when only the null-cwd connection is online, dispatch still selects it (old daemon is dispatchable)", async () => {
+      // Two cwd connections that are STALE (offline) + one online null-cwd connection.
+      const c1 = await register(agentUuid, { host: HOST, cwd: "/work/one" });
+      const c2 = await register(agentUuid, { host: HOST, cwd: "/work/two" });
+      const cNull = await register(agentUuid, { host: HOST });
+      await makeStale(c1!.uuid);
+      await makeStale(c2!.uuid);
+
+      const turn = await maybeCreateTurnForWakeNotification(wakeCtx());
+      expect(turn).not.toBeNull();
+      const session = await realPrisma.daemonSession.findFirst({
+        where: { companyUuid, agentUuid, sessionId: DIRECT_IDEA },
+        select: { originConnectionUuid: true },
+      });
+      // The ONLY online connection (the null-cwd old daemon) is selected — no miss.
+      expect(session.originConnectionUuid).toBe(cNull!.uuid);
+    });
+  });
+
+  // =========================================================================
+  // AC4 — HARD-1: a fully cwd-less OLD daemon end-to-end (register null row → dispatch by
+  //       agent → resume off origin, not blocked by cwd check); new + old daemon coexist.
+  // =========================================================================
+  describe("AC4 (HARD-1): cwd-less old daemon end-to-end; coexists with a new daemon", () => {
+    it("an old daemon registers a null row, is dispatched to, and its session resumes off the (null-cwd) origin while online — never blocked by the cwd check", async () => {
+      // The old-daemon agent reports NO cwd → a single null row (no pileup on reconnect).
+      const first = await register(oldAgentUuid, { host: HOST });
+      const again = await register(oldAgentUuid, { host: HOST });
+      const reconnected = await register(oldAgentUuid, { host: HOST });
+      expect(first).not.toBeNull();
+      // Reconnect REUSES the same null row (the HARD-1 compat path) — no null-row pileup.
+      expect(again!.uuid).toBe(first!.uuid);
+      expect(reconnected!.uuid).toBe(first!.uuid);
+
+      const rows = await realPrisma.daemonConnection.findMany({
+        where: { companyUuid, agentUuid: oldAgentUuid },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].cwd).toBeNull();
+
+      // Dispatch to the old agent: selection is by (company, agent) — the null-cwd row is
+      // dispatchable exactly like today (no error, no miss).
+      const turn = await maybeCreateTurnForWakeNotification(
+        wakeCtx({ recipientUuid: oldAgentUuid }),
+      );
+      expect(turn).not.toBeNull();
+
+      const session = await realPrisma.daemonSession.findFirst({
+        where: { companyUuid, agentUuid: oldAgentUuid, sessionId: DIRECT_IDEA },
+        select: { uuid: true, originConnectionUuid: true },
+      });
+      expect(session.originConnectionUuid).toBe(first!.uuid);
+
+      // Resume off the null-cwd origin: it is online, and the cwd-consistency check is a
+      // NO-OP for null (null = "unconstrained"). So a continuation is allowed — exactly
+      // as before the multi-path change.
+      const target = await assertContinuable(companyUuid, session.uuid);
+      expect(target).toBe(first!.uuid);
+
+      // When the old daemon goes offline, the session is read-only just like any other —
+      // the null cwd never CAUSES read-only, but offline still does (parity with today).
+      await makeStale(first!.uuid);
+      await expect(assertContinuable(companyUuid, session.uuid)).rejects.toBeInstanceOf(
+        SessionReadOnlyError,
+      );
+    });
+
+    it("a new (cwd) daemon and an old (null-cwd) daemon under the SAME agent+host coexist as two rows without interfering", async () => {
+      const oldHandle = await register(agentUuid, { host: HOST }); // null row
+      const newHandle = await register(agentUuid, { host: HOST, cwd: "/work/new" });
+      expect(oldHandle!.uuid).not.toBe(newHandle!.uuid);
+
+      let views = await listConnectionsForAgent(companyUuid, agentUuid);
+      expect(views).toHaveLength(2);
+      // Order-independent set comparison (JS sort would place null last).
+      expect(views.map((v) => v.cwd)).toContain(null);
+      expect(views.map((v) => v.cwd)).toContain("/work/new");
+
+      // The old daemon reconnecting does NOT disturb the new daemon's cwd row.
+      await register(agentUuid, { host: HOST });
+      views = await listConnectionsForAgent(companyUuid, agentUuid);
+      expect(views).toHaveLength(2);
+      expect(views.map((v) => v.cwd)).toContain(null);
+      expect(views.map((v) => v.cwd)).toContain("/work/new");
+      // Both still online and independent.
+      expect(views.every((v) => v.effectiveStatus === "online")).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // AC5 — MIGRATION BACKFILL: an existing cwd=null row (the migration-era state) →
+  //       after the daemon upgrades and self-reports a real cwd → a row carrying that
+  //       cwd; functionality never regresses across the transition.
+  // =========================================================================
+  describe("AC5: migration backfill — cwd=null row transitions to a real cwd on upgrade", () => {
+    it("simulates a migration-era null row, then an upgraded self-report; the agent ends with a cwd-bearing connection and stays dispatchable + resumable throughout", async () => {
+      // (a) Migration-era state: the daemon predates self-report → a cwd=null row.
+      // This is exactly what the T1 migration leaves behind: ADD COLUMN cwd (nullable)
+      // backfills every existing row to NULL. We reproduce that row via the real
+      // registerConnection null path (what a still-old daemon would write on reconnect).
+      const nullHandle = await register(agentUuid, { host: HOST });
+      expect(nullHandle).not.toBeNull();
+      let rows = await realPrisma.daemonConnection.findMany({
+        where: { companyUuid, agentUuid },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].cwd).toBeNull();
+
+      // The old (null) daemon is dispatchable BEFORE the upgrade — establish a baseline
+      // session pinned to the null connection, to prove no regression across the upgrade.
+      const preTurn = await maybeCreateTurnForWakeNotification(wakeCtx());
+      expect(preTurn).not.toBeNull();
+      const preSession = await realPrisma.daemonSession.findFirst({
+        where: { companyUuid, agentUuid, sessionId: DIRECT_IDEA },
+        select: { uuid: true, originConnectionUuid: true },
+      });
+      expect(preSession.originConnectionUuid).toBe(nullHandle!.uuid);
+      // The pre-upgrade (null-cwd) session resumes fine while online.
+      expect(await assertContinuable(companyUuid, preSession.uuid)).toBe(nullHandle!.uuid);
+
+      // (b) The daemon UPGRADES and now self-reports a real cwd on (re)connect. Per the
+      // T1 dedup strategy (Postgres NULL is distinct in the composite key), this lands a
+      // SEPARATE cwd-bearing row rather than mutating the null row in place — the null
+      // row is the old generation, the cwd row is the upgraded generation. The KEY
+      // assertion for "backfill" is that the agent now HAS a connection carrying the
+      // real cwd, and the registry reflects the upgrade.
+      const upgradedCwd = "/work/upgraded";
+      const upgraded = await register(agentUuid, { host: HOST, cwd: upgradedCwd });
+      expect(upgraded).not.toBeNull();
+
+      rows = await realPrisma.daemonConnection.findMany({
+        where: { companyUuid, agentUuid },
+        orderBy: { cwd: "asc" },
+      });
+      // The upgraded row carries the real cwd. (The transition added a cwd-bearing row;
+      // the old null row remains until reaped by presence staleness — it never blocks
+      // the upgraded connection, matching the design's "null rows各自独立" note.)
+      const upgradedRow = rows.find((r: { cwd: string | null }) => r.cwd === upgradedCwd);
+      expect(upgradedRow).toBeTruthy();
+      expect(upgradedRow.uuid).toBe(upgraded!.uuid);
+
+      // (c) Functionality does NOT regress: a NEW session created after the upgrade pins
+      // to the upgraded (cwd-bearing) connection — it is the freshest online row — and
+      // resumes correctly off the real cwd.
+      DIRECT_IDEA = "idea-e2e-0000-0000-0000-00000000002"; // a distinct post-upgrade session
+      const postTurn = await maybeCreateTurnForWakeNotification(wakeCtx());
+      expect(postTurn).not.toBeNull();
+      const postSession = await realPrisma.daemonSession.findFirst({
+        where: { companyUuid, agentUuid, sessionId: DIRECT_IDEA },
+        select: { uuid: true, originConnectionUuid: true },
+      });
+      expect(postSession.originConnectionUuid).toBe(upgraded!.uuid);
+      expect(await assertContinuable(companyUuid, postSession.uuid)).toBe(upgraded!.uuid);
+
+      // And the pre-upgrade session (pinned to the null row) is STILL resumable while the
+      // null connection remains online — the upgrade did not break the in-flight session.
+      expect(await assertContinuable(companyUuid, preSession.uuid)).toBe(nullHandle!.uuid);
+    });
+
+    it("[alt backfill: in-place merge] if a deployment chooses to backfill the null row in place, the null row itself carries the real cwd and the same uuid keeps resuming", async () => {
+      // T1's dedup note explicitly allows two strategies. The default (NULL-distinct)
+      // strategy is covered above. This alternative proves the IN-PLACE merge is also
+      // sound end-to-end: an operator/daemon that updates the existing null row's cwd
+      // (rather than creating a new row) keeps the SAME connection uuid, so any session
+      // already pinned to it continues to resume without interruption — "功能全程不回退".
+      const nullHandle = await register(agentUuid, { host: HOST });
+      const session = await maybeCreateTurnForWakeNotification(wakeCtx());
+      expect(session).not.toBeNull();
+      const sess = await realPrisma.daemonSession.findFirst({
+        where: { companyUuid, agentUuid, sessionId: DIRECT_IDEA },
+        select: { uuid: true, originConnectionUuid: true },
+      });
+      expect(sess.originConnectionUuid).toBe(nullHandle!.uuid);
+
+      // In-place backfill: the same physical row gains the real cwd (uuid unchanged).
+      await realPrisma.daemonConnection.update({
+        where: { uuid: nullHandle!.uuid },
+        data: { cwd: "/work/backfilled" },
+      });
+      const row = await realPrisma.daemonConnection.findUnique({
+        where: { uuid: nullHandle!.uuid },
+        select: { cwd: true, status: true },
+      });
+      expect(row.cwd).toBe("/work/backfilled"); // backfilled in place
+      expect(row.status).toBe("online");
+
+      // The pre-existing session still resumes off the SAME connection uuid — no regression.
+      expect(await assertContinuable(companyUuid, sess.uuid)).toBe(nullHandle!.uuid);
+    });
+  });
+});

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -1308,6 +1308,72 @@ describe("assertContinuable", () => {
     await expect(assertContinuable(companyUuid, sessionUuid)).resolves.toBe(connectionUuid);
     vi.useRealTimers();
   });
+
+  // ===== T3 — resume 按 (host+cwd) 路由 (AC#4 / FR-7 / Module Contract 4) =====
+  // assertContinuable pins resume to the session's ORIGIN connection, which is uniquely
+  // keyed by (agentUuid, clientType, host, cwd). Pinning to that exact uuid IS the
+  // (host+cwd) consistency check — a different-cwd connection is a different row/uuid and
+  // is NEVER considered. A cross-cwd route is therefore structurally impossible: there is
+  // no fallback path. cwd⟂project — this is the session's bound cwd, not project-derived.
+  describe("T3 cwd consistency (resume by host+cwd)", () => {
+    it("resolves the origin connection's cwd (the binding is made explicit, not just uuid)", async () => {
+      mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+      mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+        status: "online",
+        lastSeenAt: new Date(),
+        cwd: "/dev/repo-a",
+      });
+      await expect(assertContinuable(companyUuid, sessionUuid)).resolves.toBe(connectionUuid);
+      // The connection lookup now also selects cwd — the (host+cwd) binding is explicit.
+      expect(mockPrisma.daemonConnection.findFirst.mock.calls[0][0].select).toMatchObject({
+        cwd: true,
+      });
+    });
+
+    it("a cross-cwd route is impossible: ONLY the origin (host+cwd) connection is ever queried", async () => {
+      // The session's origin lives on cwd repo-a. Even if the same agent has another
+      // ONLINE connection on a DIFFERENT cwd (repo-b), assertContinuable never looks at
+      // it — it queries the origin uuid alone. (We assert exactly one connection query,
+      // pinned to the origin uuid — there is no second "any-other-cwd" query.)
+      mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+      mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+        status: "online",
+        lastSeenAt: new Date(),
+        cwd: "/dev/repo-a",
+      });
+      await assertContinuable(companyUuid, sessionUuid);
+      expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.daemonConnection.findFirst.mock.calls[0][0].where.uuid).toBe(connectionUuid);
+    });
+
+    it("when the origin (host+cwd) connection is offline it REFUSES — never falls back to another cwd", async () => {
+      // Origin on repo-a is offline. The refusal is a structured SessionReadOnlyError —
+      // NOT a silent re-route to a repo-b connection (which would `claude --resume`
+      // against the wrong cwd → "No conversation found").
+      mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+      mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+        status: "offline",
+        lastSeenAt: new Date(),
+        cwd: "/dev/repo-a",
+      });
+      await expect(assertContinuable(companyUuid, sessionUuid)).rejects.toBeInstanceOf(SessionReadOnlyError);
+      // Exactly one connection query — the origin. No fallback query for another cwd.
+      expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it("[HARD-1] an OLD-daemon origin (cwd = null) passes through when online — null never makes it read-only", async () => {
+      // A session whose origin is an old daemon has cwd=null. The cwd is "unconstrained";
+      // the only gate is online-ness. assertContinuable must NOT reject just because cwd
+      // is null (Module Contract 2 — null pass-through).
+      mockPrisma.daemonSession.findFirst.mockResolvedValue({ originConnectionUuid: connectionUuid });
+      mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+        status: "online",
+        lastSeenAt: new Date(),
+        cwd: null,
+      });
+      await expect(assertContinuable(companyUuid, sessionUuid)).resolves.toBe(connectionUuid);
+    });
+  });
 });
 
 // ===== appendTranscriptMessages =====

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -41,6 +41,13 @@ export interface SelfReport {
   clientType: string; // raw query value; gated against DAEMON_CLIENT_TYPES
   clientVersion?: string | null;
   host?: string | null;
+  // Working directory this connection serves. The self-reporting representation
+  // of "unknown cwd" is `null` (NOT the empty string): a daemon that does not
+  // report cwd — i.e. an OLD daemon predating the multi-path change — yields
+  // `cwd: null`, which lands a `cwd=null` registry row (HARD-1). This matches the
+  // nullable `cwd` column and the rows backfilled to NULL at migration time, so
+  // "unknown cwd" has a single consistent representation end to end.
+  cwd?: string | null;
   startedAt?: Date | null;
 }
 
@@ -84,6 +91,11 @@ export interface ConnectionView {
   clientType: string;
   clientVersion: string | null;
   host: string; // "" when host-less (display can show a placeholder)
+  // Working directory this connection serves; null for an old daemon that did
+  // not self-report cwd (the "unknown cwd" sentinel). Two connections of the
+  // same agent+host with different cwds are distinct rows, so the cwd is what
+  // distinguishes them in the projection.
+  cwd: string | null;
   startedAt: string | null; // ISO-8601 — self-reported daemon process start
   status: string; // raw persisted status
   effectiveStatus: "online" | "offline";
@@ -111,6 +123,7 @@ interface DaemonConnectionRow {
   clientType: string;
   clientVersion: string | null;
   host: string;
+  cwd: string | null;
   startedAt: Date | null;
   status: string;
   connectedAt: Date;
@@ -139,6 +152,7 @@ function toConnectionView(row: DaemonConnectionRow): ConnectionView {
     clientType: row.clientType,
     clientVersion: row.clientVersion,
     host: row.host,
+    cwd: row.cwd,
     startedAt: row.startedAt ? row.startedAt.toISOString() : null,
     status: row.status,
     effectiveStatus,
@@ -172,6 +186,12 @@ export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
   const clientType = searchParams.get("clientType") ?? "";
   const clientVersion = searchParams.get("clientVersion");
   const host = searchParams.get("host");
+  // `cwd` is the working directory the connection serves. An absent param
+  // (an OLD daemon that predates the multi-path change) parses to `null` — the
+  // single representation of "unknown cwd" — which registerConnection lands as a
+  // `cwd=null` row (HARD-1). Unlike `host`, cwd is NOT coerced to "": null is the
+  // sentinel here, matching the nullable column and the migration-era NULL rows.
+  const cwd = searchParams.get("cwd");
 
   let startedAt: Date | null = null;
   const startedAtRaw = searchParams.get("startedAt");
@@ -186,6 +206,7 @@ export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
     clientType,
     clientVersion: clientVersion ?? null,
     host: host ?? null,
+    cwd: cwd ?? null,
     startedAt,
   };
 }
@@ -201,12 +222,38 @@ export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
  *    rest of the lifecycle — no touch / no markDisconnected), or
  *  - the persistence write fails (swallowed + logged).
  *
- * Idempotent per logical daemon: keyed on (agentUuid, clientType, host). A
- * reconnect refreshes the existing row (status→online, connectedAt/lastSeenAt
- * refreshed, disconnectedAt cleared) rather than inserting a new one. `host`
- * defaults to "" so the composite unique key is deterministic even for a
- * host-less self-report (Prisma treats null as distinct, which would defeat the
- * dedup — see schema comment).
+ * Idempotent per logical daemon: keyed on (agentUuid, clientType, host, cwd) —
+ * the composite unique key T1 widened with `cwd`. A reconnect refreshes the
+ * existing row (status→online, connectedAt/lastSeenAt refreshed, disconnectedAt
+ * cleared) rather than inserting a new one. `host` defaults to "" so the key is
+ * deterministic even for a host-less self-report.
+ *
+ * cwd carries the working directory this connection serves, which fixes the
+ * overwrite bug: the *same* agent on the *same* host driving two *different*
+ * cwds now lands two independent rows (each its own presence) instead of one
+ * overwriting the other. "Unknown cwd" is represented as SQL `NULL` (NOT the
+ * empty string) — consistent with the nullable `cwd` column and the rows
+ * backfilled to NULL at migration time. (This supersedes T1's compile-only
+ * `cwd=""` shim, which existed only to preserve deterministic dedup until this
+ * task wired the real self-report; the ""-vs-NULL asymmetry is resolved here in
+ * favor of NULL.)
+ *
+ * Two write paths, because Postgres + Prisma treat a NULL cwd specially:
+ *  - cwd PRESENT (a current daemon) → a single `upsert` on the compound unique
+ *    key. Clean idempotent reconnect.
+ *  - cwd NULL (an OLD daemon that does not self-report cwd — HARD-1) → we CANNOT
+ *    use the compound-key upsert: Postgres treats each NULL as distinct in a
+ *    UNIQUE index (so two `(agent,clientType,host,NULL)` rows never collide) AND
+ *    Prisma types the compound-key `where` field as non-null (so NULL cannot be
+ *    targeted there at all). Both verified empirically by T1 on Postgres 16. A
+ *    naive cwd=null upsert would therefore ACCUMULATE a fresh row on every
+ *    reconnect. So we implement the tech design's compatibility path: find the
+ *    existing `(agentUuid, clientType, host, cwd:null)` row via `findFirst` and
+ *    `update` it by uuid; only `create` when none exists. This keeps an old
+ *    daemon on a single stable null row across reconnects — no error, no
+ *    rejection, behavior identical to the pre-cwd world. New and old daemons
+ *    coexist under the same agent without interfering (the new daemon owns its
+ *    cwd row; the old daemon owns its null row).
  *
  * The returned `connectedAt` is the fencing token for the lifecycle calls: it is
  * stamped fresh on every (re)registration, so a later reconnect's `connectedAt`
@@ -225,51 +272,77 @@ export async function registerConnection(
   }
 
   const host = report.host ?? "";
+  // "Unknown cwd" → SQL NULL. Do NOT coerce to "" — null is the single sentinel
+  // for an old daemon that does not report cwd, matching the nullable column.
+  const cwd = report.cwd ?? null;
   const now = new Date();
 
   try {
+    // Shared field sets, so the upsert and the null-compat path stay in lockstep.
+    const createData = {
+      companyUuid,
+      agentUuid,
+      clientType: report.clientType,
+      clientVersion: report.clientVersion ?? null,
+      host,
+      cwd,
+      startedAt: report.startedAt ?? null,
+      status: "online",
+      connectedAt: now,
+      lastSeenAt: now,
+      disconnectedAt: null,
+    };
+    const refreshData = {
+      // Multi-tenancy: re-affirm companyUuid from the authenticated context.
+      companyUuid,
+      clientVersion: report.clientVersion ?? null,
+      startedAt: report.startedAt ?? null,
+      status: "online",
+      connectedAt: now,
+      lastSeenAt: now,
+      disconnectedAt: null,
+    };
+
+    if (cwd === null) {
+      // ===== Old-daemon / unknown-cwd compatibility path (HARD-1) =====
+      // Prisma cannot target a NULL cwd in the compound-unique `where`, and
+      // Postgres would never dedup two NULL-cwd rows on its own. So reuse the
+      // existing null row by uuid when present; create one only on first connect.
+      // This prevents null-row pileup on reconnect while keeping old daemons
+      // behaving exactly as before.
+      const existing = await prisma.daemonConnection.findFirst({
+        where: { agentUuid, clientType: report.clientType, host, cwd: null },
+        select: { uuid: true },
+      });
+
+      if (existing) {
+        const row = await prisma.daemonConnection.update({
+          where: { uuid: existing.uuid },
+          data: refreshData,
+          select: { uuid: true, connectedAt: true },
+        });
+        return { uuid: row.uuid, connectedAt: row.connectedAt };
+      }
+
+      const row = await prisma.daemonConnection.create({
+        data: createData,
+        select: { uuid: true, connectedAt: true },
+      });
+      return { uuid: row.uuid, connectedAt: row.connectedAt };
+    }
+
+    // ===== Current-daemon path: real cwd → clean compound-key upsert =====
     const row = await prisma.daemonConnection.upsert({
       where: {
-        // T1 (data model) added `cwd` to the composite unique key. The real
-        // cwd self-report + cwd-aware dedup/old-daemon-null-reuse path is T2 —
-        // NOT this task. This call is left functionally identical to pre-cwd
-        // behavior: it keeps deterministic one-row-per-(agent,clientType,host)
-        // dedup by pinning cwd to the empty-string sentinel, mirroring the
-        // existing `host @default("")` convention (a @@unique over a NULL-able
-        // column does not dedup — Postgres treats NULL as distinct, and Prisma
-        // types the compound-key field as non-null so NULL cannot even be
-        // targeted here; verified empirically + against Prisma docs). T2 will
-        // replace this with the real cwd and reconcile the ""-vs-null sentinel.
         agentUuid_clientType_host_cwd: {
           agentUuid,
           clientType: report.clientType,
           host,
-          cwd: "",
+          cwd,
         },
       },
-      create: {
-        companyUuid,
-        agentUuid,
-        clientType: report.clientType,
-        clientVersion: report.clientVersion ?? null,
-        host,
-        cwd: "",
-        startedAt: report.startedAt ?? null,
-        status: "online",
-        connectedAt: now,
-        lastSeenAt: now,
-        disconnectedAt: null,
-      },
-      update: {
-        // Multi-tenancy: re-affirm companyUuid from the authenticated context.
-        companyUuid,
-        clientVersion: report.clientVersion ?? null,
-        startedAt: report.startedAt ?? null,
-        status: "online",
-        connectedAt: now,
-        lastSeenAt: now,
-        disconnectedAt: null,
-      },
+      create: createData,
+      update: refreshData,
       select: { uuid: true, connectedAt: true },
     });
     return { uuid: row.uuid, connectedAt: row.connectedAt };

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -230,10 +230,21 @@ export async function registerConnection(
   try {
     const row = await prisma.daemonConnection.upsert({
       where: {
-        agentUuid_clientType_host: {
+        // T1 (data model) added `cwd` to the composite unique key. The real
+        // cwd self-report + cwd-aware dedup/old-daemon-null-reuse path is T2 —
+        // NOT this task. This call is left functionally identical to pre-cwd
+        // behavior: it keeps deterministic one-row-per-(agent,clientType,host)
+        // dedup by pinning cwd to the empty-string sentinel, mirroring the
+        // existing `host @default("")` convention (a @@unique over a NULL-able
+        // column does not dedup — Postgres treats NULL as distinct, and Prisma
+        // types the compound-key field as non-null so NULL cannot even be
+        // targeted here; verified empirically + against Prisma docs). T2 will
+        // replace this with the real cwd and reconcile the ""-vs-null sentinel.
+        agentUuid_clientType_host_cwd: {
           agentUuid,
           clientType: report.clientType,
           host,
+          cwd: "",
         },
       },
       create: {
@@ -242,6 +253,7 @@ export async function registerConnection(
         clientType: report.clientType,
         clientVersion: report.clientVersion ?? null,
         host,
+        cwd: "",
         startedAt: report.startedAt ?? null,
         status: "online",
         connectedAt: now,

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -913,6 +913,21 @@ export class SessionReadOnlyError extends Error {
  * single staleness threshold, reused — NOT a new constant). It NEVER considers any
  * other connection of the same agent: continuation is pinned to the origin, full stop.
  *
+ * cwd consistency (T3 — resume 按 (host+cwd) 路由, FR-7 / Module Contract 4): a
+ * `DaemonConnection` is uniquely keyed by `(agentUuid, clientType, host, cwd)`, so the
+ * session's `originConnectionUuid` ALREADY identifies one specific (host + cwd). Pinning
+ * resume to that exact connection IS the (host+cwd) consistency check — a connection on
+ * a DIFFERENT cwd is a DIFFERENT row with a different uuid, and is never considered.
+ * Routing the resume anywhere else would `claude --resume` against the wrong working
+ * directory and fail with `No conversation found`; we refuse with a structured
+ * `SessionReadOnlyError` instead of falling back to another cwd. This is purely the
+ * session's already-bound cwd — NOT derived from any project (DEC-5: cwd ⟂ project).
+ *
+ * HARD-1 (Module Contract 2): a session whose origin is an OLD daemon (cwd = null)
+ * passes through unchanged — the cwd is "unknown / unconstrained", so the only gate is
+ * the origin's online-ness, exactly as before. The null cwd never makes a continuable
+ * session read-only.
+ *
  * Throws `SessionReadOnlyError` when the origin is offline/stale (the caller renders a
  * read-only / origin-offline error and does not route elsewhere). Throws a plain
  * not-found Error when the session does not resolve in-company. companyUuid-scoped; a
@@ -933,16 +948,21 @@ export async function assertContinuable(
     throw new Error(`DaemonSession ${sessionUuid} not found`);
   }
 
+  // Resolve the origin connection by its uuid — which pins BOTH host AND cwd (the
+  // registry key includes cwd). `cwd` is selected so the (host+cwd) binding is explicit
+  // here even though uuid already encodes it; it is never used to route ELSEWHERE.
   const conn = await prisma.daemonConnection.findFirst({
     where: { uuid: session.originConnectionUuid, companyUuid },
-    select: { status: true, lastSeenAt: true },
+    select: { status: true, lastSeenAt: true, cwd: true },
   });
   const online =
     conn != null &&
     conn.status === "online" &&
     Date.now() - conn.lastSeenAt.getTime() <= STALE_THRESHOLD_MS;
   if (!online) {
-    // Read-only: origin offline. NEVER route to another connection.
+    // Read-only: origin offline/stale, or the origin (host+cwd) row no longer exists.
+    // NEVER route to another connection / another cwd — that would resume against the
+    // wrong working directory (`No conversation found`).
     throw new SessionReadOnlyError(session.originConnectionUuid);
   }
   return session.originConnectionUuid;


### PR DESCRIPTION
## daemon multi-path cwd support — promote the working directory to a first-class connection-identity dimension

Implements idea `c1cfbde7` ([Arch · Large] daemon multi-path support). Promotes `cwd` to part of `DaemonConnection` identity, fixing the existing "same agent / same host / different cwd overwrite each other" bug, and lets a single daemon process serve multiple local paths.

Produced via the full Chorus AI-DLC flow (idea → elaboration → proposal → 4 tasks → per-task independent review → ship-time code review).

### What changed
- **T1 — data model + migration**: add `cwd String?` to `DaemonConnection`; change the unique key `(agentUuid, clientType, host)` → `(agentUuid, clientType, host, cwd)`. Non-destructive migration (DROP old index + ADD nullable column + CREATE new composite index; no table recreate).
- **T2 — handshake self-report + registration**: the daemon self-reports `cwd`; the server's `parseSelfReport()` parses it; `registerConnection()` upserts on the cwd-bearing composite key — fixing the overwrite bug.
- **T3 — single-daemon multi-path engine**: `resolveDaemonCwds()` declares the **set of served paths** (`--cwd` / `CHORUS_DAEMON_CWDS` / `~/.chorus/daemon.json` `cwds:[]`); `daemon.mjs` registers one independent connection per path; `Waker.resolveCwd()` is the single cwd source of truth (shared by transcript-probe / spawn / resume); per-spawn cwd while the daemon process cwd never changes; `assertContinuable()` incorporates cwd consistency so resume strictly routes back to the origin-cwd connection, cross-cwd rejected (`SessionReadOnlyError`, never fallback).
- **T4 — end-to-end integration checkpoint**: 8 scenarios against a real Postgres covering multi-path no-overwrite / resume-to-origin-cwd / dispatch-selection-not-broken / HARD-1 / migration backfill.

### Key design decisions (human-authorized)
- **cwd ⟂ project**: cwd is NOT bound to project (in multi-person collaboration the same project has many different cwds). There is **no** server-side project→cwd dispatch routing — dispatch keeps selecting by agent / online status. Targeting a specific `(agent, cwd)` instance is done by explicit user addressing → deferred to a child idea.
- **Breaking the "one-process-one-cwd" invariant**: preserves `claude --resume`'s cwd/machine-bound physical constraint — resume only returns to the connection serving that session's original cwd.
- **"Unknown cwd" is represented as NULL** (not an empty string): old daemons take a findFirst-null → update / else-create compatibility path to avoid null-row pileup.
- **HARD-1 backward compatibility (hard requirement)**: old daemons that don't report cwd keep working — register as a null row / receive dispatch by agent selection / spawn at the process default cwd / resume to the origin connection, equivalent to today; new and old daemons coexist without interfering.

### Tests & review
- Full `pnpm test` → **2957 passed / 0 failed**; `pnpm db:generate` and `npx tsc --noEmit` clean.
- Real-Postgres integration tests are gated behind `T2_REAL_DB_URL` / `T4_REAL_DB_URL` (they skip automatically without a throwaway DB, never touching the live store).
- Each task passed an independent task-reviewer; the ship-time code-reviewer reviewed the aggregate change → **PASS WITH NOTES** (both NOTEs pre-exist on `develop` and are not introduced by this PR: one pre-existing flaky test, two pre-existing `prefer-const` lint errors).

### Not in this PR (split into derived ideas)
- Addressable `(agent, cwd)` @mention / dispatch + frontend UI presence drill-down.
- Multi-daemon coordination, dynamic path add/remove, and richer multi-path management.

Chorus idea: `c1cfbde7-ae38-4de5-bfff-16f6c9baa1e5` · proposal: `45063db8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
