### PR TITLE
docs(daemon): fix stale CLI help, document daemon.json, show config path on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,47 @@ chorus daemon logs               # View daemon logs
 - **Claude Code integration** — Auto-detects `claude` CLI on your PATH
 - **Background mode** — Run with `-d` flag; manage with `stop/restart/logs`
 - **Permission modes** — Default is full access (yolo); use `--chorus-only` to restrict to Chorus MCP tools only
+- **Multi-path** — Serve several working directories from one daemon with repeatable `--cwd` (see below)
 - **Interactive setup** — Prompts for credentials on first start if not already configured
 
 The daemon requires authentication. Run `chorus login` first, or it will prompt for credentials interactively on first start (if running in a terminal).
+
+#### Serve multiple working directories
+
+One daemon can serve several local working directories at once — each declared path registers as an independent connection (its own session + wake loop) under the same agent. A path is **just** a directory the daemon serves; it carries no project binding.
+
+```bash
+chorus daemon --cwd ~/work/repo-a --cwd ~/work/repo-b   # repeatable flag
+CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # or env (`:`- or `,`-separated)
+```
+
+With no `--cwd`, the daemon serves the single directory it was launched from.
+
+#### Configuration file — `~/.chorus/daemon.json`
+
+`chorus login` writes credentials here (mode `0600`). You can also add daemon tunables to the **same** file. Every field is optional; flags and environment variables always take precedence over the file.
+
+```json
+{
+  "url": "https://chorus.example.com",
+  "apiKey": "cho_xxxxxxxxxxxxxxxxxxxxxxxx",
+  "agentUuid": "00000000-0000-0000-0000-000000000000",
+  "agentName": "My Daemon Agent",
+  "cwds": ["~/work/repo-a", "~/work/repo-b"],
+  "sigintTimeoutMs": 10000
+}
+```
+
+| Field | Type | Written by / used for | Precedence (highest first) |
+|-------|------|-----------------------|----------------------------|
+| `url` | string | Remote Chorus server URL | `--url` flag → `CHORUS_URL` → file |
+| `apiKey` | string | Agent API key (`cho_…`) | `--api-key` flag → `CHORUS_API_KEY` → file |
+| `agentUuid` / `agentName` | string | Authenticated identity (recorded at login) | written by `chorus login` |
+| `cwds` | string[] | Working directories the daemon serves (multi-path) | `--cwd` flag(s) → `CHORUS_DAEMON_CWDS` → file → launch dir |
+| `sigintTimeoutMs` | number | Grace window (ms) after SIGINT before a forceful kill (default `10000`) | `--sigint-timeout` flag → `CHORUS_DAEMON_SIGINT_TIMEOUT` → file → `10000` |
+| `yoloAckAt` | string | Internal — timestamp of a TTY yolo confirmation (managed automatically) | — |
+
+On startup the daemon banner prints the **exact `daemon.json` path it read** (and whether the file exists), so you always know which file to edit.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -114,9 +114,47 @@ chorus daemon logs               # 查看 daemon 日志
 - **Claude Code 集成** — 自动检测 PATH 中的 `claude` CLI
 - **后台模式** — 使用 `-d` 标志后台运行；用 `stop/restart/logs` 管理
 - **权限模式** — 默认完全访问（yolo）；使用 `--chorus-only` 限制为仅 Chorus MCP 工具
+- **多路径** — 用可重复的 `--cwd` 让单个 daemon 同时服务多个工作目录（见下文）
 - **交互式设置** — 首次启动时如未配置凭证会提示输入
 
 daemon 需要先认证。首次使用请先运行 `chorus login`，或者 daemon 会在首次启动时交互式提示输入凭证（如果在终端中运行）。
+
+#### 服务多个工作目录
+
+一个 daemon 可以同时服务多个本地工作目录——每个声明的路径会注册为一条独立连接（各自拥有会话与唤起循环），归属同一个 Agent。路径**仅仅**是 daemon 服务的目录，不携带任何项目绑定。
+
+```bash
+chorus daemon --cwd ~/work/repo-a --cwd ~/work/repo-b   # 可重复传入
+CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # 或用环境变量（`:` 或 `,` 分隔）
+```
+
+不传 `--cwd` 时，daemon 只服务它的启动目录这一个路径。
+
+#### 配置文件 —— `~/.chorus/daemon.json`
+
+`chorus login` 会把凭证写入此文件（权限 `0600`）。你也可以把 daemon 的调优项写进**同一个**文件。所有字段都是可选的；命令行参数和环境变量的优先级始终高于文件。
+
+```json
+{
+  "url": "https://chorus.example.com",
+  "apiKey": "cho_xxxxxxxxxxxxxxxxxxxxxxxx",
+  "agentUuid": "00000000-0000-0000-0000-000000000000",
+  "agentName": "My Daemon Agent",
+  "cwds": ["~/work/repo-a", "~/work/repo-b"],
+  "sigintTimeoutMs": 10000
+}
+```
+
+| 字段 | 类型 | 写入方 / 用途 | 优先级（从高到低） |
+|------|------|---------------|--------------------|
+| `url` | string | 远程 Chorus 服务器 URL | `--url` 参数 → `CHORUS_URL` → 文件 |
+| `apiKey` | string | Agent API Key（`cho_…`） | `--api-key` 参数 → `CHORUS_API_KEY` → 文件 |
+| `agentUuid` / `agentName` | string | 认证身份（登录时记录） | 由 `chorus login` 写入 |
+| `cwds` | string[] | daemon 服务的工作目录（多路径） | `--cwd` 参数 → `CHORUS_DAEMON_CWDS` → 文件 → 启动目录 |
+| `sigintTimeoutMs` | number | SIGINT 后强制结束前的宽限窗口（毫秒，默认 `10000`） | `--sigint-timeout` 参数 → `CHORUS_DAEMON_SIGINT_TIMEOUT` → 文件 → `10000` |
+| `yoloAckAt` | string | 内部字段——TTY 下 yolo 确认的时间戳（自动管理） | — |
+
+daemon 启动时的横幅会打印它**实际读取的 `daemon.json` 路径**（以及该文件是否存在），让你随时清楚该编辑哪个文件。
 
 ---
 

--- a/chorus.mjs
+++ b/chorus.mjs
@@ -163,10 +163,13 @@ ENVIRONMENT VARIABLES
 DAEMON / LOGIN (client mode)
   --url <url>              Remote Chorus server URL      (env: CHORUS_URL)
   --api-key <cho_...>      Agent API key                 (env: CHORUS_API_KEY)
-  --yolo                   Give the woken Claude FULL permissions             (env: CHORUS_YOLO=1)
+  --chorus-only            Restrict the woken Claude to Chorus MCP tools only  (env: CHORUS_CHORUS_ONLY=1)
+                           (comment/claim/report/status — no Bash / file edits).
+                           Opt out of the default full-autonomy posture.
+  --yolo                   Full autonomy for the woken Claude — the DEFAULT     (env: CHORUS_YOLO=1)
                            (--dangerously-skip-permissions: Bash, file writes,
-                           any command). Default is Chorus-MCP-tools-only.
-  --sigint-timeout <ms>    Grace window after SIGINT before a forceful kill   (env: CHORUS_DAEMON_SIGINT_TIMEOUT)
+                           any command). Already on unless --chorus-only is set.
+  --sigint-timeout <ms>    Grace window after SIGINT before a forceful kill    (env: CHORUS_DAEMON_SIGINT_TIMEOUT)
                            when an interrupt is received (default: 10000).
                            Also configurable via ~/.chorus/daemon.json sigintTimeoutMs.
 
@@ -174,9 +177,9 @@ DAEMON / LOGIN (client mode)
   ~/.chorus/daemon.json (from 'chorus login') > Claude Code plugin config.
 
   The daemon spawns the local 'claude' CLI headlessly per task dispatch; it must
-  be on PATH. Override with CHORUS_CLAUDE_PATH. By default the woken Claude may
-  use only Chorus MCP tools (comment/claim/report/status) — pass --yolo for full
-  autonomy (real code-writing AI-DLC), which is dangerous: run it sandboxed.
+  be on PATH. Override with CHORUS_CLAUDE_PATH. By default the woken Claude runs
+  with FULL autonomy (real code-writing AI-DLC), which is dangerous: run it
+  sandboxed, or pass --chorus-only to restrict it to Chorus MCP tools.
 
 EXAMPLES
   chorus                                     # Embedded PGlite (default)
@@ -184,8 +187,8 @@ EXAMPLES
   chorus --data-dir /var/lib/chorus          # Custom data directory
   DATABASE_URL=postgres://... chorus --use-pglite=false   # External PostgreSQL
   chorus login                               # Interactive: validate key, save credentials
-  chorus daemon                              # Connect & wake local Claude Code (Chorus tools only)
-  chorus daemon --yolo                       # Full autonomy: woken Claude can run Bash / edit files
+  chorus daemon                              # Connect & wake local Claude Code (full autonomy by default)
+  chorus daemon --chorus-only                # Restrict the woken Claude to Chorus MCP tools only
   CHORUS_URL=https://... CHORUS_API_KEY=cho_... chorus daemon
 `);
   process.exit(0);

--- a/cli/__tests__/daemon-banner.test.mjs
+++ b/cli/__tests__/daemon-banner.test.mjs
@@ -74,6 +74,24 @@ describe("bannerRows", () => {
     const perm = rows.find(([k]) => k === "Permission")[1];
     expect(perm).toMatch(/chorus-only/);
   });
+
+  it("shows the daemon.json config path when one is provided", () => {
+    const rows = bannerRows({ ...INFO, configPath: "/home/u/.chorus/daemon.json", configExists: true });
+    const config = rows.find(([k]) => k === "Config")[1];
+    expect(config).toBe("/home/u/.chorus/daemon.json");
+  });
+
+  it("flags an absent config file so the operator knows it fell back to flags/env", () => {
+    const rows = bannerRows({ ...INFO, configPath: "/home/u/.chorus/daemon.json", configExists: false });
+    const config = rows.find(([k]) => k === "Config")[1];
+    expect(config).toContain("/home/u/.chorus/daemon.json");
+    expect(config).toMatch(/not found/i);
+  });
+
+  it("omits the Config row entirely when no path is known", () => {
+    const rows = bannerRows(INFO);
+    expect(rows.find(([k]) => k === "Config")).toBeUndefined();
+  });
 });
 
 describe("resolveAgentType", () => {

--- a/cli/daemon-banner.mjs
+++ b/cli/daemon-banner.mjs
@@ -19,6 +19,8 @@
  * @property {string} agentType        local agent backend (e.g. claude-code).
  * @property {string|null} claudePath  resolved claude path, or null when not found.
  * @property {string} [connection]     connection state line (default "connecting…").
+ * @property {string} [configPath]     absolute path to the daemon.json the CLI reads.
+ * @property {boolean} [configExists]  whether that daemon.json exists on disk.
  */
 
 /** Right-pad to width (banner box alignment). */
@@ -38,7 +40,7 @@ export function bannerRows(info) {
       ? "YOLO ⚠  (full autonomy — Bash/write/any command)"
       : "chorus-only (Chorus MCP tools only)";
   const claude = info.claudePath ? `found: ${info.claudePath}` : "NOT FOUND — install `claude` or set CHORUS_CLAUDE_PATH";
-  return [
+  const rows = [
     ["Version", `chorus v${info.version}`],
     ["Server", info.url],
     ["Agent", `${info.agentName} (${info.agentUuid})`],
@@ -48,6 +50,14 @@ export function bannerRows(info) {
     ["Connection", info.connection ?? "connecting…"],
     ["claude CLI", claude],
   ];
+  // Config file row — shown only when the path is known. Tells the operator
+  // exactly which daemon.json the CLI read (and whether it exists), so a
+  // mis-located or absent config is obvious at a glance.
+  if (info.configPath) {
+    const exists = info.configExists ? "" : " (not found — using flags/env/defaults)";
+    rows.push(["Config", `${info.configPath}${exists}`]);
+  }
+  return rows;
 }
 
 /**

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -12,7 +12,7 @@
 // NOT done here — the no-op UploadHooks reserve those seams for the derived
 // observability idea.
 
-import { resolveCredentials } from "./credentials.mjs";
+import { resolveCredentials, loginFilePath } from "./credentials.mjs";
 import { prompt, writeLoginFile } from "./login.mjs";
 import {
   resolvePermissionMode,
@@ -44,7 +44,7 @@ import {
   isRunning,
   readLog,
 } from "./daemon-lifecycle.mjs";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -415,6 +415,12 @@ export async function runDaemon(flags = {}, deps = {}) {
   // resolved path (or absence) is shown in the banner below.
   const claudePath = findClaude();
 
+  // The daemon.json the layered config readers (credentials, sigint timeout, cwds)
+  // consult. Surfacing its absolute path + presence in the banner makes it obvious
+  // which file to edit for `cwds` / `sigintTimeoutMs` and whether one exists at all.
+  const configPath = loginFilePath();
+  const configExists = existsSync(configPath);
+
   // Boxed startup banner — one screen replacing the scattered [Chorus] lines.
   log(
     formatBanner(
@@ -428,6 +434,8 @@ export async function runDaemon(flags = {}, deps = {}) {
         agentType,
         claudePath,
         connection: "connecting…",
+        configPath,
+        configExists,
       },
       { isTTY: isTTY && Boolean(process.stdout.isTTY) }
     )


### PR DESCRIPTION
## Summary
Three related daemon-CLI documentation/UX fixes, requested via the Chorus daemon UI.

- **Fix stale top-level help.** `chorus --help` still described the *old* permission model — "default is Chorus-MCP-tools-only, pass `--yolo` for full autonomy". The default flipped to **yolo (full autonomy)** with `--chorus-only` as the opt-out (see `cli/daemon-permission-mode.mjs`); the subcommand help was already correct, but the top-level help was not. Now consistent.
- **Document `daemon.json` + multi-path in both READMEs.** Added a "Serve multiple working directories" subsection (`--cwd` repeatable flag / `CHORUS_DAEMON_CWDS`) and a "Configuration file — `~/.chorus/daemon.json`" subsection with a JSON example and a field table (type · purpose · precedence) covering `url`, `apiKey`, `agentUuid`/`agentName`, `cwds`, `sigintTimeoutMs`, `yoloAckAt`.
- **Show the config path on startup.** The daemon startup banner now has a `Config` row printing the absolute `~/.chorus/daemon.json` path it reads (with a "not found" note when absent), so operators know exactly which file to edit.

## Changed files
| File | Change |
|------|--------|
| `chorus.mjs` | Rewrite the DAEMON/LOGIN section + EXAMPLES of `chorus --help`: yolo is the default, `--chorus-only` is the opt-out |
| `README.md` / `README.zh.md` | New multi-path + `daemon.json` config docs in the `chorus daemon` section |
| `cli/daemon-banner.mjs` | New optional `Config` row (configPath/configExists) in `bannerRows` |
| `cli/daemon.mjs` | Resolve `loginFilePath()` + `existsSync`, pass to the banner |
| `cli/__tests__/daemon-banner.test.mjs` | 3 new tests for the Config row (present / absent / omitted) |

## Test plan
- [x] `pnpm exec vitest run cli/__tests__` — 417 passed (incl. 3 new banner tests)
- [x] `node --check cli/daemon.mjs` passes; ESLint clean on changed files (1 pre-existing unrelated warning)
- [x] Rendered `node chorus.mjs --help` and the banner manually — both correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)