### PR TITLE
fix(daemon): field-level merge for daemon.json (preserve cwds/yoloAckAt)

### DIFF
--- a/cli/__tests__/daemon-claude-notfound-warning.test.mjs
+++ b/cli/__tests__/daemon-claude-notfound-warning.test.mjs
@@ -1,0 +1,65 @@
+// cli/__tests__/daemon-claude-notfound-warning.test.mjs
+// Covers daemon-startup-output spec: a missing `claude` emits exactly one loud ⚠
+// stderr warning at startup, while the daemon STILL subscribes (non-fatal).
+import { describe, it, expect, vi } from "vitest";
+import { runDaemon } from "../daemon.mjs";
+import { claudeNotFoundWarningLine } from "../daemon-banner.mjs";
+
+/** Minimal happy-path deps; per-test overrides merge on top. */
+function baseDeps(over = {}) {
+  return {
+    resolve: () => ({ url: "u", apiKey: "cho_x", source: "env" }),
+    validate: async () => ({ uuid: "agent-1", name: "Daemon Bot" }),
+    build: vi.fn(() => ({ async start() {}, async stop() {} })),
+    isTTY: false,
+    // restricted posture so the yolo warning doesn't add noise to these assertions
+    chorusOnly: undefined,
+    log: () => {},
+    errLog: () => {},
+    waitForever: async () => {},
+    ...over,
+  };
+}
+
+describe("runDaemon — claude CLI NOT FOUND warning", () => {
+  it("emits exactly one ⚠ stderr warning and STILL subscribes when claude is absent", async () => {
+    const errs = [];
+    const build = vi.fn(() => ({ async start() {}, async stop() {} }));
+    const code = await runDaemon(
+      { chorusOnly: true }, // restricted → no yolo warning to disambiguate from
+      baseDeps({ build, errLog: (m) => errs.push(m), resolveClaudePath: () => null })
+    );
+    expect(code).toBe(0);
+    // Daemon still subscribed (build invoked) despite the missing binary.
+    expect(build).toHaveBeenCalledOnce();
+    // Exactly one claude-not-found warning line, naming the fixes.
+    const warnings = errs.filter((m) => m.includes("claude CLI NOT FOUND"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("CHORUS_CLAUDE_PATH");
+    expect(warnings[0]).toContain(".local/bin");
+  });
+
+  it("emits NO claude-not-found warning when claude is resolvable", async () => {
+    const errs = [];
+    const build = vi.fn(() => ({ async start() {}, async stop() {} }));
+    const code = await runDaemon(
+      { chorusOnly: true },
+      baseDeps({ build, errLog: (m) => errs.push(m), resolveClaudePath: () => "/usr/bin/claude" })
+    );
+    expect(code).toBe(0);
+    expect(build).toHaveBeenCalledOnce();
+    expect(errs.join("\n")).not.toContain("claude CLI NOT FOUND");
+  });
+});
+
+describe("claudeNotFoundWarningLine — content", () => {
+  it("is a loud, actionable single line", () => {
+    const line = claudeNotFoundWarningLine();
+    expect(line).toMatch(/^⚠/);
+    expect(line).toContain("claude CLI NOT FOUND");
+    expect(line).toContain("CHORUS_CLAUDE_PATH");
+    expect(line).toContain(".local/bin");
+    // stays non-fatal — promises the daemon still subscribes
+    expect(line.toLowerCase()).toContain("still subscribe");
+  });
+});

--- a/cli/__tests__/daemon-config-write.test.mjs
+++ b/cli/__tests__/daemon-config-write.test.mjs
@@ -1,0 +1,92 @@
+// cli/__tests__/daemon-config-write.test.mjs
+// Covers the shared updateDaemonConfig(partial) read→merge→write(0600) helper
+// (daemon-config-field-merge change). Every daemon.json writer routes through it,
+// so a chorus login / credential-completion never clobbers cwds / yoloAckAt.
+import { describe, it, expect } from "vitest";
+import { updateDaemonConfig } from "../login.mjs";
+
+/**
+ * Build an injectable IO bundle that captures writes and renames in memory.
+ * `existing` is the JSON string the read seam returns (or a function that throws).
+ */
+function ioHarness(existing) {
+  const calls = { writes: [], renames: [], mkdirs: [] };
+  const deps = {
+    path: "/p/daemon.json",
+    read: typeof existing === "function" ? existing : () => existing,
+    mkdir: (p, o) => calls.mkdirs.push([p, o]),
+    write: (p, c, o) => calls.writes.push([p, c, o]),
+    rename: (from, to) => calls.renames.push([from, to]),
+  };
+  return { calls, deps };
+}
+
+describe("updateDaemonConfig — field-level merge", () => {
+  it("preserves pre-existing unrelated keys while adding the partial", () => {
+    const { calls, deps } = ioHarness(
+      JSON.stringify({ cwds: ["/a", "/b"], yoloAckAt: "2026-06-20T00:00:00.000Z" })
+    );
+    const path = updateDaemonConfig(
+      { url: "u", apiKey: "cho_x", agentUuid: "a", agentName: "n" },
+      deps
+    );
+    expect(path).toBe("/p/daemon.json");
+    const written = JSON.parse(calls.writes[0][1]);
+    expect(written).toEqual({
+      cwds: ["/a", "/b"],
+      yoloAckAt: "2026-06-20T00:00:00.000Z",
+      url: "u",
+      apiKey: "cho_x",
+      agentUuid: "a",
+      agentName: "n",
+    });
+  });
+
+  it("overwrites a key the partial also sets (partial wins)", () => {
+    const { calls, deps } = ioHarness(
+      JSON.stringify({ url: "old", cwds: ["/keep"] })
+    );
+    updateDaemonConfig({ url: "new" }, deps);
+    const written = JSON.parse(calls.writes[0][1]);
+    expect(written).toEqual({ url: "new", cwds: ["/keep"] });
+  });
+
+  it("missing file (ENOENT) → creates a file with just the partial (no throw)", () => {
+    const { calls, deps } = ioHarness(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    updateDaemonConfig({ yoloAckAt: "2026-06-21T12:00:00.000Z" }, deps);
+    const written = JSON.parse(calls.writes[0][1]);
+    expect(written).toEqual({ yoloAckAt: "2026-06-21T12:00:00.000Z" });
+  });
+
+  it("malformed file → treated as empty (no throw)", () => {
+    const { calls, deps } = ioHarness("}{ not json");
+    updateDaemonConfig({ url: "u" }, deps);
+    expect(JSON.parse(calls.writes[0][1])).toEqual({ url: "u" });
+  });
+
+  it("non-object JSON (e.g. an array) → treated as empty", () => {
+    const { calls, deps } = ioHarness("[1,2,3]");
+    updateDaemonConfig({ url: "u" }, deps);
+    expect(JSON.parse(calls.writes[0][1])).toEqual({ url: "u" });
+  });
+
+  it("writes with 0600 mode and a trailing newline", () => {
+    const { calls, deps } = ioHarness("{}");
+    updateDaemonConfig({ url: "u" }, deps);
+    expect(calls.writes[0][2]).toEqual({ mode: 0o600 });
+    expect(calls.writes[0][1].endsWith("\n")).toBe(true);
+  });
+
+  it("is atomic: writes to <path>.tmp then renames over the target", () => {
+    const { calls, deps } = ioHarness("{}");
+    updateDaemonConfig({ url: "u" }, deps);
+    // the write goes to the temp path, NOT the live file
+    expect(calls.writes[0][0]).toBe("/p/daemon.json.tmp");
+    // then the temp is renamed over the target
+    expect(calls.renames[0]).toEqual(["/p/daemon.json.tmp", "/p/daemon.json"]);
+    // mkdir of the parent dir happens (recursive)
+    expect(calls.mkdirs[0][1]).toEqual({ recursive: true });
+  });
+});

--- a/cli/__tests__/daemon-credential-completion.test.mjs
+++ b/cli/__tests__/daemon-credential-completion.test.mjs
@@ -3,6 +3,7 @@
 // daemon start (TTY only); non-TTY preserves the hard error.
 import { describe, it, expect, vi } from "vitest";
 import { runDaemon } from "../daemon.mjs";
+import { writeLoginFile } from "../login.mjs";
 
 const NO_CREDS = () => {
   throw new Error(
@@ -85,6 +86,46 @@ describe("runDaemon — TTY interactive credential completion", () => {
     expect(writeLoginFile).not.toHaveBeenCalled();
     expect(build).not.toHaveBeenCalled();
     expect(errs.join("\n")).toMatch(/NOT saved/i);
+  });
+
+  it("the completion write field-merges — preserves pre-existing cwds AND yoloAckAt (regression)", async () => {
+    // daemon.mjs preflight() writeCreds path: with the merge helper in place it must
+    // NOT clobber a daemon.json that already carries cwds/yoloAckAt (the idea's bug,
+    // second write site). Inject the REAL writeLoginFile over an in-memory store.
+    const store = { json: JSON.stringify({ cwds: ["/srv/a"], yoloAckAt: "2026-06-20T00:00:00.000Z" }) };
+    const realWriteCreds = (data) =>
+      writeLoginFile(data, {
+        path: "/p/daemon.json",
+        read: () => store.json,
+        mkdir: () => {},
+        write: (_p, c) => { store.tmp = c; },
+        rename: () => { store.json = store.tmp; },
+      });
+    const validate = vi.fn(async () => ({ uuid: "agent-9", name: "Bot" }));
+    const build = vi.fn(() => ({ async start() {}, async stop() {} }));
+
+    const code = await runDaemon(
+      {},
+      tailDeps({
+        isTTY: true,
+        resolve: NO_CREDS,
+        validate,
+        prompt: async (q) => (q.startsWith("Chorus URL") ? "https://typed" : "cho_typed"),
+        writeLoginFile: realWriteCreds,
+        build,
+      })
+    );
+
+    expect(code).toBe(0);
+    expect(build).toHaveBeenCalledOnce();
+    expect(JSON.parse(store.json)).toEqual({
+      cwds: ["/srv/a"],
+      yoloAckAt: "2026-06-20T00:00:00.000Z",
+      url: "https://typed",
+      apiKey: "cho_typed",
+      agentUuid: "agent-9",
+      agentName: "Bot",
+    });
   });
 
   it("aborts (no validate/write) when the user enters nothing", async () => {

--- a/cli/__tests__/daemon-permission-wiring.test.mjs
+++ b/cli/__tests__/daemon-permission-wiring.test.mjs
@@ -2,8 +2,8 @@
 // Covers the runDaemon wiring of daemon-permission-mode: default yolo (no
 // confirmation, always warns), --chorus-only restricted, and the permissionMode
 // threaded into build(). Also covers recordYoloAck (preserve creds) and login
-// clearing the ack — those helpers still exist even though the daemon path no
-// longer prompts/persists an ack.
+// PRESERVING the ack via field-level merge (daemon-config-field-merge) — those
+// helpers still exist even though the daemon path no longer prompts/persists an ack.
 import { describe, it, expect, vi } from "vitest";
 import { runDaemon } from "../daemon.mjs";
 import { recordYoloAck, writeLoginFile } from "../login.mjs";
@@ -72,17 +72,16 @@ describe("runDaemon — TTY yolo starts without confirmation", () => {
 describe("recordYoloAck — preserves credentials, adds ack", () => {
   it("merges yoloAckAt into the existing file without touching creds", () => {
     const existing = { url: "u", apiKey: "cho_x", agentUuid: "a", agentName: "n" };
-    let written;
+    let writtenContent;
     const path = recordYoloAck("2026-06-21T12:00:00.000Z", {
       path: "/p/daemon.json",
       read: () => JSON.stringify(existing),
-      write: (data, deps) => {
-        written = data;
-        return deps.path;
-      },
+      mkdir: () => {},
+      write: (_p, c) => { writtenContent = c; },
+      rename: () => {},
     });
     expect(path).toBe("/p/daemon.json");
-    expect(written).toEqual({ ...existing, yoloAckAt: "2026-06-21T12:00:00.000Z" });
+    expect(JSON.parse(writtenContent)).toEqual({ ...existing, yoloAckAt: "2026-06-21T12:00:00.000Z" });
   });
 });
 
@@ -117,36 +116,55 @@ describe("recordYoloAck — persists even with no prior login file (env/flag cre
   it("treats a missing login file as empty and still writes yoloAckAt", () => {
     // A TTY user whose creds came from env/flags has no ~/.chorus/daemon.json yet.
     // recordYoloAck must NOT throw on ENOENT — it must write a file carrying the ack.
-    let written;
+    let writtenContent;
     const path = recordYoloAck("2026-06-21T12:00:00.000Z", {
       path: "/p/daemon.json",
       read: () => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); },
-      write: (data, deps) => { written = data; return deps.path; },
+      mkdir: () => {},
+      write: (_p, c) => { writtenContent = c; },
+      rename: () => {},
     });
     expect(path).toBe("/p/daemon.json");
-    expect(written).toEqual({ yoloAckAt: "2026-06-21T12:00:00.000Z" });
+    expect(JSON.parse(writtenContent)).toEqual({ yoloAckAt: "2026-06-21T12:00:00.000Z" });
   });
 
   it("treats a malformed login file as empty (does not throw)", () => {
-    let written;
+    let writtenContent;
     recordYoloAck("2026-06-21T12:00:00.000Z", {
       path: "/p/daemon.json",
       read: () => "}{ not json",
-      write: (data) => { written = data; return "/p/daemon.json"; },
+      mkdir: () => {},
+      write: (_p, c) => { writtenContent = c; },
+      rename: () => {},
     });
-    expect(written).toEqual({ yoloAckAt: "2026-06-21T12:00:00.000Z" });
+    expect(JSON.parse(writtenContent)).toEqual({ yoloAckAt: "2026-06-21T12:00:00.000Z" });
   });
 });
 
-describe("writeLoginFile — a re-login clears any prior ack", () => {
-  it("writing fresh credentials omits yoloAckAt (login data carries none)", () => {
+describe("writeLoginFile — a re-login PRESERVES any prior ack (field-level merge)", () => {
+  it("writing fresh credentials keeps a pre-existing yoloAckAt and cwds", () => {
+    // daemon-config-field-merge: login now merges, so the recorded yolo ack and
+    // the served cwds survive a re-login (supersedes the old clear-on-login).
+    const existing = { cwds: ["/a", "/b"], yoloAckAt: "2026-06-20T00:00:00.000Z" };
     let body;
     writeLoginFile(
       { url: "u2", apiKey: "cho_y", agentUuid: "a2", agentName: "n2" },
-      { path: "/p", mkdir: () => {}, write: (_p, c) => (body = c) }
+      {
+        path: "/p/daemon.json",
+        read: () => JSON.stringify(existing),
+        mkdir: () => {},
+        write: (_p, c) => (body = c),
+        rename: () => {},
+      }
     );
     const parsed = JSON.parse(body);
-    expect(parsed).not.toHaveProperty("yoloAckAt");
-    expect(parsed).toEqual({ url: "u2", apiKey: "cho_y", agentUuid: "a2", agentName: "n2" });
+    expect(parsed).toEqual({
+      cwds: ["/a", "/b"],
+      yoloAckAt: "2026-06-20T00:00:00.000Z",
+      url: "u2",
+      apiKey: "cho_y",
+      agentUuid: "a2",
+      agentName: "n2",
+    });
   });
 });

--- a/cli/__tests__/login.test.mjs
+++ b/cli/__tests__/login.test.mjs
@@ -3,6 +3,28 @@
 import { describe, it, expect, vi } from "vitest";
 import { runLogin, writeLoginFile, prompt } from "../login.mjs";
 
+/**
+ * An in-memory daemon.json backing store + a `write` dep shaped like the one
+ * runLogin calls (`write(data) => path`), but routed through the REAL
+ * writeLoginFile → updateDaemonConfig merge. Lets a test assert end-to-end that
+ * `chorus login` preserves pre-existing fields (the regression this change fixes).
+ */
+function mergeBackedWrite(initialJson) {
+  const store = { json: initialJson };
+  const write = (data) =>
+    writeLoginFile(data, {
+      path: "/p/daemon.json",
+      read: () => {
+        if (store.json === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        return store.json;
+      },
+      mkdir: () => {},
+      write: (_p, c) => { store.tmp = c; },
+      rename: () => { store.json = store.tmp; },
+    });
+  return { store, write };
+}
+
 describe("runLogin success path", () => {
   it("validates, persists with identity, echoes name+uuid, returns 0", async () => {
     const written = [];
@@ -25,6 +47,32 @@ describe("runLogin success path", () => {
     ]);
     expect(logs.join("\n")).toContain("Daemon Bot");
     expect(logs.join("\n")).toContain("agent-123");
+  });
+});
+
+describe("runLogin — field-level merge preserves pre-existing fields (regression)", () => {
+  it("retains pre-existing cwds AND yoloAckAt, and gains the four credential fields", async () => {
+    // The exact bug the idea reported: a daemon.json carrying only cwds + yoloAckAt
+    // (creds previously in shell env). A `chorus login` must NOT wipe those.
+    const { store, write } = mergeBackedWrite(
+      JSON.stringify({ cwds: ["/srv/a", "/srv/b"], yoloAckAt: "2026-06-20T00:00:00.000Z" })
+    );
+    const validate = vi.fn(async () => ({ uuid: "agent-123", name: "Daemon Bot" }));
+
+    const code = await runLogin(
+      { url: "https://chorus.example", apiKey: "cho_valid" },
+      { validate, write, log: () => {}, errLog: () => {} }
+    );
+
+    expect(code).toBe(0);
+    expect(JSON.parse(store.json)).toEqual({
+      cwds: ["/srv/a", "/srv/b"],
+      yoloAckAt: "2026-06-20T00:00:00.000Z",
+      url: "https://chorus.example",
+      apiKey: "cho_valid",
+      agentUuid: "agent-123",
+      agentName: "Daemon Bot",
+    });
   });
 });
 
@@ -89,20 +137,27 @@ describe("runLogin interactive prompting", () => {
 });
 
 describe("writeLoginFile", () => {
-  it("creates the dir and writes JSON with 0600 mode", () => {
+  it("creates the dir and writes JSON with 0600 mode (atomic temp+rename)", () => {
     const mkdirCalls = [];
     const writeCalls = [];
+    const renameCalls = [];
     const path = writeLoginFile(
       { url: "u", apiKey: "k", agentUuid: "a", agentName: "n" },
       {
         path: "/home/u/.chorus/daemon.json",
+        // no prior file → defensive parse yields {}, so only the creds are written
+        read: () => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); },
         mkdir: (p, o) => mkdirCalls.push([p, o]),
         write: (p, c, o) => writeCalls.push([p, c, o]),
+        rename: (from, to) => renameCalls.push([from, to]),
       }
     );
     expect(path).toBe("/home/u/.chorus/daemon.json");
     expect(mkdirCalls[0][1]).toEqual({ recursive: true });
+    // atomic write: to the temp path at 0600, then renamed over the target
+    expect(writeCalls[0][0]).toBe("/home/u/.chorus/daemon.json.tmp");
     expect(writeCalls[0][2]).toEqual({ mode: 0o600 });
+    expect(renameCalls[0]).toEqual(["/home/u/.chorus/daemon.json.tmp", "/home/u/.chorus/daemon.json"]);
     expect(JSON.parse(writeCalls[0][1])).toEqual({ url: "u", apiKey: "k", agentUuid: "a", agentName: "n" });
   });
 });

--- a/cli/daemon-banner.mjs
+++ b/cli/daemon-banner.mjs
@@ -61,6 +61,22 @@ export function bannerRows(info) {
 }
 
 /**
+ * The prominent warning shown at startup when the `claude` executable cannot be
+ * resolved. Mirrors `yoloWarningLine()`'s loud single-line style so a missing
+ * binary is visible in an unattended / systemd journal immediately, rather than
+ * only when a wake later fails. The daemon stays non-fatal — it still subscribes.
+ * @returns {string}
+ */
+export function claudeNotFoundWarningLine() {
+  return (
+    "⚠ claude CLI NOT FOUND on PATH — wakes will FAIL until you install `claude` " +
+    "or set CHORUS_CLAUDE_PATH. For a systemd/boot service, ensure the unit's PATH " +
+    "includes the directory holding `claude` (e.g. ~/.local/bin). The daemon will " +
+    "still subscribe, but every task dispatch errors until this is fixed."
+  );
+}
+
+/**
  * Format the startup banner. On a TTY, draws a Unicode box; otherwise emits
  * plain `label: value` lines (no box-drawing chars, no width math) so piped
  * output is clean. Never throws.

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -19,7 +19,7 @@ import {
   yoloWarningLine,
 } from "./daemon-permission-mode.mjs";
 import { resolveAgentType } from "./daemon-agent.mjs";
-import { formatBanner } from "./daemon-banner.mjs";
+import { formatBanner, claudeNotFoundWarningLine } from "./daemon-banner.mjs";
 import { ChorusClient, validateAndFetchIdentity } from "./chorus-client.mjs";
 import { SseListener } from "./sse-listener.mjs";
 import { createBackfill } from "./backfill.mjs";
@@ -444,6 +444,12 @@ export async function runDaemon(flags = {}, deps = {}) {
   // ⚠ warning on stderr (it also names --chorus-only as the reclaim switch).
   if (permissionMode === "yolo") {
     errLog(`[Chorus] ${yoloWarningLine()}`);
+  }
+  // A missing `claude` binary is non-fatal (the daemon still subscribes), but the
+  // banner row alone is easy to miss in a systemd journal — emit one loud ⚠ line
+  // on stderr so the operator sees it at startup, not only when a wake fails.
+  if (claudePath === null) {
+    errLog(`[Chorus] ${claudeNotFoundWarningLine()}`);
   }
 
   // Surface the served paths so an operator sees a multi-path daemon at a glance.

--- a/cli/login.mjs
+++ b/cli/login.mjs
@@ -3,7 +3,7 @@
 // ~/.chorus/daemon.json (0600). On validation failure, nothing is written.
 // Plain ESM; the only dependency is the in-repo MCP SDK (via chorus-client).
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline";
 
@@ -49,56 +49,99 @@ export function prompt(query, opts = {}) {
 }
 
 /**
- * Persist credentials + identity to the login file with owner-only perms.
+ * Field-level merge update of the login file (`~/.chorus/daemon.json`) — the
+ * single read → merge → write(0600) helper every config writer routes through.
  *
- * Writing the file with a fresh credential object intentionally OMITS any
- * `yoloAckAt` that a previous file carried — a credential change (re-login)
- * clears the yolo acknowledgement, so the next yolo TTY start re-confirms once
- * (daemon-permission-mode spec). To preserve an existing ack across an
- * unrelated rewrite, the caller must read it first and pass it in `data`.
+ * Reads any existing file, shallow-merges `partial` over it (partial keys win,
+ * every other pre-existing field is preserved), and writes the result back with
+ * owner-only permissions. A shallow merge is correct because every field is a
+ * scalar or a flat array (`cwds`) — there are no nested objects to deep-merge.
  *
- * @param {{ url: string, apiKey: string, agentUuid: string, agentName: string, yoloAckAt?: string }} data
- * @param {{ path?: string, write?: (p: string, c: string, o: object) => void, mkdir?: (p: string, o: object) => void }} [deps]
+ * The write is atomic: the JSON is written to a sibling `<path>.tmp` at 0600 and
+ * then `rename()`d over the target, so a crash mid-write never truncates the
+ * live file. A missing / unreadable / malformed existing file is treated as an
+ * empty object (defensive parse), so a re-login still produces a valid file
+ * rather than aborting on a corrupt one.
+ *
+ * Because writes now merge, NO field is ever silently dropped — in particular a
+ * `chorus login` preserves any pre-existing `cwds` / `yoloAckAt` /
+ * `sigintTimeoutMs` (daemon-config-field-merge change; supersedes the prior
+ * "credential change clears the yolo acknowledgement" behavior).
+ *
+ * @param {Record<string, unknown>} partial  The fields to set/overwrite.
+ * @param {{
+ *   path?: string,
+ *   read?: (p: string) => string,
+ *   write?: (p: string, c: string, o: object) => void,
+ *   mkdir?: (p: string, o: object) => void,
+ *   rename?: (from: string, to: string) => void,
+ * }} [deps]
+ * @returns {string} the file path written
  */
-export function writeLoginFile(data, deps = {}) {
+export function updateDaemonConfig(partial, deps = {}) {
   const path = deps.path ?? loginFilePath();
+  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
   const write = deps.write ?? writeFileSync;
   const mkdir = deps.mkdir ?? mkdirSync;
+  const rename = deps.rename ?? renameSync;
+
+  // Defensive read: missing / unreadable / malformed → start from empty so a
+  // re-login over a corrupt file still writes a valid one (no silent abort).
+  let current = {};
+  try {
+    const parsed = JSON.parse(read(path));
+    // Only a plain object is a valid config; arrays / scalars → start fresh.
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) current = parsed;
+  } catch {
+    // treat as empty
+  }
+
+  const merged = { ...current, ...partial };
   mkdir(dirname(path), { recursive: true });
-  write(path, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
+  // Atomic write: temp file (0600) in the same dir, then rename over target.
+  const tmp = `${path}.tmp`;
+  write(tmp, JSON.stringify(merged, null, 2) + "\n", { mode: 0o600 });
+  rename(tmp, path);
   return path;
 }
 
 /**
- * Record (or refresh) the yolo acknowledgement in the existing login file,
- * preserving the credentials already on disk. Reads the current file, merges
- * `yoloAckAt`, and rewrites with 0600. Used by the daemon after an interactive
- * TTY yolo confirmation — it does NOT touch url/apiKey/identity.
+ * Persist credentials + identity to the login file with owner-only perms.
  *
- * No-silent-errors: a read/parse failure is surfaced to the caller (throws), so
- * the daemon can log it rather than silently losing the ack.
+ * Thin wrapper over {@link updateDaemonConfig}: it field-merges the given
+ * credential/identity fields over any existing file, so every OTHER pre-existing
+ * field (`cwds`, `yoloAckAt`, `sigintTimeoutMs`, …) is preserved across a
+ * `chorus login` or a daemon-start credential completion. It no longer omits
+ * `yoloAckAt` — a credential write never discards the recorded yolo ack.
+ *
+ * The `deps` seams (`path`, `write`, `mkdir`) are kept for callers/tests that
+ * inject IO; `write` is the low-level `(path, content, opts)` writer.
+ *
+ * @param {{ url: string, apiKey: string, agentUuid: string, agentName: string }} data
+ * @param {{ path?: string, write?: (p: string, c: string, o: object) => void, mkdir?: (p: string, o: object) => void, read?: (p: string) => string, rename?: (from: string, to: string) => void }} [deps]
+ */
+export function writeLoginFile(data, deps = {}) {
+  return updateDaemonConfig(data, deps);
+}
+
+/**
+ * Record (or refresh) the yolo acknowledgement in the login file, preserving
+ * everything already on disk. Delegates to {@link updateDaemonConfig}, which
+ * reads the current file, merges `yoloAckAt`, and rewrites with 0600. Used by
+ * the daemon after an interactive TTY yolo confirmation — it does NOT touch
+ * url/apiKey/identity.
+ *
+ * A TTY user whose credentials come from env / flags has no login file yet, but
+ * the ack must still persist (else they'd re-confirm yolo on every start). A
+ * file carrying only `yoloAckAt` is harmless — resolveCredentials simply falls
+ * through it.
  *
  * @param {string} yoloAckAt  ISO-8601 timestamp of the confirmation.
- * @param {{ path?: string, read?: (p: string) => string, write?: typeof writeLoginFile }} [deps]
+ * @param {{ path?: string, read?: (p: string) => string, write?: (p: string, c: string, o: object) => void, mkdir?: (p: string, o: object) => void, rename?: (from: string, to: string) => void }} [deps]
  * @returns {string} the file path written
  */
 export function recordYoloAck(yoloAckAt, deps = {}) {
-  const path = deps.path ?? loginFilePath();
-  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
-  const write = deps.write ?? writeLoginFile;
-  // Start from the existing file when present, else an empty object: a TTY user
-  // whose credentials come from env / flags has no login file yet, but the ack
-  // must still persist (else they'd re-confirm yolo on every start). A file
-  // carrying only `yoloAckAt` is harmless — resolveCredentials simply falls
-  // through it, and a later `chorus login` overwrites (clearing the ack).
-  let current = {};
-  try {
-    const parsed = JSON.parse(read(path));
-    if (parsed && typeof parsed === "object") current = parsed;
-  } catch {
-    // missing / unreadable / malformed → treat as empty (start fresh)
-  }
-  return write({ ...current, yoloAckAt }, { path });
+  return updateDaemonConfig({ yoloAckAt }, deps);
 }
 
 /**

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -30,6 +30,13 @@ URL and a masked API key, validates them against the server, saves them to
 `~/.chorus/daemon.json` (mode `0600`), and continues starting up. You do not need
 a separate `chorus login` run.
 
+**Writes are field-level merges.** Both `chorus login` and the interactive
+completion above **merge** into `~/.chorus/daemon.json` rather than overwriting
+it — they touch only `url` / `apiKey` / `agentUuid` / `agentName` and leave every
+other field (`cwds`, `yoloAckAt`, `sigintTimeoutMs`, …) intact. You can safely
+re-run `chorus login` to rotate credentials without losing your served paths or
+your YOLO acknowledgement.
+
 **Non-interactive (systemd / nohup / CI).** When stdin is **not** a TTY and no
 credentials resolve, the daemon prints the actionable multi-source error and
 exits non-zero — it never blocks waiting on a prompt no one can answer. Provide
@@ -53,8 +60,9 @@ The woken agent's permission posture determines what it may do:
 **First-run confirmation (TTY).** The first time the daemon would start in YOLO
 on a terminal, it asks for a one-time `y/N` confirmation and remembers your
 answer as `yoloAckAt` in `~/.chorus/daemon.json`. Subsequent starts don't
-re-prompt. Running `chorus login` (a credential change) clears the acknowledgement,
-so you confirm once more after switching key/URL.
+re-prompt. Re-running `chorus login` **preserves** the acknowledgement (and your
+`cwds`) — every write to `~/.chorus/daemon.json` is a field-level merge, so a
+credential change no longer wipes unrelated fields.
 
 **Unattended (non-TTY).** When YOLO starts on a non-terminal (systemd / nohup /
 CI / the detached `-d` child), it runs directly and prints one prominent `⚠`
@@ -185,6 +193,8 @@ After=network-online.target
 
 [Service]
 Type=simple
+# PATH must include the dir holding `claude` (a unit does NOT inherit your shell PATH).
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=/usr/local/bin/chorus daemon
 Restart=on-failure
 RestartSec=5
@@ -196,6 +206,29 @@ WantedBy=default.target
 To keep the service running after you log out:
 `loginctl enable-linger "$USER"`. Stop/disable with
 `systemctl --user disable --now chorus-daemon`. Logs: `journalctl --user -u chorus-daemon`.
+
+**Boot auto-start checklist (learned the hard way).** A systemd unit runs with a
+minimal environment — it does **not** source `~/.zshrc` / `~/.bashrc`. Two things
+bite operators who rely on their interactive shell setup:
+
+1. **Persist credentials with `chorus login`, not shell env.** If your
+   `CHORUS_URL` / `CHORUS_API_KEY` live only in `~/.zshrc`, the unit can't see
+   them and the daemon crash-loops (`Restart=on-failure` will retry forever).
+   Run `chorus login` once so the credentials land in `~/.chorus/daemon.json`,
+   which the daemon reads directly. (Re-running `chorus login` later is safe —
+   writes are field-level merges, so your `cwds` / `yoloAckAt` survive.)
+2. **Put `claude` on the unit's PATH.** The unit's PATH usually omits
+   `~/.local/bin`, where `claude` is commonly installed. Without it the daemon
+   starts and subscribes but every wake fails to spawn `claude` — and it now
+   prints a loud `⚠ claude CLI NOT FOUND` line at startup (visible in
+   `journalctl --user -u chorus-daemon`). Set `Environment=PATH=...` as above
+   (or `Environment=CHORUS_CLAUDE_PATH=/abs/path/to/claude`).
+
+Alternatively, declare credentials and paths explicitly on the unit instead of
+relying on the login file — e.g.
+`Environment=CHORUS_URL=… CHORUS_API_KEY=cho_… CHORUS_DAEMON_CWDS=/path/a:/path/b`
+and `ExecStart=/usr/local/bin/chorus daemon --chorus-only` for a restricted
+unattended posture.
 
 ---
 

--- a/openspec/changes/fix-daemon-config-field-merge/.openspec.yaml
+++ b/openspec/changes/fix-daemon-config-field-merge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/fix-daemon-config-field-merge/README.md
+++ b/openspec/changes/fix-daemon-config-field-merge/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-config-field-merge
+
+daemon.json writes use field-level merge so chorus login / daemon TTY completion no longer clobber cwds / yoloAckAt

--- a/openspec/changes/fix-daemon-config-field-merge/design.md
+++ b/openspec/changes/fix-daemon-config-field-merge/design.md
@@ -1,0 +1,153 @@
+# Design: daemon.json field-level merge
+
+## Context
+
+`~/.chorus/daemon.json` is the single persisted config file the chorus CLI daemon
+owns. It is a flat JSON object that accretes fields from several independent code
+paths over time:
+
+| Field | Written by | Read by |
+|---|---|---|
+| `url`, `apiKey`, `agentUuid`, `agentName` | `chorus login` / daemon TTY completion | `resolveCredentials` (`credentials.mjs`) |
+| `yoloAckAt` | daemon yolo TTY confirmation (`recordYoloAck`) | `readYoloAck` (`credentials.mjs`) |
+| `cwds` | hand-edited / future tooling | `resolveDaemonCwds` (`daemon-config.mjs`) |
+| `sigintTimeoutMs` | hand-edited / future tooling | `resolveSigintTimeoutMs` (`daemon-config.mjs`) |
+
+The readers are already layered and tolerant. The **writers** are the problem:
+`writeLoginFile()` serializes only the object it is handed and overwrites the whole
+file, so any field written by a *different* path (`cwds`, `yoloAckAt`, …) is lost.
+
+## Goals / Non-Goals
+
+**Goals**
+- A single, tested read→merge→write helper that every config writer uses.
+- `chorus login` and the daemon TTY credential-completion path preserve all
+  non-credential fields (`cwds`, `yoloAckAt`, `sigintTimeoutMs`, …).
+- `yoloAckAt` is preserved across credential writes (the q1 product decision).
+- A missing `claude` binary is loudly visible at startup, not only when a wake fails.
+- Operators learn that boot auto-start requires `chorus login` (persisted creds).
+
+**Non-Goals**
+- No cross-process locking of `daemon.json`. `chorus login` and a yolo confirmation
+  do not run concurrently in practice (login is an interactive one-shot; the yolo
+  ack happens once at daemon start). The audit flagged a theoretical race in
+  `recordYoloAck`; we keep the write atomic via temp-file + rename (below) but do
+  NOT add `flock`, to avoid a cross-platform dependency (Windows is a target).
+- No change to the layered credential *resolution* (readers are fine).
+- No plugin-side change (state.json already flock+jq-merge-safe — see Audit below).
+
+## Decisions
+
+### DEC-1 — One shared merge helper, all writers route through it (q3)
+
+Add `updateDaemonConfig(partial, deps?)`:
+
+```
+updateDaemonConfig(partial):
+  1. read existing daemon.json → current (empty object on missing/unreadable/malformed,
+     mirroring readYoloAck's defensive parse — a corrupt file must not block a re-login)
+  2. merged = { ...current, ...partial }            # shallow merge; partial wins per key
+  3. write merged as pretty JSON + trailing "\n" with mode 0600, via temp-file + atomic rename
+  4. return the path written
+```
+
+- **Shallow merge is correct here.** Every field is a scalar or a flat array
+  (`cwds`); there are no nested objects to deep-merge. `partial` keys overwrite,
+  absent keys are preserved.
+- **Atomic write:** write to `daemon.json.tmp` (same dir, mode 0600) then
+  `rename()` over the target, so a crash mid-write never truncates the live file.
+- **`writeLoginFile(data)`** becomes a thin wrapper: `updateDaemonConfig(data)`.
+  Its signature and the `deps` injection seams (`path`, `write`, `mkdir`) are kept
+  so existing callers and tests need no churn.
+- **`recordYoloAck(ts)`** drops its own hand-rolled read-merge and calls
+  `updateDaemonConfig({ yoloAckAt: ts })`.
+- **`preflight()`** keeps calling `writeCreds(...)`; since `writeCreds` defaults to
+  `writeLoginFile`, it now merges automatically. No call-site change beyond the
+  helper swap.
+
+### DEC-2 — `yoloAckAt` is always preserved across credential writes (q1)
+
+This is the crux. The current spec requirement **"Credential change clears the YOLO
+acknowledgement"** (`daemon-permission-mode`) is satisfied *because* `writeLoginFile`
+omits `yoloAckAt`. Once login merges over the existing file, `yoloAckAt` naturally
+survives — so the merge change and the "clear on re-login" requirement are in direct
+conflict.
+
+Per the elaboration the owner chose **preserve always**: a config write must never
+silently discard the recorded acknowledgement. Therefore:
+
+- `login.mjs` no longer special-cases `yoloAckAt`. It merges `{url, apiKey,
+  agentUuid, agentName}` and leaves every other field — including `yoloAckAt` — intact.
+- The `daemon-permission-mode` spec requirement "Credential change clears the YOLO
+  acknowledgement" is **REMOVED** (this change's spec delta).
+- The misleading JSDoc block in `login.mjs` (lines describing the intentional
+  `yoloAckAt` omission) is rewritten to state the new merge-preserve contract.
+
+Trade-off accepted: swapping the API key / agent on the same machine no longer forces
+a one-time YOLO re-confirmation. The owner judged the data-loss footgun worse than the
+re-confirm. `--chorus-only` and the per-start non-TTY warning still bound YOLO risk.
+
+### DEC-3 — Loud `claude` NOT FOUND warning, still non-fatal (q5 + q6)
+
+Keep the existing non-fatal contract (the daemon subscribes even without `claude`),
+but add visibility: when `resolveClaudePath()` returns null, the startup path emits
+**one** prominent `⚠` line to **stderr** (the same channel and style as the existing
+YOLO warning at `daemon.mjs`), e.g.:
+
+```
+[Chorus] ⚠ claude CLI NOT FOUND on PATH — wakes will fail until you install `claude` or set CHORUS_CLAUDE_PATH (PATH must include e.g. ~/.local/bin).
+```
+
+- Emitted once at startup, after the banner, gated on `claudePath === null`.
+- stderr so it lands in `journalctl` for the unit even when stdout is captured.
+- The banner row ("claude CLI: NOT FOUND …") is retained; the warning line is
+  additive. We do NOT take the more aggressive "non-zero exit on non-TTV" option —
+  the owner chose loud-stderr to preserve the daemon-still-subscribes guarantee.
+
+### DEC-4 — Onboarding doc: boot auto-start requires `chorus login` (q5)
+
+`docs/DAEMON.md` gets a short "Running on boot (systemd)" subsection covering:
+- credentials must be persisted via `chorus login` (a unit does not source `.zshrc`,
+  so shell-env-only credentials make the daemon crash-loop);
+- the field-merge guarantee (re-running `chorus login` preserves `cwds`/`yoloAckAt`);
+- the unit's PATH must include the dir holding `claude` (e.g. `~/.local/bin`), else
+  the new NOT-FOUND warning fires and wakes fail.
+
+## Audit: plugin-side state.json (q4) — no change needed
+
+The elaboration expanded scope to verify the plugin's `~/.chorus/state.json`. Audit result:
+
+- Claude Code plugin (`public/chorus-plugin/bin/chorus-api.sh`): `state_set` and
+  `state_delete` both run under `flock -w 5` and use a `jq` read-merge-write to a
+  temp file followed by `mv` (atomic). Per-key merge means independent hooks
+  (`on-session-start`, `on-subagent-start`, `on-subagent-stop`) cannot clobber each
+  other's keys. Session metadata files under `~/.chorus/sessions/<name>.json` are
+  whole-file `cat >` writes but are single-writer per session name (no concurrent
+  clobber). `ensure_state` only writes `{}` on first init.
+- Codex plugin (`plugins/chorus/`): stateless — writes no `~/.chorus/` files.
+
+Conclusion: the clobber bug is **CLI-only**. Plugin state is already concurrency-safe.
+Recorded here so the q4 scope expansion is closed with evidence, not silence.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Merge helper reads a corrupt `daemon.json` and aborts the write, blocking re-login | Defensive parse: malformed/missing file → treat as `{}` (mirrors `recordYoloAck`); a re-login then rewrites a clean file |
+| Atomic rename leaves a stray `.tmp` on crash | `.tmp` is same-dir, 0600, overwritten next write; harmless |
+| Preserving `yoloAckAt` weakens the "re-confirm on credential change" guard | Explicit owner decision (DEC-2); `--chorus-only` + per-start non-TTY warning still bound YOLO exposure |
+| Loud warning line becomes noise on hosts that intentionally lack `claude` | One line only, stderr, gated on actual absence; matches the existing single-line YOLO warning pattern |
+
+## Test Plan
+
+- **Merge helper unit tests** (new): writing a partial preserves pre-existing unrelated
+  keys; partial keys overwrite; missing file → file created with just the partial;
+  malformed file → treated as empty, no throw; mode is 0600; atomic temp+rename path.
+- **login**: after `runLogin`, a pre-existing `{cwds, yoloAckAt}` file retains both
+  `cwds` AND `yoloAckAt`, and gains the four credential fields (this is the regression
+  the idea reported — and asserts the q1 preserve-always behavior).
+- **daemon credential completion** (`preflight`): the TTY-completion write preserves
+  pre-existing `cwds`/`yoloAckAt`.
+- **banner/startup**: when `claudePath` is null, exactly one `⚠` stderr warning line is
+  emitted and the daemon still proceeds to subscribe; when found, no warning line.
+- All existing daemon/login/banner tests continue to pass (no resolver changes).

--- a/openspec/changes/fix-daemon-config-field-merge/proposal.md
+++ b/openspec/changes/fix-daemon-config-field-merge/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: daemon.json field-level merge (stop clobbering cwds / yoloAckAt)
+
+## Why
+
+Setting up `chorus daemon` as a boot-time service (systemd user unit + linger) on EC2 surfaced a data-loss root cause: **every write to `~/.chorus/daemon.json` is a whole-file overwrite, not a field-level merge.**
+
+Reproduction:
+
+1. `~/.chorus/daemon.json` originally held only `{ cwds: [...], yoloAckAt: "..." }` (credentials lived in shell env / `~/.zshrc`).
+2. The systemd unit does not source `.zshrc`, so the daemon could not resolve credentials and crash-looped.
+3. To persist credentials to disk, the operator ran `chorus login --url ... --api-key ...`.
+4. **`chorus login` overwrote the entire file with `{ url, apiKey, agentUuid, agentName }`, destroying the pre-existing `cwds` and `yoloAckAt`.**
+   - Losing `yoloAckAt` → the next foreground run re-prompts the one-time YOLO confirmation.
+   - Losing `cwds` → unless the unit's `--cwd` flag backstops it, the daemon falls back to serving only its process cwd.
+
+The operator had to hand-merge `cwds`/`yoloAckAt` back with a Node script. A normal user would not.
+
+The code audit found **two** whole-file overwrite sites, not one:
+
+- `cli/login.mjs` `writeLoginFile()` — the `chorus login` write (and it currently, by design, drops `yoloAckAt`).
+- `cli/daemon.mjs` `preflight()` — the daemon's TTY interactive credential-completion path calls the same `writeLoginFile()`, so it clobbers `cwds`/`yoloAckAt` identically.
+
+A correct read→merge→write template already exists in `recordYoloAck()` (`cli/login.mjs`) — but it is not atomic and is not reused by the other writers.
+
+The audit also confirmed (elaboration q4) that on the **plugin** side `~/.chorus/state.json` is already safe: the Claude Code plugin's `chorus-api.sh` serializes every write with `flock` + `jq` merge, and the Codex plugin is stateless. No plugin change is required — only that the audit be recorded.
+
+## What Changes
+
+- **New shared merge helper `updateDaemonConfig(partial)`** (elaboration q3) — a single read→merge→write(0600) function that reads the existing `~/.chorus/daemon.json`, shallow-merges the caller's partial over it, and writes back with owner-only permissions. It is the one place that knows how to persist the config. `writeLoginFile`, the daemon `preflight` completion path, and the existing `recordYoloAck` are all routed through it.
+
+- **Both whole-file overwrite sites become merges** (elaboration q2 = both):
+  - `chorus login` (`writeLoginFile`) merges `{ url, apiKey, agentUuid, agentName }` over the existing file, preserving `cwds`, `sigintTimeoutMs`, and any other future field.
+  - The daemon `preflight` TTY credential-completion path merges the just-entered credentials the same way.
+
+- **`yoloAckAt` is always preserved across a `chorus login` / credential write** (elaboration q1 = preserve always). This **intentionally retires** the existing normative behavior "a credential change clears the YOLO acknowledgement" (`daemon-permission-mode` spec). The product decision: a config write must never silently discard the user's recorded YOLO acknowledgement. The `login.mjs` JSDoc and the `daemon-permission-mode` spec are updated to match, so code and spec do not drift.
+
+- **`claude` CLI "NOT FOUND" gets a loud startup warning** (elaboration q5 fold-in + q6 = loud stderr). Today a missing `claude` is shown only as one banner row; the daemon still subscribes and the failure surfaces only when a wake arrives. We add one prominent `⚠` stderr line at startup (parallel to the existing YOLO warning line) so a missing binary is visible in a `systemd journal` immediately. The daemon still starts and subscribes — non-fatal behavior is preserved.
+
+- **Onboarding documentation** (elaboration q5 fold-in): `docs/DAEMON.md` gains an explicit "auto-start on boot requires `chorus login`" note — credentials must be persisted to `daemon.json`, not left only in shell env, because a systemd unit does not source `.zshrc`. It also documents the field-merge guarantee and the `claude` PATH requirement (e.g. `~/.local/bin`).
+
+- **Plugin `state.json` audit recorded** (elaboration q4): the finding that plugin state writes are already flock+jq-merge-safe (no clobber) is captured in the design doc; no code change.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `cli-auth`: the `chorus login` persist requirement and the daemon TTY credential-completion requirement change from "persist `{url, apiKey, agentUuid, agentName}`" (whole-file) to "field-level merge that preserves all other existing fields."
+- `daemon-permission-mode`: the "Credential change clears the YOLO acknowledgement" requirement is **removed** — `yoloAckAt` is now always preserved across credential writes.
+- `daemon-startup-output`: the `claude` installation detection requirement is extended to also emit one prominent `⚠` stderr warning line at startup when `claude` is not found (banner row alone was insufficient for unattended/systemd visibility).
+
+## Impact
+
+- **Affected code:** `cli/login.mjs`, `cli/daemon.mjs`, `cli/credentials.mjs` (or a new small `cli/daemon-config-write.mjs`) for the merge helper; `cli/daemon-banner.mjs` / `cli/daemon.mjs` startup path for the warning line.
+- **Affected tests:** `cli/__tests__/login.test.mjs`, `daemon-credential-completion.test.mjs`, `daemon-banner.test.mjs`, plus new merge-helper tests.
+- **Affected docs:** `docs/DAEMON.md`.
+- **Behavior change (intentional):** re-login no longer re-prompts the YOLO confirmation, because `yoloAckAt` is preserved.
+- **No schema / DB / API changes.** This is entirely CLI-local file I/O.
+- **Out of scope:** plugin-side `state.json` (audited, already safe); `state.json`/`sessions.json` clobber concerns on the CLI side (the CLI writes neither — `sessions.json` was already removed per the lineage-anchored session change).

--- a/openspec/changes/fix-daemon-config-field-merge/specs/cli-auth/spec.md
+++ b/openspec/changes/fix-daemon-config-field-merge/specs/cli-auth/spec.md
@@ -1,0 +1,84 @@
+# cli-auth Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: Interactive login command
+
+The CLI SHALL provide a `chorus login` subcommand that accepts a server URL and `cho_` API key (via flags or interactive prompt), validates the key against the server by fetching the authenticated agent identity, and on success persists `{ url, apiKey, agentUuid, agentName }` to `~/.chorus/daemon.json` with owner-only file permissions. The persist SHALL be a **field-level merge**: the command SHALL read any existing `~/.chorus/daemon.json`, overwrite only the credential/identity keys it sets (`url`, `apiKey`, `agentUuid`, `agentName`), and preserve every other pre-existing field (including `cwds`, `yoloAckAt`, and `sigintTimeoutMs`). A missing, unreadable, or malformed existing file SHALL be treated as an empty object so the merge still produces a valid file. On validation failure it SHALL NOT write the file. When the API key is entered interactively, the input SHALL be masked (not echoed to the terminal).
+
+#### Scenario: Successful login persists credentials and echoes identity
+
+- **WHEN** the user runs `chorus login` with a reachable URL and a valid `cho_` API key
+- **THEN** the command fetches and displays the resolved agent identity (name + uuid) and writes the credentials to `~/.chorus/daemon.json` with owner-only permissions
+
+#### Scenario: Login preserves pre-existing non-credential fields
+
+- **WHEN** `~/.chorus/daemon.json` already contains `cwds` and/or `yoloAckAt` (and possibly `sigintTimeoutMs`) and the user runs a successful `chorus login`
+- **THEN** the written file gains the four credential/identity fields AND retains the pre-existing `cwds`, `yoloAckAt`, and `sigintTimeoutMs` values unchanged
+
+#### Scenario: Interactive key entry is masked
+
+- **WHEN** the user is prompted interactively for the `cho_` API key
+- **THEN** the typed key is not echoed to the terminal
+
+#### Scenario: Invalid key is rejected without writing
+
+- **WHEN** the user runs `chorus login` with an invalid or revoked API key
+- **THEN** the command reports the authentication failure and does not create or overwrite `~/.chorus/daemon.json`
+
+### Requirement: Interactive credential completion at daemon start (TTY only)
+
+The daemon SHALL, when it cannot resolve a complete `url` + `cho_` API key pair
+from the layered sources (flags → env → `~/.chorus/daemon.json` → plugin
+fallback) **and** standard input is a TTY, NOT fail with the hard error.
+Instead it SHALL run the same interactive completion flow as `chorus login` —
+prompting for the server URL and a **masked** API key, validating them against
+the server by fetching the authenticated agent identity, and on success
+persisting `{ url, apiKey, agentUuid, agentName }` to `~/.chorus/daemon.json`
+with owner-only permissions — and then SHALL continue daemon startup using the
+just-completed credentials. The persist SHALL be the same **field-level merge**
+as `chorus login`: it SHALL read any existing `~/.chorus/daemon.json`, overwrite
+only the four credential/identity keys, and preserve every other pre-existing
+field (including `cwds`, `yoloAckAt`, and `sigintTimeoutMs`). The completion flow
+SHALL reuse the existing `chorus login` masked-prompt, validate, and persist
+logic rather than reimplementing it. On validation failure during completion, the
+daemon SHALL NOT write the file and SHALL exit non-zero.
+
+When credentials cannot be resolved and standard input is **not** a TTY
+(systemd / nohup / CI / background), the daemon SHALL preserve the existing
+behavior: it SHALL NOT prompt or block, and SHALL emit the single
+human-actionable multi-source error and exit non-zero.
+
+#### Scenario: TTY start with no credentials completes interactively
+
+- **WHEN** the user runs `chorus daemon` on a TTY with no resolvable credentials
+- **THEN** the daemon prompts for URL and a masked API key, validates them, writes
+  `~/.chorus/daemon.json` (owner-only) on success, and continues starting up
+  without requiring a separate `chorus login` run
+
+#### Scenario: Daemon completion preserves pre-existing non-credential fields
+
+- **WHEN** the daemon completes credentials interactively at start and
+  `~/.chorus/daemon.json` already contains `cwds` and/or `yoloAckAt`
+- **THEN** the written file gains the four credential/identity fields AND retains the
+  pre-existing `cwds`, `yoloAckAt`, and `sigintTimeoutMs` values unchanged
+
+#### Scenario: Masked entry during daemon completion
+
+- **WHEN** the daemon prompts interactively for the API key during start-time
+  completion
+- **THEN** the typed key is not echoed to the terminal
+
+#### Scenario: Non-TTY start with no credentials errors without blocking
+
+- **WHEN** `chorus daemon` starts with no resolvable credentials and stdin is not
+  a TTY
+- **THEN** the daemon does not prompt, emits the multi-source actionable error,
+  and exits non-zero — it never blocks waiting on input no one can provide
+
+#### Scenario: Failed validation during completion writes nothing
+
+- **WHEN** the user completes credentials interactively at daemon start but the
+  key fails server validation
+- **THEN** the daemon reports the failure, does not create or overwrite
+  `~/.chorus/daemon.json`, and exits non-zero

--- a/openspec/changes/fix-daemon-config-field-merge/specs/daemon-permission-mode/spec.md
+++ b/openspec/changes/fix-daemon-config-field-merge/specs/daemon-permission-mode/spec.md
@@ -1,0 +1,9 @@
+# daemon-permission-mode Spec Delta
+
+## REMOVED Requirements
+
+### Requirement: Credential change clears the YOLO acknowledgement
+
+**Reason:** Superseded by the daemon.json field-level merge decision (elaboration q1 = preserve always). All writes to `~/.chorus/daemon.json` are now field-level merges that preserve every pre-existing field, including `yoloAckAt`. A config write — including `chorus login` — must never silently discard the user's recorded YOLO acknowledgement, which was the data-loss footgun this change fixes. Consequently re-login no longer clears the ack and no longer forces a one-time re-confirmation. The remaining permission-mode requirements (default YOLO, TTY first-run confirmation + persisted ack, non-TTY warn-and-run, `--chorus-only`) are unchanged and continue to bound YOLO exposure.
+
+**Migration:** none. Existing `daemon.json` files that already carry `yoloAckAt` simply retain it across the next `chorus login`. Files without an ack behave as before (a TTY yolo start still prompts once and persists the ack).

--- a/openspec/changes/fix-daemon-config-field-merge/specs/daemon-startup-output/spec.md
+++ b/openspec/changes/fix-daemon-config-field-merge/specs/daemon-startup-output/spec.md
@@ -1,0 +1,34 @@
+# daemon-startup-output Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: `claude` installation detection at startup
+
+On startup the daemon SHALL detect whether the `claude` executable is installed
+(reusing the existing PATH resolution, including the Windows `claude.cmd` shim and
+any configured override) and SHALL report the result in the startup banner —
+showing the resolved path when found, or a clear "not found" indication with
+guidance when absent. When `claude` is **not** found, the daemon SHALL, in
+addition to the banner row, emit exactly one prominent `⚠` warning line to
+**stderr** at startup — in the visual style of the YOLO autonomy warning line —
+stating that wakes will fail until `claude` is installed (or `CHORUS_CLAUDE_PATH`
+is set) and that `PATH` must include the directory holding `claude` (e.g.
+`~/.local/bin`). This stderr line ensures the missing binary is visible in an
+unattended/systemd journal at startup rather than only when a wake later fails.
+A missing `claude` SHALL NOT prevent the daemon from subscribing; the daemon SHALL
+still start, with wakes also surfacing the missing-binary error visibly when one
+arrives (preserving current non-fatal behavior).
+
+#### Scenario: Installed claude is reported with its path
+
+- **WHEN** `claude` is resolvable on PATH (or via the configured override) at
+  startup
+- **THEN** the banner shows that claude is installed and the resolved path, and no
+  `⚠` claude-not-found warning line is emitted
+
+#### Scenario: Missing claude is reported but does not block startup
+
+- **WHEN** `claude` cannot be resolved at startup
+- **THEN** the banner clearly indicates claude was not found with guidance, the
+  daemon emits exactly one prominent `⚠` stderr warning line naming how to fix it,
+  and the daemon still starts and subscribes

--- a/openspec/changes/fix-daemon-config-field-merge/tasks.md
+++ b/openspec/changes/fix-daemon-config-field-merge/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## 1. Shared merge helper + route all writers through it
+- [ ] 1.1 Add `updateDaemonConfig(partial, deps?)` — read→shallow-merge→atomic write(0600), defensive parse of a missing/corrupt file as `{}`
+- [ ] 1.2 Make `writeLoginFile(data)` a thin wrapper over `updateDaemonConfig(data)`; keep its `deps` seams
+- [ ] 1.3 Rewrite `recordYoloAck(ts)` to call `updateDaemonConfig({ yoloAckAt: ts })`
+- [ ] 1.4 Rewrite the misleading `login.mjs` JSDoc to state the merge-preserve contract (no more "omits yoloAckAt")
+- [ ] 1.5 Unit tests: preserve unrelated keys, partial overwrites, missing file, malformed file, mode 0600, atomic temp+rename
+
+## 2. login + daemon completion preserve all fields (the regression fix)
+- [ ] 2.1 Verify `chorus login` now preserves pre-existing `cwds` AND `yoloAckAt` (q1 preserve-always)
+- [ ] 2.2 Verify daemon `preflight()` TTY credential-completion path preserves `cwds`/`yoloAckAt` (q2 = both sites)
+- [ ] 2.3 Regression tests in `login.test.mjs` + `daemon-credential-completion.test.mjs`
+
+## 3. Loud `claude` NOT FOUND startup warning (q6 loud-stderr)
+- [ ] 3.1 Emit one `⚠` stderr line at startup when `resolveClaudePath()` is null; keep banner row; stay non-fatal
+- [ ] 3.2 Tests: warning emitted iff claude absent; daemon still subscribes
+
+## 4. Onboarding documentation (q5 fold-in)
+- [ ] 4.1 `docs/DAEMON.md`: "Running on boot (systemd)" — creds must be persisted via `chorus login`; field-merge guarantee; PATH must include claude dir
+
+## 5. Spec sync + plugin audit record (q4)
+- [ ] 5.1 daemon-permission-mode spec: REMOVE "Credential change clears the YOLO acknowledgement" (done in this change's delta)
+- [ ] 5.2 Record plugin state.json audit (flock+jq-merge safe; Codex stateless) in design — no code change
+
+## 6. Verify
+- [ ] 6.1 `pnpm test` (cli suite) + `npx tsc --noEmit` + `openspec validate fix-daemon-config-field-merge --strict`


### PR DESCRIPTION
## Summary

`chorus login` and the daemon's TTY credential-completion path overwrote the **entire** `~/.chorus/daemon.json`, clobbering pre-existing `cwds` / `yoloAckAt`. This bit setting the daemon up as a boot service (systemd unit didn't source `.zshrc` → no creds → operator runs `chorus login` → loses `cwds`/`yoloAckAt`). Fixes idea `2fbef34d` (Chorus 0.12.1).

- **Single merge helper** — every `daemon.json` write routes through `updateDaemonConfig(partial)`: read → shallow-merge → atomic temp+rename write at `0600`. `writeLoginFile` + `recordYoloAck` are now thin wrappers.
- **`yoloAckAt` preserved always** — intentionally retires the `daemon-permission-mode` requirement "Credential change clears the YOLO acknowledgement" (owner decision; a config write must never silently discard the ack). Both write sites (`login.mjs`, `daemon.mjs` preflight) now merge.
- **Loud `claude` NOT FOUND warning** — one `⚠` stderr line at startup when `claude` is unresolved (still non-fatal; daemon still subscribes).
- **Onboarding docs** — `docs/DAEMON.md` gains a boot/systemd checklist (persist creds via `chorus login`; PATH must include the `claude` dir).
- **Plugin `state.json`** — audited, left unchanged (already `flock`+`jq` merge-safe; Codex plugin stateless).

Authored in OpenSpec mode — change `fix-daemon-config-field-merge` (3 spec deltas: cli-auth MODIFIED, daemon-permission-mode REMOVED, daemon-startup-output MODIFIED). `openspec archive` is intentionally deferred until merge.

## Changed files

| File | Change |
|------|--------|
| `cli/login.mjs` | New `updateDaemonConfig` merge helper; `writeLoginFile`/`recordYoloAck` thin wrappers; JSDoc rewrite |
| `cli/daemon.mjs` | preflight completion now merges; loud claude-NOT-FOUND stderr warning |
| `cli/daemon-banner.mjs` | New `claudeNotFoundWarningLine()` |
| `docs/DAEMON.md` | Boot/systemd onboarding; fixed now-stale "login clears yoloAckAt" line |
| `cli/__tests__/*` | New `daemon-config-write` + `daemon-claude-notfound-warning`; updated `login`, `daemon-permission-wiring`, `daemon-credential-completion` (flipped the old clear-on-login test) |
| `openspec/changes/fix-daemon-config-field-merge/` | proposal/design/tasks + 3 spec deltas |

## Test plan

- [x] `npx vitest run cli/` → 37 files, 429 tests pass
- [x] `npx tsc --noEmit` → clean
- [x] `openspec validate fix-daemon-config-field-merge --strict` → valid
- [x] Per-task reviewers + aggregate code-reviewer: PASS / PASS WITH NOTES (no blockers)

## Follow-up (out of scope, tracked separately)

Child idea `ebfe6cd6`: the daemon hardcodes `hasAck:false` and never reads the persisted `yoloAckAt`, so the TTY still re-prompts YOLO on every start. This PR fixes the data-loss root cause; the "stop re-prompting" payoff needs that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)