### PR TITLE
feat: (agent, host, cwd) addressable daemon instances

### DIFF
--- a/docs/design.pen
+++ b/docs/design.pen
@@ -91963,6 +91963,17 @@
                                   ]
                                 },
                                 {
+                                  "id": "P9k7fy",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "instanceIdentityChip",
+                                  "descendants": {
+                                    "uGuVR": {
+                                      "content": "ai-pm/src"
+                                    }
+                                  }
+                                },
+                                {
                                   "type": "frame",
                                   "id": "TQxsb",
                                   "name": "detailsToggle",
@@ -91994,7 +92005,7 @@
                                       "id": "xiABy",
                                       "name": "detMeta",
                                       "fill": "#B6B0A6",
-                                      "content": "·  Laptop-Q3  ·  Uptime 00:07:42  ·  Started 14:21",
+                                      "content": "·  Uptime 00:07:42  ·  Started 14:21",
                                       "fontFamily": "IBM Plex Mono",
                                       "fontSize": 11,
                                       "fontWeight": "normal"
@@ -97977,6 +97988,4070 @@
               "fontFamily": "IBM Plex Sans",
               "fontSize": 11,
               "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rJSQr",
+      "x": 1580,
+      "y": 25146,
+      "name": "Path Chip",
+      "reusable": true,
+      "fill": "#F1ECE3",
+      "cornerRadius": 6,
+      "gap": 5,
+      "padding": [
+        3,
+        7
+      ],
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "icon",
+          "id": "g1QHIz",
+          "name": "folderIcon",
+          "width": 11,
+          "height": 11,
+          "icon": "folder",
+          "library": "lucide",
+          "fill": "#9A8C7E"
+        },
+        {
+          "type": "text",
+          "id": "uGuVR",
+          "name": "pathText",
+          "fill": "#6B6B6B",
+          "content": "dev/chorus",
+          "fontFamily": "IBM Plex Mono",
+          "fontSize": 11,
+          "fontWeight": "500"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Gy5au",
+      "x": 4812,
+      "y": 24126,
+      "name": "Chorus - Presence Popover (cwd drill-down)",
+      "clip": true,
+      "width": 1440,
+      "height": 940,
+      "fill": "#FAF8F4",
+      "children": [
+        {
+          "type": "frame",
+          "id": "R96su",
+          "name": "Sidebar",
+          "width": 220,
+          "height": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": "#E5E2DC",
+          "strokeWidth": {
+            "right": 1
+          },
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            24,
+            20
+          ],
+          "justifyContent": "space_between",
+          "children": [
+            {
+              "type": "frame",
+              "id": "DhTP0",
+              "name": "Sidebar Top",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 32,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "f5aMg",
+                  "name": "Logo",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 4,
+                      "id": "PYU9R",
+                      "name": "logoMark",
+                      "fill": "#C67A52",
+                      "width": 28,
+                      "height": 28
+                    },
+                    {
+                      "type": "text",
+                      "id": "xIDAb",
+                      "name": "logoText",
+                      "fill": "#2C2C2C",
+                      "content": "Chorus",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vTvNN",
+                  "name": "Navigation",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "YImTr",
+                      "name": "navProjects",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "IvR0m",
+                          "name": "ProjectsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "folder",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Q6msdS",
+                          "name": "ProjectsText",
+                          "fill": "#6B6B6B",
+                          "content": "Projects",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Zo20g",
+                      "name": "navActivity",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "Lpdhr",
+                          "name": "ActivityIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "activity",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "TiRPB",
+                          "name": "ActivityText",
+                          "fill": "#6B6B6B",
+                          "content": "Activity",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ut59u",
+                      "name": "navDaemons",
+                      "width": "fill_container",
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "N9pIzI",
+                          "name": "DaemonsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "radio-tower",
+                          "library": "lucide",
+                          "fill": "#2C2C2C"
+                        },
+                        {
+                          "type": "text",
+                          "id": "HCuiN",
+                          "name": "DaemonsText",
+                          "fill": "#2C2C2C",
+                          "content": "Agent Connections",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L3cZ2",
+                      "name": "navSettings",
+                      "width": "fill_container",
+                      "cornerRadius": 8,
+                      "gap": 10,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "YF5Yz",
+                          "name": "SettingsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "settings",
+                          "library": "lucide",
+                          "fill": "#6B6B6B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PMo4b",
+                          "name": "SettingsText",
+                          "fill": "#6B6B6B",
+                          "content": "Settings",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fFOI5",
+              "name": "Sidebar Bottom",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "L7MaAi",
+                  "name": "Agent Presence Pill",
+                  "width": "fill_container",
+                  "fill": "#FCFBF8",
+                  "cornerRadius": 12,
+                  "stroke": "#E7E1D7",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "gap": 9,
+                  "padding": [
+                    9,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "CnBDg",
+                      "name": "dotWrap",
+                      "width": 12,
+                      "height": 12,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "gVjUj",
+                          "x": 0,
+                          "y": 0,
+                          "name": "halo",
+                          "fill": "#15803D33",
+                          "width": 12,
+                          "height": 12
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "KHRJ1",
+                          "x": 3,
+                          "y": 3,
+                          "name": "dot",
+                          "fill": "#15803D",
+                          "width": 6,
+                          "height": 6
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "xJoFd",
+                      "name": "count",
+                      "fill": "#15803D",
+                      "content": "2",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 14,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "WE2qc",
+                      "name": "unit",
+                      "fill": "#4B7A57",
+                      "content": "agents online",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BqpaO",
+                  "name": "userProfile",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QiyeP",
+                      "name": "avatar",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#C67A52",
+                      "cornerRadius": 18,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pMx0s",
+                          "name": "avatarText",
+                          "fill": "#FFFFFF",
+                          "content": "A",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GfnV6",
+                      "name": "userInfo",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kEJC9",
+                          "name": "userName",
+                          "fill": "#2C2C2C",
+                          "content": "Alice Chen",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "z8tXEt",
+                          "name": "userRole",
+                          "fill": "#6B6B6B",
+                          "content": "Tech Lead",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "sDOgF",
+          "name": "Main Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 22,
+          "padding": [
+            24,
+            32
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "nkzff",
+              "name": "Top Bar",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "x168Iq",
+                  "name": "bc",
+                  "fill": "#9A9A9A",
+                  "content": "Chorus / Projects",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "sNroH",
+                  "name": "acts",
+                  "gap": 16,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "hiyq2",
+                      "name": "s",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "search",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "Of7C1",
+                      "name": "b",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "bell",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IU8jD",
+              "name": "Title Section",
+              "width": 680,
+              "layout": "vertical",
+              "gap": 5,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Wgkhx",
+                  "name": "pt",
+                  "fill": "#2C2C2C",
+                  "content": "Projects",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 24,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "QJgfR",
+                  "name": "ps",
+                  "fill": "#6B6B6B",
+                  "content": "Your active projects and recent work.",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dmr84",
+              "name": "projGrid",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ysat7",
+                  "name": "proj Chorus 0.11.0",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MYZBv",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xjPjK",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "Chorus 0.11.0",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "cVFQ2",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "12 ideas · 3 in progress",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "rtXi8",
+                      "name": "ar",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BqeRE",
+                  "name": "proj MCS 1.3.0",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "S7tN4Q",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "izIwy",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "MCS 1.3.0",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tBDGv",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "1 idea · awaiting conduct",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "M34S1i",
+                      "name": "ar",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "cuvpW",
+                  "name": "proj Data Engine Demo",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "P7DJr",
+                      "name": "l",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "iJy9Z",
+                          "name": "pn",
+                          "fill": "#2C2C2C",
+                          "content": "Data Engine Demo",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "D8OTN",
+                          "name": "pd",
+                          "fill": "#9A9A9A",
+                          "content": "1 idea · in progress",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "NHSGd",
+                      "name": "ar",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "#C7C1B7"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "cfYNB",
+          "layoutPosition": "absolute",
+          "x": 212,
+          "y": 262,
+          "name": "Presence Popover",
+          "width": 340,
+          "fill": "#FFFFFF",
+          "cornerRadius": 14,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#1A141033",
+            "offset": {
+              "x": 0,
+              "y": 16
+            },
+            "blur": 40
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "U8IHRZ",
+              "name": "popHeader",
+              "width": "fill_container",
+              "padding": [
+                13,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "S8SK7",
+                  "name": "pht",
+                  "fill": "#6B6B6B",
+                  "content": "ONLINE AGENTS",
+                  "fontFamily": "IBM Plex Mono",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.6
+                },
+                {
+                  "type": "frame",
+                  "id": "q9oJNs",
+                  "name": "summary",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "dV6sn",
+                      "name": "d",
+                      "fill": "#15803D",
+                      "width": 6,
+                      "height": 6
+                    },
+                    {
+                      "type": "text",
+                      "id": "Iwd6y",
+                      "name": "t",
+                      "fill": "#9A9A9A",
+                      "content": "2 online",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "GKPaL",
+              "name": "div",
+              "fill": "#EFEBE4",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "h1t7g5",
+              "name": "connList",
+              "width": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Uo9G0",
+                  "name": "agent Admin Claude",
+                  "width": "fill_container",
+                  "stroke": "#F2EEE7",
+                  "strokeWidth": {
+                    "bottom": 1
+                  },
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "V5tJmy",
+                      "name": "agentHead",
+                      "width": "fill_container",
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hHpGt",
+                          "name": "left",
+                          "gap": 9,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "Tlcex",
+                              "name": "chev",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "chevron-down",
+                              "library": "lucide",
+                              "fill": "#9A9A9A"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "kQjVz",
+                              "name": "av",
+                              "width": 26,
+                              "height": 26,
+                              "fill": "#C67A52",
+                              "cornerRadius": 13,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "bUqDh",
+                                  "name": "b",
+                                  "width": 14,
+                                  "height": 14,
+                                  "icon": "bot",
+                                  "library": "lucide",
+                                  "fill": "#FFFFFF"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "yXg8g",
+                              "name": "nm",
+                              "layout": "vertical",
+                              "gap": 1,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "qDMS6",
+                                  "name": "an",
+                                  "fill": "#2C2C2C",
+                                  "content": "Admin Claude",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13.5,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "hHPf6",
+                                  "name": "host",
+                                  "fill": "#9A9A9A",
+                                  "content": "Claude Code · 2 hosts",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Hy4D3",
+                          "name": "right",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "JclIe",
+                              "name": "pc",
+                              "fill": "#9A9A9A",
+                              "content": "3 instances",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "HmA36",
+                              "name": "dot",
+                              "fill": "#15803D",
+                              "width": 7,
+                              "height": 7
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gFzgt",
+                      "name": "cwdList",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        2,
+                        16,
+                        10,
+                        38
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WPpkj",
+                          "name": "cwd dev/chorus Laptop-Q3",
+                          "width": "fill_container",
+                          "cornerRadius": 7,
+                          "layout": "vertical",
+                          "gap": 3,
+                          "padding": [
+                            7,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "dA5Mi",
+                              "name": "top",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "lqY0i",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "path",
+                                  "descendants": {
+                                    "g1QHIz": {
+                                      "icon": "folder",
+                                      "fill": "#9A8C7E"
+                                    },
+                                    "uGuVR": {
+                                      "content": "dev/chorus",
+                                      "fill": "#5A5247"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "ASzhE",
+                                  "name": "dot",
+                                  "fill": "#C67A52",
+                                  "width": 6,
+                                  "height": 6
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Mqs0x",
+                              "name": "meta",
+                              "gap": 6,
+                              "padding": [
+                                0,
+                                0,
+                                0,
+                                2
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "s6J0Sv",
+                                  "name": "hi",
+                                  "width": 10,
+                                  "height": 10,
+                                  "icon": "monitor",
+                                  "library": "lucide",
+                                  "fill": "#B6B0A6"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "YvU2a",
+                                  "name": "h",
+                                  "fill": "#8C8475",
+                                  "content": "Laptop-Q3",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "fiKvL",
+                                  "name": "sep",
+                                  "fill": "#CFC8BC",
+                                  "content": "·",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10.5,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "EiAcX",
+                                  "name": "act",
+                                  "fill": "#9A9A9A",
+                                  "content": "building · 01:42",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10.5,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "E5VVE",
+                          "name": "cwd dev/chorus ci-runner-02",
+                          "width": "fill_container",
+                          "cornerRadius": 7,
+                          "layout": "vertical",
+                          "gap": 3,
+                          "padding": [
+                            7,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "DqXSN",
+                              "name": "top",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "camEl",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "path",
+                                  "descendants": {
+                                    "g1QHIz": {
+                                      "icon": "folder",
+                                      "fill": "#9A8C7E"
+                                    },
+                                    "uGuVR": {
+                                      "content": "dev/chorus",
+                                      "fill": "#5A5247"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "SnOlk",
+                                  "name": "dot",
+                                  "fill": "#15803D",
+                                  "width": 6,
+                                  "height": 6
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Uhv0s",
+                              "name": "meta",
+                              "gap": 6,
+                              "padding": [
+                                0,
+                                0,
+                                0,
+                                2
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "qUB1a",
+                                  "name": "hi",
+                                  "width": 10,
+                                  "height": 10,
+                                  "icon": "monitor",
+                                  "library": "lucide",
+                                  "fill": "#B6B0A6"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "exV29",
+                                  "name": "h",
+                                  "fill": "#8C8475",
+                                  "content": "ci-runner-02",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "YOW2K",
+                                  "name": "sep",
+                                  "fill": "#CFC8BC",
+                                  "content": "·",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10.5,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "VYL7c",
+                                  "name": "act",
+                                  "fill": "#9A9A9A",
+                                  "content": "idle",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10.5,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "EiNgm",
+                          "name": "cwd dev/chorus-cdk Laptop-Q3",
+                          "width": "fill_container",
+                          "cornerRadius": 7,
+                          "layout": "vertical",
+                          "gap": 3,
+                          "padding": [
+                            7,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "xn7lS",
+                              "name": "top",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "K4Q9c",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "path",
+                                  "descendants": {
+                                    "g1QHIz": {
+                                      "icon": "folder-x",
+                                      "fill": "#C2BAAD"
+                                    },
+                                    "uGuVR": {
+                                      "content": "dev/chorus-cdk",
+                                      "fill": "#A99F90"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "yTlcD",
+                                  "name": "dot",
+                                  "fill": "#C2BAAD",
+                                  "width": 6,
+                                  "height": 6
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "QbPgk",
+                              "name": "meta",
+                              "gap": 6,
+                              "padding": [
+                                0,
+                                0,
+                                0,
+                                2
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "PNtTp",
+                                  "name": "hi",
+                                  "width": 10,
+                                  "height": 10,
+                                  "icon": "monitor",
+                                  "library": "lucide",
+                                  "fill": "#B6B0A6"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "noxR1",
+                                  "name": "h",
+                                  "fill": "#8C8475",
+                                  "content": "Laptop-Q3",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "SeLpF",
+                                  "name": "sep",
+                                  "fill": "#CFC8BC",
+                                  "content": "·",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10.5,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "uJcfY",
+                                  "name": "act",
+                                  "fill": "#B0A89B",
+                                  "content": "offline · 14m ago",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10.5,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RvWoU",
+                  "name": "agent PM Agent",
+                  "width": "fill_container",
+                  "stroke": "#F2EEE7",
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "lmMKX",
+                      "name": "agentHead",
+                      "width": "fill_container",
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "OoXPI",
+                          "name": "left",
+                          "gap": 9,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "uwbdo",
+                              "name": "chev",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "chevron-down",
+                              "library": "lucide",
+                              "fill": "#9A9A9A"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "L4zIkw",
+                              "name": "av",
+                              "width": 26,
+                              "height": 26,
+                              "fill": "#C67A52",
+                              "cornerRadius": 13,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "YOvNP",
+                                  "name": "b",
+                                  "width": 14,
+                                  "height": 14,
+                                  "icon": "bot",
+                                  "library": "lucide",
+                                  "fill": "#FFFFFF"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "QEEVm",
+                              "name": "nm",
+                              "layout": "vertical",
+                              "gap": 1,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "JB25y",
+                                  "name": "an",
+                                  "fill": "#2C2C2C",
+                                  "content": "PM Agent",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 13.5,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "qJEpJ",
+                                  "name": "host",
+                                  "fill": "#9A9A9A",
+                                  "content": "ci-runner-02",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jbxRl",
+                          "name": "right",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ISRMt",
+                              "name": "pc",
+                              "fill": "#9A9A9A",
+                              "content": "1 instance",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "uRr4n",
+                              "name": "dot",
+                              "fill": "#15803D",
+                              "width": 7,
+                              "height": 7
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NcMq1",
+                      "name": "cwdList",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        0,
+                        16,
+                        10,
+                        38
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "zDbK7",
+                          "name": "cwd unknown path null",
+                          "width": "fill_container",
+                          "cornerRadius": 7,
+                          "layout": "vertical",
+                          "gap": 3,
+                          "padding": [
+                            7,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "AiajS",
+                              "name": "top",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "nnuO6",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "path",
+                                  "descendants": {
+                                    "g1QHIz": {
+                                      "icon": "folder",
+                                      "fill": "#9A8C7E"
+                                    },
+                                    "uGuVR": {
+                                      "content": "unknown path",
+                                      "fill": "#5A5247"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "SGWWd",
+                                  "name": "dot",
+                                  "fill": "#15803D",
+                                  "width": 6,
+                                  "height": 6
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Cjto4",
+                              "name": "meta",
+                              "gap": 6,
+                              "padding": [
+                                0,
+                                0,
+                                0,
+                                2
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "f7GJP",
+                                  "name": "act",
+                                  "fill": "#9A9A9A",
+                                  "content": "idle",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 10.5,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "Mi0o2",
+              "name": "div2",
+              "fill": "#EFEBE4",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "HCfeK",
+              "name": "viewAll",
+              "width": "fill_container",
+              "padding": [
+                12,
+                0
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "EBTVK",
+                  "name": "vat",
+                  "fill": "#C67A52",
+                  "content": "View all",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12.5,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "zMQTC",
+      "x": 6372,
+      "y": 24126,
+      "name": "Chorus - @mention cwd Picker",
+      "clip": true,
+      "width": 620,
+      "height": 760,
+      "fill": "#FAF8F4",
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "qCNMZ",
+          "name": "header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "p2kmuD",
+              "name": "t",
+              "fill": "#2C2C2C",
+              "content": "Mention an agent at a path",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 20,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "RfoIZ",
+              "name": "s",
+              "fill": "#6B6B6B",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "When the agent runs in more than one working directory, pick which one should pick up the work.",
+              "lineHeight": 1.45,
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "l9ZyM",
+          "name": "Composer Card",
+          "clip": true,
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "cornerRadius": 14,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "dyFHy",
+              "name": "cmHead",
+              "width": "fill_container",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "gap": 8,
+              "padding": [
+                12,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "JVDKJ",
+                  "name": "i",
+                  "width": 14,
+                  "height": 14,
+                  "icon": "message-square",
+                  "library": "lucide",
+                  "fill": "#9A9A9A"
+                },
+                {
+                  "type": "text",
+                  "id": "C0TRik",
+                  "name": "l",
+                  "fill": "#6B6B6B",
+                  "content": "Comment on  Daemon multi-path cwd",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 12.5,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KPzQU",
+              "name": "editor",
+              "width": "fill_container",
+              "height": 96,
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qwXrl",
+                  "name": "line",
+                  "width": "fill_container",
+                  "gap": 2,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "CZwnG",
+                      "name": "mentionPill",
+                      "fill": "#F3E9E2",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        3,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "uELQN",
+                          "name": "av",
+                          "width": 18,
+                          "height": 18,
+                          "fill": "#C67A52",
+                          "cornerRadius": 9,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "jTPE3",
+                              "name": "b",
+                              "width": 11,
+                              "height": 11,
+                              "icon": "bot",
+                              "library": "lucide",
+                              "fill": "#FFFFFF"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "U7GzY",
+                          "name": "nm",
+                          "fill": "#A0562E",
+                          "content": "Admin Claude",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "d0FKkf",
+                      "name": "caret",
+                      "fill": "#C67A52",
+                      "width": 1.5,
+                      "height": 18
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Faxgj",
+                  "name": "hint",
+                  "fill": "#C7C1B7",
+                  "content": "can you take the failing build here…",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "p3ocM",
+          "name": "cwd Picker Popover",
+          "clip": true,
+          "width": 340,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#1A141026",
+            "offset": {
+              "x": 0,
+              "y": 12
+            },
+            "blur": 32
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "cRP7G",
+              "name": "pickerHead",
+              "width": "fill_container",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "layout": "vertical",
+              "gap": 3,
+              "padding": [
+                12,
+                14
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Bdm1o",
+                  "name": "top",
+                  "width": "fill_container",
+                  "gap": 7,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "bJ9vB",
+                      "name": "i",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "folder-tree",
+                      "library": "lucide",
+                      "fill": "#C67A52"
+                    },
+                    {
+                      "type": "text",
+                      "id": "C4dGKm",
+                      "name": "t",
+                      "fill": "#2C2C2C",
+                      "content": "Which working directory?",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12.5,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "YNQIq",
+                  "name": "s",
+                  "fill": "#9A9A9A",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Admin Claude is live in 3 instances across 2 hosts",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "I882M",
+              "name": "pick dev/chorus",
+              "width": "fill_container",
+              "fill": "#FBF4EF",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "gap": 10,
+              "padding": [
+                10,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "urrXQ",
+                  "name": "left",
+                  "width": "fill_container",
+                  "gap": 9,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "D9u2jC",
+                      "type": "ref",
+                      "ref": "rJSQr",
+                      "name": "path",
+                      "descendants": {
+                        "g1QHIz": {
+                          "fill": "#9A8C7E"
+                        },
+                        "uGuVR": {
+                          "content": "dev/chorus",
+                          "fontSize": 12,
+                          "fill": "#2C2C2C"
+                        }
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "J2bBa4",
+                      "name": "host",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "cAxei",
+                          "name": "hi",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "monitor",
+                          "library": "lucide",
+                          "fill": "#A99F90"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mhEnc",
+                          "name": "h",
+                          "fill": "#8C8475",
+                          "content": "Laptop-Q3",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "C7BWF6",
+                      "name": "meta",
+                      "fill": "#9A9A9A",
+                      "content": "· running 01:42",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "px2Rk",
+                  "name": "right",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "zqhiu",
+                      "name": "check",
+                      "width": 15,
+                      "height": 15,
+                      "icon": "check",
+                      "library": "lucide",
+                      "fill": "#C67A52"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eome7",
+              "name": "pick dev/chorus-cdk",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "gap": 10,
+              "padding": [
+                10,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "r9Kxn",
+                  "name": "left",
+                  "width": "fill_container",
+                  "gap": 9,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "o1yxa",
+                      "type": "ref",
+                      "ref": "rJSQr",
+                      "name": "path",
+                      "descendants": {
+                        "g1QHIz": {
+                          "fill": "#9A8C7E"
+                        },
+                        "uGuVR": {
+                          "content": "dev/chorus",
+                          "fontSize": 12,
+                          "fill": "#2C2C2C"
+                        }
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FjaFR",
+                      "name": "host",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "lxWhy",
+                          "name": "hi",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "monitor",
+                          "library": "lucide",
+                          "fill": "#A99F90"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tPtg2",
+                          "name": "h",
+                          "fill": "#8C8475",
+                          "content": "ci-runner-02",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "kAHDs",
+                      "name": "meta",
+                      "fill": "#9A9A9A",
+                      "content": "· idle",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JSrze",
+                  "name": "right",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "IQ4wJ",
+                      "name": "dot",
+                      "fill": "#15803D",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yP7uc",
+              "name": "pick work/scratch",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": "#F2EEE7",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "gap": 10,
+              "padding": [
+                10,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "S7iLOJ",
+                  "name": "left",
+                  "width": "fill_container",
+                  "gap": 9,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "JlD1L",
+                      "type": "ref",
+                      "ref": "rJSQr",
+                      "name": "path",
+                      "descendants": {
+                        "g1QHIz": {
+                          "fill": "#C2BAAD"
+                        },
+                        "uGuVR": {
+                          "content": "dev/chorus-cdk",
+                          "fontSize": 12,
+                          "fill": "#B0A89B"
+                        }
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hPOUz",
+                      "name": "host",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "V5NhA",
+                          "name": "hi",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "monitor",
+                          "library": "lucide",
+                          "fill": "#C2BAAD"
+                        },
+                        {
+                          "type": "text",
+                          "id": "QgZug",
+                          "name": "h",
+                          "fill": "#B6B0A6",
+                          "content": "Laptop-Q3",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "gpVNT",
+                      "name": "meta",
+                      "fill": "#B0A89B",
+                      "content": "· offline 14m",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bijZA",
+                  "name": "right",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BxcIo",
+                      "name": "queueTag",
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 5,
+                      "gap": 4,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "G1tE0y",
+                          "name": "qi",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "clock-3",
+                          "library": "lucide",
+                          "fill": "#9A8C7E"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ZmFUC",
+                          "name": "qt",
+                          "fill": "#9A8C7E",
+                          "content": "Queue",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10.5,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "W9H7Pt",
+          "name": "behaviorNote",
+          "width": "fill_container",
+          "fill": "#FCFBF8",
+          "cornerRadius": 10,
+          "stroke": "#EFEAE1",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": 14,
+          "children": [
+            {
+              "type": "frame",
+              "id": "Vc3nr",
+              "name": "r1",
+              "width": "fill_container",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "JdBN3",
+                  "name": "i",
+                  "width": 14,
+                  "height": 14,
+                  "icon": "folder-symlink",
+                  "library": "lucide",
+                  "fill": "#9A8C7E"
+                },
+                {
+                  "type": "text",
+                  "id": "w7xCx",
+                  "name": "t",
+                  "fill": "#6B6B6B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "The path (and host, when the agent spans machines) is pinned to the mention. The wake routes to that exact instance — never inferred from the project.",
+                  "lineHeight": 1.5,
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 11.5,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "F0dia",
+              "name": "r2",
+              "width": "fill_container",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "F5C1E",
+                  "name": "i",
+                  "width": 14,
+                  "height": 14,
+                  "icon": "clock-3",
+                  "library": "lucide",
+                  "fill": "#9A8C7E"
+                },
+                {
+                  "type": "text",
+                  "id": "bGnLL",
+                  "name": "t",
+                  "fill": "#6B6B6B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Pick an offline path and the turn is queued — it runs when that directory's daemon reconnects.",
+                  "lineHeight": 1.5,
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 11.5,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "vdnY0",
+      "x": 7112,
+      "y": 24126,
+      "name": "Chorus - Assign Task (pin cwd)",
+      "clip": true,
+      "width": 620,
+      "height": 760,
+      "fill": "#FAF8F4",
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "pou5f",
+          "name": "header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "f7KZu",
+              "name": "t",
+              "fill": "#2C2C2C",
+              "content": "Assign task",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 20,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "oAHXE",
+              "name": "s",
+              "fill": "#6B6B6B",
+              "content": "Add Athena adapter to the data-engine layer",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "BESah",
+          "name": "Assign Card",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "cornerRadius": 14,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 18,
+          "padding": 20,
+          "children": [
+            {
+              "type": "frame",
+              "id": "Ldbua",
+              "name": "fl ASSIGNEE",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "zSgR8",
+                  "name": "lab",
+                  "fill": "#9A9A9A",
+                  "content": "ASSIGNEE",
+                  "fontFamily": "IBM Plex Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.6
+                },
+                {
+                  "type": "frame",
+                  "id": "tn1TE",
+                  "name": "AgentTrigger",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    9,
+                    12
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GtDXh",
+                      "name": "left",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "S5RDA",
+                          "name": "av",
+                          "width": 20,
+                          "height": 20,
+                          "fill": "#C67A52",
+                          "cornerRadius": 10,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "d91jN",
+                              "name": "b",
+                              "width": 12,
+                              "height": 12,
+                              "icon": "bot",
+                              "library": "lucide",
+                              "fill": "#FFFFFF"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "OtSLB",
+                          "name": "v",
+                          "fill": "#2C2C2C",
+                          "content": "Admin Claude",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "FiThE",
+                      "name": "chev",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "i7GiP",
+              "name": "fl WORKING DIRECTORY",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "wsbCw",
+                  "name": "labRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "PAhEB",
+                      "name": "lab",
+                      "fill": "#9A9A9A",
+                      "content": "WORKING DIRECTORY",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 11,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.6
+                    },
+                    {
+                      "type": "text",
+                      "id": "xVFg0",
+                      "name": "hint",
+                      "fill": "#B0A89B",
+                      "content": "3 live across 2 hosts",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "n6DG7t",
+                  "name": "cwdRadioList",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "y27Ob4",
+                      "name": "opt dev/chorus-cdk",
+                      "width": "fill_container",
+                      "fill": "#FBF4EF",
+                      "cornerRadius": 9,
+                      "stroke": "#E2B89E",
+                      "strokeWidth": 1.5,
+                      "strokeAlignment": "inner",
+                      "gap": 11,
+                      "padding": [
+                        11,
+                        13
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "eIRg6",
+                          "name": "ring",
+                          "width": 17,
+                          "height": 17,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 9,
+                          "stroke": "#C67A52",
+                          "strokeWidth": 5,
+                          "strokeAlignment": "inner"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "r1T6yJ",
+                          "name": "mid",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ZVDOU",
+                              "name": "top",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "KYsGZ",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "path",
+                                  "descendants": {
+                                    "uGuVR": {
+                                      "content": "dev/chorus",
+                                      "fontSize": 12.5,
+                                      "fill": "#2C2C2C"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "nSPHW",
+                                  "name": "host",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "B4jfK",
+                                      "name": "hi",
+                                      "width": 11,
+                                      "height": 11,
+                                      "icon": "monitor",
+                                      "library": "lucide",
+                                      "fill": "#A99F90"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "t7f8s",
+                                      "name": "h",
+                                      "fill": "#8C8475",
+                                      "content": "ci-runner-02",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10.5,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "y6Kkt",
+                                  "name": "dot",
+                                  "fill": "#15803D",
+                                  "width": 7,
+                                  "height": 7
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "hKttI",
+                              "name": "sub",
+                              "fill": "#9A9A9A",
+                              "content": "Idle · ready now",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11.5,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GP4lq",
+                      "name": "opt dev/chorus",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 9,
+                      "stroke": "#E5E0D8",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 11,
+                      "padding": [
+                        11,
+                        13
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "q5sSkn",
+                          "name": "ring",
+                          "width": 17,
+                          "height": 17,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 9,
+                          "stroke": "#CFC8BC",
+                          "strokeWidth": 1.5,
+                          "strokeAlignment": "inner"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "tjCNs",
+                          "name": "mid",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "xcY01",
+                              "name": "top",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "f03cIy",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "path",
+                                  "descendants": {
+                                    "uGuVR": {
+                                      "content": "dev/chorus",
+                                      "fontSize": 12.5,
+                                      "fill": "#2C2C2C"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Akdvw",
+                                  "name": "host",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "zGgfq",
+                                      "name": "hi",
+                                      "width": 11,
+                                      "height": 11,
+                                      "icon": "monitor",
+                                      "library": "lucide",
+                                      "fill": "#A99F90"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "c5aNT1",
+                                      "name": "h",
+                                      "fill": "#8C8475",
+                                      "content": "Laptop-Q3",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10.5,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "k4lgJ",
+                                  "name": "dot",
+                                  "fill": "#15803D",
+                                  "width": 7,
+                                  "height": 7
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "ma20O",
+                              "name": "sub",
+                              "fill": "#9A9A9A",
+                              "content": "Running 1 task · 01:42",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11.5,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CjjUU",
+                      "name": "opt work/scratch",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 9,
+                      "stroke": "#E5E0D8",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 11,
+                      "padding": [
+                        11,
+                        13
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "umi7W",
+                          "name": "ring",
+                          "width": 17,
+                          "height": 17,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 9,
+                          "stroke": "#CFC8BC",
+                          "strokeWidth": 1.5,
+                          "strokeAlignment": "inner"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "P1SIf",
+                          "name": "mid",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "tDGUV",
+                              "name": "top",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "i3h5Y0",
+                                  "type": "ref",
+                                  "ref": "rJSQr",
+                                  "name": "path",
+                                  "descendants": {
+                                    "uGuVR": {
+                                      "content": "dev/chorus-cdk",
+                                      "fontSize": 12.5,
+                                      "fill": "#2C2C2C"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "RgCE6",
+                                  "name": "host",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "B2RvWl",
+                                      "name": "hi",
+                                      "width": 11,
+                                      "height": 11,
+                                      "icon": "monitor",
+                                      "library": "lucide",
+                                      "fill": "#A99F90"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "UU0HC",
+                                      "name": "h",
+                                      "fill": "#8C8475",
+                                      "content": "Laptop-Q3",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10.5,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "q3Hij",
+                                  "name": "offTag",
+                                  "fill": "#F5F2EC",
+                                  "cornerRadius": 5,
+                                  "gap": 4,
+                                  "padding": [
+                                    2,
+                                    7
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "MCBOe",
+                                      "name": "i",
+                                      "width": 10,
+                                      "height": 10,
+                                      "icon": "moon",
+                                      "library": "lucide",
+                                      "fill": "#9A8C7E"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "b8HXP",
+                                      "name": "t",
+                                      "fill": "#9A8C7E",
+                                      "content": "offline",
+                                      "fontFamily": "IBM Plex Sans",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "tXu4V",
+                              "name": "sub",
+                              "fill": "#A99F90",
+                              "content": "Last seen 14m ago · the turn will queue until it reconnects",
+                              "fontFamily": "IBM Plex Sans",
+                              "fontSize": 11.5,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "s0QEf",
+              "name": "infoStrip",
+              "width": "fill_container",
+              "fill": "#FCFBF8",
+              "cornerRadius": 9,
+              "stroke": "#EFEAE1",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 8,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "CcEyd",
+                  "name": "i",
+                  "width": 14,
+                  "height": 14,
+                  "icon": "info",
+                  "library": "lucide",
+                  "fill": "#9A8C7E"
+                },
+                {
+                  "type": "text",
+                  "id": "BvhHF",
+                  "name": "t",
+                  "fill": "#6B6B6B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "The autonomous wake routes this task to the exact (host, path) you pin here — even an offline one, which runs on reconnect. Paths are never inferred from the project.",
+                  "lineHeight": 1.5,
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 11.5,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "diTWD",
+          "name": "actions",
+          "width": "fill_container",
+          "gap": 10,
+          "justifyContent": "end",
+          "children": [
+            {
+              "type": "frame",
+              "id": "vi81H",
+              "name": "Cancel",
+              "fill": "#FFFFFF",
+              "cornerRadius": 8,
+              "stroke": "#E5E0D8",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "padding": [
+                10,
+                18
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "NDBx8",
+                  "name": "l",
+                  "fill": "#6B6B6B",
+                  "content": "Cancel",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tmcbD",
+              "name": "Assign",
+              "fill": "#C67A52",
+              "cornerRadius": 8,
+              "gap": 7,
+              "padding": [
+                10,
+                18
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "yAtlg",
+                  "name": "i",
+                  "width": 15,
+                  "height": 15,
+                  "icon": "user-check",
+                  "library": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "DAjuV",
+                  "name": "l",
+                  "fill": "#FFFFFF",
+                  "content": "Assign at dev/chorus · ci-runner-02",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "DRY0i",
+      "x": 7852,
+      "y": 24126,
+      "name": "Chorus - Ad-hoc Send (pick path, live)",
+      "clip": true,
+      "width": 620,
+      "height": 760,
+      "fill": "#FAF8F4",
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "mNW5A",
+          "name": "header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "WxuFx",
+              "name": "t",
+              "fill": "#2C2C2C",
+              "content": "Start a conversation",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 20,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "y2IKAF",
+              "name": "s",
+              "fill": "#6B6B6B",
+              "content": "Send an instruction now. Live sends need the path to be online.",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "vXSdR",
+          "name": "Send Card",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "cornerRadius": 14,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 20,
+          "children": [
+            {
+              "type": "frame",
+              "id": "x5WFYU",
+              "name": "agentRow",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "MISI8",
+                  "name": "lab",
+                  "fill": "#9A9A9A",
+                  "content": "AGENT",
+                  "fontFamily": "IBM Plex Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.6
+                },
+                {
+                  "type": "frame",
+                  "id": "dY25R",
+                  "name": "AgentTrigger",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    9,
+                    12
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "WlWK6",
+                      "name": "left",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "YRce7",
+                          "name": "av",
+                          "width": 20,
+                          "height": 20,
+                          "fill": "#C67A52",
+                          "cornerRadius": 10,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "JEv6P",
+                              "name": "b",
+                              "width": 12,
+                              "height": 12,
+                              "icon": "bot",
+                              "library": "lucide",
+                              "fill": "#FFFFFF"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "FWqNy",
+                          "name": "v",
+                          "fill": "#2C2C2C",
+                          "content": "Admin Claude",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "N9Yk1v",
+                      "name": "chev",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "#9A9A9A"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "t7DMDT",
+              "name": "pathRow",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "y5WOP",
+                  "name": "lab",
+                  "fill": "#9A9A9A",
+                  "content": "WORKING DIRECTORY",
+                  "fontFamily": "IBM Plex Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.6
+                },
+                {
+                  "type": "frame",
+                  "id": "Gj3JZ",
+                  "name": "segmented",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "q0Pdxs",
+                      "name": "seg dev/chorus",
+                      "width": "fill_container",
+                      "fill": "#FBF4EF",
+                      "cornerRadius": 9,
+                      "stroke": "#E2B89E",
+                      "strokeWidth": 1.5,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "O22gl1",
+                          "name": "top",
+                          "width": "fill_container",
+                          "gap": 6,
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "id": "dOpV2",
+                              "type": "ref",
+                              "ref": "rJSQr",
+                              "name": "path",
+                              "descendants": {
+                                "g1QHIz": {
+                                  "fill": "#9A8C7E"
+                                },
+                                "uGuVR": {
+                                  "content": "dev/chorus",
+                                  "fontSize": 11.5,
+                                  "fill": "#2C2C2C"
+                                }
+                              }
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "h6isE",
+                              "name": "dot",
+                              "fill": "#15803D",
+                              "width": 7,
+                              "height": 7
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Z42nn",
+                          "name": "hostLine",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "YaD3i",
+                              "name": "hi",
+                              "width": 10,
+                              "height": 10,
+                              "icon": "monitor",
+                              "library": "lucide",
+                              "fill": "#A99F90"
+                            },
+                            {
+                              "type": "text",
+                              "id": "DUK46",
+                              "name": "h",
+                              "fill": "#8C8475",
+                              "content": "Laptop-Q3",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "F8FW2Q",
+                          "name": "st",
+                          "fill": "#A0562E",
+                          "content": "Selected · online",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eD8O6",
+                      "name": "seg dev/chorus-cdk",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 9,
+                      "stroke": "#E5E0D8",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "R1LDQ7",
+                          "name": "top",
+                          "width": "fill_container",
+                          "gap": 6,
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "id": "ArF9h",
+                              "type": "ref",
+                              "ref": "rJSQr",
+                              "name": "path",
+                              "descendants": {
+                                "g1QHIz": {
+                                  "fill": "#9A8C7E"
+                                },
+                                "uGuVR": {
+                                  "content": "dev/chorus",
+                                  "fontSize": 11.5,
+                                  "fill": "#2C2C2C"
+                                }
+                              }
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "N7Ii4",
+                              "name": "dot",
+                              "fill": "#15803D",
+                              "width": 7,
+                              "height": 7
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "MMYmP",
+                          "name": "hostLine",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "EQHBW",
+                              "name": "hi",
+                              "width": 10,
+                              "height": 10,
+                              "icon": "monitor",
+                              "library": "lucide",
+                              "fill": "#A99F90"
+                            },
+                            {
+                              "type": "text",
+                              "id": "z24eYI",
+                              "name": "h",
+                              "fill": "#8C8475",
+                              "content": "ci-runner-02",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "DMlv9",
+                          "name": "st",
+                          "fill": "#9A9A9A",
+                          "content": "Online",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "D81y0R",
+                      "name": "seg work/scratch",
+                      "opacity": 0.7,
+                      "width": "fill_container",
+                      "fill": "#FAF8F4",
+                      "cornerRadius": 9,
+                      "stroke": "#E5E0D8",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "RX9O1",
+                          "name": "top",
+                          "width": "fill_container",
+                          "gap": 6,
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "id": "rA205",
+                              "type": "ref",
+                              "ref": "rJSQr",
+                              "name": "path",
+                              "descendants": {
+                                "g1QHIz": {
+                                  "fill": "#C2BAAD"
+                                },
+                                "uGuVR": {
+                                  "content": "dev/chorus-cdk",
+                                  "fontSize": 11.5,
+                                  "fill": "#A99F90"
+                                }
+                              }
+                            },
+                            {
+                              "type": "icon",
+                              "id": "jikpp",
+                              "name": "lock",
+                              "width": 12,
+                              "height": 12,
+                              "icon": "ban",
+                              "library": "lucide",
+                              "fill": "#B0A89B"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "k2ifoz",
+                          "name": "hostLine",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "KI2a3",
+                              "name": "hi",
+                              "width": 10,
+                              "height": 10,
+                              "icon": "monitor",
+                              "library": "lucide",
+                              "fill": "#C2BAAD"
+                            },
+                            {
+                              "type": "text",
+                              "id": "blNmR",
+                              "name": "h",
+                              "fill": "#B6B0A6",
+                              "content": "Laptop-Q3",
+                              "fontFamily": "IBM Plex Mono",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "Mz8AT",
+                          "name": "st",
+                          "fill": "#B0A89B",
+                          "content": "Offline — can't send live",
+                          "fontFamily": "IBM Plex Sans",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "g43Yo",
+              "name": "msgRow",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "wNCgq",
+                  "name": "lab",
+                  "fill": "#9A9A9A",
+                  "content": "MESSAGE",
+                  "fontFamily": "IBM Plex Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.6
+                },
+                {
+                  "type": "frame",
+                  "id": "gg6Fr",
+                  "name": "textarea",
+                  "width": "fill_container",
+                  "height": 84,
+                  "fill": "#FCFBF8",
+                  "cornerRadius": 9,
+                  "stroke": "#E5E0D8",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "bYWyJ",
+                      "name": "ph",
+                      "fill": "#2C2C2C",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Rebase onto develop and rerun the failing suite…",
+                      "lineHeight": 1.5,
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "lRDeK",
+              "name": "sendFooter",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "towSQ",
+                  "name": "target",
+                  "gap": 7,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "eiUvZ",
+                      "name": "i",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "corner-down-right",
+                      "library": "lucide",
+                      "fill": "#9A8C7E"
+                    },
+                    {
+                      "type": "text",
+                      "id": "m4RBp",
+                      "name": "l",
+                      "fill": "#9A9A9A",
+                      "content": "Sending to",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "id": "Q9WoUR",
+                      "type": "ref",
+                      "ref": "rJSQr",
+                      "name": "path",
+                      "descendants": {
+                        "g1QHIz": {
+                          "fill": "#C67A52"
+                        },
+                        "uGuVR": {
+                          "content": "dev/chorus",
+                          "fill": "#A0562E"
+                        }
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Z77iD6",
+                      "name": "tgtHost",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "a0wDmq",
+                          "name": "hi",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "monitor",
+                          "library": "lucide",
+                          "fill": "#C67A52"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wtGCX",
+                          "name": "h",
+                          "fill": "#A0562E",
+                          "content": "Laptop-Q3",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gGciD",
+                  "name": "Send",
+                  "fill": "#C67A52",
+                  "cornerRadius": 8,
+                  "gap": 7,
+                  "padding": [
+                    10,
+                    18
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "qOX7e",
+                      "name": "i",
+                      "width": 15,
+                      "height": 15,
+                      "icon": "send-horizontal",
+                      "library": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "G1AB6",
+                      "name": "l",
+                      "fill": "#FFFFFF",
+                      "content": "Send",
+                      "fontFamily": "IBM Plex Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "note",
+      "id": "zQ0hK",
+      "x": 4784,
+      "y": 23748,
+      "name": "NOTE Screen 1 — Presence popover, cwd drill-down (idea A · Q1=a, Q5, Q6)",
+      "width": 560,
+      "height": 0,
+      "content": "Screen 1 — Presence popover, cwd drill-down (idea A · Q1=a, Q5, Q6 · R2 qh1=a)\n• Agent stays one row; expand reveals one sub-row per live INSTANCE = (host, cwd), each with its own status dot.\n• IDENTITY IS (agent, clientType, host, cwd). Path is the primary label (Mono chip, abbreviated tail, full path on hover). host is de-emphasized: a dimmed Mono subline per row, shown because this agent spans 2+ hosts.\n• Note the two 'dev/chorus' rows split ONLY by host (Laptop-Q3 vs ci-runner-02) — this is why host can't be dropped: same path on two machines = two distinct instances.\n• Single-host agent (PM Agent) shows host once at the header, not per row. Legacy cwd=null → 'unknown path', no host line."
+    },
+    {
+      "type": "note",
+      "id": "KJWat",
+      "x": 6372,
+      "y": 23832,
+      "name": "NOTE Screen 2 — @mention secondary cwd picker (idea A · Q3=b, Q4, Q7=c)",
+      "width": 560,
+      "height": 0,
+      "content": "Screen 2 — @mention secondary cwd picker (idea A · Q3=b, Q4, Q7=c · R2 qh1=a)\n• Picker appears ONLY when agent has 2+ live instances; single instance auto-selects.\n• Rows are path-first; host shown as dimmed Mono suffix because targets here span 2 hosts. Pinned (host, path) routes the wake to that exact instance — never inferred from project (DEC-5).\n• Offline instance selectable (durable intent) → Queue, backfills on reconnect (Q4)."
+    },
+    {
+      "type": "note",
+      "id": "UXwtz",
+      "x": 7112,
+      "y": 23832,
+      "name": "NOTE Screen 3 — Assign task, pin a cwd (idea A · Q2=c, Q4 durable, Q7=c)",
+      "width": 560,
+      "height": 0,
+      "content": "Screen 3 — Assign task, pin an instance (idea A · Q2=c, Q4 durable, Q7=c · R2 qh1=a)\n• Pin which (host, path) instance runs the task. Two same-path options split by host; idle ci-runner-02 picked over busy Laptop-Q3.\n• Offline instance IS selectable (durable intent) — 'offline' tag + 'will queue'. Contrast with Screen 4.\n• CTA names the pinned (path · host). Wake honors this pin (Q7=c)."
+    },
+    {
+      "type": "note",
+      "id": "hmFUH",
+      "x": 7852,
+      "y": 23871,
+      "name": "NOTE Screen 4 — Ad-hoc send, live (idea A · Q4 live gate)",
+      "width": 560,
+      "height": 0,
+      "content": "Screen 4 — Ad-hoc send, live (idea A · Q4 live gate · R2 qh1=a)\n• Immediate 'send now' — deliberate contrast with Screen 3.\n• Offline instance DISABLED (ban icon): live sends require online, matching today's 409-if-offline.\n• Two live chips split by host; footer confirms resolved (path · host) target before send."
+    },
+    {
+      "type": "note",
+      "id": "U3JQ0L",
+      "x": 4784,
+      "y": 23318,
+      "name": "NOTE R2 host decision",
+      "width": 880,
+      "height": 0,
+      "content": "Appended elaboration Round 2 (host vs cwd) — grounded in code review of daemon-connection.service.ts\n\nUnique key = (agentUuid, clientType, host, cwd). host is part of identity, NOT redundant with cwd: the same path on two machines = two real connections (different files, different `claude --resume` binding). So host is NOT removed.\n\nDecision (R2 qh1=a / qh2=a): PATH-FIRST, HOST-CONDITIONAL. cwd is the primary label everywhere (it was previously rendered NOWHERE while host was shown everywhere — exactly inverted from the multi-path model). host is de-emphasized: dimmed per-row suffix, surfaced only when the agent spans 2+ hosts; single-host agents show host once at the header. Dispatch/mention/send targets carry host only when it disambiguates. Reusable 'Path Chip' = the shared instance-identity element across all 4 screens.\n\nAlso (qh2=a): the chat/transcript header should PROMOTE cwd inline (which directory the conversation runs in) and keep host in the existing 'Connection details' collapsible — see Conversations modal frame."
+    },
+    {
+      "type": "frame",
+      "id": "WbKBY",
+      "x": 4812,
+      "y": 25186,
+      "name": "Chorus - Path & Host Truncation (spec)",
+      "clip": true,
+      "width": 620,
+      "fill": "#FAF8F4",
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "tuBCl",
+          "name": "header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "V8fbaW",
+              "name": "t",
+              "fill": "#2C2C2C",
+              "content": "Path & host truncation",
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 20,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "HoNTa",
+              "name": "s",
+              "fill": "#6B6B6B",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Hostnames and paths can both be long. Keep the disambiguating end visible, cap each label's width, and never let either push the status dot, tag, or action off the row.",
+              "lineHeight": 1.5,
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "u0ImL",
+          "name": "rule Path — truncate from the left",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "cornerRadius": 14,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 12,
+          "padding": 18,
+          "children": [
+            {
+              "type": "frame",
+              "id": "U3Rt1O",
+              "name": "h",
+              "width": "fill_container",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "fNLfg",
+                  "name": "i",
+                  "width": 15,
+                  "height": 15,
+                  "icon": "folder",
+                  "library": "lucide",
+                  "fill": "#C67A52"
+                },
+                {
+                  "type": "text",
+                  "id": "Tum4C",
+                  "name": "t",
+                  "fill": "#2C2C2C",
+                  "content": "Path — truncate from the left",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "tothi",
+              "name": "r",
+              "fill": "#6B6B6B",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Show the abbreviated tail (last 2 segments). If it still overflows, drop leading segments with a leading ellipsis and ALWAYS keep the final segment (the actual repo/working dir) whole. Full absolute path on hover (title attr).",
+              "lineHeight": 1.5,
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "XT8Y8",
+              "name": "examples",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "uBiEv",
+                  "name": "ex",
+                  "width": "fill_container",
+                  "fill": "#FCFBF8",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Epl7b",
+                      "name": "full",
+                      "fill": "#B6B0A6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "/home/u/dev/payments-platform/services/billing-api",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 10.5,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "P7NQv",
+                      "name": "arr",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "arrow-right",
+                      "library": "lucide",
+                      "fill": "#CFC8BC"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "heY5f",
+                      "name": "chip",
+                      "clip": true,
+                      "width": 170,
+                      "fill": "#F1ECE3",
+                      "cornerRadius": 6,
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        7
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "RmC14",
+                          "name": "fi",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "folder",
+                          "library": "lucide",
+                          "fill": "#9A8C7E"
+                        },
+                        {
+                          "type": "text",
+                          "id": "qhMU6",
+                          "name": "p",
+                          "fill": "#6B6B6B",
+                          "content": "…/billing-api",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "P9abe",
+                  "name": "ex",
+                  "width": "fill_container",
+                  "fill": "#FCFBF8",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "e0sHuM",
+                      "name": "full",
+                      "fill": "#B6B0A6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "/Users/q/work/a-really-long-monorepo-package",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 10.5,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "XSypS",
+                      "name": "arr",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "arrow-right",
+                      "library": "lucide",
+                      "fill": "#CFC8BC"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "poHRA",
+                      "name": "chip",
+                      "clip": true,
+                      "width": 170,
+                      "fill": "#F1ECE3",
+                      "cornerRadius": 6,
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        7
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "N8wWV4",
+                          "name": "fi",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "folder",
+                          "library": "lucide",
+                          "fill": "#9A8C7E"
+                        },
+                        {
+                          "type": "text",
+                          "id": "JtqwG",
+                          "name": "p",
+                          "fill": "#6B6B6B",
+                          "content": "…long-monorepo-package",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "RqlZP",
+          "name": "rule Host",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "cornerRadius": 14,
+          "stroke": "#E5E0D8",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 12,
+          "padding": 18,
+          "children": [
+            {
+              "type": "frame",
+              "id": "v2n7A",
+              "name": "h",
+              "width": "fill_container",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "FSvHY",
+                  "name": "i",
+                  "width": 15,
+                  "height": 15,
+                  "icon": "monitor",
+                  "library": "lucide",
+                  "fill": "#C67A52"
+                },
+                {
+                  "type": "text",
+                  "id": "J0z4vS",
+                  "name": "t",
+                  "fill": "#2C2C2C",
+                  "content": "Host — truncate from the right, cap width",
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "IL4T0",
+              "name": "r",
+              "fill": "#6B6B6B",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Hostnames disambiguate from the front (the machine name), so truncate at the end with a trailing ellipsis. Cap the host label at a fixed max width (≈120px) so it never crowds the path. Full host on hover.",
+              "lineHeight": 1.5,
+              "fontFamily": "IBM Plex Sans",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "Vb4H3",
+              "name": "examples",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Su0B1",
+                  "name": "ex",
+                  "width": "fill_container",
+                  "fill": "#FCFBF8",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "p6kOF",
+                      "name": "full",
+                      "fill": "#B6B0A6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "ip-10-0-42-118.ec2.internal",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 10.5,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "t3wOR5",
+                      "name": "arr",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "arrow-right",
+                      "library": "lucide",
+                      "fill": "#CFC8BC"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QECQ5",
+                      "name": "chip",
+                      "clip": true,
+                      "width": 130,
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 6,
+                      "gap": 4,
+                      "padding": [
+                        3,
+                        7
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "V2WcqQ",
+                          "name": "hi",
+                          "width": 10,
+                          "height": 10,
+                          "icon": "monitor",
+                          "library": "lucide",
+                          "fill": "#A99F90"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DgJcg",
+                          "name": "h",
+                          "fill": "#8C8475",
+                          "content": "ip-10-0-42-118.ec…",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yEvfV",
+                  "name": "ex",
+                  "width": "fill_container",
+                  "fill": "#FCFBF8",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qZbgD",
+                      "name": "full",
+                      "fill": "#B6B0A6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "johns-macbook-pro-16-inch.local",
+                      "fontFamily": "IBM Plex Mono",
+                      "fontSize": 10.5,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "gAqrl",
+                      "name": "arr",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "arrow-right",
+                      "library": "lucide",
+                      "fill": "#CFC8BC"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ICUY9",
+                      "name": "chip",
+                      "clip": true,
+                      "width": 130,
+                      "fill": "#F5F2EC",
+                      "cornerRadius": 6,
+                      "gap": 4,
+                      "padding": [
+                        3,
+                        7
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "e7ahLS",
+                          "name": "hi",
+                          "width": 10,
+                          "height": 10,
+                          "icon": "monitor",
+                          "library": "lucide",
+                          "fill": "#A99F90"
+                        },
+                        {
+                          "type": "text",
+                          "id": "kFSgv",
+                          "name": "h",
+                          "fill": "#8C8475",
+                          "content": "johns-macbook-pr…",
+                          "fontFamily": "IBM Plex Mono",
+                          "fontSize": 10.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "d1EnB7",
+          "name": "rowGuard",
+          "width": "fill_container",
+          "fill": "#FCFBF8",
+          "cornerRadius": 12,
+          "stroke": "#EFEAE1",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "k3KiF",
+              "name": "g1",
+              "width": "fill_container",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "nU8DT",
+                  "name": "i",
+                  "width": 14,
+                  "height": 14,
+                  "icon": "shield-check",
+                  "library": "lucide",
+                  "fill": "#9A8C7E"
+                },
+                {
+                  "type": "text",
+                  "id": "bSFSn",
+                  "name": "t",
+                  "fill": "#6B6B6B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Row integrity: status dot, Queue/offline tag, and the radio/check are pinned to the row edges and never shrink. Only the path (then host) flex-shrinks and truncates. When both are long, the path keeps priority — it is the primary identity.",
+                  "lineHeight": 1.5,
+                  "fontFamily": "IBM Plex Sans",
+                  "fontSize": 11.5,
+                  "fontWeight": "normal"
+                }
+              ]
             }
           ]
         }

--- a/messages/en.json
+++ b/messages/en.json
@@ -120,6 +120,18 @@
     "releaseAssignee": "Release (Clear Assignee)",
     "releaseAssigneeDesc": "Remove current assignee and make this task available again"
   },
+  "assignInstance": {
+    "workingDirectory": "Working directory",
+    "loadingInstances": "Loading working directories…",
+    "noInstances": "This agent has no online daemon. The task is assigned and the agent is notified; it will pick it up the next time it comes online.",
+    "pinNote": "The autonomous wake routes this task to the exact (host, path) you pin here. Only online instances can be pinned. Paths are never inferred from the project.",
+    "assignTo": "Assign at {path}",
+    "assignToWithHost": "Assign at {path} · {host}",
+    "sendingTo": "Sending to {path}",
+    "sendingToWithHost": "Sending to {path} · {host}",
+    "liveSendNote": "Send an instruction now. Live sends need the path to be online.",
+    "offlineCantRun": "Offline — can't run until it reconnects"
+  },
   "time": {
     "justNow": "Just now",
     "minutesAgo": "{minutes}m ago",
@@ -1490,7 +1502,10 @@
     "selectPrompt": "Select a conversation to read its transcript.",
     "loadErrorTitle": "Couldn't load this conversation",
     "loadErrorBody": "We couldn't reach the transcript service. This is a loading problem, not an empty conversation. Retrying when you reopen it.",
-    "originOfflineNote": "This conversation's origin daemon is offline, so it's read-only. Its history still shows; start a new conversation to send.",
+    "originOfflineNote": "This conversation's origin daemon is offline, so it's read-only. Its history still shows; continue it on an online directory to send.",
+    "continueOnlineAction": "Continue on an online directory",
+    "continueOnlineHelp": "Keep this same conversation but continue it on one of this agent's online working directories. It picks up there with a fresh start (the history above stays as read-only context).",
+    "continueOnlineStarted": "Continuing on the online directory",
     "detailsLabel": "Connection details",
     "detailsHostUnknown": "Unknown host",
     "detailUptime": "Uptime",
@@ -1507,7 +1522,24 @@
     "pillAria": "Online agents — open details",
     "popoverTitle": "Online agents",
     "connectionIdle": "Idle — no running or queued work.",
-    "viewAll": "View all"
+    "viewAll": "View all",
+    "unknownPath": "unknown path",
+    "unknownHost": "unknown host",
+    "drilldown": {
+      "instancesCount": "{count, plural, one {# instance} other {# instances}}",
+      "hostsCount": "{count, plural, one {# host} other {# hosts}}",
+      "expandAgent": "Show {agent}'s working directories",
+      "collapseAgent": "Hide {agent}'s working directories",
+      "idle": "idle",
+      "runningFor": "running · {time}",
+      "queuedCount": "{count, plural, one {# queued} other {# queued}}",
+      "offlineSince": "offline · {time}",
+      "fieldPath": "Working directory"
+    }
+  },
+  "transcriptHeader": {
+    "cwdAriaLabel": "Working directory",
+    "hostAriaLabel": "Host"
   },
   "daemonConnectCta": {
     "headline": "Next step: keep your agent online",
@@ -1523,5 +1555,12 @@
     "offline": "Offline",
     "activeCount": "{count} active",
     "idle": "Idle"
+  },
+  "mentionInstance": {
+    "title": "Which working directory?",
+    "subtitle": "{name} is live in {count, plural, one {# instance} other {# instances}} across {hosts, plural, one {# host} other {# hosts}}.",
+    "confirm": "Pin instance",
+    "cancel": "Cancel",
+    "noInstances": "No live instances"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -120,6 +120,18 @@
     "releaseAssignee": "释放（清除负责人）",
     "releaseAssigneeDesc": "移除当前负责人，使此任务重新可用"
   },
+  "assignInstance": {
+    "workingDirectory": "工作目录",
+    "loadingInstances": "正在加载工作目录…",
+    "noInstances": "该智能体没有在线的守护进程。任务已分配并已通知该智能体，它将在下次上线时领取。",
+    "pinNote": "自主唤醒会将此任务路由到你在此固定的确切（主机，路径）实例。只能固定在线实例。路径绝不会从项目推断。",
+    "assignTo": "分配到 {path}",
+    "assignToWithHost": "分配到 {path} · {host}",
+    "sendingTo": "发送到 {path}",
+    "sendingToWithHost": "发送到 {path} · {host}",
+    "liveSendNote": "立即发送指令。实时发送要求该路径处于在线状态。",
+    "offlineCantRun": "离线 — 重新连接前无法运行"
+  },
   "time": {
     "justNow": "刚刚",
     "minutesAgo": "{minutes}分钟前",
@@ -1491,7 +1503,10 @@
     "selectPrompt": "选择一个对话以查看其记录。",
     "loadErrorTitle": "无法加载该对话",
     "loadErrorBody": "无法连接到记录服务。这是加载问题，而非空对话。重新打开时会自动重试。",
-    "originOfflineNote": "该对话的来源守护进程已离线，因此为只读。历史记录仍会显示；如需发送请开启新对话。",
+    "originOfflineNote": "该对话的来源守护进程已离线，因此为只读。历史记录仍会显示；如需发送，请在某个在线目录中继续。",
+    "continueOnlineAction": "在在线目录中继续",
+    "continueOnlineHelp": "保留本对话，并在该智能体的某个在线工作目录中继续。它会在该目录中以全新状态接续（上方历史记录将保留为只读上下文）。",
+    "continueOnlineStarted": "正在该在线目录中继续",
     "detailsLabel": "连接详情",
     "detailsHostUnknown": "未知主机",
     "detailUptime": "运行时长",
@@ -1508,7 +1523,24 @@
     "pillAria": "在线智能体 — 打开详情",
     "popoverTitle": "在线智能体",
     "connectionIdle": "空闲 — 没有正在运行或排队的工作。",
-    "viewAll": "查看全部"
+    "viewAll": "查看全部",
+    "unknownPath": "未知路径",
+    "unknownHost": "未知主机",
+    "drilldown": {
+      "instancesCount": "{count, plural, other {# 个实例}}",
+      "hostsCount": "{count, plural, other {# 台主机}}",
+      "expandAgent": "展开 {agent} 的工作目录",
+      "collapseAgent": "收起 {agent} 的工作目录",
+      "idle": "空闲",
+      "runningFor": "运行中 · {time}",
+      "queuedCount": "{count, plural, other {# 个排队}}",
+      "offlineSince": "离线 · {time}",
+      "fieldPath": "工作目录"
+    }
+  },
+  "transcriptHeader": {
+    "cwdAriaLabel": "工作目录",
+    "hostAriaLabel": "主机"
   },
   "daemonConnectCta": {
     "headline": "下一步：让你的智能体保持在线",
@@ -1524,5 +1556,12 @@
     "offline": "离线",
     "activeCount": "进行中 {count}",
     "idle": "空闲"
+  },
+  "mentionInstance": {
+    "title": "选择工作目录？",
+    "subtitle": "{name} 在 {hosts, plural, other {# 台主机}}上有 {count, plural, other {# 个在线实例}}。",
+    "confirm": "固定实例",
+    "cancel": "取消",
+    "noInstances": "没有在线实例"
   }
 }

--- a/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/README.md
+++ b/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/README.md
@@ -1,0 +1,3 @@
+# add-cwd-addressable-instances
+
+Make (agent, host, cwd) daemon instances individually addressable in presence, @mention, task assignment, and ad-hoc send; path-first host-conditional display.

--- a/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/design.md
+++ b/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/design.md
@@ -1,0 +1,60 @@
+# Design — cwd-addressable daemon instances
+
+## Context
+
+PR #353 made `cwd` part of `DaemonConnection`'s unique identity: `@@unique([agentUuid, clientType, host, cwd])`. `listConnectionsForAgent` already returns multiple cwd connections per agent, each with `cwd` (nullable) + `effectiveStatus`. What's missing is entirely above the registry: the UI never renders `cwd`, and the dispatch path never lets an owner choose which instance.
+
+Two hard constraints inherited from the parent idea, unchanged here:
+- **DEC-5**: no `project → cwd` inference. The owner explicitly picks the instance; the server never derives it from the project.
+- **`claude --resume` is cwd/host-bound**: a session's `originConnectionUuid` is fixed at creation and never re-routed. Continuation always goes back to the connection that owns the on-disk transcript.
+
+## Goals / Non-goals
+
+**Goals**: render every `(agent, host, cwd)` instance path-first; let owners pin a target instance for @-mention, task assignment, and ad-hoc send; make the autonomous wake honor a pinned cwd; consistent path/host truncation.
+
+**Non-goals**: multi-daemon coordination, dynamic path add/remove, per-task sandboxes (these are derived idea B). No change to the resume routing constraint. No new permission bit.
+
+## Key decision 1 — where the "pinned target instance" lives
+
+Q2=c + Q3=b + Q7=c together require that the instance an owner picks at **mention / assignment** time is read by the **autonomous wake** later (`notification-turn.ts`, which today picks the first online connection). The pin must therefore be persisted on the dispatch trigger, not only on the live send.
+
+**Decision**: persist the pinned target as a **nullable `targetCwd` (string) + `targetHost` (string)** pair on the wake trigger, resolved to a concrete `connectionUuid` at wake time (not a stored `connectionUuid`, because connections churn — a daemon restart yields a new connection row for the same `(host, cwd)`, and we want the pin to survive that). Specifically:
+
+- **Task assignment**: a nullable `assignedCwd` / `assignedHost` on the assignment (the existing assignee fields gain two optional siblings). When a `task_assigned` notification wakes the agent, `notification-turn.ts` resolves the live connection matching `(agentUuid, host, cwd)` and pins the session origin there; if none matches (or none pinned) it falls back to online-first.
+- **@-mention**: the pinned `(host, cwd)` travels with the mention so the `mentioned` wake resolves the same way. Mentions are stored in the comment body as `@[name](type:uuid)`; the instance pin is carried as an additional, optional structured field on the mention record / wake notification metadata (additive — a mention with no pin behaves exactly as today).
+
+Rationale for `(host, cwd)` over a stored `connectionUuid`: the pin is a *durable intent to run in a place*, and "a place" is `(host, cwd)`, which is stable across daemon restarts; a `connectionUuid` is ephemeral. Resolution to a live connection happens at wake time against the current registry.
+
+## Key decision 2 — offline target: durable-intent-queues vs live-requires-online
+
+- **Durable intent** (mention-pinned, assignment-pinned): allow selecting an offline instance. The wake creates the pending turn anyway; the existing persisted-turn backfill net delivers it when that `(host, cwd)` daemon reconnects. This is just the existing reconnect-backfill behavior, now keyed to a specific instance.
+- **Live ad-hoc send** ("send now"): keep today's gate — the chosen instance must be online or the call is rejected (409), because it is an interactive immediate action. The ad-hoc path already takes an explicit `connectionUuid` and already 409s on offline; this change only surfaces the cwd in its picker and disables offline rows in the UI.
+
+This split is the single most load-bearing UX contract of the feature and is mirrored visually in design.pen (assign-task screen allows offline + "will queue"; ad-hoc send disables offline).
+
+## Key decision 3 — path-first, host-conditional display + truncation
+
+- `cwd` is the primary per-instance label everywhere, rendered as a monospace path chip showing the **abbreviated tail (last 2 segments)**; full absolute path on hover/title.
+- `host` is part of identity and is **not removed**. It is de-emphasized: shown once (dimmed) at the agent header for single-host agents; promoted to a per-row dimmed monospace suffix only when the agent has live instances on 2+ distinct hosts. Dispatch/mention/send target confirmations include host only when it disambiguates.
+- Legacy `cwd = null` (old daemon) renders as an explicit "unknown path" instance, still individually selectable/addressable.
+
+**Truncation contract** (a shared helper, since none exists today — all host display is currently inline empty-string coercion):
+- `formatCwd(absPath)`: returns the last 2 path segments; if still over the chip's max width, drop leading segments with a leading ellipsis but **always keep the final segment whole** (it's the actual repo/working dir). Title = full absolute path.
+- `formatHost(host)`: truncate from the right with a trailing ellipsis, capped at a fixed max width (≈120px) so host never crowds the path. Title = full host. `""` host → localized "unknown host" placeholder (existing behavior preserved).
+- **Row integrity**: status dot, Queue/offline tag, and the radio/check control are pinned to row edges and never shrink; only the path (then host) flex-shrinks. When both are long, the path keeps shrink priority — it is the primary identity.
+
+## Module contracts
+
+- **`formatCwd` / `formatHost`** (new shared util, e.g. `src/lib/daemon-instance-format.ts`): pure functions, unit-tested against long-path / long-host / null-cwd / empty-host cases.
+- **Presence rendering** (`agent-presence-pill.tsx`, `connections-view.tsx`, `identity-block.tsx`): group `listConnectionsForAgent` output by agent; render the per-agent header (with host once if single-host) and an expandable list of instance rows. Reuse `effectiveStatus` per row.
+- **Instance picker** (new small component): given an agent's live instances, render a path-first selectable list; used by both the @-mention secondary picker and the assign-task / ad-hoc surfaces. Single instance auto-selects. Offline-selectability is a prop (true for durable intent, false for live send).
+- **Mention resolution** (`mention.service.ts`): expose per-instance metadata so the picker can list `(host, cwd)` options for an agent with 2+ live instances. Additive to the existing `Mentionable` shape.
+- **Wake routing** (`notification-turn.ts`): after resolving the agent, if the trigger carries a pinned `(host, cwd)`, resolve the matching live connection and pin the session origin there; else online-first as today. Never infer from project.
+- **Chat header** (`transcript-view.tsx`): promote the session's cwd (path chip) inline; keep host in the "Connection details" collapsible, inline only when cross-host.
+
+## Risks
+
+- **Pin resolves to no live connection**: handled by fallback (online-first for live wakes) or queue+backfill (durable intent). Never a hard failure; never silently drops the turn.
+- **HARD-1 (legacy daemons)**: old daemons reporting no cwd must keep working — they appear as "unknown path", are still addressable, and the online-first fallback covers them. No behavior regression for single-path / single-host setups.
+- **i18n**: every new string (picker labels, "unknown path", "will queue", offline tooltips, truncation titles) localized in `en` + `zh`.
+- **Migration**: the `targetCwd`/`targetHost` (and `assignedCwd`/`assignedHost`) columns ship via a Prisma-CLI migration, nullable, non-breaking, DDL-only (no backfill DML).

--- a/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/proposal.md
+++ b/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The daemon multi-path engine (PR #353) made `cwd` a first-class dimension of connection identity — the unique key is now `(agentUuid, clientType, host, cwd)`, so one daemon can serve several working directories and each `(agent, host, cwd)` is a distinct, independently-online instance. But the frontend never caught up: `ConnectionView.cwd` is fetched and rendered **nowhere**, while `host` is shown everywhere — exactly inverted from the model. Users can see that "an agent" is online but cannot see, choose, or address *which working directory* a turn will run in. This change closes that gap: it makes each `(agent, host, cwd)` instance visible and individually addressable across presence, @-mention, task assignment, and ad-hoc send.
+
+## What Changes
+
+- **Presence drill-down**: the agent-presence popover / connections list keeps one row per agent but expands to one sub-row per live instance, each showing its own `cwd` (primary, path-first) and online state. Legacy connections that report no cwd render as an explicit "unknown path" instance.
+- **Path-first, host-conditional display**: `cwd` becomes the primary per-instance label on every surface (a monospace path chip). `host` is **not** removed (it is part of the unique identity — the same path on two machines is two real instances) but is de-emphasized: shown once at the agent header for single-host agents, and promoted to a per-row suffix only when the agent spans 2+ hosts.
+- **Path/host truncation rule**: paths truncate from the **left** (keep the final repo/working-dir segment, leading ellipsis); hosts truncate from the **right** (capped width, trailing ellipsis); status/tag/action controls never shrink. Full value on hover.
+- **@-mention instance targeting**: a mention stays `@agent`; when that agent has 2+ live instances a secondary picker lets the owner choose which `(host, cwd)`; a single live instance auto-selects with no extra click. The chosen instance is pinned to the mention.
+- **Task-assignment cwd pin**: assigning a task to an agent can pin which instance runs it. An **offline** instance is selectable here (durable intent) — the turn queues and backfills on reconnect.
+- **Ad-hoc send instance pick**: the immediate "send now" flow lets the owner pick an instance, but an **offline** instance is **disabled** — live sends require the instance online, matching today's 409-if-offline gate. (The deliberate contrast with task assignment.)
+- **Autonomous wake honors a pinned cwd**: when a `task_assigned` / `mentioned` notification wakes an agent, the wake routes to the pinned `(host, cwd)` instance if one was chosen; otherwise it falls back to today's online-first selection. No `project → cwd` inference (parent idea DEC-5).
+- **Chat header surfaces cwd**: the transcript header shows the session's `cwd` inline as its instance identity; `host` stays in the existing "Connection details" disclosure, surfaced inline only when cross-host.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-cwd-instance-addressing`: a daemon instance is identified by `(agent, clientType, host, cwd)`; this capability defines how every owner-facing surface (presence, @-mention, task assignment, ad-hoc send, chat header) displays the instance path-first / host-conditional, how paths and hosts are truncated, how an owner pins a target instance, the durable-intent-queues vs live-requires-online split for offline targets, and how the autonomous wake honors a pinned cwd without inferring it from the project.
+
+### Modified Capabilities
+
+- None. This change is additive: it layers instance-addressing behavior on top of the existing `agent-connection-observability`, `mention-agent-liveness`, and `daemon-instruction-injection` capabilities without changing their established requirements. The connection registry, read API, liveness rule, and live-delivery contract are reused as-is.
+
+## Impact
+
+- **Frontend (primary)**: `agent-presence-pill.tsx`, `agent-presence/connections-view.tsx`, `agent-presence/identity-block.tsx`, `agent-presence/chat/transcript-view.tsx`, `mention-editor.tsx`, `send-instruction-box.tsx`, plus a new shared cwd/host formatting helper and a small instance-picker component. New i18n keys in `en.json` + `zh.json`.
+- **Backend**: a persisted "pinned target instance" on the dispatch path so the autonomous wake (`notification-turn.ts`) can honor it (data-model choice detailed in design.md); the ad-hoc/instruction send paths thread a chosen `connectionUuid`/cwd; mention resolution exposes per-instance candidates. No new permission bit. Any schema change goes through a Prisma-CLI migration (no hand-written SQL, DDL-only).
+- **Reused unchanged**: `DaemonConnection` identity key, `effectiveStatus` / `STALE_THRESHOLD_MS`, the persisted-turn backfill net, the `claude --resume` cwd/host binding constraint.
+- **Design**: `docs/design.pen` already updated with the four path-aware screens + truncation spec (Path Chip component, presence drill-down, @mention picker, assign-task pin, ad-hoc send, chat header).

--- a/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/specs/daemon-cwd-instance-addressing/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-cwd-addressable-instances/specs/daemon-cwd-instance-addressing/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Presence SHALL drill an agent down to its per-instance cwd rows
+
+The agent-presence surface (the presence popover and the connections list) SHALL keep one row per agent and SHALL allow that agent row to expand to one sub-row per live daemon instance, where an instance is a distinct `DaemonConnection` identified by `(agentUuid, clientType, host, cwd)`. Each instance sub-row SHALL display its own `cwd` as the primary label and its own `effectiveStatus` (online/offline) independently of sibling instances. A connection whose `cwd` is null (a legacy daemon that did not self-report a working directory) SHALL be rendered as an explicit "unknown path" instance that is still individually listed. The grouping SHALL reuse the existing `listConnectionsForAgent` output and the registry's `effectiveStatus` rule; it SHALL NOT introduce a new endpoint, permission bit, or liveness threshold.
+
+#### Scenario: An agent with multiple live cwds expands to per-instance rows
+
+- **GIVEN** an agent with three live `DaemonConnection` rows differing by `cwd` and/or `host`
+- **WHEN** the owner expands that agent in the presence surface
+- **THEN** the UI MUST render three instance sub-rows, each showing its own cwd as the primary label and its own online/offline state
+
+#### Scenario: A legacy null-cwd connection renders as an unknown-path instance
+
+- **GIVEN** a live `DaemonConnection` whose `cwd` is null
+- **WHEN** the owner views that agent's instances
+- **THEN** that instance MUST be shown as an explicit "unknown path" instance and MUST still be individually selectable as a target
+
+### Requirement: Instance surfaces SHALL display cwd path-first and host host-conditionally
+
+On every surface that displays a daemon instance (presence rows, the @-mention instance picker, the task-assignment cwd picker, the ad-hoc send picker, and target confirmations), `cwd` SHALL be the primary label. `host` SHALL NOT be removed — it is part of the instance's unique identity, so the same `cwd` on two different hosts denotes two distinct instances — but it SHALL be de-emphasized: for an agent whose live instances are all on a single host, the host SHALL be shown once (e.g. at the agent header) rather than repeated on every instance row; for an agent whose live instances span two or more distinct hosts, each instance row SHALL render its host as a secondary per-row suffix so the rows remain distinguishable. A dispatch/mention/send target confirmation SHALL include the host only when the host is needed to disambiguate the chosen instance.
+
+#### Scenario: Single-host agent does not repeat the host on every row
+
+- **GIVEN** an agent whose live instances are all on host `Laptop-Q3`
+- **WHEN** its instance rows render
+- **THEN** each row MUST lead with its cwd as the primary label
+- **AND** the host MUST be shown once (not repeated per instance row)
+
+#### Scenario: Same cwd on two hosts stays distinguishable
+
+- **GIVEN** an agent with two live instances that share the cwd `dev/chorus` but differ by host (`Laptop-Q3` versus `ci-runner-02`)
+- **WHEN** its instance rows render
+- **THEN** each row MUST show its host as a secondary suffix so the two same-cwd rows are visually distinct
+
+### Requirement: The UI SHALL truncate long paths and hosts without losing the disambiguating part
+
+The UI SHALL provide a shared formatting rule for instance paths and hosts so that long values never break row layout or push status, tag, or action controls off the row. A `cwd` SHALL be displayed as its abbreviated tail (last two path segments); when even that exceeds the available width it SHALL be truncated from the left with a leading ellipsis while always preserving the final path segment (the working directory's own name) intact. A `host` SHALL be truncated from the right with a trailing ellipsis and capped at a fixed maximum width so it never crowds the path. The full absolute path and the full host SHALL be available on hover (title). Within a row, the status indicator, any queue/offline tag, and the selection control SHALL NOT shrink; only the path — and then the host — SHALL flex-shrink, with the path retaining shrink priority as the primary identity.
+
+#### Scenario: A long path keeps its final segment and reveals the full path on hover
+
+- **GIVEN** an instance whose absolute cwd is `/home/u/dev/payments-platform/services/billing-api`
+- **WHEN** its path chip renders in a constrained row
+- **THEN** the visible label MUST keep the final segment `billing-api` intact (truncating earlier segments with a leading ellipsis)
+- **AND** the full absolute path MUST be available on hover
+
+#### Scenario: A long host is right-truncated and width-capped
+
+- **GIVEN** an instance whose host is `ip-10-0-42-118.ec2.internal`
+- **WHEN** its host suffix renders
+- **THEN** the host MUST be truncated from the right with a trailing ellipsis within a fixed maximum width
+- **AND** it MUST NOT push the path or the status indicator out of the row
+
+### Requirement: An owner SHALL be able to pin a target instance when @-mentioning an agent
+
+When an owner @-mentions an agent in a comment, the mention SHALL remain addressed to the agent. When the mentioned agent has two or more live instances, the UI SHALL present a secondary picker letting the owner choose which `(host, cwd)` instance the mention targets; when the agent has exactly one live instance the UI SHALL auto-select it with no additional interaction. The chosen instance SHALL be pinned to the mention so that the resulting autonomous wake routes to that instance. The pinned target SHALL be expressed as `(host, cwd)` (a durable "place") rather than a specific connection id, and SHALL never be inferred from the comment's project. A mention that carries no pin SHALL behave exactly as before this change.
+
+#### Scenario: Two live instances trigger a secondary picker
+
+- **GIVEN** an owner @-mentions an agent that has two live instances
+- **WHEN** the mention is being composed
+- **THEN** the UI MUST present a secondary picker of the agent's live `(host, cwd)` instances for the owner to choose from
+
+#### Scenario: A single live instance is auto-selected
+
+- **GIVEN** an owner @-mentions an agent that has exactly one live instance
+- **WHEN** the mention is being composed
+- **THEN** that instance MUST be auto-selected with no additional picker interaction required
+
+### Requirement: An owner SHALL be able to pin a target instance when assigning a task, including an offline one
+
+When an owner assigns a task to an agent, the UI SHALL let the owner pin which `(host, cwd)` instance should run the task. Because a task assignment is a durable intent rather than an immediate action, an instance that is currently offline SHALL be selectable; selecting an offline instance SHALL be accepted and the resulting turn SHALL be queued and delivered when that instance's daemon reconnects, relying on the existing persisted-turn backfill, with the UI indicating that the turn will queue. The pinned target SHALL be persisted with the assignment as `(host, cwd)` and SHALL never be inferred from the task's project.
+
+#### Scenario: Assigning to an offline instance queues rather than fails
+
+- **GIVEN** an owner assigns a task and pins an instance whose daemon is currently offline
+- **WHEN** the assignment is submitted
+- **THEN** the assignment MUST be accepted and the wake turn MUST be queued for delivery when that `(host, cwd)` daemon reconnects
+- **AND** the UI MUST indicate that the turn will queue rather than run immediately
+
+#### Scenario: The pinned instance is persisted with the assignment
+
+- **GIVEN** an owner pins instance `(ci-runner-02, dev/chorus)` when assigning a task
+- **WHEN** the assignment is saved
+- **THEN** the pinned `(host, cwd)` MUST be persisted with the assignment so a later autonomous wake can resolve it
+
+### Requirement: The ad-hoc send flow SHALL let an owner pick an instance but SHALL require it to be online
+
+The immediate ad-hoc "send now" flow SHALL let the owner pick which `(host, cwd)` instance receives the instruction. Because this is an interactive immediate action rather than a durable intent, an offline instance SHALL be presented as disabled and SHALL NOT be selectable for a live send; only online instances SHALL be sendable, preserving the existing behavior that an instruction to an offline origin is rejected. The send confirmation SHALL show the resolved instance — including its host when the host is needed to disambiguate — before the instruction is sent.
+
+#### Scenario: An offline instance is not sendable in the live ad-hoc flow
+
+- **GIVEN** the ad-hoc send picker lists an agent's instances, one of which is offline
+- **WHEN** the owner views the picker
+- **THEN** the offline instance MUST be shown as disabled and MUST NOT be selectable for an immediate send
+
+#### Scenario: The send confirms the resolved instance
+
+- **GIVEN** the owner has picked an online instance in the ad-hoc flow
+- **WHEN** the send control renders
+- **THEN** it MUST confirm the resolved `(host, cwd)` target before the instruction is sent
+
+### Requirement: The autonomous wake SHALL honor a pinned cwd and fall back to online-first
+
+When a `task_assigned` or `mentioned` notification wakes an agent, the connection-selection step SHALL honor a pinned target instance if one was recorded with the trigger: it SHALL resolve the live `DaemonConnection` matching the pinned `(agentUuid, host, cwd)` and pin the session origin to it. When no target was pinned, or no live connection currently matches the pinned `(host, cwd)`, the wake SHALL fall back to the existing online-first connection selection. The wake SHALL NOT infer a cwd from the project under any circumstance. This behavior SHALL be additive: a trigger with no pin selects a connection exactly as before this change.
+
+#### Scenario: A pinned instance is honored at wake time
+
+- **GIVEN** a `task_assigned` notification whose assignment pinned `(Laptop-Q3, dev/chorus)`
+- **AND** a live connection matching that `(agent, host, cwd)` exists
+- **WHEN** the wake selects a connection
+- **THEN** it MUST pin the session origin to that matching connection rather than the first online connection
+
+#### Scenario: An unpinned wake uses online-first as before
+
+- **GIVEN** a wake notification that carries no pinned instance
+- **WHEN** the wake selects a connection
+- **THEN** it MUST select the first online connection exactly as before this change, with no cwd inference from the project
+
+### Requirement: The chat transcript header SHALL surface the session's cwd
+
+The daemon conversation transcript header SHALL display the session's working directory (`cwd`) inline as the conversation's instance identity, rendered with the same path-first treatment used elsewhere. The connection's `host` SHALL remain in the existing "Connection details" disclosure rather than the headline, surfaced inline only when needed to disambiguate across hosts. When the session's origin connection reports no cwd, the header SHALL show the "unknown path" treatment consistent with the presence surface.
+
+#### Scenario: The header shows which directory a conversation runs in
+
+- **GIVEN** an open daemon conversation whose origin connection has cwd `dev/chorus`
+- **WHEN** the transcript header renders
+- **THEN** it MUST show `dev/chorus` inline (path-first) as the conversation's instance identity
+- **AND** the host MUST remain in the "Connection details" disclosure rather than the headline

--- a/openspec/specs/daemon-cwd-instance-addressing/spec.md
+++ b/openspec/specs/daemon-cwd-instance-addressing/spec.md
@@ -1,0 +1,147 @@
+# daemon-cwd-instance-addressing Specification
+
+## Purpose
+TBD - created by archiving change add-cwd-addressable-instances. Update Purpose after archive.
+## Requirements
+### Requirement: Presence SHALL drill an agent down to its per-instance cwd rows
+
+The agent-presence surface (the presence popover and the connections list) SHALL keep one row per agent and SHALL allow that agent row to expand to one sub-row per live daemon instance, where an instance is a distinct `DaemonConnection` identified by `(agentUuid, clientType, host, cwd)`. Each instance sub-row SHALL display its own `cwd` as the primary label and its own `effectiveStatus` (online/offline) independently of sibling instances. A connection whose `cwd` is null (a legacy daemon that did not self-report a working directory) SHALL be rendered as an explicit "unknown path" instance that is still individually listed. The grouping SHALL reuse the existing `listConnectionsForAgent` output and the registry's `effectiveStatus` rule; it SHALL NOT introduce a new endpoint, permission bit, or liveness threshold.
+
+#### Scenario: An agent with multiple live cwds expands to per-instance rows
+
+- **GIVEN** an agent with three live `DaemonConnection` rows differing by `cwd` and/or `host`
+- **WHEN** the owner expands that agent in the presence surface
+- **THEN** the UI MUST render three instance sub-rows, each showing its own cwd as the primary label and its own online/offline state
+
+#### Scenario: A legacy null-cwd connection renders as an unknown-path instance
+
+- **GIVEN** a live `DaemonConnection` whose `cwd` is null
+- **WHEN** the owner views that agent's instances
+- **THEN** that instance MUST be shown as an explicit "unknown path" instance and MUST still be individually listed (and, when online, selectable as a target)
+
+### Requirement: Instance surfaces SHALL display cwd path-first and host host-conditionally
+
+On every surface that displays a daemon instance (presence rows, the @-mention instance picker, the task-assignment cwd picker, the ad-hoc send picker, and target confirmations), `cwd` SHALL be the primary label. `host` SHALL NOT be removed — it is part of the instance's unique identity, so the same `cwd` on two different hosts denotes two distinct instances — but it SHALL be de-emphasized: for an agent whose live instances are all on a single host, the host SHALL be shown once (e.g. at the agent header) rather than repeated on every instance row; for an agent whose live instances span two or more distinct hosts, each instance row SHALL render its host as a secondary per-row suffix so the rows remain distinguishable. A dispatch/mention/send target confirmation SHALL include the host only when the host is needed to disambiguate the chosen instance.
+
+#### Scenario: Single-host agent does not repeat the host on every row
+
+- **GIVEN** an agent whose live instances are all on host `Laptop-Q3`
+- **WHEN** its instance rows render
+- **THEN** each row MUST lead with its cwd as the primary label
+- **AND** the host MUST be shown once (not repeated per instance row)
+
+#### Scenario: Same cwd on two hosts stays distinguishable
+
+- **GIVEN** an agent with two live instances that share the cwd `dev/chorus` but differ by host (`Laptop-Q3` versus `ci-runner-02`)
+- **WHEN** its instance rows render
+- **THEN** each row MUST show its host as a secondary suffix so the two same-cwd rows are visually distinct
+
+### Requirement: The UI SHALL truncate long paths and hosts without losing the disambiguating part
+
+The UI SHALL provide a shared formatting rule for instance paths and hosts so that long values never break row layout or push status, tag, or action controls off the row. A `cwd` SHALL be displayed as its abbreviated tail (last two path segments); when even that exceeds the available width it SHALL be truncated from the left with a leading ellipsis while always preserving the final path segment (the working directory's own name) intact. A `host` SHALL be truncated from the right with a trailing ellipsis and capped at a fixed maximum width so it never crowds the path. The full absolute path and the full host SHALL be available on hover (title). Within a row, the status indicator and the selection control SHALL NOT shrink; only the path — and then the host — SHALL flex-shrink, with the path retaining shrink priority as the primary identity.
+
+#### Scenario: A long path keeps its final segment and reveals the full path on hover
+
+- **GIVEN** an instance whose absolute cwd is `/home/u/dev/payments-platform/services/billing-api`
+- **WHEN** its path chip renders in a constrained row
+- **THEN** the visible label MUST keep the final segment `billing-api` intact (truncating earlier segments with a leading ellipsis)
+- **AND** the full absolute path MUST be available on hover
+
+#### Scenario: A long host is right-truncated and width-capped
+
+- **GIVEN** an instance whose host is `ip-10-0-42-118.ec2.internal`
+- **WHEN** its host suffix renders
+- **THEN** the host MUST be truncated from the right with a trailing ellipsis within a fixed maximum width
+- **AND** it MUST NOT push the path or the status indicator out of the row
+
+### Requirement: An owner SHALL be able to pin a target instance when @-mentioning an agent
+
+When an owner @-mentions an agent in a comment, the mention SHALL remain addressed to the agent. When the mentioned agent has two or more live instances, the UI SHALL present a secondary picker letting the owner choose which `(host, cwd)` instance the mention targets; when the agent has exactly one live instance the UI SHALL auto-select it with no additional interaction. The chosen instance SHALL be pinned to the mention so that the resulting autonomous wake routes to that instance. The pinned target SHALL be expressed as `(host, cwd)` (a durable "place") rather than a specific connection id, and SHALL never be inferred from the comment's project. A mention that carries no pin SHALL behave exactly as before this change.
+
+#### Scenario: Two live instances trigger a secondary picker
+
+- **GIVEN** an owner @-mentions an agent that has two live instances
+- **WHEN** the mention is being composed
+- **THEN** the UI MUST present a secondary picker of the agent's live `(host, cwd)` instances for the owner to choose from
+
+#### Scenario: A single live instance is auto-selected
+
+- **GIVEN** an owner @-mentions an agent that has exactly one live instance
+- **WHEN** the mention is being composed
+- **THEN** that instance MUST be auto-selected with no additional picker interaction required
+
+### Requirement: Instance pickers SHALL show only online instances; a fully-offline agent SHALL receive a plain notification
+
+On every instance-picker surface (the @-mention secondary picker, the task-assignment cwd picker, and the ad-hoc send picker), the picker SHALL list ONLY online `(host, cwd)` instances. An offline instance SHALL NOT be shown at all — there SHALL be no disabled row and no "will queue" affordance, and an offline instance SHALL never be selectable. Over the online instances the rule SHALL be uniform across @-mention and task assignment: zero online instances → no picker is shown; exactly one → it is auto-pinned with no interaction; two or more → the picker is presented. Targeting an agent whose instances are ALL offline (a fully-offline agent) SHALL be allowed for both @-mention and task assignment and SHALL never be blocked; doing so SHALL record a PLAIN ordinary notification with NO pin and NO wake/turn/broadcast — there is no durable queue or backfill. When a task is assigned to a fully-offline agent, the assignment (assignee) SHALL still be persisted, but with NO `(host, cwd)` pin. A pinned target, when one is chosen, SHALL be persisted as `(host, cwd)` and SHALL never be inferred from the task's project.
+
+#### Scenario: The picker shows only online instances
+
+- **GIVEN** an agent with three instances, one online and two offline
+- **WHEN** the owner opens the task-assignment or @-mention instance picker
+- **THEN** the picker MUST list only the one online instance
+- **AND** no offline row, disabled row, or "will queue" affordance MUST be shown
+
+#### Scenario: Targeting a fully-offline agent records a plain notification
+
+- **GIVEN** an owner assigns a task to (or @-mentions) an agent whose every instance is offline
+- **WHEN** the action is submitted
+- **THEN** it MUST be accepted (never blocked) and MUST record a plain notification with no pin
+- **AND** NO DaemonSessionTurn MUST be created and NO wake/broadcast MUST be emitted (there is no durable queue)
+- **AND** for a task assignment the assignee MUST still be persisted, with no `(host, cwd)` pin
+
+#### Scenario: A single online instance is auto-pinned and a chosen pin is persisted
+
+- **GIVEN** an owner assigns a task to an agent that has exactly one online instance
+- **WHEN** the assignment is saved
+- **THEN** that online instance MUST be auto-pinned and its `(host, cwd)` MUST be persisted with the assignment so a later autonomous wake can resolve it
+
+### Requirement: The ad-hoc send flow SHALL let an owner pick an online instance
+
+The immediate ad-hoc "send now" flow SHALL let the owner pick which online `(host, cwd)` instance receives the instruction. The picker SHALL list ONLY online instances — an offline instance is never a live-send target and SHALL NOT be shown — preserving the existing behavior that an instruction to an offline origin is rejected. The send confirmation SHALL show the resolved instance — including its host when the host is needed to disambiguate — before the instruction is sent.
+
+#### Scenario: Only online instances appear in the ad-hoc picker
+
+- **GIVEN** an agent with one online and one offline instance
+- **WHEN** the owner opens the ad-hoc send picker
+- **THEN** the picker MUST list only the online instance, and the offline one MUST NOT appear
+
+#### Scenario: The send confirms the resolved instance
+
+- **GIVEN** the owner has picked an online instance in the ad-hoc flow
+- **WHEN** the send control renders
+- **THEN** it MUST confirm the resolved `(host, cwd)` target before the instruction is sent
+
+### Requirement: The autonomous wake SHALL honor a pinned cwd and fall back to online-first
+
+When a `task_assigned` or `mentioned` notification wakes an agent, the connection-selection step SHALL honor a pinned target instance if one was recorded with the trigger: it SHALL resolve the `DaemonConnection` matching the pinned `(agentUuid, host, cwd)` AND being ONLINE, and pin the session origin to it. Only an online connection is wakeable — there is no durable queue, so a pin that matches an OFFLINE connection (or no connection at all), or a trigger with no pin, SHALL fall back to the existing online-first connection selection. When the agent has NO online connection at all, the wake SHALL create no turn and the already-recorded notification SHALL stand as the plain record. The wake SHALL NOT infer a cwd from the project under any circumstance. This behavior SHALL be additive: a trigger with no pin selects a connection exactly as before this change.
+
+#### Scenario: A pinned online instance is honored at wake time
+
+- **GIVEN** a `task_assigned` notification whose assignment pinned `(Laptop-Q3, dev/chorus)`
+- **AND** an ONLINE connection matching that `(agent, host, cwd)` exists
+- **WHEN** the wake selects a connection
+- **THEN** it MUST pin the session origin to that matching online connection rather than the first online connection
+
+#### Scenario: A pin matching an offline instance falls back to online-first (no queue)
+
+- **GIVEN** a wake whose pin matches an OFFLINE connection while another instance is online
+- **WHEN** the wake selects a connection
+- **THEN** it MUST fall back to the online-first connection (the offline pin is not wakeable and is NOT queued/backfilled)
+
+#### Scenario: An unpinned wake uses online-first as before
+
+- **GIVEN** a wake notification that carries no pinned instance
+- **WHEN** the wake selects a connection
+- **THEN** it MUST select the first online connection exactly as before this change, with no cwd inference from the project
+
+### Requirement: The chat transcript header SHALL surface the session's cwd
+
+The daemon conversation transcript header SHALL display the session's working directory (`cwd`) inline as the conversation's instance identity, rendered with the same path-first treatment used elsewhere. The connection's `host` SHALL remain in the existing "Connection details" disclosure rather than the headline, surfaced inline only when needed to disambiguate across hosts. When the session's origin connection reports no cwd, the header SHALL show the "unknown path" treatment consistent with the presence surface.
+
+#### Scenario: The header shows which directory a conversation runs in
+
+- **GIVEN** an open daemon conversation whose origin connection has cwd `dev/chorus`
+- **WHEN** the transcript header renders
+- **THEN** it MUST show `dev/chorus` inline (path-first) as the conversation's instance identity
+- **AND** the host MUST remain in the "Connection details" disclosure rather than the headline
+

--- a/prisma/migrations/20260623020208_task_pinned_target_instance/migration.sql
+++ b/prisma/migrations/20260623020208_task_pinned_target_instance/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "targetCwd" TEXT,
+ADD COLUMN     "targetHost" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -214,6 +214,17 @@ model Task {
   assigneeUuid            String? // User or Agent UUID (polymorphic)
   assignedAt              DateTime? // Assignment timestamp
   assignedByUuid          String? // User UUID (human assignment)
+  // Pinned target daemon instance for the durable-intent wake (cwd-addressable
+  // instances). When an owner pins which (host, cwd) instance should run a task
+  // at assignment time, these record that "place" so a later autonomous wake
+  // (notification-turn.ts) resolves the matching live DaemonConnection and pins
+  // the session origin there — falling back to online-first if none matches.
+  // Stored as (host, cwd) rather than a connectionUuid because connections
+  // churn on daemon restart while the place is stable. Nullable: an unpinned
+  // assignment behaves exactly as before this change. Never inferred from the
+  // project (parent idea DEC-5).
+  targetHost              String? // pinned instance host ("" = unknown-host instance)
+  targetCwd               String? // pinned instance working directory
   proposalUuid            String? // Source Proposal UUID (traceable, optional)
   createdByUuid           String // User or Agent UUID
   createdAt               DateTime              @default(now())

--- a/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { getServerAuthContext } from "@/lib/auth-server";
 import { claimTask, getTaskByUuid, updateTask, releaseTask, createTask, deleteTask, checkAcceptanceCriteriaGate, replaceAcceptanceCriteria } from "@/services/task.service";
 import { getAssignableAgents, getCompanyUsers } from "@/services/agent.service";
+import { listConnectionsForAgent } from "@/services/daemon-connection.service";
 import { createActivity } from "@/services/activity.service";
 import type { AcceptanceCriteriaItemInput } from "@/lib/acceptance-criteria";
 import logger from "@/lib/logger";
@@ -56,8 +57,16 @@ export async function claimTaskAction(taskUuid: string) {
   }
 }
 
-// Claim task to a specific agent
-export async function claimTaskToAgentAction(taskUuid: string, agentUuid: string) {
+// Claim task to a specific agent, optionally pinning a (host, cwd) daemon
+// instance for the autonomous wake (cwd-addressable instances, T4). The pin is a
+// durable "place" — an offline instance is a valid pin (the turn queues and
+// backfills on reconnect), so this path does NOT gate on the instance being
+// online. `targetHost`/`targetCwd` are both omitted for an un-pinned assignment.
+export async function claimTaskToAgentAction(
+  taskUuid: string,
+  agentUuid: string,
+  pin?: { targetHost: string | null; targetCwd: string | null },
+) {
   const auth = await getServerAuthContext();
   if (!auth || auth.type !== "user") {
     return { success: false, error: "Unauthorized" };
@@ -79,6 +88,8 @@ export async function claimTaskToAgentAction(taskUuid: string, agentUuid: string
       assigneeType: "agent",
       assigneeUuid: agentUuid,
       assignedByUuid: auth.actorUuid,
+      targetHost: pin?.targetHost ?? null,
+      targetCwd: pin?.targetCwd ?? null,
     });
 
     // Record activity
@@ -90,7 +101,15 @@ export async function claimTaskToAgentAction(taskUuid: string, agentUuid: string
       actorType: auth.type,
       actorUuid: auth.actorUuid,
       action: "assigned",
-      value: { assigneeType: "agent", assigneeUuid: agentUuid },
+      value: {
+        assigneeType: "agent",
+        assigneeUuid: agentUuid,
+        // Record the pin in the activity value so the timeline reflects which
+        // (host, cwd) place was chosen (omitted when un-pinned).
+        ...(pin?.targetCwd !== undefined || pin?.targetHost !== undefined
+          ? { targetHost: pin?.targetHost ?? null, targetCwd: pin?.targetCwd ?? null }
+          : {}),
+      },
     });
 
     revalidatePath(`/projects/${task.projectUuid}/tasks/${taskUuid}`);
@@ -402,5 +421,47 @@ export async function getDeveloperAgentsAction() {
   } catch (error) {
     logger.error({ err: error }, "Failed to get assignable agents");
     return { agents: [], users: [] };
+  }
+}
+
+// One selectable daemon instance for the assign-task cwd picker (cwd-addressable
+// instances) — the structural subset the shared InstancePicker renders. Both
+// online AND offline instances are returned here (each carries effectiveStatus);
+// the modal filters to ONLINE before showing the picker, since an offline
+// instance is not a wake target. A fully-offline agent yields no online
+// instances → no picker → the task is assigned plainly with no pin.
+export interface AgentInstanceCandidate {
+  connectionUuid: string;
+  host: string;
+  cwd: string | null;
+  effectiveStatus: "online" | "offline";
+}
+
+// Get one agent's daemon instances (online + offline, each with effectiveStatus)
+// so the assign-task modal can let the owner pin which ONLINE (host, cwd) place
+// runs the task. The modal filters to online before rendering the picker.
+// Company-scoped read; returns [] for any non-user caller or on error (the picker
+// then shows its own "no instances" empty state — never a silent throw).
+export async function getAgentInstancesAction(
+  agentUuid: string,
+): Promise<{ instances: AgentInstanceCandidate[] }> {
+  const auth = await getServerAuthContext();
+  if (!auth || auth.type !== "user") {
+    return { instances: [] };
+  }
+
+  try {
+    const connections = await listConnectionsForAgent(auth.companyUuid, agentUuid);
+    return {
+      instances: connections.map((c) => ({
+        connectionUuid: c.uuid,
+        host: c.host,
+        cwd: c.cwd,
+        effectiveStatus: c.effectiveStatus,
+      })),
+    };
+  } catch (error) {
+    logger.error({ err: error }, "Failed to get agent instances");
+    return { instances: [] };
   }
 }

--- a/src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { X, Bot, User, Loader2 } from "lucide-react";
+import { X, Bot, User, Loader2, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -15,11 +15,20 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  InstancePicker,
+  type InstanceCandidate,
+} from "@/components/agent-presence/instance-picker";
+import {
+  formatCwd,
+  formatHost,
+} from "@/lib/daemon-instance-format";
+import {
   claimTaskAction,
   claimTaskToAgentAction,
   claimTaskToUserAction,
   releaseTaskAction,
   getDeveloperAgentsAction,
+  getAgentInstancesAction,
 } from "./[taskUuid]/actions";
 
 interface Task {
@@ -73,6 +82,16 @@ export function AssignTaskModal({
   const [isLoadingData, setIsLoadingData] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // The selected agent's ONLINE (host, cwd) daemon instances for the cwd pin
+  // (cwd-addressable instances). Only online instances are pinnable — an offline
+  // instance is not a wake target, so it is filtered out (a fully-offline agent
+  // shows no picker and just assigns plainly with no pin).
+  const [instances, setInstances] = useState<InstanceCandidate[]>([]);
+  const [isLoadingInstances, setIsLoadingInstances] = useState(false);
+  const [pinnedConnectionUuid, setPinnedConnectionUuid] = useState<string | null>(
+    null,
+  );
+
   const isAssigned = !!task.assignee;
 
   // Load agents and users
@@ -89,6 +108,61 @@ export function AssignTaskModal({
 
   // All developer agents in the company are available for assignment
 
+  // Load the selected agent's daemon instances whenever the agent changes (and
+  // the agent option is active). Resets the pin so a stale (host, cwd) from a
+  // previously-selected agent never leaks across agents.
+  useEffect(() => {
+    if (selectedOption !== "agent" || !selectedAgentUuid) {
+      setInstances([]);
+      setPinnedConnectionUuid(null);
+      return;
+    }
+    let cancelled = false;
+    setIsLoadingInstances(true);
+    setPinnedConnectionUuid(null);
+    getAgentInstancesAction(selectedAgentUuid)
+      .then((res) => {
+        if (cancelled) return;
+        // Online-only: an offline instance is not a wake target, so it never
+        // appears in the picker. A fully-offline agent yields [] → no picker.
+        setInstances(
+          res.instances.filter((i) => i.effectiveStatus === "online"),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingInstances(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedOption, selectedAgentUuid]);
+
+  // The instance the owner pinned, resolved from the controlled connectionUuid.
+  const pinnedInstance =
+    instances.find((i) => i.connectionUuid === pinnedConnectionUuid) ?? null;
+  // Host is included in a target confirmation only when it disambiguates — i.e.
+  // the agent's instances span 2+ distinct hosts (same rule as the picker rows).
+  const isMultiHost = new Set(instances.map((i) => i.host)).size > 1;
+
+  // The CTA label / footer confirmation names the resolved (path · host) of the
+  // pinned online instance; host only when it disambiguates (2+ hosts).
+  function resolvePinLabel(): string {
+    if (selectedOption !== "agent" || !pinnedInstance) {
+      return t("common.assign");
+    }
+    const cwd = formatCwd(pinnedInstance.cwd);
+    const pathLabel = cwd.isUnknown ? t(cwd.label) : cwd.label;
+    const host = formatHost(pinnedInstance.host);
+    const hostLabel = host.isUnknown ? t(host.label) : host.label;
+    if (isMultiHost) {
+      return t("assignInstance.assignToWithHost", {
+        path: pathLabel,
+        host: hostLabel,
+      });
+    }
+    return t("assignInstance.assignTo", { path: pathLabel });
+  }
+
   const handleSubmit = async () => {
     setIsLoading(true);
     setError(null);
@@ -97,7 +171,13 @@ export function AssignTaskModal({
     if (selectedOption === "self") {
       result = await claimTaskAction(task.uuid);
     } else if (selectedOption === "agent" && selectedAgentUuid) {
-      result = await claimTaskToAgentAction(task.uuid, selectedAgentUuid);
+      // Thread the durable (host, cwd) pin when the owner picked one. We send the
+      // place (host + cwd), NOT the ephemeral connectionUuid, so the pin survives
+      // a daemon restart and the wake resolves it at run time. No pin → undefined.
+      const pin = pinnedInstance
+        ? { targetHost: pinnedInstance.host, targetCwd: pinnedInstance.cwd }
+        : undefined;
+      result = await claimTaskToAgentAction(task.uuid, selectedAgentUuid, pin);
     } else if (selectedOption === "user" && selectedUserUuid) {
       result = await claimTaskToUserAction(task.uuid, selectedUserUuid);
     } else if (selectedOption === "release") {
@@ -228,7 +308,7 @@ export function AssignTaskModal({
                 </p>
 
                 {selectedOption === "agent" && (
-                  <div className="mt-3 ml-6">
+                  <div className="mt-3 ml-6 space-y-3">
                     <Select
                       value={selectedAgentUuid}
                       onValueChange={setSelectedAgentUuid}
@@ -253,6 +333,42 @@ export function AssignTaskModal({
                         )}
                       </SelectContent>
                     </Select>
+
+                    {/* Working-directory pin (cwd-addressable instances).
+                        ONLINE-only: an offline instance is not a wake target, so
+                        it is filtered out and never shown. A fully-offline agent
+                        yields no instances → no picker; the task is assigned
+                        plainly with no pin (a plain notification, no wake). */}
+                    {selectedAgentUuid && (
+                      <div className="space-y-2">
+                        <span className="text-[11px] font-medium uppercase tracking-wide text-[#9A9A9A]">
+                          {t("assignInstance.workingDirectory")}
+                        </span>
+                        {isLoadingInstances ? (
+                          <div className="flex items-center gap-2 py-2 text-xs text-[#9A9A9A]">
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            {t("assignInstance.loadingInstances")}
+                          </div>
+                        ) : instances.length === 0 ? (
+                          <p className="rounded-lg bg-[#FAF8F4] p-2.5 text-[11px] leading-relaxed text-[#6B6B6B]">
+                            {t("assignInstance.noInstances")}
+                          </p>
+                        ) : (
+                          <InstancePicker
+                            instances={instances}
+                            selectedConnectionUuid={pinnedConnectionUuid}
+                            onSelect={(inst) =>
+                              setPinnedConnectionUuid(inst.connectionUuid)
+                            }
+                            ariaLabel={t("assignInstance.workingDirectory")}
+                          />
+                        )}
+                        <div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-[#9A8C7E]">
+                          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                          <span>{t("assignInstance.pinNote")}</span>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
@@ -350,7 +466,9 @@ export function AssignTaskModal({
             ) : selectedOption === "release" ? (
               t("common.release")
             ) : (
-              t("common.assign")
+              // When an instance is pinned the CTA names the resolved (path · host)
+              // target (cwd-addressable instances, T4); otherwise the plain label.
+              resolvePinLabel()
             )}
           </Button>
         </div>

--- a/src/app/api/daemon-sessions/[sessionUuid]/repoint/__tests__/route.test.ts
+++ b/src/app/api/daemon-sessions/[sessionUuid]/repoint/__tests__/route.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ===== Mocks =====
+const mockGetAuthContext = vi.fn();
+const mockRepoint = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+// Typed errors defined INSIDE the factory (hoisted with the mock) so the route's instanceof
+// mapping is exercised against the same classes the test constructs; re-imported below.
+vi.mock("@/services/daemon-instruction.service", () => {
+  class SessionNotVisibleError extends Error {
+    readonly code = "session_not_visible";
+    constructor() {
+      super("Daemon session not found");
+      this.name = "SessionNotVisibleError";
+    }
+  }
+  class ConnectionNotVisibleError extends Error {
+    readonly code = "connection_not_visible";
+    constructor() {
+      super("Connection not found");
+      this.name = "ConnectionNotVisibleError";
+    }
+  }
+  class ConnectionOfflineError extends Error {
+    readonly code = "connection_offline";
+    readonly connectionUuid: string;
+    constructor(connectionUuid: string) {
+      super("connection offline");
+      this.name = "ConnectionOfflineError";
+      this.connectionUuid = connectionUuid;
+    }
+  }
+  class RepointOriginLiveError extends Error {
+    readonly code = "repoint_origin_live";
+    readonly originConnectionUuid: string;
+    constructor(originConnectionUuid: string) {
+      super("origin still online");
+      this.name = "RepointOriginLiveError";
+      this.originConnectionUuid = originConnectionUuid;
+    }
+  }
+  class InstructionTextError extends Error {
+    readonly code = "invalid_instruction_text";
+    readonly reason: string;
+    constructor(reason: string) {
+      super(reason);
+      this.name = "InstructionTextError";
+      this.reason = reason;
+    }
+  }
+  return {
+    repointSessionOriginAndSend: (...args: unknown[]) => mockRepoint(...args),
+    SessionNotVisibleError,
+    ConnectionNotVisibleError,
+    ConnectionOfflineError,
+    RepointOriginLiveError,
+    InstructionTextError,
+  };
+});
+
+import { POST } from "@/app/api/daemon-sessions/[sessionUuid]/repoint/route";
+import {
+  SessionNotVisibleError,
+  ConnectionNotVisibleError,
+  ConnectionOfflineError,
+  RepointOriginLiveError,
+  InstructionTextError,
+} from "@/services/daemon-instruction.service";
+
+// ===== Helpers =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const ownerUuid = "owner-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const sessionUuid = "sess-0000-0000-0000-000000000001";
+const targetConnectionUuid = "conn-0000-0000-0000-0000000000ff";
+
+const userAuth = { type: "user", companyUuid, actorUuid: ownerUuid };
+const ctx = { params: Promise.resolve({ sessionUuid }) };
+// The missing-param case: the route reads `sessionUuid` off the resolved params and 400s
+// when absent. Cast through the typed param shape (the runtime value is genuinely empty).
+const emptyCtx = {
+  params: Promise.resolve({}) as Promise<{ sessionUuid: string }>,
+};
+
+const session = {
+  uuid: sessionUuid,
+  agentUuid,
+  sessionId: "idea-1",
+  directIdeaUuid: "idea-1",
+  // Re-pointed to the chosen online connection — SAME session uuid/sessionId.
+  originConnectionUuid: targetConnectionUuid,
+  status: "active",
+  title: null,
+  lastTurnAt: "2026-06-23T03:00:00.000Z",
+  createdAt: "2026-06-23T03:00:00.000Z",
+  updatedAt: "2026-06-23T03:00:00.000Z",
+};
+const turn = {
+  uuid: "turn-1",
+  sessionUuid,
+  seq: 5,
+  trigger: "human_instruction",
+  promptText: "pick up where we left off",
+  status: "pending",
+  executionUuid: null,
+  startedAt: null,
+  endedAt: null,
+  createdAt: "2026-06-23T03:00:00.000Z",
+};
+
+const validBody = {
+  connectionUuid: targetConnectionUuid,
+  instructionText: "pick up where we left off",
+};
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    new URL(`http://localhost:3000/api/daemon-sessions/${sessionUuid}/repoint`),
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue(userAuth);
+  mockRepoint.mockResolvedValue({ session, turn });
+});
+
+describe("POST /api/daemon-sessions/[sessionUuid]/repoint", () => {
+  it("401 + no re-point when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+    const res = await POST(postRequest(validBody), ctx);
+    expect(res.status).toBe(401);
+    expect(mockRepoint).not.toHaveBeenCalled();
+  });
+
+  it("400 when sessionUuid param is missing", async () => {
+    const res = await POST(postRequest(validBody), emptyCtx);
+    expect(res.status).toBe(400);
+    expect(mockRepoint).not.toHaveBeenCalled();
+  });
+
+  it("200 with the SAME (re-pointed) session + turn; service called with auth + {sessionUuid, body}", async () => {
+    const res = await POST(postRequest(validBody), ctx);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { session, turn }, meta: undefined });
+    expect(mockRepoint).toHaveBeenCalledTimes(1);
+    expect(mockRepoint.mock.calls[0][0]).toBe(userAuth);
+    expect(mockRepoint.mock.calls[0][1]).toEqual({
+      sessionUuid,
+      connectionUuid: targetConnectionUuid,
+      instructionText: "pick up where we left off",
+    });
+    // The returned session keeps its identity — the same uuid + sessionId.
+    expect(body.data.session.uuid).toBe(sessionUuid);
+    expect(body.data.session.sessionId).toBe("idea-1");
+  });
+
+  it("400 when body is not valid JSON", async () => {
+    const req = new NextRequest(
+      new URL(`http://localhost:3000/api/daemon-sessions/${sessionUuid}/repoint`),
+      { method: "POST", body: "{nope", headers: { "content-type": "application/json" } },
+    );
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+    expect(mockRepoint).not.toHaveBeenCalled();
+  });
+
+  it("422 when required fields are missing (zod), no re-point", async () => {
+    const res = await POST(postRequest({ instructionText: "go" }), ctx);
+    expect(res.status).toBe(422);
+    expect(mockRepoint).not.toHaveBeenCalled();
+  });
+
+  it("404 (non-disclosure) for a not-visible session", async () => {
+    mockRepoint.mockRejectedValue(new SessionNotVisibleError());
+    const res = await POST(postRequest(validBody), ctx);
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("404 (non-disclosure) for a target connection not of the same agent", async () => {
+    mockRepoint.mockRejectedValue(new ConnectionNotVisibleError());
+    const res = await POST(postRequest(validBody), ctx);
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("409 (conflict) when the current origin is still online (live session)", async () => {
+    mockRepoint.mockRejectedValue(new RepointOriginLiveError("conn-live"));
+    const res = await POST(postRequest(validBody), ctx);
+    const body = await res.json();
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("CONFLICT");
+  });
+
+  it("409 (conflict) for an offline target connection", async () => {
+    mockRepoint.mockRejectedValue(new ConnectionOfflineError("conn-offline"));
+    const res = await POST(postRequest(validBody), ctx);
+    const body = await res.json();
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("CONFLICT");
+  });
+
+  it("400 for empty/over-length instruction text (service InstructionTextError)", async () => {
+    mockRepoint.mockRejectedValue(new InstructionTextError("empty"));
+    const res = await POST(postRequest({ ...validBody, instructionText: "" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("an unexpected error propagates to the 500 handler", async () => {
+    mockRepoint.mockRejectedValue(new Error("db boom"));
+    const res = await POST(postRequest(validBody), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/daemon-sessions/[sessionUuid]/repoint/route.ts
+++ b/src/app/api/daemon-sessions/[sessionUuid]/repoint/route.ts
@@ -1,0 +1,98 @@
+// src/app/api/daemon-sessions/[sessionUuid]/repoint/route.ts
+// Re-point a read-only (origin-offline) daemon session onto a chosen ONLINE connection of
+// the SAME agent, then send a fresh human instruction there — KEEPING the same DaemonSession
+// (same uuid, same sessionId, same directIdeaUuid). This is the corrected "Continue on an
+// online directory" escape hatch (T12): it does NOT mint a new ad-hoc session (the T11
+// mistake), so the conversation keeps its identity. The daemon, finding no transcript at the
+// new cwd, spawns `claude --session-id <sameId>` — a fresh transcript under the same id.
+//
+// POST — for a session the caller owns whose CURRENT origin is offline, re-points its
+// `originConnectionUuid` to the (online, same-agent) target connection and creates the first
+// `human_instruction` turn on the SAME session (via the 子1 chokepoint), delivered to the new
+// origin. The single deliberate reversal of the origin write-once invariant lives in the
+// service; this route only maps the typed errors.
+//
+// Auth posture mirrors the other daemon routes: any valid auth context, no MCP tool, no new
+// permission bit — visibility is enforced by the service's owner/self scope. Typed errors →
+// status: not-visible session OR not-same-agent target → 404 (non-disclosure); current origin
+// still LIVE OR target offline → 409; empty/over-length text → 400.
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import {
+  repointSessionOriginAndSend,
+  SessionNotVisibleError,
+  ConnectionNotVisibleError,
+  ConnectionOfflineError,
+  RepointOriginLiveError,
+  InstructionTextError,
+} from "@/services/daemon-instruction.service";
+
+// Request body schema. `instructionText` length is validated in the service (against the
+// single `MAX_INSTRUCTION_CHARS` constant) so the cap is single-sourced; here we only require
+// the target connection + text fields to be present as identifiers.
+const bodySchema = z.object({
+  connectionUuid: z.string().min(1),
+  instructionText: z.string(),
+});
+
+// POST /api/daemon-sessions/{sessionUuid}/repoint — re-point origin + first instruction turn.
+export const POST = withErrorHandler<{ sessionUuid: string }>(
+  async (request: NextRequest, context) => {
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return errors.unauthorized();
+    }
+
+    const { sessionUuid } = await context.params;
+    if (!sessionUuid) {
+      return errors.badRequest("sessionUuid is required");
+    }
+
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return errors.badRequest("Invalid JSON body");
+    }
+    const parsed = bodySchema.safeParse(raw);
+    if (!parsed.success) {
+      return errors.validationError(parsed.error.flatten());
+    }
+    const { connectionUuid, instructionText } = parsed.data;
+
+    try {
+      const { session, turn } = await repointSessionOriginAndSend(auth, {
+        sessionUuid,
+        connectionUuid,
+        instructionText,
+      });
+      return success({ session, turn });
+    } catch (err) {
+      // not-visible session OR target connection not of the same agent → 404 (never confirm
+      // another owner's session/connection exists).
+      if (
+        err instanceof SessionNotVisibleError ||
+        err instanceof ConnectionNotVisibleError
+      ) {
+        return errors.notFound("Daemon session");
+      }
+      // current origin still online (nothing to rescue) → 409; never re-point a live session.
+      if (err instanceof RepointOriginLiveError) {
+        return errors.conflict(err.message);
+      }
+      // target connection offline → 409 (no re-point, no turn created).
+      if (err instanceof ConnectionOfflineError) {
+        return errors.conflict(err.message);
+      }
+      // empty / over-length text → 400 (no re-point, no turn created).
+      if (err instanceof InstructionTextError) {
+        return errors.badRequest(err.message);
+      }
+      throw err;
+    }
+  },
+);

--- a/src/app/api/mentionables/route.ts
+++ b/src/app/api/mentionables/route.ts
@@ -17,6 +17,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const query = parseQuery(request);
   const q = query.q || "";
   const limit = Math.min(50, Math.max(1, parseInt(query.limit || "10", 10)));
+  // Opt-in: the @mention flow requests per-instance (host, cwd) candidates so it
+  // can surface the secondary instance picker (cwd-addressable instances, T3).
+  // Default off so existing callers (and the cheap suggestion list) are unchanged.
+  const withInstances = query.withInstances === "1" || query.withInstances === "true";
 
   const results = await mentionService.searchMentionables({
     companyUuid: auth.companyUuid,
@@ -25,6 +29,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     actorUuid: auth.actorUuid,
     ownerUuid: isAgent(auth) ? auth.ownerUuid : auth.actorUuid,
     limit,
+    withInstances,
   });
 
   return success(results);

--- a/src/app/api/tasks/[uuid]/claim/__tests__/route.test.ts
+++ b/src/app/api/tasks/[uuid]/claim/__tests__/route.test.ts
@@ -112,6 +112,52 @@ describe("POST /api/tasks/[uuid]/claim — agent selection gating", () => {
     expect(mockClaimTask).not.toHaveBeenCalled();
   });
 
+  it("threads a pinned (host, cwd) to claimTask when assigning to an agent (cwd-addressable instances, T4)", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: ["developer_agent"],
+      permissions: [],
+    });
+    mockClaimTask.mockResolvedValue({ uuid: taskUuid, assigneeUuid: agentUuid });
+
+    // An OFFLINE pin is a valid durable intent — the route does NOT gate on
+    // online (only the live ad-hoc send does), so it must pass the pin through.
+    const res = await POST(
+      jsonRequest({
+        agentUuid,
+        targetHost: "ci-runner-02",
+        targetCwd: "/home/u/dev/chorus",
+      }),
+      ctx(),
+    );
+    expect(res.status).toBe(200);
+    expect(mockClaimTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigneeType: "agent",
+        assigneeUuid: agentUuid,
+        targetHost: "ci-runner-02",
+        targetCwd: "/home/u/dev/chorus",
+      }),
+    );
+  });
+
+  it("passes null host/cwd to claimTask when no pin is sent (un-pinned assignment)", async () => {
+    mockPrisma.agent.findFirst.mockResolvedValue({
+      uuid: agentUuid,
+      roles: ["developer_agent"],
+      permissions: [],
+    });
+    mockClaimTask.mockResolvedValue({ uuid: taskUuid, assigneeUuid: agentUuid });
+
+    await POST(jsonRequest({ agentUuid }), ctx());
+    expect(mockClaimTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetHost: null,
+        targetCwd: null,
+      }),
+    );
+  });
+
   it("looks up the agent scoped by companyUuid (no cross-tenant leakage)", async () => {
     mockPrisma.agent.findFirst.mockResolvedValue({
       uuid: agentUuid,

--- a/src/app/api/tasks/[uuid]/claim/route.ts
+++ b/src/app/api/tasks/[uuid]/claim/route.ts
@@ -31,6 +31,11 @@ export const POST = withErrorHandler<{ uuid: string }>(
     let assigneeType: string;
     let assigneeUuid: string;
     let assignedByUuid: string | null = null;
+    // Pinned (host, cwd) daemon instance to run the assignment on (cwd-
+    // addressable instances, T4). Only the user→agent path threads a pin; an
+    // agent self-claim never pins one (it runs wherever it already is).
+    let targetHost: string | null = null;
+    let targetCwd: string | null = null;
 
     if (isAgent(auth)) {
       // Agents need task:write permission to claim
@@ -44,6 +49,12 @@ export const POST = withErrorHandler<{ uuid: string }>(
       const body = await parseBody<{
         assignToSelf?: boolean;
         agentUuid?: string;
+        // Optional durable pin (cwd-addressable instances, T4): the (host, cwd)
+        // "place" the autonomous wake should route this assignment to. An
+        // offline place is accepted (durable intent — the turn queues and
+        // backfills on reconnect). Omitted → no pin.
+        targetHost?: string | null;
+        targetCwd?: string | null;
       }>(request);
 
       if (body.agentUuid) {
@@ -75,6 +86,11 @@ export const POST = withErrorHandler<{ uuid: string }>(
         assigneeType = "agent";
         assigneeUuid = agent.uuid;
         assignedByUuid = auth.actorUuid;
+        // Carry the pin only when assigning to an agent. A pin is a durable
+        // intent for the autonomous wake; an offline place is accepted here (the
+        // 409-if-offline gate is the LIVE-send contract, not the assignment one).
+        targetHost = body.targetHost ?? null;
+        targetCwd = body.targetCwd ?? null;
       } else {
         // Assign to self (all owned Developer Agents can handle it)
         assigneeType = "user";
@@ -92,6 +108,8 @@ export const POST = withErrorHandler<{ uuid: string }>(
         assigneeType,
         assigneeUuid,
         assignedByUuid,
+        targetHost,
+        targetCwd,
       });
 
       return success(updated);

--- a/src/components/__tests__/agent-presence-pill.test.tsx
+++ b/src/components/__tests__/agent-presence-pill.test.tsx
@@ -112,6 +112,18 @@ import { ExecutionRow } from "@/components/agent-presence";
 
 const TRIGGER_LABEL = "Online agents — open details";
 
+// T11: the agent group is COLLAPSED by default in the popover, so its per-cwd
+// instance rows (and their executions / idle line / Interrupt control) only
+// render after the agent header toggle is clicked. Expand every agent so the
+// nested rows under test become visible (the header `aria-label` is
+// "Show <agent>'s working directories" while collapsed).
+async function expandAgents(user: ReturnType<typeof userEvent.setup>) {
+  const toggles = await screen.findAllByRole("button", {
+    name: /Show .*working directories/,
+  });
+  for (const toggle of toggles) await user.click(toggle);
+}
+
 function makeConnection(over: Partial<ConnectionView> = {}): ConnectionView {
   return {
     uuid: "conn-1",
@@ -294,6 +306,8 @@ describe("AgentPresencePill — popover content", () => {
 
     // PopoverContent renders in a portal — assert against the document text.
     await screen.findByText("Builder Bot");
+    // T11: expand the (default-collapsed) agent so its execution rows render.
+    await expandAgents(user);
     const popoverText = document.body.textContent ?? "";
     expect(popoverText).toContain("Running task A");
     expect(popoverText).toContain("Queued task B");
@@ -312,7 +326,40 @@ describe("AgentPresencePill — popover content", () => {
     const user = userEvent.setup();
     render(<AgentPresencePill />);
     await user.click(screen.getByRole("button", { name: TRIGGER_LABEL }));
+    // T11: expand the (default-collapsed) agent so its idle line renders.
+    await expandAgents(user);
 
+    expect(
+      await screen.findByText("Idle — no running or queued work."),
+    ).toBeTruthy();
+  });
+
+  it("default COLLAPSED: agent header shows name + count but hides instance rows until expanded (T11)", async () => {
+    setPresence({
+      status: "ok",
+      onlineCount: 1,
+      connections: [makeConnection({ agentName: "Builder Bot" })],
+      executionsByConnection: {},
+    });
+
+    const user = userEvent.setup();
+    render(<AgentPresencePill />);
+    await user.click(screen.getByRole("button", { name: TRIGGER_LABEL }));
+
+    // The collapsed agent header is present (a real toggle, aria-expanded=false)…
+    const toggle = await screen.findByRole("button", {
+      name: /Show .*working directories/,
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(await screen.findByText("Builder Bot")).toBeTruthy();
+    // …but the per-cwd idle line is NOT visible while collapsed.
+    expect(
+      screen.queryByText("Idle — no running or queued work."),
+    ).toBeNull();
+
+    // Expanding flips aria-expanded and reveals the rows.
+    await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(
       await screen.findByText("Idle — no running or queued work."),
     ).toBeTruthy();
@@ -383,6 +430,9 @@ describe("AgentPresencePill — widened popover + stacked task rows", () => {
     const user = userEvent.setup();
     render(<AgentPresencePill />);
     await user.click(screen.getByRole("button", { name: TRIGGER_LABEL }));
+    // T11: expand the (default-collapsed) agent so the idle line (used as the
+    // "portal mounted" proof) renders.
+    await expandAgents(user);
     // The popover empty-connection line proves the portal content has mounted.
     await screen.findByText("Idle — no running or queued work.");
 
@@ -416,6 +466,8 @@ describe("AgentPresencePill — widened popover + stacked task rows", () => {
     const user = userEvent.setup();
     render(<AgentPresencePill />);
     await user.click(screen.getByRole("button", { name: TRIGGER_LABEL }));
+    // T11: expand the (default-collapsed) agent so its running row renders.
+    await expandAgents(user);
 
     // Interrupt control is still present in the popover (controls retained).
     const interruptBtn = await screen.findByRole("button", {

--- a/src/components/agent-presence-pill.tsx
+++ b/src/components/agent-presence-pill.tsx
@@ -16,6 +16,7 @@
 // hides an error. So idle (0 online), loading, and error are three visually
 // distinct states and none of them is blank.
 
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { ListChecks, Play } from "lucide-react";
 import {
@@ -26,12 +27,17 @@ import {
 import { Button } from "@/components/ui/button";
 import { useAgentPresence } from "@/contexts/agent-presence-context";
 import {
+  AgentGroupHeader,
   DaemonConnectCta,
   ExecutionRow,
   ExecutionSection,
-  IdentityBlock,
+  InstanceRow,
   StatusDot,
+  groupConnectionsByAgent,
+  onlineConnectionsOnly,
+  useInstanceActivity,
   useNowTick,
+  type AgentInstanceGroup,
   type ConnectionView,
   type ExecutionView,
 } from "@/components/agent-presence";
@@ -67,87 +73,183 @@ function PillDot({
   );
 }
 
-// The list of online connections + their running/queued executions, rendered
-// inside the popover. Interrupted rows are deliberately dropped here — the
-// popover is glanceable and has no resume control (that is the modal's job).
-function PopoverBody({
-  onlineConnections,
-  executionsByConnection,
+// One instance sub-row inside an agent group. The path-first `InstanceRow`
+// (cwd + host-conditional suffix + tinted activity dot) is the drill-down
+// identity; nested beneath it the instance's running/queued executions render
+// as the SAME stacked `ExecutionRow`s used before the drill-down rework — so
+// the per-execution titles AND the Interrupt control (子3) stay reachable from
+// the glanceable popover. Interrupted rows are still dropped here (the popover
+// has no resume affordance — that is the modal's job). An ONLINE instance with
+// no running/queued work shows the quiet idle line instead, never a blank gap.
+function PopoverInstanceRow({
+  connection,
+  executions,
+  showHost,
   nowMs,
 }: {
-  onlineConnections: ConnectionView[];
-  executionsByConnection: Record<string, ExecutionView[]>;
+  connection: ConnectionView;
+  executions: ExecutionView[];
+  showHost: boolean;
   nowMs: number;
 }) {
   const t = useTranslations("agentPresence");
   const ta = useTranslations("agentConnections");
+  const { text, dot } = useInstanceActivity(connection, executions, nowMs);
+
+  // Glanceable surface: only running + queued executions are detailed.
+  // Interrupted rows are the modal's concern (they carry a resume affordance
+  // this popover lacks), so they are filtered out here.
+  const running = executions.filter((e) => e.status === "running");
+  const queued = executions.filter((e) => e.status === "queued");
+  const hasActive = running.length > 0 || queued.length > 0;
+  const online = connection.effectiveStatus === "online";
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <InstanceRow
+        connection={connection}
+        showHost={showHost}
+        activity={text}
+        dot={dot}
+      />
+      {hasActive ? (
+        <div className="flex flex-col gap-4 pl-1">
+          {running.length > 0 && (
+            <ExecutionSection
+              icon={Play}
+              label={ta("execRunning")}
+              count={running.length}
+            >
+              {running.map((exec) => (
+                <ExecutionRow
+                  key={exec.uuid}
+                  exec={exec}
+                  nowMs={nowMs}
+                  layout="stacked"
+                />
+              ))}
+            </ExecutionSection>
+          )}
+          {queued.length > 0 && (
+            <ExecutionSection
+              icon={ListChecks}
+              label={ta("execQueued")}
+              count={queued.length}
+            >
+              {queued.map((exec) => (
+                <ExecutionRow
+                  key={exec.uuid}
+                  exec={exec}
+                  nowMs={nowMs}
+                  layout="stacked"
+                />
+              ))}
+            </ExecutionSection>
+          )}
+        </div>
+      ) : (
+        // A quiet idle line for an ONLINE instance with no running/queued work —
+        // never blank. An offline instance already reads "offline · <last seen>"
+        // in its own row, so the idle line is online-only to avoid redundancy.
+        online && (
+          <p className="pl-1 text-[12px] text-[#9A9A9A]">{t("connectionIdle")}</p>
+        )
+      )}
+    </div>
+  );
+}
+
+// One agent group: a host-conditional COLLAPSIBLE header + (when expanded) one
+// path-first sub-row per ONLINE instance. The group is grouped from the
+// online-only connection set (offline instances — including a legacy null-cwd
+// "unknown path" — never reach this surface), so every listed instance is live.
+//
+// Collapse (T11 / qr1): DEFAULT COLLAPSED. Collapsed shows just the header
+// (agent name + online count + status dot); the per-cwd instance rows are
+// revealed only when the user expands the agent via the header toggle. The pill
+// popover is meant to be glanceable, so the per-cwd rows are opt-in noise.
+function PopoverAgentGroup({
+  group,
+  executionsByConnection,
+  nowMs,
+  expanded,
+  onToggle,
+}: {
+  group: AgentInstanceGroup;
+  executionsByConnection: Record<string, ExecutionView[]>;
+  nowMs: number;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <AgentGroupHeader group={group} expanded={expanded} onToggle={onToggle} />
+      {expanded && (
+        <div className="flex flex-col gap-3 pl-7">
+          {group.connections.map((connection) => (
+            <PopoverInstanceRow
+              key={connection.uuid}
+              connection={connection}
+              executions={executionsByConnection[connection.uuid] ?? []}
+              showHost={group.multiHost}
+              nowMs={nowMs}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The drill-down body: one COLLAPSIBLE row per ONLINE agent. Collapsed by
+// default (just the agent header); expanding an agent reveals one sub-row per
+// live instance keyed by (agent, host, cwd). Each instance row surfaces its
+// running/queued executions (with the Interrupt control) and a quiet idle line
+// when it has none; interrupted rows are deliberately dropped here (the popover
+// is glanceable and has no resume control — that is the modal's job).
+//
+// Per-agent expand state lives here in a Set of expanded agentUuids (local
+// React state), so toggling one agent never re-fetches or re-mounts the others.
+function PopoverBody({
+  groups,
+  executionsByConnection,
+  nowMs,
+}: {
+  groups: AgentInstanceGroup[];
+  executionsByConnection: Record<string, ExecutionView[]>;
+  nowMs: number;
+}) {
+  // DEFAULT COLLAPSED — the set starts empty so every agent is collapsed; a
+  // header toggle adds/removes its agentUuid.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (agentUuid: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(agentUuid)) next.delete(agentUuid);
+      else next.add(agentUuid);
+      return next;
+    });
 
   // 0-online empty state: no longer a dead-end "nobody online" sentence — show
   // the daemon-connect CTA (compact) so the user knows HOW to bring an agent
   // online. Not dismissible: once a daemon connects, this branch is replaced by
-  // the live connection list below, so the CTA disappears on its own.
-  if (onlineConnections.length === 0) {
+  // the live agent groups below, so the CTA disappears on its own.
+  if (groups.length === 0) {
     return <DaemonConnectCta variant="compact" />;
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      {onlineConnections.map((connection) => {
-        const execs = executionsByConnection[connection.uuid] ?? [];
-        // Glanceable surface: only running + queued. Interrupted rows are the
-        // modal's concern (they carry a resume affordance this popover lacks).
-        const running = execs.filter((e) => e.status === "running");
-        const queued = execs.filter((e) => e.status === "queued");
-        const hasActive = running.length > 0 || queued.length > 0;
-
-        return (
-          <div key={connection.uuid} className="flex flex-col gap-2.5">
-            <IdentityBlock connection={connection} size="sm" />
-            {hasActive ? (
-              <div className="flex flex-col gap-4 pl-1">
-                {running.length > 0 && (
-                  <ExecutionSection
-                    icon={Play}
-                    label={ta("execRunning")}
-                    count={running.length}
-                  >
-                    {running.map((exec) => (
-                      <ExecutionRow
-                        key={exec.uuid}
-                        exec={exec}
-                        nowMs={nowMs}
-                        layout="stacked"
-                      />
-                    ))}
-                  </ExecutionSection>
-                )}
-                {queued.length > 0 && (
-                  <ExecutionSection
-                    icon={ListChecks}
-                    label={ta("execQueued")}
-                    count={queued.length}
-                  >
-                    {queued.map((exec) => (
-                      <ExecutionRow
-                        key={exec.uuid}
-                        exec={exec}
-                        nowMs={nowMs}
-                        layout="stacked"
-                      />
-                    ))}
-                  </ExecutionSection>
-                )}
-              </div>
-            ) : (
-              // Quiet idle line — never blank — when an online connection has no
-              // running or queued work.
-              <p className="pl-1 text-[12px] text-[#9A9A9A]">
-                {t("connectionIdle")}
-              </p>
-            )}
-          </div>
-        );
-      })}
+    <div className="flex flex-col gap-5">
+      {groups.map((group) => (
+        <PopoverAgentGroup
+          key={group.agentUuid}
+          group={group}
+          executionsByConnection={executionsByConnection}
+          nowMs={nowMs}
+          expanded={expanded.has(group.agentUuid)}
+          onToggle={() => toggle(group.agentUuid)}
+        />
+      ))}
     </div>
   );
 }
@@ -226,9 +328,17 @@ export function AgentPresencePill({ mobile = false }: { mobile?: boolean }) {
     );
   }
 
-  const onlineConnections = connections.filter(
-    (c) => c.effectiveStatus === "online",
-  );
+  // Online-only presence (T11 / qr2): filter to the ONLINE connection set FIRST,
+  // then group. The popover lists only live (host, cwd) instances — an offline
+  // instance (including a legacy null-cwd "unknown path" row) never appears, and
+  // an agent with zero online instances produces no group at all (it disappears
+  // from presence rather than lingering as an all-offline row). Because every
+  // grouped connection is now online, each group's onlineCount equals its
+  // instance count, so the `> 0` filter is just defensive (a group can't be
+  // empty). The service's online-first sort still orders the rows.
+  const onlineAgentGroups = groupConnectionsByAgent(
+    onlineConnectionsOnly(connections),
+  ).filter((g) => g.onlineCount > 0);
 
   return (
     <Popover>
@@ -249,7 +359,7 @@ export function AgentPresencePill({ mobile = false }: { mobile?: boolean }) {
         className="max-h-[60vh] w-[min(92vw,400px)] overflow-y-auto p-3"
       >
         <PopoverContentInner
-          onlineConnections={onlineConnections}
+          groups={onlineAgentGroups}
           executionsByConnection={executionsByConnection}
           onViewAll={() => setModalOpen(true)}
         />
@@ -262,11 +372,11 @@ export function AgentPresencePill({ mobile = false }: { mobile?: boolean }) {
 // elapsed timers) only mounts when the popover is open — the PopoverContent is
 // unmounted while closed, so the interval lives exactly as long as the popover.
 function PopoverContentInner({
-  onlineConnections,
+  groups,
   executionsByConnection,
   onViewAll,
 }: {
-  onlineConnections: ConnectionView[];
+  groups: AgentInstanceGroup[];
   executionsByConnection: Record<string, ExecutionView[]>;
   onViewAll: () => void;
 }) {
@@ -281,7 +391,7 @@ function PopoverContentInner({
         </span>
       </div>
       <PopoverBody
-        onlineConnections={onlineConnections}
+        groups={groups}
         executionsByConnection={executionsByConnection}
         nowMs={nowMs}
       />

--- a/src/components/agent-presence/__tests__/conversation-reply-box.test.tsx
+++ b/src/components/agent-presence/__tests__/conversation-reply-box.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+//
+// ConversationReplyBox — the chat footer composer (子3) + the T12 (corrects T11)
+// origin-offline ESCAPE HATCH. Covers:
+//   - origin ONLINE → a live composer (no read-only banner, no escape hatch),
+//   - origin OFFLINE + agent has another ONLINE cwd → the read-only banner stays
+//     AND a "Continue on an online directory" action appears; clicking it opens
+//     the RepointForm on the online instances, and a successful re-point POSTs to
+//     the CURRENT session's /repoint endpoint (NOT /ad-hoc — no new session) and
+//     hands the SAME (re-pointed) session back to onSessionStarted so the chat
+//     keeps it selected,
+//   - origin OFFLINE + NO other online cwd → plain read-only, no escape hatch.
+//
+// next-intl resolves real en.json strings (a missing key surfaces as its dotted
+// path and would fail a text assertion). authFetch + sonner are mocked.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    let node: unknown = en;
+    for (const p of fullKey.split(".")) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations:
+      (namespace = "") =>
+      (key: string, params?: Record<string, string | number>) => {
+        let s = resolve(namespace, key);
+        if (params) {
+          for (const [k, v] of Object.entries(params)) {
+            s = s.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          }
+        }
+        return s;
+      },
+  };
+});
+
+const mockAuthFetch = vi.fn();
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
+vi.mock("@/lib/logger-client", () => ({
+  clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const mockToast = { success: vi.fn(), error: vi.fn() };
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToast.success(...args),
+    error: (...args: unknown[]) => mockToast.error(...args),
+  },
+}));
+
+import { ConversationReplyBox } from "@/components/agent-presence/send-instruction-box";
+import type { ConnectionView } from "@/components/agent-presence/types";
+
+const NOW = "2026-06-23T12:00:00.000Z";
+
+function conn(o: Partial<ConnectionView> & { uuid: string }): ConnectionView {
+  return {
+    agentUuid: "agent-1",
+    agentName: "Alpha",
+    clientType: "claude_code",
+    clientVersion: "0.11.0",
+    host: "host-1",
+    cwd: "/home/u/dev/chorus",
+    startedAt: NOW,
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: NOW,
+    lastSeenAt: NOW,
+    disconnectedAt: null,
+    ...o,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // A successful re-point returns the SAME session (its uuid is unchanged — re-point keeps
+  // the conversation's identity), now pointing at the chosen online connection.
+  mockAuthFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: {
+        session: {
+          uuid: "sess-1",
+          agentUuid: "agent-1",
+          originConnectionUuid: "online-elsewhere",
+        },
+      },
+    }),
+  });
+});
+afterEach(() => cleanup());
+
+describe("ConversationReplyBox — origin online", () => {
+  it("renders a live composer (no read-only banner, no escape hatch)", () => {
+    render(
+      <ConversationReplyBox
+        sessionUuid="sess-1"
+        originOnline
+        agentUuid="agent-1"
+        onlineConnections={[conn({ uuid: "c1" })]}
+      />,
+    );
+    // No read-only banner; the escape-hatch action is absent.
+    expect(
+      screen.queryByText(/this conversation's origin daemon is offline/i),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Continue on an online directory" }),
+    ).toBeNull();
+  });
+});
+
+describe("ConversationReplyBox — origin offline escape hatch (qr3)", () => {
+  it("offers 'Continue on an online directory' when the agent has another online cwd", () => {
+    render(
+      <ConversationReplyBox
+        sessionUuid="sess-1"
+        originOnline={false}
+        agentUuid="agent-1"
+        onlineConnections={[conn({ uuid: "online-elsewhere", cwd: "/home/u/dev/live" })]}
+      />,
+    );
+    // The read-only banner stays (origin is offline)…
+    expect(
+      screen.getByText(/this conversation's origin daemon is offline/i),
+    ).toBeTruthy();
+    // …AND the escape-hatch action is offered.
+    expect(
+      screen.getByRole("button", { name: "Continue on an online directory" }),
+    ).toBeTruthy();
+  });
+
+  it("opening the escape hatch reveals the re-point composer on the online instance", async () => {
+    render(
+      <ConversationReplyBox
+        sessionUuid="sess-1"
+        originOnline={false}
+        agentUuid="agent-1"
+        onlineConnections={[conn({ uuid: "online-elsewhere", cwd: "/home/u/dev/live" })]}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue on an online directory" }),
+    );
+    // The re-point composer surfaces the working-directory picker confirmation
+    // ("Sending to …") and its own "Send" affordance (a second Send button — the
+    // read-only banner's composer also has one, so we assert ≥1 appears).
+    await waitFor(() => expect(screen.getByText(/sending to/i)).toBeTruthy());
+    expect(
+      screen.getAllByRole("button", { name: "Send" }).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("a successful re-point POSTs the CURRENT session's /repoint (NOT /ad-hoc, NOT a new session) and hands the SAME session back to onSessionStarted", async () => {
+    const onSessionStarted = vi.fn();
+    render(
+      <ConversationReplyBox
+        sessionUuid="sess-1"
+        originOnline={false}
+        agentUuid="agent-1"
+        onlineConnections={[conn({ uuid: "online-elsewhere", cwd: "/home/u/dev/live" })]}
+        onSessionStarted={onSessionStarted}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue on an online directory" }),
+    );
+    const textarea = (await screen.findByPlaceholderText(
+      "Type an instruction for this session…",
+    )) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "pick up where we left off" } });
+    // Two "Send" buttons exist (the read-only banner's, always disabled; the re-point
+    // composer's, enabled once text is typed). Click the ENABLED one — the re-point Send.
+    const sendButton = screen
+      .getAllByRole("button", { name: "Send" })
+      .find((b) => !(b as HTMLButtonElement).disabled);
+    expect(sendButton).toBeTruthy();
+    fireEvent.click(sendButton!);
+
+    await waitFor(() => expect(onSessionStarted).toHaveBeenCalled());
+    // The POST went to the CURRENT session's /repoint endpoint with the chosen ONLINE
+    // connection + instruction text — re-pointing the SAME conversation, keeping its id.
+    const repointCall = mockAuthFetch.mock.calls.find(
+      (c) => c[0] === "/api/daemon-sessions/sess-1/repoint",
+    );
+    expect(repointCall).toBeTruthy();
+    const body = JSON.parse((repointCall![1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      connectionUuid: "online-elsewhere",
+      instructionText: "pick up where we left off",
+    });
+    // NO new ad-hoc session was minted — the /ad-hoc endpoint was NOT hit.
+    expect(
+      mockAuthFetch.mock.calls.some((c) => c[0] === "/api/daemon-sessions/ad-hoc"),
+    ).toBe(false);
+    // The SAME session (same uuid) is handed back so the chat keeps it selected.
+    expect(onSessionStarted.mock.calls[0][0]).toMatchObject({ uuid: "sess-1" });
+  });
+
+  it("keeps plain read-only (NO escape hatch) when the agent has no online cwd", () => {
+    render(
+      <ConversationReplyBox
+        sessionUuid="sess-1"
+        originOnline={false}
+        agentUuid="agent-1"
+        onlineConnections={[]}
+      />,
+    );
+    expect(
+      screen.getByText(/this conversation's origin daemon is offline/i),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Continue on an online directory" }),
+    ).toBeNull();
+  });
+});

--- a/src/components/agent-presence/__tests__/instance-group.test.ts
+++ b/src/components/agent-presence/__tests__/instance-group.test.ts
@@ -1,0 +1,196 @@
+// Unit tests for the presence drill-down pure grouping + activity helpers
+// (`groupConnectionsByAgent`, `deriveInstanceActivity`). These are framework-
+// agnostic functions (no React, no i18n) so they are tested directly, mirroring
+// the daemon-instance-format (T1) test style.
+
+import { describe, it, expect } from "vitest";
+import {
+  groupConnectionsByAgent,
+  onlineConnectionsOnly,
+  deriveInstanceActivity,
+} from "../instance-group";
+import type { ConnectionView, ExecutionView } from "../types";
+
+const NOW = "2026-06-23T12:00:00.000Z";
+
+function conn(overrides: Partial<ConnectionView> & { uuid: string }): ConnectionView {
+  return {
+    agentUuid: "agent-1",
+    agentName: "Alpha",
+    clientType: "claude_code",
+    clientVersion: "0.11.0",
+    host: "host-1",
+    cwd: "/home/u/dev/chorus",
+    startedAt: NOW,
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: NOW,
+    lastSeenAt: NOW,
+    disconnectedAt: null,
+    ...overrides,
+  };
+}
+
+function exec(overrides: Partial<ExecutionView> & { uuid: string }): ExecutionView {
+  return {
+    agentUuid: "agent-1",
+    connectionUuid: "conn-1",
+    entityType: "task",
+    entityUuid: "task-" + overrides.uuid,
+    rootIdeaUuid: null,
+    status: "running",
+    interruptedReason: null,
+    startedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    entityTitle: "Task",
+    projectUuid: "proj-1",
+    rootIdeaTitle: null,
+    ...overrides,
+  };
+}
+
+describe("groupConnectionsByAgent", () => {
+  it("groups connections by agent, preserving first-appearance order", () => {
+    const groups = groupConnectionsByAgent([
+      conn({ uuid: "a1", agentUuid: "A", agentName: "Alpha" }),
+      conn({ uuid: "b1", agentUuid: "B", agentName: "Beta" }),
+      conn({ uuid: "a2", agentUuid: "A", agentName: "Alpha" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].agentUuid).toBe("A");
+    expect(groups[0].connections.map((c) => c.uuid)).toEqual(["a1", "a2"]);
+    expect(groups[1].agentUuid).toBe("B");
+  });
+
+  it("counts only effectively-online connections per agent", () => {
+    const [group] = groupConnectionsByAgent([
+      conn({ uuid: "a1", effectiveStatus: "online" }),
+      conn({ uuid: "a2", effectiveStatus: "offline" }),
+      conn({ uuid: "a3", effectiveStatus: "online" }),
+    ]);
+    expect(group.onlineCount).toBe(2);
+    expect(group.connections).toHaveLength(3);
+  });
+
+  it("is single-host when all connections share one host", () => {
+    const [group] = groupConnectionsByAgent([
+      conn({ uuid: "a1", host: "Laptop-Q3" }),
+      conn({ uuid: "a2", host: "Laptop-Q3", cwd: "/home/u/dev/other" }),
+    ]);
+    expect(group.multiHost).toBe(false);
+    expect(group.singleHost).toBe("Laptop-Q3");
+  });
+
+  it("is multi-host when connections span 2+ distinct hosts", () => {
+    const [group] = groupConnectionsByAgent([
+      conn({ uuid: "a1", host: "Laptop-Q3" }),
+      conn({ uuid: "a2", host: "ci-runner-02" }),
+    ]);
+    expect(group.multiHost).toBe(true);
+    expect(group.singleHost).toBeUndefined();
+  });
+
+  it("treats a host-less connection as its own distinct host (disambiguates)", () => {
+    // A host-less "" connection + a named one read as 2 hosts so the per-row
+    // suffix appears to keep them distinct.
+    const [group] = groupConnectionsByAgent([
+      conn({ uuid: "a1", host: "" }),
+      conn({ uuid: "a2", host: "Laptop-Q3" }),
+    ]);
+    expect(group.multiHost).toBe(true);
+  });
+
+  it("carries the single-host '' through as singleHost (caller localizes)", () => {
+    const [group] = groupConnectionsByAgent([conn({ uuid: "a1", host: "" })]);
+    expect(group.multiHost).toBe(false);
+    expect(group.singleHost).toBe("");
+  });
+});
+
+describe("onlineConnectionsOnly", () => {
+  it("keeps only effectively-online connections (drops offline)", () => {
+    const result = onlineConnectionsOnly([
+      conn({ uuid: "a1", effectiveStatus: "online" }),
+      conn({ uuid: "a2", effectiveStatus: "offline" }),
+      conn({ uuid: "a3", effectiveStatus: "online" }),
+    ]);
+    expect(result.map((c) => c.uuid)).toEqual(["a1", "a3"]);
+  });
+
+  it("drops a legacy null-cwd OFFLINE 'unknown path' connection from presence", () => {
+    // The legacy null-cwd offline row must simply disappear from presence (T11).
+    const result = onlineConnectionsOnly([
+      conn({ uuid: "a1", cwd: null, effectiveStatus: "offline" }),
+      conn({ uuid: "a2", cwd: "/home/u/dev/chorus", effectiveStatus: "online" }),
+    ]);
+    expect(result.map((c) => c.uuid)).toEqual(["a2"]);
+  });
+
+  it("removes an agent entirely when it has zero online connections (empty group source)", () => {
+    // Grouping the online-only filter of an all-offline agent yields no group, so
+    // the agent disappears from presence rather than lingering as an offline row.
+    const offlineOnly = onlineConnectionsOnly([
+      conn({ uuid: "b1", agentUuid: "B", effectiveStatus: "offline" }),
+      conn({ uuid: "b2", agentUuid: "B", effectiveStatus: "offline" }),
+    ]);
+    expect(offlineOnly).toHaveLength(0);
+    expect(groupConnectionsByAgent(offlineOnly)).toHaveLength(0);
+  });
+
+  it("preserves input order of the surviving online connections", () => {
+    const result = onlineConnectionsOnly([
+      conn({ uuid: "a1", effectiveStatus: "online" }),
+      conn({ uuid: "a2", effectiveStatus: "offline" }),
+      conn({ uuid: "a3", effectiveStatus: "online" }),
+      conn({ uuid: "a4", effectiveStatus: "online" }),
+    ]);
+    expect(result.map((c) => c.uuid)).toEqual(["a1", "a3", "a4"]);
+  });
+});
+
+describe("deriveInstanceActivity", () => {
+  it("returns offline for an offline connection regardless of executions", () => {
+    const result = deriveInstanceActivity(
+      conn({ uuid: "a1", effectiveStatus: "offline" }),
+      [exec({ uuid: "e1", status: "running" })],
+    );
+    expect(result.state).toBe("offline");
+    expect(result.runningStartedAt).toBeNull();
+  });
+
+  it("returns running anchored to the earliest running execution start", () => {
+    const result = deriveInstanceActivity(conn({ uuid: "a1" }), [
+      exec({ uuid: "e1", status: "running", startedAt: "2026-06-23T12:05:00.000Z" }),
+      exec({ uuid: "e2", status: "running", startedAt: "2026-06-23T12:01:00.000Z" }),
+      exec({ uuid: "e3", status: "queued" }),
+    ]);
+    expect(result.state).toBe("running");
+    expect(result.runningStartedAt).toBe("2026-06-23T12:01:00.000Z");
+    expect(result.queuedCount).toBe(1);
+  });
+
+  it("falls back to createdAt when a running execution has no startedAt", () => {
+    const result = deriveInstanceActivity(conn({ uuid: "a1" }), [
+      exec({ uuid: "e1", status: "running", startedAt: null, createdAt: NOW }),
+    ]);
+    expect(result.state).toBe("running");
+    expect(result.runningStartedAt).toBe(NOW);
+  });
+
+  it("returns queued (with count) when online and only queued work", () => {
+    const result = deriveInstanceActivity(conn({ uuid: "a1" }), [
+      exec({ uuid: "e1", status: "queued" }),
+      exec({ uuid: "e2", status: "queued" }),
+    ]);
+    expect(result.state).toBe("queued");
+    expect(result.queuedCount).toBe(2);
+  });
+
+  it("returns idle when online with no running or queued work", () => {
+    const result = deriveInstanceActivity(conn({ uuid: "a1" }), [
+      exec({ uuid: "e1", status: "interrupted" }),
+    ]);
+    expect(result.state).toBe("idle");
+  });
+});

--- a/src/components/agent-presence/__tests__/instance-picker.test.tsx
+++ b/src/components/agent-presence/__tests__/instance-picker.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// InstancePicker — the SHARED path-first instance picker (cwd-addressable
+// instances) wired into the dispatch surfaces (@mention / assign / ad-hoc send).
+// This test pins the ONLINE-ONLY contract: every consumer filters its candidate
+// list to online instances BEFORE handing it here, so the picker only ever
+// renders online rows. Every rendered row is therefore selectable — there is no
+// disabled state, no "Offline" tag, and no "will queue" affordance. A single
+// instance auto-selects with no extra click.
+//
+// (An offline instance is not a target on any surface: a fully-offline agent
+// receives a plain notification, so its caller shows NO picker. That collapse is
+// asserted at the callers, not here — here the picker simply never sees offline
+// rows.)
+//
+// next-intl resolves real en.json strings so a missing key surfaces as its dotted
+// path (same harness as the other agent-presence component tests).
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    let node: unknown = en;
+    for (const p of fullKey.split(".")) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations:
+      (namespace = "") =>
+      (key: string, params?: Record<string, string | number>) => {
+        let s = resolve(namespace, key);
+        if (params) {
+          for (const [k, v] of Object.entries(params)) {
+            s = s.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          }
+        }
+        return s;
+      },
+  };
+});
+
+import {
+  InstancePicker,
+  type InstanceCandidate,
+} from "@/components/agent-presence/instance-picker";
+
+const onlineA: InstanceCandidate = {
+  connectionUuid: "conn-online-a",
+  host: "Laptop-Q3",
+  cwd: "/home/u/dev/chorus",
+  effectiveStatus: "online",
+};
+const onlineB: InstanceCandidate = {
+  connectionUuid: "conn-online-b",
+  host: "ci-runner-02",
+  cwd: "/home/u/dev/payments",
+  effectiveStatus: "online",
+};
+
+// Find the radio input for a given connectionUuid (the picker ids them
+// `instance-<connectionUuid>`).
+function radioFor(connectionUuid: string): HTMLInputElement {
+  return document.getElementById(
+    `instance-${connectionUuid}`,
+  ) as HTMLInputElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+describe("InstancePicker — online-only rows (2+ instances)", () => {
+  it("renders every (online) row enabled and selectable", () => {
+    render(
+      <InstancePicker
+        instances={[onlineA, onlineB]}
+        selectedConnectionUuid={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(radioFor("conn-online-a").disabled).toBe(false);
+    expect(radioFor("conn-online-b").disabled).toBe(false);
+  });
+
+  it("fires onSelect with the chosen candidate when a row is clicked", () => {
+    const onSelect = vi.fn();
+    render(
+      <InstancePicker
+        instances={[onlineA, onlineB]}
+        selectedConnectionUuid={onlineA.connectionUuid}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(radioFor("conn-online-b"));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionUuid: "conn-online-b" }),
+    );
+  });
+
+  it("shows NO 'Offline' tag and NO 'Queue' affordance (those concepts are gone)", () => {
+    render(
+      <InstancePicker
+        instances={[onlineA, onlineB]}
+        selectedConnectionUuid={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    // The durable-offline-queue UI was removed: neither tag should ever render.
+    expect(screen.queryByText("Offline")).toBeNull();
+    expect(screen.queryByText("Queue")).toBeNull();
+  });
+});
+
+describe("InstancePicker — single-instance auto-select", () => {
+  it("auto-selects a sole online instance with no extra click", () => {
+    const onSelect = vi.fn();
+    render(
+      <InstancePicker
+        instances={[onlineA]}
+        selectedConnectionUuid={null}
+        onSelect={onSelect}
+      />,
+    );
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionUuid: "conn-online-a" }),
+    );
+  });
+
+  it("does not re-fire onSelect once the sole instance is already selected", () => {
+    const onSelect = vi.fn();
+    render(
+      <InstancePicker
+        instances={[onlineA]}
+        selectedConnectionUuid={onlineA.connectionUuid}
+        onSelect={onSelect}
+      />,
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("InstancePicker — empty set", () => {
+  it("renders the localized 'no instances' empty state when given no instances", () => {
+    render(
+      <InstancePicker
+        instances={[]}
+        selectedConnectionUuid={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    // mentionInstance.noInstances = "No live instances".
+    expect(screen.getByText("No live instances")).toBeTruthy();
+  });
+});

--- a/src/components/agent-presence/__tests__/presence-pill-drilldown.test.tsx
+++ b/src/components/agent-presence/__tests__/presence-pill-drilldown.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+//
+// Drill-down rendering test for the sidebar presence pill popover (T2 + T11).
+// Covers the spec requirements that an agent row EXPANDS (T11: collapsed by
+// default — the per-cwd rows are revealed only after the user clicks the agent
+// header toggle) to one instance sub-row per ONLINE connection — each with its
+// own cwd (path-first) — that host is shown once for a single-host agent but
+// promoted to a per-row suffix when the agent spans 2+ hosts, that a legacy
+// null-cwd connection renders as an explicit "unknown path" instance, and that a
+// long path keeps its final segment with the full path on hover (the T1
+// formatter). Also covers the T11 online-only contract (an offline instance is
+// hidden; an all-offline agent disappears) and that the agent starts COLLAPSED.
+//
+// The pill is rendered inside a real AgentPresenceProvider; authFetch is mocked
+// + routed by URL and the SSE stream is a mock EventSource (no production seam),
+// mirroring connections-execution-view.test.tsx.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    let node: unknown = en;
+    for (const p of fullKey.split(".")) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations:
+      (namespace = "") =>
+      (key: string, params?: Record<string, string | number>) => {
+        // Simple param substitution (matches the sibling execution-view test
+        // mock). ICU plural strings are not expanded here — the tests assert on
+        // the path/host text rather than the pluralized count labels (the count
+        // derivation itself is covered by the pure instance-group unit tests).
+        let s = resolve(namespace, key);
+        if (params) {
+          for (const [k, v] of Object.entries(params)) {
+            s = s.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          }
+        }
+        return s;
+      },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const mockAuthFetch = vi.fn();
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
+vi.mock("@/lib/logger-client", () => ({
+  clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { AgentPresenceProvider } from "@/contexts/agent-presence-context";
+import { AgentPresencePill } from "@/components/agent-presence-pill";
+
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  url: string;
+  constructor(url: string) {
+    this.url = url;
+  }
+  close() {
+    this.readyState = MockEventSource.CLOSED;
+  }
+}
+
+const NOW = "2026-06-23T12:00:00.000Z";
+
+function conn(o: Record<string, unknown> & { uuid: string }) {
+  return {
+    agentUuid: "agent-1",
+    agentName: "Admin Claude",
+    clientType: "claude_code",
+    clientVersion: "0.11.0",
+    host: "Laptop-Q3",
+    cwd: "/home/u/dev/chorus",
+    startedAt: NOW,
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: NOW,
+    lastSeenAt: NOW,
+    disconnectedAt: null,
+    ...o,
+  };
+}
+
+function routeFetch(connections: unknown[], executions: unknown[] = []) {
+  mockAuthFetch.mockImplementation((url: string) => {
+    if (typeof url === "string" && url.startsWith("/api/daemon/executions")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ success: true, data: { executions } }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ success: true, data: { connections } }),
+    });
+  });
+}
+
+async function openPopover(connections: unknown[], executions: unknown[] = []) {
+  routeFetch(connections, executions);
+  render(
+    <AgentPresenceProvider>
+      <AgentPresencePill />
+    </AgentPresenceProvider>,
+  );
+  // Wait for the first poll to settle (the pill shows the online count).
+  await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+  const trigger = await screen.findByLabelText("Online agents — open details");
+  fireEvent.click(trigger);
+}
+
+// T11: the agent group is COLLAPSED by default — its per-cwd instance rows only
+// render after the header toggle is clicked. Expand every agent header so the
+// rows under test become visible (the `aria-label` is "Show <agent>'s working
+// directories" while collapsed). Wrapped in waitFor so the header has rendered
+// after the popover opened.
+async function expandAllAgents() {
+  await waitFor(() =>
+    expect(
+      screen.getAllByRole("button", { name: /working directories/ }).length,
+    ).toBeGreaterThan(0),
+  );
+  for (const toggle of screen.getAllByRole("button", {
+    name: /Show .*working directories/,
+  })) {
+    fireEvent.click(toggle);
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  // @ts-expect-error inject mock EventSource
+  global.EventSource = MockEventSource;
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  mockAuthFetch.mockReset();
+});
+
+describe("presence pill drill-down", () => {
+  it("starts COLLAPSED: instance rows are hidden until the agent is expanded", async () => {
+    await openPopover([
+      conn({ uuid: "c1", cwd: "/home/u/dev/chorus", host: "Laptop-Q3" }),
+    ]);
+    // The agent header renders (collapsed) but its per-cwd row is NOT visible yet.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Show .*working directories/ }),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByText("…/dev/chorus")).toBeNull();
+    // After expanding, the row appears and the toggle flips to the collapse label.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show .*working directories/ }),
+    );
+    await waitFor(() => expect(screen.getByText("…/dev/chorus")).toBeTruthy());
+    expect(
+      screen.getByRole("button", { name: /Hide .*working directories/ }),
+    ).toBeTruthy();
+  });
+
+  it("expands an agent into one instance sub-row per cwd connection", async () => {
+    await openPopover([
+      conn({ uuid: "c1", cwd: "/home/u/dev/chorus", host: "Laptop-Q3" }),
+      conn({ uuid: "c2", cwd: "/home/u/dev/chorus-cdk", host: "Laptop-Q3" }),
+    ]);
+    await expandAllAgents();
+    // The path chip renders the abbreviated tail (last 2 segments) as one node;
+    // two distinct cwds → two distinct instance sub-rows under the one agent.
+    await waitFor(() => {
+      expect(screen.getByText("…/dev/chorus")).toBeTruthy();
+      expect(screen.getByText("…/dev/chorus-cdk")).toBeTruthy();
+    });
+    // One agent header (not two): both instances are grouped under it.
+    expect(screen.getAllByText("Admin Claude")).toHaveLength(1);
+  });
+
+  it("shows host once at the header for a single-host agent (no per-row suffix)", async () => {
+    await openPopover([
+      conn({ uuid: "c1", cwd: "/home/u/dev/chorus", host: "Laptop-Q3" }),
+      conn({ uuid: "c2", cwd: "/home/u/dev/other", host: "Laptop-Q3" }),
+    ]);
+    await expandAllAgents();
+    await waitFor(() => expect(screen.getByText("…/dev/chorus")).toBeTruthy());
+    // Header subline carries the single host exactly once (not per-row).
+    const hostMatches = screen.getAllByText(/Laptop-Q3/);
+    expect(hostMatches).toHaveLength(1);
+  });
+
+  it("promotes host to a per-row suffix when the agent spans 2+ hosts", async () => {
+    await openPopover([
+      conn({ uuid: "c1", cwd: "/home/u/dev/chorus", host: "Laptop-Q3" }),
+      conn({ uuid: "c2", cwd: "/home/u/dev/chorus", host: "ci-runner-02" }),
+    ]);
+    await expandAllAgents();
+    await waitFor(() => expect(screen.getAllByText("…/dev/chorus").length).toBe(2));
+    // Both hosts now appear (one per instance row) so the two same-cwd rows
+    // stay distinguishable.
+    expect(screen.getByText("Laptop-Q3")).toBeTruthy();
+    expect(screen.getByText("ci-runner-02")).toBeTruthy();
+  });
+
+  it("renders a legacy null-cwd ONLINE connection as an explicit 'unknown path' instance", async () => {
+    // A null-cwd connection that is still ONLINE is a live instance (the offline
+    // 'unknown path' rows are what T11 hides — see the online-only test below).
+    await openPopover([conn({ uuid: "c1", cwd: null })]);
+    await expandAllAgents();
+    await waitFor(() => expect(screen.getByText("unknown path")).toBeTruthy());
+  });
+
+  it("keeps a long path's final segment and exposes the full path on hover", async () => {
+    await openPopover([
+      conn({
+        uuid: "c1",
+        cwd: "/home/u/dev/payments-platform/services/billing-api",
+      }),
+    ]);
+    await expandAllAgents();
+    // The abbreviated tail keeps the final segment (billing-api) intact.
+    await waitFor(() =>
+      expect(screen.getByText("…/services/billing-api")).toBeTruthy(),
+    );
+    // The chip's title is the full absolute path (hover reveal).
+    const chip = screen.getByTitle(
+      "/home/u/dev/payments-platform/services/billing-api",
+    );
+    expect(chip).toBeTruthy();
+  });
+
+  it("online-only: hides an offline sibling instance and drops an all-offline agent", async () => {
+    await openPopover([
+      // Agent A: one online + one OFFLINE instance — only the online one shows.
+      conn({
+        uuid: "a-online",
+        agentUuid: "A",
+        agentName: "Agent A",
+        cwd: "/home/u/dev/live",
+        effectiveStatus: "online",
+      }),
+      conn({
+        uuid: "a-offline",
+        agentUuid: "A",
+        agentName: "Agent A",
+        cwd: "/home/u/dev/stale",
+        effectiveStatus: "offline",
+      }),
+      // Agent B: entirely offline — its header does not appear at all.
+      conn({
+        uuid: "b-offline",
+        agentUuid: "B",
+        agentName: "Agent B",
+        cwd: "/home/u/dev/gone",
+        effectiveStatus: "offline",
+      }),
+    ]);
+    // Agent A is the only group; Agent B (all-offline) is absent.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Show Agent A.*working directories/ }),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.queryByRole("button", { name: /Agent B.*working directories/ }),
+    ).toBeNull();
+    // Expanding Agent A reveals only its ONLINE instance, never the offline one.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show Agent A.*working directories/ }),
+    );
+    await waitFor(() => expect(screen.getByText("…/dev/live")).toBeTruthy());
+    expect(screen.queryByText("…/dev/stale")).toBeNull();
+  });
+});

--- a/src/components/agent-presence/__tests__/send-instruction-box.test.tsx
+++ b/src/components/agent-presence/__tests__/send-instruction-box.test.tsx
@@ -282,18 +282,21 @@ describe("Send-instruction dock — default is a NEW conversation (ad-hoc), not 
     );
   });
 
-  it("shows only a localized 'no online connection' reason when nothing is online", async () => {
+  it("online-only deck: an all-offline connection set shows the empty 'connect a daemon' card, no send dock", async () => {
+    // T11 / qr2 reverses the old behavior where an offline connection still
+    // rendered in the deck with a disabled dock. Presence is online-only now, so
+    // an all-offline set surfaces the "no connections" empty card — never an
+    // offline row, never a (disabled) send dock to a connection that isn't shown.
     routeFetch({
       connections: [{ ...connection, status: "offline", effectiveStatus: "offline" }],
       sessions: [],
     });
     await renderView();
     await waitFor(() =>
-      expect(screen.getAllByText("Send instruction").length).toBeGreaterThan(0),
+      expect(screen.getAllByText("No agent connections yet").length).toBeGreaterThan(0),
     );
-    expect(
-      screen.getAllByText(/no online connection to send to/i).length,
-    ).toBeGreaterThan(0);
+    // No offline row, no send dock, no compose/start affordance reachable.
+    expect(screen.queryAllByText("Send instruction").length).toBe(0);
     expect(screen.queryAllByRole("button", { name: "Start session" }).length).toBe(0);
     expect(screen.queryAllByRole("button", { name: "Send" }).length).toBe(0);
   });

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -500,7 +500,22 @@ export function DaemonChat() {
   }, [detail, connections]);
   const originOnline = originConnection?.effectiveStatus === "online";
 
-  // The agent's online connections — the ad-hoc picker candidates for the send box.
+  // Whether the origin agent currently spans MULTIPLE distinct hosts. The transcript
+  // header is path-first (cwd as the instance identity) and de-emphasizes host into the
+  // "Connection details" disclosure; host is only worth surfacing inline when it actually
+  // disambiguates — i.e. the same agent has connections on >1 host, so a bare path could be
+  // ambiguous. Distinct non-empty hosts only (an unknown/"" host can't disambiguate).
+  const originCrossHost = useMemo(() => {
+    const agentUuid = originConnection?.agentUuid;
+    if (!agentUuid) return false;
+    const hosts = new Set<string>();
+    for (const c of connections) {
+      if (c.agentUuid === agentUuid && c.host !== "") hosts.add(c.host);
+    }
+    return hosts.size > 1;
+  }, [originConnection, connections]);
+
+  // The agent's online connections — gates whether the ad-hoc path is offered.
   const selectedAgentOnlineConnections = useMemo(
     () =>
       selectedAgentUuid
@@ -512,6 +527,20 @@ export function DaemonChat() {
         : [],
     [connections, selectedAgentUuid],
   );
+
+  // The OPEN conversation's agent's online connections — the candidate set for the
+  // origin-offline "Continue on an online directory" escape hatch (T11 / qr3).
+  // Sourced from the origin connection's agent (not the picked agent) so the escape
+  // hatch is always pinned to the conversation actually on screen. When the origin
+  // is offline but this set is non-empty, the reply box offers starting a NEW
+  // conversation on one of these online instances; the original stays read-only.
+  const originAgentOnlineConnections = useMemo(() => {
+    const agentUuid = originConnection?.agentUuid;
+    if (!agentUuid) return [];
+    return connections.filter(
+      (c) => c.agentUuid === agentUuid && c.effectiveStatus === "online",
+    );
+  }, [originConnection, connections]);
 
   // Display name for the selected agent (the new-conversation pane's header).
   const selectedAgentName =
@@ -570,9 +599,14 @@ export function DaemonChat() {
     setMobileDetailOpen(true);
   }, []);
 
-  // A freshly-started ad-hoc session: pull it into the list immediately (so it
-  // appears without waiting for the 15s poll) and auto-select it, sliding the new
-  // conversation's (empty) transcript into view.
+  // A freshly-started ad-hoc session OR a RE-POINTED existing conversation (T12): pull/patch
+  // it into the list immediately (so it appears / flips online without waiting for the 15s
+  // poll) and (re)select it.
+  //  - Ad-hoc start: a brand-new uuid → prepend it as a new online row, sliding the new
+  //    conversation's (empty) transcript into view.
+  //  - Re-point: the SAME uuid already in the list → patch its origin (the chosen online
+  //    connection) + `originOnline: true` IN PLACE so the SAME conversation stays selected
+  //    and flips read-only → live immediately (no switch to a different session).
   const handleSessionStarted = useCallback(
     (created: SessionView) => {
       const target: SessionTarget = {
@@ -584,17 +618,49 @@ export function DaemonChat() {
         status: created.status,
         title: created.title,
         lastTurnAt: created.lastTurnAt,
-        // The ad-hoc session is pinned to a connection we just verified online.
+        // The session is pinned to a connection we just verified online (ad-hoc start) or
+        // re-pointed to one (T12 re-point) — either way its origin is online right now.
         originOnline: true,
         // Naming fields settle on the next fetchSessions() re-sync (the just-sent
         // instruction becomes this conversation's firstInstruction server-side).
         firstInstruction: null,
         ideaTitle: null,
       };
-      setSessions((prev) =>
-        prev.some((s) => s.uuid === target.uuid)
-          ? prev
-          : [target, ...prev],
+      setSessions((prev) => {
+        const idx = prev.findIndex((s) => s.uuid === target.uuid);
+        if (idx === -1) {
+          // New conversation (ad-hoc) — prepend.
+          return [target, ...prev];
+        }
+        // Re-pointed existing conversation — patch its origin + online flag in place,
+        // preserving the naming fields the list already resolved.
+        const next = [...prev];
+        next[idx] = {
+          ...next[idx],
+          originConnectionUuid: created.originConnectionUuid,
+          originOnline: true,
+          status: created.status,
+          lastTurnAt: created.lastTurnAt,
+        };
+        return next;
+      });
+      // If the re-pointed conversation is the one currently OPEN, patch the loaded detail's
+      // origin in place too — `originConnection` (and thus the reply box's online gate) is
+      // derived from `detail.session.originConnectionUuid`, so without this the open pane
+      // would keep reading the OLD offline origin until the next reselect. This is what
+      // flips the open transcript read-only → live on the new origin immediately.
+      setDetail((prev) =>
+        prev && prev.session.uuid === created.uuid
+          ? {
+              ...prev,
+              session: {
+                ...prev.session,
+                originConnectionUuid: created.originConnectionUuid,
+                status: created.status,
+                lastTurnAt: created.lastTurnAt,
+              },
+            }
+          : prev,
       );
       setSelectedSessionUuid(created.uuid);
       // Re-sync from the server in the background (authoritative ordering + fields).
@@ -629,12 +695,15 @@ export function DaemonChat() {
       error={detailError}
       originConnection={originConnection}
       originOnline={originOnline}
+      originCrossHost={originCrossHost}
       sessionExecutions={sessionExecutions}
       executionsByUuid={executionsByUuid}
       footerLayout={footerLayout}
       hasMoreEarlier={hasMoreEarlier}
       loadingEarlier={loadingEarlier}
       onLoadEarlier={loadEarlier}
+      originAgentOnlineConnections={originAgentOnlineConnections}
+      onSessionStarted={handleSessionStarted}
     />
   );
   const transcriptPane = renderTranscript("inline");

--- a/src/components/agent-presence/chat/new-conversation-pane.tsx
+++ b/src/components/agent-presence/chat/new-conversation-pane.tsx
@@ -36,7 +36,9 @@ export function NewConversationPane({
   // composer is gated behind a non-null uuid.
   agentUuid: string | null;
   agentName: string;
-  // The selected agent's ONLINE connections — the ad-hoc picker candidates.
+  // The selected agent's ONLINE connections — gates whether the composer is live
+  // AND is the only instance set the ad-hoc picker renders (offline is never a
+  // target).
   onlineConnections: ConnectionView[];
   onStarted: (session: SessionView) => void;
 }) {

--- a/src/components/agent-presence/chat/transcript-view.tsx
+++ b/src/components/agent-presence/chat/transcript-view.tsx
@@ -31,9 +31,11 @@ import {
   ChevronDown,
   ChevronUp,
   Copy,
+  Folder,
   Info,
   Loader2,
   Lock,
+  Server,
   WifiOff,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -46,6 +48,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { clientLogger } from "@/lib/logger-client";
+import { formatCwd, formatHost } from "@/lib/daemon-instance-format";
 import { IdentityBlock } from "../identity-block";
 import { ConversationReplyBox } from "../send-instruction-box";
 import {
@@ -81,6 +84,76 @@ function DetailField({
       >
         {value}
       </div>
+    </div>
+  );
+}
+
+// The conversation's INSTANCE IDENTITY chip, shown inline in the header beneath the
+// title: path-first (the origin connection's cwd is what makes this conversation a
+// distinct (agent, host, cwd) instance), via the shared T1 `formatCwd` truncation
+// contract. A legacy daemon that never self-reported a cwd renders the localized
+// "unknown path" treatment (formatCwd(null), reusing agentPresence.unknownPath) so the
+// chip never silently disappears. Host stays DEMOTED to the "Connection details"
+// disclosure and is only surfaced here — as a second, de-emphasized badge — when
+// `crossHost` is true (the same agent spans multiple hosts, so the path alone is
+// ambiguous). The full path / host is exposed as a hover title.
+function InstanceIdentity({
+  cwd,
+  host,
+  crossHost,
+}: {
+  cwd: string | null;
+  host: string;
+  crossHost: boolean;
+}) {
+  // Root-scoped resolver: formatCwd/formatHost return i18n KEYS (e.g.
+  // "agentPresence.unknownPath") for unknown values, so we resolve them off the message
+  // root rather than a single namespace.
+  const tRoot = useTranslations();
+  const th = useTranslations("transcriptHeader");
+
+  const cwdFmt = formatCwd(cwd);
+  const cwdLabel = cwdFmt.isUnknown ? tRoot(cwdFmt.label) : cwdFmt.label;
+  const cwdTitle = cwdFmt.isUnknown ? tRoot(cwdFmt.title) : cwdFmt.title;
+
+  const hostFmt = crossHost ? formatHost(host) : null;
+  const hostLabel = hostFmt
+    ? hostFmt.isUnknown
+      ? tRoot(hostFmt.label)
+      : hostFmt.label
+    : null;
+  const hostTitle = hostFmt
+    ? hostFmt.isUnknown
+      ? tRoot(hostFmt.title)
+      : hostFmt.title
+    : null;
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+      <span
+        className={`inline-flex max-w-full items-center gap-1.5 rounded-md bg-[#F1ECE3] px-2 py-0.5 ${
+          cwdFmt.isUnknown ? "italic text-[#9A9A9A]" : "text-[#6B6B6B]"
+        }`}
+        title={`${th("cwdAriaLabel")}: ${cwdTitle}`}
+        aria-label={`${th("cwdAriaLabel")}: ${cwdTitle}`}
+      >
+        <Folder className="h-3 w-3 shrink-0 text-[#9A8C7E]" aria-hidden />
+        <span className="truncate font-mono text-[11px] font-medium">
+          {cwdLabel}
+        </span>
+      </span>
+      {hostLabel !== null && (
+        <span
+          className="inline-flex max-w-full items-center gap-1 text-[11px] font-medium text-[#9A9A9A]"
+          title={`${th("hostAriaLabel")}: ${hostTitle}`}
+          aria-label={`${th("hostAriaLabel")}: ${hostTitle}`}
+        >
+          <Server className="h-3 w-3 shrink-0" aria-hidden />
+          <span className={`truncate ${hostFmt?.isUnknown ? "italic" : ""}`}>
+            {hostLabel}
+          </span>
+        </span>
+      )}
     </div>
   );
 }
@@ -148,6 +221,12 @@ export function TranscriptView({
   // note + the details disclosure. When online, the send box + interrupt are live.
   originConnection,
   originOnline,
+  // True when the origin agent currently spans MORE THAN ONE distinct host. The header is
+  // path-first (cwd is the instance identity) and host normally lives only in the
+  // "Connection details" disclosure; we promote host INLINE beside the path chip only when
+  // it actually disambiguates — i.e. this same agent is connected on multiple hosts, so a
+  // bare path could belong to either. Resolved by the container from the connection set.
+  originCrossHost = false,
   // THIS conversation's CURRENT live executions (running / interrupted), already
   // filtered to the open session by the container (idea:<directIdeaUuid> or
   // daemon_session:<sessionId>). The single relevant one is threaded into the reply
@@ -170,6 +249,14 @@ export function TranscriptView({
   hasMoreEarlier,
   loadingEarlier,
   onLoadEarlier,
+  // Origin-offline escape hatch (T11 / qr3): the origin agent's currently-online
+  // connections. When the origin is offline BUT this set is non-empty, the reply box
+  // offers a "Continue on an online directory" action that starts a NEW conversation
+  // on a chosen online instance (the original stays read-only history). Empty → plain
+  // read-only. `onSessionStarted` hands the new session back to the container to
+  // auto-select it.
+  originAgentOnlineConnections = [],
+  onSessionStarted,
 }: {
   session: SessionView | null;
   turns: TurnWithMessagesView[];
@@ -178,12 +265,15 @@ export function TranscriptView({
   error: boolean;
   originConnection: ConnectionView | null;
   originOnline: boolean;
+  originCrossHost?: boolean;
   sessionExecutions: ExecutionView[];
   executionsByUuid: Map<string, ExecutionView>;
   footerLayout?: "inline" | "stacked";
   hasMoreEarlier: boolean;
   loadingEarlier: boolean;
   onLoadEarlier: () => void;
+  originAgentOnlineConnections?: ConnectionView[];
+  onSessionStarted?: (session: SessionView) => void;
 }) {
   const t = useTranslations("daemonChat");
   const nowMs = useNowTick();
@@ -248,16 +338,34 @@ export function TranscriptView({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Header — the <h3> title on its own line, then a SINGLE flex-wrap line that
-          carries the status badges (active/ended + running pulse + elapsed) AND the
-          'Connection details' disclosure trigger together (wrapping only if truly
-          unavoidable), saving a vertical row. The collapsible CONTENT still expands
-          below the whole line on click. The Collapsible wraps both the inline trigger
-          and the content so Radix open/close state binds correctly. */}
+      {/* Header — the title row carries the <h3> on the LEFT and the path-first instance
+          identity chip RIGHT-ALIGNED on the SAME line (justify-between), then a SINGLE
+          flex-wrap line below that carries the status badges (active/ended + running pulse
+          + elapsed) AND the 'Connection details' disclosure trigger together (wrapping only
+          if truly unavoidable). Two rows, not three. The collapsible CONTENT still expands
+          below the whole line on click. The Collapsible wraps both the inline trigger and
+          the content so Radix open/close state binds correctly. */}
       <div className="flex flex-col gap-2 px-6 py-2.5 lg:gap-3 lg:py-4">
-        <h3 className="truncate text-[17px] font-semibold text-[#2C2C2C]">
-          {title}
-        </h3>
+        {/* Title row: title left (truncates), instance-identity chip right (shrink-0). The
+            cwd path is the conversation's working-directory identity, so it shares the title
+            line rather than claiming its own full-width row. Host stays in the "Connection
+            details" disclosure below and only re-surfaces in the chip when the agent spans
+            multiple hosts (`originCrossHost`). The chip is gated on `originConnection` —
+            without one there is no instance to identify. */}
+        <div className="flex items-center justify-between gap-4">
+          <h3 className="truncate text-[17px] font-semibold text-[#2C2C2C] min-w-0">
+            {title}
+          </h3>
+          {originConnection && (
+            <div className="shrink-0">
+              <InstanceIdentity
+                cwd={originConnection.cwd}
+                host={originConnection.host}
+                crossHost={originCrossHost}
+              />
+            </div>
+          )}
+        </div>
         <Collapsible>
           <div className="flex flex-wrap items-center gap-2">
             <Badge
@@ -453,6 +561,9 @@ export function TranscriptView({
             originOnline={originOnline}
             layout={footerLayout}
             controllableExecution={composerExecution}
+            agentUuid={originConnection?.agentUuid ?? null}
+            onlineConnections={originAgentOnlineConnections}
+            onSessionStarted={onSessionStarted}
           />
         </div>
       )}

--- a/src/components/agent-presence/connections-view.tsx
+++ b/src/components/agent-presence/connections-view.tsx
@@ -59,9 +59,11 @@ import {
   ExecutionRow,
   ExecutionSection,
   IdentityBlock,
+  PathChip,
   SendInstructionBox,
   StatusBadge,
   StatusDot,
+  onlineConnectionsOnly,
   useClientTypeLabel,
   useNowTick,
   useRelativeTime,
@@ -86,6 +88,23 @@ function StatTile({ label, value, mono }: { label: string; value: string; mono?:
         className={`mt-1.5 truncate text-[15px] font-medium text-[#2C2C2C] ${mono ? "font-mono" : ""}`}
       >
         {value}
+      </div>
+    </div>
+  );
+}
+
+// The connection's working-directory tile — path-first via the shared PathChip
+// (a null cwd renders the "unknown path" treatment, the full absolute path is
+// on hover). Uses a slightly larger char budget than a row chip since the tile
+// has room. The chip self-truncates so a long path never overflows the tile.
+function PathTile({ label, cwd }: { label: string; cwd: string | null }) {
+  return (
+    <div className="rounded-xl border border-[#E5E0D8] bg-white p-4">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-[#9A9A9A]">
+        {label}
+      </div>
+      <div className="mt-1.5 flex min-w-0">
+        <PathChip cwd={cwd} formatOptions={{ charBudget: 40 }} />
       </div>
     </div>
   );
@@ -254,11 +273,16 @@ function RailRow({
         <span className="shrink-0">
           <StatusDot online={online} size="md" />
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-[14px] font-semibold text-[#2C2C2C]">
+        <span className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="truncate text-[14px] font-semibold text-[#2C2C2C]">
             {agentName}
           </span>
-          <span className="mt-0.5 flex items-center gap-1.5">
+          {/* Path-first: the connection's working directory is the primary
+              per-instance identity (a monospace path chip), so two connections
+              of one agent that differ only by cwd stay distinguishable in the
+              rail. The client type + host are demoted to a dimmed suffix. */}
+          <PathChip cwd={connection.cwd} />
+          <span className="mt-0.5 flex min-w-0 items-center gap-1.5">
             <Badge
               variant="secondary"
               className="shrink-0 border-0 bg-[#F0EDE8] px-1.5 py-0 text-[10px] font-medium text-[#6B6B6B]"
@@ -364,6 +388,7 @@ function DetailContent({
   onlineConnections: ConnectionView[];
 }) {
   const t = useTranslations("agentConnections");
+  const td = useTranslations("agentPresence.drilldown");
   const formatRelative = useRelativeTime();
   const formatUptime = useUptimeMono();
   const online = connection.effectiveStatus === "online";
@@ -409,6 +434,7 @@ function DetailContent({
                   : t("startedUnknown")
               }
             />
+            <PathTile label={td("fieldPath")} cwd={connection.cwd} />
             <StatTile
               label={t("fieldHost")}
               value={connection.host === "" ? t("hostUnknown") : connection.host}
@@ -471,6 +497,7 @@ function DetailContent({
             }
           />
         </div>
+        <PathTile label={td("fieldPath")} cwd={connection.cwd} />
         <StatTile
           label={t("fieldHost")}
           value={connection.host === "" ? t("hostUnknown") : connection.host}
@@ -542,6 +569,19 @@ export function AgentConnectionsView() {
 
   const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
 
+  // Online-only presence (T11 / qr2): this "View all" deck shows ONLY live
+  // instances — the same online-only contract as the pill popover. We derive the
+  // visible set once and feed it to the rail (desktop), the card list (mobile),
+  // the selection/derivation, and the rail count, so an offline instance
+  // (including a legacy null-cwd "unknown path" row) never appears and an agent
+  // with no online instance drops out entirely. The provider's raw `connections`
+  // is still the source of `onlineCount`/`status` (the no-silent-error gate) and
+  // of `selectedAgentOnlineConnections` (which independently filters online).
+  const visibleConnections = useMemo(
+    () => onlineConnectionsOnly(connections),
+    [connections],
+  );
+
   // "loading" only on the very first poll before any data has settled. Once the
   // provider has connections, an in-flight re-poll keeps showing the list.
   const loading = status === "loading";
@@ -559,10 +599,10 @@ export function AgentConnectionsView() {
   // one-frame flash of the "select a connection" prompt before an effect fires.
   const selected = useMemo(
     () =>
-      connections.find((c) => c.uuid === selectedUuid) ??
-      connections[0] ??
+      visibleConnections.find((c) => c.uuid === selectedUuid) ??
+      visibleConnections[0] ??
       null,
-    [connections, selectedUuid],
+    [visibleConnections, selectedUuid],
   );
   // Highlight the rail row that matches what the detail pane actually shows,
   // which is the derived selection (not the raw `selectedUuid`, which may be
@@ -606,11 +646,11 @@ export function AgentConnectionsView() {
     if (
       mobileDetailOpen &&
       selectedUuid &&
-      !connections.some((c) => c.uuid === selectedUuid)
+      !visibleConnections.some((c) => c.uuid === selectedUuid)
     ) {
       setMobileDetailOpen(false);
     }
-  }, [connections, mobileDetailOpen, selectedUuid]);
+  }, [visibleConnections, mobileDetailOpen, selectedUuid]);
 
   return (
     <div className="min-h-full bg-[#FAF8F4]">
@@ -665,11 +705,17 @@ export function AgentConnectionsView() {
               {t("subtitle")}
             </p>
           </div>
-          {!loading && connections.length > 0 && (
+          {!loading && visibleConnections.length > 0 && (
             <div className="inline-flex items-center gap-2 self-start rounded-full border border-[#E5E0D8] bg-white px-3.5 py-1.5">
               <StatusDot online={onlineCount > 0} size="md" />
+              {/* Online-only deck: `total` is the VISIBLE (online) count, not the
+                  raw connection count — offline rows are hidden, so claiming a
+                  higher total than the rendered rows would be misleading. */}
               <span className="text-[13px] font-medium text-[#2C2C2C]">
-                {t("summary", { online: onlineCount, total: connections.length })}
+                {t("summary", {
+                  online: onlineCount,
+                  total: visibleConnections.length,
+                })}
               </span>
             </div>
           )}
@@ -692,7 +738,7 @@ export function AgentConnectionsView() {
               {t("loadErrorBody")}
             </p>
           </Card>
-        ) : connections.length === 0 ? (
+        ) : visibleConnections.length === 0 ? (
           <Card className="items-center gap-4 rounded-2xl border-[#E5E0D8] bg-white p-8 text-center shadow-none md:p-12">
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#C67A5215]">
               <RadioTower className="h-6 w-6 text-[#C67A52]" />
@@ -710,9 +756,9 @@ export function AgentConnectionsView() {
           </Card>
         ) : (
           <>
-            {/* MOBILE: stacked card list (< lg) */}
+            {/* MOBILE: stacked card list (< lg) — online instances only. */}
             <div className="flex flex-col gap-3 lg:hidden">
-              {connections.map((connection) => (
+              {visibleConnections.map((connection) => (
                 <MobileCard
                   key={connection.uuid}
                   connection={connection}
@@ -734,12 +780,12 @@ export function AgentConnectionsView() {
                     {t("railHeader")}
                   </span>
                   <span className="font-mono text-[11px] font-medium text-[#9A9A9A]">
-                    {connections.length}
+                    {visibleConnections.length}
                   </span>
                 </div>
                 <div className="h-px w-full bg-[#EFEBE4]" />
                 <div className="flex flex-col">
-                  {connections.map((connection, idx) => (
+                  {visibleConnections.map((connection, idx) => (
                     <div key={connection.uuid}>
                       <RailRow
                         connection={connection}
@@ -747,7 +793,7 @@ export function AgentConnectionsView() {
                         onSelect={() => setSelectedUuid(connection.uuid)}
                         nowMs={nowMs}
                       />
-                      {idx < connections.length - 1 && (
+                      {idx < visibleConnections.length - 1 && (
                         <div className="h-px w-full bg-[#F2EEE7]" />
                       )}
                     </div>

--- a/src/components/agent-presence/identity-block.tsx
+++ b/src/components/agent-presence/identity-block.tsx
@@ -12,7 +12,9 @@
 import { useTranslations } from "next-intl";
 import { Bot, Clock3 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { formatHost } from "@/lib/daemon-instance-format";
 import { useClientTypeLabel } from "./hooks";
+import { PathChip } from "./instance-group";
 import type { ConnectionView } from "./types";
 
 // Identity tile (icon-on-tinted-square + agent name + clientType badge + version·host subline).
@@ -41,7 +43,14 @@ export function IdentityBlock({
 
   const agentName = connection.agentName?.trim() || t("unknownAgent");
   const version = connection.clientVersion ?? t("versionUnknown");
-  const host = connection.host === "" ? t("hostUnknown") : connection.host;
+  // Host is de-emphasized + truncated via the shared T1 formatter so a long
+  // host never breaks the subline; the formatter maps a host-less "" to the
+  // localized "unknown host" KEY which we resolve here.
+  const hostFmt = formatHost(connection.host);
+  const hostLabel = hostFmt.isUnknown
+    ? t("hostUnknown")
+    : hostFmt.label;
+  const hostTitle = hostFmt.isUnknown ? t("hostUnknown") : hostFmt.title;
 
   return (
     <div className="flex min-w-0 items-center gap-3">
@@ -55,15 +64,24 @@ export function IdentityBlock({
         <div className={`truncate font-semibold text-[#2C2C2C] ${nameSize}`}>
           {agentName}
         </div>
-        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+        {/* Path-first: the connection's working directory leads as a monospace
+            path chip (the primary per-instance identity). A null cwd renders
+            the "unknown path" treatment. The chip flex-shrinks within the
+            subline so a long path truncates (keeping its final segment) rather
+            than overflowing. */}
+        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+          <PathChip cwd={connection.cwd} />
           <Badge
             variant="secondary"
             className="shrink-0 border-0 bg-[#F0EDE8] px-2 py-0.5 text-[10px] font-medium text-[#6B6B6B]"
           >
             {clientTypeLabel(connection.clientType)}
           </Badge>
-          <span className="truncate font-mono text-[11px] text-[#9A9A9A]">
-            v{version} · {host}
+          <span
+            title={hostTitle}
+            className="truncate font-mono text-[11px] text-[#9A9A9A]"
+          >
+            v{version} · {hostLabel}
           </span>
         </div>
       </div>

--- a/src/components/agent-presence/index.ts
+++ b/src/components/agent-presence/index.ts
@@ -22,6 +22,23 @@ export {
 } from "./hooks";
 export { StatusDot, StatusBadge } from "./status";
 export { IdentityBlock } from "./identity-block";
+export {
+  groupConnectionsByAgent,
+  onlineConnectionsOnly,
+  deriveInstanceActivity,
+  useInstanceActivity,
+  AgentGroupHeader,
+  InstanceRow,
+  PathChip,
+  type AgentInstanceGroup,
+  type InstanceActivity,
+  type InstanceActivityState,
+} from "./instance-group";
+export {
+  InstancePicker,
+  type InstancePickerProps,
+  type InstanceCandidate,
+} from "./instance-picker";
 export { ExecutionRow, ExecutionSection } from "./execution-row";
 export { SendInstructionBox, type SessionTarget } from "./send-instruction-box";
 export { AgentConnectionsView } from "./connections-view";

--- a/src/components/agent-presence/instance-group.tsx
+++ b/src/components/agent-presence/instance-group.tsx
@@ -1,0 +1,449 @@
+"use client";
+
+// Presence drill-down — per-(agent, host, cwd) instance rendering vocabulary.
+//
+// PR #353 made `cwd` part of a DaemonConnection's unique identity
+// `(agentUuid, clientType, host, cwd)`, so one agent can be online in several
+// working directories at once and each `(agent, host, cwd)` is a distinct,
+// independently-online instance. The presence surface keeps one row per AGENT
+// and expands it to one sub-row per live INSTANCE, each leading with its own
+// `cwd` (path-first) and carrying its own `effectiveStatus` dot.
+//
+// Host is part of identity (the same path on two machines is two real
+// instances) so it is NOT removed — it is de-emphasized: shown once at the
+// agent header for a single-host agent, and promoted to a dimmed per-row
+// monospace suffix only when the agent has live instances on 2+ DISTINCT hosts.
+// A legacy `cwd = null` connection (an old daemon that never self-reported a
+// working directory) renders as an explicit "unknown path" instance and is
+// still individually listed.
+//
+// Truncation is delegated wholesale to the T1 formatter
+// (`src/lib/daemon-instance-format.ts`): a long path left-truncates keeping its
+// final segment, a long host right-truncates within a capped width, and the
+// full value is exposed on hover (title). The status dot, any tag, and the
+// path chip are laid out so the dot never shrinks and a long path/host never
+// pushes it off the row.
+//
+// Presentational + prop-driven (no data fetching). Shared by the pill popover
+// and (the cwd surfacing in) the modal so the path-first vocabulary stays
+// byte-identical.
+
+import { useTranslations } from "next-intl";
+import { Bot, ChevronDown, Folder, FolderX, Monitor } from "lucide-react";
+import {
+  formatCwd,
+  formatHost,
+  type FormatCwdOptions,
+} from "@/lib/daemon-instance-format";
+import { Button } from "@/components/ui/button";
+import { StatusDot } from "./status";
+import { useClientTypeLabel, useElapsedMono, useRelativeTime } from "./hooks";
+import type { ConnectionView, ExecutionView } from "./types";
+
+// ===== Pure grouping helpers (unit-tested independent of React) =====
+
+// One agent's live + offline instances, plus the derived host-conditional flag.
+export interface AgentInstanceGroup {
+  agentUuid: string;
+  agentName: string | null;
+  // The client type carried by this agent's connections. Connections of one
+  // agent can in principle differ by clientType (the unique key includes it),
+  // but for the header badge we surface the first connection's type — the rows
+  // themselves are keyed by the full connection so nothing is lost.
+  clientType: string;
+  connections: ConnectionView[];
+  // How many connections are effectively online (drives the header dot + count).
+  onlineCount: number;
+  // True when this agent has connections on 2+ DISTINCT hosts. When true, each
+  // instance row promotes its host to a per-row suffix so same-cwd rows on
+  // different hosts stay distinguishable; when false, the host is shown once at
+  // the agent header instead of repeated per row.
+  multiHost: boolean;
+  // The single host to show at the header when `multiHost` is false. The empty
+  // string ("") means host-less — the caller resolves it to "unknown host".
+  // Undefined when `multiHost` is true (host lives per-row instead).
+  singleHost: string | undefined;
+}
+
+/**
+ * Group a flat, already-sorted (online-first, lastSeenAt desc — see
+ * `sortConnectionViews`) list of connections into one entry per agent,
+ * preserving the input order of agents (first appearance wins) and of
+ * connections within an agent. Pure: no side effects, safe in render/test.
+ *
+ * `multiHost` is derived from the count of DISTINCT non-empty-considered host
+ * strings across the agent's connections (the empty-string host counts as its
+ * own host so a host-less + a named connection still reads as 2 hosts and the
+ * suffix appears to disambiguate them). `singleHost` is set only when there is
+ * exactly one distinct host.
+ */
+export function groupConnectionsByAgent(
+  connections: ConnectionView[],
+): AgentInstanceGroup[] {
+  const order: string[] = [];
+  const byAgent = new Map<string, ConnectionView[]>();
+  for (const conn of connections) {
+    if (!byAgent.has(conn.agentUuid)) {
+      byAgent.set(conn.agentUuid, []);
+      order.push(conn.agentUuid);
+    }
+    byAgent.get(conn.agentUuid)!.push(conn);
+  }
+
+  return order.map((agentUuid) => {
+    const conns = byAgent.get(agentUuid)!;
+    const hosts = new Set(conns.map((c) => c.host));
+    const multiHost = hosts.size > 1;
+    return {
+      agentUuid,
+      agentName: conns[0].agentName,
+      clientType: conns[0].clientType,
+      connections: conns,
+      onlineCount: conns.filter((c) => c.effectiveStatus === "online").length,
+      multiHost,
+      singleHost: multiHost ? undefined : conns[0].host,
+    };
+  });
+}
+
+/**
+ * Keep only the effectively-ONLINE connections. Presence is "what is live right
+ * now" — an offline (host, cwd) place is not a presence fact and a legacy
+ * null-cwd offline row would otherwise surface as a phantom "unknown path"
+ * instance. Filtering centrally here (rather than at each surface) means BOTH
+ * the pill popover and the connections-view "View all" render the same
+ * online-only set, and an agent that drops to zero online connections simply
+ * produces no group (so it disappears from presence rather than lingering as an
+ * all-offline row). Pure: no side effects, safe in render/test.
+ *
+ * NOTE: this does NOT replace the picker/assign online-only filtering (those
+ * surfaces already feed `InstancePicker` an online-only candidate set) nor the
+ * assign "fully-offline agent → plain notification" path — it is purely the
+ * PRESENCE surfaces' online-only filter.
+ */
+export function onlineConnectionsOnly(
+  connections: ConnectionView[],
+): ConnectionView[] {
+  return connections.filter((c) => c.effectiveStatus === "online");
+}
+
+// The derived activity state of one instance, used to drive both the subline
+// text and the status-dot tint. Pure so the branch logic is unit-testable
+// independent of React / i18n.
+//   - "offline"  → grey dot + "offline · <relative last-seen>"
+//   - "running"  → terracotta dot + "<running> · <elapsed>" (earliest running)
+//   - "queued"   → green dot + "<N queued>"
+//   - "idle"     → green dot + "idle"
+export type InstanceActivityState = "offline" | "running" | "queued" | "idle";
+
+export interface InstanceActivity {
+  state: InstanceActivityState;
+  // For "running": the ISO start of the earliest running execution (drives the
+  // elapsed timer). For "queued": the queued count. Null/0 otherwise.
+  runningStartedAt: string | null;
+  queuedCount: number;
+}
+
+/**
+ * Derive an instance's activity state from its `effectiveStatus` and its
+ * current execution slice. Offline always wins (an offline daemon shows no
+ * activity); among online states a running execution outranks a queued one,
+ * which outranks idle. The earliest running execution's `startedAt` anchors the
+ * elapsed timer (falling back to `createdAt` when a running row has no
+ * `startedAt` yet). Pure — no React, no i18n.
+ */
+export function deriveInstanceActivity(
+  connection: ConnectionView,
+  executions: ExecutionView[],
+): InstanceActivity {
+  if (connection.effectiveStatus !== "online") {
+    return { state: "offline", runningStartedAt: null, queuedCount: 0 };
+  }
+  const running = executions.filter((e) => e.status === "running");
+  const queued = executions.filter((e) => e.status === "queued");
+  if (running.length > 0) {
+    // Earliest running first so the elapsed timer reflects the longest-running
+    // turn on this instance.
+    const earliest = [...running].sort((a, b) =>
+      (a.startedAt ?? a.createdAt).localeCompare(b.startedAt ?? b.createdAt),
+    )[0];
+    return {
+      state: "running",
+      runningStartedAt: earliest.startedAt ?? earliest.createdAt,
+      queuedCount: queued.length,
+    };
+  }
+  if (queued.length > 0) {
+    return { state: "queued", runningStartedAt: null, queuedCount: queued.length };
+  }
+  return { state: "idle", runningStartedAt: null, queuedCount: 0 };
+}
+
+// Resolve an instance's activity into a localized subline string + a tinted
+// status dot. Kept as a hook (not a component) so the caller composes it into
+// the `InstanceRow`'s `activity` / `dot` props. `nowMs` drives the elapsed
+// timer for a running instance.
+export function useInstanceActivity(
+  connection: ConnectionView,
+  executions: ExecutionView[],
+  nowMs: number,
+): { text: string; dot: React.ReactNode } {
+  const td = useTranslations("agentPresence.drilldown");
+  const formatElapsed = useElapsedMono();
+  const formatRelative = useRelativeTime();
+  const activity = deriveInstanceActivity(connection, executions);
+
+  switch (activity.state) {
+    case "offline":
+      return {
+        text: td("offlineSince", {
+          time: formatRelative(connection.lastSeenAt, nowMs),
+        }),
+        dot: <StatusDot online={false} size="md" />,
+      };
+    case "running":
+      return {
+        text: td("runningFor", {
+          time: activity.runningStartedAt
+            ? formatElapsed(activity.runningStartedAt, nowMs)
+            : "",
+        }),
+        // Terracotta "busy" dot — distinct from the green online-idle dot so a
+        // working instance reads as active at a glance (matches design.pen).
+        dot: (
+          <span
+            aria-hidden
+            className="inline-flex h-2.5 w-2.5 rounded-full bg-[#C67A52]"
+          />
+        ),
+      };
+    case "queued":
+      return {
+        text: td("queuedCount", { count: activity.queuedCount }),
+        dot: <StatusDot online size="md" />,
+      };
+    default:
+      return {
+        text: td("idle"),
+        dot: <StatusDot online size="md" />,
+      };
+  }
+}
+
+// ===== Presentational sub-components =====
+
+// The monospace path chip — the primary per-instance identity. A null cwd
+// (legacy daemon) renders the "unknown path" sentinel with a distinct
+// folder-x icon; the full absolute path is exposed on hover (title) for a
+// known cwd. The chip flex-shrinks (it owns the truncation budget) so it never
+// pushes the row's status dot off the row.
+export function PathChip({
+  cwd,
+  formatOptions,
+}: {
+  cwd: string | null;
+  formatOptions?: FormatCwdOptions;
+}) {
+  const t = useTranslations("agentPresence");
+  // Coerce a missing cwd (`undefined`, e.g. a connection projected before the
+  // cwd column existed) to the `null` "unknown path" sentinel so the formatter
+  // — whose contract is `string | null` — never sees `undefined`.
+  const formatted = formatCwd(cwd ?? null, formatOptions);
+  // The formatter returns an i18n KEY when the value is unknown — resolve it
+  // here so the raw key is never printed. The `agentPresence` namespace is the
+  // root because `UNKNOWN_PATH_KEY` is `agentPresence.unknownPath`.
+  const label = formatted.isUnknown ? t("unknownPath") : formatted.label;
+  const title = formatted.isUnknown ? t("unknownPath") : formatted.title;
+  const Icon = formatted.isUnknown ? FolderX : Folder;
+
+  return (
+    <span
+      title={title}
+      className="inline-flex min-w-0 items-center gap-1.5 rounded-md bg-[#F0EDE8] px-2 py-1"
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0 text-[#9A8E7E]" aria-hidden />
+      <span
+        className={`min-w-0 truncate font-mono text-[12px] font-semibold ${
+          formatted.isUnknown ? "text-[#9A9A9A]" : "text-[#3A3631]"
+        }`}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}
+
+// A dimmed monospace host suffix (used only when the agent spans 2+ hosts).
+// Right-truncated + width-capped by the T1 formatter; full host on hover.
+function HostSuffix({ host }: { host: string }) {
+  const t = useTranslations("agentPresence");
+  const formatted = formatHost(host);
+  const label = formatted.isUnknown ? t("unknownHost") : formatted.label;
+  const title = formatted.isUnknown ? t("unknownHost") : formatted.title;
+  return (
+    <span
+      title={title}
+      className="inline-flex min-w-0 max-w-[140px] shrink items-center gap-1 truncate font-mono text-[11px] text-[#9A9A9A]"
+    >
+      <Monitor className="h-3 w-3 shrink-0" aria-hidden />
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+// One instance sub-row: path chip (primary) + a secondary subline that carries
+// the per-row host suffix (multi-host agents only) and an optional activity
+// string, with the instance's own status dot pinned to the right edge.
+//
+// `dotColor` lets a caller (the popover) tint the dot for a running instance
+// (terracotta) distinctly from an online-idle (green) / offline (grey) one;
+// when omitted it falls back to the shared online/offline StatusDot.
+export function InstanceRow({
+  connection,
+  showHost,
+  activity,
+  dot,
+}: {
+  connection: ConnectionView;
+  // When true (agent spans 2+ hosts), render the per-row host suffix.
+  showHost: boolean;
+  // Optional activity / status text for the subline (e.g. "building · 01:42",
+  // "idle", "offline · 14m ago"). Already localized + formatted by the caller.
+  activity?: string;
+  // Optional custom dot; when omitted the shared online/offline dot is used.
+  dot?: React.ReactNode;
+}) {
+  const online = connection.effectiveStatus === "online";
+  const hasSubline = showHost || !!activity;
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <PathChip cwd={connection.cwd} />
+        {hasSubline && (
+          <div className="flex min-w-0 items-center gap-1.5 pl-0.5">
+            {showHost && <HostSuffix host={connection.host} />}
+            {showHost && activity && (
+              <span aria-hidden className="shrink-0 text-[11px] text-[#C9C2B6]">
+                ·
+              </span>
+            )}
+            {activity && (
+              <span className="min-w-0 truncate text-[11px] text-[#9A9A9A]">
+                {activity}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+      <span className="shrink-0">
+        {dot ?? <StatusDot online={online} size="md" />}
+      </span>
+    </div>
+  );
+}
+
+// The agent group header: bot tile + agent name + a host-conditional subline
+// (single host once, or "client · N hosts" when multi-host) + an instance count
+// and the agent's aggregate online dot on the right.
+//
+// Collapse toggle (T11 / qr1): when `onToggle` is supplied the WHOLE header is a
+// real, keyboard-accessible toggle button carrying `aria-expanded`, and the
+// chevron rotates to reflect `expanded` (default COLLAPSED — the caller seeds
+// `expanded={false}` so the noisy per-cwd rows are hidden until the user opens
+// the agent). Without `onToggle` the header is a plain, non-interactive row
+// (the chevron is then purely decorative) so static surfaces keep their current
+// look. The instance count reflects whatever connection set the caller grouped
+// (presence surfaces group online-only, so it reads as the online count).
+export function AgentGroupHeader({
+  group,
+  expanded,
+  onToggle,
+}: {
+  group: AgentInstanceGroup;
+  // Current expand state — drives the chevron rotation + `aria-expanded`. Only
+  // meaningful when `onToggle` is supplied (an interactive header).
+  expanded?: boolean;
+  // When supplied, the header becomes a real expand/collapse toggle button.
+  onToggle?: () => void;
+}) {
+  const t = useTranslations("agentPresence");
+  const td = useTranslations("agentPresence.drilldown");
+  const tc = useTranslations("agentConnections");
+  const clientTypeLabel = useClientTypeLabel();
+
+  const agentName = group.agentName?.trim() || tc("unknownAgent");
+  const anyOnline = group.onlineCount > 0;
+  const interactive = typeof onToggle === "function";
+
+  // Subline: for a single-host agent show the client type + the one host
+  // (resolving the host-less "" to "unknown host"); for a multi-host agent show
+  // the client type + an "N hosts" count (the per-row host suffix disambiguates
+  // the actual hosts).
+  const distinctHosts = new Set(group.connections.map((c) => c.host)).size;
+  const hostLabel =
+    group.singleHost === ""
+      ? t("unknownHost")
+      : (group.singleHost ?? "");
+  const subline = group.multiHost
+    ? `${clientTypeLabel(group.clientType)} · ${td("hostsCount", { count: distinctHosts })}`
+    : `${clientTypeLabel(group.clientType)} · ${hostLabel}`;
+
+  const inner = (
+    <>
+      <ChevronDown
+        className={`h-4 w-4 shrink-0 text-[#B7AE9F] transition-transform ${
+          interactive && expanded ? "rotate-180" : ""
+        }`}
+        aria-hidden
+      />
+      <div
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+        style={{ backgroundColor: anyOnline ? "#C67A5214" : "#9A9A9A14" }}
+      >
+        {/* Bot glyph — warm terracotta when any instance is online, else grey.
+            Mirrors the IdentityBlock tile vocabulary. */}
+        <Bot
+          className="h-5 w-5"
+          style={{ color: anyOnline ? "#C67A52" : "#9A9A9A" }}
+          aria-hidden
+        />
+      </div>
+      <div className="min-w-0 flex-1 text-left">
+        <div className="truncate text-[14px] font-semibold text-[#2C2C2C]">
+          {agentName}
+        </div>
+        <div className="mt-0.5 truncate text-[12px] text-[#9A9A9A]">
+          {subline}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <span className="text-[12px] text-[#9A9A9A]">
+          {td("instancesCount", { count: group.connections.length })}
+        </span>
+        <StatusDot online={anyOnline} size="md" />
+      </div>
+    </>
+  );
+
+  if (!interactive) {
+    return <div className="flex items-center gap-2.5">{inner}</div>;
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-label={
+        expanded
+          ? td("collapseAgent", { agent: agentName })
+          : td("expandAgent", { agent: agentName })
+      }
+      className="flex h-auto w-full items-center justify-start gap-2.5 rounded-lg px-1.5 py-1 hover:bg-[#FBF4EF]"
+    >
+      {inner}
+    </Button>
+  );
+}

--- a/src/components/agent-presence/instance-picker.tsx
+++ b/src/components/agent-presence/instance-picker.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+// Shared instance picker — a path-first selectable list of an agent's ONLINE
+// (host, cwd) daemon instances.
+//
+// A daemon instance is identified by `(agentUuid, clientType, host, cwd)` (see
+// DaemonConnection). This component renders one selectable row per instance,
+// path-first (cwd primary via formatCwd) and host-conditional (host shown as a
+// per-row suffix only when the agent spans 2+ distinct hosts, per the spec's
+// "host-conditional" rule). It is consumed by:
+//   - the @mention secondary picker (live wake target),
+//   - the task-assignment cwd pin,
+//   - the ad-hoc send picker (live send).
+//
+// ONLINE-ONLY: every consumer filters its candidate list to online instances
+// BEFORE handing it here, so the picker never sees an offline (host, cwd) place.
+// An offline instance is not a valid target on any surface — a fully-offline
+// agent simply receives a plain notification (no pin, no wake), so its caller
+// shows NO picker at all. Consequently every row this component renders is
+// selectable; there is no disabled state and no "will queue" affordance.
+//
+// A SINGLE instance auto-selects (no extra click) via an effect — the common
+// single-daemon case needs no interaction.
+//
+// Presentational + prop-driven: it never fetches the instance list itself. The
+// caller passes the online instances (each {connectionUuid, host, cwd,
+// effectiveStatus}) and owns the selected connectionUuid.
+
+import { useEffect, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { Folder } from "lucide-react";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { cn } from "@/lib/utils";
+import {
+  formatCwd,
+  formatHost,
+  type FormatCwdOptions,
+  type FormatHostOptions,
+} from "@/lib/daemon-instance-format";
+import { StatusDot } from "./status";
+
+/**
+ * One selectable daemon instance. A structural subset of `ConnectionView`
+ * (daemon-connection.service) carrying exactly the fields the picker renders, so
+ * every consumer (mention / assign / send) maps its data to this shape.
+ */
+export interface InstanceCandidate {
+  /** The current live `DaemonConnection.uuid` for this (host, cwd) place. */
+  connectionUuid: string;
+  /** Host the instance runs on. "" denotes an unknown/host-less self-report. */
+  host: string;
+  /** Working directory. null for a legacy daemon that never self-reported one. */
+  cwd: string | null;
+  /**
+   * Server-derived liveness verdict. The picker only ever renders online
+   * instances (callers filter beforehand); this field is retained so the
+   * candidate shape stays a structural subset of `ConnectionView` and the
+   * status dot can render verbatim.
+   */
+  effectiveStatus: "online" | "offline";
+}
+
+export interface InstancePickerProps {
+  /** The agent's ONLINE instances to choose from (callers filter offline out). */
+  instances: InstanceCandidate[];
+  /**
+   * The currently selected instance's connectionUuid, or null when none picked.
+   * Controlled: the caller owns selection state.
+   */
+  selectedConnectionUuid: string | null;
+  /**
+   * Selection callback. Receives the full candidate (so the caller can read the
+   * durable (host, cwd) place, not just the ephemeral connectionUuid).
+   */
+  onSelect: (instance: InstanceCandidate) => void;
+  /** Optional className on the root list. */
+  className?: string;
+  /** Forwarded to formatCwd for callers with a tighter/looser path budget. */
+  cwdFormatOptions?: FormatCwdOptions;
+  /** Forwarded to formatHost for callers with a tighter/looser host budget. */
+  hostFormatOptions?: FormatHostOptions;
+  /** Accessible label for the radio group (defaults to the localized title). */
+  ariaLabel?: string;
+}
+
+/**
+ * Monospace path chip — a folder glyph + the path-first cwd label. The full
+ * absolute path (or the localized "unknown path" for a legacy null-cwd) is
+ * exposed on hover via the title. Matches design.pen "Path Chip".
+ */
+function PathChip({
+  cwd,
+  formatOptions,
+}: {
+  cwd: string | null;
+  formatOptions?: FormatCwdOptions;
+}) {
+  const t = useTranslations();
+  const formatted = formatCwd(cwd, formatOptions);
+  // isUnknown → label/title are i18n KEYS; resolve via t(). Otherwise the helper
+  // already returned the (possibly truncated) literal path / full path title.
+  const label = formatted.isUnknown ? t(formatted.label) : formatted.label;
+  const title = formatted.isUnknown ? t(formatted.title) : formatted.title;
+  return (
+    <span
+      title={title}
+      className={cn(
+        "inline-flex min-w-0 items-center gap-1.5 rounded-md border border-[#E5E0D8] bg-[#FAF8F4] px-2 py-0.5",
+        "font-mono text-xs",
+        formatted.isUnknown ? "text-[#9A9A9A] italic" : "text-[#2C2C2C]",
+      )}
+    >
+      <Folder className="size-3 shrink-0 text-[#9A9A9A]" aria-hidden />
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+/**
+ * De-emphasized host suffix — a dimmed monospace host, right-truncated and
+ * width-capped (formatHost). Rendered only when the agent spans 2+ hosts (the
+ * caller passes `show`). The full host is on hover via title.
+ */
+function HostSuffix({
+  host,
+  formatOptions,
+}: {
+  host: string;
+  formatOptions?: FormatHostOptions;
+}) {
+  const t = useTranslations();
+  const formatted = formatHost(host, formatOptions);
+  const label = formatted.isUnknown ? t(formatted.label) : formatted.label;
+  const title = formatted.isUnknown ? t(formatted.title) : formatted.title;
+  return (
+    <span
+      title={title}
+      className="shrink-0 truncate font-mono text-[10px] text-[#9A9A9A]"
+    >
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Path-first, host-conditional selectable list of an agent's ONLINE (host, cwd)
+ * instances. See module header for the online-only contract.
+ */
+export function InstancePicker({
+  instances,
+  selectedConnectionUuid,
+  onSelect,
+  className,
+  cwdFormatOptions,
+  hostFormatOptions,
+  ariaLabel,
+}: InstancePickerProps) {
+  const t = useTranslations("mentionInstance");
+
+  // Host-conditional rule: only surface a per-row host suffix when the agent's
+  // instances span 2+ DISTINCT hosts (otherwise the host is redundant noise and
+  // is shown once at the header by the caller). Memoized over the host set.
+  const isMultiHost = useMemo(() => {
+    const hosts = new Set(instances.map((i) => i.host));
+    return hosts.size > 1;
+  }, [instances]);
+
+  // Single-instance auto-select: when exactly one (online) instance exists, pick
+  // it with no extra click. Guarded so it never re-fires once it is already the
+  // selection.
+  const soleInstance = instances.length === 1 ? instances[0] : null;
+  useEffect(() => {
+    if (soleInstance && selectedConnectionUuid !== soleInstance.connectionUuid) {
+      onSelect(soleInstance);
+    }
+    // onSelect is treated as stable per the controlled-component contract.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [soleInstance, selectedConnectionUuid]);
+
+  if (instances.length === 0) {
+    return (
+      <div className={cn("py-2 text-xs text-[#9A9A9A]", className)}>
+        {t("noInstances")}
+      </div>
+    );
+  }
+
+  return (
+    <RadioGroup
+      aria-label={ariaLabel ?? t("title")}
+      value={selectedConnectionUuid ?? undefined}
+      onValueChange={(value) => {
+        const next = instances.find((i) => i.connectionUuid === value);
+        if (next) onSelect(next);
+      }}
+      className={cn("gap-1.5", className)}
+    >
+      {instances.map((instance) => {
+        const radioId = `instance-${instance.connectionUuid}`;
+        return (
+          <label
+            key={instance.connectionUuid}
+            htmlFor={radioId}
+            className={cn(
+              "flex items-center gap-2.5 rounded-md border px-2.5 py-2 transition-colors",
+              "cursor-pointer border-[#E5E0D8] hover:bg-[#FAF8F4]",
+              selectedConnectionUuid === instance.connectionUuid &&
+                "border-[#C67A52] bg-[#FAF8F4]",
+            )}
+          >
+            {/* Status dot — pinned to the row edge, never shrinks. Always online
+                (the picker only renders online instances). */}
+            <span className="flex shrink-0 items-center" aria-hidden>
+              <StatusDot online />
+            </span>
+
+            {/* Path-first identity. Path keeps shrink priority; host follows. */}
+            <span className="flex min-w-0 flex-1 items-center gap-2">
+              <PathChip cwd={instance.cwd} formatOptions={cwdFormatOptions} />
+              {isMultiHost && (
+                <HostSuffix
+                  host={instance.host}
+                  formatOptions={hostFormatOptions}
+                />
+              )}
+            </span>
+
+            {/* Selection control — pinned to the row edge, never shrinks. */}
+            <RadioGroupItem
+              id={radioId}
+              value={instance.connectionUuid}
+              className="shrink-0"
+            />
+          </label>
+        );
+      })}
+    </RadioGroup>
+  );
+}

--- a/src/components/agent-presence/send-instruction-box.tsx
+++ b/src/components/agent-presence/send-instruction-box.tsx
@@ -44,8 +44,9 @@ import {
 import { authFetch } from "@/lib/auth-client";
 import { clientLogger } from "@/lib/logger-client";
 import { isImeComposing } from "@/lib/ime";
-import { useClientTypeLabel } from "./hooks";
+import { formatCwd, formatHost } from "@/lib/daemon-instance-format";
 import { InterruptButton, ResumeButton } from "./execution-row";
+import { InstancePicker, type InstanceCandidate } from "./instance-picker";
 import type { ConnectionView, ExecutionView } from "./types";
 import type { SessionView } from "@/services/daemon-session.service";
 
@@ -242,6 +243,20 @@ function ComposeField({
 // (the server re-checks and 409s otherwise); when offline the box is disabled
 // with the localized read-only reason, never silently inert.
 //
+// Origin-offline escape hatch (T12 — corrects T11): `claude --resume` is cwd/machine-
+// bound, so THIS conversation cannot be resumed on its offline origin. But when the SAME
+// agent still has ≥1 OTHER ONLINE (host, cwd) instance, we surface a "Continue on an
+// online directory" action beside the read-only banner. It opens the RepointForm
+// (→ POST /api/daemon-sessions/{sessionUuid}/repoint) which RE-POINTS this SAME
+// conversation's origin onto the chosen online instance and sends a fresh turn there —
+// KEEPING the same DaemonSession (same uuid + sessionId). The daemon, finding no
+// transcript at the new cwd, starts a fresh transcript under the SAME id (cold start, no
+// context injection); the prior turns stay as read-only history. `onSessionStarted` hands
+// the SAME (now re-pointed, online) session back so the chat keeps it selected and it
+// flips read-only → live. We do NOT mint a new ad-hoc session (the T11 mistake, which lost
+// the conversation's identity). When the agent has NO online instance, the box stays plain
+// read-only.
+//
 // Action row (子 — daemon chat refinement): the footer no longer stacks a
 // standalone ExecutionRow card above this box. Instead this conversation's
 // in-flight execution (running / user-interrupted / crash) is threaded into
@@ -255,6 +270,9 @@ export function ConversationReplyBox({
   originOnline,
   layout = "inline",
   controllableExecution,
+  agentUuid,
+  onlineConnections = [],
+  onSessionStarted,
 }: {
   // The open conversation's uuid — replies POST to its `/instruction` endpoint.
   sessionUuid: string;
@@ -265,11 +283,29 @@ export function ConversationReplyBox({
   // THIS conversation's controllable execution (running or user/crash-interrupted),
   // if any — hosted in the composer's action row (Interrupt / Resume / hint).
   controllableExecution?: ExecutionView | null;
+  // The conversation's agent — the target for the origin-offline escape hatch's
+  // ad-hoc start. Null when the origin connection isn't resolved (no escape hatch).
+  agentUuid?: string | null;
+  // The SAME agent's currently-online connections (the escape-hatch candidate set,
+  // fed straight to the ad-hoc picker). Empty when nothing else is online → no
+  // escape hatch is offered (plain read-only).
+  onlineConnections?: ConnectionView[];
+  // Auto-select the freshly-started conversation after an ad-hoc start.
+  onSessionStarted?: (session: SessionView) => void;
 }) {
   const t = useTranslations("agentConnections");
   const tc = useTranslations("daemonChat");
   const [value, setValue] = useState("");
   const [pending, setPending] = useState(false);
+  // The escape-hatch ad-hoc composer is collapsed by default — it appears only
+  // after the user opts in via the "Continue on an online directory" action, so
+  // the offline conversation isn't crowded by a picker the user may not want.
+  const [continueOpen, setContinueOpen] = useState(false);
+
+  // The origin-offline escape hatch is available only when the origin is offline
+  // AND the same agent has at least one OTHER online instance to dispatch to.
+  const canContinueElsewhere =
+    !originOnline && !!agentUuid && onlineConnections.length > 0;
 
   const send = async () => {
     const trimmed = value.trim();
@@ -300,18 +336,212 @@ export function ConversationReplyBox({
   };
 
   return (
-    <ComposeField
-      value={value}
-      onChange={setValue}
-      onSend={send}
-      pending={pending}
-      disabled={!originOnline}
-      disabledReason={!originOnline ? tc("originOfflineNote") : null}
-      placeholder={tc("replyPlaceholder")}
-      sendLabel={t("send")}
-      layout={layout}
-      controllableExecution={controllableExecution}
-    />
+    <div className="flex flex-col gap-2.5">
+      <ComposeField
+        value={value}
+        onChange={setValue}
+        onSend={send}
+        pending={pending}
+        disabled={!originOnline}
+        disabledReason={!originOnline ? tc("originOfflineNote") : null}
+        placeholder={tc("replyPlaceholder")}
+        sendLabel={t("send")}
+        layout={layout}
+        controllableExecution={controllableExecution}
+      />
+      {/* Origin-offline escape hatch — only when the same agent has another online
+          instance. This RE-POINTS the SAME conversation's origin onto a chosen online
+          (host, cwd) and sends a fresh turn there (same sessionId, cold start); the prior
+          turns stay as read-only history. It does NOT start a new conversation. */}
+      {canContinueElsewhere &&
+        (continueOpen ? (
+          <div className="flex flex-col gap-2">
+            <span className="text-[12px] font-medium text-[#6B6B6B]">
+              {tc("continueOnlineHelp")}
+            </span>
+            <RepointForm
+              sessionUuid={sessionUuid}
+              onlineConnections={onlineConnections}
+              layout={layout}
+              onRepointed={onSessionStarted}
+            />
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setContinueOpen(true)}
+            className="h-8 w-fit gap-1.5 rounded-lg border-[#E5D5C6] bg-white text-[12px] font-medium text-[#C67A52] hover:bg-[#FBF4EF] hover:text-[#A65F3C]"
+          >
+            <MessageCirclePlus className="h-3.5 w-3.5" aria-hidden />
+            {tc("continueOnlineAction")}
+          </Button>
+        ))}
+    </div>
+  );
+}
+
+// =====================================================================
+// RepointForm — the origin-offline escape-hatch composer (T12). A connection picker
+// (the SAME agent's ONLINE instances) + compose surface that RE-POINTS the CURRENT
+// conversation's origin onto the chosen online instance and sends a fresh turn there,
+// via POST /api/daemon-sessions/{sessionUuid}/repoint. It KEEPS the same DaemonSession
+// (same uuid + sessionId): the server moves `originConnectionUuid` and creates a turn on
+// the SAME row; the daemon, finding no transcript at the new cwd, starts a fresh
+// transcript under the same id (cold start). On success `onRepointed` hands the SAME
+// (now online) session back so the chat keeps it selected and it flips read-only → live —
+// it does NOT auto-switch to a different conversation.
+//
+// Visually mirrors AdHocSendForm (the same picker + "Sending to …" confirmation + compose)
+// so the escape hatch reads identically; the ONLY difference is the endpoint + that it
+// re-points an existing conversation rather than starting a new one.
+// =====================================================================
+
+export function RepointForm({
+  sessionUuid,
+  onlineConnections,
+  layout,
+  onRepointed,
+}: {
+  // The CURRENT conversation's session uuid — the re-point targets THIS session (same id).
+  sessionUuid: string;
+  // The SAME agent's currently-online connections (the re-point candidate set). A live
+  // re-point requires online, so only the online set is shown; the server re-verifies
+  // same-agent + online on POST.
+  onlineConnections: ConnectionView[];
+  layout: "inline" | "stacked";
+  // Called with the SAME (now re-pointed, online) session after success, so the chat keeps
+  // this conversation selected and it flips read-only → live on the new origin.
+  onRepointed?: (session: SessionView) => void;
+}) {
+  const t = useTranslations("agentConnections");
+  const ta = useTranslations("assignInstance");
+  const tc = useTranslations("daemonChat");
+
+  // The picker's instance set: the ONLINE connection set only (a live re-point needs
+  // online). Mapped to the shared InstanceCandidate shape.
+  const instances: InstanceCandidate[] = useMemo(
+    () =>
+      onlineConnections.map((c) => ({
+        connectionUuid: c.uuid,
+        host: c.host ?? "",
+        cwd: c.cwd ?? null,
+        effectiveStatus: c.effectiveStatus,
+      })),
+    [onlineConnections],
+  );
+
+  // Default to the first ONLINE connection so the common single-other-daemon case needs no
+  // extra click. Live re-points require online, so the default never lands on an offline row.
+  const [connectionUuid, setConnectionUuid] = useState<string>(
+    onlineConnections[0]?.uuid ?? "",
+  );
+  const [value, setValue] = useState("");
+  const [pending, setPending] = useState(false);
+
+  const selectedInstance =
+    instances.find(
+      (i) =>
+        i.connectionUuid === connectionUuid && i.effectiveStatus === "online",
+    ) ?? null;
+  const isMultiHost = useMemo(
+    () => new Set(instances.map((i) => i.host)).size > 1,
+    [instances],
+  );
+
+  const send = async () => {
+    const trimmed = value.trim();
+    // Block only no-connection / empty (both already disable Send); over-length goes to the
+    // server so its 400 reason toasts (no silent dead button).
+    if (!connectionUuid || trimmed.length === 0) {
+      return;
+    }
+    setPending(true);
+    try {
+      const res = await authFetch(
+        `/api/daemon-sessions/${sessionUuid}/repoint`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ connectionUuid, instructionText: trimmed }),
+        },
+      );
+      if (!res.ok) {
+        toast.error(await extractError(res, t("instructionError")));
+        return;
+      }
+      // Surface the re-pointed session so the chat keeps it selected (same uuid) and it
+      // flips read-only → live. Tolerate a fieldless body (the toast still fires).
+      let repointedSession: SessionView | null = null;
+      try {
+        const json = await res.json();
+        if (json?.success && json.data?.session) {
+          repointedSession = json.data.session as SessionView;
+        }
+      } catch {
+        // Non-JSON success body — nothing to hand back, not an error.
+      }
+      toast.success(tc("continueOnlineStarted"));
+      setValue("");
+      if (repointedSession) onRepointed?.(repointedSession);
+    } catch (error) {
+      clientLogger.error("Failed to re-point daemon session:", error);
+      toast.error(t("instructionError"));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  // The send confirmation line — names the resolved (path · host) before re-pointing. Host
+  // is shown only when it disambiguates (the agent spans 2+ hosts). Hidden until an online
+  // instance is selected.
+  const sendingToLabel = (() => {
+    if (!selectedInstance) return null;
+    const cwd = formatCwd(selectedInstance.cwd);
+    const pathLabel = cwd.isUnknown ? ta(cwd.label) : cwd.label;
+    if (isMultiHost) {
+      const host = formatHost(selectedInstance.host);
+      const hostLabel = host.isUnknown ? ta(host.label) : host.label;
+      return ta("sendingToWithHost", { path: pathLabel, host: hostLabel });
+    }
+    return ta("sendingTo", { path: pathLabel });
+  })();
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-dashed border-[#E5E0D8] bg-white p-4">
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-[#9A9A9A]">
+          {ta("workingDirectory")}
+        </span>
+        {/* Live re-point → online instances ONLY (offline is never a target). The server
+            still re-verifies same-agent + online on POST. */}
+        <InstancePicker
+          instances={instances}
+          selectedConnectionUuid={connectionUuid || null}
+          onSelect={(inst) => setConnectionUuid(inst.connectionUuid)}
+          ariaLabel={t("pickConnection")}
+        />
+      </div>
+      {/* Resolved-target confirmation, shown before the re-point fires. */}
+      {sendingToLabel && (
+        <div className="flex items-center gap-1.5 text-[11px] text-[#6B6B6B]">
+          <SendHorizonal className="h-3 w-3 shrink-0 text-[#9A9A9A]" aria-hidden />
+          <span className="min-w-0 truncate">{sendingToLabel}</span>
+        </div>
+      )}
+      <ComposeField
+        value={value}
+        onChange={setValue}
+        onSend={send}
+        pending={pending}
+        disabled={!selectedInstance}
+        disabledReason={!selectedInstance ? ta("offlineCantRun") : null}
+        placeholder={t("sendInstructionPlaceholder")}
+        sendLabel={t("send")}
+        layout={layout}
+      />
+    </div>
   );
 }
 
@@ -331,7 +561,10 @@ export function AdHocSendForm({
 }: {
   agentUuid: string;
   // Online connections of the SELECTED agent only (the picker never lists another
-  // agent's connections — the server re-verifies ownership + online on POST).
+  // agent's connections — the server re-verifies ownership + online on POST). The
+  // common single-daemon case auto-selects the sole online instance. A live send
+  // requires online, so the picker is fed the online set ONLY — an offline
+  // instance is never shown.
   onlineConnections: ConnectionView[];
   layout: "inline" | "stacked";
   // When the surrounding pane already carries its own heading (e.g. the chat's
@@ -342,14 +575,43 @@ export function AdHocSendForm({
   onStarted?: (session: SessionView) => void;
 }) {
   const t = useTranslations("agentConnections");
-  const clientTypeLabel = useClientTypeLabel();
-  // Default to the first online connection so the common single-daemon case needs
-  // no extra click; the user can re-pick when several are online.
+  const ta = useTranslations("assignInstance");
+
+  // The picker's instance set: the ONLINE connection set only (a live send needs
+  // online). Mapped to the shared InstanceCandidate shape.
+  const instances: InstanceCandidate[] = useMemo(
+    () =>
+      onlineConnections.map((c) => ({
+        connectionUuid: c.uuid,
+        host: c.host ?? "",
+        // null (and any missing self-report) → the "unknown path" instance.
+        cwd: c.cwd ?? null,
+        effectiveStatus: c.effectiveStatus,
+      })),
+    [onlineConnections],
+  );
+
+  // Default to the first ONLINE connection so the common single-daemon case needs
+  // no extra click (the picker also auto-selects a sole online instance). Live
+  // sends require online, so the default never lands on an offline row.
   const [connectionUuid, setConnectionUuid] = useState<string>(
     onlineConnections[0]?.uuid ?? "",
   );
   const [value, setValue] = useState("");
   const [pending, setPending] = useState(false);
+
+  // The resolved (online) instance, for the send confirmation footer. A live send
+  // is only ever to an online instance, so an unresolved/offline selection yields
+  // no footer (and Send is disabled).
+  const selectedInstance =
+    instances.find(
+      (i) =>
+        i.connectionUuid === connectionUuid && i.effectiveStatus === "online",
+    ) ?? null;
+  const isMultiHost = useMemo(
+    () => new Set(instances.map((i) => i.host)).size > 1,
+    [instances],
+  );
 
   const send = async () => {
     const trimmed = value.trim();
@@ -391,6 +653,21 @@ export function AdHocSendForm({
     }
   };
 
+  // The send confirmation line — names the resolved (path · host) before sending
+  // (cwd-addressable instances, T4). Host is shown only when it disambiguates
+  // (the agent spans 2+ hosts). Hidden until an online instance is selected.
+  const sendingToLabel = (() => {
+    if (!selectedInstance) return null;
+    const cwd = formatCwd(selectedInstance.cwd);
+    const pathLabel = cwd.isUnknown ? ta(cwd.label) : cwd.label;
+    if (isMultiHost) {
+      const host = formatHost(selectedInstance.host);
+      const hostLabel = host.isUnknown ? ta(host.label) : host.label;
+      return ta("sendingToWithHost", { path: pathLabel, host: hostLabel });
+    }
+    return ta("sendingTo", { path: pathLabel });
+  })();
+
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-dashed border-[#E5E0D8] bg-white p-4">
       {!hideHeader && (
@@ -399,40 +676,40 @@ export function AdHocSendForm({
             {t("adHocTitle")}
           </span>
           <span className="text-[12px] leading-relaxed text-[#9A9A9A]">
-            {t("adHocBody")}
+            {ta("liveSendNote")}
           </span>
         </div>
       )}
       <div className="flex flex-col gap-1.5">
         <span className="text-[11px] font-medium uppercase tracking-wide text-[#9A9A9A]">
-          {t("pickConnection")}
+          {ta("workingDirectory")}
         </span>
-        <Select value={connectionUuid} onValueChange={setConnectionUuid}>
-          <SelectTrigger
-            aria-label={t("pickConnection")}
-            className="w-full rounded-lg border-[#E5E0D8] bg-white text-[13px] text-[#2C2C2C]"
-          >
-            <SelectValue placeholder={t("pickConnectionPlaceholder")} />
-          </SelectTrigger>
-          <SelectContent>
-            {onlineConnections.map((conn) => (
-              <SelectItem key={conn.uuid} value={conn.uuid}>
-                {(conn.agentName?.trim() || t("unknownAgent")) +
-                  " · " +
-                  clientTypeLabel(conn.clientType) +
-                  (conn.host ? " · " + conn.host : "")}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {/* Live send → online instances ONLY (offline is never a send target).
+            The server still re-verifies ownership + online on POST. */}
+        <InstancePicker
+          instances={instances}
+          selectedConnectionUuid={connectionUuid || null}
+          onSelect={(inst) => setConnectionUuid(inst.connectionUuid)}
+          ariaLabel={t("pickConnection")}
+        />
       </div>
+      {/* Resolved-target confirmation, shown before the live send fires. */}
+      {sendingToLabel && (
+        <div className="flex items-center gap-1.5 text-[11px] text-[#6B6B6B]">
+          <SendHorizonal className="h-3 w-3 shrink-0 text-[#9A9A9A]" aria-hidden />
+          <span className="min-w-0 truncate">{sendingToLabel}</span>
+        </div>
+      )}
       <ComposeField
         value={value}
         onChange={setValue}
         onSend={send}
         pending={pending}
-        disabled={false}
-        disabledReason={null}
+        // No online instance selected → hard-disable with a visible reason rather
+        // than a dead Send (e.g. the user picked an offline row, which the picker
+        // already blocks, or no online instance exists at all).
+        disabled={!selectedInstance}
+        disabledReason={!selectedInstance ? ta("offlineCantRun") : null}
         placeholder={t("sendInstructionPlaceholder")}
         sendLabel={t("startSession")}
         layout={layout}
@@ -463,7 +740,8 @@ export function SendInstructionBox({
   // The caller's visible daemon sessions (GET /api/daemon-sessions). Filtered here to the
   // selected connection's agent; the user may pick one to CONTINUE, or start a new one.
   sessions: SessionTarget[];
-  // The agent's currently-online connections, for the ad-hoc picker.
+  // The agent's currently-online connections — gates whether the ad-hoc path is offered
+  // AND is the ONLY instance set the ad-hoc picker renders (offline is never a target).
   onlineConnections: ConnectionView[];
   layout?: "inline" | "stacked";
 }) {

--- a/src/components/mention-editor.tsx
+++ b/src/components/mention-editor.tsx
@@ -14,6 +14,20 @@ import Mention from "@tiptap/extension-mention";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { isImeComposing } from "@/lib/ime";
+import { buildMentionMarker, decodePinSuffix } from "@/lib/mention-format";
+import {
+  InstancePicker,
+  type InstanceCandidate,
+} from "@/components/agent-presence/instance-picker";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
 // Localized strings the (module-level, hook-less) popup renderer needs. Built in
 // the component via useTranslations and threaded through as plain strings.
@@ -26,7 +40,11 @@ interface MentionPopupLabels {
   activeCount: (n: number) => string;
 }
 
-// Extend Mention to support custom `mentionType` attribute (user | agent)
+// Extend Mention to support custom `mentionType` (user | agent) plus the
+// optional pinned (host, cwd) instance target (cwd-addressable instances, T3).
+// The pin attributes are carried on the node and serialized into the markup's
+// query-string suffix by editorToPlainText; an un-pinned mention leaves them at
+// their `null` default and serializes byte-identically to before this change.
 const CustomMention = Mention.extend({
   addAttributes() {
     return {
@@ -38,6 +56,27 @@ const CustomMention = Mention.extend({
         renderHTML: (attributes: Record<string, unknown>) => ({
           "data-mention-type": attributes.mentionType || "user",
         }),
+      },
+      // Pinned instance host ("" = unknown-host instance, null = un-pinned).
+      pinnedHost: {
+        default: null,
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-pinned-host"),
+        renderHTML: (attributes: Record<string, unknown>) =>
+          attributes.pinnedHost == null
+            ? {}
+            : { "data-pinned-host": String(attributes.pinnedHost) },
+      },
+      // Pinned instance cwd (null = unknown-path instance OR un-pinned; the
+      // presence of pinnedHost or a non-null cwd marks the mention as pinned).
+      pinnedCwd: {
+        default: null,
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-pinned-cwd"),
+        renderHTML: (attributes: Record<string, unknown>) =>
+          attributes.pinnedCwd == null
+            ? {}
+            : { "data-pinned-cwd": String(attributes.pinnedCwd) },
       },
     };
   },
@@ -55,6 +94,11 @@ interface Mentionable {
   // status dot; `activeCount` drives the count badge (shown only when > 0).
   online?: boolean;
   activeCount?: number;
+  // Live (host, cwd) instances for an agent (cwd-addressable instances, T3),
+  // populated when the editor requests them (withInstances). When an agent has
+  // 2+ instances the editor surfaces the secondary picker; a single instance
+  // auto-selects; 0 instances → un-pinned mention (behaves as before).
+  instances?: InstanceCandidate[];
 }
 
 export interface MentionEditorProps {
@@ -115,9 +159,18 @@ function editorToPlainText(editor: Editor): string {
 
   function processNode(node: Record<string, unknown>): string {
     if (node.type === "mention") {
-      const attrs = node.attrs as Record<string, string> | undefined;
+      const attrs = node.attrs as Record<string, string | null> | undefined;
       if (attrs) {
-        return `@[${attrs.label || attrs.id}](${attrs.mentionType || "user"}:${attrs.id})`;
+        // Serialize via the shared codec so the optional pinned (host, cwd)
+        // suffix matches what the service parser reads. Un-pinned (both null) →
+        // byte-identical to the legacy `@[Name](type:uuid)` form.
+        return buildMentionMarker(
+          (attrs.label || attrs.id) as string,
+          ((attrs.mentionType as string) || "user") as "user" | "agent",
+          attrs.id as string,
+          attrs.pinnedHost ?? null,
+          attrs.pinnedCwd ?? null,
+        );
       }
       return "";
     }
@@ -150,7 +203,10 @@ function plainTextToEditorContent(text: string): Record<string, unknown> {
     return { type: "doc", content: [{ type: "paragraph" }] };
   }
 
-  const MENTION_RE = /@\[([^\]]+)\]\((user|agent):([a-f0-9-]+)\)/g;
+  // Matches the legacy `@[Name](type:uuid)` form plus an OPTIONAL pinned-instance
+  // suffix `?cwd=…&host=…` (cwd-addressable instances, T3). Group 4 is the raw
+  // pin query string (or undefined for an un-pinned mention).
+  const MENTION_RE = /@\[([^\]]+)\]\((user|agent):([a-f0-9-]+)(?:\?([^)]*))?\)/g;
   const lines = text.split("\n");
 
   const content = lines.map((line) => {
@@ -167,12 +223,15 @@ function plainTextToEditorContent(text: string): Record<string, unknown> {
         });
       }
 
+      const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
       inlineContent.push({
         type: "mention",
         attrs: {
           id: match[3],
           label: match[1],
           mentionType: match[2],
+          pinnedHost,
+          pinnedCwd,
         },
       });
 
@@ -206,7 +265,17 @@ export function createSuggestionPopupRenderer(
   command: (attrs: any) => void,
   keyDownRef: React.MutableRefObject<KeyDownHandler | null>,
   container: HTMLDivElement,
-  labels: MentionPopupLabels
+  labels: MentionPopupLabels,
+  // Decides what happens when a candidate is chosen (cwd-addressable instances,
+  // T3). When provided, it owns the secondary-picker branch: an agent with 2+
+  // live instances defers the insert and opens the picker; otherwise it inserts
+  // (auto-pinning a single instance). Omitted → legacy behavior: insert the bare
+  // mention immediately. Tests can omit it to assert the un-pinned DOM/flow.
+  selectMentionable?: (
+    item: Mentionable,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    command: (attrs: any) => void,
+  ) => void,
 ) {
   container.innerHTML = "";
 
@@ -232,6 +301,13 @@ export function createSuggestionPopupRenderer(
   let selectedIdx = 0;
 
   const doCommand = (item: Mentionable) => {
+    if (selectMentionable) {
+      // Delegate to the React owner: it decides immediate insert (auto-pinning a
+      // single instance) vs. opening the secondary picker for 2+ instances.
+      selectMentionable(item, command);
+      return;
+    }
+    // Legacy path (no instance pinning): insert the bare mention.
     command({
       id: item.uuid,
       label: item.name,
@@ -351,6 +427,75 @@ export function createSuggestionPopupRenderer(
   };
 }
 
+// ── Secondary instance picker dialog (cwd-addressable instances, T3) ───────
+//
+// Shown when an @mentioned agent has 2+ ONLINE instances: the owner pins which
+// (host, cwd) the mention targets. The caller passes ONLINE instances only — an
+// offline instance is never a wake target and is not shown. Owns its own
+// selection state; Confirm calls onConfirm with the chosen instance, Cancel
+// discards (inserting nothing — the user can re-type the mention). Matches
+// design.pen "@mention cwd Picker".
+function MentionInstancePickerDialog({
+  open,
+  agentName,
+  instances,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  agentName: string;
+  instances: InstanceCandidate[];
+  onConfirm: (instance: InstanceCandidate) => void;
+  onCancel: () => void;
+}) {
+  const t = useTranslations("mentionInstance");
+  const [selected, setSelected] = useState<InstanceCandidate | null>(null);
+
+  // Reset the local selection whenever a new pick opens the dialog.
+  useEffect(() => {
+    if (open) setSelected(null);
+  }, [open, instances]);
+
+  const distinctHosts = new Set(instances.map((i) => i.host)).size;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogDescription>
+            {t("subtitle", { name: agentName, count: instances.length, hosts: distinctHosts })}
+          </DialogDescription>
+        </DialogHeader>
+        <InstancePicker
+          instances={instances}
+          selectedConnectionUuid={selected?.connectionUuid ?? null}
+          onSelect={setSelected}
+          ariaLabel={t("title")}
+        />
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel}>
+            {t("cancel")}
+          </Button>
+          <Button
+            disabled={!selected}
+            onClick={() => {
+              if (selected) onConfirm(selected);
+            }}
+          >
+            {t("confirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ── MentionEditor Component ────────────────────────────────────
 
 export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
@@ -388,8 +533,11 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
       forceUpdate((n) => n + 1);
 
       try {
+        // withInstances=1 → candidates carry their live (host, cwd) instances so
+        // an agent with 2+ surfaces the secondary picker (cwd-addressable
+        // instances, T3). Additive; the suggestion-row rendering is unchanged.
         const res = await fetch(
-          `/api/mentionables?q=${encodeURIComponent(query)}&limit=10`
+          `/api/mentionables?q=${encodeURIComponent(query)}&limit=10&withInstances=1`
         );
         if (res.ok) {
           const json = await res.json();
@@ -407,6 +555,73 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
 
     const debouncedFetch = useDebouncedCallback(fetchMentionables, 250);
 
+    // ── Secondary instance picker (cwd-addressable instances, T3) ──────────
+    //
+    // When an agent with 2+ live instances is chosen, defer the mention insert
+    // and open this picker so the owner pins which (host, cwd) the wake targets.
+    // A single live instance auto-selects (no extra click) — handled inline so
+    // we never open the picker for it. An agent with 0/1 instances, or a user,
+    // inserts immediately and un-pinned (behaves exactly as before this change).
+    const [pendingPick, setPendingPick] = useState<{
+      item: Mentionable;
+      // The ONLINE instances to offer in the picker (offline is never a wake
+      // target, so it is filtered out before the dialog opens).
+      onlineInstances: InstanceCandidate[];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      command: (attrs: any) => void;
+    } | null>(null);
+
+    const insertMention = useCallback(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (item: Mentionable, command: (attrs: any) => void, pin?: InstanceCandidate) => {
+        command({
+          id: item.uuid,
+          label: item.name,
+          mentionType: item.type,
+          // A pin carries the durable (host, cwd) "place"; null for an un-pinned
+          // mention. host "" is preserved (unknown-host instance).
+          pinnedHost: pin ? pin.host : null,
+          pinnedCwd: pin ? pin.cwd : null,
+        });
+      },
+      [],
+    );
+
+    // The renderer calls this when a candidate is chosen. Kept in a ref so the
+    // long-lived Tiptap suggestion callbacks always see the current closure.
+    const selectMentionableRef = useRef<
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (item: Mentionable, command: (attrs: any) => void) => void
+    >(() => {});
+    selectMentionableRef.current = (item, command) => {
+      const liveInstances =
+        item.type === "agent"
+          ? (item.instances ?? []).filter((i) => i.effectiveStatus === "online")
+          : [];
+      if (liveInstances.length >= 2) {
+        // Multiple live (online) instances: open the picker over the online set,
+        // defer the insert.
+        setPendingPick({ item, onlineInstances: liveInstances, command });
+        return;
+      }
+      if (liveInstances.length === 1) {
+        // Exactly one live instance: auto-select it, no extra interaction.
+        insertMention(item, command, liveInstances[0]);
+        return;
+      }
+      // No live instances (or a user): un-pinned mention, exactly as before.
+      insertMention(item, command);
+    };
+
+    // Stable wrapper passed to the (long-lived) renderer; always dispatches to
+    // the current selectMentionableRef closure so there is no stale capture.
+    const selectMentionable = useCallback(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (item: Mentionable, command: (attrs: any) => void) =>
+        selectMentionableRef.current(item, command),
+      [],
+    );
+
     // Re-render popup when items change
     useEffect(() => {
       if (popupRef.current && currentCommandRef.current) {
@@ -416,7 +631,8 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
           currentCommandRef.current,
           keyDownRef,
           popupRef.current,
-          labelsRef.current
+          labelsRef.current,
+          selectMentionable
         );
       }
     });
@@ -494,7 +710,8 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
                     props.command,
                     keyDownRef,
                     popup,
-                    labelsRef.current
+                    labelsRef.current,
+                    selectMentionable
                   );
                 },
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -525,7 +742,8 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
                       props.command,
                       keyDownRef,
                       popupRef.current,
-                      labelsRef.current
+                      labelsRef.current,
+                      selectMentionable
                     );
                   }
                 },
@@ -619,6 +837,21 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
         )}
       >
         <EditorContent editor={editor} />
+        {/* Secondary instance picker — opened only for an agent with 2+ ONLINE
+            instances (cwd-addressable instances). Offline instances are filtered
+            out before the dialog opens (never a wake target). */}
+        <MentionInstancePickerDialog
+          open={pendingPick !== null}
+          agentName={pendingPick?.item.name ?? ""}
+          instances={pendingPick?.onlineInstances ?? []}
+          onConfirm={(instance) => {
+            if (pendingPick) {
+              insertMention(pendingPick.item, pendingPick.command, instance);
+            }
+            setPendingPick(null);
+          }}
+          onCancel={() => setPendingPick(null)}
+        />
         <style>{`
           .tiptap p.is-editor-empty:first-child::before {
             content: attr(data-placeholder);

--- a/src/lib/__tests__/daemon-instance-format.test.ts
+++ b/src/lib/__tests__/daemon-instance-format.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatCwd,
+  formatHost,
+  UNKNOWN_PATH_KEY,
+  UNKNOWN_HOST_KEY,
+} from "../daemon-instance-format";
+
+describe("formatCwd", () => {
+  it("shows the last 2 segments with a leading ellipsis for a long path", () => {
+    const result = formatCwd(
+      "/home/u/dev/payments-platform/services/billing-api",
+    );
+    // Abbreviated tail = last 2 segments, leading segments dropped with "…/".
+    expect(result.label).toBe("…/services/billing-api");
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it("preserves the final segment intact when the path is over budget", () => {
+    // last-2 tail "services/billing-api" is 20 chars; force a tight budget so
+    // the leading segment of the tail must also be dropped.
+    const result = formatCwd(
+      "/home/u/dev/payments-platform/services/billing-api",
+      { charBudget: 12 },
+    );
+    // Final segment kept whole; everything earlier collapsed to "…/".
+    expect(result.label).toBe("…/billing-api");
+    expect(result.label).toContain("billing-api");
+  });
+
+  it("never truncates the final segment even if it alone exceeds the budget", () => {
+    const result = formatCwd("/srv/a-very-long-working-directory-name", {
+      charBudget: 8,
+    });
+    // The working dir name is preserved whole; only a leading ellipsis is added.
+    expect(result.label).toBe("…/a-very-long-working-directory-name");
+  });
+
+  it("exposes the full absolute path as the title", () => {
+    const full = "/home/u/dev/payments-platform/services/billing-api";
+    const result = formatCwd(full);
+    expect(result.title).toBe(full);
+  });
+
+  it("returns the last-2 segments without ellipsis when nothing is dropped", () => {
+    const result = formatCwd("/var/log");
+    expect(result.label).toBe("var/log");
+    expect(result.title).toBe("/var/log");
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it("normalizes a trailing slash before abbreviating", () => {
+    const result = formatCwd("/home/user/dev/chorus/");
+    expect(result.label).toBe("…/dev/chorus");
+    expect(result.title).toBe("/home/user/dev/chorus/");
+  });
+
+  it("handles a single-segment path with no ellipsis", () => {
+    const result = formatCwd("/chorus");
+    expect(result.label).toBe("chorus");
+    expect(result.title).toBe("/chorus");
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it("shows the root path as-is", () => {
+    const result = formatCwd("/");
+    expect(result.label).toBe("/");
+    expect(result.title).toBe("/");
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it("normalizes Windows-style separators by tail", () => {
+    const result = formatCwd("C:\\Users\\q\\dev\\chorus");
+    expect(result.label).toBe("…/dev/chorus");
+  });
+
+  it("maps a null cwd to an explicit unknown-path sentinel", () => {
+    const result = formatCwd(null);
+    expect(result.isUnknown).toBe(true);
+    expect(result.label).toBe(UNKNOWN_PATH_KEY);
+    expect(result.title).toBe(UNKNOWN_PATH_KEY);
+  });
+
+  it("respects a custom tailSegments option", () => {
+    const result = formatCwd("/home/u/dev/chorus/src/lib", {
+      tailSegments: 3,
+      charBudget: 100,
+    });
+    expect(result.label).toBe("…/chorus/src/lib");
+  });
+});
+
+describe("formatHost", () => {
+  it("right-truncates a long host with a trailing ellipsis within the cap", () => {
+    const result = formatHost("ip-10-0-42-118.ec2.internal");
+    expect(result.isUnknown).toBe(false);
+    expect(result.label.endsWith("…")).toBe(true);
+    // Default budget is 18 chars including the ellipsis.
+    expect(result.label.length).toBeLessThanOrEqual(18);
+    expect(result.label).toBe("ip-10-0-42-118.ec…");
+  });
+
+  it("exposes the full host as the title when truncated", () => {
+    const result = formatHost("ip-10-0-42-118.ec2.internal");
+    expect(result.title).toBe("ip-10-0-42-118.ec2.internal");
+  });
+
+  it("returns a short host unchanged with no ellipsis", () => {
+    const result = formatHost("Laptop-Q3");
+    expect(result.label).toBe("Laptop-Q3");
+    expect(result.title).toBe("Laptop-Q3");
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it("respects a custom charBudget", () => {
+    const result = formatHost("ci-runner-02.internal", { charBudget: 10 });
+    // budget 10 = 9 kept chars + 1 ellipsis char.
+    expect(result.label).toBe("ci-runner…");
+    expect(result.label.length).toBe(10);
+    expect(result.label.length).toBeLessThanOrEqual(10);
+  });
+
+  it("maps an empty host to the localized unknown-host placeholder key", () => {
+    const result = formatHost("");
+    expect(result.isUnknown).toBe(true);
+    expect(result.label).toBe(UNKNOWN_HOST_KEY);
+    expect(result.title).toBe(UNKNOWN_HOST_KEY);
+  });
+});

--- a/src/lib/__tests__/mention-format.test.ts
+++ b/src/lib/__tests__/mention-format.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodePinSuffix,
+  decodePinSuffix,
+  buildMentionMarker,
+} from "../mention-format";
+
+const UUID = "abcdef12-3456-7890-abcd-ef1234567890";
+
+describe("encodePinSuffix", () => {
+  it("returns '' when nothing is pinned (un-pinned mention is unchanged)", () => {
+    expect(encodePinSuffix(null, null)).toBe("");
+    expect(encodePinSuffix(undefined, undefined)).toBe("");
+  });
+
+  it("encodes host + cwd as a ?cwd=…&host=… query suffix", () => {
+    expect(encodePinSuffix("Laptop-Q3", "/home/u/dev/chorus")).toBe(
+      "?cwd=%2Fhome%2Fu%2Fdev%2Fchorus&host=Laptop-Q3",
+    );
+  });
+
+  it("writes an empty cwd value for a null-cwd pin (unknown-path instance)", () => {
+    // host pinned but cwd unknown → cwd present-but-empty so the decoder can
+    // distinguish "pinned to unknown path" from "not pinned".
+    expect(encodePinSuffix("ci-runner", null)).toBe("?cwd=&host=ci-runner");
+  });
+
+  it("preserves an empty-string host ('' = unknown-host instance)", () => {
+    expect(encodePinSuffix("", "/srv/app")).toBe("?cwd=%2Fsrv%2Fapp&host=");
+  });
+
+  it("escapes parens so the payload never breaks the closing-paren match", () => {
+    const suffix = encodePinSuffix("h(1)", "/a(b)/c");
+    expect(suffix).not.toContain("(");
+    expect(suffix).not.toContain(")");
+    // And it round-trips back to the originals.
+    expect(decodePinSuffix(suffix.slice(1))).toEqual({
+      pinnedHost: "h(1)",
+      pinnedCwd: "/a(b)/c",
+    });
+  });
+});
+
+describe("decodePinSuffix", () => {
+  it("returns both null for an absent/empty suffix (un-pinned)", () => {
+    expect(decodePinSuffix(undefined)).toEqual({ pinnedHost: null, pinnedCwd: null });
+    expect(decodePinSuffix("")).toEqual({ pinnedHost: null, pinnedCwd: null });
+    expect(decodePinSuffix(null)).toEqual({ pinnedHost: null, pinnedCwd: null });
+  });
+
+  it("decodes a host + cwd pin", () => {
+    expect(decodePinSuffix("cwd=%2Fhome%2Fu%2Fdev%2Fchorus&host=Laptop-Q3")).toEqual({
+      pinnedHost: "Laptop-Q3",
+      pinnedCwd: "/home/u/dev/chorus",
+    });
+  });
+
+  it("maps an empty cwd value to a null cwd (unknown-path pin)", () => {
+    expect(decodePinSuffix("cwd=&host=ci-runner")).toEqual({
+      pinnedHost: "ci-runner",
+      pinnedCwd: null,
+    });
+  });
+
+  it("maps an empty host value to '' (unknown-host pin)", () => {
+    expect(decodePinSuffix("cwd=%2Fsrv%2Fapp&host=")).toEqual({
+      pinnedHost: "",
+      pinnedCwd: "/srv/app",
+    });
+  });
+
+  it("treats a host-absent suffix as host=null", () => {
+    expect(decodePinSuffix("cwd=%2Fsrv%2Fapp")).toEqual({
+      pinnedHost: null,
+      pinnedCwd: "/srv/app",
+    });
+  });
+});
+
+describe("buildMentionMarker", () => {
+  it("produces the legacy bare form when un-pinned (byte-identical)", () => {
+    expect(buildMentionMarker("DevBot", "agent", UUID)).toBe(
+      `@[DevBot](agent:${UUID})`,
+    );
+    expect(buildMentionMarker("DevBot", "agent", UUID, null, null)).toBe(
+      `@[DevBot](agent:${UUID})`,
+    );
+  });
+
+  it("appends the pin suffix when pinned", () => {
+    expect(
+      buildMentionMarker("DevBot", "agent", UUID, "Laptop-Q3", "/home/u/dev/chorus"),
+    ).toBe(`@[DevBot](agent:${UUID}?cwd=%2Fhome%2Fu%2Fdev%2Fchorus&host=Laptop-Q3)`);
+  });
+
+  it("round-trips a pinned marker through encode→decode", () => {
+    const marker = buildMentionMarker("DevBot", "agent", UUID, "h", "/p");
+    // Extract the suffix between the uuid and the closing paren.
+    const suffix = marker.slice(marker.indexOf("?") + 1, marker.length - 1);
+    expect(decodePinSuffix(suffix)).toEqual({ pinnedHost: "h", pinnedCwd: "/p" });
+  });
+});

--- a/src/lib/daemon-instance-format.ts
+++ b/src/lib/daemon-instance-format.ts
@@ -1,0 +1,208 @@
+/**
+ * Shared, pure formatting helpers for daemon (agent, host, cwd) instances.
+ *
+ * A daemon instance is identified by `(agentUuid, clientType, host, cwd)`
+ * (see `DaemonConnection`). Every owner-facing surface (presence drill-down,
+ * @-mention picker, task-assignment pin, ad-hoc send picker, chat header)
+ * renders the instance **path-first** (cwd primary) and **host-conditional**
+ * (host de-emphasized). These helpers centralize the truncation contract so a
+ * long `cwd` or `host` never breaks row layout or pushes status/tag/action
+ * controls off the row.
+ *
+ * Truncation contract (tech_design "Key decision 3"):
+ * - `formatCwd`: show the abbreviated tail (last 2 path segments). When even
+ *   that exceeds the budget, drop leading segments with a leading ellipsis but
+ *   ALWAYS keep the final segment (the working dir's own name) whole. The full
+ *   absolute path is exposed as `title` for hover. A null cwd (legacy daemon
+ *   that never self-reported one) maps to an explicit "unknown path" sentinel.
+ * - `formatHost`: truncate from the RIGHT with a trailing ellipsis, capped at a
+ *   fixed max width so host never crowds the path. Full host exposed as `title`.
+ *   An empty host ("") maps to a localized "unknown host" placeholder.
+ *
+ * These functions are pure and i18n-agnostic: an "unknown" value resolves to an
+ * i18n KEY (string), not English text. The caller resolves the key via
+ * next-intl (`t(result.labelKey)`). This keeps the helper unit-testable and
+ * avoids hardcoding English per the project i18n rules.
+ */
+
+/** i18n key the UI resolves when a cwd is unknown (legacy null-cwd daemon). */
+export const UNKNOWN_PATH_KEY = "agentPresence.unknownPath";
+
+/** i18n key the UI resolves when a host is unknown (empty self-report). */
+export const UNKNOWN_HOST_KEY = "agentPresence.unknownHost";
+
+/** Ellipsis used for left-truncation of a path's leading segments. */
+const PATH_ELLIPSIS = "…/";
+
+/** Ellipsis used for right-truncation of a host. */
+const HOST_ELLIPSIS = "…";
+
+/**
+ * Default number of trailing path segments shown when the full path is long.
+ * The abbreviated tail is "last 2 segments" per the truncation contract.
+ */
+const DEFAULT_TAIL_SEGMENTS = 2;
+
+/**
+ * Default character budget for a rendered cwd label. When the abbreviated tail
+ * exceeds this, leading segments are dropped (with a "…/" prefix) until it fits,
+ * but the final segment is never truncated — it is the actual repo/working dir.
+ * Chosen to comfortably fit a monospace path chip; callers may override.
+ */
+const DEFAULT_CWD_CHAR_BUDGET = 28;
+
+/**
+ * Default maximum character width for a rendered host. Hosts are de-emphasized
+ * and capped tighter than paths (design.md: "≈120px"). Callers may override.
+ */
+const DEFAULT_HOST_CHAR_BUDGET = 18;
+
+export interface FormatCwdOptions {
+  /** How many trailing segments to keep as the abbreviated tail. Default 2. */
+  tailSegments?: number;
+  /** Character budget for the visible label. Default 28. */
+  charBudget?: number;
+}
+
+export interface FormattedCwd {
+  /**
+   * The label to render. When `isUnknown` is true this is the i18n KEY
+   * (`UNKNOWN_PATH_KEY`) the caller must resolve via `t(...)`; otherwise it is
+   * the already-formatted, possibly-truncated path string ready to render.
+   */
+  label: string;
+  /**
+   * The full value for a hover title. The full absolute path when known; for an
+   * unknown cwd this is the same i18n KEY (caller resolves), so the title never
+   * leaks raw English either.
+   */
+  title: string;
+  /** True when the source cwd was null (legacy daemon, "unknown path"). */
+  isUnknown: boolean;
+}
+
+export interface FormatHostOptions {
+  /** Character budget for the visible host. Default 18. */
+  charBudget?: number;
+}
+
+export interface FormattedHost {
+  /**
+   * The label to render. When `isUnknown` is true this is the i18n KEY
+   * (`UNKNOWN_HOST_KEY`) the caller must resolve via `t(...)`; otherwise it is
+   * the already-formatted, possibly-truncated host string.
+   */
+  label: string;
+  /**
+   * The full host for a hover title. For an unknown host this is the same i18n
+   * KEY (caller resolves).
+   */
+  title: string;
+  /** True when the source host was empty (""), i.e. not self-reported. */
+  isUnknown: boolean;
+}
+
+/**
+ * Split an absolute (or relative) path into its non-empty segments, tolerant of
+ * a leading slash, trailing slash, and repeated separators. The path is
+ * normalized to "/" separators first so a Windows-style cwd still abbreviates
+ * by its tail.
+ */
+function splitSegments(path: string): string[] {
+  return path
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((seg) => seg.length > 0);
+}
+
+/**
+ * Format a daemon instance's working directory for path-first display.
+ *
+ * - `null` cwd → the "unknown path" sentinel (`isUnknown: true`, label/title =
+ *   `UNKNOWN_PATH_KEY` for the caller to localize).
+ * - Otherwise → the abbreviated tail (last `tailSegments` segments). If that
+ *   tail still exceeds `charBudget`, leading segments are dropped one at a time
+ *   with a leading "…/", but the FINAL segment is always kept whole. If even a
+ *   single final segment exceeds the budget, it is still shown in full (never
+ *   truncated) — the contract guarantees the working dir name stays intact.
+ *
+ * `title` is always the full original absolute path (with original separators)
+ * for hover, even when the visible label is abbreviated.
+ */
+export function formatCwd(
+  absPath: string | null,
+  opts: FormatCwdOptions = {},
+): FormattedCwd {
+  if (absPath === null) {
+    return { label: UNKNOWN_PATH_KEY, title: UNKNOWN_PATH_KEY, isUnknown: true };
+  }
+
+  const tailSegments = opts.tailSegments ?? DEFAULT_TAIL_SEGMENTS;
+  const charBudget = opts.charBudget ?? DEFAULT_CWD_CHAR_BUDGET;
+
+  const segments = splitSegments(absPath);
+
+  // No real segments (e.g. "/", "", "//"). Show the raw path as-is so root and
+  // empty strings remain visible; full path stays the title.
+  if (segments.length === 0) {
+    return { label: absPath, title: absPath, isUnknown: false };
+  }
+
+  // The abbreviated tail: at most the last `tailSegments` segments.
+  const isAbbreviatedFromFull = segments.length > tailSegments;
+  const tail = segments.slice(-tailSegments);
+
+  // Build the candidate label. If we already dropped leading segments to form
+  // the tail, prefix the ellipsis; otherwise it's the whole (short) path.
+  const buildLabel = (segs: string[], droppedLeading: boolean): string => {
+    const joined = segs.join("/");
+    return droppedLeading ? `${PATH_ELLIPSIS}${joined}` : joined;
+  };
+
+  let visibleSegs = tail;
+  let droppedLeading = isAbbreviatedFromFull;
+  let label = buildLabel(visibleSegs, droppedLeading);
+
+  // Over budget: drop leading segments of the tail one at a time, always
+  // keeping at least the final segment. Each drop forces the leading ellipsis.
+  while (label.length > charBudget && visibleSegs.length > 1) {
+    visibleSegs = visibleSegs.slice(1);
+    droppedLeading = true;
+    label = buildLabel(visibleSegs, droppedLeading);
+  }
+
+  return { label, title: absPath, isUnknown: false };
+}
+
+/**
+ * Format a daemon instance's host for de-emphasized, host-conditional display.
+ *
+ * - `""` host (not self-reported) → the "unknown host" sentinel
+ *   (`isUnknown: true`, label/title = `UNKNOWN_HOST_KEY` for the caller to
+ *   localize). This preserves the existing empty-string-coercion behavior in a
+ *   single, testable place.
+ * - Otherwise → right-truncated with a trailing "…" so the visible string never
+ *   exceeds `charBudget` characters (the ellipsis counts toward the budget).
+ *   `title` is the full host for hover.
+ */
+export function formatHost(
+  host: string,
+  opts: FormatHostOptions = {},
+): FormattedHost {
+  if (host === "") {
+    return { label: UNKNOWN_HOST_KEY, title: UNKNOWN_HOST_KEY, isUnknown: true };
+  }
+
+  const charBudget = opts.charBudget ?? DEFAULT_HOST_CHAR_BUDGET;
+
+  if (host.length <= charBudget) {
+    return { label: host, title: host, isUnknown: false };
+  }
+
+  // Reserve room for the trailing ellipsis. Guard against a tiny budget so we
+  // always emit at least the ellipsis rather than a negative slice.
+  const keep = Math.max(0, charBudget - HOST_ELLIPSIS.length);
+  const label = `${host.slice(0, keep)}${HOST_ELLIPSIS}`;
+
+  return { label, title: host, isUnknown: false };
+}

--- a/src/lib/mention-format.ts
+++ b/src/lib/mention-format.ts
@@ -1,0 +1,80 @@
+// Pure, dependency-free mention-markup codec — shared by the SERVER mention
+// service (parse/create) and the CLIENT mention editor (serialize/parse), so the
+// producer and the parser of the on-disk markup can never drift.
+//
+// Markup: `@[DisplayName](type:uuid)` with an OPTIONAL pinned-instance suffix
+// `?cwd=…&host=…` INSIDE the parens (cwd-addressable instances, T3). An
+// un-pinned mention is byte-identical to before this change. This module is
+// importable from client components (it pulls in NO prisma / server code).
+
+/**
+ * Encode a pinned (host, cwd) into the mention markup's query-string suffix:
+ * `?cwd=<enc>&host=<enc>`. Returns "" (no suffix) when nothing is pinned, so an
+ * un-pinned mention serializes byte-identically to before this change.
+ *
+ * Values are percent-encoded AND have `(`/`)` additionally escaped (which
+ * encodeURIComponent leaves intact) so the payload is paren-free — the markup
+ * regex matches the suffix as "everything up to the closing paren". cwd is
+ * always written (even null, as an empty value) when ANY pin is present so the
+ * decoder can distinguish "pinned to unknown path" from "not pinned".
+ */
+export function encodePinSuffix(
+  pinnedHost: string | null | undefined,
+  pinnedCwd: string | null | undefined,
+): string {
+  // No pin at all → no suffix (un-pinned mention is unchanged).
+  if (
+    (pinnedHost === null || pinnedHost === undefined) &&
+    (pinnedCwd === null || pinnedCwd === undefined)
+  ) {
+    return "";
+  }
+  const enc = (v: string) =>
+    encodeURIComponent(v).replace(/\(/g, "%28").replace(/\)/g, "%29");
+  const parts: string[] = [];
+  // cwd present-but-null → empty value (distinct from "absent" by the decoder).
+  parts.push(`cwd=${pinnedCwd == null ? "" : enc(pinnedCwd)}`);
+  if (pinnedHost != null) parts.push(`host=${enc(pinnedHost)}`);
+  return `?${parts.join("&")}`;
+}
+
+/**
+ * Decode a pin query-string suffix (the text after `?`, without the `?`) into
+ * (pinnedHost, pinnedCwd). Returns both null when the suffix is absent/empty
+ * (un-pinned). A present `cwd=` with an empty value decodes to null (pinned to
+ * an unknown-path instance); a present `host=` with an empty value decodes to
+ * "" (the unknown-host sentinel).
+ */
+export function decodePinSuffix(suffix: string | undefined | null): {
+  pinnedHost: string | null;
+  pinnedCwd: string | null;
+} {
+  if (!suffix) return { pinnedHost: null, pinnedCwd: null };
+  const params = new URLSearchParams(suffix);
+  const hasCwd = params.has("cwd");
+  const hasHost = params.has("host");
+  if (!hasCwd && !hasHost) return { pinnedHost: null, pinnedCwd: null };
+  const rawCwd = params.get("cwd") ?? "";
+  const rawHost = params.get("host");
+  return {
+    // Empty cwd value → unknown-path pin (null). Otherwise the decoded path.
+    pinnedCwd: hasCwd && rawCwd !== "" ? rawCwd : null,
+    // host present (even empty) → the host pin ("" = unknown-host). Absent → null.
+    pinnedHost: hasHost ? rawHost ?? "" : null,
+  };
+}
+
+/**
+ * Build a full mention marker, optionally pinned. `@[Name](type:uuid)` when
+ * un-pinned (unchanged), `@[Name](type:uuid?cwd=…&host=…)` when pinned. Shared
+ * by the editor's serializer and the service so producer and parser can't drift.
+ */
+export function buildMentionMarker(
+  displayName: string,
+  type: "user" | "agent",
+  uuid: string,
+  pinnedHost?: string | null,
+  pinnedCwd?: string | null,
+): string {
+  return `@[${displayName}](${type}:${uuid}${encodePinSuffix(pinnedHost, pinnedCwd)})`;
+}

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -566,13 +566,21 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "proposal:write",
     "chorus_pm_assign_task",
     {
-      description: "Assign a task to an agent that has task:write permission (task must be in open or assigned status)",
+      description: "Assign a task to an agent that has task:write permission (task must be in open or assigned status). Optionally pin which (host, cwd) daemon instance the autonomous wake should route the task to — an offline instance is a valid durable pin (the turn queues and backfills when that place's daemon reconnects).",
       inputSchema: z.object({
         taskUuid: z.string().describe("Task UUID"),
         agentUuid: z.string().describe("Target Agent UUID (must have task:write permission)"),
+        targetHost: z
+          .string()
+          .nullish()
+          .describe("Optional pinned instance host (\"\" = unknown-host instance). Omit for no pin."),
+        targetCwd: z
+          .string()
+          .nullish()
+          .describe("Optional pinned instance working directory (null = unknown-path instance). Omit for no pin."),
       }),
     },
-    async ({ taskUuid, agentUuid }) => {
+    async ({ taskUuid, agentUuid, targetHost, targetCwd }) => {
       // Validate task exists
       const task = await taskService.getTaskByUuid(auth.companyUuid, taskUuid);
       if (!task) {
@@ -614,6 +622,11 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
           assigneeType: "agent",
           assigneeUuid: agentUuid,
           assignedByUuid: auth.actorUuid,
+          // Thread the optional durable (host, cwd) pin (cwd-addressable
+          // instances, T4); both undefined → no pin, coerced to null by the
+          // service so a re-assignment clears a stale pin.
+          targetHost: targetHost ?? null,
+          targetCwd: targetCwd ?? null,
         });
 
         // Log activity
@@ -625,7 +638,14 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
           actorType: "agent",
           actorUuid: auth.actorUuid,
           action: "assigned",
-          value: { assigneeType: "agent", assigneeUuid: agentUuid, assignedBy: auth.actorUuid },
+          value: {
+            assigneeType: "agent",
+            assigneeUuid: agentUuid,
+            assignedBy: auth.actorUuid,
+            ...(targetHost != null || targetCwd != null
+              ? { targetHost: targetHost ?? null, targetCwd: targetCwd ?? null }
+              : {}),
+          },
         });
 
         // Fetch full task details with dependencies

--- a/src/services/__tests__/cwd-pin-chain.integration.test.ts
+++ b/src/services/__tests__/cwd-pin-chain.integration.test.ts
@@ -1,0 +1,938 @@
+// src/services/__tests__/cwd-pin-chain.integration.test.ts
+//
+// INTEGRATION CHECKPOINT (T7 — cwd-addressable daemon instances).
+//
+// The single most load-bearing contract of this feature is a WRITE → READ chain that
+// spans three tasks and would pass in isolation while the feature is broken:
+//
+//   T4 (write): an owner pins (host, cwd) at TASK ASSIGNMENT → claimTask persists it to
+//               the Task's `targetHost`/`targetCwd` columns.
+//   T3 (write): an owner pins (host, cwd) at @MENTION → the pin is encoded in the mention
+//               markup `@[Name](agent:uuid?cwd=…&host=…)`, parseMentions decodes it, and
+//               createMentions threads it as `pinnedHost`/`pinnedCwd` into the wake.
+//   T5 (read):  the autonomous wake (notification-turn.ts) reads the SAME shape — the
+//               Task columns for a `task_assigned` wake, the threaded context fields for a
+//               `mentioned` wake — resolves the matching live DaemonConnection, and pins
+//               the session origin THERE.
+//
+// The reviewer's flagged failure mode: each side unit-tested in isolation passes even if
+// T4 wrote `targetCwd` but T5 read a differently-named field. This test defeats that by
+// wiring the REAL write functions and the REAL read function against ONE stateful
+// in-memory prisma store: claimTask WRITES to `store.data.task[...]`, then the wake calls
+// the REAL `prisma.task.findFirst({ select: { targetHost, targetCwd } })` and reads back
+// what claimTask actually stored. If the field names disagree, the pin resolves to
+// nothing, the wake falls back to online-first, and the origin-pinning assertion FAILS —
+// exactly the silent-mismatch this checkpoint must catch (the `KEY ASSERTION` test below
+// proves this by deliberately corrupting the field name and asserting the pin breaks).
+//
+// Threads exercised end-to-end as ONE flow:
+//   (1) task-assignment pin: claimTask write → Task columns → task_assigned wake reads
+//       them → origin pinned to the matching LIVE connection.
+//       @mention pin: pinned marker → parseMentions → createMentions → mentioned wake
+//       reads the threaded (host, cwd) → origin pinned to the matching LIVE connection.
+//   (2) KEY ASSERTION: the write shape ≡ the read shape, proven against the REAL field
+//       names on both ends (a deliberate mismatch fails, not passes silently).
+//   (3) OFFLINE pin / fully-offline agent: an offline place is NOT wakeable and there is
+//       NO durable queue → NO turn is created; the already-created Notification stands as
+//       the plain record. The pin only ever wakes a matching ONLINE connection.
+//   (4) live ad-hoc send to an OFFLINE instance → rejected (409). Online-only holds end
+//       to end on both the autonomous-wake side and the live-send side.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Stateful in-memory prisma fake =====
+//
+// A SINGLE store the REAL write functions (claimTask) write to and the REAL read function
+// (the wake bridge's prisma.task.findFirst) read from — this is the crux: a per-side mock
+// could never prove the two halves agree on the column names.
+
+interface Row {
+  [k: string]: unknown;
+}
+
+function makeStore() {
+  const data = {
+    task: [] as Row[],
+    daemonSession: [] as Row[],
+    daemonSessionTurn: [] as Row[],
+    daemonConnection: [] as Row[],
+    notification: [] as Row[],
+    notificationPreference: [] as Row[],
+    mention: [] as Row[],
+    project: [] as Row[],
+    user: [] as Row[],
+    agent: [] as Row[],
+  };
+  let autoId = 1;
+  let autoUuid = 1;
+  const nextId = () => autoId++;
+  const nextUuid = (prefix: string) => `${prefix}-${String(autoUuid++).padStart(4, "0")}`;
+  return { data, nextId, nextUuid };
+}
+
+type Store = ReturnType<typeof makeStore>;
+
+// Match a row against a Prisma `where` clause. Supports scalar equality, the `{ in: [...] }`
+// operator, and the nested `session` relation filter the backfill read uses
+// (turn.session.{companyUuid,agentUuid,originConnectionUuid}).
+function matchWhere(store: Store, model: keyof Store["data"], row: Row, where: Row): boolean {
+  for (const [key, cond] of Object.entries(where ?? {})) {
+    if (cond === undefined) continue;
+
+    if (key === "session" && model === "daemonSessionTurn") {
+      const session = store.data.daemonSession.find((s) => s.uuid === row.sessionUuid);
+      if (!session) return false;
+      if (!matchWhere(store, "daemonSession", session, cond as Row)) return false;
+      continue;
+    }
+
+    const val = row[key];
+    if (cond !== null && typeof cond === "object") {
+      const c = cond as Row;
+      if ("in" in c) {
+        if (!Array.isArray(c.in) || !(c.in as unknown[]).includes(val)) return false;
+        continue;
+      }
+      if ("not" in c) {
+        if (val === c.not) return false;
+        continue;
+      }
+      // Unknown operator object — no match, surfaced loudly rather than silently passing.
+      return false;
+    }
+    if (val !== cond) return false;
+  }
+  return true;
+}
+
+function applyOrderBy(store: Store, model: keyof Store["data"], rows: Row[], orderBy: unknown): Row[] {
+  if (!orderBy) return rows;
+  const orders = Array.isArray(orderBy) ? orderBy : [orderBy];
+  return [...rows].sort((a, b) => {
+    for (const o of orders as Row[]) {
+      for (const [field, dir] of Object.entries(o)) {
+        let av: unknown;
+        let bv: unknown;
+        if (field === "session" && model === "daemonSessionTurn") {
+          const sa = store.data.daemonSession.find((s) => s.uuid === a.sessionUuid) ?? {};
+          const sb = store.data.daemonSession.find((s) => s.uuid === b.sessionUuid) ?? {};
+          const inner = Object.entries(dir as Row)[0];
+          av = (sa as Row)[inner[0]];
+          bv = (sb as Row)[inner[0]];
+          const cmp = compare(av, bv);
+          if (cmp !== 0) return inner[1] === "desc" ? -cmp : cmp;
+          continue;
+        }
+        av = a[field];
+        bv = b[field];
+        const cmp = compare(av, bv);
+        if (cmp !== 0) return dir === "desc" ? -cmp : cmp;
+      }
+    }
+    return 0;
+  });
+}
+
+// Materialize the one relation select the backfill read uses:
+// daemonSessionTurn.select.session → attach the related DaemonSession (with its inner
+// select applied) so `row.session.sessionId` / `row.session.directIdeaUuid` resolve.
+function projectSelect(
+  store: Store,
+  model: keyof Store["data"],
+  row: Row,
+  select: Row | undefined,
+): Row {
+  if (!select) return row;
+  if (model === "daemonSessionTurn" && select.session) {
+    const session = store.data.daemonSession.find((s) => s.uuid === row.sessionUuid);
+    const sel = (select.session as Row).select as Row | undefined;
+    if (session) {
+      if (sel) {
+        const picked: Row = {};
+        for (const k of Object.keys(sel)) picked[k] = session[k];
+        row.session = picked;
+      } else {
+        row.session = { ...session };
+      }
+    } else {
+      row.session = null;
+    }
+  }
+  return row;
+}
+
+function compare(a: unknown, b: unknown): number {
+  if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  if (typeof a === "string" && typeof b === "string") return a < b ? -1 : a > b ? 1 : 0;
+  return 0;
+}
+
+function buildPrismaFake(store: Store) {
+  function findMany(model: keyof Store["data"], args: Row = {}) {
+    let rows = store.data[model].filter((r) => matchWhere(store, model, r, (args.where as Row) ?? {}));
+    rows = applyOrderBy(store, model, rows, args.orderBy);
+    if (typeof args.take === "number") rows = rows.slice(0, args.take as number);
+    return rows.map((r) => projectSelect(store, model, { ...r }, args.select as Row | undefined));
+  }
+  function findFirst(model: keyof Store["data"], args: Row = {}) {
+    const rows = findMany(model, args);
+    return rows.length > 0 ? rows[0] : null;
+  }
+  function count(model: keyof Store["data"], args: Row = {}) {
+    return store.data[model].filter((r) => matchWhere(store, model, r, (args.where as Row) ?? {})).length;
+  }
+
+  return {
+    // --- Task: the WRITE side (claimTask) AND the READ side (wake's findFirst) ---
+    task: {
+      // claimTask issues prisma.task.update({ where: { uuid, status: { in } }, data, include }).
+      update: vi.fn(async (args: Row) => {
+        const where = args.where as Row;
+        const row = store.data.task.find(
+          (t) => matchWhere(store, "task", t, where),
+        );
+        if (!row) {
+          // Mirror Prisma's P2025 so claimTask's isPrismaNotFound branch is reachable.
+          const err = new Error("Record to update not found.") as Error & { code?: string };
+          err.code = "P2025";
+          throw err;
+        }
+        Object.assign(row, args.data as Row, { updatedAt: new Date() });
+        const out: Row = { ...row };
+        // include: { project: { select: { uuid, name } } } — attach the project relation.
+        const include = args.include as Row | undefined;
+        if (include?.project) {
+          out.project = { uuid: row.projectUuid, name: "Chorus 0.11.2" };
+        }
+        return out;
+      }),
+      // The wake bridge reads the pin via prisma.task.findFirst({ where, select }).
+      findFirst: vi.fn(async (args: Row) => findFirst("task", args)),
+      findMany: vi.fn(async (args: Row) => findMany("task", args)),
+    },
+    daemonSession: {
+      upsert: vi.fn(async (args: Row) => {
+        const key = (args.where as Row).agentUuid_sessionId as Row;
+        const existing = store.data.daemonSession.find(
+          (s) => s.agentUuid === key.agentUuid && s.sessionId === key.sessionId,
+        );
+        if (existing) {
+          Object.assign(existing, args.update as Row, { updatedAt: new Date() });
+          return { ...existing };
+        }
+        const now = new Date();
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("session"),
+          status: "active",
+          title: null,
+          directIdeaUuid: null,
+          lastTurnAt: now,
+          createdAt: now,
+          updatedAt: now,
+          ...(args.create as Row),
+        };
+        store.data.daemonSession.push(row);
+        return { ...row };
+      }),
+      findUnique: vi.fn(async (args: Row) => findFirst("daemonSession", { where: args.where, select: args.select })),
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonSession", args)),
+      findMany: vi.fn(async (args: Row) => findMany("daemonSession", args)),
+      update: vi.fn(async (args: Row) => {
+        const row = store.data.daemonSession.find((s) => s.uuid === (args.where as Row).uuid);
+        if (!row) throw new Error("session not found for update");
+        Object.assign(row, args.data as Row, { updatedAt: new Date() });
+        return { ...row };
+      }),
+    },
+    daemonSessionTurn: {
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonSessionTurn", args)),
+      findUnique: vi.fn(async (args: Row) => findFirst("daemonSessionTurn", { where: args.where })),
+      findMany: vi.fn(async (args: Row) => findMany("daemonSessionTurn", args)),
+      create: vi.fn(async (args: Row) => {
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("turn"),
+          promptText: null,
+          executionUuid: null,
+          startedAt: null,
+          endedAt: null,
+          createdAt: new Date(),
+          ...(args.data as Row),
+        };
+        store.data.daemonSessionTurn.push(row);
+        return { ...row };
+      }),
+      update: vi.fn(async (args: Row) => {
+        const row = store.data.daemonSessionTurn.find((t) => t.uuid === (args.where as Row).uuid);
+        if (!row) throw new Error("turn not found for update");
+        Object.assign(row, args.data as Row);
+        return { ...row };
+      }),
+    },
+    daemonConnection: {
+      findFirst: vi.fn(async (args: Row) => findFirst("daemonConnection", args)),
+      findMany: vi.fn(async (args: Row) => findMany("daemonConnection", args)),
+      count: vi.fn(async (args: Row) => count("daemonConnection", args)),
+    },
+    notification: {
+      create: vi.fn(async (args: Row) => {
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("notif"),
+          readAt: null,
+          archivedAt: null,
+          instructionText: null,
+          createdAt: new Date(),
+          ...(args.data as Row),
+        };
+        store.data.notification.push(row);
+        return { ...row };
+      }),
+      count: vi.fn(async (args: Row) => count("notification", args)),
+      findMany: vi.fn(async (args: Row) => findMany("notification", args)),
+    },
+    user: {
+      findUnique: vi.fn(async (args: Row) => findFirst("user", { where: args.where })),
+      findFirst: vi.fn(async (args: Row) => findFirst("user", args)),
+      findMany: vi.fn(async (args: Row) => findMany("user", args)),
+    },
+    agent: {
+      findUnique: vi.fn(async (args: Row) => findFirst("agent", { where: args.where })),
+      findFirst: vi.fn(async (args: Row) => findFirst("agent", args)),
+      findMany: vi.fn(async (args: Row) => findMany("agent", args)),
+      count: vi.fn(async (args: Row) => count("agent", args)),
+    },
+    project: {
+      findUnique: vi.fn(async (args: Row) => findFirst("project", { where: args.where })),
+    },
+    notificationPreference: {
+      // getPreferences: findUnique by composite { ownerType_ownerUuid }, else create default.
+      findUnique: vi.fn(async (args: Row) => {
+        const key = (args.where as Row).ownerType_ownerUuid as Row;
+        return (
+          store.data.notificationPreference.find(
+            (p) => p.ownerType === key.ownerType && p.ownerUuid === key.ownerUuid,
+          ) ?? null
+        );
+      }),
+      create: vi.fn(async (args: Row) => {
+        // Default-on preferences (Prisma schema defaults are all true), incl. `mentioned`.
+        const row: Row = {
+          id: store.nextId(),
+          uuid: store.nextUuid("pref"),
+          taskAssigned: true,
+          taskStatusChanged: true,
+          taskVerified: true,
+          taskReopened: true,
+          proposalSubmitted: true,
+          proposalApproved: true,
+          proposalRejected: true,
+          ideaClaimed: true,
+          commentAdded: true,
+          elaborationRequested: true,
+          elaborationAnswered: true,
+          mentioned: true,
+          ...(args.data as Row),
+        };
+        store.data.notificationPreference.push(row);
+        return { ...row };
+      }),
+    },
+    mention: {
+      createMany: vi.fn(async (args: Row) => {
+        const rows = (args.data as Row[]) ?? [];
+        for (const d of rows) {
+          store.data.mention.push({ id: store.nextId(), uuid: store.nextUuid("mention"), ...d });
+        }
+        return { count: rows.length };
+      }),
+    },
+  };
+}
+
+// ===== Module mocks =====
+
+const hoisted = vi.hoisted(() => {
+  const s = makeStore();
+  return { store: s, prismaFake: buildPrismaFake(s) };
+});
+const store = hoisted.store;
+vi.mock("@/lib/prisma", () => ({ prisma: hoisted.prismaFake }));
+
+// Silence the logger; the real in-process event bus is used (Redis off).
+const mockLogger = vi.hoisted(() => {
+  const l = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn(), child: () => l };
+  return l;
+});
+vi.mock("@/lib/logger", () => ({ default: mockLogger, createRequestLogger: () => mockLogger }));
+
+// Lineage: a task / idea under IDEA resolves to that direct idea; everything else → null.
+const mockResolveRootIdea = vi.hoisted(() => vi.fn());
+vi.mock("@/services/lineage.service", () => ({ resolveRootIdea: mockResolveRootIdea }));
+
+// Connection registry: the wake bridge AND the mention picker ask for the agent's
+// connections. Keep STALE_THRESHOLD_MS REAL (the session service re-exports it) — only
+// swap listConnectionsForAgent, reading the seeded store so the (host, cwd)/effectiveStatus
+// the wake matches against is exactly what we seeded as the registry's verdict.
+const mockListConnectionsForAgent = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-connection.service", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, listConnectionsForAgent: mockListConnectionsForAgent };
+});
+
+// ===== Imports under test (REAL) =====
+import * as notificationService from "@/services/notification.service";
+import { claimTask } from "@/services/task.service";
+import { parseMentions, createMentions } from "@/services/mention.service";
+import { buildMentionMarker } from "@/lib/mention-format";
+import {
+  maybeCreateTurnForWakeNotification,
+  type WakeNotificationContext,
+} from "@/services/notification-turn";
+import { createAdHocSessionWithInstruction } from "@/services/daemon-instruction.service";
+import { getPendingTurnsForConnection } from "@/services/daemon-session.service";
+
+// ===== Fixtures =====
+// UUIDs are real-shaped: parseMentions' markup regex only matches a lowercase hex UUID,
+// so the @mention round-trip exercises the actual codec (not a loosened test double).
+const COMPANY = "11111111-1111-4111-8111-111111111111";
+const PROJECT = "22222222-2222-4222-8222-222222222222";
+const AGENT = "33333333-3333-4333-8333-333333333333";
+const USER = "44444444-4444-4444-8444-444444444444";
+const IDEA = "55555555-5555-4555-8555-555555555555";
+const TASK = "66666666-6666-4666-8666-666666666666";
+const COMMENT = "77777777-7777-4777-8777-777777777777";
+
+// The pinned "place" the owner chooses on both the assignment and the @mention.
+const PIN_HOST = "Laptop-Q3";
+const PIN_CWD = "/home/u/dev/payments";
+
+// The connection at the pinned (host, cwd) place vs. an online "elsewhere" connection.
+const PINNED_CONN = "conn-pinned-0001";
+const OTHER_CONN = "conn-other-0002";
+
+// A ConnectionView (the shape listConnectionsForAgent returns), online-first then
+// lastSeenAt desc per the registry contract. We build the list explicitly per test.
+function connView(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: PINNED_CONN,
+    agentUuid: AGENT,
+    agentName: "Daemon Agent",
+    clientType: "claude_code",
+    clientVersion: null,
+    host: PIN_HOST,
+    cwd: PIN_CWD,
+    startedAt: null,
+    status: "online",
+    effectiveStatus: "online" as "online" | "offline",
+    connectedAt: "2026-06-22T00:00:00.000Z",
+    lastSeenAt: "2026-06-22T00:00:00.000Z",
+    disconnectedAt: null,
+    ...overrides,
+  };
+}
+
+// Seed an open Task so the REAL claimTask can write to it.
+function seedTask(overrides: Record<string, unknown> = {}) {
+  const now = new Date();
+  const row: Row = {
+    id: store.nextId(),
+    uuid: TASK,
+    companyUuid: COMPANY,
+    projectUuid: PROJECT,
+    title: "Build the thing",
+    description: null,
+    status: "open",
+    priority: "high",
+    storyPoints: 3,
+    acceptanceCriteria: null,
+    assigneeType: null,
+    assigneeUuid: null,
+    assignedAt: null,
+    assignedByUuid: null,
+    targetHost: null,
+    targetCwd: null,
+    proposalUuid: null,
+    createdByUuid: USER,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+  store.data.task.push(row);
+  return row;
+}
+
+// Seed a connection row so connectionBelongsToAgent / isConnectionLive (REAL, reading the
+// store) can verify it for the ad-hoc 409 path.
+function seedConnection(uuid: string, status: string, host: string, cwd: string | null, lastSeenAt: Date) {
+  store.data.daemonConnection.push({
+    id: store.nextId(),
+    uuid,
+    companyUuid: COMPANY,
+    agentUuid: AGENT,
+    status,
+    host,
+    cwd,
+    lastSeenAt,
+  });
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(store.data) as (keyof Store["data"])[]) {
+    store.data[k].length = 0;
+  }
+  vi.clearAllMocks();
+
+  // The actor-name resolver (formatTaskResponse → getActorName), the mention-target
+  // validator (validateMentionTarget), and project-name lookup read these rows.
+  store.data.user.push({ id: store.nextId(), uuid: USER, companyUuid: COMPANY, name: "Alice", email: "a@x.com" });
+  store.data.agent.push({ id: store.nextId(), uuid: AGENT, companyUuid: COMPANY, name: "Daemon Agent", ownerUuid: USER });
+  store.data.project.push({ id: store.nextId(), uuid: PROJECT, companyUuid: COMPANY, name: "Chorus 0.11.2" });
+
+  // task / idea under IDEA resolves to that direct idea; everything else null.
+  mockResolveRootIdea.mockImplementation(async (_c: string, type: string, uuid: string) => {
+    if ((type === "task" && uuid === TASK) || (type === "idea" && uuid === IDEA)) {
+      return { rootIdeaUuid: IDEA, directIdeaUuid: IDEA };
+    }
+    return { rootIdeaUuid: null, directIdeaUuid: null };
+  });
+
+  // Default registry verdict: a single online connection at the pinned place. Tests that
+  // need an "elsewhere" connection or an offline place override this per-case. Without a
+  // default, the wake bridge (REAL) would see `undefined` and throw.
+  mockListConnectionsForAgent.mockResolvedValue([connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD })]);
+});
+
+// ===========================================================================================
+// THREAD 1 + 2 — task-assignment pin: the REAL write (claimTask) feeds the REAL read (wake).
+// ===========================================================================================
+
+describe("integration: task-assignment pin written by claimTask is the SAME shape the wake reads", () => {
+  it("claimTask persists (host, cwd) to Task.targetHost/targetCwd, then the task_assigned wake reads THAT shape and pins the matching live connection", async () => {
+    seedTask();
+
+    // --- WRITE (T4): the REAL claimTask threads the owner-chosen pin into the assignment. ---
+    const claimed = await claimTask({
+      taskUuid: TASK,
+      companyUuid: COMPANY,
+      assigneeType: "agent",
+      assigneeUuid: AGENT,
+      assignedByUuid: USER,
+      targetHost: PIN_HOST,
+      targetCwd: PIN_CWD,
+    });
+
+    // The pin surfaces on the response in the exact field names T4 added ...
+    expect(claimed.targetHost).toBe(PIN_HOST);
+    expect(claimed.targetCwd).toBe(PIN_CWD);
+    // ... and is PERSISTED to the Task row's targetHost/targetCwd columns (the durable
+    // storage the wake reads). This is the write shape, asserted against the stored row.
+    const storedTask = store.data.task.find((t) => t.uuid === TASK)!;
+    expect(storedTask.targetHost).toBe(PIN_HOST);
+    expect(storedTask.targetCwd).toBe(PIN_CWD);
+
+    // --- READ (T5): a task_assigned wake. listConnectionsForAgent returns an online
+    // "elsewhere" connection FIRST (so online-first would pick it) and the pinned-place
+    // connection second. The pin must override online-first and select the pinned one. ---
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: OTHER_CONN, host: "other-host", cwd: "/home/u/dev/other" }),
+      connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD }),
+    ]);
+
+    // Drive the wake through the REAL notification chokepoint → REAL notification-turn
+    // bridge → REAL prisma.task.findFirst (which reads back what claimTask stored).
+    const turn = await notificationService.createReturningTurn({
+      companyUuid: COMPANY,
+      projectUuid: PROJECT,
+      recipientType: "agent",
+      recipientUuid: AGENT,
+      entityType: "task",
+      entityUuid: TASK,
+      entityTitle: "Build the thing",
+      projectName: "Chorus 0.11.2",
+      action: "task_assigned",
+      message: "Task assigned",
+      actorType: "user",
+      actorUuid: USER,
+      actorName: "Alice",
+    });
+
+    // The session origin is pinned to the (host, cwd)-MATCHING connection — proving the
+    // wake read the same columns claimTask wrote. If T5 read a wrong field, no pin would
+    // resolve and the session would pin to OTHER_CONN (online-first) instead.
+    expect(store.data.daemonSession).toHaveLength(1);
+    expect(store.data.daemonSession[0].originConnectionUuid).toBe(PINNED_CONN);
+    expect(turn.turn?.trigger).toBe("task_assigned");
+    expect(turn.turn?.status).toBe("pending");
+    // The bridge actually read the Task columns (not the project, not inference).
+    expect(hoisted.prismaFake.task.findFirst).toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("@mention pin survives the markup round-trip (buildMentionMarker → parseMentions) and the mentioned wake pins the matching live connection", async () => {
+    // --- WRITE (T3): the editor serializes a pinned mention; the service parses it back. ---
+    const marker = buildMentionMarker("Daemon Agent", "agent", AGENT, PIN_HOST, PIN_CWD);
+    // The pin rides INSIDE the parens as a query-string suffix (paren-free payload).
+    expect(marker).toContain(`(agent:${AGENT}?`);
+    expect(marker).toContain("host=");
+    expect(marker).toContain("cwd=");
+
+    const parsed = parseMentions(`Hey ${marker}, take a look`);
+    expect(parsed).toHaveLength(1);
+    // The parsed ref carries the SAME (host, cwd) the marker encoded — the codec the
+    // client editor and the server service share, so producer and parser cannot drift.
+    expect(parsed[0]).toMatchObject({ type: "agent", uuid: AGENT, pinnedHost: PIN_HOST, pinnedCwd: PIN_CWD });
+
+    // --- READ (T5): a mentioned wake. The pin is threaded on the CONTEXT (not the Task),
+    // and must override online-first to select the pinned-place connection. ---
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: OTHER_CONN, host: "other-host", cwd: "/home/u/dev/other" }),
+      connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD }),
+    ]);
+
+    const turn = await maybeCreateTurnForWakeNotification({
+      companyUuid: COMPANY,
+      recipientType: "agent",
+      recipientUuid: AGENT,
+      entityType: "comment",
+      entityUuid: COMMENT,
+      action: "mentioned",
+      // Threaded from the parsed mention ref by createMentions — proven identical here.
+      pinnedHost: parsed[0].pinnedHost,
+      pinnedCwd: parsed[0].pinnedCwd,
+    });
+
+    expect(store.data.daemonSession).toHaveLength(1);
+    expect(store.data.daemonSession[0].originConnectionUuid).toBe(PINNED_CONN);
+    expect(turn?.trigger).toBe("mentioned");
+    expect(turn?.status).toBe("pending");
+    // A mentioned wake reads its pin from the context, NEVER from the Task table.
+    expect(hoisted.prismaFake.task.findFirst).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("createMentions threads the pinned (host, cwd) from the markup into the wake notification (full @mention chain)", async () => {
+    // The REAL createMentions parses a pinned marker and feeds the wake chokepoint
+    // (createBatch). We spy on createBatch to capture the params it threads
+    // (pinnedHost/pinnedCwd) — proving the mention service does NOT drop the pin between
+    // parse and wake. sourceType "task" keeps the navigable entity the task itself (no
+    // comment-lookup needed) so the chain stays focused on the pin threading.
+    const batchSpy = vi
+      .spyOn(notificationService, "createBatch")
+      .mockResolvedValue([]);
+    try {
+      const marker = buildMentionMarker("Daemon Agent", "agent", AGENT, PIN_HOST, PIN_CWD);
+      await createMentions({
+        companyUuid: COMPANY,
+        sourceType: "task",
+        sourceUuid: TASK,
+        content: `Please review ${marker}`,
+        actorType: "user",
+        actorUuid: USER,
+        projectUuid: PROJECT,
+        entityTitle: "Build the thing",
+      });
+
+      expect(batchSpy).toHaveBeenCalledTimes(1);
+      const threadedList = batchSpy.mock.calls[0][0];
+      expect(threadedList).toHaveLength(1);
+      const threaded = threadedList[0];
+      expect(threaded.action).toBe("mentioned");
+      expect(threaded.recipientType).toBe("agent");
+      expect(threaded.recipientUuid).toBe(AGENT);
+      // The owner-chosen pin is threaded verbatim into the wake — same (host, cwd) that
+      // the markup encoded, NOT dropped between parseMentions and the chokepoint.
+      expect(threaded.pinnedHost).toBe(PIN_HOST);
+      expect(threaded.pinnedCwd).toBe(PIN_CWD);
+    } finally {
+      batchSpy.mockRestore();
+    }
+  });
+});
+
+// ===========================================================================================
+// THREAD 2 — KEY ASSERTION: write shape ≡ read shape (a deliberate mismatch must FAIL).
+// ===========================================================================================
+
+describe("integration: KEY ASSERTION — the wake reads the EXACT field names claimTask writes", () => {
+  it("a deliberate field-name mismatch (pin stored under a wrong column) breaks the pin → online-first fallback (the silent-mismatch this checkpoint must catch)", async () => {
+    seedTask();
+
+    // Write the pin under a WRONG column name — simulating the reviewer's flagged drift
+    // where T4 and T5 disagree on the field. The REAL wake reads `targetHost`/`targetCwd`;
+    // a pin written elsewhere is invisible to it.
+    const storedTask = store.data.task.find((t) => t.uuid === TASK)!;
+    storedTask.assigneeType = "agent";
+    storedTask.assigneeUuid = AGENT;
+    storedTask.status = "assigned";
+    // The CORRECT columns stay null (the mismatch); the pin is misfiled under a typo'd key.
+    storedTask.targetHost = null;
+    storedTask.targetCwd = null;
+    (storedTask as Record<string, unknown>).pinnedHostTYPO = PIN_HOST;
+    (storedTask as Record<string, unknown>).pinnedCwdTYPO = PIN_CWD;
+
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: OTHER_CONN, host: "other-host", cwd: "/home/u/dev/other" }),
+      connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification({
+      companyUuid: COMPANY,
+      recipientType: "agent",
+      recipientUuid: AGENT,
+      entityType: "task",
+      entityUuid: TASK,
+      action: "task_assigned",
+    });
+
+    // Because the wake found NO pin in its real columns, it fell back to online-first
+    // (OTHER_CONN) rather than the pinned place. This is the failure the integration
+    // catches: with the columns aligned (the test above) the origin is PINNED_CONN; with
+    // them misaligned it is NOT. The two assertions together prove the contract is real.
+    expect(store.data.daemonSession[0].originConnectionUuid).toBe(OTHER_CONN);
+    expect(store.data.daemonSession[0].originConnectionUuid).not.toBe(PINNED_CONN);
+  });
+
+  it("the field names the wake reads are exactly the field names claimTask writes (no codec drift between write and read)", async () => {
+    // A structural guard against silent rename of either side: the wake's task-pin read
+    // selects targetHost/targetCwd, and claimTask's write data sets targetHost/targetCwd.
+    // Drive the REAL write, then capture the REAL read's select clause.
+    seedTask();
+    await claimTask({
+      taskUuid: TASK,
+      companyUuid: COMPANY,
+      assigneeType: "agent",
+      assigneeUuid: AGENT,
+      assignedByUuid: USER,
+      targetHost: PIN_HOST,
+      targetCwd: PIN_CWD,
+    });
+    // claimTask wrote these exact keys onto the Task row.
+    const stored = store.data.task.find((t) => t.uuid === TASK)!;
+    expect(Object.keys(stored)).toEqual(expect.arrayContaining(["targetHost", "targetCwd"]));
+
+    mockListConnectionsForAgent.mockResolvedValue([connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD })]);
+    await maybeCreateTurnForWakeNotification({
+      companyUuid: COMPANY,
+      recipientType: "agent",
+      recipientUuid: AGENT,
+      entityType: "task",
+      entityUuid: TASK,
+      action: "task_assigned",
+    });
+    // The wake's read selected the SAME two columns (and scoped by uuid + companyUuid).
+    const readArgs = hoisted.prismaFake.task.findFirst.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      select: Record<string, unknown>;
+    };
+    expect(readArgs.select).toMatchObject({ targetHost: true, targetCwd: true });
+    expect(readArgs.where).toMatchObject({ uuid: TASK, companyUuid: COMPANY });
+  });
+});
+
+// ===========================================================================================
+// THREAD 3 — OFFLINE pin / fully-offline agent: NOT wakeable, NO durable queue. An offline
+// place never becomes the origin; the pin only ever wakes a matching ONLINE connection.
+// ===========================================================================================
+
+describe("integration: an OFFLINE pin is NOT wakeable — no durable queue, the notification stands", () => {
+  it("a task_assigned wake pinned to an OFFLINE place falls back to online-first (the offline place is NOT the origin, NO backfill queue)", async () => {
+    seedTask();
+
+    // WRITE: pin the assignment to (PIN_HOST, PIN_CWD) via the REAL claimTask.
+    await claimTask({
+      taskUuid: TASK,
+      companyUuid: COMPANY,
+      assigneeType: "agent",
+      assigneeUuid: AGENT,
+      assignedByUuid: USER,
+      targetHost: PIN_HOST,
+      targetCwd: PIN_CWD,
+    });
+
+    // The pinned place is OFFLINE; another instance is online elsewhere. The offline pin
+    // is NOT wakeable, so the wake falls back to online-first and pins the ONLINE place.
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: OTHER_CONN, host: "other-host", cwd: "/home/u/dev/other", effectiveStatus: "online" }),
+      connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD, status: "offline", effectiveStatus: "offline" }),
+    ]);
+
+    await notificationService.create({
+      companyUuid: COMPANY,
+      projectUuid: PROJECT,
+      recipientType: "agent",
+      recipientUuid: AGENT,
+      entityType: "task",
+      entityUuid: TASK,
+      entityTitle: "Build the thing",
+      projectName: "Chorus 0.11.2",
+      action: "task_assigned",
+      message: "Task assigned",
+      actorType: "user",
+      actorUuid: USER,
+      actorName: "Alice",
+    });
+
+    // A turn IS created (an online connection exists), but pinned to the ONLINE-elsewhere
+    // place — NOT the offline pinned one. There is no durable queue at the offline place.
+    expect(store.data.daemonSessionTurn).toHaveLength(1);
+    expect(store.data.daemonSession[0].originConnectionUuid).toBe(OTHER_CONN);
+    expect(store.data.daemonSession[0].originConnectionUuid).not.toBe(PINNED_CONN);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+
+    // No pending turn is queued at the OFFLINE pinned place — a reconnect there reads
+    // nothing (the durable-intent backfill net is gone).
+    const pendingAtOffline = await getPendingTurnsForConnection({
+      companyUuid: COMPANY,
+      agentUuid: AGENT,
+      connectionUuid: PINNED_CONN,
+    });
+    expect(pendingAtOffline).toHaveLength(0);
+  });
+
+  it("a fully-offline agent records a PLAIN notification with NO turn (no durable queue)", async () => {
+    seedTask();
+    await claimTask({
+      taskUuid: TASK,
+      companyUuid: COMPANY,
+      assigneeType: "agent",
+      assigneeUuid: AGENT,
+      assignedByUuid: USER,
+      targetHost: PIN_HOST,
+      targetCwd: PIN_CWD,
+    });
+
+    // Agent fully offline; the pinned place exists (offline) but nothing is wakeable.
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD, status: "offline", effectiveStatus: "offline" }),
+    ]);
+
+    await notificationService.create({
+      companyUuid: COMPANY,
+      projectUuid: PROJECT,
+      recipientType: "agent",
+      recipientUuid: AGENT,
+      entityType: "task",
+      entityUuid: TASK,
+      entityTitle: "Build the thing",
+      projectName: "Chorus 0.11.2",
+      action: "task_assigned",
+      message: "Task assigned",
+      actorType: "user",
+      actorUuid: USER,
+      actorName: "Alice",
+    });
+
+    // The plain Notification IS recorded, but NO turn / NO session is created — the
+    // fully-offline target is a notification-only event. A skipped wake is not an error.
+    expect(store.data.notification).toHaveLength(1);
+    expect(store.data.daemonSessionTurn).toHaveLength(0);
+    expect(store.data.daemonSession).toHaveLength(0);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+
+    // A later reconnect at the (offline) pinned place reads nothing — no queued turn.
+    const pending = await getPendingTurnsForConnection({
+      companyUuid: COMPANY,
+      agentUuid: AGENT,
+      connectionUuid: PINNED_CONN,
+    });
+    expect(pending).toHaveLength(0);
+  });
+});
+
+// ===========================================================================================
+// THREAD 4 — live ad-hoc send to an OFFLINE instance → rejected (409). The durable-vs-live
+// split holds end to end: durable intent (above) queues; the live send refuses.
+// ===========================================================================================
+
+describe("integration: live ad-hoc send to an OFFLINE instance is rejected (409) — durable-vs-live split", () => {
+  it("createAdHocSessionWithInstruction throws ConnectionOfflineError (→ 409) when the chosen instance is offline, creating NO session/turn", async () => {
+    // The SAME (host, cwd) place that durable intent happily queued for above is, for a
+    // LIVE send, a hard 409: the connection is offline. Seed it offline (stale lastSeenAt).
+    seedConnection(PINNED_CONN, "online", PIN_HOST, PIN_CWD, new Date(Date.now() - 10 * 60_000));
+
+    await expect(
+      createAdHocSessionWithInstruction(
+        { type: "user", companyUuid: COMPANY, actorUuid: USER },
+        { agentUuid: AGENT, connectionUuid: PINNED_CONN, instructionText: "Run it now" },
+      ),
+    ).rejects.toMatchObject({
+      // The typed error the route maps to 409 (errors.conflict).
+      code: "connection_offline",
+      connectionUuid: PINNED_CONN,
+    });
+
+    // No durable side effects: the live-send gate fires BEFORE any session/turn creation.
+    expect(store.data.daemonSession).toHaveLength(0);
+    expect(store.data.daemonSessionTurn).toHaveLength(0);
+    expect(store.data.notification).toHaveLength(0);
+  });
+
+  it("the SAME online instance accepts a live ad-hoc send (proving the 409 is the offline gate, not a blanket reject)", async () => {
+    // Online (fresh lastSeenAt): the live send succeeds, creating the ad-hoc session + turn.
+    seedConnection(PINNED_CONN, "online", PIN_HOST, PIN_CWD, new Date());
+
+    const { session, turn } = await createAdHocSessionWithInstruction(
+      { type: "user", companyUuid: COMPANY, actorUuid: USER },
+      { agentUuid: AGENT, connectionUuid: PINNED_CONN, instructionText: "Run it now" },
+    );
+
+    expect(turn.trigger).toBe("human_instruction");
+    expect(turn.promptText).toBe("Run it now");
+    expect(turn.status).toBe("pending");
+    // Ad-hoc session is pinned to the chosen (online) connection, with no idea anchor.
+    expect(session.originConnectionUuid).toBe(PINNED_CONN);
+    expect(session.directIdeaUuid).toBeNull();
+    expect(store.data.daemonSession).toHaveLength(1);
+    expect(store.data.daemonSessionTurn).toHaveLength(1);
+  });
+});
+
+// ===========================================================================================
+// Guard: an UN-pinned assignment/mention behaves exactly as before (additive feature).
+// ===========================================================================================
+
+describe("integration: an un-pinned assignment behaves exactly as before this change", () => {
+  it("claimTask without a pin writes null columns, and the task_assigned wake stays online-first", async () => {
+    seedTask();
+    const claimed = await claimTask({
+      taskUuid: TASK,
+      companyUuid: COMPANY,
+      assigneeType: "agent",
+      assigneeUuid: AGENT,
+      assignedByUuid: USER,
+      // No targetHost/targetCwd → no pin.
+    });
+    expect(claimed.targetHost).toBeNull();
+    expect(claimed.targetCwd).toBeNull();
+    const stored = store.data.task.find((t) => t.uuid === TASK)!;
+    expect(stored.targetHost).toBeNull();
+    expect(stored.targetCwd).toBeNull();
+
+    // Online-first should pick the first online connection (no pin narrowing).
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: OTHER_CONN, host: "host-A", cwd: "/home/u/dev/a", effectiveStatus: "online" }),
+      connView({ uuid: PINNED_CONN, host: PIN_HOST, cwd: PIN_CWD, status: "offline", effectiveStatus: "offline" }),
+    ]);
+
+    await notificationService.create({
+      companyUuid: COMPANY,
+      projectUuid: PROJECT,
+      recipientType: "agent",
+      recipientUuid: AGENT,
+      entityType: "task",
+      entityUuid: TASK,
+      entityTitle: "Build the thing",
+      projectName: "Chorus 0.11.2",
+      action: "task_assigned",
+      message: "Task assigned",
+      actorType: "user",
+      actorUuid: USER,
+      actorName: "Alice",
+    });
+
+    expect(store.data.daemonSession[0].originConnectionUuid).toBe(OTHER_CONN);
+  });
+});

--- a/src/services/__tests__/daemon-instruction.service.test.ts
+++ b/src/services/__tests__/daemon-instruction.service.test.ts
@@ -4,6 +4,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockPrisma = vi.hoisted(() => ({
   daemonSession: {
     findFirst: vi.fn(),
+    // T12 re-point: the SUT UPDATEs originConnectionUuid then reads the row back.
+    update: vi.fn(),
+    findUnique: vi.fn(),
   },
   daemonSessionTurn: {
     findMany: vi.fn(),
@@ -87,8 +90,10 @@ import {
   SessionNotVisibleError,
   ConnectionNotVisibleError,
   ConnectionOfflineError,
+  RepointOriginLiveError,
   sendInstruction,
   createAdHocSessionWithInstruction,
+  repointSessionOriginAndSend,
   getVisibleSessionsWithOrigin,
 } from "@/services/daemon-instruction.service";
 // The mocked SessionReadOnlyError class (defined in the vi.mock factory above), imported
@@ -154,6 +159,21 @@ beforeEach(() => {
     sessionId: ideaUuid,
     directIdeaUuid: ideaUuid,
     originConnectionUuid: connectionUuid,
+  });
+  // T12 re-point defaults: the UPDATE resolves, and the read-back returns a full row whose
+  // origin is now the (online) target connection — Date objects (Prisma row, not the view).
+  mockPrisma.daemonSession.update.mockResolvedValue({});
+  mockPrisma.daemonSession.findUnique.mockResolvedValue({
+    uuid: sessionUuid,
+    agentUuid,
+    sessionId: ideaUuid,
+    directIdeaUuid: ideaUuid,
+    originConnectionUuid: otherConnectionUuid,
+    status: "active",
+    title: null,
+    lastTurnAt: new Date("2026-06-19T03:00:00.000Z"),
+    createdAt: new Date("2026-06-19T03:00:00.000Z"),
+    updatedAt: new Date("2026-06-19T03:00:00.000Z"),
   });
   mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
   // Naming enrichment defaults: no instruction turns + no ideas resolved unless a test
@@ -435,6 +455,232 @@ describe("createAdHocSessionWithInstruction", () => {
       }),
     ).rejects.toBeInstanceOf(ConnectionNotVisibleError);
     expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+  });
+});
+
+// ===== repointSessionOriginAndSend (T12 — corrects T11) =====
+describe("repointSessionOriginAndSend", () => {
+  // The session's CURRENT origin (offline) vs the chosen ONLINE target (a DIFFERENT
+  // connection of the SAME agent). `isConnectionLive` is consulted twice in order:
+  // (1) the current origin → must be OFFLINE (false) to allow re-point; (2) the target →
+  // must be ONLINE (true). Each test wires this sequence explicitly.
+  const currentOrigin = connectionUuid; // offline
+  const targetOnline = otherConnectionUuid; // online
+
+  function wireRepointHappyPath() {
+    // Visible, owned, idea-anchored session whose current origin is `currentOrigin`.
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      agentUuid,
+      sessionId: ideaUuid,
+      directIdeaUuid: ideaUuid,
+      originConnectionUuid: currentOrigin,
+    });
+    // (1) current origin OFFLINE, (2) target ONLINE.
+    mockIsConnectionLive
+      .mockReset()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mockConnectionBelongsToAgent.mockResolvedValue(true);
+  }
+
+  it("keeps the SAME session (uuid + sessionId + directIdeaUuid), re-points origin to the target, creates a turn, delivers to the NEW origin", async () => {
+    wireRepointHappyPath();
+    const { session, turn } = await repointSessionOriginAndSend(userAuth, {
+      sessionUuid,
+      connectionUuid: targetOnline,
+      instructionText: "  pick up where we left off  ",
+    });
+
+    // The origin is RE-POINTED — the single deliberate write-once reversal — scoped to the
+    // session uuid + company (no cross-company write).
+    expect(mockPrisma.daemonSession.update).toHaveBeenCalledTimes(1);
+    const upd = mockPrisma.daemonSession.update.mock.calls[0][0];
+    expect(upd.where).toMatchObject({ uuid: sessionUuid, companyUuid });
+    expect(upd.data).toEqual({ originConnectionUuid: targetOnline });
+
+    // NO new ad-hoc session is minted — resolveOrCreateSession is NOT called.
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+
+    // The turn is created on the SAME session, idea-aligned (same directIdeaUuid → lands on
+    // the existing row), with the trimmed canonical text.
+    expect(mockNotificationCreate).toHaveBeenCalledTimes(1);
+    const notif = mockNotificationCreate.mock.calls[0][0];
+    expect(notif.action).toBe("human_instruction");
+    expect(notif.entityType).toBe("idea");
+    expect(notif.entityUuid).toBe(ideaUuid);
+    expect(notif.instructionText).toBe("pick up where we left off");
+
+    // Delivered to the NEW origin connection (never the offline one), precise turnUuid.
+    expect(mockDispatchControl).toHaveBeenCalledWith({
+      companyUuid,
+      targetConnectionUuid: targetOnline,
+      command: "deliver_turn",
+      turnUuid,
+    });
+
+    // The returned session is the SAME one, now pointing at the online target.
+    expect(session.uuid).toBe(sessionUuid);
+    expect(session.sessionId).toBe(ideaUuid);
+    expect(session.directIdeaUuid).toBe(ideaUuid);
+    expect(session.originConnectionUuid).toBe(targetOnline);
+    expect(turn.uuid).toBe(turnUuid);
+  });
+
+  it("ad-hoc session re-point keeps its sessionId and stays non-lineage aligned (entityUuid = sessionId)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      agentUuid,
+      sessionId: adHocSessionId,
+      directIdeaUuid: null,
+      originConnectionUuid: currentOrigin,
+    });
+    mockIsConnectionLive
+      .mockReset()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({
+      uuid: sessionUuid,
+      agentUuid,
+      sessionId: adHocSessionId,
+      directIdeaUuid: null,
+      originConnectionUuid: targetOnline,
+      status: "active",
+      title: null,
+      lastTurnAt: new Date("2026-06-19T03:00:00.000Z"),
+      createdAt: new Date("2026-06-19T03:00:00.000Z"),
+      updatedAt: new Date("2026-06-19T03:00:00.000Z"),
+    });
+
+    const { session } = await repointSessionOriginAndSend(userAuth, {
+      sessionUuid,
+      connectionUuid: targetOnline,
+      instructionText: "go",
+    });
+    const notif = mockNotificationCreate.mock.calls[0][0];
+    expect(notif.entityType).toBe(AD_HOC_ENTITY_TYPE);
+    expect(notif.entityUuid).toBe(adHocSessionId);
+    expect(session.sessionId).toBe(adHocSessionId);
+  });
+
+  it("refuses to re-point a LIVE session (current origin online) → RepointOriginLiveError, no update/turn", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      agentUuid,
+      sessionId: ideaUuid,
+      directIdeaUuid: ideaUuid,
+      originConnectionUuid: currentOrigin,
+    });
+    // current origin ONLINE → refuse.
+    mockIsConnectionLive.mockReset().mockResolvedValueOnce(true);
+    await expect(
+      repointSessionOriginAndSend(userAuth, {
+        sessionUuid,
+        connectionUuid: targetOnline,
+        instructionText: "go",
+      }),
+    ).rejects.toBeInstanceOf(RepointOriginLiveError);
+    expect(mockPrisma.daemonSession.update).not.toHaveBeenCalled();
+    expect(mockNotificationCreate).not.toHaveBeenCalled();
+    expect(mockDispatchControl).not.toHaveBeenCalled();
+    // The target's liveness is never even consulted once the live-origin guard trips.
+    expect(mockIsConnectionLive).toHaveBeenCalledTimes(1);
+  });
+
+  it("not-visible session → SessionNotVisibleError, no liveness check, no update/turn", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+    await expect(
+      repointSessionOriginAndSend(userAuth, {
+        sessionUuid,
+        connectionUuid: targetOnline,
+        instructionText: "go",
+      }),
+    ).rejects.toBeInstanceOf(SessionNotVisibleError);
+    expect(mockIsConnectionLive).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonSession.update).not.toHaveBeenCalled();
+    expect(mockNotificationCreate).not.toHaveBeenCalled();
+  });
+
+  it("target connection NOT of the same agent → ConnectionNotVisibleError (non-disclosure), no update/turn", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      agentUuid,
+      sessionId: ideaUuid,
+      directIdeaUuid: ideaUuid,
+      originConnectionUuid: currentOrigin,
+    });
+    // current origin OFFLINE (passes), then same-agent check fails.
+    mockIsConnectionLive.mockReset().mockResolvedValueOnce(false);
+    mockConnectionBelongsToAgent.mockResolvedValue(false);
+    await expect(
+      repointSessionOriginAndSend(userAuth, {
+        sessionUuid,
+        connectionUuid: targetOnline,
+        instructionText: "go",
+      }),
+    ).rejects.toBeInstanceOf(ConnectionNotVisibleError);
+    expect(mockPrisma.daemonSession.update).not.toHaveBeenCalled();
+    expect(mockNotificationCreate).not.toHaveBeenCalled();
+  });
+
+  it("offline TARGET connection → ConnectionOfflineError, no update/turn", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      agentUuid,
+      sessionId: ideaUuid,
+      directIdeaUuid: ideaUuid,
+      originConnectionUuid: currentOrigin,
+    });
+    // current origin OFFLINE (passes), same-agent ok, target OFFLINE → 409.
+    mockIsConnectionLive
+      .mockReset()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    mockConnectionBelongsToAgent.mockResolvedValue(true);
+    await expect(
+      repointSessionOriginAndSend(userAuth, {
+        sessionUuid,
+        connectionUuid: targetOnline,
+        instructionText: "go",
+      }),
+    ).rejects.toBeInstanceOf(ConnectionOfflineError);
+    expect(mockPrisma.daemonSession.update).not.toHaveBeenCalled();
+    expect(mockNotificationCreate).not.toHaveBeenCalled();
+  });
+
+  it("validates text BEFORE any lookup/liveness/update — empty → InstructionTextError", async () => {
+    await expect(
+      repointSessionOriginAndSend(userAuth, {
+        sessionUuid,
+        connectionUuid: targetOnline,
+        instructionText: "   ",
+      }),
+    ).rejects.toBeInstanceOf(InstructionTextError);
+    expect(mockPrisma.daemonSession.findFirst).not.toHaveBeenCalled();
+    expect(mockIsConnectionLive).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonSession.update).not.toHaveBeenCalled();
+    expect(mockNotificationCreate).not.toHaveBeenCalled();
+  });
+
+  it("agent-key caller is owner/self-scoped on the session lookup (agentUuid filter)", async () => {
+    wireRepointHappyPath();
+    await repointSessionOriginAndSend(agentAuth, {
+      sessionUuid,
+      connectionUuid: targetOnline,
+      instructionText: "go",
+    });
+    const where = mockPrisma.daemonSession.findFirst.mock.calls[0][0].where;
+    expect(where).toMatchObject({ uuid: sessionUuid, companyUuid, agentUuid });
+  });
+
+  it("a deliver_turn dispatch FAILURE does NOT fail the re-point (turn already persisted; non-fatal)", async () => {
+    wireRepointHappyPath();
+    mockDispatchControl.mockImplementation(() => {
+      throw new Error("event bus down");
+    });
+    const { session, turn } = await repointSessionOriginAndSend(userAuth, {
+      sessionUuid,
+      connectionUuid: targetOnline,
+      instructionText: "go",
+    });
+    expect(session.originConnectionUuid).toBe(targetOnline);
+    expect(turn.uuid).toBe(turnUuid);
+    expect(mockPrisma.daemonSession.update).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/services/__tests__/daemon-session-conversation.integration.test.ts
+++ b/src/services/__tests__/daemon-session-conversation.integration.test.ts
@@ -56,6 +56,11 @@ function makeStore() {
     daemonExecution: [] as Row[],
     notification: [] as Row[],
     notificationPreference: [] as Row[],
+    // T5: the wake bridge reads a task_assigned wake's pinned (host, cwd) from the Task's
+    // targetHost/targetCwd columns. This integration exercises UN-pinned task wakes, so
+    // the store has no task rows — task.findFirst returns null → no pin → online-first
+    // (the behavior this checkpoint asserts), exactly as before the pin feature.
+    task: [] as Row[],
   };
   let autoId = 1;
   let autoUuid = 1;
@@ -285,6 +290,11 @@ function buildPrismaFake(store: Store) {
     },
     daemonExecution: {
       findFirst: vi.fn(async (args: Row) => findFirst("daemonExecution", args)),
+    },
+    task: {
+      // T5 pin read for a task_assigned wake. No task rows are seeded here (un-pinned
+      // wakes), so this resolves null → the bridge derives no pin and stays online-first.
+      findFirst: vi.fn(async (args: Row) => findFirst("task", args)),
     },
     notification: {
       create: vi.fn(async (args: Row) => {

--- a/src/services/__tests__/mention.service.instances.test.ts
+++ b/src/services/__tests__/mention.service.instances.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ===== Mocks (hoisted) =====
+// This suite covers the cwd-addressable-instances additions (T3): parseMentions
+// pin extraction, enrichAgentInstances, and searchMentionables({withInstances}).
+// It mocks listConnectionsForAgent directly (rather than the prisma row shape)
+// so the per-instance candidate mapping is asserted in isolation.
+
+const {
+  mockPrisma,
+  mockGetActorName,
+  mockGetPreferences,
+  mockCreateBatch,
+  mockListConnectionsForAgent,
+} = vi.hoisted(() => ({
+  mockPrisma: {
+    mention: { createMany: vi.fn() },
+    user: { findFirst: vi.fn(), findMany: vi.fn() },
+    agent: { findFirst: vi.fn(), findMany: vi.fn() },
+    project: { findUnique: vi.fn() },
+    comment: { findUnique: vi.fn() },
+    daemonConnection: { findMany: vi.fn() },
+    daemonExecution: { groupBy: vi.fn() },
+  },
+  mockGetActorName: vi.fn().mockResolvedValue("Test Actor"),
+  mockGetPreferences: vi.fn().mockResolvedValue({ mentioned: true }),
+  mockCreateBatch: vi.fn().mockResolvedValue([]),
+  mockListConnectionsForAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/uuid-resolver", () => ({ getActorName: mockGetActorName }));
+vi.mock("@/services/notification.service", () => ({
+  getPreferences: (...args: unknown[]) => mockGetPreferences(...args),
+  createBatch: (...args: unknown[]) => mockCreateBatch(...args),
+}));
+vi.mock("@/services/daemon-connection.service", () => ({
+  // STALE_THRESHOLD_MS is also imported by the service; keep it a plain constant.
+  STALE_THRESHOLD_MS: 90_000,
+  listConnectionsForAgent: (...args: unknown[]) =>
+    mockListConnectionsForAgent(...args),
+}));
+
+import {
+  parseMentions,
+  enrichAgentInstances,
+  searchMentionables,
+  type Mentionable,
+} from "@/services/mention.service";
+
+const COMPANY_UUID = "11111111-1111-1111-1111-111111111111";
+const AGENT_A = "aaaaaaaa-1111-1111-1111-111111111111";
+const AGENT_B = "bbbbbbbb-2222-2222-2222-222222222222";
+const USER_UUID = "44444444-4444-4444-4444-444444444444";
+
+function connView(over: Record<string, unknown>) {
+  return {
+    uuid: "conn-x",
+    agentUuid: AGENT_A,
+    agentName: "DevBot",
+    clientType: "claude_code",
+    clientVersion: "0.11.0",
+    host: "Laptop-Q3",
+    cwd: "/home/u/dev/chorus",
+    startedAt: null,
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: "2026-06-23T00:00:00.000Z",
+    lastSeenAt: "2026-06-23T00:00:00.000Z",
+    disconnectedAt: null,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
+  mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
+  mockListConnectionsForAgent.mockResolvedValue([]);
+});
+
+describe("parseMentions — pinned instance suffix (T3)", () => {
+  it("extracts a pinned (host, cwd) from the markup suffix", () => {
+    const content = `@[DevBot](agent:${AGENT_A}?cwd=%2Fhome%2Fu%2Fdev%2Fchorus&host=Laptop-Q3)`;
+    const refs = parseMentions(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toEqual({
+      type: "agent",
+      uuid: AGENT_A,
+      displayName: "DevBot",
+      pinnedHost: "Laptop-Q3",
+      pinnedCwd: "/home/u/dev/chorus",
+    });
+  });
+
+  it("leaves an un-pinned mention object-identical to the legacy shape", () => {
+    const refs = parseMentions(`@[DevBot](agent:${AGENT_A})`);
+    expect(refs[0]).toEqual({
+      type: "agent",
+      uuid: AGENT_A,
+      displayName: "DevBot",
+    });
+    // No additive keys on an un-pinned ref.
+    expect("pinnedHost" in refs[0]).toBe(false);
+    expect("pinnedCwd" in refs[0]).toBe(false);
+  });
+
+  it("decodes an unknown-path pin (empty cwd) to a null cwd", () => {
+    const refs = parseMentions(`@[DevBot](agent:${AGENT_A}?cwd=&host=ci-runner)`);
+    expect(refs[0].pinnedCwd).toBeNull();
+    expect(refs[0].pinnedHost).toBe("ci-runner");
+  });
+});
+
+describe("enrichAgentInstances (T3)", () => {
+  it("issues NO connection query when there are no agent candidates", async () => {
+    const results: Mentionable[] = [
+      { type: "user", uuid: USER_UUID, name: "Alice" },
+    ];
+    await enrichAgentInstances(COMPANY_UUID, results);
+    expect(mockListConnectionsForAgent).not.toHaveBeenCalled();
+    expect(results[0].instances).toBeUndefined();
+  });
+
+  it("maps listConnectionsForAgent rows to per-instance candidates (online + offline)", async () => {
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: "c1", host: "Laptop-Q3", cwd: "/home/u/dev/chorus", effectiveStatus: "online" }),
+      connView({ uuid: "c2", host: "ci-runner-02", cwd: "/home/u/dev/chorus", effectiveStatus: "offline" }),
+      connView({ uuid: "c3", host: "Laptop-Q3", cwd: null, effectiveStatus: "online" }),
+    ]);
+    const results: Mentionable[] = [
+      { type: "agent", uuid: AGENT_A, name: "DevBot" },
+    ];
+    await enrichAgentInstances(COMPANY_UUID, results);
+
+    expect(mockListConnectionsForAgent).toHaveBeenCalledWith(COMPANY_UUID, AGENT_A);
+    expect(results[0].instances).toEqual([
+      { connectionUuid: "c1", host: "Laptop-Q3", cwd: "/home/u/dev/chorus", effectiveStatus: "online" },
+      { connectionUuid: "c2", host: "ci-runner-02", cwd: "/home/u/dev/chorus", effectiveStatus: "offline" },
+      { connectionUuid: "c3", host: "Laptop-Q3", cwd: null, effectiveStatus: "online" },
+    ]);
+  });
+
+  it("attaches an empty instances array for an agent with no connections", async () => {
+    mockListConnectionsForAgent.mockResolvedValue([]);
+    const results: Mentionable[] = [
+      { type: "agent", uuid: AGENT_A, name: "DevBot" },
+    ];
+    await enrichAgentInstances(COMPANY_UUID, results);
+    expect(results[0].instances).toEqual([]);
+  });
+
+  it("never enriches user candidates", async () => {
+    mockListConnectionsForAgent.mockResolvedValue([connView({ uuid: "c1" })]);
+    const results: Mentionable[] = [
+      { type: "user", uuid: USER_UUID, name: "Alice" },
+      { type: "agent", uuid: AGENT_A, name: "DevBot" },
+    ];
+    await enrichAgentInstances(COMPANY_UUID, results);
+    expect(results[0].instances).toBeUndefined();
+    expect(results[1].instances).toHaveLength(1);
+  });
+
+  it("batches one query per candidate agent", async () => {
+    mockListConnectionsForAgent.mockResolvedValue([]);
+    const results: Mentionable[] = [
+      { type: "agent", uuid: AGENT_A, name: "A" },
+      { type: "agent", uuid: AGENT_B, name: "B" },
+    ];
+    await enrichAgentInstances(COMPANY_UUID, results);
+    expect(mockListConnectionsForAgent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("searchMentionables — withInstances (T3)", () => {
+  it("attaches instances only when withInstances is set", async () => {
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: AGENT_A, name: "DevBot", roles: [] },
+    ]);
+    // Online via liveness enrichment so the agent survives the slice.
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { agentUuid: AGENT_A, status: "online", lastSeenAt: new Date() },
+    ]);
+    mockListConnectionsForAgent.mockResolvedValue([
+      connView({ uuid: "c1" }),
+      connView({ uuid: "c2", host: "ci-runner-02", effectiveStatus: "offline" }),
+    ]);
+
+    const withOff = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "",
+      actorType: "user",
+      actorUuid: USER_UUID,
+      withInstances: true,
+    });
+    expect(withOff[0].instances).toHaveLength(2);
+    expect(mockListConnectionsForAgent).toHaveBeenCalledWith(COMPANY_UUID, AGENT_A);
+  });
+
+  it("does NOT query instances when withInstances is omitted (default)", async () => {
+    mockPrisma.agent.findMany.mockResolvedValue([
+      { uuid: AGENT_A, name: "DevBot", roles: [] },
+    ]);
+    const res = await searchMentionables({
+      companyUuid: COMPANY_UUID,
+      query: "",
+      actorType: "user",
+      actorUuid: USER_UUID,
+    });
+    expect(res[0].instances).toBeUndefined();
+    expect(mockListConnectionsForAgent).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -18,6 +18,15 @@ vi.mock("@/services/daemon-session.service", () => ({
   resolveDirectIdeaUuid: mockResolveDirectIdeaUuid,
 }));
 
+// The task-assignment pin (T5) is read from the Task's targetHost/targetCwd columns,
+// so the bridge now touches prisma.task.findFirst for a task_assigned wake. Mock it so
+// these stay pure unit tests with no DB. Default: no pin recorded (both null) — the
+// unchanged online-first path. Pin-honoring tests override the resolved value.
+const mockTaskFindFirst = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/prisma", () => ({
+  prisma: { task: { findFirst: mockTaskFindFirst } },
+}));
+
 // Capture logger.error so we can assert the VISIBLE-failure (no silent swallow) rule.
 // The child logger object is built at hoist time so the module-level
 // `logger.child(...)` call (evaluated at import) returns a stable spy-bearing object.
@@ -61,6 +70,7 @@ function onlineConn(overrides: Record<string, unknown> = {}) {
     clientType: "claude_code",
     clientVersion: null,
     host: "host-1",
+    cwd: "/home/u/dev/chorus",
     startedAt: null,
     status: "online",
     effectiveStatus: "online" as const,
@@ -129,6 +139,9 @@ beforeEach(() => {
   mockCreatePendingTurn.mockImplementation(async (p: { trigger: string; promptText?: string | null }) =>
     turnView({ trigger: p.trigger, promptText: p.promptText ?? null }),
   );
+  // Default: the assigned Task records NO pin (both columns null) — the unchanged
+  // online-first path. Pin-honoring tests override this per-case.
+  mockTaskFindFirst.mockResolvedValue({ targetHost: null, targetCwd: null });
 });
 
 // ===== Action → trigger mapping =====
@@ -309,6 +322,231 @@ describe("maybeCreateTurnForWakeNotification — creates exactly one pending tur
 
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: fresh }),
+    );
+  });
+});
+
+// ===== Pinned-target instance routing (cwd-addressable instances, T5) =====
+//
+// The wake honors a pinned (host, cwd): a `mentioned` wake carries the pin on the
+// context (threaded from the mention markup by mention.service); a `task_assigned`
+// wake reads it from the Task's targetHost/targetCwd columns. ONLINE-ONLY selection:
+//   - pin matches an ONLINE connection       → pin the session origin THERE (not [0])
+//   - pin matches an OFFLINE connection       → NOT wakeable (no durable queue) →
+//                                              online-first fallback
+//   - pin matches NO connection / no pin      → online-first fallback (unchanged)
+//   - no online connection at all             → no turn (the notification stands)
+// DEC-5: the cwd is ONLY ever the explicit pin — never inferred from the project.
+describe("maybeCreateTurnForWakeNotification — pinned-target instance routing (T5)", () => {
+  const pinnedHost = "Laptop-Q3";
+  const pinnedCwd = "/home/u/dev/payments";
+  const pinnedConnUuid = "conn-pinned-target";
+
+  function pinnedConn(overrides: Record<string, unknown> = {}) {
+    return onlineConn({ uuid: pinnedConnUuid, host: pinnedHost, cwd: pinnedCwd, ...overrides });
+  }
+
+  // ----- mentioned wake: pin carried on the context -----
+
+  it("pins the session origin to the (host, cwd)-matching LIVE connection (not online-first) for a mentioned wake", async () => {
+    // Online-first would pick `conn-online-first`; the pin must override that and
+    // select the pinned-target connection even though it is NOT first in the list.
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "other-host", cwd: "/home/u/dev/other" }),
+      pinnedConn(),
+    ]);
+
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ action: "mentioned", pinnedHost, pinnedCwd }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: pinnedConnUuid }),
+    );
+    expect(result?.trigger).toBe("mentioned");
+    expect(result?.status).toBe("pending");
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    // A mentioned wake reads its pin from the context, NOT from the Task table.
+    expect(mockTaskFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("does NOT read the Task pin for a mentioned wake (pin is context-only)", async () => {
+    await maybeCreateTurnForWakeNotification(
+      ctx({ action: "mentioned", pinnedHost, pinnedCwd, entityType: "task", entityUuid: taskUuid }),
+    );
+    expect(mockTaskFindFirst).not.toHaveBeenCalled();
+  });
+
+  // ----- task_assigned wake: pin read from the Task columns -----
+
+  it("reads the Task targetHost/targetCwd and pins the matching LIVE connection for a task_assigned wake", async () => {
+    mockTaskFindFirst.mockResolvedValue({ targetHost: pinnedHost, targetCwd: pinnedCwd });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "other-host", cwd: "/home/u/dev/other" }),
+      pinnedConn(),
+    ]);
+
+    const result = await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(mockTaskFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ uuid: taskUuid, companyUuid }),
+      }),
+    );
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: pinnedConnUuid }),
+    );
+    expect(result?.status).toBe("pending");
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  // ----- pin → online-first fallback (no matching live connection) -----
+
+  it("falls back to online-first when the pin matches NO connection at all (mentioned)", async () => {
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      offlineConn({ uuid: "conn-offline", host: "host-B", cwd: "/home/u/dev/b" }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification(
+      // Pin to a place that is not registered for this agent at all.
+      ctx({ action: "mentioned", pinnedHost: "ghost-host", pinnedCwd: "/no/such/path" }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("falls back to online-first when the Task pin matches NO connection (task_assigned)", async () => {
+    mockTaskFindFirst.mockResolvedValue({ targetHost: "ghost-host", targetCwd: "/no/such/path" });
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+  });
+
+  // ----- OFFLINE pin is NOT wakeable: falls back to online-first / no turn -----
+
+  it("a pin matching an OFFLINE connection is NOT wakeable: falls back to online-first (no durable queue)", async () => {
+    // The pinned (host, cwd) instance is OFFLINE; another instance is online. An offline
+    // place is not wakeable — there is no durable queue — so the wake falls back to
+    // online-first and pins the ONLINE-elsewhere connection, NOT the offline pinned one.
+    const onlineElsewhere = "conn-online-elsewhere";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineElsewhere, host: "other-host", cwd: "/home/u/dev/other" }),
+      offlineConn({ uuid: pinnedConnUuid, host: pinnedHost, cwd: pinnedCwd }),
+    ]);
+
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ action: "mentioned", pinnedHost, pinnedCwd }),
+    );
+
+    // A turn IS created, but pinned to the ONLINE-elsewhere connection (online-first) —
+    // the offline pin did not win and there is no backfill queue.
+    expect(mockCreatePendingTurn).toHaveBeenCalledTimes(1);
+    expect(result?.status).toBe("pending");
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineElsewhere }),
+    );
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: pinnedConnUuid }),
+    );
+    // A skipped offline wake is normal, not an error.
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("an OFFLINE Task pin with NO online connection at all creates NO turn (the notification stands as the plain record)", async () => {
+    // Agent is fully offline; the pinned instance exists (offline). An offline place is
+    // not wakeable and there is no durable queue, so NO turn is created — the already-
+    // created Notification stands as the plain record. This is the durable-queue removal.
+    mockTaskFindFirst.mockResolvedValue({ targetHost: pinnedHost, targetCwd: pinnedCwd });
+    mockListConnectionsForAgent.mockResolvedValue([
+      offlineConn({ uuid: pinnedConnUuid, host: pinnedHost, cwd: pinnedCwd }),
+    ]);
+
+    const result = await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(result).toBeNull();
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+    // Not an error — a fully-offline target is a notification-only event.
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  // ----- un-pinned: unchanged online-first -----
+
+  it("an un-pinned mentioned wake uses online-first exactly as before (no Task read, no pin narrowing)", async () => {
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-older", host: "host-B", cwd: "/home/u/dev/b" }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification(ctx({ action: "mentioned" }));
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    // No pin on a mentioned wake → never reads the Task table.
+    expect(mockTaskFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("a task_assigned wake whose Task records no pin (both columns null) uses online-first, unchanged", async () => {
+    // mockTaskFindFirst default already returns { targetHost: null, targetCwd: null }.
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      offlineConn({ uuid: "conn-offline", host: pinnedHost, cwd: pinnedCwd }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification(ctx({ action: "task_assigned" }));
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+  });
+
+  it("treats an unknown-host + unknown-path pin (host '' + cwd null) as no pin → online-first (no false narrowing)", async () => {
+    // A pin carrying no disambiguating info matches any legacy/unknown instance, so it
+    // is NOT used to narrow — the wake stays online-first.
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification(
+      ctx({ action: "mentioned", pinnedHost: "", pinnedCwd: null }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+  });
+
+  it("matches a pin against the registry's sentinels: host-only pin (unknown-path cwd null) on an ONLINE instance", async () => {
+    // The owner pinned a host but the instance has an unknown path (legacy null cwd).
+    // The pin's cwd normalizes to null and must match the connection's null cwd. The
+    // matched instance is ONLINE, so the pin wins over the online-first entry.
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-nullcwd", host: pinnedHost, cwd: null }),
+    ]);
+
+    await maybeCreateTurnForWakeNotification(
+      ctx({ action: "mentioned", pinnedHost, pinnedCwd: null }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: "conn-nullcwd" }),
     );
   });
 });

--- a/src/services/__tests__/task.service.test.ts
+++ b/src/services/__tests__/task.service.test.ts
@@ -589,6 +589,84 @@ describe("claimTask", () => {
     const updateData = mockPrisma.task.update.mock.calls[0][0].data;
     expect(updateData.assignedByUuid).toBe("user-123");
   });
+
+  // cwd-addressable instances (T4): the durable (host, cwd) pin is persisted with
+  // the assignment so the autonomous wake (T5) can resolve it later.
+  it("persists the pinned (host, cwd) instance when provided", async () => {
+    const claimed = {
+      ...rawTask({
+        status: "assigned",
+        assigneeType: "agent",
+        assigneeUuid: "a1",
+        targetHost: "ci-runner-02",
+        targetCwd: "/home/u/dev/chorus",
+      }),
+      project: { uuid: PROJECT_UUID, name: "Test Project" },
+    };
+    mockPrisma.task.update.mockResolvedValue(claimed);
+
+    const result = await claimTask({
+      taskUuid: TASK_UUID,
+      companyUuid: COMPANY_UUID,
+      assigneeType: "agent",
+      assigneeUuid: "a1",
+      targetHost: "ci-runner-02",
+      targetCwd: "/home/u/dev/chorus",
+    });
+
+    const updateData = mockPrisma.task.update.mock.calls[0][0].data;
+    expect(updateData.targetHost).toBe("ci-runner-02");
+    expect(updateData.targetCwd).toBe("/home/u/dev/chorus");
+    // The pin is surfaced on the formatted response too.
+    expect(result.targetHost).toBe("ci-runner-02");
+    expect(result.targetCwd).toBe("/home/u/dev/chorus");
+  });
+
+  // An offline pin is a valid durable intent — the host "" / cwd null sentinels
+  // (unknown-host / unknown-path instance) must round-trip unchanged.
+  it("preserves the unknown-host (\"\") / unknown-path (null) pin sentinels", async () => {
+    const claimed = {
+      ...rawTask({ status: "assigned", targetHost: "", targetCwd: null }),
+      project: { uuid: PROJECT_UUID, name: "Test Project" },
+    };
+    mockPrisma.task.update.mockResolvedValue(claimed);
+
+    await claimTask({
+      taskUuid: TASK_UUID,
+      companyUuid: COMPANY_UUID,
+      assigneeType: "agent",
+      assigneeUuid: "a1",
+      targetHost: "",
+      targetCwd: null,
+    });
+
+    const updateData = mockPrisma.task.update.mock.calls[0][0].data;
+    // "" host is preserved (NOT coerced to null) — it denotes a real instance.
+    expect(updateData.targetHost).toBe("");
+    expect(updateData.targetCwd).toBeNull();
+  });
+
+  // RE-assigning without a pin must CLEAR a stale pin from a prior assignment
+  // rather than silently inheriting it: undefined → null on both columns.
+  it("clears a prior pin when re-assigned with no pin (undefined → null)", async () => {
+    const claimed = {
+      ...rawTask({ status: "assigned", targetHost: null, targetCwd: null }),
+      project: { uuid: PROJECT_UUID, name: "Test Project" },
+    };
+    mockPrisma.task.update.mockResolvedValue(claimed);
+
+    await claimTask({
+      taskUuid: TASK_UUID,
+      companyUuid: COMPANY_UUID,
+      assigneeType: "agent",
+      assigneeUuid: "a2",
+      // no targetHost / targetCwd
+    });
+
+    const updateData = mockPrisma.task.update.mock.calls[0][0].data;
+    expect(updateData.targetHost).toBeNull();
+    expect(updateData.targetCwd).toBeNull();
+  });
 });
 
 // ---------- releaseTask ----------
@@ -613,6 +691,10 @@ describe("releaseTask", () => {
           assigneeUuid: null,
           assignedAt: null,
           assignedByUuid: null,
+          // Releasing clears the pin with the assignment (cwd-addressable
+          // instances, T4) so a re-assignment picks a fresh instance.
+          targetHost: null,
+          targetCwd: null,
         }),
       }),
     );

--- a/src/services/daemon-instruction.service.ts
+++ b/src/services/daemon-instruction.service.ts
@@ -120,6 +120,28 @@ export class ConnectionOfflineError extends Error {
   }
 }
 
+/**
+ * The session whose origin is being RE-POINTED is currently LIVE (its origin connection is
+ * online) — so re-pointing is refused (409). The re-point escape hatch exists ONLY to
+ * rescue a session whose origin went offline (read-only) onto another online instance; a
+ * live session has no dead-end to route around, and `sendInstruction` already delivers to
+ * its online origin. Re-pointing a live session would orphan a running daemon's transcript,
+ * so this is a hard guard, not a fallback.
+ */
+export class RepointOriginLiveError extends Error {
+  readonly code = "repoint_origin_live";
+  readonly originConnectionUuid: string;
+  constructor(originConnectionUuid: string) {
+    super(
+      "This conversation's origin is still online, so it cannot be re-pointed. " +
+        "Re-pointing only rescues a read-only conversation whose origin went offline; " +
+        "send to the live origin instead.",
+    );
+    this.name = "RepointOriginLiveError";
+    this.originConnectionUuid = originConnectionUuid;
+  }
+}
+
 /** Reasons the free-text instruction fails validation, so the route maps a 400. */
 export type InstructionTextErrorReason = "empty" | "too_long";
 
@@ -473,6 +495,147 @@ export async function createAdHocSessionWithInstruction(
   });
 
   return { session, turn };
+}
+
+// ===== Re-point an offline session's origin onto a chosen online instance =====
+
+/**
+ * RE-POINT a read-only (origin-offline) daemon session onto a caller-chosen ONLINE
+ * connection of the SAME agent, then send a fresh `human_instruction` turn there — keeping
+ * the SAME `DaemonSession` (same `uuid`, same `sessionId`, same `directIdeaUuid`). This is
+ * the corrected "Continue on an online directory" escape hatch (T12): it does NOT mint a new
+ * ad-hoc session (the T11 mistake, which lost the conversation's identity). The session's
+ * Claude session id is preserved, so when the daemon spawns on the new cwd it finds no
+ * transcript there and starts a FRESH transcript under the SAME id (`claude --session-id
+ * <sameId>`) — a cold start, no context injection. The prior turns remain as Chorus-visible
+ * read-only history.
+ *
+ * Order (each gate before any mutation):
+ *  1. Validate `instructionText` (trim non-empty, ≤ `MAX_INSTRUCTION_CHARS`) →
+ *     `InstructionTextError` (route → 400) BEFORE any lookup or write.
+ *  2. Resolve the session under the caller's visibility scope → `SessionNotVisibleError`
+ *     (route → 404 non-disclosure) when not visible/owned.
+ *  3. Assert the session's CURRENT origin is OFFLINE — re-point is ONLY for a read-only
+ *     session. A live origin is refused with `RepointOriginLiveError` (route → 409): a live
+ *     session has no dead-end to route around (use `sendInstruction` on its online origin).
+ *     Reuses the SAME staleness verdict (`isConnectionLive`).
+ *  4. Assert the target `connectionUuid` belongs to the SAME agent as the session AND is
+ *     ONLINE: same-agent miss → `ConnectionNotVisibleError` (route → 404 non-disclosure),
+ *     offline → `ConnectionOfflineError` (route → 409). Reuses `connectionBelongsToAgent` +
+ *     `isConnectionLive`.
+ *  5. UPDATE `DaemonSession.originConnectionUuid` to the target. *** THIS is the single,
+ *     deliberate place the 'originConnectionUuid is write-once / never re-routed' invariant
+ *     (resolveOrCreateSession + assertContinuable) is reversed — and ONLY under this explicit
+ *     user action. The autonomous wake path (notification-turn) never re-points. *** The
+ *     UPDATE is companyUuid-scoped (the visibility fence above already proved ownership) so a
+ *     cross-company write is impossible.
+ *  6. Create the `human_instruction` turn through the SAME chokepoint `sendInstruction`/the
+ *     ad-hoc path use, bound to the SAME session (same `uuid`/`sessionId`/`directIdeaUuid`),
+ *     then deliver it to the NEW origin connection.
+ *
+ * Returns `{ session, turn }` — the SAME session (now re-pointed, so its derived
+ * `originOnline` is true) plus the created turn. Throws the typed errors above (mapped by the
+ * route). A query/write failure propagates (no silent swallow).
+ */
+export async function repointSessionOriginAndSend(
+  auth: { type: string; companyUuid: string; actorUuid: string },
+  params: { sessionUuid: string; connectionUuid: string; instructionText: string },
+): Promise<{ session: SessionView; turn: TurnView }> {
+  // (1) Validate text first — a bad instruction must never re-point or create a turn.
+  const instructionText = validateInstructionText(params.instructionText);
+
+  // (2) Owner-scoped visibility fence (404 non-disclosure when not visible/owned).
+  const session = await findVisibleSession(auth, params.sessionUuid);
+  if (!session) {
+    throw new SessionNotVisibleError();
+  }
+
+  // (3) The CURRENT origin must be OFFLINE — re-point is only for a read-only session. A live
+  // origin has no dead-end to route around, so refuse (409) rather than orphan a running run.
+  const currentOriginLive = await isConnectionLive(
+    auth.companyUuid,
+    session.originConnectionUuid,
+  );
+  if (currentOriginLive) {
+    throw new RepointOriginLiveError(session.originConnectionUuid);
+  }
+
+  // (4) The TARGET connection must belong to the SAME agent as the session AND be online.
+  // Same-agent miss collapses to ONE 404 non-disclosure (an unowned/foreign/absent
+  // connection is indistinguishable); an offline target is a 409.
+  const connectionOfAgent = await connectionBelongsToAgent(
+    auth.companyUuid,
+    session.agentUuid,
+    params.connectionUuid,
+  );
+  if (!connectionOfAgent) {
+    throw new ConnectionNotVisibleError();
+  }
+  const targetOnline = await isConnectionLive(auth.companyUuid, params.connectionUuid);
+  if (!targetOnline) {
+    throw new ConnectionOfflineError(params.connectionUuid);
+  }
+
+  // (5) Re-point the origin. *** SINGLE DELIBERATE REVERSAL of the write-once
+  // `originConnectionUuid` invariant (resolveOrCreateSession stamps it once and never moves
+  // it; assertContinuable refuses to route a continuation anywhere else). This explicit
+  // user action is the ONLY path that moves it — the autonomous wake / resolve paths stay
+  // write-once. companyUuid-scoped (ownership already proven above) so no cross-company
+  // write is possible. The SAME sessionId/uuid/directIdeaUuid are untouched. ***
+  await prisma.daemonSession.update({
+    where: { uuid: params.sessionUuid, companyUuid: auth.companyUuid },
+    data: { originConnectionUuid: params.connectionUuid },
+  });
+
+  // (6) Create the turn on the SAME session via the chokepoint (same sessionId/directIdeaUuid
+  // → it lands on this very row, no new session), then deliver to the NEW origin connection.
+  const turn = await createInstructionTurn({
+    auth,
+    agentUuid: session.agentUuid,
+    sessionUuid: params.sessionUuid,
+    sessionId: session.sessionId,
+    directIdeaUuid: session.directIdeaUuid,
+    instructionText,
+  });
+
+  // (7) Origin-only live delivery: ping ONLY the NEW origin connection (verified online in
+  // (4)), carrying the PRECISE turnUuid so it runs ONLY this turn. Fire-and-forget +
+  // non-fatal — the persisted turn + reconnect-backfill are the durability net.
+  deliverTurnPing({
+    companyUuid: auth.companyUuid,
+    originConnectionUuid: params.connectionUuid,
+    turnUuid: turn.uuid,
+  });
+
+  // Read back the re-pointed session so the caller (the UI) sees the new origin reflected —
+  // the SAME session uuid/sessionId, now pointing at the online connection. Mapped to the
+  // wire `SessionView` shape (ISO timestamps) inline rather than reaching for the session
+  // service's private mapper.
+  const updated = await prisma.daemonSession.findUnique({
+    where: { uuid: params.sessionUuid },
+  });
+  if (!updated) {
+    // The row was just updated above; a missing one means a torn write — surface it rather
+    // than fabricate a stale view (no silent errors).
+    throw new Error(
+      `repointSessionOriginAndSend: session ${params.sessionUuid} missing after re-point`,
+    );
+  }
+
+  const sessionView: SessionView = {
+    uuid: updated.uuid,
+    agentUuid: updated.agentUuid,
+    sessionId: updated.sessionId,
+    directIdeaUuid: updated.directIdeaUuid,
+    originConnectionUuid: updated.originConnectionUuid,
+    status: updated.status,
+    title: updated.title,
+    lastTurnAt: updated.lastTurnAt.toISOString(),
+    createdAt: updated.createdAt.toISOString(),
+    updatedAt: updated.updatedAt.toISOString(),
+  };
+
+  return { session: sessionView, turn };
 }
 
 /**

--- a/src/services/mention.service.ts
+++ b/src/services/mention.service.ts
@@ -5,18 +5,43 @@
 import { prisma } from "@/lib/prisma";
 import { getActorName } from "@/lib/uuid-resolver";
 import * as notificationService from "@/services/notification.service";
+// Pure mention-markup codec, shared with the client editor so producer and
+// parser of the on-disk markup cannot drift (cwd-addressable instances, T3).
+import { decodePinSuffix } from "@/lib/mention-format";
+// Re-exported for callers that build pinned markers (kept here so existing
+// imports of these symbols from the service keep resolving).
+export {
+  encodePinSuffix,
+  buildMentionMarker,
+} from "@/lib/mention-format";
 // Reuse the daemon-connection registry's single liveness threshold and the
 // execution service's active-status set — do NOT restate either rule here, so
-// producer and consumer cannot drift.
-import { STALE_THRESHOLD_MS } from "@/services/daemon-connection.service";
+// producer and consumer cannot drift. listConnectionsForAgent supplies the
+// per-instance (host, cwd) candidates with their effectiveStatus already
+// derived, so the instance picker shows exactly the registry's liveness verdict.
+import {
+  STALE_THRESHOLD_MS,
+  listConnectionsForAgent,
+} from "@/services/daemon-connection.service";
 import { ACTIVE_EXECUTION_STATUSES } from "@/services/daemon-execution.service";
 
 // ===== Constants =====
 
 const MAX_MENTIONS_PER_CONTENT = 10;
 
-// Regex to match @[DisplayName](type:uuid)
-const MENTION_REGEX = /@\[([^\]]+)\]\((user|agent):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)/gi;
+// Regex to match @[DisplayName](type:uuid) with an OPTIONAL pinned-instance
+// suffix (cwd-addressable instances, T3). The base form is byte-identical to
+// before this change: `@[Name](agent:uuid)`. A mention that pins a target
+// instance carries an additional `?cwd=…&host=…` query-string suffix INSIDE the
+// parens — `@[Name](agent:uuid?cwd=…&host=…)` — so an UN-pinned mention is
+// unchanged (the suffix group is optional). The suffix is matched as "anything
+// up to the closing paren" so the pin codec (see encodePinSuffix) must keep the
+// payload paren-free; the codec percent-escapes `(`/`)` to guarantee that.
+//
+// ADDITIVE / backward-compatible: every existing parser/renderer that matched
+// the old shape still matches the base; the new optional group only captures the
+// pin when present. Group 4 is the raw pin query string (or undefined).
+const MENTION_REGEX = /@\[([^\]]+)\]\((user|agent):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\?([^)]*))?\)/gi;
 
 // ===== Type Definitions =====
 
@@ -24,6 +49,32 @@ export interface MentionRef {
   type: "user" | "agent";
   uuid: string;
   displayName: string;
+  // Pinned target daemon instance (cwd-addressable instances, T3). When the
+  // owner picked a specific (host, cwd) instance for this mention, these carry
+  // the durable "place" so the autonomous wake (T5) routes to it. Both null for
+  // an un-pinned mention — which behaves exactly as before this change. The pin
+  // is the durable (host, cwd), NOT a connectionUuid (connections churn on
+  // daemon restart while the place is stable). `pinnedHost` is "" for an
+  // unknown-host instance; `pinnedCwd` is null for an unknown-path instance.
+  pinnedHost?: string | null;
+  pinnedCwd?: string | null;
+}
+
+/**
+ * A live (host, cwd) daemon instance candidate for the instance picker. A
+ * structural subset of `ConnectionView` (daemon-connection.service) carrying
+ * exactly what the picker needs. Populated for agent `Mentionable`s only, by
+ * enrichAgentInstances. The picker auto-selects when there is exactly one.
+ */
+export interface MentionableInstance {
+  /** Current live `DaemonConnection.uuid` for this (host, cwd) place. */
+  connectionUuid: string;
+  /** Host the instance runs on. "" = unknown/host-less self-report. */
+  host: string;
+  /** Working directory. null = legacy daemon that never self-reported one. */
+  cwd: string | null;
+  /** Server-derived liveness verdict (rendered verbatim). */
+  effectiveStatus: "online" | "offline";
 }
 
 export interface Mentionable {
@@ -40,6 +91,13 @@ export interface Mentionable {
   // agent reports 0). See enrichAgentLiveness.
   online?: boolean;
   activeCount?: number;
+  // Live (host, cwd) instances for this agent (cwd-addressable instances, T3),
+  // populated for `type: "agent"` candidates by enrichAgentInstances. The
+  // @mention secondary picker lists these when the agent has 2+ of them; a
+  // single instance auto-selects. ADDITIVE: existing consumers that ignore this
+  // field are unaffected. Undefined when not enriched (e.g. user candidates, or
+  // the empty-query / search paths that don't request instances).
+  instances?: MentionableInstance[];
 }
 
 export interface CreateMentionsParams {
@@ -60,13 +118,26 @@ export interface SearchMentionablesParams {
   actorUuid: string;
   ownerUuid?: string;
   limit?: number;
+  // When true, enrich agent candidates with their per-instance (host, cwd)
+  // candidates (the `instances` field) so the @mention secondary picker can list
+  // them (cwd-addressable instances, T3). Off by default — only the @mention
+  // flow needs them, and it costs one connection query per returned agent. The
+  // sort/slice still runs on liveness only; instances are attached AFTER the
+  // slice so we query connections only for the agents actually returned.
+  withInstances?: boolean;
 }
 
 // ===== Service Methods =====
 
 /**
- * Parse @[Name](type:uuid) patterns from content string.
- * Returns deduplicated list of mention references (max 10).
+ * Parse @[Name](type:uuid) patterns from content string, including any optional
+ * pinned-instance suffix `?cwd=…&host=…` (cwd-addressable instances, T3).
+ * Returns deduplicated list of mention references (max 10). An UN-pinned mention
+ * yields a `MentionRef` with NO `pinnedHost`/`pinnedCwd` keys at all — so it is
+ * object-identical to before this change (existing consumers and tests that
+ * deep-equal the un-pinned shape are unaffected). A pinned mention adds the
+ * two keys. Dedup key is `type:uuid` (the pin does not widen the key: a mention
+ * targets the agent; the pin only refines which instance wakes).
  */
 export function parseMentions(content: string): MentionRef[] {
   const mentions: MentionRef[] = [];
@@ -82,11 +153,19 @@ export function parseMentions(content: string): MentionRef[] {
     const displayName = match[1];
     const type = match[2].toLowerCase() as "user" | "agent";
     const uuid = match[3].toLowerCase();
+    const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
     const key = `${type}:${uuid}`;
 
     if (!seen.has(key)) {
       seen.add(key);
-      mentions.push({ type, uuid, displayName });
+      const ref: MentionRef = { type, uuid, displayName };
+      // Only attach the pin when present, keeping un-pinned refs byte-identical
+      // to the legacy shape (additive — existing consumers unaffected).
+      if (pinnedHost !== null || pinnedCwd !== null) {
+        ref.pinnedHost = pinnedHost;
+        ref.pinnedCwd = pinnedCwd;
+      }
+      mentions.push(ref);
     }
   }
 
@@ -206,6 +285,14 @@ export async function createMentions(params: CreateMentionsParams): Promise<void
       actorType,
       actorUuid,
       actorName,
+      // Thread the owner-chosen pinned instance (cwd-addressable instances, T5) from
+      // the mention markup into the wake-turn chokepoint so the `mentioned` autonomous
+      // wake routes to that `(host, cwd)` instance. Only present when the mention was
+      // pinned (parseMentions attaches pinnedHost/pinnedCwd only for a pinned ref); an
+      // un-pinned mention omits them → online-first selection, exactly as before. The
+      // pin is transport-only here — it is NOT persisted on the Notification row.
+      pinnedHost: mention.pinnedHost,
+      pinnedCwd: mention.pinnedCwd,
     });
   }
 
@@ -322,13 +409,66 @@ async function enrichAgentLiveness(
 }
 
 /**
+ * Enrich agent candidates in place with their per-instance (host, cwd)
+ * candidates (cwd-addressable instances, T3): the `instances` field the @mention
+ * secondary picker lists when an agent has 2+ live instances.
+ *
+ * Reuses `listConnectionsForAgent` (which already returns one row per
+ * `(host, cwd)` connection with `effectiveStatus` derived from the registry's
+ * single liveness rule, sorted online-first) — the rule is NOT restated here, so
+ * the picker shows exactly the registry's verdict. BATCHED and owner-scoped: it
+ * is gated to run only over the candidate agents that already passed the
+ * owner-scoping in searchMentionables, and issues NO query when there are zero
+ * agent candidates. Calls listConnectionsForAgent once per agent in parallel
+ * (each is itself a single companyUuid-scoped query). No new permission bit.
+ *
+ * We surface ALL connections (online + offline) with each one's
+ * `effectiveStatus`; the CONSUMER filters to online before showing the picker
+ * (an offline instance is never a wake target, so the secondary picker only ever
+ * lists online instances and a fully-offline agent shows no picker). Users are
+ * never enriched. Mutates the `instances` field of the agent entries in
+ * `results`.
+ */
+export async function enrichAgentInstances(
+  companyUuid: string,
+  results: Mentionable[]
+): Promise<void> {
+  const agents = results.filter((r) => r.type === "agent");
+  // Cheap empty path: no agents → no connection queries at all.
+  if (agents.length === 0) return;
+
+  // One companyUuid-scoped query per candidate agent, run in parallel. The set
+  // of agents is already owner-scoped by the caller (searchMentionables), so
+  // this never widens visibility beyond what the owner can already mention.
+  const perAgent = await Promise.all(
+    agents.map(async (agent) => {
+      const connections = await listConnectionsForAgent(companyUuid, agent.uuid);
+      const instances: MentionableInstance[] = connections.map((c) => ({
+        connectionUuid: c.uuid,
+        host: c.host,
+        cwd: c.cwd,
+        effectiveStatus: c.effectiveStatus,
+      }));
+      return { uuid: agent.uuid, instances };
+    })
+  );
+
+  const byAgent = new Map<string, MentionableInstance[]>();
+  for (const { uuid, instances } of perAgent) byAgent.set(uuid, instances);
+  for (const r of results) {
+    if (r.type !== "agent") continue;
+    r.instances = byAgent.get(r.uuid) ?? [];
+  }
+}
+
+/**
  * Search for mentionable users and agents within a company.
  * Permission scoping:
  * - User caller: all company users + own agents (agents with ownerUuid = actorUuid)
  * - Agent caller: all company users + same-owner agents (agents with same ownerUuid)
  */
 export async function searchMentionables(params: SearchMentionablesParams): Promise<Mentionable[]> {
-  const { companyUuid, query, actorType, actorUuid, ownerUuid, limit = 10 } = params;
+  const { companyUuid, query, actorType, actorUuid, ownerUuid, limit = 10, withInstances = false } = params;
 
   const effectiveLimit = Math.min(limit, 50);
   const results: Mentionable[] = [];
@@ -377,7 +517,11 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
     // then order online agents to the front, then trim to the display cap (≤5).
     await enrichAgentLiveness(companyUuid, results);
     results.sort(compareMentionables);
-    return results.slice(0, Math.min(DEFAULT_EMPTY_QUERY_LIMIT, effectiveLimit));
+    const sliced = results.slice(0, Math.min(DEFAULT_EMPTY_QUERY_LIMIT, effectiveLimit));
+    // Attach per-instance candidates AFTER the slice so we only query connections
+    // for the agents actually returned (cwd-addressable instances, T3).
+    if (withInstances) await enrichAgentInstances(companyUuid, sliced);
+    return sliced;
   }
   // Search users (all company users are mentionable)
   const users = await prisma.user.findMany({
@@ -450,7 +594,11 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
   // this is what keeps online agents from being sliced out by a flood of users.
   await enrichAgentLiveness(companyUuid, results);
   results.sort(compareMentionables);
-  return results.slice(0, effectiveLimit);
+  const sliced = results.slice(0, effectiveLimit);
+  // Attach per-instance candidates AFTER the slice so we only query connections
+  // for the agents actually returned (cwd-addressable instances, T3).
+  if (withInstances) await enrichAgentInstances(companyUuid, sliced);
+  return sliced;
 }
 
 /**

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -12,6 +12,12 @@
 // (`resolveOrCreateSession` + `createPendingTurn` + `resolveDirectIdeaUuid`) and the
 // connection registry (`listConnectionsForAgent`, to pin the cwd-bound origin).
 //
+// ONLINE-ONLY WAKE: only an ONLINE connection is wakeable. A pin only ever wakes when
+// it matches an online connection; an offline/no-match pin falls through to online-first,
+// and when the agent has NO online connection at all, no turn is created — the
+// already-created Notification stands as the plain record (a fully-offline target is a
+// notification-only event; there is NO durable queue / backfill of pending turns).
+//
 // FAILURE ISOLATION (repo "no silent errors" + the wake notification must always
 // survive): turn creation runs AFTER the notification row already exists, and any
 // throw is logged VISIBLY (never swallowed) but is NOT propagated — a lost turn must
@@ -21,6 +27,7 @@
 // daemon, the action is not wake-triggering, or creation failed and was logged).
 
 import logger from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
 import {
   resolveOrCreateSession,
   createPendingTurn,
@@ -28,7 +35,10 @@ import {
   type TurnTrigger,
   type TurnView,
 } from "@/services/daemon-session.service";
-import { listConnectionsForAgent } from "@/services/daemon-connection.service";
+import {
+  listConnectionsForAgent,
+  type ConnectionView,
+} from "@/services/daemon-connection.service";
 import type { LineageEntityType } from "@/services/lineage.service";
 
 const turnLogger = logger.child({ module: "notification-turn" });
@@ -126,6 +136,126 @@ export interface WakeNotificationContext {
   // lives on the created turn's `promptText`; the notification row carries the
   // denormalized copy. Null/undefined for autonomous wakes.
   instructionText?: string | null;
+  // Pinned target daemon instance carried by a `mentioned` wake (cwd-addressable
+  // instances): the owner-chosen `(host, cwd)` parsed from the mention markup and
+  // threaded here by mention.service. The wake resolves it to a matching ONLINE
+  // connection and pins the session origin there. A `task_assigned` wake does NOT use
+  // these — it reads its pin from the Task's `targetHost`/`targetCwd` columns (the
+  // durable storage) instead. Both undefined/null → no pin (online-first, exactly as
+  // before). `pinnedHost` "" = unknown-host instance; `pinnedCwd` null = unknown-path
+  // instance.
+  pinnedHost?: string | null;
+  pinnedCwd?: string | null;
+}
+
+/**
+ * A resolved pinned target instance: the durable "place" `(host, cwd)` an owner chose
+ * for a wake (cwd-addressable instances). `host` is "" for an unknown-host instance;
+ * `cwd` is null for an unknown-path (legacy null-cwd) instance — the SAME sentinels the
+ * connection registry uses, so a pin matches a `ConnectionView` by strict `(host, cwd)`
+ * equality (then gated on ONLINE by selectOriginConnection). A wake with no pin yields
+ * `null` (not this shape).
+ */
+interface PinnedTarget {
+  host: string;
+  cwd: string | null;
+}
+
+/**
+ * Resolve the wake's pinned target instance — the durable `(host, cwd)` an owner chose
+ * (cwd-addressable instances, T5) — or null when the wake carries no pin. DEC-5: the
+ * cwd is NEVER inferred from the project; the ONLY pin sources are the two explicit
+ * owner choices below.
+ *
+ *  - `mentioned` wake: the pin travels in the mention markup and is threaded onto the
+ *    context (`ctx.pinnedHost`/`ctx.pinnedCwd`) by mention.service.
+ *  - `task_assigned` wake on a TASK entity: the pin is the durable storage on the Task
+ *    itself — its `targetHost`/`targetCwd` columns (T1/T4). Read here against the
+ *    company-scoped row; a missing row or both-null columns is "no pin".
+ *
+ * Every other wake (elaboration / elaboration_verified / human_instruction, or a
+ * task_assigned-trigger action on a non-task entity such as idea_claimed /
+ * proposal_*) carries no pinned instance, so this returns null and the caller uses the
+ * unchanged online-first selection. A pin where BOTH host is "" AND cwd is null is
+ * treated as "no pin" — there is nothing to disambiguate against (it matches any
+ * unknown/legacy instance), so it falls through to online-first rather than narrowing.
+ */
+async function resolvePinnedTarget(
+  ctx: WakeNotificationContext,
+  trigger: TurnTrigger,
+): Promise<PinnedTarget | null> {
+  let host: string | null | undefined;
+  let cwd: string | null | undefined;
+
+  if (trigger === "mentioned") {
+    // @mention pin threaded from the mention markup by mention.service.
+    host = ctx.pinnedHost;
+    cwd = ctx.pinnedCwd;
+  } else if (trigger === "task_assigned" && ctx.entityType === "task") {
+    // Task-assignment pin: the durable storage is the Task's own columns (T1/T4). Only
+    // a wake anchored on the task entity reads them — never inferred from the project.
+    const task = await prisma.task.findFirst({
+      where: { uuid: ctx.entityUuid, companyUuid: ctx.companyUuid },
+      select: { targetHost: true, targetCwd: true },
+    });
+    host = task?.targetHost;
+    cwd = task?.targetCwd;
+  }
+
+  // No host AND no cwd was recorded → no pin (online-first, exactly as before). A pin
+  // is "present" when EITHER coordinate was recorded. Note: an unknown-host ("") +
+  // unknown-path (null) pin carries no disambiguating information, so we treat it as
+  // no pin and fall through to online-first rather than forcing a match.
+  const hasHost = host != null && host !== "";
+  const hasCwd = cwd != null && cwd !== "";
+  if (!hasHost && !hasCwd) return null;
+
+  // Normalize to the registry's sentinels: host "" = unknown-host, cwd null =
+  // unknown-path. (A pin that recorded only one coordinate keeps the other at its
+  // sentinel so the (host, cwd) equality below behaves predictably.)
+  return { host: host ?? "", cwd: cwd != null && cwd !== "" ? cwd : null };
+}
+
+/**
+ * Select the ONLINE origin connection for the wake (cwd-addressable instances):
+ *
+ *  - With a pin: the connection whose `(host, cwd)` EXACTLY matches the pinned place AND
+ *    is ONLINE. Only an online match can be woken, so the pin wakes the daemon at that
+ *    exact place when it is running. An OFFLINE match is NOT wakeable — there is no
+ *    durable queue / backfill, so an offline pin is treated as "no match" and falls
+ *    through to online-first below.
+ *  - With a pin that matches no ONLINE connection (offline match, or the place is not
+ *    registered at all), or no pin: fall back to the online-first selection
+ *    (`effectiveStatus === "online"`, first entry — the list is already sorted
+ *    online-first then lastSeenAt desc), exactly as an un-pinned wake.
+ *
+ * Returns the chosen ONLINE `ConnectionView`, or null when there is nothing to wake (no
+ * online connection at all — the agent has no running daemon). A null result means the
+ * caller creates NO turn; the already-created Notification stands as the plain record.
+ */
+function selectOriginConnection(
+  connections: ConnectionView[],
+  pin: PinnedTarget | null,
+): ConnectionView | null {
+  if (pin) {
+    // Strict (host, cwd) equality against the registry's sentinels, gated on ONLINE: a
+    // pin only wakes the daemon at that exact place when it is actually running. An
+    // offline match is not wakeable and is ignored here (no durable queue).
+    const matched = connections.find(
+      (c) =>
+        c.host === pin.host &&
+        c.cwd === pin.cwd &&
+        c.effectiveStatus === "online",
+    );
+    if (matched) return matched;
+    // Pin matched no ONLINE connection (offline place, or not registered at all):
+    // fall through to online-first, exactly as an un-pinned wake.
+  }
+
+  // No pin, or pin matched no online connection → online-first (the existing behavior).
+  // The list is pre-sorted online-first, so the first online entry is the freshest
+  // connection. None online → null → no turn (a notification-only event).
+  return connections.find((c) => c.effectiveStatus === "online") ?? null;
 }
 
 /**
@@ -134,9 +264,14 @@ export interface WakeNotificationContext {
  *
  *  1. Map `action → trigger`; bail (null) if the action is not wake-triggering.
  *  2. Only agent recipients can be daemons — bail for `user` recipients.
- *  3. Resolve the agent's ONLINE origin connection (`listConnectionsForAgent`, already
- *     sorted online-first; the first `effectiveStatus === "online"` entry owns the
- *     cwd-bound transcript). No online connection ⇒ no daemon to wake ⇒ bail (null).
+ *  3. Resolve the wake's pinned target instance (cwd-addressable instances): the
+ *     mention's `(host, cwd)` for a `mentioned` wake, the Task's `targetHost`/`targetCwd`
+ *     for a `task_assigned` wake on a task, else none (DEC-5: NEVER inferred from the
+ *     project). Then pick the ONLINE origin connection: the `(host, cwd)`-matching
+ *     ONLINE connection when pinned, else online-first. An offline pin (or one matching
+ *     no online place) is NOT wakeable — there is no durable queue — so it falls through
+ *     to online-first. No online connection at all ⇒ bail (null): the agent is fully
+ *     offline and the already-created Notification stands as the plain record.
  *  4. Derive the session id: the entity's `directIdeaUuid` via lineage when the
  *     entityType is lineage-walkable, else the entity uuid (ad-hoc session). This is
  *     the stable `(agentUuid, sessionId)` business key.
@@ -148,7 +283,7 @@ export interface WakeNotificationContext {
  * to null — a turn-creation failure MUST NOT abort or block the already-created
  * notification (the notification row exists before this runs). Returns the created
  * `TurnView`, or null when no turn was created (not wake-triggering, human recipient,
- * agent offline, or a logged failure).
+ * nothing to wake, or a logged failure).
  */
 export async function maybeCreateTurnForWakeNotification(
   ctx: WakeNotificationContext,
@@ -161,17 +296,25 @@ export async function maybeCreateTurnForWakeNotification(
   if (ctx.recipientType !== "agent") return null;
 
   try {
-    // (3) Resolve the agent's online origin connection (cwd-bound transcript owner).
-    // listConnectionsForAgent is sorted online-first, then lastSeenAt desc, so the
-    // first online entry is the freshest connection to pin the session to.
+    // (3) Resolve the agent's connections, then select the ONLINE origin (cwd-bound
+    // transcript owner) honoring any pinned target instance. listConnectionsForAgent is
+    // sorted online-first, then lastSeenAt desc.
     const connections = await listConnectionsForAgent(
       ctx.companyUuid,
       ctx.recipientUuid,
     );
-    const origin = connections.find((c) => c.effectiveStatus === "online");
+    // The wake's pinned (host, cwd), or null when un-pinned. DEC-5: cwd is only ever the
+    // explicit pin — never inferred from the project.
+    const pin = await resolvePinnedTarget(ctx, trigger);
+    // Pin-aware selection: the (host, cwd)-matching ONLINE connection when pinned, else
+    // online-first. Only an online connection is wakeable — an offline pin (or one with
+    // no online match) falls through to online-first; none online → no turn.
+    const origin = selectOriginConnection(connections, pin);
     if (!origin) {
-      // No online daemon for this agent — nothing to wake, so no turn. (Not an error:
-      // a notification can target an agent with no running daemon.)
+      // Nothing to wake: the agent has no online daemon (whether or not a pin was set).
+      // This is NORMAL, not an error: a notification can target a fully-offline agent.
+      // The already-created Notification stands as the plain record — there is no durable
+      // queue / backfill of pending turns.
       return null;
     }
 

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -28,6 +28,17 @@ export interface NotificationCreateParams {
   // copy lives on the created `DaemonSessionTurn.promptText`. Null for every
   // non-instruction notification.
   instructionText?: string | null;
+  // Pinned target daemon instance carried by a `mentioned` wake (cwd-addressable
+  // instances, T5). The mention markup encodes the owner-chosen `(host, cwd)` and
+  // mention.service threads it here so the autonomous wake (notification-turn.ts)
+  // routes to that instance. These are NOT persisted on the Notification row — they
+  // are transport-only into the wake-turn chokepoint, which resolves them to a live
+  // connection at wake time. A `task_assigned` wake reads its pin from the Task's
+  // `targetHost`/`targetCwd` columns instead (the durable storage), so it does not
+  // need these. Both undefined/null → no pin (online-first, exactly as before).
+  // `pinnedHost` "" = unknown-host instance; `pinnedCwd` null = unknown-path instance.
+  pinnedHost?: string | null;
+  pinnedCwd?: string | null;
 }
 
 export interface NotificationListParams {

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -47,6 +47,14 @@ export interface TaskClaimParams {
   assigneeType: string;
   assigneeUuid: string;
   assignedByUuid?: string | null;
+  // Pinned (host, cwd) daemon instance the assignment should run on (cwd-
+  // addressable instances, T4). A durable "place" (host + working directory),
+  // NOT an ephemeral connectionUuid, so the pin survives a daemon restart and is
+  // resolved to a live connection at wake time (T5). Both undefined → no pin
+  // (behaves exactly as before this change). host "" denotes an unknown-host
+  // instance; cwd null denotes an unknown-path (legacy null-cwd) instance.
+  targetHost?: string | null;
+  targetCwd?: string | null;
 }
 
 export interface TaskUpdateParams {
@@ -113,6 +121,11 @@ export interface TaskResponse {
     assignedBy: { type: string; uuid: string; name: string } | null;
   } | null;
   proposalUuid: string | null;
+  // Pinned (host, cwd) daemon instance for the autonomous wake (cwd-addressable
+  // instances, T4). null when no instance was pinned at assignment time. host ""
+  // = unknown-host instance; cwd null = unknown-path (legacy null-cwd) instance.
+  targetHost: string | null;
+  targetCwd: string | null;
   project?: { uuid: string; name: string };
   createdBy: { type: string; uuid: string; name: string } | null;
   dependsOn: TaskDependencyInfo[];
@@ -210,6 +223,8 @@ async function formatTaskResponse(
     assigneeUuid: string | null;
     assignedAt: Date | null;
     assignedByUuid: string | null;
+    targetHost?: string | null;
+    targetCwd?: string | null;
     proposalUuid: string | null;
     createdByUuid: string;
     createdAt: Date;
@@ -256,6 +271,8 @@ async function formatTaskResponse(
     acceptanceSummary,
     assignee,
     proposalUuid: task.proposalUuid,
+    targetHost: task.targetHost ?? null,
+    targetCwd: task.targetCwd ?? null,
     ...(task.project && { project: task.project }),
     createdBy,
     dependsOn,
@@ -279,6 +296,8 @@ type RawTaskForBatch = {
   assigneeUuid: string | null;
   assignedAt: Date | null;
   assignedByUuid: string | null;
+  targetHost?: string | null;
+  targetCwd?: string | null;
   proposalUuid: string | null;
   createdByUuid: string;
   createdAt: Date;
@@ -370,6 +389,8 @@ async function formatTaskResponsesBatch(
       acceptanceSummary,
       assignee,
       proposalUuid: task.proposalUuid,
+      targetHost: task.targetHost ?? null,
+      targetCwd: task.targetCwd ?? null,
       ...(task.project && { project: task.project }),
       createdBy,
       dependsOn,
@@ -437,6 +458,8 @@ export async function listTasks({
         assigneeUuid: true,
         assignedAt: true,
         assignedByUuid: true,
+        targetHost: true,
+        targetCwd: true,
         proposalUuid: true,
         createdByUuid: true,
         createdAt: true,
@@ -594,12 +617,15 @@ export async function updateTask(
 }
 
 // Claim Task (atomic: only succeeds if status is "open")
+// `companyUuid` is part of the params contract for callers but unused here — the
+// atomic update is keyed on the task uuid + status guard, not company scope.
 export async function claimTask({
   taskUuid,
-  companyUuid,
   assigneeType,
   assigneeUuid,
   assignedByUuid,
+  targetHost,
+  targetCwd,
 }: TaskClaimParams): Promise<TaskResponse> {
   try {
     const task = await prisma.task.update({
@@ -610,6 +636,12 @@ export async function claimTask({
         assigneeUuid,
         assignedAt: new Date(),
         assignedByUuid,
+        // Persist the pinned (host, cwd) instance with the assignment when the
+        // caller threaded one (cwd-addressable instances, T4). Always write both
+        // (coercing undefined → null) so RE-assigning without a pin CLEARS a
+        // stale pin from a prior assignment rather than silently inheriting it.
+        targetHost: targetHost ?? null,
+        targetCwd: targetCwd ?? null,
       },
       include: {
         project: { select: { uuid: true, name: true } },
@@ -638,6 +670,11 @@ export async function releaseTask(uuid: string): Promise<TaskResponse> {
         assigneeUuid: null,
         assignedAt: null,
         assignedByUuid: null,
+        // Releasing clears the assignment, so the pinned (host, cwd) instance
+        // goes with it (cwd-addressable instances, T4) — a re-assignment picks a
+        // fresh instance rather than inheriting the released one's pin.
+        targetHost: null,
+        targetCwd: null,
       },
       include: {
         project: { select: { uuid: true, name: true } },
@@ -1175,6 +1212,8 @@ export async function getUnblockedTasks({
         assigneeUuid: true,
         assignedAt: true,
         assignedByUuid: true,
+        targetHost: true,
+        targetCwd: true,
         proposalUuid: true,
         createdByUuid: true,
         createdAt: true,


### PR DESCRIPTION
## Summary

The **L2 addressable layer** on top of the shipped multi-path cwd engine (PR #353): make each `(agent, host, cwd)` daemon instance individually visible and addressable across presence, @mention, task assignment, ad-hoc send, and the chat header. Idea `d48f83c4` (4 elaboration rounds), OpenSpec change `add-cwd-addressable-instances`.

- **Path-first / host-conditional display** — `formatCwd`/`formatHost` with left-truncate-path (keep final segment) / right-truncate-host; host stays part of identity (same path on two hosts = two real instances) but is de-emphasized.
- **Presence** — collapsible agent card (default collapsed) → per-cwd instance rows; **all presence surfaces show ONLINE instances only** (offline / legacy null-cwd rows hidden; agents with no online instance disappear).
- **@mention / task-assign / ad-hoc send** — shared online-only `InstancePicker`; 2+ live instances → secondary cwd picker, single → auto-pin.
- **Durable pin** — `Task.targetHost/targetCwd` (nullable, DDL-only migration); autonomous wake honors a pinned `(host,cwd)` with online-first fallback, never inferred from project (DEC-5). Targeting a fully-offline agent records a plain notification (no wake).
- **Chat re-point** — when a conversation's origin cwd is offline but the agent has another online cwd, **"Continue on an online directory"** re-points the **SAME** session's origin (keeps `sessionId`; daemon spawns `claude --session-id`, fresh transcript) via a new owner-scoped `POST /api/daemon-sessions/[uuid]/repoint`. The read-only dead-end and the write-once `originConnectionUuid` invariant are reversed **only** for this explicit, gated action.

## Changed files (highlights)

| Area | Files |
|------|-------|
| Helper + migration | `src/lib/daemon-instance-format.ts`, `src/lib/mention-format.ts`, `prisma/migrations/20260623020208_*`, `prisma/schema.prisma` |
| Presence UI | `agent-presence/instance-group.tsx`, `instance-picker.tsx`, `agent-presence-pill.tsx`, `connections-view.tsx`, `identity-block.tsx` |
| Dispatch / mention | `mention-editor.tsx`, `mention.service.ts`, `assign-task-modal.tsx`, `tasks/[taskUuid]/actions.ts`, `claim/route.ts`, `mcp/tools/pm.ts` |
| Wake / pin | `notification-turn.ts`, `notification.service.ts`, `task.service.ts` |
| Chat re-point | `chat/transcript-view.tsx`, `chat/daemon-chat.tsx`, `chat/new-conversation-pane.tsx`, `send-instruction-box.tsx`, `api/daemon-sessions/[sessionUuid]/repoint/route.ts` |
| Specs / i18n | `openspec/...daemon-cwd-instance-addressing`, `messages/en.json`, `messages/zh.json` |

## Test plan

- [x] `pnpm test` — 3076 passed / 0 failed; `npx tsc --noEmit` clean; `pnpm lint` clean on changed files
- [x] Independent `chorus:code-reviewer` — PASS (incl. the security-sensitive re-point route: owner/same-agent/companyUuid scoping, refuse-live-origin / require-online-target gates, invariant reversal contained)
- [x] Real-browser e2e (Playwright + live daemon): presence drill-down (collapse + online-only), @mention picker, assign picker, fully-offline-agent plain assignment, and the **sessionId-preserving re-point** (DB-confirmed: same sessionId, origin moved to online cwd, no new session)

## Notes

- `docs/design.pen` carries the initial design screens; the T8/T11/T12 visual corrections are a tracked follow-up (Pencil tooling outage this session) — runtime behavior is the source of truth and is verified.
- Migration is nullable DDL-only (no backfill DML).

Generated with [Claude Code](https://claude.com/claude-code)