### PR TITLE
fix: make Assign Idea/Task modals mobile-safe via shared ScrollableDialog

### DIFF
--- a/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/README.md
+++ b/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/README.md
@@ -1,0 +1,3 @@
+# fix-assign-modals-mobile-overflow
+
+Make the Assign Idea / Assign Task hand-written modals mobile-safe via a shared scrollable shadcn-Dialog skeleton (capped svh height, pinned header/footer, scrolling body)

--- a/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/design.md
+++ b/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/design.md
@@ -1,0 +1,166 @@
+# Design: mobile-safe Assign Idea / Assign Task modals via a shared scrollable-dialog skeleton
+
+## Context
+
+Two hand-written fixed-position modals overflow short mobile viewports and cannot
+scroll, hiding their footer Assign / Cancel buttons (see `proposal.md` for the
+root cause). The resolved elaboration chose: keep a centered card (not
+full-screen), cap height with dynamic viewport units + internal scroll, extract a
+reusable skeleton, and build it on shadcn `Dialog`.
+
+Both modals are structurally near-identical today:
+
+```
+<>
+  <div className="fixed inset-0 z-50 bg-black/40" onClick={onClose} />   {/* backdrop */}
+  <div className="fixed left-1/2 top-1/2 z-50 w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-2xl ...">
+    <div className="... px-6 py-5 border-b">{/* Header: title + X close */}</div>
+    <div className="p-6 space-y-4">{/* Body: idea/task info, radio options, agent select, InstancePicker, release */}</div>
+    <div className="... px-6 py-6 border-t">{/* Footer: Cancel + Assign */}</div>
+  </div>
+</>
+```
+
+The body grows with the shared `InstancePicker`
+(`src/components/agent-presence/instance-picker.tsx`), one row per online
+`(host, cwd)` instance, no height ceiling. There is the reference pattern in
+`src/components/agent-presence/connections-modal.tsx` (`h-dvh max-h-dvh` full-screen
+— rejected by q1=A) and `src/components/assign-modal.tsx`
+(`max-h-[80vh] overflow-y-auto` — close, but a single scroll container, not a
+pinned header/footer).
+
+## Goals / Non-Goals
+
+**Goals**
+- One reusable skeleton: pinned header + scrolling body + pinned footer, height
+  capped in dynamic viewport units, narrow-viewport width fallback, built on
+  shadcn `Dialog`.
+- Adopt it in both assign modals with **zero** business-logic change and **zero**
+  call-site change.
+
+**Non-Goals**
+- No full-screen mobile layout (rejected: q1=A).
+- No change to assignment / instance-pin / wake logic.
+- No migration of other modals (the mention picker `d3f31086` is separate); the
+  skeleton is merely *available* for future reuse.
+
+## The skeleton component
+
+New component family under `src/components/ui/scrollable-dialog.tsx`, composed from
+the existing `@/components/ui/dialog` primitives (Radix-backed). Proposed shape
+(final names/props settle in implementation; behavior is normative):
+
+```tsx
+// Wraps DialogContent with a flex column whose body is the only scroll region.
+<ScrollableDialog open={open} onOpenChange={onOpenChange}>
+  <ScrollableDialogHeader>{title}</ScrollableDialogHeader>   {/* pinned, shrink-0 */}
+  <ScrollableDialogBody>{children}</ScrollableDialogBody>     {/* min-h-0 flex-1 overflow-y-auto */}
+  <ScrollableDialogFooter>{actions}</ScrollableDialogFooter>  {/* pinned, shrink-0 */}
+</ScrollableDialog>
+```
+
+Layout contract on the `DialogContent`:
+
+- `flex max-h-[85svh] flex-col overflow-hidden` — the content is a flex column
+  capped at a fraction of the **small** viewport height (`svh`, which excludes the
+  mobile browser UI / accounts for the soft keyboard) so it never exceeds the
+  viewport. `overflow-hidden` confines scrolling to the body.
+  - Rationale for `svh` over `dvh`/`vh`: `vh` ignores mobile browser chrome and is
+    the original bug; `svh` is the conservative (smallest) stable height so the
+    dialog fits even with the URL bar expanded and is not clipped when the soft
+    keyboard is up. (`dvh` is acceptable but reflows as chrome shows/hides; `svh`
+    is steadier for a capped centered card. Either dynamic unit satisfies the
+    requirement; `svh` is the chosen default.)
+- Header & footer: `shrink-0` so they never compress; the body is the only flexible
+  row.
+- Body: `min-h-0 flex-1 overflow-y-auto` — `min-h-0` is **required** so the flex
+  child is allowed to shrink below its content size and actually scroll (a flex
+  item defaults to `min-height:auto`, which would otherwise let it grow and re-push
+  the footer off-screen — the exact bug).
+- Width: rely on shadcn `DialogContent`'s base `w-full max-w-[calc(100%-2rem)]`
+  plus a `sm:max-w-[400px]` to preserve the current desktop 400px width. This also
+  fixes the secondary horizontal-overflow symptom (the old fixed `w-[400px]`).
+- Centering, backdrop, Esc, focus-trap, aria, and the close button come from
+  shadcn `DialogContent` for free; the bespoke backdrop `div` and `X` button are
+  dropped.
+
+The header/body/footer are simple slot wrappers (padding + borders matching the
+current look: header `border-b`, footer `border-t`, both opaque so body content
+scrolling under them is clipped by `overflow-hidden`).
+
+## Open/close contract (critical)
+
+The call sites mount conditionally and pass only `onClose` — there is no `open`
+prop today:
+
+```tsx
+{showAssignModal && <AssignIdeaModal … onClose={() => setShowAssignModal(false)} />}
+{task && showAssignModal && <AssignTaskModal … onClose={() => setShowAssignModal(false)} />}
+```
+
+(Call sites: `ideas/idea-detail-panel.tsx`, `dashboard/panels/idea-detail-panel.tsx`,
+`dashboard/panels/basic-view.tsx`, `tasks/task-detail-panel.tsx`.)
+
+A Radix `Dialog` is controlled by `open` / `onOpenChange`. To keep all call sites
+untouched, each assign modal continues to own the `onClose` prop and internally
+renders the skeleton as **always open**, translating a close intent back to
+`onClose`:
+
+```tsx
+<ScrollableDialog open onOpenChange={(o) => { if (!o) onClose(); }}>
+```
+
+Because the parent only mounts the modal while `showAssignModal` is true,
+`open` is effectively always `true` while mounted, and any close path (Esc, overlay
+click, the close button, Cancel) funnels through `onOpenChange(false) → onClose()`,
+which unmounts it. No exit-animation regression matters because the component
+unmounts immediately on close, exactly as the hand-written version did.
+
+## Migration mapping per modal
+
+For each of `assign-idea-modal.tsx` and `assign-task-modal.tsx`, replace only the
+outer JSX shell — keep all hooks, state, effects, `handleSubmit`, `canSubmit`,
+`resolvePinLabel`, the `RadioGroup` options, the agent `Select`, the
+`InstancePicker`, and the `error` block exactly as-is:
+
+| Old | New |
+|---|---|
+| `<><div backdrop/><div fixed card>…</div></>` | `<ScrollableDialog open onOpenChange={…}>…</ScrollableDialog>` |
+| Header `div` with `<h2>` + `<button><X/></button>` | `<ScrollableDialogHeader>` with the title (shadcn close button replaces the bespoke `X`) |
+| Body `<div className="p-6 space-y-4">` | `<ScrollableDialogBody className="space-y-4">` (the wrapper owns padding) |
+| Footer `<div … border-t>` Cancel/Assign | `<ScrollableDialogFooter>` Cancel/Assign (unchanged Buttons) |
+
+The Cancel `Button` keeps calling `onClose`; the Assign `Button` keeps calling
+`handleSubmit`. No prop signatures change.
+
+## Risks & Mitigations
+
+- **Risk:** moving to a portal-based Radix `Dialog` changes stacking / z-index vs
+  the old `z-50` siblings. **Mitigation:** shadcn `DialogContent` already portals
+  to `document.body` at `z-50` with an overlay; verify the modal still sits above
+  the detail panels in the Playwright pass.
+- **Risk:** the `min-h-0` flex pitfall — forgetting it silently reintroduces the
+  exact "footer pushed off-screen" bug. **Mitigation:** it is encoded once in the
+  skeleton (not per-modal) and covered by an explicit acceptance criterion +
+  Playwright check at a short viewport with ≥3 instances.
+- **Risk:** desktop visual drift (radius, width, padding). **Mitigation:** match
+  `sm:max-w-[400px]` and the existing padding/border tokens; desktop is expected to
+  look unchanged.
+- **Risk:** focus-trap now active (was absent in the hand-written version) could
+  change tab behavior. **Mitigation:** this is an accessibility *improvement* and
+  the intended q3=B benefit; just confirm the agent `Select`/`InstancePicker`
+  remain operable inside the trap.
+
+## Verification
+
+Per the idea's acceptance, reproduce and verify in a real mobile browser viewport
+(Playwright), covering all three:
+
+1. Standard mobile viewport (375×667): open Assign Idea and Assign Task, choose
+   Assign to Agent, expand a multi-instance `InstancePicker`.
+2. Soft-keyboard-shortened short viewport (≈360×420).
+3. Longest body: ≥3 online instances + already-assigned (the Release option shows).
+
+In all three: the title and the bottom Cancel / Assign buttons stay visible and
+clickable, and the body scrolls to any row. Plus `pnpm lint`, `npx tsc --noEmit`,
+and `pnpm test` for the new skeleton's unit tests.

--- a/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/proposal.md
+++ b/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/proposal.md
@@ -1,0 +1,110 @@
+# Fix Assign Idea / Assign Task modals overflowing the mobile viewport (footer buttons unreachable)
+
+## Why
+
+On a mobile viewport, opening **Assign Idea** or **Assign Task** can push the
+modal taller than the visible viewport, and the modal **cannot scroll**, so the
+bottom **Assign / Cancel** buttons are pushed off-screen and the user cannot
+complete (or cancel) the assignment.
+
+Two **hand-written fixed-position modals** are affected (verified against the
+`develop` / 0.11.2 working tree). They are neither shadcn `Dialog` nor the
+generic `src/components/assign-modal.tsx` (which already has
+`max-h-[80vh] overflow-y-auto` and is fine):
+
+- `src/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal.tsx`
+- `src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx`
+
+Both use the same container:
+
+```
+fixed left-1/2 top-1/2 z-50 w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-2xl ...
+```
+
+Root cause:
+
+1. **No `max-height`, no internal scroll.** The card is vertically centered with
+   `top-1/2 -translate-y-1/2`, but the container has no height ceiling and the
+   body has no `overflow-y-auto`. When the user picks **Assign to Agent** the body
+   grows: an agent `Select` + the working-directory `InstancePicker` (one row per
+   online `(host, cwd)` instance — multiple rows for multiple instances) + a pin
+   note + a **Release** option (when already assigned). Enough content and the
+   total height exceeds a short viewport.
+2. **Because it is vertically centered**, once total height > viewport height the
+   card overflows the **top and bottom edges simultaneously**: the title is
+   clipped above the screen and the footer (`flex justify-end` Cancel/Assign in
+   `px-6 py-6 border-t`) is pushed below it — with no scrollbar that can reach
+   either. This is the "bottom buttons unreachable" symptom.
+3. **(Secondary)** `w-[400px]` is a fixed pixel width, so on a 360px-wide viewport
+   the card also overflows horizontally (there is no `max-w-[calc(100vw-2rem)]`
+   fallback). A mobile soft keyboard further shortens the visible viewport, making
+   the height symptom easier to trigger.
+
+The body-growth driver is the shared `InstancePicker`
+(`src/components/agent-presence/instance-picker.tsx`), a list that grows linearly
+with the number of online instances and has no height ceiling of its own.
+
+## What Changes
+
+Per the resolved elaboration (decisions A / B / B):
+
+- **(q1 = A) Centered card + capped height + internal scroll** — NOT full-screen.
+  The modals stay centered cards on every viewport; desktop appearance is
+  unchanged. A mobile-safe `max-height` (using `svh`/`dvh` dynamic viewport units,
+  soft-keyboard safe) plus a scrollable body solves the overflow, rather than the
+  `connections-modal.tsx` `h-dvh w-screen` full-screen approach.
+- **(q2 = B) Extract a reusable mobile-safe dialog skeleton** — the structure
+  "pinned Header + scrolling Body + pinned Footer + capped dynamic-viewport height
+  + narrow-viewport width fallback" becomes one reusable component (a new
+  `ScrollableDialog` family under `src/components/ui/`) with header / body / footer
+  slots. It is used by these two assign modals now and is available for other
+  modals later.
+- **(q3 = B) Built on shadcn `Dialog`** — the skeleton wraps shadcn
+  `DialogContent` (which already provides Esc / focus-trap / aria and a
+  `max-w-[calc(100%-2rem)]` narrow-viewport fallback, also fixing symptom 3), in
+  line with the CLAUDE.md "always use shadcn/ui" rule. The two hand-written cards
+  drop their `fixed top-1/2 -translate-y-1/2` backdrop+card and adopt the skeleton.
+
+This is a **pure UI / layout refactor**: all existing open/close wiring and the
+assignment / instance-pin business logic are preserved verbatim — only the modal
+shell and layout change.
+
+### Call-site contract is preserved
+
+All three call sites mount the modals conditionally
+(`{showAssignModal && <AssignIdeaModal onClose={…} />}`) with no `open` prop. The
+skeleton therefore self-drives `open={true}` internally and maps
+`onOpenChange(false)` (Esc / overlay / close button) to the existing `onClose`
+callback, so the parents
+(`ideas/idea-detail-panel.tsx`, `dashboard/panels/idea-detail-panel.tsx`,
+`dashboard/panels/basic-view.tsx`, `tasks/task-detail-panel.tsx`) need **no
+changes**.
+
+## Capabilities
+
+- **assign-modal-mobile-layout** — adds normative requirements that (a) a reusable
+  scrollable-dialog skeleton built on shadcn `Dialog` keeps its header and footer
+  pinned and visible while only its body scrolls, within a dynamic-viewport height
+  cap and a narrow-viewport width fallback; and (b) both the Assign Idea and Assign
+  Task modals adopt it so their title and Cancel / Assign controls remain visible
+  and clickable on any viewport, with the body scrollable to any row, without
+  changing assignment behavior.
+
+## Impact
+
+- Affected code (all frontend, no API / DB change):
+  - New `ScrollableDialog` skeleton component under `src/components/ui/` (built on
+    `@/components/ui/dialog`) + its unit tests.
+  - `src/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal.tsx` — adopts the
+    skeleton; business logic unchanged.
+  - `src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx` — adopts the
+    skeleton; business logic unchanged.
+- i18n: no new user-facing strings expected (the modals reuse their existing
+  keys); if any incidental string is added it goes into both `messages/en.json`
+  and `messages/zh.json`.
+- `docs/design.pen`: update the two assign-modal screens to the new
+  pinned-header/footer + scrolling-body layout (per the design-update convention).
+- Out of scope: the comment-area `@`-mention picker `MentionInstancePickerDialog`
+  (that is the separate idea `d3f31086`, slug `fix-mention-cwd-picker-mobile-overflow`);
+  the generic `src/components/assign-modal.tsx` (already mobile-safe); any change to
+  assignment, instance-pin, or wake business logic.

--- a/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/specs/assign-modal-mobile-layout/spec.md
+++ b/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/specs/assign-modal-mobile-layout/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: A reusable scrollable-dialog skeleton keeps header and footer pinned while only the body scrolls
+
+The project SHALL provide a reusable dialog skeleton, built on the shadcn `Dialog`
+primitive, that lays out a pinned header, a scrolling body, and a pinned footer
+inside a single height-capped, width-bounded container. The container's maximum
+height SHALL be expressed in a dynamic viewport unit (`svh` or `dvh`) so that it
+never exceeds the visible viewport when mobile browser chrome or a soft keyboard
+reduces it. The body region SHALL be the only scrollable region: when its content
+is taller than the available space it SHALL scroll internally (vertical
+overflow), while the header and footer remain fully visible and do not shrink. The
+container's width SHALL fall back to fit narrow viewports (no fixed pixel width
+that overflows a ~360px-wide screen). The skeleton SHALL inherit the shadcn
+`Dialog` accessibility and dismissal behavior (Escape to close, focus management,
+labelled dialog, overlay).
+
+#### Scenario: Body taller than the cap scrolls while header and footer stay pinned
+
+- **WHEN** the skeleton's body content is taller than the height-capped container
+- **THEN** the body scrolls internally and both the header and the footer remain
+  visible and clickable without being pushed outside the container
+
+#### Scenario: Height cap uses a dynamic viewport unit
+
+- **WHEN** the dialog is open on a viewport shortened by mobile browser chrome or a
+  soft keyboard
+- **THEN** the container's height is bounded by a dynamic viewport unit (`svh`/`dvh`)
+  so the whole dialog, including its footer, stays within the visible viewport
+
+#### Scenario: Narrow viewport does not overflow horizontally
+
+- **WHEN** the dialog is open on a viewport about 360px wide
+- **THEN** the dialog width fits within the viewport (a margin remains on both
+  sides) rather than overflowing horizontally
+
+### Requirement: Assign Idea and Assign Task modals stay fully operable on any viewport
+
+The Assign Idea modal and the Assign Task modal SHALL render using the reusable scrollable-dialog skeleton (`assign-idea-modal.tsx` and `assign-task-modal.tsx`). On any viewport size — including a short mobile viewport and a
+soft-keyboard-shortened viewport — the modal title and the footer Cancel and
+Assign controls SHALL remain visible and clickable, and the modal body SHALL be
+scrollable to any row regardless of how many online instances the working-directory
+picker lists or whether the Release option is present. This change SHALL be a
+pure UI/layout refactor: the existing assignment options (assign to self, to an
+agent with an optional instance pin, to another user, and release), the
+instance-pin behavior, the submit/CTA labeling, and the open/close contract with
+the existing call sites SHALL be preserved unchanged.
+
+#### Scenario: Long body on a short viewport keeps Cancel and Assign reachable
+
+- **WHEN** a user opens Assign Idea or Assign Task on a short mobile viewport,
+  selects "Assign to Agent", and the body grows with a multi-row instance picker
+  (and the Release option when already assigned)
+- **THEN** the title and the Cancel and Assign buttons stay visible and clickable,
+  and the user can scroll the body to reach every row
+
+#### Scenario: Assignment behavior is unchanged
+
+- **WHEN** a user completes an assignment through either modal (to self, to an
+  agent with or without an instance pin, to another user, or release)
+- **THEN** the same assignment action runs and the same result occurs as before the
+  layout refactor
+
+#### Scenario: Call sites are not changed
+
+- **WHEN** a parent that previously mounted the modal conditionally and passed only
+  an `onClose` callback continues to do so
+- **THEN** the modal opens and closes correctly (including via Escape, overlay
+  click, the close button, and Cancel) without any change to the call site
+
+#### Scenario: Desktop appearance is preserved
+
+- **WHEN** either modal is opened on a desktop-width viewport
+- **THEN** it renders as a centered card of the existing width with the existing
+  header, body, and footer styling

--- a/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/tasks.md
+++ b/openspec/changes/archive/2026-06-26-fix-assign-modals-mobile-overflow/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## 1. Build the reusable scrollable-dialog skeleton
+
+- [ ] 1.1 Add `src/components/ui/scrollable-dialog.tsx` composing shadcn `Dialog`:
+      flex-column `DialogContent` with `max-h-[85svh]`, `overflow-hidden`,
+      `sm:max-w-[400px]`; `shrink-0` header & footer slots; `min-h-0 flex-1
+      overflow-y-auto` body slot.
+- [ ] 1.2 Self-driving open contract: accept `open` / `onOpenChange`; keep shadcn
+      Esc / overlay / focus-trap / close button.
+- [ ] 1.3 Unit tests: body scrolls while header/footer pinned; `min-h-0` present;
+      `onOpenChange(false)` fires on close paths.
+
+## 2. Adopt the skeleton in both assign modals
+
+- [ ] 2.1 `assign-idea-modal.tsx`: replace the backdrop + fixed card shell with the
+      skeleton, mapping `onOpenChange(false) → onClose`; keep all hooks, state,
+      `handleSubmit`, `canSubmit`, `resolvePinLabel`, RadioGroup, Select,
+      InstancePicker, error block verbatim.
+- [ ] 2.2 `assign-task-modal.tsx`: same migration; business logic unchanged.
+- [ ] 2.3 Confirm all four call sites compile unchanged (no `open` prop added).
+
+## 3. Verify
+
+- [ ] 3.1 `pnpm lint`, `npx tsc --noEmit`, `pnpm test` all green.
+- [ ] 3.2 Playwright real-viewport checks: 375×667, 360×420 (soft keyboard), and
+      ≥3 instances + already-assigned — title + Cancel/Assign always visible &
+      clickable, body scrolls to any row, for both modals.
+- [ ] 3.3 Update `docs/design.pen` for the two assign-modal screens.

--- a/openspec/specs/assign-modal-mobile-layout/spec.md
+++ b/openspec/specs/assign-modal-mobile-layout/spec.md
@@ -1,0 +1,79 @@
+# assign-modal-mobile-layout Specification
+
+## Purpose
+TBD - created by archiving change fix-assign-modals-mobile-overflow. Update Purpose after archive.
+## Requirements
+### Requirement: A reusable scrollable-dialog skeleton keeps header and footer pinned while only the body scrolls
+
+The project SHALL provide a reusable dialog skeleton, built on the shadcn `Dialog`
+primitive, that lays out a pinned header, a scrolling body, and a pinned footer
+inside a single height-capped, width-bounded container. The container's maximum
+height SHALL be expressed in a dynamic viewport unit (`svh` or `dvh`) so that it
+never exceeds the visible viewport when mobile browser chrome or a soft keyboard
+reduces it. The body region SHALL be the only scrollable region: when its content
+is taller than the available space it SHALL scroll internally (vertical
+overflow), while the header and footer remain fully visible and do not shrink. The
+container's width SHALL fall back to fit narrow viewports (no fixed pixel width
+that overflows a ~360px-wide screen). The skeleton SHALL inherit the shadcn
+`Dialog` accessibility and dismissal behavior (Escape to close, focus management,
+labelled dialog, overlay).
+
+#### Scenario: Body taller than the cap scrolls while header and footer stay pinned
+
+- **WHEN** the skeleton's body content is taller than the height-capped container
+- **THEN** the body scrolls internally and both the header and the footer remain
+  visible and clickable without being pushed outside the container
+
+#### Scenario: Height cap uses a dynamic viewport unit
+
+- **WHEN** the dialog is open on a viewport shortened by mobile browser chrome or a
+  soft keyboard
+- **THEN** the container's height is bounded by a dynamic viewport unit (`svh`/`dvh`)
+  so the whole dialog, including its footer, stays within the visible viewport
+
+#### Scenario: Narrow viewport does not overflow horizontally
+
+- **WHEN** the dialog is open on a viewport about 360px wide
+- **THEN** the dialog width fits within the viewport (a margin remains on both
+  sides) rather than overflowing horizontally
+
+### Requirement: Assign Idea and Assign Task modals stay fully operable on any viewport
+
+The Assign Idea modal and the Assign Task modal SHALL render using the reusable scrollable-dialog skeleton (`assign-idea-modal.tsx` and `assign-task-modal.tsx`). On any viewport size — including a short mobile viewport and a
+soft-keyboard-shortened viewport — the modal title and the footer Cancel and
+Assign controls SHALL remain visible and clickable, and the modal body SHALL be
+scrollable to any row regardless of how many online instances the working-directory
+picker lists or whether the Release option is present. This change SHALL be a
+pure UI/layout refactor: the existing assignment options (assign to self, to an
+agent with an optional instance pin, to another user, and release), the
+instance-pin behavior, the submit/CTA labeling, and the open/close contract with
+the existing call sites SHALL be preserved unchanged.
+
+#### Scenario: Long body on a short viewport keeps Cancel and Assign reachable
+
+- **WHEN** a user opens Assign Idea or Assign Task on a short mobile viewport,
+  selects "Assign to Agent", and the body grows with a multi-row instance picker
+  (and the Release option when already assigned)
+- **THEN** the title and the Cancel and Assign buttons stay visible and clickable,
+  and the user can scroll the body to reach every row
+
+#### Scenario: Assignment behavior is unchanged
+
+- **WHEN** a user completes an assignment through either modal (to self, to an
+  agent with or without an instance pin, to another user, or release)
+- **THEN** the same assignment action runs and the same result occurs as before the
+  layout refactor
+
+#### Scenario: Call sites are not changed
+
+- **WHEN** a parent that previously mounted the modal conditionally and passed only
+  an `onClose` callback continues to do so
+- **THEN** the modal opens and closes correctly (including via Escape, overlay
+  click, the close button, and Cancel) without any change to the call site
+
+#### Scenario: Desktop appearance is preserved
+
+- **WHEN** either modal is opened on a desktop-width viewport
+- **THEN** it renders as a centered card of the existing width with the existing
+  header, body, and footer styling
+

--- a/src/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal.tsx
@@ -3,8 +3,12 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { X, Bot, User, Loader2, Info } from "lucide-react";
+import { Bot, User, Loader2, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  ScrollableDialog,
+  ScrollableDialogTitle,
+} from "@/components/ui/scrollable-dialog";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
@@ -200,31 +204,52 @@ export function AssignIdeaModal({
     (selectedOption === "release" && isAssigned);
 
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-50 bg-black/40"
-        onClick={onClose}
-      />
-
-      {/* Modal */}
-      <div className="fixed left-1/2 top-1/2 z-50 w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white shadow-xl border border-[#E5E0D8]">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-[#E5E0D8] px-6 py-5">
-          <h2 className="text-base font-semibold text-[#2C2C2C]">
-            {t("ideas.assignIdea")}
-          </h2>
-          <button
+    // Mobile-safe shell: ScrollableDialog (shadcn Dialog) keeps the title and the
+    // footer Cancel/Assign pinned and the body scrollable within a dynamic-viewport
+    // height cap. Conditionally mounted by the parent (no `open` prop there), so we
+    // render it always-open and route every close path back to onClose.
+    <ScrollableDialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      className="bg-white sm:max-w-[400px]"
+      header={
+        <ScrollableDialogTitle className="text-base font-semibold text-[#2C2C2C]">
+          {t("ideas.assignIdea")}
+        </ScrollableDialogTitle>
+      }
+      footer={
+        <div className="flex w-full items-center justify-end gap-4">
+          <Button
+            variant="outline"
             onClick={onClose}
-            className="text-[#9A9A9A] hover:text-[#6B6B6B] transition-colors"
+            disabled={isLoading}
+            className="border-[#E5E0D8]"
           >
-            <X className="h-5 w-5" />
-          </button>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isLoading || !canSubmit}
+            className="bg-[#C67A52] hover:bg-[#B56A42] text-white"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : selectedOption === "release" ? (
+              t("common.release")
+            ) : (
+              // When an instance is pinned the CTA names the resolved (path · host)
+              // target; otherwise the plain label.
+              resolvePinLabel()
+            )}
+          </Button>
         </div>
-
-        {/* Body */}
-        <div className="p-6 space-y-4">
-          {/* Idea Info */}
+      }
+      bodyClassName="space-y-4"
+    >
+      {/* Body */}
+      {/* Idea Info */}
           <div className="rounded-lg bg-[#FAF8F4] p-3">
             <p className="text-[13px] font-medium text-[#2C2C2C]">{idea.title}</p>
             {idea.content && (
@@ -313,7 +338,7 @@ export function AssignIdeaModal({
                       <SelectTrigger className="w-full border-[#E5E0D8]">
                         <SelectValue placeholder={t("ideas.selectPmAgent")} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="z-[120]">
                         {agents.length > 0 ? (
                           agents.map((agent) => (
                             <SelectItem key={agent.uuid} value={agent.uuid}>
@@ -400,7 +425,7 @@ export function AssignIdeaModal({
                       <SelectTrigger className="w-full border-[#E5E0D8]">
                         <SelectValue placeholder={t("tasks.selectUser")} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="z-[120]">
                         {users.length > 0 ? (
                           users.map((user) => (
                             <SelectItem key={user.uuid} value={user.uuid}>
@@ -444,35 +469,6 @@ export function AssignIdeaModal({
               )}
             </RadioGroup>
           )}
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-end gap-4 rounded-b-2xl bg-white px-6 py-6 border-t border-[#E5E0D8]">
-          <Button
-            variant="outline"
-            onClick={onClose}
-            disabled={isLoading}
-            className="border-[#E5E0D8]"
-          >
-            {t("common.cancel")}
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={isLoading || !canSubmit}
-            className="bg-[#C67A52] hover:bg-[#B56A42] text-white"
-          >
-            {isLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : selectedOption === "release" ? (
-              t("common.release")
-            ) : (
-              // When an instance is pinned the CTA names the resolved (path · host)
-              // target; otherwise the plain label.
-              resolvePinLabel()
-            )}
-          </Button>
-        </div>
-      </div>
-    </>
+    </ScrollableDialog>
   );
 }

--- a/src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx
@@ -3,8 +3,12 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { X, Bot, User, Loader2, Info } from "lucide-react";
+import { Bot, User, Loader2, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  ScrollableDialog,
+  ScrollableDialogTitle,
+} from "@/components/ui/scrollable-dialog";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
@@ -205,31 +209,52 @@ export function AssignTaskModal({
     (selectedOption === "release" && isAssigned);
 
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-50 bg-black/40"
-        onClick={onClose}
-      />
-
-      {/* Modal */}
-      <div className="fixed left-1/2 top-1/2 z-50 w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white shadow-xl border border-[#E5E0D8]">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-[#E5E0D8] px-6 py-5">
-          <h2 className="text-base font-semibold text-[#2C2C2C]">
-            {t("tasks.assignTask")}
-          </h2>
-          <button
+    // Mobile-safe shell: ScrollableDialog (shadcn Dialog) keeps the title and the
+    // footer Cancel/Assign pinned and the body scrollable within a dynamic-viewport
+    // height cap. Conditionally mounted by the parent (no `open` prop there), so we
+    // render it always-open and route every close path back to onClose.
+    <ScrollableDialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      className="bg-white sm:max-w-[400px]"
+      header={
+        <ScrollableDialogTitle className="text-base font-semibold text-[#2C2C2C]">
+          {t("tasks.assignTask")}
+        </ScrollableDialogTitle>
+      }
+      footer={
+        <div className="flex w-full items-center justify-end gap-4">
+          <Button
+            variant="outline"
             onClick={onClose}
-            className="text-[#9A9A9A] hover:text-[#6B6B6B] transition-colors"
+            disabled={isLoading}
+            className="border-[#E5E0D8]"
           >
-            <X className="h-5 w-5" />
-          </button>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isLoading || !canSubmit}
+            className="bg-[#C67A52] hover:bg-[#B56A42] text-white"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : selectedOption === "release" ? (
+              t("common.release")
+            ) : (
+              // When an instance is pinned the CTA names the resolved (path · host)
+              // target (cwd-addressable instances, T4); otherwise the plain label.
+              resolvePinLabel()
+            )}
+          </Button>
         </div>
-
-        {/* Body */}
-        <div className="p-6 space-y-4">
-          {/* Task Info */}
+      }
+      bodyClassName="space-y-4"
+    >
+      {/* Body */}
+      {/* Task Info */}
           <div className="rounded-lg bg-[#FAF8F4] p-3">
             <p className="text-[13px] font-medium text-[#2C2C2C]">{task.title}</p>
             {task.description && (
@@ -318,7 +343,7 @@ export function AssignTaskModal({
                       <SelectTrigger className="w-full border-[#E5E0D8]">
                         <SelectValue placeholder={t("tasks.selectAgent")} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="z-[120]">
                         {agents.length > 0 ? (
                           agents.map((agent) => (
                             <SelectItem key={agent.uuid} value={agent.uuid}>
@@ -402,7 +427,7 @@ export function AssignTaskModal({
                       <SelectTrigger className="w-full border-[#E5E0D8]">
                         <SelectValue placeholder={t("tasks.selectUser")} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="z-[120]">
                         {users.length > 0 ? (
                           users.map((user) => (
                             <SelectItem key={user.uuid} value={user.uuid}>
@@ -446,35 +471,6 @@ export function AssignTaskModal({
               )}
             </RadioGroup>
           )}
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-end gap-4 rounded-b-2xl bg-white px-6 py-6 border-t border-[#E5E0D8]">
-          <Button
-            variant="outline"
-            onClick={onClose}
-            disabled={isLoading}
-            className="border-[#E5E0D8]"
-          >
-            {t("common.cancel")}
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={isLoading || !canSubmit}
-            className="bg-[#C67A52] hover:bg-[#B56A42] text-white"
-          >
-            {isLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : selectedOption === "release" ? (
-              t("common.release")
-            ) : (
-              // When an instance is pinned the CTA names the resolved (path · host)
-              // target (cwd-addressable instances, T4); otherwise the plain label.
-              resolvePinLabel()
-            )}
-          </Button>
-        </div>
-      </div>
-    </>
+    </ScrollableDialog>
   );
 }

--- a/src/components/ui/__tests__/scrollable-dialog.test.tsx
+++ b/src/components/ui/__tests__/scrollable-dialog.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+//
+// ScrollableDialog — the reusable mobile-safe dialog skeleton. This test pins the
+// LAYOUT CONTRACT that prevents the "modal taller than the viewport, footer
+// unreachable" bug (fix-assign-modals-mobile-overflow):
+//
+//   - the DialogContent caps its height with a DYNAMIC small-viewport unit
+//     (max-h-[85svh]) — not a static `vh` — and is a flex column with
+//     overflow-hidden, so it can never grow taller than the visible
+//     (soft-keyboard-shortened) viewport;
+//   - the header and footer are shrink-0 siblings OUTSIDE the scroll region, so
+//     they stay visible and tappable however tall the body;
+//   - the body is the ONE overflow-y-auto scroll region with `min-h-0 flex-1`, so
+//     long content scrolls inside the dialog rather than pushing the footer off;
+//   - the controlled open contract forwards onOpenChange(false) on close paths.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
+
+import {
+  ScrollableDialog,
+  ScrollableDialogTitle,
+} from "@/components/ui/scrollable-dialog";
+
+// The Radix DialogContent node carries data-slot="dialog-content".
+function dialogContent(): HTMLElement {
+  const el = document.querySelector('[data-slot="dialog-content"]');
+  if (!el) throw new Error("dialog-content not rendered");
+  return el as HTMLElement;
+}
+
+function renderDialog(
+  props: Partial<React.ComponentProps<typeof ScrollableDialog>> = {},
+) {
+  const onOpenChange = props.onOpenChange ?? vi.fn();
+  render(
+    <ScrollableDialog
+      open
+      onOpenChange={onOpenChange}
+      header={<ScrollableDialogTitle>Assign</ScrollableDialogTitle>}
+      footer={
+        <>
+          <button type="button">Cancel</button>
+          <button type="button">Assign</button>
+        </>
+      }
+      {...props}
+    >
+      <div data-testid="body-content">
+        {Array.from({ length: 20 }, (_, i) => (
+          <p key={i}>row {i}</p>
+        ))}
+      </div>
+    </ScrollableDialog>,
+  );
+  return { onOpenChange };
+}
+
+describe("ScrollableDialog — mobile-safe layout", () => {
+  afterEach(() => cleanup());
+
+  it("caps height with a dynamic small-viewport unit and lays out as a flex column with overflow-hidden", () => {
+    renderDialog();
+    const content = dialogContent();
+    // Dynamic viewport unit (svh/dvh) — NOT a static `vh` (the bug's root cause).
+    expect(content.className).toMatch(/max-h-\[\d+(svh|dvh)\]/);
+    expect(content.className).not.toMatch(/max-h-\[\d+vh\]/);
+    expect(content.className).toContain("flex");
+    expect(content.className).toContain("flex-col");
+    expect(content.className).toContain("overflow-hidden");
+  });
+
+  it("puts the body in the only overflow-y-auto scroll region, with header and footer outside it", () => {
+    renderDialog();
+    const content = dialogContent();
+
+    // Exactly one scroll region directly under the content.
+    const scrollRegions = [...content.querySelectorAll(":scope > .overflow-y-auto")];
+    expect(scrollRegions).toHaveLength(1);
+    const scroll = scrollRegions[0] as HTMLElement;
+    // min-h-0 + flex-1 is what lets the flex child shrink and actually scroll.
+    expect(scroll.className).toContain("min-h-0");
+    expect(scroll.className).toContain("flex-1");
+
+    // The body content lives INSIDE the scroll region.
+    expect(within(scroll).getByTestId("body-content")).toBeTruthy();
+
+    // The footer (with Cancel + Assign) is a SIBLING of the scroll region, never
+    // inside it — so it can't be scrolled away — and is shrink-0.
+    const footer = content.querySelector('[data-slot="dialog-footer"]') as HTMLElement;
+    expect(footer).toBeTruthy();
+    expect(scroll.contains(footer)).toBe(false);
+    expect(footer.className).toContain("shrink-0");
+    const assign = within(footer).getByRole("button", { name: "Assign" });
+    expect(scroll.contains(assign)).toBe(false);
+
+    // The header is also a shrink-0 sibling outside the scroll region.
+    const header = content.querySelector('[data-slot="dialog-header"]') as HTMLElement;
+    expect(header.className).toContain("shrink-0");
+    expect(scroll.contains(header)).toBe(false);
+  });
+
+  it("lifts BOTH the content and the overlay above a z-50 side panel by default", () => {
+    renderDialog();
+    const content = dialogContent();
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
+    expect(overlay).toBeTruthy();
+
+    const zOf = (el: HTMLElement) => {
+      const m = el.className.match(/(?:^|\s)z-\[(\d+)\]/);
+      return m ? Number(m[1]) : NaN;
+    };
+    expect(zOf(content)).toBeGreaterThan(50);
+    expect(zOf(overlay)).toBeGreaterThan(50);
+  });
+
+  it("forwards onOpenChange(false) when the close button is clicked", () => {
+    const { onOpenChange } = renderDialog();
+    // The shadcn corner close button has the sr-only label "Close".
+    const close = screen.getByRole("button", { name: "Close" });
+    fireEvent.click(close);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders an accessible dialog with the provided title", () => {
+    renderDialog();
+    // Radix wires the title as the dialog's accessible name.
+    expect(screen.getByRole("dialog", { name: "Assign" })).toBeTruthy();
+  });
+});

--- a/src/components/ui/scrollable-dialog.tsx
+++ b/src/components/ui/scrollable-dialog.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+// ScrollableDialog — a reusable, mobile-safe dialog skeleton built on the shadcn
+// `Dialog` primitive. It solves the recurring "modal taller than the viewport,
+// footer buttons unreachable" bug once, in one place, so individual modals don't
+// each have to re-derive the flex-column + dynamic-viewport-cap recipe (and don't
+// each re-introduce the bug by forgetting `min-h-0`).
+//
+// Layout contract (the actual fix):
+//   - The DialogContent is a FLEX COLUMN capped to `max-h-[85svh]` — a DYNAMIC
+//     small-viewport unit that shrinks with the mobile soft keyboard / URL bar,
+//     unlike a static `vh` which tracks only the layout viewport (that static unit
+//     was the original bug). `overflow-hidden` confines all scrolling to the body.
+//   - Header and Footer are `shrink-0` siblings, so they NEVER compress and stay
+//     visible + tappable however tall the body content is.
+//   - The Body is the ONE scroll region: `min-h-0 flex-1 overflow-y-auto`. The
+//     `min-h-0` is REQUIRED — a flex child defaults to `min-height:auto`, which
+//     lets it grow past the cap and re-push the footer off-screen (exactly the bug
+//     this component exists to prevent).
+//   - Width falls back to the shadcn base `max-w-[calc(100%-2rem)]` on narrow
+//     viewports; callers pass `sm:max-w-[...]` to set the desktop width.
+//
+// Stacking: these dialogs are often opened from inside a `fixed z-50` side panel.
+// The default Dialog overlay+content are also `z-50`, so the dialog would only sit
+// above the panel by PAINT ORDER — a tie some mobile browsers resolve the other
+// way, leaving the panel painted over the dialog (title occluded, footer untappable).
+// So BOTH the content and the overlay default to `z-[110]` (the same high band the
+// @mention picker uses), overridable via `zIndexClassName` for callers that don't
+// need the lift.
+//
+// Open contract: this is a thin controlled wrapper — it forwards `open` /
+// `onOpenChange` straight to `Dialog`, so Esc, overlay-click, focus-trap, and the
+// shadcn close button all keep working. Callers that mount conditionally (and thus
+// have no `open` state) render it with `open` hard-true and map `onOpenChange(false)`
+// back to their own `onClose`.
+
+import * as React from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+export interface ScrollableDialogProps {
+  /** Controlled open state — forwarded verbatim to the shadcn `Dialog`. */
+  open: boolean;
+  /**
+   * Open-state change callback — forwarded to `Dialog`. Fires with `false` on
+   * every dismissal path (Esc, overlay click, the close button). Conditionally
+   * mounted callers map `(o) => { if (!o) onClose(); }`.
+   */
+  onOpenChange: (open: boolean) => void;
+  /** Header slot — typically a `<ScrollableDialogTitle>` (+ optional description). */
+  header: React.ReactNode;
+  /** Footer slot — typically the action buttons (Cancel / confirm). */
+  footer: React.ReactNode;
+  /** Body content — the ONLY scroll region; grows/scrolls within the height cap. */
+  children: React.ReactNode;
+  /** Extra classes on the DialogContent (e.g. `sm:max-w-[400px]` for desktop width). */
+  className?: string;
+  /** Extra classes on the body scroll region. */
+  bodyClassName?: string;
+  /**
+   * z-index class applied to BOTH the content and the overlay. Defaults to
+   * `z-[110]` so the dialog clears a `fixed z-50` side panel by z-index, not paint
+   * order. Pass `undefined` to fall back to the shadcn default `z-50`.
+   */
+  zIndexClassName?: string;
+  /** Whether to render the shadcn corner close button. Defaults to true. */
+  showCloseButton?: boolean;
+}
+
+/**
+ * Mobile-safe scrollable dialog: pinned header + scrolling body + pinned footer,
+ * capped to the dynamic small-viewport height. See the module header for the full
+ * layout + stacking contract.
+ */
+export function ScrollableDialog({
+  open,
+  onOpenChange,
+  header,
+  footer,
+  children,
+  className,
+  bodyClassName,
+  zIndexClassName = "z-[110]",
+  showCloseButton = true,
+}: ScrollableDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        // Flex column, capped to the dynamic small-viewport height, scroll confined
+        // to the body. `gap-0` because the slots own their own spacing/borders.
+        className={cn(
+          "flex max-h-[85svh] flex-col gap-0 overflow-hidden p-0",
+          zIndexClassName,
+          className,
+        )}
+        overlayClassName={zIndexClassName}
+        showCloseButton={showCloseButton}
+      >
+        {/* Pinned header — never compresses, never scrolls away. */}
+        <DialogHeader className="shrink-0 border-b border-[#E5E0D8] px-6 py-5 text-left">
+          {header}
+        </DialogHeader>
+
+        {/* The ONE scroll region. `min-h-0` is what lets this flex child shrink
+            below its content height and actually scroll, instead of growing past
+            the cap and pushing the footer off-screen. */}
+        <div
+          className={cn("min-h-0 flex-1 overflow-y-auto px-6 py-4", bodyClassName)}
+        >
+          {children}
+        </div>
+
+        {/* Pinned footer — stays visible + tappable however tall the body is. */}
+        <DialogFooter className="shrink-0 border-t border-[#E5E0D8] px-6 py-5">
+          {footer}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Accessible dialog title for the header slot. Re-exported from the shadcn
+ * primitive so callers import the whole skeleton from one module. A dialog MUST
+ * render one (Radix warns otherwise); wrap it in a visually-hidden span if the
+ * design has no visible title.
+ */
+export const ScrollableDialogTitle = DialogTitle;
+
+/** Optional description line for the header slot (re-exported for convenience). */
+export const ScrollableDialogDescription = DialogDescription;


### PR DESCRIPTION
## Summary
- The two hand-written assign modals (`assign-idea-modal.tsx`, `assign-task-modal.tsx`) used a fixed, vertically-centered card with no max-height and no internal scroll. On short mobile viewports (or with a soft keyboard) a long body — agent select + multi-instance working-directory picker + Release option — overflowed both viewport edges and pushed the footer **Assign / Cancel** off-screen with no way to scroll to them.
- Extract a reusable **`ScrollableDialog`** skeleton (`src/components/ui/scrollable-dialog.tsx`) built on shadcn `Dialog`: flex-column `DialogContent` capped at `max-h-[85svh]`, `overflow-hidden`, pinned `shrink-0` header, `min-h-0 flex-1 overflow-y-auto` body (the one scroll region), pinned footer.
- Adopt it in both assign modals as a **pure UI refactor** — all assignment / instance-pin logic and the four conditional-mount call sites unchanged.

## Details
- **Decisions** (from idea elaboration): centered capped card, *not* full-screen (q1=A); reusable skeleton, not per-modal patch (q2=B); built on shadcn `Dialog` (q3=B).
- `svh` (small dynamic viewport unit) is soft-keyboard safe; static `vh` was the original bug.
- Migrating to shadcn `Dialog` also fixes the secondary `w-[400px]` horizontal-overflow on ~360px viewports (base `max-w-[calc(100%-2rem)]`) and adds Esc / focus-trap / aria for free.
- **z-index:** the overlay sits at `z-[110]` to clear the fixed `z-50` detail side panel; the agent/user `Select` dropdowns are lifted to `z-[120]` so the portaled poppers stay above the overlay (regression found + fixed via real-viewport Playwright verification).

## Changed files
| File | Change |
|------|--------|
| `src/components/ui/scrollable-dialog.tsx` | New reusable mobile-safe dialog skeleton |
| `src/components/ui/__tests__/scrollable-dialog.test.tsx` | New unit tests (5) for the layout contract |
| `src/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal.tsx` | Adopt ScrollableDialog; Select → z-[120] |
| `src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx` | Adopt ScrollableDialog; Select → z-[120] |
| `openspec/specs/assign-modal-mobile-layout/spec.md` + archived change | OpenSpec spec (archived) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — full suite green (incl. 5 new ScrollableDialog tests; idea/task detail-panel call-site tests unaffected)
- [x] `pnpm lint` — 0 new errors (2 pre-existing `daemonClient` errors + `projectUuid` warnings unrelated to this change)
- [x] Real-browser Playwright verification of **both** modals across **375×667**, **360×420 (soft keyboard)**, **≥3 online instances + already-assigned**, and **desktop** — title + Cancel/Assign always visible & clickable, body scrolls to any row, no horizontal overflow, desktop unchanged (centered 400px card)
- [ ] `docs/design.pen` refresh — deferred to follow-up (Pencil unavailable in headless run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)