### PR TITLE
fix: confine server SIGINT/SIGTERM handlers to the server launch path

### DIFF
--- a/chorus.mjs
+++ b/chorus.mjs
@@ -34,6 +34,10 @@ import {
   daemonHelpText,
   loginHelpText,
 } from "./cli/client-args.mjs";
+// Server-only signal-handler installer, guarded so a client subcommand
+// (`chorus daemon` / `chorus login`) never registers the server's handlers.
+// Pure module → unit-testable without this entry's import-time side effects.
+import { installServerSignalHandlers } from "./cli/server-signal-handlers.mjs";
 
 /** Read the package version once for help/version output. */
 function pkgVersion() {
@@ -451,12 +455,21 @@ function shutdown() {
   }
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-process.on("exit", () => {
-  if (pgliteProcess && !pgliteProcess.killed) {
-    pgliteProcess.kill("SIGKILL");
-  }
+// Install the server's SIGINT/SIGTERM/exit handlers ONLY on the server launch
+// path. On a client subcommand (`chorus daemon` / `chorus login`) this installs
+// nothing, so the daemon's OWN graceful shutdown handler is the sole signal
+// disposition — otherwise the server's handler (registered first) would pre-empt
+// it with a synchronous `process.exit(0)`, leaving the daemon to disconnect
+// non-gracefully (stale presence) and printing a misleading bare "Shutting down...".
+installServerSignalHandlers({
+  isSubcommand,
+  processRef: process,
+  shutdown,
+  cleanupExit: () => {
+    if (pgliteProcess && !pgliteProcess.killed) {
+      pgliteProcess.kill("SIGKILL");
+    }
+  },
 });
 
 // ---------------------------------------------------------------------------

--- a/cli/__tests__/daemon-shutdown-signal.test.mjs
+++ b/cli/__tests__/daemon-shutdown-signal.test.mjs
@@ -1,0 +1,152 @@
+// cli/__tests__/daemon-shutdown-signal.test.mjs
+// End-to-end regression for the server-signal-handler leak (root-cause discriminator).
+//
+// Before the fix, a `chorus daemon` process ALSO registered the server's
+// SIGINT/SIGTERM handler (it was never guarded by `!isSubcommand`). That handler
+// runs first (registration order) and synchronously calls process.exit(0) after
+// logging a bare "Shutting down..." — pre-empting the daemon's own graceful
+// `daemon.stop()` (which logs "[Chorus] shutting down daemon...").
+//
+// This test spawns the REAL `node chorus.mjs daemon` entry against a hermetic
+// in-process MCP server (answers chorus_checkin so preflight passes and the daemon
+// reaches "daemon running"), sends the child SIGTERM, and asserts the captured
+// output shows the daemon's graceful line and NOT the server's bare one. The SSE
+// subscription fails fast against the fake server (no /api/events stream) — the
+// daemon tolerates that and still reaches "daemon running", which is the only state
+// this test needs before signalling.
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const ENTRY = join(dirname(dirname(dirname(fileURLToPath(import.meta.url)))), "chorus.mjs");
+
+/**
+ * Start a hermetic, stateless MCP HTTP server that answers chorus_checkin with a
+ * fake agent identity — enough for the daemon's preflight (validateAndFetchIdentity)
+ * to succeed. Mirrors the real stateless route: a fresh server+transport per request.
+ * @returns {Promise<{ url: string, close: () => Promise<void> }>}
+ */
+function startFakeChorus() {
+  return new Promise((resolve) => {
+    const httpServer = createServer(async (req, res) => {
+      if (!req.url || !req.url.startsWith("/api/mcp")) {
+        // Anything else (notably the SSE /api/events/notifications subscription)
+        // gets a 404 — the daemon treats a non-ok SSE response as a reconnectable
+        // failure and still reaches "daemon running".
+        res.statusCode = 404;
+        res.end("not found");
+        return;
+      }
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      res.on("close", () => transport.close());
+      const server = new McpServer({ name: "fake-chorus", version: "0.0.0" });
+      server.registerTool(
+        "chorus_checkin",
+        { description: "fake checkin", inputSchema: {} },
+        async () => ({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ agent: { uuid: "agent-e2e", name: "E2E Daemon Bot" } }),
+            },
+          ],
+        })
+      );
+      await server.connect(transport);
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", async () => {
+        let parsed;
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          parsed = undefined;
+        }
+        await transport.handleRequest(req, res, parsed);
+      });
+    });
+    httpServer.listen(0, "127.0.0.1", () => {
+      const { port } = /** @type {import("node:net").AddressInfo} */ (httpServer.address());
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise((r) => httpServer.close(() => r())),
+      });
+    });
+  });
+}
+
+let fake;
+let child;
+
+afterEach(async () => {
+  if (child && child.exitCode === null && child.signalCode === null) {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // already gone
+    }
+  }
+  child = undefined;
+  if (fake) {
+    await fake.close();
+    fake = undefined;
+  }
+});
+
+describe("chorus daemon graceful shutdown on SIGTERM (signal-handler-leak regression)", () => {
+  it("shuts down via the daemon's own graceful path, never the server's bare 'Shutting down...'", async () => {
+    fake = await startFakeChorus();
+
+    let out = "";
+    child = spawn(process.execPath, [ENTRY, "daemon"], {
+      env: {
+        ...process.env,
+        CHORUS_URL: fake.url,
+        CHORUS_API_KEY: "cho_e2e_test_key",
+        // Force a clean, non-interactive, headless-equivalent run: no TTY prompts,
+        // no plugin-config fallback, throwaway HOME so we never read a real login file.
+        HOME: "/tmp/chorus-daemon-shutdown-test-home",
+        CHORUS_DAEMON_HEADLESS: "1",
+        CHORUS_YOLO: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.on("data", (c) => (out += c));
+    child.stderr.on("data", (c) => (out += c));
+
+    // Wait for the daemon to reach "daemon running" (its SIGTERM handler is now
+    // registered), then send SIGTERM. Poll the captured output up to ~12s.
+    const deadline = Date.now() + 12000;
+    while (Date.now() < deadline && !/daemon running/.test(out)) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(out, `daemon never reached "daemon running". Output so far:\n${out}`).toMatch(
+      /daemon running/
+    );
+
+    // Capture the exit, then signal.
+    const exited = new Promise((resolve) => child.on("close", () => resolve()));
+    child.kill("SIGTERM");
+    // Give the graceful path a moment to log + exit; kill hard if it hangs.
+    const hardKill = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+    }, 5000);
+    await exited;
+    clearTimeout(hardKill);
+
+    // The daemon's own graceful handler ran...
+    expect(out).toMatch(/\[Chorus\] shutting down daemon\.\.\./);
+    // ...and the server's bare line did NOT (that string is server-only; the
+    // daemon's line always carries the "[Chorus] " prefix). Assert no bare
+    // "Shutting down..." appears at the start of a line.
+    expect(out).not.toMatch(/^Shutting down\.\.\./m);
+  }, 25000);
+});

--- a/cli/__tests__/server-signal-handlers.test.mjs
+++ b/cli/__tests__/server-signal-handlers.test.mjs
@@ -1,0 +1,72 @@
+// cli/__tests__/server-signal-handlers.test.mjs
+// Regression for the signal-handler leak: `chorus.mjs` used to register the
+// server's SIGINT/SIGTERM/exit handlers UNCONDITIONALLY, so a `chorus daemon`
+// process installed the server's `shutdown` (bare "Shutting down...", synchronous
+// process.exit(0)) ahead of the daemon's own graceful handler. The guard lives in
+// installServerSignalHandlers — this test drives it with a FAKE processRef so we can
+// assert exactly which listeners get attached, without importing the side-effectful
+// entry module and without delivering a real fatal signal to the test runner.
+import { describe, it, expect, vi } from "vitest";
+import { installServerSignalHandlers } from "../server-signal-handlers.mjs";
+
+/** A minimal process-like recorder: captures every .on(event, fn) call. */
+function fakeProcess() {
+  const calls = [];
+  return {
+    calls,
+    on(event, listener) {
+      calls.push({ event, listener });
+      return this;
+    },
+    /** events registered, in order */
+    events() {
+      return calls.map((c) => c.event);
+    },
+  };
+}
+
+describe("installServerSignalHandlers", () => {
+  it("client subcommand (isSubcommand=true): registers ZERO handlers and returns false", () => {
+    const proc = fakeProcess();
+    const shutdown = vi.fn();
+    const cleanupExit = vi.fn();
+
+    const installed = installServerSignalHandlers({
+      isSubcommand: true,
+      processRef: proc,
+      shutdown,
+      cleanupExit,
+    });
+
+    expect(installed).toBe(false);
+    expect(proc.calls).toHaveLength(0);
+    expect(proc.events()).toEqual([]);
+    // The handlers themselves are never invoked as a side effect of registration.
+    expect(shutdown).not.toHaveBeenCalled();
+    expect(cleanupExit).not.toHaveBeenCalled();
+  });
+
+  it("server path (isSubcommand=false): registers exactly SIGINT, SIGTERM, exit and returns true", () => {
+    const proc = fakeProcess();
+    const shutdown = vi.fn();
+    const cleanupExit = vi.fn();
+
+    const installed = installServerSignalHandlers({
+      isSubcommand: false,
+      processRef: proc,
+      shutdown,
+      cleanupExit,
+    });
+
+    expect(installed).toBe(true);
+    expect(proc.events()).toEqual(["SIGINT", "SIGTERM", "exit"]);
+    // SIGINT + SIGTERM are wired to `shutdown`; `exit` is wired to `cleanupExit`.
+    const byEvent = Object.fromEntries(proc.calls.map((c) => [c.event, c.listener]));
+    expect(byEvent.SIGINT).toBe(shutdown);
+    expect(byEvent.SIGTERM).toBe(shutdown);
+    expect(byEvent.exit).toBe(cleanupExit);
+    // Registration must not invoke the listeners.
+    expect(shutdown).not.toHaveBeenCalled();
+    expect(cleanupExit).not.toHaveBeenCalled();
+  });
+});

--- a/cli/server-signal-handlers.mjs
+++ b/cli/server-signal-handlers.mjs
@@ -1,0 +1,41 @@
+// cli/server-signal-handlers.mjs
+// The Chorus CLI entry (`chorus.mjs`) is dual-purpose: with no subcommand it
+// launches the embedded Next.js server (with a PGlite child); with `daemon` /
+// `login` it dispatches a client subcommand that connects OUT to a remote
+// server. The server-launch path installs three process-signal handlers — a
+// SIGINT/SIGTERM graceful-shutdown handler and an `exit` handler that
+// force-kills the PGlite child — but those are MEANINGLESS (and actively
+// harmful) on a client-subcommand process: a `chorus daemon` never starts
+// PGlite, and the server's SIGINT/SIGTERM handler would otherwise pre-empt the
+// daemon's OWN graceful shutdown (it runs first, in registration order, and
+// calls `process.exit(0)` synchronously). See the idea / design docs.
+//
+// This module is intentionally PURE — it runs no side effects at import — so a
+// unit test can import the function in isolation and drive it with a fake
+// `process`-like object, without executing `chorus.mjs`'s import-time side
+// effects (subcommand dispatch, server-config parsing) and without delivering a
+// real fatal signal to the test runner.
+
+/**
+ * Install the server-only process-signal handlers, but ONLY for the server
+ * launch path (no client subcommand). When invoked as a client subcommand
+ * (`chorus daemon` / `chorus login`), this registers NOTHING and returns false,
+ * so the process terminates exclusively through the subcommand's own handler
+ * (e.g. the daemon's graceful `daemon.stop()`).
+ *
+ * @param {object} params
+ * @param {boolean} params.isSubcommand  true when a client subcommand is running.
+ * @param {{ on(event: string, listener: (...args: any[]) => void): unknown }} params.processRef
+ *   the process to attach listeners to (real `process`, or a fake in tests).
+ * @param {(...args: any[]) => void} params.shutdown    SIGINT/SIGTERM handler.
+ * @param {(...args: any[]) => void} params.cleanupExit `exit` handler (PGlite SIGKILL).
+ * @returns {boolean} true if the server handlers were installed, false if skipped.
+ */
+export function installServerSignalHandlers({ isSubcommand, processRef, shutdown, cleanupExit }) {
+  // Client subcommand → install none of the server's signal handlers.
+  if (isSubcommand) return false;
+  processRef.on("SIGINT", shutdown);
+  processRef.on("SIGTERM", shutdown);
+  processRef.on("exit", cleanupExit);
+  return true;
+}

--- a/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/README.md
+++ b/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-server-signal-handler-leak
+
+Guard the server SIGINT/SIGTERM/exit handlers behind !isSubcommand so chorus daemon shuts down via its own graceful path

--- a/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/design.md
+++ b/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/design.md
@@ -1,0 +1,135 @@
+# Design — confine server signal handlers to the server launch path
+
+## Context
+
+`chorus.mjs` is a dual-purpose entry: with no subcommand it launches the Next.js
+server (embedded PGlite, migrations, etc.); with `daemon` / `login` it dispatches a
+client subcommand. The two modes share one module body, separated by an
+`isSubcommand` boolean.
+
+Today the separation is incomplete. The relevant structure:
+
+```js
+const SUBCOMMANDS = new Set(["daemon", "login"]);
+
+{
+  const sub = process.argv[2];
+  if (sub && SUBCOMMANDS.has(sub)) {
+    runSubcommand(sub, process.argv.slice(3))
+      .then((code) => process.exit(typeof code === "number" ? code : 0))
+      .catch(...);
+    // "Stop the server-launch module body from executing in this process tick."
+    // ^ comment only — there is NO return/guard here.
+  }
+}
+
+const isSubcommand = SUBCOMMANDS.has(process.argv[2]);
+
+// ...server config + main()...
+
+let pgliteProcess = null;
+function shutdown() { ...; console.log("\nShutting down..."); ...process.exit(0); }
+process.on("SIGINT", shutdown);     // ← runs even for `chorus daemon`
+process.on("SIGTERM", shutdown);    // ← runs even for `chorus daemon`
+process.on("exit", () => { if (pgliteProcess && !pgliteProcess.killed) pgliteProcess.kill("SIGKILL"); });
+
+if (!isSubcommand) { main().catch(...); }   // main() IS guarded
+```
+
+`main()` is guarded by `!isSubcommand`; the three `process.on(...)` registrations are
+not. So `chorus daemon` installs the server's `shutdown` as its first SIGINT/SIGTERM
+listener. When a signal arrives, the server handler prints `Shutting down...`, finds
+`pgliteProcess === null`, and calls `process.exit(0)` synchronously — pre-empting the
+daemon's own graceful handler (registered later inside `runDaemon`, which does
+`daemon.stop()` → SSE disconnect + MCP disconnect, logging `[Chorus] shutting down
+daemon...`).
+
+## Goals / Non-goals
+
+- **Goal:** a `chorus daemon` (or `chorus login`) process must NOT register the server's
+  signal handlers; only the daemon's own graceful handler should be active.
+- **Goal:** the guard must be unit-testable without spawning a process or sending a real
+  fatal signal.
+- **Goal:** preserve server behavior exactly for the no-subcommand path.
+- **Non-goal:** changing *why* signals arrive (operational — use `chorus daemon -d`).
+- **Non-goal:** touching the daemon's own shutdown logic in `cli/daemon.mjs` (already
+  correct).
+
+## Decision
+
+### 1. Guard via `!isSubcommand` (matches `main()`)
+
+Wrap the three registrations in the same `!isSubcommand` condition that already guards
+`main()`. Minimal, semantics-preserving, no change to top-level module execution order.
+(Chosen over restructuring the dispatch block to `return`, which would require reordering
+the whole module body and carries more risk.)
+
+### 2. Extract a testable, injectable installer into its own side-effect-free module
+
+Move the registration into a small function in a **dedicated module**
+(`cli/server-signal-handlers.mjs`) so a unit test can drive it with a fake `process`-like
+object and assert which listeners get attached — without sending a real SIGINT/SIGTERM to
+the test runner:
+
+```js
+// cli/server-signal-handlers.mjs — pure, no top-level side effects.
+export function installServerSignalHandlers({ isSubcommand, processRef, shutdown, cleanupExit }) {
+  if (isSubcommand) return false;          // client subcommand → install nothing
+  processRef.on("SIGINT", shutdown);
+  processRef.on("SIGTERM", shutdown);
+  processRef.on("exit", cleanupExit);
+  return true;
+}
+```
+
+Top-level call site in `chorus.mjs`:
+
+```js
+import { installServerSignalHandlers } from "./cli/server-signal-handlers.mjs";
+// ...
+installServerSignalHandlers({
+  isSubcommand,
+  processRef: process,
+  shutdown,
+  cleanupExit: () => { if (pgliteProcess && !pgliteProcess.killed) pgliteProcess.kill("SIGKILL"); },
+});
+```
+
+**Why a separate module, not an `export` from `chorus.mjs`:** `chorus.mjs` is the CLI
+entry and runs side effects at import (the subcommand dispatch at L70-82, server-config
+parsing, etc.). In ES modules a named import cannot be loaded without first running the
+target module's top-level body, so `import { installServerSignalHandlers } from
+"../chorus.mjs"` would execute all of those side effects in the test runner. Housing the
+function in a pure module lets the unit test import it in isolation and pass a fake
+`processRef` (an object recording `.on(event, fn)` calls), with zero entry-module side
+effects. This keeps the existing `isSubcommand`-dispatch + side-effect structure in
+`chorus.mjs` untouched apart from swapping the three inline `process.on(...)` lines for the
+one guarded call.
+
+> Fallback if the extraction proves disruptive: keep the inline `if (!isSubcommand) {
+> process.on(...) }` guard and assert the behavior with the spawn-based e2e test only. The
+> injectable installer is preferred because it gives a fast, deterministic unit test.
+
+### 3. Both `exit` and the fatal-signal handlers are guarded together
+
+The `process.on("exit")` PGlite-cleanup is a no-op when `pgliteProcess === null` (always
+true on the daemon path), so it is harmless — but it is pure noise there. Guarding all
+three together keeps the rule simple and the intent obvious: *server-only handlers live
+behind `!isSubcommand`.*
+
+## Risks
+
+- **Low.** The server path is unchanged: `isSubcommand` is `false`, so all three handlers
+  install exactly as before. Verified by the e2e on the daemon path (graceful line, no bare
+  `Shutting down...`) plus the unchanged server behavior.
+
+## Test Plan
+
+1. **Unit** (`installServerSignalHandlers`): with `isSubcommand=true`, a fake `processRef`
+   records ZERO `.on()` calls and the function returns `false`; with `isSubcommand=false`,
+   it records `SIGINT`, `SIGTERM`, `exit` and returns `true`.
+2. **E2E** (real process): start an actual `chorus daemon` (local server + `.mcp.json`
+   local key), wait for `daemon running`, send the PID `SIGTERM`, and assert the captured
+   output contains `[Chorus] shutting down daemon...` (daemon graceful path) and does NOT
+   contain a bare `Shutting down...` line (server path). This is the direct, root-cause
+   discriminator from the elaboration.

--- a/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/proposal.md
+++ b/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/proposal.md
@@ -1,0 +1,69 @@
+# Fix: server signal handlers leak into the `chorus daemon` subcommand path
+
+## Why
+
+Users report that `chorus daemon` "keeps disconnecting on its own." The daemon log
+ends with a bare line — **`Shutting down...`** with no `[Chorus]` prefix — right after
+a wake completed:
+
+```
+[Chorus] ✓ wake done: daemon_session:787e4680-... (exit=0, 904374ms)
+[Chorus] execution-state uploaded (0 active)
+
+Shutting down...
+```
+
+That exact string `Shutting down...` is emitted by **exactly one** place in the
+codebase: `chorus.mjs`'s **server** shutdown handler. The daemon's own handler logs
+`[Chorus] shutting down daemon...` instead. So the log proves the process received a
+SIGINT/SIGTERM and the **wrong handler** (the server's) ran.
+
+Root cause: `chorus.mjs` dispatches the `daemon` / `login` subcommands asynchronously
+at the top of the module, with a comment claiming this "stops the server-launch module
+body from executing." But nothing actually stops it — there is no `return`/guard, so
+the rest of the module body keeps running. `main()` is correctly guarded by
+`if (!isSubcommand)`, **but the `process.on("SIGINT"|"SIGTERM"|"exit")` registrations
+are NOT.** So a `chorus daemon` process ends up with TWO competing signal dispositions:
+
+1. the **server's** handler (registered first, synchronously) → prints `Shutting
+   down...`, sees `pgliteProcess === null` (a daemon never starts PGlite) → calls
+   `process.exit(0)` **immediately**;
+2. the **daemon's** handler (registered later, async inside `runDaemon`) → would run a
+   graceful `daemon.stop()` (SSE disconnect + MCP disconnect).
+
+Node runs listeners in registration order; #1's synchronous `process.exit(0)` halts the
+process before #2 ever runs. Consequences: the daemon never disconnects gracefully (so
+the server shows it online — stale presence — for a while), and the shutdown message is
+misleading (looks like a server / PGlite shutdown).
+
+## What Changes
+
+- Guard the server-only signal handlers (`SIGINT`, `SIGTERM`, and the `exit` PGlite
+  SIGKILL cleanup) behind `!isSubcommand`, exactly as `main()` is already guarded — so a
+  `chorus daemon` (or `chorus login`) process registers ONLY the daemon's own graceful
+  handler.
+- Extract the registration into a small injectable function so the guard is unit-testable
+  without spawning a process or actually killing one.
+- Add a unit test asserting the server handlers are NOT installed on the subcommand path
+  (and ARE on the server path).
+- Add a real end-to-end test: start an actual `chorus daemon`, send it SIGTERM, and assert
+  the log shows the daemon's graceful line (`[Chorus] shutting down daemon...`) and NOT
+  the server's bare `Shutting down...`.
+
+## Capabilities
+
+- **cli-daemon** — adds a normative requirement that the server's process-signal handlers
+  are confined to the server launch path and never installed for a client subcommand, so a
+  `chorus daemon` process shuts down via its own graceful path.
+
+## Impact
+
+- Affected code: `chorus.mjs` (swaps the three inline `process.on(...)` registrations for
+  one guarded call), a new pure module `cli/server-signal-handlers.mjs` holding the
+  injectable installer, a new unit test for that installer, and a new daemon-shutdown e2e
+  test.
+- No behavior change for `chorus` with no subcommand (the server) — it still installs the
+  same handlers and shuts down identically.
+- No schema, API, or dependency changes. Out of scope: *why* a signal arrives (foreground
+  daemon, a co-located agent running `kill`/`pkill`, terminal Ctrl+C). That is an
+  operational concern — run `chorus daemon -d` (detached) — not a code bug.

--- a/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/specs/cli-daemon/spec.md
+++ b/openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/specs/cli-daemon/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Server signal handlers confined to the server launch path
+
+The CLI entry SHALL install the server's process-signal handlers — the `SIGINT` and
+`SIGTERM` graceful-shutdown handler and the `exit` handler that force-kills an embedded
+PGlite process — ONLY when invoked with no client subcommand (i.e. when launching the
+Chorus server). When invoked as a client subcommand (`chorus daemon` or `chorus login`),
+the entry SHALL NOT install any of these server signal handlers. Consequently a
+`chorus daemon` process SHALL terminate on `SIGINT`/`SIGTERM` exclusively through the
+daemon's own graceful shutdown path (which disconnects the SSE subscription and the MCP
+client and logs `[Chorus] shutting down daemon...`), and SHALL NOT emit the server's bare
+`Shutting down...` line. The registration of these handlers SHALL be encapsulated such that
+the guard is verifiable in isolation, without spawning a process or delivering a real
+fatal signal.
+
+#### Scenario: Daemon subcommand does not install server signal handlers
+
+- **WHEN** the CLI entry is evaluated for a client subcommand (`chorus daemon` or
+  `chorus login`)
+- **THEN** no server `SIGINT`, `SIGTERM`, or `exit` handler is registered, so only the
+  daemon's own graceful shutdown handler is active
+
+#### Scenario: Bare CLI still installs the server signal handlers
+
+- **WHEN** the CLI entry is evaluated with no subcommand (launching the server)
+- **THEN** the server's `SIGINT`, `SIGTERM`, and `exit` handlers are registered exactly as
+  before, and the server shuts down via its existing path
+
+#### Scenario: Daemon shuts down gracefully on SIGTERM
+
+- **WHEN** a running `chorus daemon` process receives `SIGTERM`
+- **THEN** the process shuts down through the daemon's graceful path — disconnecting the
+  SSE subscription and the MCP client and logging `[Chorus] shutting down daemon...` — and
+  does NOT print the server's bare `Shutting down...` line

--- a/openspec/specs/cli-daemon/spec.md
+++ b/openspec/specs/cli-daemon/spec.md
@@ -232,3 +232,37 @@ subsequent wakes for the same direct idea.
 - **THEN** the failure is logged and the next queued wake for that same direct idea
   still proceeds
 
+### Requirement: Server signal handlers confined to the server launch path
+
+The CLI entry SHALL install the server's process-signal handlers — the `SIGINT` and
+`SIGTERM` graceful-shutdown handler and the `exit` handler that force-kills an embedded
+PGlite process — ONLY when invoked with no client subcommand (i.e. when launching the
+Chorus server). When invoked as a client subcommand (`chorus daemon` or `chorus login`),
+the entry SHALL NOT install any of these server signal handlers. Consequently a
+`chorus daemon` process SHALL terminate on `SIGINT`/`SIGTERM` exclusively through the
+daemon's own graceful shutdown path (which disconnects the SSE subscription and the MCP
+client and logs `[Chorus] shutting down daemon...`), and SHALL NOT emit the server's bare
+`Shutting down...` line. The registration of these handlers SHALL be encapsulated such that
+the guard is verifiable in isolation, without spawning a process or delivering a real
+fatal signal.
+
+#### Scenario: Daemon subcommand does not install server signal handlers
+
+- **WHEN** the CLI entry is evaluated for a client subcommand (`chorus daemon` or
+  `chorus login`)
+- **THEN** no server `SIGINT`, `SIGTERM`, or `exit` handler is registered, so only the
+  daemon's own graceful shutdown handler is active
+
+#### Scenario: Bare CLI still installs the server signal handlers
+
+- **WHEN** the CLI entry is evaluated with no subcommand (launching the server)
+- **THEN** the server's `SIGINT`, `SIGTERM`, and `exit` handlers are registered exactly as
+  before, and the server shuts down via its existing path
+
+#### Scenario: Daemon shuts down gracefully on SIGTERM
+
+- **WHEN** a running `chorus daemon` process receives `SIGTERM`
+- **THEN** the process shuts down through the daemon's graceful path — disconnecting the
+  SSE subscription and the MCP client and logging `[Chorus] shutting down daemon...` — and
+  does NOT print the server's bare `Shutting down...` line
+


### PR DESCRIPTION
## Summary
- `chorus daemon` "kept disconnecting on its own" because `chorus.mjs` registered the server's `SIGINT`/`SIGTERM`/`exit` handlers **unconditionally** (never guarded by `!isSubcommand`).
- On a signal the server's `shutdown` ran first (registration order), printed a bare `Shutting down...`, and called `process.exit(0)` **synchronously** — pre-empting the daemon's own graceful `daemon.stop()` (SSE + MCP disconnect). Result: the daemon never disconnected gracefully (stale presence) and the shutdown message was misleading.
- Fix: move the three registrations into a new **pure, injectable** module `cli/server-signal-handlers.mjs`, guarded behind `!isSubcommand` (matching the existing `main()` guard). A `chorus daemon`/`chorus login` process now installs **none** of the server handlers and shuts down exclusively through its own graceful path. The server (no-subcommand) path is byte-equivalent.

## Changed files
| File | Change |
|------|--------|
| `cli/server-signal-handlers.mjs` | **New** pure module exporting `installServerSignalHandlers({ isSubcommand, processRef, shutdown, cleanupExit })` — registers SIGINT/SIGTERM/exit only when `isSubcommand` is false; no import-time side effects |
| `chorus.mjs` | Import the installer; replace the three inline top-level `process.on(...)` registrations with one guarded `installServerSignalHandlers(...)` call |
| `cli/__tests__/server-signal-handlers.test.mjs` | **New** unit test — fake `processRef`: `isSubcommand=true` ⇒ 0 registrations + false; `false` ⇒ exactly SIGINT/SIGTERM/exit + true |
| `cli/__tests__/daemon-shutdown-signal.test.mjs` | **New** hermetic real-spawn e2e — in-process MCP server answers `chorus_checkin` so the real `node chorus.mjs daemon` reaches "daemon running", then SIGTERM; asserts `[Chorus] shutting down daemon...` and NOT a bare `Shutting down...` |
| `openspec/specs/cli-daemon/spec.md` | New ADDED requirement (archived from the OpenSpec change) |
| `openspec/changes/archive/2026-06-23-fix-daemon-server-signal-handler-leak/` | Archived OpenSpec change (proposal/design/spec) |

## Test plan
- [x] Unit + e2e pass (`npx vitest run cli/__tests__/server-signal-handlers.test.mjs cli/__tests__/daemon-shutdown-signal.test.mjs`)
- [x] **Mutation-verified**: reverting the fix to the buggy unconditional registration makes the e2e FAIL with the bare `Shutting down...` line (reproduces the production symptom) — the test is a genuine regression guard, not a tautology
- [x] `npx tsc --noEmit` exit 0; changed-file eslint 0 errors
- [x] Full suite `pnpm test` green (3081 passed; one unrelated pre-existing flake in `daemon-integration.test.mjs` — a hardcoded-pid SIGKILL timer leak — independent of this change)

Out of scope (operational, not a code bug): *why* a signal arrives at a foreground daemon — mitigated by `chorus daemon -d` (detached).

Generated with [Claude Code](https://claude.com/claude-code)