### PR TITLE
fix(auth): harden root-route session probe + redirect already-authed users off /login

### DIFF
--- a/src/app/login/__tests__/role-picker.test.tsx
+++ b/src/app/login/__tests__/role-picker.test.tsx
@@ -42,6 +42,14 @@ vi.mock("@/lib/logger-client", () => ({
   clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
 
+// auth-client's authFetch/primeSessionCookie are used by the page's mount-time
+// already-authenticated check. Delegate authFetch to global.fetch (which each test
+// stubs) so the URL-based stubs drive it; primeSessionCookie is a no-op here.
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (url: string, init?: RequestInit) => fetch(url, init),
+  primeSessionCookie: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Use real translations so the test asserts on user-visible copy.
 vi.mock("next-intl", async () => {
   const en = (await import("../../../../messages/en.json")).default as Record<
@@ -112,6 +120,18 @@ function installFetch(handlers: {
     }
     if (url === "/api/agents") {
       return { ok: true, json: { success: true, data: [] } };
+    }
+    // The mount-time already-authenticated check (root-reopen fix): default to NOT
+    // authenticated so the login form renders as before. admin session not-success,
+    // user session not-success, keepalive prime is a no-op here.
+    if (url === "/api/admin/session") {
+      return { ok: true, json: { success: false } };
+    }
+    if (url === "/api/auth/session") {
+      return { ok: true, json: { success: false } };
+    }
+    if (url === "/api/keepalive") {
+      return { ok: true, json: { ok: true } };
     }
     throw new Error(`Unexpected fetch in test: ${url}`);
   };
@@ -378,5 +398,68 @@ describe("LoginPage role picker — Trigger B (identify multi_role)", () => {
       expect(screen.queryByText("Sign in as Super Admin")).toBeNull();
     });
     expect(screen.getByPlaceholderText("you@company.com")).toBeTruthy();
+  });
+});
+
+describe("LoginPage — already-authenticated redirect (root-reopen fix)", () => {
+  // Install a fetch stub where the user session probe reports an authenticated user,
+  // so the mount-time check should redirect into the app instead of showing the form.
+  function installAuthedFetch(opts: { admin?: boolean } = {}) {
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const u = typeof input === "string" ? input : String(input);
+      if (u === "/api/admin/session") {
+        return { ok: true, json: async () => ({ success: !!opts.admin }) } as Response;
+      }
+      if (u === "/api/auth/session") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, data: { user: { uuid: "u1", email: "a@b.c" } } }),
+        } as Response;
+      }
+      if (u === "/api/keepalive") {
+        return { ok: true, json: async () => ({ ok: true }) } as Response;
+      }
+      if (u === "/api/auth/check-default") {
+        return { ok: true, json: async () => ({ success: true, data: { enabled: false } }) } as Response;
+      }
+      throw new Error(`Unexpected fetch in test: ${u}`);
+    }) as unknown as typeof fetch;
+  }
+
+  it("redirects an already-logged-in user to /projects instead of showing the form", async () => {
+    installAuthedFetch();
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith("/projects");
+    });
+    // (In production router.replace unmounts this page; jsdom does not navigate, so we
+    // assert on the redirect call itself — the page-level contract — not DOM teardown.)
+  });
+
+  it("redirects an authenticated super admin to /admin", async () => {
+    installAuthedFetch({ admin: true });
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith("/admin");
+    });
+  });
+
+  it("shows the login form for an unauthenticated visitor (no redirect)", async () => {
+    // Default installFetch: admin session + user session both not-success.
+    installFetch({
+      checkDefault: { success: true, data: { enabled: false } },
+    });
+
+    render(<LoginPage />);
+
+    // The email/SSO form renders (the normal unauthenticated path).
+    expect(await screen.findByPlaceholderText("you@company.com")).toBeTruthy();
+    expect(mockRouterReplace).not.toHaveBeenCalledWith("/projects");
+    expect(mockRouterReplace).not.toHaveBeenCalledWith("/admin");
   });
 });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { createUserManager, storeOidcConfig, type OidcConfig } from "@/lib/oidc";
+import { authFetch, primeSessionCookie } from "@/lib/auth-client";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -27,6 +28,10 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const [defaultAuth, setDefaultAuth] = useState<DefaultAuthInfo | null>(null);
   const [defaultAuthChecked, setDefaultAuthChecked] = useState(false);
+  // Until we've confirmed the visitor is NOT already logged in, hold the form back so an
+  // already-authenticated user (e.g. bounced here after an iOS reopen) is redirected into
+  // the app instead of being stranded on the login form. See the auth-check effect below.
+  const [authChecked, setAuthChecked] = useState(false);
   const [showSsoForm, setShowSsoForm] = useState(false);
   // When non-null, the role picker is shown instead of any auth form. Seeded by
   // a check-default superAdminCollision (Trigger A) or an identify multi_role
@@ -57,6 +62,49 @@ export default function LoginPage() {
     }
     checkDefaultAuth();
   }, []);
+
+  // If the visitor is ALREADY logged in, send them into the app instead of showing the
+  // login form. This is the other half of the iOS-reopen fix: when a still-valid session
+  // gets bounced to /login (e.g. a root-route probe that 401'd before the cookie was
+  // refreshed), /login previously had no auth check and stranded the user on the form.
+  // We prime the cookie (matcher-covered request → middleware refreshes from the refresh
+  // token) and then probe; an admin session goes to /admin, a user session to /projects.
+  // A 401 / transient failure just falls through to render the form (the normal path).
+  useEffect(() => {
+    let cancelled = false;
+    async function redirectIfAuthenticated() {
+      try {
+        // Admin session first (mirrors the root route's precedence).
+        const adminRes = await fetch("/api/admin/session");
+        const adminData = await adminRes.json().catch(() => ({}));
+        if (!cancelled && adminData?.success) {
+          router.replace("/admin");
+          return;
+        }
+
+        let res = await authFetch("/api/auth/session");
+        if (res.status === 401) {
+          await primeSessionCookie();
+          res = await authFetch("/api/auth/session");
+        }
+        if (!cancelled && res.ok) {
+          const data = await res.json().catch(() => ({}));
+          if (data?.success && data?.data?.user) {
+            router.replace("/projects");
+            return;
+          }
+        }
+      } catch {
+        // Not authenticated / transient — fall through and show the login form.
+      } finally {
+        if (!cancelled) setAuthChecked(true);
+      }
+    }
+    redirectIfAuthenticated();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
 
   const handlePasswordLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -204,7 +252,10 @@ export default function LoginPage() {
     setShowSsoForm(false);
   };
 
-  if (!defaultAuthChecked) {
+  // Hold the form until BOTH checks resolve: default-auth config AND the
+  // already-authenticated probe. This prevents the login form from flashing before an
+  // already-logged-in visitor is redirected into the app.
+  if (!defaultAuthChecked || !authChecked) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-muted-foreground">{t("common.loading")}</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { authFetch, primeSessionCookie } from "@/lib/auth-client";
 
 export default function Home() {
   const t = useTranslations();
@@ -21,8 +22,20 @@ export default function Home() {
           return;
         }
 
-        // Check user session (works for both OIDC and default auth via cookie)
-        const userResponse = await fetch("/api/auth/session");
+        // Check user session (works for both OIDC and default auth via cookie).
+        // The session probe (/api/auth/session) is NOT covered by the middleware
+        // matcher, so it can't refresh the cookie itself. When the page is reopened
+        // after a long idle (iOS bfcache/frozen-tab restore), the access cookie may
+        // have expired with no preceding middleware-covered request — so a first probe
+        // would 401 even though the refresh token is still valid. Prime the cookie via
+        // a matcher-covered request and retry once before deciding. Mirrors the contract
+        // in (dashboard)/layout.tsx checkSession and auth-context.fetchSession.
+        let userResponse = await authFetch("/api/auth/session");
+        if (userResponse.status === 401) {
+          await primeSessionCookie();
+          userResponse = await authFetch("/api/auth/session");
+        }
+
         if (userResponse.ok) {
           const userData = await userResponse.json();
           if (userData.success) {
@@ -31,10 +44,15 @@ export default function Home() {
           }
         }
 
-        // Not logged in, redirect to login
-        router.replace("/login");
+        // Redirect to login ONLY on a true 401 that survived the prime+retry — a
+        // genuine "not logged in" signal. A transient/non-401 failure must NOT bounce
+        // a still-valid session (e.g. a network blip right after an iOS resume); stay
+        // on this lightweight loading screen and let a retry / navigation resolve it.
+        if (userResponse.status === 401) {
+          router.replace("/login");
+        }
       } catch {
-        router.replace("/login");
+        // Network/transient error — do NOT treat as logged-out; do not redirect.
       }
     };
 


### PR DESCRIPTION
## Problem (user repro, production SSO)

After leaving the phone browser idle for a long time, reopening it bounces the user to `/login` — **but the session is not actually lost**: manually navigating to another route works fine. And `/login` itself never checks auth state, so once bounced there the already-authenticated user is stranded on the form.

## Root cause — two missed entry points (same class as the earlier iOS-reopen fixes)

The session probe `/api/auth/session` is **not** covered by the middleware matcher, so it can't refresh the cookie itself. On an iOS bfcache / frozen-tab restore the access cookie is briefly stale with no preceding middleware-covered request. The earlier fixes hardened `(dashboard)/layout.tsx` and `auth-context.fetchSession`, but **two entry points were missed**:

1. **`src/app/page.tsx` (root `/`)** still used a raw `fetch` to `/api/auth/session` with no prime and no retry, and redirected to `/login` on **any** non-ok response or thrown error. On reopen-onto-root this 401s and bounces even though the refresh token is valid. (Manual nav works because those routes go through the already-fixed dashboard layout.)
2. **`src/app/login/page.tsx`** never checked whether the visitor was already authenticated, so anyone who lands on `/login` (e.g. bounced by #1) is stuck on the form.

## Fix (IdP-agnostic; reuses the proven `primeSessionCookie` contract)

- **`page.tsx`**: use `authFetch`, prime the cookie via the matcher-covered `/api/keepalive` and retry once on 401, redirect to `/login` **only** on a true post-prime 401, and never bounce on a transient/network error. Admin-session check unchanged.
- **`login/page.tsx`**: on mount, check if already authenticated (admin → `/admin`, user → `/projects`) after a prime and redirect into the app; hold the form behind a loading gate until both the default-auth and already-authenticated checks resolve (no flash). Unauthenticated visitors still see the form exactly as before.

## Scope / non-goals

No change to MCP/API-key auth, SuperAdmin, default-auth semantics, `getAuthContext` precedence, or middleware.

## Tests

`role-picker.test.tsx` gains an already-authenticated block (redirect to `/projects`, super-admin → `/admin`, unauthenticated still shows the form) and its fetch stub now models the mount-time probe. **121 auth tests pass; tsc clean.** Online Playwright verification on production (real Cognito) to follow after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)