### PR TITLE
feat: render comment agent @mentions as online-status badges

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1554,7 +1554,11 @@
     "online": "Online",
     "offline": "Offline",
     "activeCount": "{count} active",
-    "idle": "Idle"
+    "idle": "Idle",
+    "openConversation": "Open conversation",
+    "host": "Host",
+    "workingDirectory": "Working directory",
+    "badgeAria": "{name} — {status}"
   },
   "mentionInstance": {
     "title": "Which working directory?",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1555,7 +1555,11 @@
     "online": "在线",
     "offline": "离线",
     "activeCount": "进行中 {count}",
-    "idle": "空闲"
+    "idle": "空闲",
+    "openConversation": "打开对话",
+    "host": "主机",
+    "workingDirectory": "工作目录",
+    "badgeAria": "{name} — {status}"
   },
   "mentionInstance": {
     "title": "选择工作目录？",

--- a/openspec/changes/add-comment-mention-badges/.openspec.yaml
+++ b/openspec/changes/add-comment-mention-badges/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/add-comment-mention-badges/README.md
+++ b/openspec/changes/add-comment-mention-badges/README.md
@@ -1,0 +1,3 @@
+# add-comment-mention-badges
+
+Render agent @mentions in comments as interactive online-status badges with a click popover and owner-only open-conversation button

--- a/openspec/changes/add-comment-mention-badges/design.md
+++ b/openspec/changes/add-comment-mention-badges/design.md
@@ -1,0 +1,196 @@
+# Technical Design: Comment Mention Badges
+
+## Overview
+
+Upgrade agent `@mentions` in the comment area from static text spans into interactive,
+online-aware badges. Clicking a badge opens a popover with the agent/instance identity and
+an owner-only, online-only "Open conversation" button that opens the existing daemon chat.
+
+The work is almost entirely frontend. It composes three already-shipped subsystems:
+
+- **Mention token + pin codec** — `@[Name](agent:uuid?cwd=…&host=…)` parsed via
+  `decodePinSuffix` (`src/lib/mention-format.ts`); server side already understands this
+  (`MentionRef.pinnedHost/pinnedCwd` in `src/services/mention.service.ts`).
+- **Presence** — `AgentPresenceProvider` (`src/contexts/agent-presence-context.tsx`)
+  exposes `connections: ConnectionView[]` (`{ agentUuid, host, cwd, effectiveStatus,
+  lastSeenAt, … }`), polled from `/api/agent-connections`, and `setOpenSession`.
+- **Daemon chat** — `DaemonChat` (`src/components/agent-presence/chat/daemon-chat.tsx`),
+  rendered inside the presence modal (`modalOpen` / `setModalOpen`), reads `connections`
+  and `setOpenSession`/`subscribeTranscript`.
+
+## Two structural blockers (verified against source)
+
+### B1 — Client mention regex does not parse the instance suffix
+
+`src/components/mention-renderer.tsx:13` uses
+`/@\[([^\]]+)\]\((user|agent):([a-f0-9-]+)\)/g`. A pinned token
+`@[Name](agent:uuid?cwd=%2Fhome%2Fx&host=prod)` does NOT match (the `?…` defeats the
+trailing `)`), so it renders as broken raw text. The server-side parser
+(`mention.service.ts`) already uses an extended regex with an optional 4th group; the
+**client** path must match that, then decode the suffix with `decodePinSuffix` from
+`src/lib/mention-format.ts` (pure, dependency-free, already exported). No new parsing
+logic is invented — we reuse the existing codec.
+
+### B2 — Comment mentions render via imperative DOM injection
+
+`ContentWithMentions` → `MentionPostProcessor` (`mention-renderer.tsx:163`) walks the
+rendered markdown's text nodes with a `TreeWalker` and replaces placeholder text with
+`document.createElement("span")`. Imperatively-injected DOM cannot host an interactive
+React component (`<Popover>` with state, event handlers). Therefore the **comment render
+path** must render mentions as real React nodes.
+
+To keep scope to comments only (elaboration answer q6 = "comments only"), we do NOT change
+the shared `ContentWithMentions` DOM-injection behavior for other surfaces. Instead the
+comment path opts into a React-native mention renderer. Two viable approaches — the task
+implementer picks based on what keeps the blast radius smallest:
+
+- **(preferred) A comment-scoped variant**: `unified-comments.tsx`'s `CommentItem`
+  renders the body through a markdown renderer whose mention placeholders are replaced by
+  React `<MentionBadge>` / text nodes (e.g. a `components`/rehype mapping, or splitting the
+  body into markdown segments + React mention nodes), instead of calling the DOM-injecting
+  `ContentWithMentions`.
+- **(alternative) A render-prop on `ContentWithMentions`**: add an optional
+  `renderMention?: (ref) => ReactNode` prop; when provided, render mentions as React nodes
+  via a non-DOM-injection path; when absent, behavior is byte-for-byte unchanged. Only the
+  comment path passes the prop.
+
+Either way: **agent** mentions in comments become `<MentionBadge>`; **user** mentions keep
+the current styled-text appearance (q1 = agent mentions only).
+
+## Architecture
+
+```
+unified-comments.tsx (CommentItem)
+  └─ comment-scoped mention rendering (React-native, NOT DOM injection)
+       ├─ user mention      → existing styled text span (unchanged)
+       └─ agent mention     → <MentionBadge ref={MentionRef} />
+                                 ├─ resolves liveness from useAgentPresence().connections
+                                 │     - pinned:    match (agentUuid, host, cwd) → effectiveStatus
+                                 │     - non-pinned: agent online if ANY connection for agentUuid is online
+                                 ├─ <Badge> name + online dot   (click → <Popover>)
+                                 └─ <PopoverContent>
+                                       ├─ identity: name, online status
+                                       │     + cwd + host  (pinned only)
+                                       └─ owner? && online? → <Button> "Open conversation"
+                                              → openChatForAgent(agentUuid, pin?)
+```
+
+## Data Model
+
+No schema changes.
+
+`ConnectionView` (`src/components/agent-presence/types.ts`) must expose **`ownerUuid`** so
+the client can gate the owner-only button without an extra fetch. If it is not already
+present, add it and populate it in the `/api/agent-connections` response (the server
+already knows the connection's agent and the agent's owner — see the owner check in
+`src/app/api/daemon/control/route.ts`, which compares `target.ownerUuid` to
+`auth.actorUuid`). This mirrors the **same** owner rule on the client.
+
+## Liveness resolution (the core matching rule)
+
+Given a parsed `MentionRef` and `connections: ConnectionView[]` from `useAgentPresence()`:
+
+- **Pinned mention** (`pinnedCwd`/`pinnedHost` present — elaboration q2 = precise
+  instance level): online iff there exists a connection with
+  `agentUuid === ref.uuid && host === ref.pinnedHost && cwd === ref.pinnedCwd &&
+  effectiveStatus === "online"`. The popover shows that instance's `cwd`/`host` formatted
+  via `formatCwd`/`formatHost` (`src/lib/daemon-instance-format.ts`).
+- **Non-pinned mention** (q9 = agent-overall online): online iff ANY connection with
+  `agentUuid === ref.uuid` has `effectiveStatus === "online"`. The popover shows name +
+  overall online state only — **no** cwd/host (there is no single instance).
+
+Owner gate (q5): the "Open conversation" button renders only when
+`currentUserUuid === ownerUuid` for the agent. Resolve `ownerUuid` from the matched
+connection's `ownerUuid` (preferred) or, if no connection exists (offline), the button is
+moot because it is also online-gated. Resolve `currentUserUuid` via `useAuth().user.uuid`
+(`src/contexts/auth-context.tsx`) — already available app-wide; do NOT thread a new prop if
+the hook is accessible at the comment render site.
+
+Online gate (q4): when offline, the button is **hidden** (not disabled). Everyone — owner
+or not — still sees the badge + popover identity (q5 option a).
+
+## Open-conversation action contract
+
+A new imperative entry point on the presence provider, e.g.
+`openChatForAgent(agentUuid: string, pin?: { host: string; cwd: string | null })`:
+
+1. `setModalOpen(true)` to open the presence modal hosting `DaemonChat`.
+2. Communicate the target so `DaemonChat` focuses the right instance/session:
+   - **pinned**: target the connection matching `(agentUuid, host, cwd)`. The elaboration
+     answer q3 = "just open the daemon chat" — so we open the chat focused on that
+     instance; precise auto-selection of a specific past session is NOT required.
+   - **non-pinned** (q8 = open daemon chat, owner picks inside): open the chat focused on
+     the agent; the existing `DaemonChat` left rail / instance picker
+     (`src/components/agent-presence/instance-picker.tsx`) lets the owner choose the
+     instance/conversation.
+3. `DaemonChat` already drives `setOpenSession` when a conversation is selected; we only
+   need to seed which agent/instance it focuses. The exact seam (a `focusTarget` field on
+   the provider that `DaemonChat` reads on open, vs. a param to `setModalOpen`) is an
+   implementation detail for the task; it MUST NOT regress existing modal/`setOpenSession`
+   behavior.
+
+> The presence provider sits at the shell, ABOVE per-project `RealtimeProvider`s, and the
+> comment area is within its tree — so `useAgentPresence()` is available at the comment
+> render site (consistent with the existing presence-pill usage). Confirm during
+> implementation that the comment render site is inside `AgentPresenceProvider`.
+
+## Module Contracts
+
+- **Mention parse (client)**: returns, per mention, `{ type: "user"|"agent", uuid,
+  displayName, pinnedHost?: string|null, pinnedCwd?: string|null }` — same shape as
+  `MentionRef`, produced by reusing `decodePinSuffix`. Non-pinned → both pin fields
+  null/absent (byte-compatible with today's behavior for unpinned tokens).
+- **`ConnectionView`** gains `ownerUuid: string | null`.
+- **`MentionBadge` props**: the parsed `MentionRef` (agent only) + the resolved
+  `displayName`. It reads presence + auth via hooks; it does not require liveness to be
+  passed in.
+- **`openChatForAgent`** on `AgentPresenceValue`: documented above; additive, does not
+  change existing `setOpenSession`/`subscribeTranscript`/`setModalOpen` signatures.
+
+## UI / primitives
+
+Reuse existing `src/components/ui/` primitives: `Badge`, `Popover`/`PopoverTrigger`/
+`PopoverContent`, `Button`. Online dot can reuse the existing presence dot styling
+(e.g. the pattern in `presence-indicator.tsx`). Formatting of `cwd`/`host` reuses
+`formatCwd`/`formatHost` (`src/lib/daemon-instance-format.ts`) with their i18n keys.
+
+## i18n
+
+All new strings via `t()` in both `messages/en.json` and `messages/zh.json`:
+"Open conversation", online/offline labels, popover field labels (host, working
+directory), and any tooltips. Follows the project's CRITICAL i18n rule.
+
+## Implementation Plan
+
+1. **Parser + liveness foundation**: extend client mention parsing to read the pin suffix
+   (reuse `decodePinSuffix`); add `ownerUuid` to `ConnectionView` + `/api/agent-connections`;
+   add a small `useMentionLiveness(ref)` helper (or inline) implementing the matching rule.
+2. **`MentionBadge` component**: badge + online dot + popover identity + owner/online-gated
+   "Open conversation" button; wire `openChatForAgent`. Add i18n keys.
+3. **Comment render integration**: move the comment body mention rendering to a
+   React-native path so agent mentions mount `<MentionBadge>` and user mentions keep
+   current text; leave all other `ContentWithMentions` surfaces untouched.
+
+## Risks & Mitigations
+
+- **Regressing other mention surfaces**: keep the DOM-injection `ContentWithMentions`
+  default behavior unchanged; comments opt in explicitly. Mitigation: the comment-scoped
+  variant / opt-in render-prop, with a test asserting non-comment surfaces are byte-stable.
+- **Popover inside scrollable comment list**: use the Radix `Popover` portal (already the
+  default in `src/components/ui/popover.tsx`) so clipping/overflow is not an issue.
+- **Owner identity drift**: gate strictly on `ownerUuid === currentUserUuid`, mirroring the
+  server rule in `daemon/control/route.ts`; never infer ownership from name/email.
+- **`ConnectionView.ownerUuid` already present**: verify before adding; if present, the API
+  task is a no-op and only the type doc is confirmed.
+- **Pinned-but-offline / instance gone**: matching simply yields offline → dot offline,
+  button hidden. No special-casing required.
+
+## Verification anchors
+
+- `src/components/mention-renderer.tsx` (B1, B2), `src/lib/mention-format.ts`
+  (`decodePinSuffix`), `src/components/unified-comments.tsx` (`CommentItem`),
+  `src/contexts/agent-presence-context.tsx` (`connections`, `setOpenSession`,
+  `setModalOpen`), `src/components/agent-presence/chat/daemon-chat.tsx`,
+  `src/components/agent-presence/instance-picker.tsx`,
+  `src/lib/daemon-instance-format.ts`, `src/app/api/daemon/control/route.ts` (owner rule),
+  `src/contexts/auth-context.tsx` (`useAuth().user.uuid`).

--- a/openspec/changes/add-comment-mention-badges/proposal.md
+++ b/openspec/changes/add-comment-mention-badges/proposal.md
@@ -1,0 +1,77 @@
+# Comment mention badges: online-status agent badges with click-to-popover and owner-only open-conversation
+
+## Why
+
+Today, an `@mention` of an agent in the comment area renders as a static, styled text
+span (`src/components/mention-renderer.tsx` → `ContentWithMentions`). It carries no live
+signal: a reader cannot tell whether the agent is online, which working directory it is
+pinned to, or jump from the comment straight into its conversation.
+
+The underlying data already exists. Mention tokens support an optional instance suffix
+`@[Name](agent:uuid?cwd=…&host=…)` (`src/services/mention.service.ts` `MENTION_REGEX`
+/ `MentionRef`, codec in `src/lib/mention-format.ts`). Presence is already plumbed:
+`AgentPresenceProvider` (`src/contexts/agent-presence-context.tsx`) polls
+`/api/agent-connections` and exposes `connections: ConnectionView[]` (each with
+`effectiveStatus`, `host`, `cwd`), plus `setOpenSession` and a daemon chat UI
+(`src/components/agent-presence/chat/daemon-chat.tsx`).
+
+So this change is fundamentally a **rendering upgrade**: turn the dead mention text in
+comments into a live control that reflects online status and, for the agent's owner,
+opens the conversation in one click.
+
+Two concrete blockers in the current code must be cleared (both verified against source):
+
+1. **The client mention regex cannot parse the instance suffix.** `mention-renderer.tsx`
+   uses `/@\[([^\]]+)\]\((user|agent):([a-f0-9-]+)\)/g`, which fails to match a pinned
+   token (`?cwd=…` breaks the trailing `)`), so pinned mentions render as broken raw
+   text today. The pin codec (`decodePinSuffix` in `src/lib/mention-format.ts`) already
+   exists and is reused.
+2. **Comment mentions are rendered by imperative DOM injection.** `MentionPostProcessor`
+   walks text nodes and inserts plain `document.createElement("span")` elements — that
+   cannot host an interactive React `<Popover>`. The comment render path must move to
+   React-native mention rendering.
+
+## What Changes
+
+- **Badge all agent mentions in the comment area** (user mentions are unchanged). A
+  mention pinned to a `(host, cwd)` shows an **instance-precise** online dot; a non-pinned
+  agent mention shows the agent's **overall** online dot.
+- **Click a badge → popover.** The popover shows a minimal identity set: agent name +
+  online status, plus `cwd` + `host` for a pinned mention (omitted for non-pinned, which
+  has no single instance).
+- **Owner-only, online-only "Open conversation" button** inside the popover. It is visible
+  ONLY to the agent's owner (`agent.ownerUuid === current user`) and ONLY when the relevant
+  instance/agent is online (hidden otherwise — no disabled state). Clicking it opens the
+  existing daemon chat: for a pinned mention, focused on that instance; for a non-pinned
+  mention, focused on the agent so the owner picks the instance/session inside.
+- **Scope is the comment area only.** Only the comment render path
+  (`unified-comments.tsx` → its mention rendering) changes; other `ContentWithMentions`
+  surfaces (idea / proposal / task descriptions) are untouched.
+- **Supporting data plumbing:** extend the client mention parser to read the instance
+  suffix (reusing `decodePinSuffix`), and ensure the presence connection data carries the
+  agent's `ownerUuid` so the client can gate the owner-only button.
+
+## Capabilities
+
+- **comment-mention-badge** — adds normative requirements that agent mentions in the
+  comment area render as online-aware badges, that clicking a badge opens an identity
+  popover, and that an owner-only / online-only "Open conversation" action opens the
+  daemon chat targeted at the mentioned agent (or pinned instance).
+
+## Impact
+
+- Affected code (all frontend except one small API enrichment):
+  - `src/components/mention-renderer.tsx` — client parser learns the pin suffix.
+  - `src/components/unified-comments.tsx` — comment render path moves to React-native
+    mention rendering and mounts the new badge for agent mentions.
+  - New `MentionBadge` component (popover + owner/online-gated button) under
+    `src/components/agent-presence/` (or alongside the mention renderer).
+  - `src/contexts/agent-presence-context.tsx` + `src/components/agent-presence/chat/daemon-chat.tsx`
+    — a mechanism to open the chat modal targeted at a given agent / pinned instance.
+  - `/api/agent-connections` + `ConnectionView` type — include `ownerUuid` (only when not
+    already present).
+- i18n: every new user-facing string (popover labels, button, tooltips, statuses) added to
+  both `messages/en.json` and `messages/zh.json`.
+- No database schema change. No new dependency. Out of scope: badge-ifying mentions
+  outside comments; auto-creating ad-hoc sessions or resolving a "most recent session"
+  precisely (the button simply opens the daemon chat); user-mention badges.

--- a/openspec/changes/add-comment-mention-badges/specs/comment-mention-badge/spec.md
+++ b/openspec/changes/add-comment-mention-badges/specs/comment-mention-badge/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: Agent mentions in comments render as online-aware badges
+
+In the comment area, every agent `@mention` SHALL render as an interactive badge that
+shows the agent's display name and an online-status indicator. User `@mentions` SHALL be
+unchanged. For a mention pinned to a specific instance (`@[Name](agent:uuid?cwd=…&host=…)`),
+the online indicator SHALL reflect that exact instance: it is online if and only if a
+connection exists for the same `(agentUuid, host, cwd)` whose `effectiveStatus` is
+`online`. For a non-pinned agent mention, the online indicator SHALL reflect the agent's
+overall liveness: online if and only if any connection for that `agentUuid` is `online`.
+Badge rendering SHALL be confined to the comment area; other surfaces that render mentions
+(idea, proposal, task, and document descriptions) SHALL keep their existing rendering.
+
+#### Scenario: Pinned mention shows instance-precise online dot
+
+- **WHEN** a comment contains `@[Name](agent:uuid?cwd=/work&host=prod)` and a connection
+  for that exact `(agentUuid, host="prod", cwd="/work")` has `effectiveStatus === "online"`
+- **THEN** the mention renders as a badge with the agent name and an online indicator
+
+#### Scenario: Pinned mention shows offline when that instance is not online
+
+- **WHEN** a comment contains a pinned agent mention and no connection for that exact
+  `(agentUuid, host, cwd)` is online (even if the agent is online elsewhere)
+- **THEN** the badge renders with an offline indicator
+
+#### Scenario: Non-pinned mention shows agent-overall online dot
+
+- **WHEN** a comment contains `@[Name](agent:uuid)` with no instance suffix and at least
+  one connection for that `agentUuid` has `effectiveStatus === "online"`
+- **THEN** the badge renders with an online indicator
+
+#### Scenario: User mentions are not badge-ified
+
+- **WHEN** a comment contains a user mention `@[Name](user:uuid)`
+- **THEN** it renders with the existing mention text style and no online indicator or badge
+  behavior
+
+### Requirement: Clicking a mention badge opens an identity popover
+
+Clicking an agent mention badge SHALL open a popover. The popover SHALL display a minimal
+identity set: the agent name and its online status. For a pinned mention, the popover SHALL
+additionally display the instance's working directory (`cwd`) and host, formatted for
+display. For a non-pinned mention, the popover SHALL NOT display a `cwd` or host, because
+no single instance is identified. The badge and its popover SHALL be visible to all users
+regardless of whether they own the agent.
+
+#### Scenario: Popover for a pinned mention shows cwd and host
+
+- **WHEN** a user clicks the badge of a pinned agent mention
+- **THEN** the popover shows the agent name, online status, and the instance's cwd and host
+
+#### Scenario: Popover for a non-pinned mention omits cwd and host
+
+- **WHEN** a user clicks the badge of a non-pinned agent mention
+- **THEN** the popover shows the agent name and overall online status, and shows no cwd or
+  host
+
+#### Scenario: Non-owner sees the badge and popover
+
+- **WHEN** a user who does not own the mentioned agent clicks its badge
+- **THEN** the popover opens and shows the identity information
+
+### Requirement: Owner-only, online-only Open conversation action
+
+The mention popover SHALL contain an "Open conversation" action that is shown ONLY when
+both conditions hold: the current user is the owner of the mentioned agent
+(`agent.ownerUuid` equals the current user's UUID, mirroring the server-side owner rule),
+AND the relevant target is online (the pinned instance for a pinned mention, or the agent
+overall for a non-pinned mention). When either condition is false the action SHALL be
+hidden (not merely disabled). Activating the action SHALL open the existing daemon chat
+interface targeted at the mentioned agent: for a pinned mention, focused on that
+`(host, cwd)` instance; for a non-pinned mention, focused on the agent so the owner can
+select the instance/conversation within the chat. The action SHALL NOT change the existing
+daemon chat or presence-modal behavior for any other entry point.
+
+#### Scenario: Owner of an online pinned instance sees and uses Open conversation
+
+- **WHEN** the agent's owner opens the popover for a pinned mention whose instance is online
+- **THEN** the "Open conversation" action is shown, and activating it opens the daemon chat
+  focused on that instance
+
+#### Scenario: Owner of a non-pinned online agent opens chat to pick an instance
+
+- **WHEN** the agent's owner opens the popover for a non-pinned mention and the agent is
+  online
+- **THEN** the "Open conversation" action is shown, and activating it opens the daemon chat
+  focused on that agent so the owner can choose the instance/conversation
+
+#### Scenario: Non-owner never sees Open conversation
+
+- **WHEN** a user who is not the agent's owner opens the popover (online or offline)
+- **THEN** the "Open conversation" action is not shown
+
+#### Scenario: Offline hides Open conversation even for the owner
+
+- **WHEN** the agent's owner opens the popover but the relevant target (pinned instance, or
+  the agent overall for a non-pinned mention) is offline
+- **THEN** the "Open conversation" action is not shown
+
+### Requirement: Client mention parsing supports the instance suffix
+
+The client-side comment mention renderer SHALL parse the optional instance suffix
+`?cwd=…&host=…` of an agent mention token, reusing the shared pin codec, so that a pinned
+mention is recognized rather than rendered as raw text. A non-pinned mention SHALL continue
+to parse exactly as before (no pinned host or cwd).
+
+#### Scenario: Pinned token is parsed into host and cwd
+
+- **WHEN** the comment renderer encounters `@[Name](agent:uuid?cwd=%2Fwork&host=prod)`
+- **THEN** it parses a mention with the agent UUID, pinned host `prod`, and pinned cwd
+  `/work`, and renders a badge (not raw text)
+
+#### Scenario: Non-pinned token parses with no pin
+
+- **WHEN** the comment renderer encounters `@[Name](agent:uuid)`
+- **THEN** it parses a mention with the agent UUID and no pinned host or cwd

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -22,6 +22,7 @@ import { authFetch, logout as authLogout, clearUserManager } from "@/lib/auth-cl
 import { PixelCanvasWidget } from "@/components/pixel-canvas-widget";
 import { RealtimeProvider } from "@/contexts/realtime-context";
 import { AgentPresenceProvider } from "@/contexts/agent-presence-context";
+import { AuthProvider } from "@/contexts/auth-context";
 import { AgentPresencePill } from "@/components/agent-presence-pill";
 import { AgentConnectionsModal } from "@/components/agent-presence";
 import { NotificationProvider } from "@/contexts/notification-context";
@@ -480,6 +481,16 @@ export default function DashboardLayout({
 
   return (
     <NotificationProvider>
+    {/* AuthProvider exposes the current user via useAuth() to the whole shell.
+        It is mounted here (not the root layout) because only the authenticated
+        dashboard tree needs it: the comment mention badge's owner gate reads
+        useAuth().user.uuid. AuthProvider self-fetches /api/auth/session (the same
+        endpoint this layout already polls), so it is additive — the layout keeps
+        its own local `user` state for the sidebar; this provider serves consumers
+        deep in the tree that can't be prop-threaded (e.g. MentionBadge inside a
+        rendered comment body). Without it, useAuth() throws and any agent mention
+        in a comment crashes the comment area. */}
+    <AuthProvider>
     {/* AgentPresenceProvider is the single shell-level data spine for the
         sidebar presence pill + popover + modal. Mounted ONCE here, wrapping the
         whole shell (sidebar + main), so it survives route changes (does not
@@ -546,6 +557,7 @@ export default function DashboardLayout({
       )}
     </div>
     </AgentPresenceProvider>
+    </AuthProvider>
     <Toaster position={isMobile ? "top-center" : "top-right"} closeButton={!isMobile} />
     </NotificationProvider>
   );

--- a/src/components/__tests__/agent-presence-pill.test.tsx
+++ b/src/components/__tests__/agent-presence-pill.test.tsx
@@ -129,6 +129,7 @@ function makeConnection(over: Partial<ConnectionView> = {}): ConnectionView {
     uuid: "conn-1",
     agentUuid: "agent-1",
     agentName: "Builder Bot",
+    ownerUuid: null,
     clientType: "claude_code",
     clientVersion: "1.2.3",
     host: "macbook",
@@ -171,6 +172,9 @@ function setPresence(over: Partial<AgentPresenceValue>) {
     openSession: null,
     setOpenSession: vi.fn(),
     subscribeTranscript: vi.fn(() => () => {}),
+    focusTarget: null,
+    openChatForAgent: vi.fn(),
+    clearChatFocusTarget: vi.fn(),
     ...over,
   };
   mockPresence.mockReturnValue(value);

--- a/src/components/__tests__/mention-renderer.test.ts
+++ b/src/components/__tests__/mention-renderer.test.ts
@@ -1,0 +1,190 @@
+// Unit tests for the CLIENT mention parser's pin-suffix support
+// (src/components/mention-renderer.tsx). The internal `parseMentions` is exercised
+// through the exported `extractMentions`, which runs the same regex + shared
+// `decodePinSuffix` codec and emits the `ParsedMentionRef` shape — the exact parse
+// contract this task must guarantee (pinned recognized, non-pinned byte-compatible).
+
+import { describe, it, expect } from "vitest";
+import {
+  extractMentions,
+  hasMentions,
+  preprocessMentions,
+  preprocessMentionsAsTags,
+  type ParsedMentionRef,
+} from "@/components/mention-renderer";
+
+const AGENT = "abcdef12-3456-7890-abcd-ef1234567890";
+const USER = "11111111-2222-3333-4444-555555555555";
+
+describe("client mention parser — pin suffix support", () => {
+  it("parses a pinned agent token into {uuid, pinnedHost, pinnedCwd} (the broken-text bug is fixed)", () => {
+    const text = `hey @[DevBot](agent:${AGENT}?cwd=%2Fwork&host=prod) please look`;
+    // The pinned token IS recognized (previously it fell through as raw text).
+    expect(hasMentions(text)).toBe(true);
+
+    const refs = extractMentions(text);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toEqual<ParsedMentionRef>({
+      type: "agent",
+      uuid: AGENT,
+      displayName: "DevBot",
+      pinnedHost: "prod",
+      pinnedCwd: "/work",
+    });
+  });
+
+  it("parses a non-pinned token with NO pin fields (byte-compatible with legacy shape)", () => {
+    const refs = extractMentions(`ping @[DevBot](agent:${AGENT}) now`);
+    expect(refs).toHaveLength(1);
+    // Object-identical to the legacy three-field shape: the pin keys must be ABSENT,
+    // not present-with-null.
+    expect(refs[0]).toEqual({
+      type: "agent",
+      uuid: AGENT,
+      displayName: "DevBot",
+    });
+    expect("pinnedHost" in refs[0]).toBe(false);
+    expect("pinnedCwd" in refs[0]).toBe(false);
+  });
+
+  it("parses an unknown-path pin (cwd=&host=…) as pinnedCwd:null, pinnedHost set", () => {
+    const refs = extractMentions(`@[CI](agent:${AGENT}?cwd=&host=ci-runner)`);
+    expect(refs[0]).toEqual<ParsedMentionRef>({
+      type: "agent",
+      uuid: AGENT,
+      displayName: "CI",
+      pinnedHost: "ci-runner",
+      pinnedCwd: null,
+    });
+  });
+
+  it("parses an unknown-host pin (host=) as pinnedHost:'' (the unknown-host sentinel)", () => {
+    const refs = extractMentions(`@[Srv](agent:${AGENT}?cwd=%2Fsrv%2Fapp&host=)`);
+    expect(refs[0]).toEqual<ParsedMentionRef>({
+      type: "agent",
+      uuid: AGENT,
+      displayName: "Srv",
+      pinnedHost: "",
+      pinnedCwd: "/srv/app",
+    });
+  });
+
+  it("parses user mentions (with no pin) exactly as before", () => {
+    const refs = extractMentions(`cc @[Alice](user:${USER})`);
+    expect(refs[0]).toEqual({
+      type: "user",
+      uuid: USER,
+      displayName: "Alice",
+    });
+  });
+
+  it("recognizes an uppercase-hex UUID token (case-insensitive)", () => {
+    const upper = AGENT.toUpperCase();
+    const text = `@[DevBot](agent:${upper})`;
+    expect(hasMentions(text)).toBe(true);
+    const refs = extractMentions(text);
+    // uuid is normalized to lowercase (mirrors the server parser).
+    expect(refs[0].uuid).toBe(AGENT);
+  });
+
+  it("parses a mix of pinned, non-pinned, and user tokens in one body", () => {
+    const text =
+      `@[A](agent:${AGENT}?cwd=%2Fa&host=h1) and @[B](agent:${AGENT}) and @[C](user:${USER})`;
+    const refs = extractMentions(text);
+    expect(refs).toEqual<ParsedMentionRef[]>([
+      { type: "agent", uuid: AGENT, displayName: "A", pinnedHost: "h1", pinnedCwd: "/a" },
+      { type: "agent", uuid: AGENT, displayName: "B" },
+      { type: "user", uuid: USER, displayName: "C" },
+    ]);
+  });
+});
+
+// ── Comment-path React-native preprocessing vs. the byte-stable default path ──
+//
+// Task 3 (the integration task) moves the COMMENT surface off imperative DOM
+// injection onto a React-native path: ContentWithMentions, given the opt-in
+// `renderMention` prop, preprocesses mentions into `<chorus-mention>` custom tags
+// (which Streamdown renders through a `components` override as real React nodes —
+// e.g. an interactive MentionBadge). CRITICAL constraint (q6 = comments only):
+// every OTHER surface (idea/proposal/task/document descriptions) keeps the legacy
+// zero-width-placeholder DOM-injection path BYTE-STABLE. These tests pin both the
+// new comment-path output AND the unchanged default-path output without mounting
+// the heavy Streamdown renderer.
+
+describe("default-path preprocessing (every NON-comment surface) is byte-stable", () => {
+  const PLACEHOLDER_RE = /​​MENTION_(\d+)​​/;
+
+  it("emits the legacy zero-width placeholders — NOT chorus-mention tags", () => {
+    const text = `hi @[DevBot](agent:${AGENT}) and @[Alice](user:${USER})`;
+    const { processed, mentions } = preprocessMentions(text);
+
+    // The DOM-injection path must keep producing zero-width placeholders, and must
+    // NOT leak the comment-only custom tag onto other surfaces.
+    expect(processed).not.toContain("chorus-mention");
+    expect(PLACEHOLDER_RE.test(processed)).toBe(true);
+    // Both mentions captured, index-aligned.
+    expect(mentions).toHaveLength(2);
+    expect(mentions[0]).toMatchObject({ type: "agent", uuid: AGENT });
+    expect(mentions[1]).toMatchObject({ type: "user", uuid: USER });
+  });
+
+  it("preserves a pinned token's pin fields in the default path", () => {
+    const { mentions } = preprocessMentions(
+      `@[DevBot](agent:${AGENT}?cwd=%2Fwork&host=prod)`,
+    );
+    expect(mentions[0]).toMatchObject({
+      type: "agent",
+      uuid: AGENT,
+      pinnedHost: "prod",
+      pinnedCwd: "/work",
+    });
+  });
+});
+
+describe("comment-path preprocessing (React-native) emits chorus-mention tags", () => {
+  it("replaces each mention with an indexed <chorus-mention> tag and parses refs", () => {
+    const text = `hi @[DevBot](agent:${AGENT}) and @[Alice](user:${USER})`;
+    const { processed, mentions } = preprocessMentionsAsTags(text);
+
+    // Custom tags, index-aligned with the parsed refs.
+    expect(processed).toContain(`<chorus-mention idx="0">@DevBot</chorus-mention>`);
+    expect(processed).toContain(`<chorus-mention idx="1">@Alice</chorus-mention>`);
+    // No leftover zero-width placeholders on the comment path.
+    expect(processed).not.toContain("​");
+    expect(mentions).toEqual<ParsedMentionRef[]>([
+      { type: "agent", uuid: AGENT, displayName: "DevBot" },
+      { type: "user", uuid: USER, displayName: "Alice" },
+    ]);
+  });
+
+  it("carries the pin fields for a pinned agent mention (badge reads them)", () => {
+    const { mentions } = preprocessMentionsAsTags(
+      `@[DevBot](agent:${AGENT}?cwd=%2Fwork&host=prod)`,
+    );
+    expect(mentions[0]).toEqual<ParsedMentionRef>({
+      type: "agent",
+      uuid: AGENT,
+      displayName: "DevBot",
+      pinnedHost: "prod",
+      pinnedCwd: "/work",
+    });
+  });
+
+  it("escapes <,>,& in a display name so it can't break out of the tag", () => {
+    const { processed } = preprocessMentionsAsTags(
+      `@[<b>&Bot</b>](agent:${AGENT})`,
+    );
+    expect(processed).toContain(
+      `<chorus-mention idx="0">@&lt;b&gt;&amp;Bot&lt;/b&gt;</chorus-mention>`,
+    );
+  });
+
+  it("leaves non-mention markdown untouched (mentions inside prose)", () => {
+    const text = `**bold** then @[DevBot](agent:${AGENT}) in a *list*`;
+    const { processed } = preprocessMentionsAsTags(text);
+    // Surrounding markdown is preserved verbatim; only the token is swapped.
+    expect(processed).toBe(
+      `**bold** then <chorus-mention idx="0">@DevBot</chorus-mention> in a *list*`,
+    );
+  });
+});

--- a/src/components/agent-presence/__tests__/conversation-reply-box.test.tsx
+++ b/src/components/agent-presence/__tests__/conversation-reply-box.test.tsx
@@ -81,6 +81,7 @@ function conn(o: Partial<ConnectionView> & { uuid: string }): ConnectionView {
   return {
     agentUuid: "agent-1",
     agentName: "Alpha",
+    ownerUuid: null,
     clientType: "claude_code",
     clientVersion: "0.11.0",
     host: "host-1",

--- a/src/components/agent-presence/__tests__/instance-group.test.ts
+++ b/src/components/agent-presence/__tests__/instance-group.test.ts
@@ -17,6 +17,7 @@ function conn(overrides: Partial<ConnectionView> & { uuid: string }): Connection
   return {
     agentUuid: "agent-1",
     agentName: "Alpha",
+    ownerUuid: null,
     clientType: "claude_code",
     clientVersion: "0.11.0",
     host: "host-1",

--- a/src/components/agent-presence/__tests__/mention-badge.test.tsx
+++ b/src/components/agent-presence/__tests__/mention-badge.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+//
+// MentionBadge — the interactive agent-mention badge (子2). These tests pin the
+// behaviors the acceptance criteria call out:
+//   - the badge renders the agent name + an online dot (StatusDot),
+//   - clicking opens a portaled Popover with the minimal identity (name + status),
+//   - a PINNED mention's popover shows cwd + host (formatted), a NON-PINNED one
+//     omits them,
+//   - the owner/online gating MATRIX for "Open conversation":
+//       owner + online   → shown
+//       owner + offline   → hidden
+//       non-owner + online → hidden
+//   - activating "Open conversation" calls `openChatForAgent(agentUuid, pin?)`
+//     with the pinned `(host, cwd)` for a pinned mention and `undefined` for a
+//     non-pinned one.
+//
+// Presence + auth are injected by mocking `useAgentPresence` (which both the badge
+// AND its internal `useMentionLiveness` read) and `useAuth`. next-intl resolves
+// real en.json strings (a missing key surfaces as its dotted path and fails the
+// assertion), matching the sibling agent-presence component tests.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    let node: unknown = en;
+    for (const p of fullKey.split(".")) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations:
+      (namespace = "") =>
+      (key: string, params?: Record<string, string | number>) => {
+        let s = resolve(namespace, key);
+        if (params) {
+          for (const [k, v] of Object.entries(params)) {
+            s = s.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          }
+        }
+        return s;
+      },
+  };
+});
+
+// Inject presence (connections + the openChatForAgent spy). The badge reads
+// `openChatForAgent` directly and `connections` transitively via
+// `useMentionLiveness`, so one mock covers both.
+const mockOpenChatForAgent = vi.fn();
+let mockConnections: ConnectionView[] = [];
+vi.mock("@/contexts/agent-presence-context", () => ({
+  useAgentPresence: () => ({
+    connections: mockConnections,
+    openChatForAgent: mockOpenChatForAgent,
+  }),
+}));
+
+// Inject the current user for the owner gate.
+let mockUserUuid: string | null = null;
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ user: mockUserUuid ? { uuid: mockUserUuid } : null }),
+}));
+
+import type { ConnectionView } from "@/components/agent-presence/types";
+import { MentionBadge } from "@/components/agent-presence/mention-badge";
+import type { ParsedMentionRef } from "@/components/mention-renderer";
+
+const OWNER = "owner-user-uuid";
+const OTHER = "other-user-uuid";
+const AGENT = "agent-uuid-1";
+
+function makeConnection(over: Partial<ConnectionView> = {}): ConnectionView {
+  return {
+    uuid: "conn-1",
+    agentUuid: AGENT,
+    agentName: "Builder Bot",
+    ownerUuid: OWNER,
+    clientType: "claude_code",
+    clientVersion: "1.0.0",
+    host: "prod-host",
+    cwd: "/home/u/dev/chorus",
+    startedAt: "2026-06-18T09:00:00.000Z",
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: "2026-06-18T09:00:00.000Z",
+    lastSeenAt: "2026-06-18T09:30:00.000Z",
+    disconnectedAt: null,
+    ...over,
+  };
+}
+
+const pinnedRef: ParsedMentionRef = {
+  type: "agent",
+  uuid: AGENT,
+  displayName: "Builder Bot",
+  pinnedHost: "prod-host",
+  pinnedCwd: "/home/u/dev/chorus",
+};
+
+const nonPinnedRef: ParsedMentionRef = {
+  type: "agent",
+  uuid: AGENT,
+  displayName: "Builder Bot",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConnections = [];
+  mockUserUuid = null;
+});
+afterEach(() => cleanup());
+
+// Open the badge's popover by clicking its trigger (the badge).
+function openPopover() {
+  // The trigger is the badge — find it by its accessible label / name text.
+  const trigger = screen.getByText("@Builder Bot");
+  fireEvent.click(trigger);
+}
+
+describe("MentionBadge — badge + popover identity", () => {
+  it("renders the agent name on a clickable badge", () => {
+    mockConnections = [makeConnection()];
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    expect(screen.getByText("@Builder Bot")).toBeTruthy();
+  });
+
+  it("pinned mention popover shows name + status + cwd + host", () => {
+    mockConnections = [makeConnection()]; // online pinned instance exists
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    // Identity
+    expect(screen.getAllByText("Builder Bot").length).toBeGreaterThan(0);
+    // Online status label (mention.online = "Online")
+    expect(screen.getByText("Online")).toBeTruthy();
+    // Pinned fields: working-directory + host labels are present
+    expect(screen.getByText("Working directory")).toBeTruthy();
+    expect(screen.getByText("Host")).toBeTruthy();
+    // The host value renders (formatHost keeps a short host whole)
+    expect(screen.getByText("prod-host")).toBeTruthy();
+    // The cwd tail renders (formatCwd keeps the final segment)
+    expect(screen.getByText((txt) => txt.includes("chorus"))).toBeTruthy();
+  });
+
+  it("non-pinned mention popover omits cwd + host", () => {
+    mockConnections = [makeConnection()];
+    render(<MentionBadge mention={nonPinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    expect(screen.getByText("Online")).toBeTruthy();
+    // No pinned-instance fields for a non-pinned mention (q9).
+    expect(screen.queryByText("Working directory")).toBeNull();
+    expect(screen.queryByText("Host")).toBeNull();
+  });
+
+  it("offline pinned instance shows the offline status", () => {
+    // A connection exists for the agent but NOT for this pinned place → offline.
+    mockConnections = [
+      makeConnection({ host: "other-host", cwd: "/elsewhere" }),
+    ];
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    expect(screen.getByText("Offline")).toBeTruthy();
+  });
+});
+
+describe("MentionBadge — owner/online gating matrix for Open conversation", () => {
+  it("owner + online → button SHOWN", () => {
+    mockConnections = [makeConnection()]; // online, ownerUuid = OWNER
+    mockUserUuid = OWNER;
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    expect(screen.getByText("Open conversation")).toBeTruthy();
+  });
+
+  it("owner + offline → button HIDDEN (not disabled)", () => {
+    // No connection for the pinned place → offline; owner borrowed from agent conn.
+    mockConnections = [
+      makeConnection({ host: "other-host", cwd: "/elsewhere" }),
+    ];
+    mockUserUuid = OWNER;
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    expect(screen.queryByText("Open conversation")).toBeNull();
+  });
+
+  it("non-owner + online → button HIDDEN", () => {
+    mockConnections = [makeConnection()]; // online, ownerUuid = OWNER
+    mockUserUuid = OTHER; // not the owner
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    expect(screen.queryByText("Open conversation")).toBeNull();
+  });
+
+  it("non-owner still sees the badge + popover identity (q5)", () => {
+    mockConnections = [makeConnection()];
+    mockUserUuid = OTHER;
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    // Identity is visible to everyone.
+    expect(screen.getByText("Online")).toBeTruthy();
+    expect(screen.getByText("Working directory")).toBeTruthy();
+  });
+});
+
+describe("MentionBadge — Open conversation action payload", () => {
+  it("pinned: calls openChatForAgent with the pinned (host, cwd)", () => {
+    mockConnections = [makeConnection()];
+    mockUserUuid = OWNER;
+    render(<MentionBadge mention={pinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    fireEvent.click(screen.getByText("Open conversation"));
+    expect(mockOpenChatForAgent).toHaveBeenCalledWith(AGENT, {
+      host: "prod-host",
+      cwd: "/home/u/dev/chorus",
+    });
+  });
+
+  it("non-pinned: calls openChatForAgent with no pin (undefined)", () => {
+    mockConnections = [makeConnection()];
+    mockUserUuid = OWNER;
+    render(<MentionBadge mention={nonPinnedRef} displayName="Builder Bot" />);
+    openPopover();
+    fireEvent.click(screen.getByText("Open conversation"));
+    expect(mockOpenChatForAgent).toHaveBeenCalledWith(AGENT, undefined);
+  });
+});

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -183,6 +183,8 @@ export function DaemonChat() {
     executionsByConnection,
     setOpenSession,
     subscribeTranscript,
+    focusTarget,
+    clearChatFocusTarget,
   } = useAgentPresence();
 
   // ===== Conversation list (GET /api/daemon-sessions) =====
@@ -598,6 +600,24 @@ export function DaemonChat() {
     setSelectedSessionUuid(null);
     setMobileDetailOpen(true);
   }, []);
+
+  // Consume a one-shot chat focus target (seeded by `openChatForAgent`, e.g. the
+  // comment mention badge's "Open conversation" action): pin the left rail to the
+  // focused agent and clear any prior conversation selection so the owner lands on
+  // that agent's conversation list / composer. Per the Tech Design contract
+  // (elaboration q3), focusing the agent is sufficient — for a pinned mention the
+  // `(host, cwd)` instance belongs to the SAME agentUuid, so focusing the agent
+  // already lands the owner on the right surface; precise past-session
+  // auto-selection is intentionally not done here. ADDITIVE: this only seeds the
+  // existing `pickedAgentUuid` selection state and does not touch
+  // `setOpenSession`/`subscribeTranscript`. The target is consumed (cleared) so a
+  // later manual modal open is not re-hijacked.
+  useEffect(() => {
+    if (!focusTarget) return;
+    setPickedAgentUuid(focusTarget.agentUuid);
+    setSelectedSessionUuid(null);
+    clearChatFocusTarget();
+  }, [focusTarget, clearChatFocusTarget]);
 
   // A freshly-started ad-hoc session OR a RE-POINTED existing conversation (T12): pull/patch
   // it into the list immediately (so it appears / flips online without waiting for the 15s

--- a/src/components/agent-presence/index.ts
+++ b/src/components/agent-presence/index.ts
@@ -43,6 +43,7 @@ export { ExecutionRow, ExecutionSection } from "./execution-row";
 export { SendInstructionBox, type SessionTarget } from "./send-instruction-box";
 export { AgentConnectionsView } from "./connections-view";
 export { AgentConnectionsModal } from "./connections-modal";
+export { MentionBadge, type MentionBadgeProps } from "./mention-badge";
 export {
   DaemonConnectCta,
   type DaemonConnectCtaVariant,

--- a/src/components/agent-presence/mention-badge.tsx
+++ b/src/components/agent-presence/mention-badge.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+// MentionBadge — the interactive rendering of an AGENT @mention in the comment
+// area (子2 of the comment-mention-badges feature). It turns the dead mention
+// text into a live control:
+//   - a <Badge> with the agent name + an online dot (StatusDot, the shared
+//     presence-dot vocabulary). Online state is the Task-1 liveness verdict
+//     (instance-precise for a pinned mention, agent-overall for a non-pinned one).
+//   - clicking opens a portaled Radix <Popover> with a minimal identity set
+//     (name + online status), plus cwd + host for a PINNED mention (omitted for a
+//     non-pinned one, which identifies no single instance — q9).
+//   - an OWNER-ONLY, ONLINE-ONLY "Open conversation" <Button> inside the popover
+//     (q4/q5/q8): shown ONLY when the current user owns the agent AND the relevant
+//     target is online; HIDDEN (never disabled) otherwise. Activating it calls the
+//     additive `openChatForAgent(agentUuid, pin?)` presence action, which opens the
+//     daemon chat focused on the pinned instance (pinned) or the agent (non-pinned).
+//
+// The badge + popover identity are visible to EVERYONE (owner or not — q5 option
+// a); only the "Open conversation" action is owner/online-gated.
+//
+// It reads presence/liveness/owner via hooks (useMentionLiveness over
+// useAgentPresence) and the current user via useAuth — no liveness/owner props are
+// threaded in, matching the Tech Design's "Module Contracts".
+
+import { useTranslations } from "next-intl";
+import { MessageSquare } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { StatusDot } from "@/components/agent-presence/status";
+import { useAgentPresence } from "@/contexts/agent-presence-context";
+import { useAuth } from "@/contexts/auth-context";
+import { useMentionLiveness } from "@/lib/use-mention-liveness";
+import {
+  formatCwd,
+  formatHost,
+} from "@/lib/daemon-instance-format";
+import type { ParsedMentionRef } from "@/components/mention-renderer";
+
+export interface MentionBadgeProps {
+  /**
+   * The parsed AGENT mention reference (user mentions are not badge-ified). The
+   * optional `pinnedHost`/`pinnedCwd` decide pinned (instance-precise) vs
+   * non-pinned (agent-overall) liveness + popover fields.
+   */
+  mention: ParsedMentionRef;
+  /** The resolved display name shown on the badge + popover. */
+  displayName: string;
+}
+
+export function MentionBadge({ mention, displayName }: MentionBadgeProps) {
+  const t = useTranslations("mention");
+  const tPresence = useTranslations("agentPresence");
+  const { openChatForAgent } = useAgentPresence();
+  const { user } = useAuth();
+
+  // Liveness verdict from the Task-1 rule: pinned → instance-precise; non-pinned →
+  // agent-overall. Also yields the matched instance's owner/host/cwd. Pass only the
+  // fields the rule needs (uuid + pin), preserving the "pinned iff a pin key is
+  // present" contract — a pinned ref still carries the keys (even when null), an
+  // un-pinned one omits them.
+  const liveness = useMentionLiveness(
+    mention.pinnedHost !== undefined || mention.pinnedCwd !== undefined
+      ? {
+          uuid: mention.uuid,
+          pinnedHost: mention.pinnedHost,
+          pinnedCwd: mention.pinnedCwd,
+        }
+      : { uuid: mention.uuid },
+  );
+
+  const { pinned, online, ownerUuid, host, cwd } = liveness;
+
+  // The owner-only, online-only "Open conversation" gate (mirrors the server owner
+  // rule: agent.ownerUuid === current user). Hidden — not disabled — when either
+  // condition fails (q4/q5/q8). When offline there is no live row, so ownerUuid may
+  // be null; the online check alone already hides it then, but we gate on both so a
+  // non-owner with an online agent never sees it either.
+  const isOwner = user?.uuid != null && user.uuid === ownerUuid;
+  const showOpenConversation = isOwner && online;
+
+  const statusLabel = online ? t("online") : t("offline");
+
+  // Pinned identity fields, formatted via the shared truncation helpers. An
+  // "unknown" value resolves to an i18n KEY the caller localizes (per the helper
+  // contract), so we never leak raw English.
+  const cwdFmt = pinned ? formatCwd(cwd) : null;
+  const hostFmt = pinned ? formatHost(host ?? "") : null;
+
+  const handleOpenConversation = () => {
+    openChatForAgent(
+      mention.uuid,
+      pinned ? { host: host ?? "", cwd: cwd ?? null } : undefined,
+    );
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Badge
+          variant="secondary"
+          // A real button role for the trigger so keyboard users can open the
+          // popover; the inline-flex badge keeps the name + dot on one line.
+          className="cursor-pointer gap-1 align-baseline"
+          aria-label={t("badgeAria", { name: displayName, status: statusLabel })}
+        >
+          <StatusDot online={online} />
+          <span>@{displayName}</span>
+        </Badge>
+      </PopoverTrigger>
+      {/* Portaled by default (src/components/ui/popover.tsx) so it escapes the
+          scrollable comment list's overflow. */}
+      <PopoverContent className="w-64" align="start">
+        <div className="flex flex-col gap-3">
+          {/* Identity header: name + online status. Visible to everyone (q5). */}
+          <div className="flex items-center gap-2">
+            <StatusDot online={online} size="md" />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold text-foreground">
+                {displayName}
+              </p>
+              <p className="text-xs text-muted-foreground">{statusLabel}</p>
+            </div>
+          </div>
+
+          {/* Pinned mention → the instance's working directory + host. A non-pinned
+              mention identifies no single instance, so these are omitted (q9). */}
+          {pinned && cwdFmt && hostFmt && (
+            <dl className="flex flex-col gap-1.5 text-xs">
+              <div className="flex flex-col gap-0.5">
+                <dt className="text-muted-foreground">
+                  {t("workingDirectory")}
+                </dt>
+                <dd
+                  className="truncate font-mono text-foreground"
+                  title={
+                    cwdFmt.isUnknown ? tPresence("unknownPath") : cwdFmt.title
+                  }
+                >
+                  {cwdFmt.isUnknown
+                    ? tPresence("unknownPath")
+                    : cwdFmt.label}
+                </dd>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <dt className="text-muted-foreground">{t("host")}</dt>
+                <dd
+                  className="truncate font-mono text-foreground"
+                  title={
+                    hostFmt.isUnknown ? tPresence("unknownHost") : hostFmt.title
+                  }
+                >
+                  {hostFmt.isUnknown
+                    ? tPresence("unknownHost")
+                    : hostFmt.label}
+                </dd>
+              </div>
+            </dl>
+          )}
+
+          {/* Owner-only, online-only action. Hidden (not disabled) otherwise. */}
+          {showOpenConversation && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-full"
+              onClick={handleOpenConversation}
+            >
+              <MessageSquare />
+              {t("openConversation")}
+            </Button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/agent-presence/types.ts
+++ b/src/components/agent-presence/types.ts
@@ -8,6 +8,11 @@ export interface ConnectionView {
   uuid: string;
   agentUuid: string;
   agentName: string | null;
+  // Owning agent's human owner (Agent.ownerUuid); null for an unowned/system
+  // agent or an unresolved relation. Mirrors the server owner rule in
+  // daemon-control.service so the client can gate owner-only actions (e.g. the
+  // mention badge's "Open conversation") against useAuth().user.uuid.
+  ownerUuid: string | null;
   clientType: string;
   clientVersion: string | null;
   host: string; // "" when host-less

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -1,12 +1,30 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Streamdown } from "streamdown";
+import { Streamdown, type Components } from "streamdown";
 
 import {
   streamdownPlugins,
   streamdownControls,
 } from "@/lib/streamdown-plugins";
+
+// Custom-tag passthrough for Streamdown. The default markdown surfaces pass none
+// of these, so their render is byte-identical to before. The comment mention path
+// (ContentWithMentions' opt-in `renderMention`) passes a `<chorus-mention>` custom
+// tag mapping so an agent @mention renders as a real, interactive React node
+// (MentionBadge) instead of imperatively-injected DOM — which a Radix Popover
+// cannot live inside. `literalTagContent` keeps the tag's child label out of the
+// markdown parser, and `allowedTags` whitelists the tag + its attributes through
+// Streamdown's sanitizer.
+export interface MarkdownContentProps {
+  children: string;
+  /** react-markdown-style element overrides (e.g. a custom `<chorus-mention>`). */
+  components?: Components;
+  /** Custom tags + permitted attributes allowed through sanitization. */
+  allowedTags?: Record<string, string[]>;
+  /** Tags whose children are treated as plain text (no markdown parsing). */
+  literalTagContent?: string[];
+}
 
 function useDarkClass(): boolean {
   const [isDark, setIsDark] = useState(false);
@@ -23,7 +41,12 @@ function useDarkClass(): boolean {
   return isDark;
 }
 
-export function MarkdownContent({ children }: { children: string }) {
+export function MarkdownContent({
+  children,
+  components,
+  allowedTags,
+  literalTagContent,
+}: MarkdownContentProps) {
   const isDark = useDarkClass();
 
   const mermaidOptions = useMemo(
@@ -36,12 +59,18 @@ export function MarkdownContent({ children }: { children: string }) {
   // React to tear down and rebuild the subtree on theme change, which is what
   // actually triggers the repaint. Don't drop the key while keeping the prop —
   // the prop alone won't repaint cached diagrams and the bug returns silently.
+  //
+  // `components`/`allowedTags`/`literalTagContent` are forwarded only when set
+  // (the default markdown surfaces pass none, so their render stays byte-stable).
   return (
     <Streamdown
       key={isDark ? "dark" : "light"}
       plugins={streamdownPlugins}
       controls={streamdownControls}
       mermaid={mermaidOptions}
+      components={components}
+      allowedTags={allowedTags}
+      literalTagContent={literalTagContent}
     >
       {children}
     </Streamdown>

--- a/src/components/mention-renderer.tsx
+++ b/src/components/mention-renderer.tsx
@@ -3,27 +3,63 @@
 import React from "react";
 
 import { MarkdownContent } from "@/components/markdown-content";
+import type { Components } from "streamdown";
+// Reuse the SHARED pin codec (pure, dependency-free) so the client parser and the
+// server mention service can never drift on how the `?cwd=…&host=…` suffix decodes.
+import { decodePinSuffix } from "@/lib/mention-format";
 
 /**
- * Regex to match @[DisplayName](type:uuid) patterns in text.
- * - DisplayName: any non-] characters
- * - type: user | agent
- * - uuid: standard UUID format
+ * Regex to match `@[DisplayName](type:uuid)` patterns in text, with an OPTIONAL
+ * pinned-instance suffix `?cwd=…&host=…` INSIDE the parens (cwd-addressable
+ * instances). This is byte-identical in source to the SERVER parser's
+ * `MENTION_REGEX` (src/services/mention.service.ts) so the client recognizes the
+ * exact same set of tokens the server produces — including pinned ones.
+ * - Group 1 (DisplayName): any non-`]` characters
+ * - Group 2 (type): user | agent
+ * - Group 3 (uuid): a strict UUID
+ * - Group 4 (pin): the raw pin query string after `?` (or undefined when unpinned),
+ *   matched as "everything up to the closing paren" — the codec keeps the payload
+ *   paren-free by percent-escaping `(`/`)`.
+ *
+ * NOTE (bug fix): the previous client regex `/@\[([^\]]+)\]\((user|agent):([a-f0-9-]+)\)/g`
+ * could NOT match a pinned token — the `?…` defeated the trailing `)` — so pinned
+ * mentions rendered as broken raw text. The optional 4th group fixes that while
+ * leaving un-pinned tokens parsed exactly as before.
  */
-const MENTION_REGEX = /@\[([^\]]+)\]\((user|agent):([a-f0-9-]+)\)/g;
+const MENTION_REGEX =
+  /@\[([^\]]+)\]\((user|agent):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\?([^)]*))?\)/gi;
+
+/**
+ * A parsed mention's reference shape, aligned with `MentionRef`
+ * (src/services/mention.service.ts): `type`, `uuid`, `displayName`, plus the
+ * OPTIONAL pinned-instance `pinnedHost`/`pinnedCwd`. The pin fields are present
+ * ONLY for a pinned token — an un-pinned token omits them entirely, so its shape
+ * is object-identical to before this change.
+ */
+export interface ParsedMentionRef {
+  type: "user" | "agent";
+  uuid: string;
+  displayName: string;
+  pinnedHost?: string | null;
+  pinnedCwd?: string | null;
+}
 
 interface MentionPart {
   type: "text" | "mention";
   content: string;
   mentionType?: "user" | "agent";
   mentionUuid?: string;
+  // Pinned-instance fields, present only when the matched token was pinned
+  // (mirrors ParsedMentionRef / MentionRef — absent on un-pinned tokens).
+  pinnedHost?: string | null;
+  pinnedCwd?: string | null;
 }
 
 function parseMentions(text: string): MentionPart[] {
   const parts: MentionPart[] = [];
   let lastIndex = 0;
 
-  const regex = new RegExp(MENTION_REGEX.source, "g");
+  const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
   let match;
 
   while ((match = regex.exec(text)) !== null) {
@@ -34,12 +70,21 @@ function parseMentions(text: string): MentionPart[] {
       });
     }
 
-    parts.push({
+    // Decode the optional pin suffix (group 4) via the shared codec. Attach the
+    // pin fields ONLY when present, keeping un-pinned parts byte-identical to the
+    // legacy shape (mirrors the server parser in mention.service.ts).
+    const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
+    const part: MentionPart = {
       type: "mention",
       content: match[1],
-      mentionType: match[2] as "user" | "agent",
-      mentionUuid: match[3],
-    });
+      mentionType: match[2].toLowerCase() as "user" | "agent",
+      mentionUuid: match[3].toLowerCase(),
+    };
+    if (pinnedHost !== null || pinnedCwd !== null) {
+      part.pinnedHost = pinnedHost;
+      part.pinnedCwd = pinnedCwd;
+    }
+    parts.push(part);
 
     lastIndex = match.index + match[0].length;
   }
@@ -62,19 +107,118 @@ const MENTION_PLACEHOLDER_REGEX = /\u200B\u200BMENTION_(\d+)\u200B\u200B/g;
 /**
  * Pre-process content: replace @[Name](type:uuid) with placeholders
  * so markdown renderers don't mangle the mention syntax.
+ *
+ * This is the DEFAULT (non-comment) path's preprocessing. Exported so the
+ * byte-stability test can assert it is unchanged by the comment-path addition —
+ * its placeholder output must remain identical for every other surface.
  */
-function preprocessMentions(content: string): {
+export function preprocessMentions(content: string): {
   processed: string;
-  mentions: Array<{ displayName: string; type: string; uuid: string }>;
+  mentions: Array<{
+    displayName: string;
+    type: string;
+    uuid: string;
+    pinnedHost?: string | null;
+    pinnedCwd?: string | null;
+  }>;
 } {
-  const mentions: Array<{ displayName: string; type: string; uuid: string }> =
-    [];
-  const regex = new RegExp(MENTION_REGEX.source, "g");
+  const mentions: Array<{
+    displayName: string;
+    type: string;
+    uuid: string;
+    pinnedHost?: string | null;
+    pinnedCwd?: string | null;
+  }> = [];
+  const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
 
-  const processed = content.replace(regex, (_match, name, type, uuid) => {
+  // The 4th group (`pin`) is the raw pin query string (or undefined) — decode it
+  // via the shared codec and attach pin fields only when present (un-pinned
+  // placeholders stay byte-identical).
+  const processed = content.replace(regex, (_match, name, type, uuid, pin) => {
     const index = mentions.length;
-    mentions.push({ displayName: name, type, uuid });
+    const { pinnedHost, pinnedCwd } = decodePinSuffix(pin);
+    const entry: {
+      displayName: string;
+      type: string;
+      uuid: string;
+      pinnedHost?: string | null;
+      pinnedCwd?: string | null;
+    } = { displayName: name, type, uuid };
+    if (pinnedHost !== null || pinnedCwd !== null) {
+      entry.pinnedHost = pinnedHost;
+      entry.pinnedCwd = pinnedCwd;
+    }
+    mentions.push(entry);
     return `${MENTION_PLACEHOLDER_PREFIX}${index}${MENTION_PLACEHOLDER_SUFFIX}`;
+  });
+
+  return { processed, mentions };
+}
+
+// ── React-native mention rendering (opt-in, comment path only) ──────────────
+//
+// The default ContentWithMentions path above renders mentions via imperative DOM
+// injection (MentionPostProcessor: document.createElement spans). That cannot host
+// an interactive React component (a Radix Popover with state/handlers), so the
+// comment surface needs a React-native path: mentions become real React nodes.
+//
+// Approach: instead of a zero-width text placeholder, preprocess each mention into
+// a `<chorus-mention idx="N">@Name</chorus-mention>` custom inline TAG, then let
+// Streamdown render that tag through a `components` override (markdown structure
+// stays fully intact — a mention inside a list/heading/bold still works, unlike
+// splitting the body at mention boundaries). `literalTagContent` keeps the tag's
+// child label out of the markdown parser; `allowedTags` whitelists it through the
+// sanitizer. This is gated behind the opt-in `renderMention` prop so EVERY OTHER
+// surface keeps the byte-stable DOM-injection path untouched (q6 = comments only).
+
+const MENTION_TAG = "chorus-mention";
+const MENTION_TAG_ATTR = "idx";
+
+/**
+ * The parsed mention shape handed to a `renderMention` render-prop — a
+ * `ParsedMentionRef` plus its stable index in the body (so the consumer can key
+ * the node). This is the contract the comment path renders against.
+ */
+export interface RenderMentionArg extends ParsedMentionRef {
+  index: number;
+}
+
+/**
+ * Pre-process content for the React-native path: replace each `@[Name](type:uuid?…)`
+ * with a `<chorus-mention idx="N">@Name</chorus-mention>` custom tag. Returns the
+ * processed markdown plus the parsed mention refs (index-aligned with the `idx`
+ * attribute). The display label is escaped of `<`/`>`/`&` so a name can never break
+ * out of the tag; the badge re-derives its own label from the ref's displayName.
+ *
+ * Exported for the byte-stability test: a test can assert the comment path emits
+ * `<chorus-mention>` tags WITHOUT mounting the heavy Streamdown renderer, and that
+ * the legacy `preprocessMentions` (every other surface) is left unchanged.
+ */
+export function preprocessMentionsAsTags(content: string): {
+  processed: string;
+  mentions: ParsedMentionRef[];
+} {
+  const mentions: ParsedMentionRef[] = [];
+  const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
+
+  const processed = content.replace(regex, (_match, name, type, uuid, pin) => {
+    const index = mentions.length;
+    const { pinnedHost, pinnedCwd } = decodePinSuffix(pin);
+    const ref: ParsedMentionRef = {
+      type: (type as string).toLowerCase() as "user" | "agent",
+      uuid: (uuid as string).toLowerCase(),
+      displayName: name,
+    };
+    if (pinnedHost !== null || pinnedCwd !== null) {
+      ref.pinnedHost = pinnedHost;
+      ref.pinnedCwd = pinnedCwd;
+    }
+    mentions.push(ref);
+    const label = `@${name}`
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+    return `<${MENTION_TAG} ${MENTION_TAG_ATTR}="${index}">${label}</${MENTION_TAG}>`;
   });
 
   return { processed, mentions };
@@ -122,22 +266,45 @@ export function MentionRenderer({ children, className }: MentionRendererProps) {
 
 interface ContentWithMentionsProps {
   children: string;
+  /**
+   * OPT-IN React-native mention rendering. When provided, each `@mention` is
+   * rendered as a real React node returned by this render-prop (so an interactive
+   * MentionBadge / Radix Popover can be mounted) instead of via the default
+   * imperative DOM injection. When ABSENT, rendering is byte-for-byte identical to
+   * before — the DOM-injection path (MentionPostProcessor) is used unchanged. Only
+   * the comment surface passes this, keeping every other surface (idea / proposal /
+   * task / document descriptions) untouched (q6 = comments only).
+   */
+  renderMention?: (arg: RenderMentionArg) => React.ReactNode;
 }
 
 /**
  * Renders markdown content with @mention support.
- * Pre-processes mentions into placeholders, renders through Streamdown,
- * then replaces placeholders with styled mention spans via DOM effect.
  *
- * Drop-in replacement for <Streamdown>{content}</Streamdown>.
+ * Default (no `renderMention`): pre-processes mentions into zero-width placeholders,
+ * renders through Streamdown, then replaces placeholders with styled mention spans
+ * via a DOM effect. Drop-in replacement for <Streamdown>{content}</Streamdown>.
+ *
+ * Opt-in (`renderMention` provided): pre-processes mentions into `<chorus-mention>`
+ * custom tags and renders them as React nodes via a Streamdown `components`
+ * override — used ONLY by the comment path so agent mentions can become an
+ * interactive MentionBadge. The default path is unchanged.
  */
-export function ContentWithMentions({ children }: ContentWithMentionsProps) {
+export function ContentWithMentions({
+  children,
+  renderMention,
+}: ContentWithMentionsProps) {
   if (!children || typeof children !== "string") {
     return null;
   }
 
-  // Check if there are any mentions at all
-  const hasMentionPatterns = new RegExp(MENTION_REGEX.source).test(children);
+  // Check if there are any mentions at all. Reuse the source AND flags (the regex
+  // is case-insensitive) so detection matches what parseMentions/preprocessMentions
+  // will actually capture.
+  const hasMentionPatterns = new RegExp(
+    MENTION_REGEX.source,
+    MENTION_REGEX.flags.replace("g", ""),
+  ).test(children);
 
   if (!hasMentionPatterns) {
     return (
@@ -147,12 +314,68 @@ export function ContentWithMentions({ children }: ContentWithMentionsProps) {
     );
   }
 
+  // ── Opt-in React-native path (comment surface only) ──────────────────────
+  if (renderMention) {
+    return (
+      <ReactNativeMentionContent renderMention={renderMention}>
+        {children}
+      </ReactNativeMentionContent>
+    );
+  }
+
+  // ── Default path (every other surface): byte-stable DOM injection ─────────
   const { processed, mentions } = preprocessMentions(children);
 
   return (
     <MentionPostProcessor mentions={mentions}>
       <MarkdownContent>{processed}</MarkdownContent>
     </MentionPostProcessor>
+  );
+}
+
+/**
+ * The React-native mention render path: preprocess mentions into `<chorus-mention>`
+ * tags and map that tag to the caller's `renderMention` node via Streamdown's
+ * `components` override. The `idx` attribute keys back into the parsed refs.
+ * Memoizes the preprocess + the components map so re-renders (e.g. presence polls
+ * upstream) don't re-parse the body or churn the Streamdown component identity.
+ */
+function ReactNativeMentionContent({
+  children,
+  renderMention,
+}: {
+  children: string;
+  renderMention: (arg: RenderMentionArg) => React.ReactNode;
+}) {
+  const { processed, mentions } = React.useMemo(
+    () => preprocessMentionsAsTags(children),
+    [children],
+  );
+
+  const components = React.useMemo<Components>(() => {
+    // `chorus-mention` is a custom (non-standard) tag, so it isn't in the
+    // react-markdown Components keys — cast through a record to register it.
+    const map: Record<string, React.ComponentType<{ idx?: string }>> = {
+      [MENTION_TAG]: ({ idx }) => {
+        const index = idx === undefined ? NaN : parseInt(idx, 10);
+        const ref = Number.isInteger(index) ? mentions[index] : undefined;
+        if (!ref) return null;
+        return <>{renderMention({ ...ref, index })}</>;
+      },
+    };
+    return map as unknown as Components;
+  }, [mentions, renderMention]);
+
+  return (
+    <div className="overflow-hidden [&_pre]:overflow-x-auto">
+      <MarkdownContent
+        components={components}
+        allowedTags={{ [MENTION_TAG]: [MENTION_TAG_ATTR] }}
+        literalTagContent={[MENTION_TAG]}
+      >
+        {processed}
+      </MarkdownContent>
+    </div>
   );
 }
 
@@ -165,7 +388,16 @@ function MentionPostProcessor({
   mentions,
 }: {
   children: React.ReactNode;
-  mentions: Array<{ displayName: string; type: string; uuid: string }>;
+  // Pin fields are carried through (for surfaces that may read them) but the
+  // DOM-injection rendering below intentionally uses only type/uuid/displayName,
+  // so this non-comment path stays byte-stable.
+  mentions: Array<{
+    displayName: string;
+    type: string;
+    uuid: string;
+    pinnedHost?: string | null;
+    pinnedCwd?: string | null;
+  }>;
 }) {
   const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -235,29 +467,37 @@ function MentionPostProcessor({
  * Utility to check if text contains any @mention patterns.
  */
 export function hasMentions(text: string): boolean {
-  return new RegExp(MENTION_REGEX.source).test(text);
+  // Drop only the global flag (a `g`-flagged regex's stateful `.test` would skip
+  // matches across calls); keep case-insensitivity.
+  return new RegExp(
+    MENTION_REGEX.source,
+    MENTION_REGEX.flags.replace("g", ""),
+  ).test(text);
 }
 
 /**
- * Extracts all mentions from text content.
+ * Extracts all mentions from text content as `ParsedMentionRef`s, including any
+ * optional pinned-instance suffix (reusing the shared codec). An un-pinned token
+ * yields a ref with NO pin fields (object-identical to the legacy shape); a
+ * pinned token adds `pinnedHost`/`pinnedCwd`.
  */
-export function extractMentions(
-  text: string
-): Array<{ displayName: string; type: "user" | "agent"; uuid: string }> {
-  const mentions: Array<{
-    displayName: string;
-    type: "user" | "agent";
-    uuid: string;
-  }> = [];
-  const regex = new RegExp(MENTION_REGEX.source, "g");
+export function extractMentions(text: string): ParsedMentionRef[] {
+  const mentions: ParsedMentionRef[] = [];
+  const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
   let match;
 
   while ((match = regex.exec(text)) !== null) {
-    mentions.push({
+    const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
+    const ref: ParsedMentionRef = {
       displayName: match[1],
-      type: match[2] as "user" | "agent",
-      uuid: match[3],
-    });
+      type: match[2].toLowerCase() as "user" | "agent",
+      uuid: match[3].toLowerCase(),
+    };
+    if (pinnedHost !== null || pinnedCwd !== null) {
+      ref.pinnedHost = pinnedHost;
+      ref.pinnedCwd = pinnedCwd;
+    }
+    mentions.push(ref);
   }
 
   return mentions;

--- a/src/components/unified-comments.tsx
+++ b/src/components/unified-comments.tsx
@@ -12,7 +12,11 @@ import {
   createCommentAction,
 } from "@/app/(dashboard)/projects/comment-actions";
 import type { CommentWithOwner } from "@/services/comment.service";
-import { ContentWithMentions } from "@/components/mention-renderer";
+import {
+  ContentWithMentions,
+  type RenderMentionArg,
+} from "@/components/mention-renderer";
+import { MentionBadge } from "@/components/agent-presence";
 import { useRealtimeEntityEvent } from "@/contexts/realtime-context";
 import { PresenceIndicator } from "@/components/ui/presence-indicator";
 import { getAgentColor } from "@/lib/agent-color";
@@ -23,6 +27,35 @@ type TargetType = "idea" | "proposal" | "task" | "document";
 type TranslateFn = ReturnType<typeof UseTranslationsType>;
 
 const COLLAPSE_THRESHOLD = 200;
+
+// React-native mention rendering for the COMMENT surface only (passed as the opt-in
+// `renderMention` prop to ContentWithMentions). AGENT mentions become an interactive
+// MentionBadge (online dot + identity popover + owner/online-gated "Open
+// conversation"); USER mentions keep the existing styled-text appearance unchanged
+// (q1 = agent mentions only). Module-level + stable identity so it never churns the
+// memoized Streamdown components map upstream. Every OTHER ContentWithMentions
+// surface omits this prop and keeps its byte-stable DOM-injection rendering.
+function renderCommentMention(mention: RenderMentionArg) {
+  if (mention.type === "agent") {
+    return (
+      <MentionBadge
+        key={mention.index}
+        mention={mention}
+        displayName={mention.displayName}
+      />
+    );
+  }
+  // User mention — same styled text the legacy DOM-injection path produced.
+  return (
+    <span
+      key={mention.index}
+      className="text-blue-600 font-medium"
+      title={`${mention.type}: ${mention.uuid}`}
+    >
+      @{mention.displayName}
+    </span>
+  );
+}
 
 function formatRelativeTime(dateString: string, t: TranslateFn): string {
   const date = new Date(dateString);
@@ -270,7 +303,7 @@ function CommentItem({
         <div className={`mt-1 ${compact ? "text-xs" : "text-[13px]"} leading-relaxed text-[#3D3D3D] max-w-none [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:mt-2 [&_h1]:mb-1 [&_h2]:text-[13px] [&_h2]:font-semibold [&_h2]:mt-2 [&_h2]:mb-1 [&_h3]:text-[13px] [&_h3]:font-semibold [&_h3]:mt-1.5 [&_h3]:mb-0.5 [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5`}>
           {shouldCollapse && !expanded ? (
             <>
-              <ContentWithMentions>
+              <ContentWithMentions renderMention={renderCommentMention}>
                 {c.content.slice(0, COLLAPSE_THRESHOLD) + "..."}
               </ContentWithMentions>
               <Button
@@ -284,7 +317,9 @@ function CommentItem({
             </>
           ) : (
             <>
-              <ContentWithMentions>{c.content}</ContentWithMentions>
+              <ContentWithMentions renderMention={renderCommentMention}>
+                {c.content}
+              </ContentWithMentions>
               {shouldCollapse && (
                 <Button
                   variant="link"

--- a/src/contexts/__tests__/agent-presence-context.test.tsx
+++ b/src/contexts/__tests__/agent-presence-context.test.tsx
@@ -70,6 +70,7 @@ function conn(uuid: string, effectiveStatus: "online" | "offline"): ConnectionVi
     uuid,
     agentUuid: `agent-${uuid}`,
     agentName: `Agent ${uuid}`,
+    ownerUuid: null,
     clientType: "claude_code",
     clientVersion: null,
     host: "host",

--- a/src/contexts/agent-presence-context.tsx
+++ b/src/contexts/agent-presence-context.tsx
@@ -84,6 +84,23 @@ export type TranscriptSubscriber = (event: TranscriptEvent) => void;
 
 export type AgentPresenceStatus = "loading" | "ok" | "error";
 
+// The chat focus target seeded by `openChatForAgent` (e.g. clicking a comment
+// mention badge's "Open conversation"). It tells `DaemonChat`, when the modal
+// opens, WHICH agent — and optionally which pinned `(host, cwd)` instance — to
+// focus the left rail on, so the owner lands on the right conversation surface
+// instead of the default most-recent agent. Per the Tech Design's
+// "Open-conversation action contract" (elaboration q3 = "just open the daemon
+// chat"), focusing the agent is sufficient; precise past-session auto-selection
+// is NOT required. `pin` is present only for a pinned mention; a non-pinned
+// mention focuses the agent and the owner picks the instance/conversation inside.
+export interface ChatFocusTarget {
+  agentUuid: string;
+  // The pinned instance's place, present ONLY for a pinned mention. `host` is ""
+  // for an unknown-host pin and `cwd` is null for an unknown-path pin (same
+  // sentinels the connection projection / liveness rule use).
+  pin?: { host: string; cwd: string | null };
+}
+
 // Map of connectionUuid → that connection's current displayable executions
 // (running/queued/interrupted; consumers filter — the popover drops interrupted,
 // the modal keeps it). Wholesale-replaced per connection by each SSE event.
@@ -113,6 +130,24 @@ export interface AgentPresenceValue {
   // subscribed to (it sets the SSE `?sessionUuid=`), so a subscriber receives only the
   // open conversation's events. Mirrors realtime-context's `subscribeExecution`.
   subscribeTranscript: (cb: TranscriptSubscriber) => () => void;
+  // The chat focus target seeded by `openChatForAgent`. `DaemonChat` reads it when
+  // the modal opens to focus the right agent/instance, then calls
+  // `clearChatFocusTarget()` to consume it (so a later manual modal open is NOT
+  // re-hijacked by a stale focus). ADDITIVE — purely a one-shot seed; it does not
+  // touch `openSession`/`subscribeTranscript`/`setModalOpen` behavior for any other
+  // entry point.
+  focusTarget: ChatFocusTarget | null;
+  // Open the daemon-chat modal focused on a given agent (and optionally a pinned
+  // `(host, cwd)` instance). Used by the comment mention badge's owner-only "Open
+  // conversation" action. Sets the focus target THEN opens the modal; `DaemonChat`
+  // consumes the target on open. Additive — does not change any existing entry
+  // point's modal/openSession behavior.
+  openChatForAgent: (
+    agentUuid: string,
+    pin?: { host: string; cwd: string | null },
+  ) => void;
+  // Consume the one-shot focus target (called by `DaemonChat` after it focuses).
+  clearChatFocusTarget: () => void;
 }
 
 const AgentPresenceContext = createContext<AgentPresenceValue | null>(null);
@@ -212,6 +247,9 @@ export function AgentPresenceProvider({ children }: { children: ReactNode }) {
   // `?sessionUuid=` (see the SSE effect). `null` = no conversation open / no transcript
   // channel subscribed.
   const [openSession, setOpenSession] = useState<string | null>(null);
+  // One-shot chat focus target (set by `openChatForAgent`, consumed by `DaemonChat`
+  // on modal open). Not a SSE/poll concern — purely UI focus seeding.
+  const [focusTarget, setFocusTarget] = useState<ChatFocusTarget | null>(null);
 
   // Live-transcript subscribers (the chat container). Held in a ref — a Set so multiple
   // mounts can coexist and unsubscribe independently — mirroring realtime-context's
@@ -413,6 +451,24 @@ export function AgentPresenceProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  // Open the chat focused on an agent (+ optional pinned instance). Seed the focus
+  // target FIRST, then open the modal, so the modal mounts with the target already
+  // available for `DaemonChat` to consume on open. Stable identity (uses only the
+  // setters, which are stable).
+  const openChatForAgent = useCallback(
+    (agentUuid: string, pin?: { host: string; cwd: string | null }) => {
+      setFocusTarget(pin ? { agentUuid, pin } : { agentUuid });
+      setModalOpen(true);
+    },
+    [],
+  );
+
+  // Consume the one-shot focus target (called by `DaemonChat` after focusing) so a
+  // later manual modal open is not re-hijacked by a stale focus.
+  const clearChatFocusTarget = useCallback(() => {
+    setFocusTarget(null);
+  }, []);
+
   const value = useMemo<AgentPresenceValue>(
     () => ({
       status,
@@ -425,6 +481,9 @@ export function AgentPresenceProvider({ children }: { children: ReactNode }) {
       openSession,
       setOpenSession,
       subscribeTranscript,
+      focusTarget,
+      openChatForAgent,
+      clearChatFocusTarget,
     }),
     [
       status,
@@ -435,6 +494,9 @@ export function AgentPresenceProvider({ children }: { children: ReactNode }) {
       modalOpen,
       openSession,
       subscribeTranscript,
+      focusTarget,
+      openChatForAgent,
+      clearChatFocusTarget,
     ],
   );
 

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -74,15 +74,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const init = async () => {
       setLoading(true);
 
-      // Check if we have an OIDC user
+      // If we have a valid OIDC user, sync its (possibly refreshed) token to the
+      // cookie first so the backend session lookup sees the freshest token.
       const oidcUser = await getOidcUser();
-
       if (oidcUser && !oidcUser.expired) {
-        // Sync token (and refresh token) to cookie in case it was refreshed while the page was away
         await syncTokenToCookie(oidcUser.access_token, oidcUser.refresh_token);
-        // We have a valid OIDC session, fetch user info from backend
-        await fetchSession();
       }
+
+      // Always resolve the session from the backend. `/api/auth/session` accepts
+      // BOTH an OIDC bearer token AND a session cookie (default-auth / superadmin
+      // set `user_session` / `admin_session` with no OIDC user), so this populates
+      // `user` for every login mode — not just OIDC. Previously this was gated
+      // behind the OIDC branch, leaving `user` permanently null for default-auth
+      // users and silently disabling every owner-gated UI (e.g. the comment
+      // mention badge's owner-only "Open conversation" button).
+      await fetchSession();
 
       setLoading(false);
     };

--- a/src/lib/__tests__/mention-liveness.test.ts
+++ b/src/lib/__tests__/mention-liveness.test.ts
@@ -1,0 +1,177 @@
+// Unit tests for the pure mention-liveness matching rule
+// (src/lib/mention-liveness.ts). React-free — exercises the rule with plain
+// ConnectionView fixtures, exactly as the Tech Design's "Liveness resolution"
+// section specifies.
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveMentionLiveness,
+  isPinnedRef,
+  type MentionLivenessRef,
+} from "@/lib/mention-liveness";
+import type { ConnectionView } from "@/components/agent-presence/types";
+
+const AGENT = "abcdef12-3456-7890-abcd-ef1234567890";
+const OTHER_AGENT = "99999999-8888-7777-6666-555555555555";
+const OWNER = "11111111-1111-1111-1111-111111111111";
+
+// Build a ConnectionView fixture; only the fields the rule reads matter, the rest
+// carry plausible defaults.
+function conn(overrides: Partial<ConnectionView>): ConnectionView {
+  return {
+    uuid: "conn-" + Math.random().toString(36).slice(2),
+    agentUuid: AGENT,
+    agentName: "DevBot",
+    ownerUuid: OWNER,
+    clientType: "claude_code",
+    clientVersion: null,
+    host: "prod",
+    cwd: "/work",
+    startedAt: null,
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: "2026-06-24T00:00:00.000Z",
+    lastSeenAt: "2026-06-24T00:00:00.000Z",
+    disconnectedAt: null,
+    ...overrides,
+  };
+}
+
+describe("isPinnedRef", () => {
+  it("is pinned when either pin key is present (even null-valued)", () => {
+    expect(isPinnedRef({ uuid: AGENT, pinnedHost: "h", pinnedCwd: "/c" })).toBe(true);
+    expect(isPinnedRef({ uuid: AGENT, pinnedHost: "", pinnedCwd: "/c" })).toBe(true);
+    expect(isPinnedRef({ uuid: AGENT, pinnedCwd: null })).toBe(true);
+    expect(isPinnedRef({ uuid: AGENT, pinnedHost: null })).toBe(true);
+  });
+
+  it("is NOT pinned when both pin keys are absent", () => {
+    expect(isPinnedRef({ uuid: AGENT })).toBe(false);
+  });
+});
+
+describe("resolveMentionLiveness — pinned mention (instance-precise)", () => {
+  const ref: MentionLivenessRef = {
+    uuid: AGENT,
+    pinnedHost: "prod",
+    pinnedCwd: "/work",
+  };
+
+  it("pinned-online: the exact (agentUuid, host, cwd) instance is online", () => {
+    const connections = [
+      conn({ host: "prod", cwd: "/work", effectiveStatus: "online" }),
+    ];
+    const r = resolveMentionLiveness(ref, connections);
+    expect(r).toEqual({
+      pinned: true,
+      online: true,
+      ownerUuid: OWNER,
+      host: "prod",
+      cwd: "/work",
+    });
+  });
+
+  it("pinned-offline-while-agent-online-elsewhere = offline (different cwd does NOT count)", () => {
+    const connections = [
+      // Same agent, online, but a DIFFERENT instance (cwd /elsewhere).
+      conn({ host: "prod", cwd: "/elsewhere", effectiveStatus: "online" }),
+    ];
+    const r = resolveMentionLiveness(ref, connections);
+    expect(r.online).toBe(false);
+    expect(r.pinned).toBe(true);
+    // The pinned place is echoed for display; owner borrowed from the known agent conn.
+    expect(r.host).toBe("prod");
+    expect(r.cwd).toBe("/work");
+    expect(r.ownerUuid).toBe(OWNER);
+  });
+
+  it("pinned place exists but its connection is offline → offline, instance identity surfaced", () => {
+    const connections = [
+      conn({ host: "prod", cwd: "/work", effectiveStatus: "offline" }),
+    ];
+    const r = resolveMentionLiveness(ref, connections);
+    expect(r.online).toBe(false);
+    expect(r.host).toBe("prod");
+    expect(r.cwd).toBe("/work");
+    expect(r.ownerUuid).toBe(OWNER);
+  });
+
+  it("a different agent's matching place does NOT satisfy the pin", () => {
+    const connections = [
+      conn({ agentUuid: OTHER_AGENT, host: "prod", cwd: "/work", effectiveStatus: "online" }),
+    ];
+    const r = resolveMentionLiveness(ref, connections);
+    expect(r.online).toBe(false);
+    expect(r.ownerUuid).toBeNull(); // no connection known for THIS agent
+  });
+
+  it("matches an unknown-host pin (pinnedHost '') against a host-less connection", () => {
+    const unknownHostRef: MentionLivenessRef = {
+      uuid: AGENT,
+      pinnedHost: "",
+      pinnedCwd: "/srv",
+    };
+    const connections = [
+      conn({ host: "", cwd: "/srv", effectiveStatus: "online" }),
+    ];
+    expect(resolveMentionLiveness(unknownHostRef, connections).online).toBe(true);
+  });
+
+  it("matches an unknown-path pin (pinnedCwd null) against a null-cwd connection", () => {
+    const unknownPathRef: MentionLivenessRef = {
+      uuid: AGENT,
+      pinnedHost: "prod",
+      pinnedCwd: null,
+    };
+    const connections = [
+      conn({ host: "prod", cwd: null, effectiveStatus: "online" }),
+    ];
+    const r = resolveMentionLiveness(unknownPathRef, connections);
+    expect(r.online).toBe(true);
+    expect(r.cwd).toBeNull();
+  });
+});
+
+describe("resolveMentionLiveness — non-pinned mention (agent-overall)", () => {
+  const ref: MentionLivenessRef = { uuid: AGENT };
+
+  it("non-pinned-online: ANY connection for the agent is online", () => {
+    const connections = [
+      conn({ host: "h1", cwd: "/a", effectiveStatus: "offline" }),
+      conn({ host: "h2", cwd: "/b", effectiveStatus: "online" }),
+    ];
+    const r = resolveMentionLiveness(ref, connections);
+    expect(r).toEqual({
+      pinned: false,
+      online: true,
+      ownerUuid: OWNER,
+      host: null, // non-pinned has no single instance
+      cwd: null,
+    });
+  });
+
+  it("non-pinned-offline: no connection for the agent is online", () => {
+    const connections = [
+      conn({ host: "h1", cwd: "/a", effectiveStatus: "offline" }),
+    ];
+    const r = resolveMentionLiveness(ref, connections);
+    expect(r.online).toBe(false);
+    expect(r.ownerUuid).toBe(OWNER); // borrowed from the offline connection
+    expect(r.host).toBeNull();
+    expect(r.cwd).toBeNull();
+  });
+
+  it("no connections at all for the agent → offline, ownerUuid null", () => {
+    const connections = [conn({ agentUuid: OTHER_AGENT, effectiveStatus: "online" })];
+    const r = resolveMentionLiveness(ref, connections);
+    expect(r.online).toBe(false);
+    expect(r.ownerUuid).toBeNull();
+  });
+
+  it("ignores other agents' online connections", () => {
+    const connections = [
+      conn({ agentUuid: OTHER_AGENT, effectiveStatus: "online" }),
+    ];
+    expect(resolveMentionLiveness(ref, connections).online).toBe(false);
+  });
+});

--- a/src/lib/mention-liveness.ts
+++ b/src/lib/mention-liveness.ts
@@ -1,0 +1,126 @@
+// Pure mention-liveness resolution — the single matching rule the comment
+// mention badge uses to turn a parsed mention + the current daemon connections
+// into an online verdict (and, when online, the owning instance's identity).
+//
+// It is intentionally REACT-FREE so it can be unit-tested with plain fixtures;
+// the `useMentionLiveness(ref)` hook (use-mention-liveness.tsx) just feeds it
+// `useAgentPresence().connections`. The rule mirrors the Tech Design's "Liveness
+// resolution" section EXACTLY:
+//   - pinned mention    → instance-precise: online iff a connection matches
+//                         (agentUuid, host, cwd) AND is effectiveStatus "online".
+//   - non-pinned mention → agent-overall: online iff ANY connection for the agent
+//                         is effectiveStatus "online".
+// "Online" is never re-derived here — it reads the server's `effectiveStatus`
+// verdict verbatim (the same source the presence count uses).
+
+import type { ConnectionView } from "@/components/agent-presence/types";
+
+/**
+ * The minimal parsed-mention shape this rule needs — a structural subset of
+ * `MentionRef` (src/services/mention.service.ts) / `ParsedMentionRef`
+ * (mention-renderer.tsx): the agent `uuid` plus the optional pinned-instance
+ * `(pinnedHost, pinnedCwd)`. A mention is treated as PINNED iff either pin key is
+ * present (even with a null value — `pinnedHost: ""` is the unknown-host pin and
+ * `pinnedCwd: null` is the unknown-path pin), matching how the parser attaches
+ * the keys only for a pinned token.
+ */
+export interface MentionLivenessRef {
+  uuid: string;
+  pinnedHost?: string | null;
+  pinnedCwd?: string | null;
+}
+
+/**
+ * Result of resolving a mention against the current connections.
+ *  - `online`      — the verdict (instance-precise for a pinned mention, agent-
+ *                    overall for a non-pinned one).
+ *  - `ownerUuid`   — the matched connection's owner for a pinned-online mention;
+ *                    for a non-pinned mention, the owner of the connection that
+ *                    satisfied the online check (or, when offline, any connection
+ *                    for that agent if one exists). null when no connection at
+ *                    all is known for the agent. Used by the owner gate.
+ *  - `host`/`cwd`  — the matched instance's place, present ONLY for a pinned
+ *                    mention that resolved to a specific connection (online OR
+ *                    the pinned place with a known connection); null for a
+ *                    non-pinned mention (no single instance) or when no pinned
+ *                    connection exists.
+ */
+export interface MentionLiveness {
+  pinned: boolean;
+  online: boolean;
+  ownerUuid: string | null;
+  host: string | null;
+  cwd: string | null;
+}
+
+/** A mention is pinned iff either pin key is present on the ref. */
+export function isPinnedRef(ref: MentionLivenessRef): boolean {
+  return ref.pinnedHost !== undefined || ref.pinnedCwd !== undefined;
+}
+
+/**
+ * Resolve a parsed mention's liveness against the current daemon connections.
+ * Pure: no side effects, safe to call in render/test.
+ *
+ * Pinned: find the connection for the exact `(agentUuid, host, cwd)` place
+ * (`host === pinnedHost && cwd === pinnedCwd`). The mention is online iff that
+ * connection exists AND its `effectiveStatus === "online"`. The matched
+ * connection's `ownerUuid`/`host`/`cwd` are surfaced so the popover can render
+ * the instance and gate the owner-only action. A pinned mention whose place has
+ * NO connection at all → offline, with `host`/`cwd` echoed from the ref (the
+ * place is still meaningful for display) and `ownerUuid` resolved from any
+ * connection of that agent if one is known.
+ *
+ * Non-pinned: online iff ANY connection for `agentUuid` is `effectiveStatus
+ * "online"`. `host`/`cwd` are null (no single instance). `ownerUuid` is taken
+ * from an online connection when online, else from any connection of the agent.
+ */
+export function resolveMentionLiveness(
+  ref: MentionLivenessRef,
+  connections: ConnectionView[],
+): MentionLiveness {
+  const pinned = isPinnedRef(ref);
+  const agentConnections = connections.filter((c) => c.agentUuid === ref.uuid);
+
+  if (pinned) {
+    const pinnedHost = ref.pinnedHost ?? null;
+    const pinnedCwd = ref.pinnedCwd ?? null;
+    // The exact (host, cwd) place. host is "" for an unknown-host pin and cwd is
+    // null for an unknown-path pin — strict equality handles both since the
+    // connection projection uses the same sentinels (host: "", cwd: null).
+    const match = agentConnections.find(
+      (c) => c.host === pinnedHost && c.cwd === pinnedCwd,
+    );
+    if (match) {
+      return {
+        pinned: true,
+        online: match.effectiveStatus === "online",
+        ownerUuid: match.ownerUuid,
+        host: match.host,
+        cwd: match.cwd,
+      };
+    }
+    // No connection for this exact place → offline. Echo the ref's place for
+    // display; borrow ownerUuid from any known connection of the agent.
+    return {
+      pinned: true,
+      online: false,
+      ownerUuid: agentConnections[0]?.ownerUuid ?? null,
+      host: pinnedHost,
+      cwd: pinnedCwd,
+    };
+  }
+
+  // Non-pinned: agent-overall liveness. Prefer an online connection's owner so
+  // the owner gate reads from a live row when the agent is online.
+  const onlineConn = agentConnections.find(
+    (c) => c.effectiveStatus === "online",
+  );
+  return {
+    pinned: false,
+    online: onlineConn !== undefined,
+    ownerUuid: (onlineConn ?? agentConnections[0])?.ownerUuid ?? null,
+    host: null,
+    cwd: null,
+  };
+}

--- a/src/lib/use-mention-liveness.tsx
+++ b/src/lib/use-mention-liveness.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+// React hook over the pure `resolveMentionLiveness` rule — feeds it the live
+// `connections` from the shell-level agent-presence spine so a mention badge can
+// read its instance-precise (pinned) / agent-overall (non-pinned) online verdict
+// without threading props. The matching rule itself lives in `mention-liveness.ts`
+// (pure, React-free, unit-tested); this file only wires the data source.
+//
+// FILE NAME: this hook module is `use-mention-liveness.tsx` (hook naming
+// convention) so it does NOT share a basename with the pure `mention-liveness.ts`.
+// A same-basename `.ts`/`.tsx` pair makes the extensionless specifier
+// `@/lib/mention-liveness` resolve to the `.ts` under `moduleResolution: bundler`,
+// which would hide this hook export; the distinct name keeps both reachable and
+// the pure module unit-testable without pulling React in.
+
+import { useMemo } from "react";
+import { useAgentPresence } from "@/contexts/agent-presence-context";
+import {
+  resolveMentionLiveness,
+  type MentionLiveness,
+  type MentionLivenessRef,
+} from "@/lib/mention-liveness";
+
+/**
+ * Resolve a parsed mention's liveness against the current daemon connections from
+ * `useAgentPresence()`. Returns the same `MentionLiveness` the pure rule yields
+ * (online verdict + matched instance owner/host/cwd). Recomputes only when the
+ * connections list or the ref's identity/pin changes.
+ *
+ * MUST be called inside an `AgentPresenceProvider` (the hook reads the presence
+ * context) — the comment render site is within the shell that mounts it.
+ */
+export function useMentionLiveness(ref: MentionLivenessRef): MentionLiveness {
+  const { connections } = useAgentPresence();
+  // Destructure the ref's identity/pin fields so the memo depends on the VALUES
+  // (not the ref object, which churns per render from a fresh parse) — keeping the
+  // verdict stable across re-parses while satisfying exhaustive-deps. A fresh
+  // MentionLivenessRef is rebuilt from these so resolveMentionLiveness sees the
+  // same shape (pin keys present iff this is a pinned ref).
+  const { uuid, pinnedHost, pinnedCwd } = ref;
+  const isPinned = "pinnedHost" in ref || "pinnedCwd" in ref;
+  return useMemo(() => {
+    const stableRef: MentionLivenessRef = isPinned
+      ? { uuid, pinnedHost, pinnedCwd }
+      : { uuid };
+    return resolveMentionLiveness(stableRef, connections);
+  }, [connections, uuid, pinnedHost, pinnedCwd, isPinned]);
+}

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -428,8 +428,8 @@ const ownerUuid = "owner-0000-0000-0000-000000000001";
 
 // Build a DaemonConnection row fixture, dating lastSeenAt `agoMs` before NOW.
 // The `agent` relation is included by default (matches the production query's
-// `include: { agent: { select: { name: true } } }`). Pass `agent: null` to
-// simulate a row whose related agent could not be resolved.
+// `include: { agent: { select: { name: true, ownerUuid: true } } }`). Pass
+// `agent: null` to simulate a row whose related agent could not be resolved.
 function makeRow(
   overrides: {
     uuid?: string;
@@ -440,7 +440,7 @@ function makeRow(
     host?: string;
     cwd?: string | null;
     disconnectedAt?: Date | null;
-    agent?: { name: string } | null;
+    agent?: { name: string; ownerUuid: string | null } | null;
   } = {},
 ) {
   const agoMs = overrides.agoMs ?? 0;
@@ -459,7 +459,10 @@ function makeRow(
     connectedAt: new Date("2026-06-15T03:30:00.000Z"),
     lastSeenAt: new Date(NOW.getTime() - agoMs),
     disconnectedAt: "disconnectedAt" in overrides ? overrides.disconnectedAt : null,
-    agent: "agent" in overrides ? overrides.agent : { name: "Build Agent" },
+    agent:
+      "agent" in overrides
+        ? overrides.agent
+        : { name: "Build Agent", ownerUuid },
   };
 }
 
@@ -475,11 +478,12 @@ describe("listConnectionsForOwner", () => {
     const result = await listConnectionsForOwner(companyUuid, ownerUuid);
 
     expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledTimes(1);
-    // The `include` is what carries Agent.name into the projection — without it
-    // agentName would silently project null for every connection.
+    // The `include` is what carries Agent.name + ownerUuid into the projection —
+    // without it agentName/ownerUuid would silently project null for every
+    // connection.
     expect(mockPrisma.daemonConnection.findMany.mock.calls[0][0]).toEqual({
       where: { companyUuid, agent: { ownerUuid } },
-      include: { agent: { select: { name: true } } },
+      include: { agent: { select: { name: true, ownerUuid: true } } },
     });
     expect(result).toHaveLength(1);
     const view = result[0];
@@ -488,6 +492,7 @@ describe("listConnectionsForOwner", () => {
       uuid: connectionUuid,
       agentUuid,
       agentName: "Build Agent",
+      ownerUuid,
       clientType: "claude_code",
       clientVersion: "0.11.0",
       host: "mac.local",
@@ -526,6 +531,8 @@ describe("listConnectionsForOwner", () => {
     mockPrisma.daemonConnection.findMany.mockResolvedValue([makeRow({ agent: null })]);
     const [view] = await listConnectionsForOwner(companyUuid, ownerUuid);
     expect(view.agentName).toBeNull();
+    // ownerUuid likewise projects null (not throw) from an unresolved relation.
+    expect(view.ownerUuid).toBeNull();
     // Other fields still project correctly.
     expect(view.uuid).toBe(connectionUuid);
     expect(view.agentUuid).toBe(agentUuid);
@@ -557,14 +564,15 @@ describe("listConnectionsForAgent", () => {
 
     expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledTimes(1);
     // Same `include` as the owner-scoped query so agent-self callers see
-    // agentName too — uniform projection across both scopes.
+    // agentName + ownerUuid too — uniform projection across both scopes.
     expect(mockPrisma.daemonConnection.findMany.mock.calls[0][0]).toEqual({
       where: { companyUuid, agentUuid },
-      include: { agent: { select: { name: true } } },
+      include: { agent: { select: { name: true, ownerUuid: true } } },
     });
     expect(result).toHaveLength(1);
     expect(result[0].uuid).toBe(connectionUuid);
     expect(result[0].agentName).toBe("Build Agent");
+    expect(result[0].ownerUuid).toBe(ownerUuid);
     expect(result[0].effectiveStatus).toBe("online");
   });
 

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -88,6 +88,14 @@ export interface ConnectionView {
   // from under the connection — we project null rather than throwing so the
   // page can still render the daemon's own self-reported clientType/host).
   agentName: string | null;
+  // Owning agent's human owner (Agent.ownerUuid). Joined from the same `agent`
+  // relation; null for an unowned/system agent or when the relation cannot be
+  // resolved. Mirrors the server owner rule in daemon-control.service
+  // (`resolveConnectionOwner` → `row.agent?.ownerUuid ?? null`) so a client can
+  // gate an owner-only action (e.g. the mention badge's "Open conversation")
+  // against `useAuth().user.uuid` without a second fetch — never inferring
+  // ownership from name/email.
+  ownerUuid: string | null;
   clientType: string;
   clientVersion: string | null;
   host: string; // "" when host-less (display can show a placeholder)
@@ -129,7 +137,9 @@ interface DaemonConnectionRow {
   connectedAt: Date;
   lastSeenAt: Date;
   disconnectedAt: Date | null;
-  agent: { name: string } | null;
+  // `name` for the display identity, `ownerUuid` for the owner gate. nullable for
+  // the rare deleted-agent case (see ConnectionView.agentName / ownerUuid).
+  agent: { name: string; ownerUuid: string | null } | null;
 }
 
 /**
@@ -149,6 +159,9 @@ function toConnectionView(row: DaemonConnectionRow): ConnectionView {
     uuid: row.uuid,
     agentUuid: row.agentUuid,
     agentName: row.agent?.name ?? null,
+    // Same non-disclosure-safe projection as resolveConnectionOwner: a deleted /
+    // unresolved agent relation projects null rather than throwing.
+    ownerUuid: row.agent?.ownerUuid ?? null,
     clientType: row.clientType,
     clientVersion: row.clientVersion,
     host: row.host,
@@ -425,9 +438,10 @@ export async function listConnectionsForOwner(
 ): Promise<ConnectionView[]> {
   const rows = await prisma.daemonConnection.findMany({
     where: { companyUuid, agent: { ownerUuid } },
-    // Pull only the owning agent's display name — the page leads with agent
-    // identity, so the read must carry it. `name`-only keeps the payload tight.
-    include: { agent: { select: { name: true } } },
+    // Pull the owning agent's display name (page leads with agent identity) and
+    // its ownerUuid (the owner gate for client owner-only actions). Selecting two
+    // scalar fields keeps the payload tight.
+    include: { agent: { select: { name: true, ownerUuid: true } } },
   });
   return sortConnectionViews(rows.map(toConnectionView));
 }
@@ -444,8 +458,9 @@ export async function listConnectionsForAgent(
   const rows = await prisma.daemonConnection.findMany({
     where: { companyUuid, agentUuid },
     // Same join as the owner-scoped read — agent self-scope still wants the
-    // display name (it's the agent's own name, but the projection stays uniform).
-    include: { agent: { select: { name: true } } },
+    // display name + ownerUuid so the projection stays uniform (it's the agent's
+    // own name/owner, but the shape is identical across both read paths).
+    include: { agent: { select: { name: true, ownerUuid: true } } },
   });
   return sortConnectionViews(rows.map(toConnectionView));
 }


### PR DESCRIPTION
## Summary
Turn agent `@mentions` in the **comment area** into interactive badges:
- a name + **online status dot** (instance-precise for a cwd-pinned mention `@[Name](agent:uuid?cwd=…&host=…)`; agent-overall for a non-pinned one),
- clicking opens a **popover** with the agent's identity (name + online status, plus working directory + host for a pinned mention),
- an **owner-only, online-only "Open conversation"** button that opens the daemon chat focused on the agent (or the pinned instance).

Scope is **comments-only**: user mentions keep their plain styled text, and every other `ContentWithMentions` surface (idea / proposal / task / document descriptions) stays byte-stable via an opt-in `renderMention` render-prop — the legacy DOM-injection path is untouched elsewhere.

Built spec-first via OpenSpec (`openspec/changes/add-comment-mention-badges`). Implements idea 8923fff4 (Chorus 0.11.2) across 3 tasks: pin-parsing + liveness foundation → MentionBadge component + `openChatForAgent` → comment render integration.

## Two latent defects fixed along the way
- **Client mention regex couldn't parse the `?cwd=&host=` suffix** → pinned mentions rendered as broken raw text. Now reuses the shared `decodePinSuffix` codec so client & server parse identically.
- **`AuthProvider` was mounted nowhere AND only fetched the session for OIDC users** → `useAuth().user` was `null` for default-auth/superadmin logins, which would crash the comment area and silently disable the owner gate. Now mounted at the dashboard shell and always calls `fetchSession()` on mount (the session endpoint resolves both OIDC tokens and session cookies). Caught by the ship-time code-review gateway.

## Changed files
| File | Change |
|------|--------|
| `src/components/mention-renderer.tsx` | Client pin-suffix parsing (reuse `decodePinSuffix`) + opt-in `renderMention` render-prop / `<chorus-mention>` tag path |
| `src/components/markdown-content.tsx` | Additive Streamdown passthrough (`components` / `allowedTags` / `literalTagContent`) |
| `src/components/unified-comments.tsx` | Comment path renders agent mentions as `MentionBadge`, user mentions as text |
| `src/components/agent-presence/mention-badge.tsx` | New: badge + online dot + identity popover + owner/online-gated button |
| `src/lib/mention-liveness.ts` / `use-mention-liveness.tsx` | Pure liveness matcher + hook |
| `src/contexts/agent-presence-context.tsx` | Additive `openChatForAgent` / `focusTarget` |
| `src/components/agent-presence/chat/daemon-chat.tsx` | Consumes `focusTarget` on open |
| `src/components/agent-presence/types.ts`, `src/services/daemon-connection.service.ts` | `ConnectionView.ownerUuid` |
| `src/app/(dashboard)/layout.tsx` | Mount `AuthProvider` at the dashboard shell |
| `src/contexts/auth-context.tsx` | Always fetch session on mount (not OIDC-only) |
| `messages/en.json`, `messages/zh.json` | `mention.*` strings (en + zh) |
| `openspec/changes/add-comment-mention-badges/**` | OpenSpec change (proposal / design / spec) |

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm test` — 197 files / 3165 passed, 14 skipped (new: mention-renderer byte-stability, mention-liveness, mention-badge gating matrix)
- [x] `pnpm lint` — feature files clean (2 pre-existing errors in `packages/openclaw-plugin/` are unrelated)
- [x] Live e2e (Playwright): pinned badge + popover (cwd/host); **owner+online → "Open conversation" shown** and opens daemon chat focused on the agent; owner+offline → button hidden; user mention as plain text; no console errors
- [ ] `docs/design.pen` update — waived by owner for this feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)