### PR TITLE
fix: instance picker second cwd row unselectable (id collision + label double-fire)

### DIFF
--- a/src/components/agent-presence/__tests__/instance-picker.test.tsx
+++ b/src/components/agent-presence/__tests__/instance-picker.test.tsx
@@ -17,7 +17,13 @@
 // path (same harness as the other agent-presence component tests).
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+} from "@testing-library/react";
 
 vi.mock("next-intl", async () => {
   const en = (await import("../../../../messages/en.json")).default as Record<
@@ -69,12 +75,20 @@ const onlineB: InstanceCandidate = {
   effectiveStatus: "online",
 };
 
-// Find the radio input for a given connectionUuid (the picker ids them
-// `instance-<connectionUuid>`).
-function radioFor(connectionUuid: string): HTMLInputElement {
-  return document.getElementById(
-    `instance-${connectionUuid}`,
-  ) as HTMLInputElement;
+// The picker no longer ids its rows (the old `instance-<uuid>` id + label htmlFor
+// double-fired and collided across two simultaneously-mounted pickers). Selection
+// is driven by a row click, so tests act on the row by its cwd label. `within` a
+// container scopes lookups to one picker so two mounted pickers don't clash.
+function rowByCwd(scope: HTMLElement, cwdLabelFragment: string): HTMLElement {
+  // The path chip renders the abbreviated tail (e.g. "…/dev/chorus"); match on the
+  // final segment which is always preserved.
+  const chip = within(scope).getByText(
+    (t) => t.includes(cwdLabelFragment),
+  );
+  // Walk up to the clickable row container.
+  const row = chip.closest('[role="presentation"]');
+  if (!row) throw new Error(`row for ${cwdLabelFragment} not found`);
+  return row as HTMLElement;
 }
 
 beforeEach(() => {
@@ -83,31 +97,85 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("InstancePicker — online-only rows (2+ instances)", () => {
-  it("renders every (online) row enabled and selectable", () => {
-    render(
+  it("renders every (online) row as an enabled radio", () => {
+    const { container } = render(
       <InstancePicker
         instances={[onlineA, onlineB]}
         selectedConnectionUuid={null}
         onSelect={vi.fn()}
       />,
     );
-    expect(radioFor("conn-online-a").disabled).toBe(false);
-    expect(radioFor("conn-online-b").disabled).toBe(false);
+    const radios = within(container).getAllByRole("radio");
+    expect(radios).toHaveLength(2);
+    radios.forEach((r) => expect(r.hasAttribute("disabled")).toBe(false));
   });
 
   it("fires onSelect with the chosen candidate when a row is clicked", () => {
     const onSelect = vi.fn();
-    render(
+    const { container } = render(
       <InstancePicker
         instances={[onlineA, onlineB]}
         selectedConnectionUuid={onlineA.connectionUuid}
         onSelect={onSelect}
       />,
     );
-    fireEvent.click(radioFor("conn-online-b"));
+    fireEvent.click(rowByCwd(container, "payments"));
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ connectionUuid: "conn-online-b" }),
     );
+  });
+
+  // REGRESSION (bug A/B root cause): selecting the SECOND (non-default) row must
+  // work. The old <label htmlFor> + wrapped RadioGroupItem id double-fired and,
+  // worse, collided with a second mounted picker's identical ids, so clicking the
+  // 2nd row forwarded activation to a stale control and selection never moved.
+  it("selects the SECOND of two rows (the previously-broken case)", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <InstancePicker
+        instances={[onlineA, onlineB]}
+        selectedConnectionUuid={onlineA.connectionUuid}
+        onSelect={onSelect}
+      />,
+    );
+    // Click the second row's container (anywhere on it).
+    fireEvent.click(rowByCwd(container, "payments"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ connectionUuid: "conn-online-b" }),
+    );
+  });
+
+  // REGRESSION (bug A repro): two pickers mounted at once (e.g. an open
+  // conversation's reply box + the new-conversation composer) must NOT share
+  // element ids — the old per-connection `instance-<uuid>` id appeared twice and
+  // broke selection. The picker now uses NO such ids; assert none leak, and that
+  // each picker selects independently.
+  it("two mounted pickers do not collide on ids and select independently", () => {
+    const onSelectFirst = vi.fn();
+    const onSelectSecond = vi.fn();
+    const { container: first } = render(
+      <InstancePicker
+        instances={[onlineA, onlineB]}
+        selectedConnectionUuid={onlineA.connectionUuid}
+        onSelect={onSelectFirst}
+      />,
+    );
+    const { container: second } = render(
+      <InstancePicker
+        instances={[onlineA, onlineB]}
+        selectedConnectionUuid={onlineA.connectionUuid}
+        onSelect={onSelectSecond}
+      />,
+    );
+    // No element carries the old colliding id pattern.
+    expect(document.querySelectorAll('[id^="instance-"]').length).toBe(0);
+    // Selecting in the SECOND picker fires only its callback with the right uuid.
+    fireEvent.click(rowByCwd(second, "payments"));
+    expect(onSelectSecond).toHaveBeenLastCalledWith(
+      expect.objectContaining({ connectionUuid: "conn-online-b" }),
+    );
+    expect(onSelectFirst).not.toHaveBeenCalled();
   });
 
   it("shows NO 'Offline' tag and NO 'Queue' affordance (those concepts are gone)", () => {

--- a/src/components/agent-presence/instance-picker.tsx
+++ b/src/components/agent-presence/instance-picker.tsx
@@ -196,16 +196,28 @@ export function InstancePicker({
       className={cn("gap-1.5", className)}
     >
       {instances.map((instance) => {
-        const radioId = `instance-${instance.connectionUuid}`;
+        const selected =
+          selectedConnectionUuid === instance.connectionUuid;
+        // The row is a plain container, NOT a <label htmlFor>. A label both
+        // wrapping the Radix radio AND pointing at it by id double-fired
+        // activation, and the per-connection id collided across two pickers
+        // mounted at once (e.g. the open conversation's reply box + this one),
+        // so a click forwarded to a stale/hidden control and the visible
+        // selection never moved. We select via an explicit row onClick instead;
+        // RadioGroupItem stays as the visual indicator + keyboard target, with
+        // NO id (so nothing can resolve to a duplicate). tabIndex=-1 keeps the
+        // row out of the tab order — Radix RadioGroup drives focus through the
+        // items themselves (arrow keys), and onClick handles pointer selection.
         return (
-          <label
+          <div
             key={instance.connectionUuid}
-            htmlFor={radioId}
+            role="presentation"
+            tabIndex={-1}
+            onClick={() => onSelect(instance)}
             className={cn(
               "flex items-center gap-2.5 rounded-md border px-2.5 py-2 transition-colors",
               "cursor-pointer border-[#E5E0D8] hover:bg-[#FAF8F4]",
-              selectedConnectionUuid === instance.connectionUuid &&
-                "border-[#C67A52] bg-[#FAF8F4]",
+              selected && "border-[#C67A52] bg-[#FAF8F4]",
             )}
           >
             {/* Status dot — pinned to the row edge, never shrinks. Always online
@@ -225,13 +237,17 @@ export function InstancePicker({
               )}
             </span>
 
-            {/* Selection control — pinned to the row edge, never shrinks. */}
+            {/* Selection control — pinned to the row edge, never shrinks. No id:
+                the row onClick + RadioGroup value drive selection; an id here
+                would re-introduce the cross-picker collision. The path chip's
+                text is the accessible name (aria-label), since the row is no
+                longer a <label>. */}
             <RadioGroupItem
-              id={radioId}
               value={instance.connectionUuid}
+              aria-label={instance.cwd ?? undefined}
               className="shrink-0"
             />
-          </label>
+          </div>
         );
       })}
     </RadioGroup>


### PR DESCRIPTION
## Summary

Fixes two human-reported bugs in the shared cwd `InstancePicker`, both traced to **one** root cause confirmed live in the DOM:

- **Bug A (desktop):** open an existing conversation, then **New conversation** → the 2nd cwd option couldn't be selected (only the default-checked first stuck).
- **Bug B (mobile):** @mention an agent → cwd picker → tap a cwd → **"Pin instance" stayed disabled** (only Cancel worked).

## Root cause

Each row was `<label htmlFor={radioId}>` **wrapping** a `<RadioGroupItem id={radioId}>` where `radioId = instance-<connectionUuid>`. Two compounding defects:

1. The label both wrapped the Radix radio **and** pointed at it via `htmlFor` → activation double-fired.
2. When a conversation is open, its reply/repoint picker stays mounted with the **same** per-connection ids; opening another picker (new-conversation / mention dialog) created **duplicate ids**, so each `label[for]` resolved to 2 targets. A click forwarded activation to the **first/stale** element in document order → the visible picker's selection never moved (and the doubled accessible name `…/repo-alpha …/repo-alpha` was the same footgun). This is why it only reproduced *after* opening a conversation first.

## Fix

Drop `htmlFor`/`id` entirely. The row is now a plain container with an explicit `onClick → onSelect`; `RadioGroupItem` stays as the visual + keyboard radio but carries **no id** (nothing can collide) with an `aria-label` of its cwd. One change fixes new-conversation, @mention (incl. mobile Pin), and assign at once. Keyboard nav + selected styling intact; single click anywhere on the row selects.

## Changed files

| File | Change |
|------|--------|
| `src/components/agent-presence/instance-picker.tsx` | Row = div + onClick; removed label htmlFor + RadioGroupItem id; aria-label per row |
| `src/components/agent-presence/__tests__/instance-picker.test.tsx` | Helper rewritten off the removed ids; +2 regression tests (second-of-N selection; two mounted pickers don't collide / select independently) |

## Test plan

- [x] `pnpm test` — 3078 passed / 0 failed (+2 regression tests); `npx tsc --noEmit` clean; eslint clean on the changed component
- [x] Real-browser e2e (local dev + 2 online cwds): **Bug A** — exact repro (open conversation → new conversation → 2nd cwd now selects, via both the radio and the row body); **Bug B** — mobile 390px @mention → tap cwd → "Pin instance" enabled → pins. DOM-confirmed `[id^=instance-]` count is 0 with two pickers mounted.

Follow-up patch to the cwd-addressable feature (PR #354), attached to the same proposal.

Generated with [Claude Code](https://claude.com/claude-code)