### PR TITLE
feat(daemon): implement the codex backend behind --agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
 
 The `chorus daemon` connects your local machine to a remote Chorus server as an agent runtime and executes tasks assigned by Chorus.
 
-> **Current version:** Only **Claude Code** is supported. Support for other agent CLIs (Codex, Copilot, etc.) is planned for future releases.
+> **Agent backends:** **Claude Code** (default) and **Codex** are supported — select with `--agent codex` (or `CHORUS_AGENT=codex`). Support for other agent CLIs (Copilot, etc.) is planned for future releases.
 
 ```bash
 chorus login                     # Authenticate (opens browser)
@@ -110,7 +110,7 @@ chorus daemon logs               # View daemon logs
 
 **Key features:**
 
-- **Claude Code integration** — Auto-detects `claude` CLI on your PATH
+- **Claude Code & Codex backends** — Auto-detects the `claude` (or `codex`) CLI on your PATH; pick with `--agent codex`
 - **Background mode** — Run with `-d` flag; manage with `stop/restart/logs`
 - **Permission modes** — Default is full access (yolo); use `--chorus-only` to restrict to Chorus MCP tools only
 - **Multi-path** — Serve several working directories from one daemon with repeatable `--cwd` (see below)

--- a/README.zh.md
+++ b/README.zh.md
@@ -87,7 +87,7 @@ DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
 
 `chorus daemon` 将你的本地机器作为 Agent 运行时连接到远程 Chorus 服务器并执行 Chorus 分配的任务。
 
-> **当前版本：** 仅支持 **Claude Code**。对其他 Agent CLI（Codex、Copilot 等）的支持计划在未来版本中实现。
+> **Agent 后端：** 支持 **Claude Code**（默认）和 **Codex**，用 `--agent codex`（或 `CHORUS_AGENT=codex`）切换。对其他 Agent CLI（Copilot 等）的支持计划在未来版本中实现。
 
 ```bash
 chorus login                     # 认证（打开浏览器）
@@ -101,7 +101,7 @@ chorus daemon logs               # 查看 daemon 日志
 
 **主要特性：**
 
-- **Claude Code 集成** — 自动检测 PATH 中的 `claude` CLI
+- **Claude Code 与 Codex 后端** — 自动检测 PATH 中的 `claude`（或 `codex`）CLI；用 `--agent codex` 选择
 - **后台模式** — 使用 `-d` 标志后台运行；用 `stop/restart/logs` 管理
 - **权限模式** — 默认完全访问（yolo）；使用 `--chorus-only` 限制为仅 Chorus MCP 工具
 - **多路径** — 用可重复的 `--cwd` 让单个 daemon 同时服务多个工作目录（见下文）

--- a/cli/__tests__/codex-backend-integration.test.mjs
+++ b/cli/__tests__/codex-backend-integration.test.mjs
@@ -1,0 +1,151 @@
+// cli/__tests__/codex-backend-integration.test.mjs
+// Integration checkpoint for add-daemon-codex-backend (task 4): proves the Codex
+// backend works through the REAL daemon wiring (tasks 1–3 together) and that the
+// claude-code default does not regress.
+//
+//   1. Interrupt parity — the real CodexSpawner spawns a detached process group,
+//      so the EXISTING killProcessTree (no new killer) group-signals its tree.
+//   2. Default backend unchanged — buildDaemon with no agentType injects a
+//      ClaudeSpawner.
+//   3. Codex backend end-to-end — buildDaemon with agentType:"codex" injects a
+//      CodexSpawner; driving its wake() through a fake spawn yields the expected
+//      `codex exec --json` (new) and `codex exec resume <id>` (known anchor) argv,
+//      prompt on stdin, daemon key in the child env (never argv).
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { buildDaemon } from "../daemon.mjs";
+import { ClaudeSpawner } from "../claude-spawner.mjs";
+import { CodexSpawner } from "../codex-spawner.mjs";
+import { killProcessTree } from "../process-killer.mjs";
+
+const CREDS = { url: "https://chorus.test", apiKey: "cho_daemonkey" };
+const ANCHOR = "11111111-1111-4111-8111-111111111111";
+const TID = "019f091a-844e-7b43-8c31-6b04ffa38149";
+const silent = { info() {}, warn() {}, error() {} };
+
+function makeFakeChild(pid = 9100) {
+  const child = new EventEmitter();
+  const stdin = new EventEmitter();
+  stdin.writes = [];
+  stdin.write = (c) => stdin.writes.push(String(c));
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+  child.stdout = new EventEmitter();
+  child.stdout.setEncoding = () => {};
+  child.stderr = new EventEmitter();
+  child.stderr.setEncoding = () => {};
+  child.pid = pid;
+  return child;
+}
+
+describe("interrupt parity — CodexSpawner detached group is reaped by the existing killProcessTree", () => {
+  it("CodexSpawner spawns detached on POSIX (process-group leader)", async () => {
+    const child = makeFakeChild();
+    let spawnOpts;
+    const spawner = new CodexSpawner({
+      codexPath: "/usr/bin/codex",
+      platform: "linux",
+      permissionMode: "yolo",
+      creds: CREDS,
+      logger: silent,
+      getThreadIdFn: () => null,
+      setThreadIdFn: () => {},
+      spawnImpl: (_c, _a, opts) => {
+        spawnOpts = opts;
+        return child;
+      },
+    });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 0);
+    await p;
+    expect(spawnOpts.detached).toBe(true);
+  });
+
+  it("killProcessTree group-signals the Codex child's pid (negative pid) — same killer, no new code", async () => {
+    const child = makeFakeChild(4321);
+    const killImpl = vi.fn();
+    const res = await killProcessTree(child, {
+      platform: "linux",
+      logger: silent,
+      killImpl,
+      sigintTimeoutMs: 20,
+      waitForExit: vi.fn(async () => true),
+    });
+    expect(killImpl).toHaveBeenCalledWith(-4321, "SIGINT");
+    expect(res).toMatchObject({ signaled: true, killed: true });
+  });
+});
+
+describe("buildDaemon spawner selection (end-to-end wiring)", () => {
+  it("default (no agentType) injects a ClaudeSpawner — claude-code unchanged", () => {
+    const daemon = buildDaemon(CREDS, { logger: silent, permissionMode: "yolo" });
+    expect(daemon.spawner).toBeInstanceOf(ClaudeSpawner);
+  });
+
+  it("agentType 'codex' injects a CodexSpawner carrying creds + permissionMode", () => {
+    const daemon = buildDaemon(CREDS, { logger: silent, permissionMode: "yolo", agentType: "codex" });
+    expect(daemon.spawner).toBeInstanceOf(CodexSpawner);
+    expect(daemon.spawner.permissionMode).toBe("yolo");
+    expect(daemon.spawner.creds).toEqual(CREDS);
+  });
+});
+
+describe("codex backend end-to-end argv (via the daemon-selected spawner)", () => {
+  /** Build a daemon, grab its CodexSpawner, and drive wake() with a fake spawn. */
+  function codexSpawnerWithFakeSpawn({ getThreadId } = {}) {
+    const daemon = buildDaemon(CREDS, { logger: silent, permissionMode: "yolo", agentType: "codex" });
+    const spawner = daemon.spawner;
+    // Inject test seams onto the real selected spawner.
+    spawner.codexPath = "/usr/bin/codex";
+    spawner.platform = "linux";
+    spawner.getThreadIdFn = getThreadId ?? (() => null);
+    spawner.setThreadIdFn = vi.fn();
+    const calls = {};
+    spawner.spawnImpl = (command, argv, opts) => {
+      calls.command = command;
+      calls.argv = argv;
+      calls.opts = opts;
+      return makeFakeChild();
+    };
+    return { spawner, calls };
+  }
+
+  it("NEW anchor → `codex exec --json …`, prompt on stdin, daemon key in env not argv", async () => {
+    const { spawner, calls } = codexSpawnerWithFakeSpawn({ getThreadId: () => null });
+    const child = makeFakeChild();
+    spawner.spawnImpl = (command, argv, opts) => {
+      calls.command = command;
+      calls.argv = argv;
+      calls.opts = opts;
+      return child;
+    };
+    const p = spawner.wake({ prompt: "wake up codex", sessionId: ANCHOR, isNew: true });
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.emit("close", 0);
+    await p;
+
+    expect(calls.command).toBe("/usr/bin/codex");
+    expect(calls.argv.slice(0, 2)).toEqual(["exec", "--json"]);
+    expect(calls.argv).toContain("--dangerously-bypass-approvals-and-sandbox");
+    expect(calls.argv).not.toContain("resume");
+    expect(child.stdin.writes.join("")).toBe("wake up codex");
+    expect(calls.argv.join(" ")).not.toContain("wake up codex");
+    expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_daemonkey");
+    expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+    expect(calls.argv.join(" ")).not.toContain("cho_daemonkey");
+  });
+
+  it("KNOWN anchor (map hit) → `codex exec resume <thread_id> --json`", async () => {
+    const { spawner, calls } = codexSpawnerWithFakeSpawn({ getThreadId: () => TID });
+    const child = makeFakeChild();
+    spawner.spawnImpl = (command, argv, opts) => {
+      calls.argv = argv;
+      calls.opts = opts;
+      return child;
+    };
+    const p = spawner.wake({ prompt: "continue", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 0);
+    await p;
+    expect(calls.argv.slice(0, 4)).toEqual(["exec", "resume", TID, "--json"]);
+  });
+});

--- a/cli/__tests__/codex-session-map.test.mjs
+++ b/cli/__tests__/codex-session-map.test.mjs
@@ -1,0 +1,130 @@
+// cli/__tests__/codex-session-map.test.mjs
+// Covers daemon-codex-backend spec "Codex session anchoring via a persisted
+// idea→thread-id map": round-trip across restarts, and best-effort degradation
+// (missing file / corrupt JSON / write failure never throw into the wake path).
+import { describe, it, expect, vi } from "vitest";
+import {
+  getThreadId,
+  setThreadId,
+  codexSessionMapPath,
+} from "../codex-session-map.mjs";
+
+const ANCHOR = "11111111-1111-4111-8111-111111111111";
+const ANCHOR2 = "22222222-2222-4222-8222-222222222222";
+const TID = "0199a213-aaaa-7bbb-cccc-dddddddddddd";
+
+/** An in-memory fake FS implementing just the inject points the module uses. */
+function makeFakeFs(initial = {}) {
+  const files = { ...initial };
+  return {
+    files,
+    read: (p) => {
+      if (!(p in files)) {
+        const err = new Error(`ENOENT: ${p}`);
+        err.code = "ENOENT";
+        throw err;
+      }
+      return files[p];
+    },
+    write: (p, c) => {
+      files[p] = String(c);
+    },
+    mkdir: () => {},
+    rename: (from, to) => {
+      files[to] = files[from];
+      delete files[from];
+    },
+  };
+}
+
+describe("codexSessionMapPath", () => {
+  it("lives under the ~/.chorus config dir family", () => {
+    expect(codexSessionMapPath()).toMatch(/[\\/]\.chorus[\\/]codex-sessions\.json$/);
+  });
+});
+
+describe("get/set round-trip", () => {
+  it("returns null for an unknown anchor on a missing file", () => {
+    const io = makeFakeFs();
+    expect(getThreadId(ANCHOR, { ...io, path: "/cfg/codex-sessions.json" })).toBeNull();
+  });
+
+  it("persists an anchor→thread_id and reads it back (separate calls = restart)", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/codex-sessions.json";
+    setThreadId(ANCHOR, TID, { ...io, path });
+    // A fresh getThreadId call (new in-process read) sees the persisted value.
+    expect(getThreadId(ANCHOR, { ...io, path })).toBe(TID);
+  });
+
+  it("keeps multiple anchors independent and preserves existing entries on set", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/codex-sessions.json";
+    setThreadId(ANCHOR, TID, { ...io, path });
+    setThreadId(ANCHOR2, "second-thread", { ...io, path });
+    expect(getThreadId(ANCHOR, { ...io, path })).toBe(TID);
+    expect(getThreadId(ANCHOR2, { ...io, path })).toBe("second-thread");
+  });
+
+  it("overwrites the thread_id when set again for the same anchor", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/codex-sessions.json";
+    setThreadId(ANCHOR, TID, { ...io, path });
+    setThreadId(ANCHOR, "new-thread", { ...io, path });
+    expect(getThreadId(ANCHOR, { ...io, path })).toBe("new-thread");
+  });
+
+  it("writes atomically via a .tmp sibling then rename", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/codex-sessions.json";
+    const rename = vi.fn(io.rename);
+    setThreadId(ANCHOR, TID, { ...io, path, rename });
+    expect(rename).toHaveBeenCalledWith(`${path}.tmp`, path);
+  });
+});
+
+describe("best-effort degradation (never throws into the wake path)", () => {
+  it("getThreadId returns null on corrupt JSON (and logs)", () => {
+    const io = makeFakeFs({ "/cfg/codex-sessions.json": "{ not json" });
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    expect(() => getThreadId(ANCHOR, { ...io, path: "/cfg/codex-sessions.json", logger })).not.toThrow();
+    expect(getThreadId(ANCHOR, { ...io, path: "/cfg/codex-sessions.json", logger })).toBeNull();
+  });
+
+  it("getThreadId returns null when the stored value for the anchor is not a string", () => {
+    const io = makeFakeFs({ "/cfg/codex-sessions.json": JSON.stringify({ [ANCHOR]: 123 }) });
+    expect(getThreadId(ANCHOR, { ...io, path: "/cfg/codex-sessions.json" })).toBeNull();
+  });
+
+  it("setThreadId swallows a write failure (logs, does not throw)", () => {
+    const io = makeFakeFs();
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    const write = () => {
+      throw new Error("EACCES");
+    };
+    expect(() =>
+      setThreadId(ANCHOR, TID, { ...io, path: "/cfg/codex-sessions.json", write, logger })
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("setThreadId swallows a rename failure (logs, does not throw)", () => {
+    const io = makeFakeFs();
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    const rename = () => {
+      throw new Error("EXDEV");
+    };
+    expect(() =>
+      setThreadId(ANCHOR, TID, { ...io, path: "/cfg/codex-sessions.json", rename, logger })
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("ignores a blank anchor or blank threadId on set (no write)", () => {
+    const io = makeFakeFs();
+    const write = vi.fn(io.write);
+    setThreadId("", TID, { ...io, path: "/cfg/codex-sessions.json", write });
+    setThreadId(ANCHOR, "", { ...io, path: "/cfg/codex-sessions.json", write });
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/cli/__tests__/codex-spawner.test.mjs
+++ b/cli/__tests__/codex-spawner.test.mjs
@@ -1,0 +1,288 @@
+// cli/__tests__/codex-spawner.test.mjs
+// Covers daemon-codex-backend spec: headless `codex exec --json` wake (prompt on
+// stdin), buildArgs for new vs resume + sandbox flag, thread-id capture from the
+// `thread.started` event + persistence, daemon-key-via-env, cross-platform exec
+// resolution, and never-throw-into-the-wake-path failure handling.
+//
+// Verified against codex-cli 0.142.3: a real `codex exec --json` first line is
+// `{"type":"thread.started","thread_id":"<uuid>"}` and the prompt is read from
+// stdin ("Reading prompt from stdin...").
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import {
+  CodexSpawner,
+  buildCodexArgs,
+  sandboxFlags,
+  resolveCodexPath,
+  extractThreadId,
+} from "../codex-spawner.mjs";
+
+const ANCHOR = "11111111-1111-4111-8111-111111111111";
+const TID = "019f091a-844e-7b43-8c31-6b04ffa38149";
+
+/** A fake child process: stdin captures writes; stdout/stderr are emitters. */
+function makeFakeChild() {
+  const child = new EventEmitter();
+  const stdinChunks = [];
+  const stdin = new EventEmitter();
+  stdin.writes = stdinChunks;
+  stdin.write = (c) => stdinChunks.push(String(c));
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+  child.stdout = new EventEmitter();
+  child.stdout.setEncoding = () => {};
+  child.stderr = new EventEmitter();
+  child.stderr.setEncoding = () => {};
+  child.pid = 4242;
+  return child;
+}
+
+describe("sandboxFlags — permission mode mapping (subcommand-aware)", () => {
+  it("yolo → --dangerously-bypass-approvals-and-sandbox (valid on both exec and resume)", () => {
+    expect(sandboxFlags("yolo")).toEqual(["--dangerously-bypass-approvals-and-sandbox"]);
+    expect(sandboxFlags("yolo", { resume: true })).toEqual(["--dangerously-bypass-approvals-and-sandbox"]);
+  });
+  it("chorus on NEW (exec) → --sandbox read-only", () => {
+    expect(sandboxFlags("chorus")).toEqual(["--sandbox", "read-only"]);
+  });
+  it("chorus on RESUME → -c sandbox_mode=read-only (codex exec resume has NO --sandbox flag)", () => {
+    // Verified against codex 0.142.3: `codex exec resume --sandbox` errors (exit 2);
+    // the read-only posture must go through the `-c` config override there.
+    expect(sandboxFlags("chorus", { resume: true })).toEqual(["-c", 'sandbox_mode="read-only"']);
+  });
+  it("defaults unknown/undefined to the restricted read-only posture (per subcommand)", () => {
+    expect(sandboxFlags(undefined)).toEqual(["--sandbox", "read-only"]);
+    expect(sandboxFlags(undefined, { resume: true })).toEqual(["-c", 'sandbox_mode="read-only"']);
+  });
+});
+
+describe("buildCodexArgs — new vs resume", () => {
+  it("new run: exec --json + sandbox + skip-git-repo-check, no resume, no prompt in argv", () => {
+    const args = buildCodexArgs({ isNew: true, permissionMode: "yolo" });
+    expect(args).toEqual(["exec", "--json", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check"]);
+    expect(args).not.toContain("resume");
+  });
+
+  it("resume run (yolo): exec resume <thread_id> --json + bypass flag", () => {
+    const args = buildCodexArgs({ isNew: false, threadId: TID, permissionMode: "yolo" });
+    expect(args).toEqual([
+      "exec",
+      "resume",
+      TID,
+      "--json",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--skip-git-repo-check",
+    ]);
+  });
+
+  it("resume run (chorus): exec resume <thread_id> --json -c sandbox_mode=read-only (NO --sandbox)", () => {
+    const args = buildCodexArgs({ isNew: false, threadId: TID, permissionMode: "chorus" });
+    expect(args).toEqual([
+      "exec",
+      "resume",
+      TID,
+      "--json",
+      "-c",
+      'sandbox_mode="read-only"',
+      "--skip-git-repo-check",
+    ]);
+    // the bug this regression-guards: `--sandbox` is rejected by `codex exec resume`.
+    expect(args).not.toContain("--sandbox");
+  });
+
+  it("chorus mode keeps read-only on new (--sandbox) and resume (-c sandbox_mode)", () => {
+    expect(buildCodexArgs({ isNew: true, permissionMode: "chorus" })).toEqual([
+      "exec",
+      "--json",
+      "--sandbox",
+      "read-only",
+      "--skip-git-repo-check",
+    ]);
+    expect(buildCodexArgs({ isNew: false, threadId: TID, permissionMode: "chorus" })).toContain('sandbox_mode="read-only"');
+  });
+
+  it("never contains the prompt (prompt is stdin-only)", () => {
+    const args = buildCodexArgs({ isNew: true, permissionMode: "yolo" });
+    expect(args.join(" ")).not.toContain("PROMPT");
+  });
+});
+
+describe("extractThreadId — capture from the thread.started event", () => {
+  it("reads thread_id from a thread.started event", () => {
+    expect(extractThreadId({ type: "thread.started", thread_id: TID })).toBe(TID);
+  });
+  it("falls back to session_meta.payload.id (on-disk rollout shape)", () => {
+    expect(extractThreadId({ type: "session_meta", payload: { id: TID } })).toBe(TID);
+  });
+  it("returns null for unrelated events", () => {
+    expect(extractThreadId({ type: "turn.completed" })).toBeNull();
+    expect(extractThreadId({ type: "item.completed", item: {} })).toBeNull();
+    expect(extractThreadId(null)).toBeNull();
+  });
+});
+
+describe("resolveCodexPath", () => {
+  const isFile = (set) => (p) => set.has(p);
+
+  it("honors CHORUS_CODEX_PATH override when it is a file", () => {
+    const env = { CHORUS_CODEX_PATH: "/opt/codex", PATH: "/usr/bin" };
+    expect(resolveCodexPath({ env, platform: "linux", isFile: isFile(new Set(["/opt/codex"])) })).toBe("/opt/codex");
+  });
+
+  it("walks PATH for `codex` on POSIX", () => {
+    const env = { PATH: "/a:/b" };
+    expect(resolveCodexPath({ env, platform: "linux", isFile: isFile(new Set(["/b/codex"])) })).toBe("/b/codex");
+  });
+
+  it("prefers codex.cmd / codex.exe on Windows", () => {
+    const env = { Path: "C:\\bin" };
+    const got = resolveCodexPath({ env, platform: "win32", isFile: isFile(new Set(["C:\\bin\\codex.cmd"])) });
+    expect(got).toBe("C:\\bin\\codex.cmd");
+  });
+
+  it("returns null when nothing resolves", () => {
+    expect(resolveCodexPath({ env: { PATH: "/x" }, platform: "linux", isFile: () => false })).toBeNull();
+  });
+});
+
+describe("CodexSpawner.wake — spawn orchestration", () => {
+  const creds = { url: "https://chorus.test", apiKey: "cho_secret" };
+
+  /** Build a spawner whose spawnImpl returns our fake child + records the call. */
+  function makeSpawner({ child, permissionMode = "yolo", getThreadId, setThreadId, codexPath = "/usr/bin/codex" } = {}) {
+    const calls = {};
+    const spawnImpl = vi.fn((command, argv, opts) => {
+      calls.command = command;
+      calls.argv = argv;
+      calls.opts = opts;
+      return child;
+    });
+    const spawner = new CodexSpawner({
+      codexPath,
+      spawnImpl,
+      permissionMode,
+      creds,
+      platform: "linux",
+      logger: { info() {}, warn() {}, error() {} },
+      getThreadIdFn: getThreadId ?? (() => null),
+      setThreadIdFn: setThreadId ?? (() => {}),
+    });
+    return { spawner, spawnImpl, calls };
+  }
+
+  it("new wake: spawns `codex exec --json …`, prompt over stdin, key in env (not argv)", async () => {
+    const child = makeFakeChild();
+    const { spawner, calls } = makeSpawner({ child });
+    const onChild = vi.fn();
+    const p = spawner.wake({ prompt: "do the thing", sessionId: ANCHOR, isNew: true, onChild });
+    // stream a thread.started then exit 0
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.emit("close", 0);
+    const result = await p;
+
+    expect(calls.argv.slice(0, 2)).toEqual(["exec", "--json"]);
+    expect(calls.argv).not.toContain("resume");
+    // prompt only on stdin, never argv
+    expect(child.stdin.writes.join("")).toBe("do the thing");
+    expect(calls.argv.join(" ")).not.toContain("do the thing");
+    // daemon key exported via env, headless flag set, key absent from argv
+    expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_secret");
+    expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+    expect(calls.argv.join(" ")).not.toContain("cho_secret");
+    // detached process group on POSIX (for interrupt parity)
+    expect(calls.opts.detached).toBe(true);
+    // onChild fired exactly once with the live child
+    expect(onChild).toHaveBeenCalledTimes(1);
+    expect(onChild).toHaveBeenCalledWith(child);
+    // returns the captured thread id as the session id
+    expect(result.exitCode).toBe(0);
+    expect(result.sessionId).toBe(TID);
+  });
+
+  it("captures thread_id and persists anchor→thread_id on a successful new run", async () => {
+    const child = makeFakeChild();
+    const setThreadId = vi.fn();
+    const { spawner } = makeSpawner({ child, setThreadId });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.emit("close", 0);
+    await p;
+    expect(setThreadId).toHaveBeenCalledWith(ANCHOR, TID);
+  });
+
+  it("does NOT persist on a non-zero exit (failed run)", async () => {
+    const child = makeFakeChild();
+    const setThreadId = vi.fn();
+    const { spawner } = makeSpawner({ child, setThreadId });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.emit("close", 1);
+    await p;
+    expect(setThreadId).not.toHaveBeenCalled();
+  });
+
+  it("resume wake: a known anchor produces `exec resume <thread_id>` (ignores passed isNew)", async () => {
+    const child = makeFakeChild();
+    const { spawner, calls } = makeSpawner({ child, getThreadId: () => TID });
+    // pass isNew:true but the map has a thread id → spawner must resume
+    const p = spawner.wake({ prompt: "again", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 0);
+    await p;
+    expect(calls.argv.slice(0, 3)).toEqual(["exec", "resume", TID]);
+  });
+
+  it("forwards each parsed event to onMessage", async () => {
+    const child = makeFakeChild();
+    const { spawner } = makeSpawner({ child });
+    const onMessage = vi.fn();
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true, onMessage });
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.stdout.emit("data", JSON.stringify({ type: "turn.completed" }) + "\n");
+    child.emit("close", 0);
+    await p;
+    expect(onMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("never throws and returns exitCode:null when the codex executable is unresolved", async () => {
+    const child = makeFakeChild();
+    const { spawner, spawnImpl } = makeSpawner({ child, codexPath: null });
+    // codexPath null AND resolver finds nothing → no spawn, no throw
+    spawner.resolveCodexPathFn = () => null;
+    const result = await spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("never throws when spawn itself throws (returns exitCode:null)", async () => {
+    const spawner = new CodexSpawner({
+      codexPath: "/usr/bin/codex",
+      spawnImpl: () => {
+        throw new Error("EACCES");
+      },
+      permissionMode: "yolo",
+      creds,
+      platform: "linux",
+      logger: { info() {}, warn() {}, error() {} },
+      getThreadIdFn: () => null,
+      setThreadIdFn: () => {},
+    });
+    const result = await spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("tolerates a thrown onChild without escaping the wake path", async () => {
+    const child = makeFakeChild();
+    const { spawner } = makeSpawner({ child });
+    const p = spawner.wake({
+      prompt: "x",
+      sessionId: ANCHOR,
+      isNew: true,
+      onChild: () => {
+        throw new Error("boom");
+      },
+    });
+    child.emit("close", 0);
+    const result = await p;
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/cli/__tests__/daemon-agent.test.mjs
+++ b/cli/__tests__/daemon-agent.test.mjs
@@ -1,0 +1,54 @@
+// cli/__tests__/daemon-agent.test.mjs
+// Covers daemon-agent-selection spec (MODIFIED for add-daemon-codex-backend):
+// resolveAgentType now accepts BOTH claude-code and codex; unknown values are
+// still rejected non-zero with no silent fallback; default stays claude-code.
+import { describe, it, expect } from "vitest";
+import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT } from "../daemon-agent.mjs";
+
+describe("resolveAgentType — known backends", () => {
+  it("defaults to claude-code with no flag and no env", () => {
+    expect(resolveAgentType({}, {})).toEqual({ ok: true, agent: "claude-code" });
+  });
+
+  it("accepts explicit claude-code (flag and env)", () => {
+    expect(resolveAgentType({ agent: "claude-code" }, {})).toEqual({ ok: true, agent: "claude-code" });
+    expect(resolveAgentType({}, { CHORUS_AGENT: "claude-code" })).toEqual({ ok: true, agent: "claude-code" });
+  });
+
+  it("accepts codex via --agent flag", () => {
+    expect(resolveAgentType({ agent: "codex" }, {})).toEqual({ ok: true, agent: "codex" });
+  });
+
+  it("accepts codex via CHORUS_AGENT env", () => {
+    expect(resolveAgentType({}, { CHORUS_AGENT: "codex" })).toEqual({ ok: true, agent: "codex" });
+  });
+
+  it("flag wins over env (codex flag overrides claude-code env)", () => {
+    expect(resolveAgentType({ agent: "codex" }, { CHORUS_AGENT: "claude-code" })).toEqual({
+      ok: true,
+      agent: "codex",
+    });
+  });
+
+  it("lists both backends in KNOWN_AGENTS and keeps claude-code default", () => {
+    expect(KNOWN_AGENTS).toContain("claude-code");
+    expect(KNOWN_AGENTS).toContain("codex");
+    expect(DEFAULT_AGENT).toBe("claude-code");
+  });
+});
+
+describe("resolveAgentType — unknown rejected (no silent fallback)", () => {
+  it("rejects an unknown --agent value with a clear error naming accepted types", () => {
+    const r = resolveAgentType({ agent: "gemini" }, {});
+    expect(r.ok).toBe(false);
+    expect(r.value).toBe("gemini");
+    expect(r.error).toContain("codex");
+    expect(r.error).toContain("claude-code");
+  });
+
+  it("rejects an unknown CHORUS_AGENT value", () => {
+    const r = resolveAgentType({}, { CHORUS_AGENT: "nope" });
+    expect(r.ok).toBe(false);
+    expect(r.value).toBe("nope");
+  });
+});

--- a/cli/__tests__/daemon-agent.test.mjs
+++ b/cli/__tests__/daemon-agent.test.mjs
@@ -3,7 +3,7 @@
 // resolveAgentType now accepts BOTH claude-code and codex; unknown values are
 // still rejected non-zero with no silent fallback; default stays claude-code.
 import { describe, it, expect } from "vitest";
-import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT } from "../daemon-agent.mjs";
+import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT, backendClientType } from "../daemon-agent.mjs";
 
 describe("resolveAgentType — known backends", () => {
   it("defaults to claude-code with no flag and no env", () => {
@@ -50,5 +50,18 @@ describe("resolveAgentType — unknown rejected (no silent fallback)", () => {
     const r = resolveAgentType({}, { CHORUS_AGENT: "nope" });
     expect(r.ok).toBe(false);
     expect(r.value).toBe("nope");
+  });
+});
+
+describe("backendClientType — agentType → self-reported clientType", () => {
+  it("maps codex → codex", () => {
+    expect(backendClientType("codex")).toBe("codex");
+  });
+  it("maps claude-code → claude_code", () => {
+    expect(backendClientType("claude-code")).toBe("claude_code");
+  });
+  it("falls back to claude_code for unknown/undefined", () => {
+    expect(backendClientType(undefined)).toBe("claude_code");
+    expect(backendClientType("whatever")).toBe("claude_code");
   });
 });

--- a/cli/__tests__/daemon-banner.test.mjs
+++ b/cli/__tests__/daemon-banner.test.mjs
@@ -2,7 +2,7 @@
 // Covers daemon-startup-output spec "Boxed startup banner" + daemon-agent-selection.
 import { describe, it, expect } from "vitest";
 import { formatBanner, bannerRows } from "../daemon-banner.mjs";
-import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT } from "../daemon-agent.mjs";
+import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT, backendCli } from "../daemon-agent.mjs";
 
 const INFO = {
   version: "0.11.0",
@@ -12,7 +12,7 @@ const INFO = {
   permissionMode: "yolo",
   credentialSource: "login-file",
   agentType: "claude-code",
-  claudePath: "/usr/bin/claude",
+  cliPath: "/usr/bin/claude",
   connection: "connecting…",
 };
 
@@ -33,6 +33,23 @@ describe("formatBanner — content", () => {
     }
   });
 
+  it("labels the CLI row for the SELECTED backend — claude-code → 'claude CLI'", () => {
+    const out = formatBanner(INFO, { isTTY: false });
+    expect(out).toContain("claude CLI");
+    expect(out).not.toContain("codex CLI");
+  });
+
+  it("labels the CLI row 'codex CLI' and shows the codex path when agentType is codex", () => {
+    const out = formatBanner(
+      { ...INFO, agentType: "codex", cliPath: "/home/u/.nvm/bin/codex" },
+      { isTTY: false }
+    );
+    expect(out).toContain("codex CLI");
+    expect(out).toContain("/home/u/.nvm/bin/codex");
+    // must NOT mislabel a codex run as claude
+    expect(out).not.toMatch(/claude CLI/);
+  });
+
   it("highlights yolo permission mode", () => {
     const out = formatBanner(INFO, { isTTY: false });
     expect(out).toMatch(/YOLO/);
@@ -44,9 +61,31 @@ describe("formatBanner — content", () => {
   });
 
   it("shows a clear not-found message when claude is missing", () => {
-    const out = formatBanner({ ...INFO, claudePath: null }, { isTTY: false });
+    const out = formatBanner({ ...INFO, cliPath: null }, { isTTY: false });
     expect(out).toMatch(/NOT FOUND/i);
     expect(out).toContain("CHORUS_CLAUDE_PATH");
+  });
+
+  it("not-found message names the CODEX override when the codex backend is missing", () => {
+    const out = formatBanner(
+      { ...INFO, agentType: "codex", cliPath: null },
+      { isTTY: false }
+    );
+    expect(out).toMatch(/NOT FOUND/i);
+    expect(out).toContain("CHORUS_CODEX_PATH");
+    expect(out).not.toContain("CHORUS_CLAUDE_PATH");
+  });
+});
+
+describe("backendCli — per-backend CLI descriptor", () => {
+  it("claude-code → claude binary + CHORUS_CLAUDE_PATH override", () => {
+    expect(backendCli("claude-code")).toEqual({ name: "claude", envVar: "CHORUS_CLAUDE_PATH" });
+  });
+  it("codex → codex binary + CHORUS_CODEX_PATH override", () => {
+    expect(backendCli("codex")).toEqual({ name: "codex", envVar: "CHORUS_CODEX_PATH" });
+  });
+  it("unknown/undefined falls back to the claude descriptor (default backend)", () => {
+    expect(backendCli(undefined)).toEqual({ name: "claude", envVar: "CHORUS_CLAUDE_PATH" });
   });
 });
 

--- a/cli/__tests__/daemon-banner.test.mjs
+++ b/cli/__tests__/daemon-banner.test.mjs
@@ -108,10 +108,15 @@ describe("resolveAgentType", () => {
     expect(resolveAgentType({ agent: "claude-code" }, { CHORUS_AGENT: "bogus" }).ok).toBe(true);
   });
 
+  it("accepts codex as a known backend", () => {
+    expect(resolveAgentType({ agent: "codex" }, {})).toEqual({ ok: true, agent: "codex" });
+    expect(KNOWN_AGENTS).toContain("codex");
+  });
+
   it("rejects an unknown agent with a non-silent actionable error", () => {
-    const r = resolveAgentType({ agent: "codex" }, {});
+    const r = resolveAgentType({ agent: "gemini" }, {});
     expect(r.ok).toBe(false);
-    expect(r.value).toBe("codex");
+    expect(r.value).toBe("gemini");
     expect(r.error).toContain("codex");
     expect(r.error).toContain("claude-code");
   });

--- a/cli/__tests__/daemon-claude-notfound-warning.test.mjs
+++ b/cli/__tests__/daemon-claude-notfound-warning.test.mjs
@@ -3,7 +3,7 @@
 // stderr warning at startup, while the daemon STILL subscribes (non-fatal).
 import { describe, it, expect, vi } from "vitest";
 import { runDaemon } from "../daemon.mjs";
-import { claudeNotFoundWarningLine } from "../daemon-banner.mjs";
+import { agentNotFoundWarningLine, claudeNotFoundWarningLine } from "../daemon-banner.mjs";
 
 /** Minimal happy-path deps; per-test overrides merge on top. */
 function baseDeps(over = {}) {
@@ -50,16 +50,50 @@ describe("runDaemon — claude CLI NOT FOUND warning", () => {
     expect(build).toHaveBeenCalledOnce();
     expect(errs.join("\n")).not.toContain("claude CLI NOT FOUND");
   });
+
+  it("with --agent codex, a missing codex emits a CODEX-specific warning (not claude)", async () => {
+    const errs = [];
+    const build = vi.fn(() => ({ async start() {}, async stop() {} }));
+    const code = await runDaemon(
+      { chorusOnly: true, agent: "codex" },
+      // resolveClaudePath must NOT be consulted for codex; inject the codex resolver
+      baseDeps({
+        build,
+        errLog: (m) => errs.push(m),
+        resolveClaudePath: () => "/usr/bin/claude", // present, but irrelevant for codex
+        resolveCodexPath: () => null, // codex missing
+      })
+    );
+    expect(code).toBe(0);
+    expect(build).toHaveBeenCalledOnce();
+    const joined = errs.join("\n");
+    expect(joined).toContain("codex CLI NOT FOUND");
+    expect(joined).toContain("CHORUS_CODEX_PATH");
+    expect(joined).not.toContain("claude CLI NOT FOUND");
+  });
 });
 
-describe("claudeNotFoundWarningLine — content", () => {
-  it("is a loud, actionable single line", () => {
-    const line = claudeNotFoundWarningLine();
+describe("agentNotFoundWarningLine — content (backend-aware)", () => {
+  it("claude backend: loud, actionable, names CHORUS_CLAUDE_PATH", () => {
+    const line = agentNotFoundWarningLine("claude-code");
     expect(line).toMatch(/^⚠/);
     expect(line).toContain("claude CLI NOT FOUND");
     expect(line).toContain("CHORUS_CLAUDE_PATH");
     expect(line).toContain(".local/bin");
-    // stays non-fatal — promises the daemon still subscribes
     expect(line.toLowerCase()).toContain("still subscribe");
+  });
+
+  it("codex backend: names codex + CHORUS_CODEX_PATH", () => {
+    const line = agentNotFoundWarningLine("codex");
+    expect(line).toMatch(/^⚠/);
+    expect(line).toContain("codex CLI NOT FOUND");
+    expect(line).toContain("CHORUS_CODEX_PATH");
+    expect(line.toLowerCase()).toContain("still subscribe");
+  });
+});
+
+describe("claudeNotFoundWarningLine — back-compat alias", () => {
+  it("still returns the claude warning (delegates to agentNotFoundWarningLine)", () => {
+    expect(claudeNotFoundWarningLine()).toBe(agentNotFoundWarningLine("claude-code"));
   });
 });

--- a/cli/__tests__/daemon-permission-wiring.test.mjs
+++ b/cli/__tests__/daemon-permission-wiring.test.mjs
@@ -91,7 +91,9 @@ describe("runDaemon — --agent validation", () => {
     const build = vi.fn();
     const errs = [];
     const code = await runDaemon(
-      { agent: "codex" },
+      // `gemini` is genuinely unknown; `codex` is now a valid backend
+      // (add-daemon-codex-backend), so it would no longer take this error path.
+      { agent: "gemini" },
       baseDeps({ resolve, build, errLog: (m) => errs.push(m) })
     );
     expect(code).toBe(1);
@@ -109,6 +111,16 @@ describe("runDaemon — --agent validation", () => {
     );
     expect(code).toBe(0);
     expect(build.mock.calls[0][1].agentType).toBe("claude-code");
+  });
+
+  it("codex is a known --agent and threads agentType=codex into build()", async () => {
+    const build = vi.fn(() => ({ async start() {}, async stop() {} }));
+    const code = await runDaemon(
+      { agent: "codex" },
+      baseDeps({ isTTY: false, build })
+    );
+    expect(code).toBe(0);
+    expect(build.mock.calls[0][1].agentType).toBe("codex");
   });
 });
 

--- a/cli/__tests__/spawner-select.test.mjs
+++ b/cli/__tests__/spawner-select.test.mjs
@@ -1,0 +1,42 @@
+// cli/__tests__/spawner-select.test.mjs
+// Covers daemon-spawner-interface spec: the daemon selects which spawner backend
+// to inject from the resolved agent type. claude-code → ClaudeSpawner (unchanged
+// construction); codex → CodexSpawner. Both satisfy the same wake(...) contract.
+import { describe, it, expect } from "vitest";
+import { selectSpawner } from "../spawner-select.mjs";
+import { ClaudeSpawner } from "../claude-spawner.mjs";
+import { CodexSpawner } from "../codex-spawner.mjs";
+
+const logger = { info() {}, warn() {}, error() {} };
+const creds = { url: "https://example.test", apiKey: "cho_test" };
+
+describe("selectSpawner", () => {
+  it("returns a ClaudeSpawner for claude-code", () => {
+    const s = selectSpawner("claude-code", { logger, permissionMode: "yolo", creds });
+    expect(s).toBeInstanceOf(ClaudeSpawner);
+  });
+
+  it("returns a CodexSpawner for codex", () => {
+    const s = selectSpawner("codex", { logger, permissionMode: "yolo", creds });
+    expect(s).toBeInstanceOf(CodexSpawner);
+  });
+
+  it("threads permissionMode into the selected spawner", () => {
+    expect(selectSpawner("claude-code", { logger, permissionMode: "chorus", creds }).permissionMode).toBe("chorus");
+    expect(selectSpawner("codex", { logger, permissionMode: "yolo", creds }).permissionMode).toBe("yolo");
+  });
+
+  it("defaults to claude-code when the agent type is unrecognized (no throw — selection is post-validation)", () => {
+    // resolveAgentType already rejected unknowns before this point; selectSpawner
+    // is total and falls back to the safe default rather than throwing.
+    const s = selectSpawner("something-else", { logger, permissionMode: "yolo", creds });
+    expect(s).toBeInstanceOf(ClaudeSpawner);
+  });
+
+  it("both backends expose a wake() method (shared contract)", () => {
+    const c = selectSpawner("claude-code", { logger, permissionMode: "yolo", creds });
+    const x = selectSpawner("codex", { logger, permissionMode: "yolo", creds });
+    expect(typeof c.wake).toBe("function");
+    expect(typeof x.wake).toBe("function");
+  });
+});

--- a/cli/__tests__/sse-listener.test.mjs
+++ b/cli/__tests__/sse-listener.test.mjs
@@ -229,6 +229,22 @@ describe("SseListener self-report URL", () => {
     listener.disconnect();
   });
 
+  it("defaults clientType to claude_code when none is given", async () => {
+    const { listener, fetchImpl } = captureUrl();
+    await listener.connect();
+    const url = new URL(fetchImpl.mock.calls[0][0]);
+    expect(url.searchParams.get("clientType")).toBe("claude_code");
+    listener.disconnect();
+  });
+
+  it("reports clientType=codex when constructed for the codex backend", async () => {
+    const { listener, fetchImpl } = captureUrl({ clientType: "codex" });
+    await listener.connect();
+    const url = new URL(fetchImpl.mock.calls[0][0]);
+    expect(url.searchParams.get("clientType")).toBe("codex");
+    listener.disconnect();
+  });
+
   it("re-sends the same self-report params on reconnect", async () => {
     vi.useFakeTimers();
     let call = 0;

--- a/cli/__tests__/transcript-upload-hooks.test.mjs
+++ b/cli/__tests__/transcript-upload-hooks.test.mjs
@@ -135,6 +135,61 @@ describe("extractTranscriptText — keep user/assistant text, drop everything el
   });
 });
 
+// ── Real captured codex `codex exec --json` event shapes (codex-cli 0.142.3) ──
+// Codex's stream is structurally different from Claude's: conversation/tool output
+// arrives as `item.completed` events whose `item.type` discriminates. Assistant
+// text is an `agent_message` item with a top-level `item.text` (verified live —
+// the user prompt is NOT echoed by codex; the chat UI renders it from the turn's
+// promptText instead, so the extractor only needs to surface assistant text).
+const CODEX_THREAD_STARTED = { type: "thread.started", thread_id: "019f0bf0-10b3-7b52-82ab-57e97481fbd1" };
+const CODEX_TURN_STARTED = { type: "turn.started" };
+const CODEX_AGENT_MESSAGE = {
+  type: "item.completed",
+  item: { id: "item_0", type: "agent_message", text: "The hostname is `ip-172`." },
+};
+const CODEX_TURN_COMPLETED = { type: "turn.completed", usage: { input_tokens: 13714, output_tokens: 6 } };
+const CODEX_REASONING = {
+  type: "item.completed",
+  item: { id: "item_1", type: "reasoning", text: "Let me think." },
+};
+const CODEX_COMMAND_EXEC = {
+  type: "item.completed",
+  item: { id: "item_2", type: "command_execution", command: "ls", aggregated_output: "a\nb\n" },
+};
+
+describe("extractTranscriptText — codex exec --json shape", () => {
+  it("keeps a codex agent_message item as assistant text", () => {
+    expect(extractTranscriptText(CODEX_AGENT_MESSAGE)).toEqual({
+      role: "assistant",
+      text: "The hostname is `ip-172`.",
+    });
+  });
+
+  it("drops codex lifecycle envelopes (thread.started / turn.started / turn.completed)", () => {
+    expect(extractTranscriptText(CODEX_THREAD_STARTED)).toBeNull();
+    expect(extractTranscriptText(CODEX_TURN_STARTED)).toBeNull();
+    expect(extractTranscriptText(CODEX_TURN_COMPLETED)).toBeNull();
+  });
+
+  it("drops a codex reasoning item (model thinking — not conversation text)", () => {
+    expect(extractTranscriptText(CODEX_REASONING)).toBeNull();
+  });
+
+  it("drops a codex command_execution item (tool activity, not assistant text)", () => {
+    expect(extractTranscriptText(CODEX_COMMAND_EXEC)).toBeNull();
+  });
+
+  it("drops a codex agent_message with only-whitespace text", () => {
+    const blank = { type: "item.completed", item: { type: "agent_message", text: "   " } };
+    expect(extractTranscriptText(blank)).toBeNull();
+  });
+
+  it("drops a codex item.completed with no item / missing text", () => {
+    expect(extractTranscriptText({ type: "item.completed" })).toBeNull();
+    expect(extractTranscriptText({ type: "item.completed", item: { type: "agent_message" } })).toBeNull();
+  });
+});
+
 /** A fake server: records every POST body and answers ok unless told otherwise. */
 function fakeServer({ ok = true, status = 200 } = {}) {
   const posts = [];

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -107,7 +107,7 @@ OPTIONS
   --url <url>              Remote Chorus server URL            (env: CHORUS_URL)
   --api-key <cho_...>      Agent API key                       (env: CHORUS_API_KEY)
   --agent <type>           Local agent backend to wake         (env: CHORUS_AGENT)
-                           (default: claude-code; only claude-code is implemented)
+                           (claude-code | codex; default: claude-code)
   --yolo                   Full autonomy for the woken agent   (env: CHORUS_YOLO=1)
                            (--dangerously-skip-permissions: Bash, file writes, any
                            command). This is the DEFAULT permission mode.

--- a/cli/codex-session-map.mjs
+++ b/cli/codex-session-map.mjs
@@ -1,0 +1,117 @@
+// cli/codex-session-map.mjs
+// Daemon-local persistence of the Codex `anchor → thread_id` map. Codex GENERATES
+// its own thread id (unlike Claude, which accepts a client-supplied --session-id),
+// so to make a wake resumable across daemon restarts we record the generated id
+// keyed by the Chorus session anchor (direct idea uuid, or the entity uuid for an
+// ad-hoc session) and `codex exec resume <thread_id>` on the next wake.
+//
+// The store is a single JSON object `{ "<anchor>": "<thread_id>" }` at
+// ~/.chorus/codex-sessions.json (same dir family as daemon.json). The anchor is a
+// globally-unique Chorus uuid, so one flat file is safe across the daemon's
+// multiple path-connections.
+//
+// CONTRACT: this is best-effort and MUST NEVER throw into the wake path. Any
+// read/parse/write/rename failure degrades to "no mapping → next wake starts
+// fresh" with a visible log (no-silent-errors). IO is injectable for tests.
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/** Absolute path to the Codex session-id map, alongside ~/.chorus/daemon.json. */
+export function codexSessionMapPath() {
+  return join(homedir(), ".chorus", "codex-sessions.json");
+}
+
+/** A non-empty trimmed string, or null. */
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Read the whole map as a plain object. Missing / unreadable / malformed file →
+ * `{}` (never throws). A non-object JSON value (array / scalar) is also treated
+ * as empty.
+ * @param {string} path
+ * @param {(p: string) => string} read
+ * @param {{warn(m:string):void}} logger
+ * @returns {Record<string, unknown>}
+ */
+function readMap(path, read, logger) {
+  let raw;
+  try {
+    raw = read(path);
+  } catch (err) {
+    // ENOENT is the normal "no map yet" case — silent. Other read errors warn.
+    if (!(err && err.code === "ENOENT")) {
+      logger.warn(`[Chorus] codex-session-map: read failed (${err}) — treating as empty`);
+    }
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+    logger.warn("[Chorus] codex-session-map: file is not a JSON object — treating as empty");
+    return {};
+  } catch (err) {
+    logger.warn(`[Chorus] codex-session-map: corrupt JSON (${err}) — treating as empty`);
+    return {};
+  }
+}
+
+/**
+ * Look up the Codex thread id recorded for `anchor`, or null when there is none
+ * (no file, no entry, or a non-string entry). Never throws.
+ * @param {string} anchor
+ * @param {{ path?: string, read?: (p: string) => string, logger?: any }} [deps]
+ * @returns {string | null}
+ */
+export function getThreadId(anchor, deps = {}) {
+  const a = nonEmpty(anchor);
+  if (!a) return null;
+  const path = deps.path ?? codexSessionMapPath();
+  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
+  const logger = deps.logger ?? NOOP_LOGGER;
+  const map = readMap(path, read, logger);
+  return nonEmpty(map[a]);
+}
+
+/**
+ * Record `anchor → threadId`, preserving every other entry. Atomic (temp file +
+ * rename). Best-effort: a blank anchor/threadId is ignored (no write), and any
+ * IO failure is logged and swallowed — it never throws into the wake path.
+ * @param {string} anchor
+ * @param {string} threadId
+ * @param {{ path?: string, read?: (p: string) => string,
+ *           write?: (p: string, c: string, o?: object) => void,
+ *           mkdir?: (p: string, o?: object) => void,
+ *           rename?: (from: string, to: string) => void, logger?: any }} [deps]
+ * @returns {void}
+ */
+export function setThreadId(anchor, threadId, deps = {}) {
+  const a = nonEmpty(anchor);
+  const t = nonEmpty(threadId);
+  if (!a || !t) return; // nothing meaningful to persist
+  const path = deps.path ?? codexSessionMapPath();
+  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
+  const write = deps.write ?? writeFileSync;
+  const mkdir = deps.mkdir ?? mkdirSync;
+  const rename = deps.rename ?? renameSync;
+  const logger = deps.logger ?? NOOP_LOGGER;
+
+  try {
+    const map = readMap(path, read, logger);
+    map[a] = t;
+    mkdir(dirname(path), { recursive: true });
+    // Atomic write: temp file (0600) in the same dir, then rename over target,
+    // so a crash mid-write never truncates the live map.
+    const tmp = `${path}.tmp`;
+    write(tmp, JSON.stringify(map, null, 2) + "\n", { mode: 0o600 });
+    rename(tmp, path);
+  } catch (err) {
+    // Best-effort: a failed persist just means the next wake starts fresh.
+    logger.warn(`[Chorus] codex-session-map: failed to persist ${a}→${t} (${err}) — wake will start fresh next time`);
+  }
+}

--- a/cli/codex-spawner.mjs
+++ b/cli/codex-spawner.mjs
@@ -1,0 +1,312 @@
+// cli/codex-spawner.mjs
+// Cross-platform headless Codex spawner — the `codex` counterpart to
+// ClaudeSpawner, satisfying the SAME backend-agnostic Spawner.wake(...) contract
+// so the daemon's wake pipeline (queue, waker, directed delivery, headless guard,
+// reporters) stays backend-neutral.
+//
+// Codex diverges structurally from Claude (verified against codex-cli 0.142.3 +
+// the ../codex source + a live `codex exec --json` run):
+//   • `codex exec --json` emits JSONL (one event per line); the prompt is read
+//     from STDIN (never argv). `codex exec resume <id> --json` continues a run.
+//   • The FIRST event is `{"type":"thread.started","thread_id":"<uuid>"}` — Codex
+//     GENERATES its own id (it does NOT accept a client `--session-id`). We capture
+//     it and persist anchor→thread_id (codex-session-map.mjs) so a later wake can
+//     `resume <thread_id>`. (serde: ThreadEvent tag="type", rename="thread.started";
+//     ThreadStartedEvent.thread_id: String — codex-rs/exec/src/exec_events.rs.)
+//   • No `--mcp-config`: MCP comes from the user's ~/.codex/config.toml; the daemon
+//     key reaches it via the configured bearer_token_env_var (default
+//     CHORUS_API_KEY) exported into the child ENV — never argv.
+//   • Permission is a SANDBOX mode, not a tool allowlist.
+//
+// Reuses claude-spawner's platform-neutral helpers: parseNdjsonChunk (NDJSON
+// stream parse) and the PATH-walk shape of resolveClaudePath.
+
+import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
+import { win32 as pathWin32, posix as pathPosix } from "node:path";
+import { parseNdjsonChunk } from "./claude-spawner.mjs";
+import { getThreadId as defaultGetThreadId, setThreadId as defaultSetThreadId } from "./codex-session-map.mjs";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/**
+ * @typedef {Object} Spawner
+ * @property {(params: {
+ *   prompt: string, sessionId: string|null, isNew: boolean,
+ *   mcpConfigPath?: string, cwd?: string,
+ *   onMessage?: (obj: any) => void,
+ *   onChild?: (child: import("node:child_process").ChildProcess) => void
+ * }) => Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }>} wake
+ *   The backend-agnostic wake contract. ClaudeSpawner and CodexSpawner both
+ *   implement it; the daemon injects one based on the resolved agent type.
+ */
+
+/**
+ * Map the daemon's backend-agnostic permission mode to a Codex sandbox posture.
+ * The expression is SUBCOMMAND-AWARE because the two surfaces differ (verified
+ * against codex 0.142.3): the top-level `codex exec` accepts `--sandbox <mode>`,
+ * but `codex exec resume` does NOT — passing `--sandbox` there errors with exit 2.
+ *   yolo   → --dangerously-bypass-approvals-and-sandbox  (valid on BOTH exec and
+ *            resume; full autonomy)
+ *   chorus → exec:   --sandbox read-only
+ *            resume: -c sandbox_mode="read-only"  (the `-c` config override is how
+ *            `codex exec resume` accepts a sandbox mode; `sandbox_mode` is a real
+ *            config key, value spelled `read-only` per protocol/src/config_types.rs,
+ *            confirmed via `--strict-config`).
+ * Anything other than yolo falls back to the restricted read-only posture.
+ * @param {"yolo"|"chorus"|undefined} permissionMode
+ * @param {{ resume?: boolean }} [opts]  resume:true selects the `codex exec resume` surface.
+ * @returns {string[]}
+ */
+export function sandboxFlags(permissionMode, opts = {}) {
+  if (permissionMode === "yolo") return ["--dangerously-bypass-approvals-and-sandbox"];
+  // restricted read-only posture, expressed per subcommand:
+  return opts.resume ? ["-c", 'sandbox_mode="read-only"'] : ["--sandbox", "read-only"];
+}
+
+/**
+ * Build the argv for a headless codex run. Prompt is NEVER here — it goes over
+ * stdin. `--skip-git-repo-check` lets a non-repo cwd still run.
+ * @param {{ isNew: boolean, threadId?: string|null, permissionMode?: "yolo"|"chorus" }} o
+ * @returns {string[]}
+ */
+export function buildCodexArgs({ isNew, threadId, permissionMode }) {
+  if (!isNew && threadId) {
+    const sandbox = sandboxFlags(permissionMode, { resume: true });
+    return ["exec", "resume", threadId, "--json", ...sandbox, "--skip-git-repo-check"];
+  }
+  const sandbox = sandboxFlags(permissionMode);
+  return ["exec", "--json", ...sandbox, "--skip-git-repo-check"];
+}
+
+/**
+ * Extract the Codex thread id from a stream event, or null. Accepts the live
+ * `thread.started` shape (authoritative) and the on-disk rollout `session_meta`
+ * shape as a defensive fallback.
+ * @param {any} obj
+ * @returns {string|null}
+ */
+export function extractThreadId(obj) {
+  if (!obj || typeof obj !== "object") return null;
+  if (obj.type === "thread.started" && typeof obj.thread_id === "string") return obj.thread_id;
+  if (obj.type === "session_meta" && obj.payload && typeof obj.payload.id === "string") {
+    return obj.payload.id;
+  }
+  return null;
+}
+
+/**
+ * Resolve the real `codex` executable WITHOUT a shell — same approach as
+ * resolveClaudePath. On Windows the bin may be `codex.cmd` (npm shim), which
+ * `spawn` can't exec directly without shell:true; we walk PATH for the platform
+ * candidates. `CHORUS_CODEX_PATH` overrides.
+ * @param {{ env?: NodeJS.ProcessEnv, platform?: NodeJS.Platform, isFile?: (p: string) => boolean }} [deps]
+ * @returns {string | null}
+ */
+export function resolveCodexPath(deps = {}) {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const isFile =
+    deps.isFile ??
+    ((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+  if (env.CHORUS_CODEX_PATH && isFile(env.CHORUS_CODEX_PATH)) {
+    return env.CHORUS_CODEX_PATH;
+  }
+
+  const isWin = platform === "win32";
+  const p = isWin ? pathWin32 : pathPosix;
+  const names = isWin ? ["codex.cmd", "codex.exe", "codex"] : ["codex"];
+  const pathVar = env.PATH || env.Path || "";
+  const dirs = pathVar.split(p.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = p.join(dir, name);
+      if (isFile(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the actual command + argv to spawn. On Windows a `.cmd`/`.bat` shim is
+ * not a PE executable, so it must run via `cmd.exe /d /s /c <path> ...args`; we
+ * keep shell:false and pass argv as an array (no shell word-splitting/injection).
+ * @param {string} codexPath @param {string[]} args
+ * @param {NodeJS.Platform} [platform] @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ command: string, argv: string[] }}
+ */
+export function resolveSpawnCommand(codexPath, args, platform = process.platform, env = process.env) {
+  const isWin = platform === "win32";
+  const lower = codexPath.toLowerCase();
+  if (isWin && (lower.endsWith(".cmd") || lower.endsWith(".bat"))) {
+    const comspec = env.ComSpec || env.COMSPEC || "cmd.exe";
+    return { command: comspec, argv: ["/d", "/s", "/c", codexPath, ...args] };
+  }
+  return { command: codexPath, argv: args };
+}
+
+/**
+ * @typedef {Object} CodexSpawnerOptions
+ * @property {string} [codexPath]   Resolved codex path (resolved lazily if omitted).
+ * @property {(o: object) => any} [spawnImpl]   Injectable spawn (tests).
+ * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
+ * @property {"chorus"|"yolo"} [permissionMode]  Maps to a Codex sandbox posture.
+ * @property {{ url: string, apiKey: string }} [creds]  Daemon creds — apiKey is exported
+ *   into the child env under the user config's bearer_token_env_var (default CHORUS_API_KEY).
+ * @property {NodeJS.Platform} [platform]  Injectable for tests; gates POSIX `detached`.
+ * @property {(anchor: string) => string|null} [getThreadIdFn]  Injectable session-map read.
+ * @property {(anchor: string, threadId: string) => void} [setThreadIdFn]  Injectable session-map write.
+ */
+
+export class CodexSpawner {
+  /** @param {CodexSpawnerOptions} [opts] */
+  constructor(opts = {}) {
+    this.codexPath = opts.codexPath ?? null;
+    this.spawnImpl = opts.spawnImpl ?? spawn;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    this.permissionMode = opts.permissionMode ?? "chorus";
+    this.creds = opts.creds ?? null;
+    this.platform = opts.platform ?? process.platform;
+    this.getThreadIdFn = opts.getThreadIdFn ?? defaultGetThreadId;
+    this.setThreadIdFn = opts.setThreadIdFn ?? defaultSetThreadId;
+    this.resolveCodexPathFn = opts.resolveCodexPathFn ?? resolveCodexPath;
+  }
+
+  /**
+   * Spawn a headless Codex run. Resolves when the subprocess exits. The prompt is
+   * written to stdin (never argv). `sessionId` is the Chorus anchor (direct idea
+   * uuid, or entity uuid). Codex owns its session id, so we IGNORE the passed
+   * `isNew`/`mcpConfigPath` and decide new-vs-resume from the persisted
+   * anchor→thread_id map: a recorded thread id → `resume`, otherwise a fresh run.
+   *
+   * @param {{ prompt: string, sessionId: string|null, isNew?: boolean, mcpConfigPath?: string,
+   *           cwd?: string, onMessage?: (obj: any) => void,
+   *           onChild?: (child: import("node:child_process").ChildProcess) => void }} params
+   * @returns {Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }>}
+   */
+  async wake({ prompt, sessionId, cwd, onMessage, onChild }) {
+    const anchor = typeof sessionId === "string" ? sessionId : "";
+
+    // new-vs-resume is OWNED by this backend (Codex session model), not the
+    // waker's Claude transcript probe: a recorded thread id means resume.
+    const knownThreadId = anchor ? this.getThreadIdFn(anchor) : null;
+    const isNew = !knownThreadId;
+
+    const codexPath = this.codexPath ?? this.resolveCodexPathFn();
+    if (!codexPath) {
+      // No crash — surface visibly and resolve with a failure result.
+      this.logger.error("[Chorus] cannot locate the `codex` executable on PATH; skipping wake");
+      return { sessionId: anchor, exitCode: null, isNew };
+    }
+
+    const args = buildCodexArgs({ isNew, threadId: knownThreadId, permissionMode: this.permissionMode });
+    const { command, argv } = resolveSpawnCommand(codexPath, args, this.platform);
+
+    // POSIX: detached process group so the interrupt path can group-kill the tree
+    // (codex exec forks child shells for tools). Windows uses taskkill /T. stdio
+    // stays piped — prompt over stdin + NDJSON stdout parse are unaffected.
+    const detached = this.platform !== "win32";
+
+    // Daemon key via ENV under the var the user's [mcp_servers.chorus] references
+    // (bearer_token_env_var, default CHORUS_API_KEY) — NEVER argv. Merged over the
+    // inherited env so PATH / model auth (Bedrock profile) / CODEX_HOME survive.
+    const childEnv = { ...process.env, CHORUS_DAEMON_HEADLESS: "1" };
+    if (this.creds && this.creds.apiKey) childEnv.CHORUS_API_KEY = this.creds.apiKey;
+
+    return new Promise((resolve) => {
+      let child;
+      try {
+        child = this.spawnImpl(command, argv, {
+          cwd: cwd ?? process.cwd(),
+          stdio: ["pipe", "pipe", "pipe"],
+          env: childEnv,
+          shell: false,
+          detached,
+          windowsHide: true,
+        });
+      } catch (err) {
+        this.logger.error(`[Chorus] failed to spawn codex: ${err}`);
+        resolve({ sessionId: anchor, exitCode: null, isNew });
+        return;
+      }
+
+      // Hand the live child to the caller (interrupt registry) before resolving.
+      // Never let a throwing callback escape into the spawn path.
+      if (onChild) {
+        try {
+          onChild(child);
+        } catch (err) {
+          this.logger.warn(`[Chorus] onChild handler threw: ${err}`);
+        }
+      }
+
+      let stdoutBuf = "";
+      let observedThreadId = knownThreadId || null;
+
+      child.stdout?.setEncoding?.("utf8");
+      child.stdout?.on("data", (chunk) => {
+        stdoutBuf = parseNdjsonChunk(
+          stdoutBuf,
+          String(chunk),
+          (obj) => {
+            const tid = extractThreadId(obj);
+            if (tid) observedThreadId = tid;
+            if (onMessage) {
+              try {
+                onMessage(obj);
+              } catch (err) {
+                this.logger.warn(`[Chorus] onMessage handler threw: ${err}`);
+              }
+            }
+          },
+          (msg) => this.logger.warn(`[Chorus] ${msg}`)
+        );
+      });
+
+      child.stderr?.setEncoding?.("utf8");
+      child.stderr?.on("data", (chunk) => {
+        const text = String(chunk).trim();
+        if (text) this.logger.warn(`[Chorus] codex stderr: ${text}`);
+      });
+
+      child.on("error", (err) => {
+        this.logger.error(`[Chorus] codex process error: ${err}`);
+        resolve({ sessionId: observedThreadId || anchor, exitCode: null, isNew });
+      });
+
+      child.on("close", (code) => {
+        if (code !== 0) {
+          this.logger.warn(`[Chorus] codex exited with code ${code}`);
+        }
+        // Persist anchor→thread_id only on a fresh, successful run that produced a
+        // new id — so a later wake for this anchor resumes it. Best-effort; the
+        // session map swallows its own IO errors.
+        if (code === 0 && isNew && anchor && observedThreadId) {
+          this.setThreadIdFn(anchor, observedThreadId);
+        }
+        resolve({ sessionId: observedThreadId || anchor, exitCode: code, isNew });
+      });
+
+      // Guard against an ASYNC stdin error (EPIPE) so it never becomes an
+      // uncaughtException that kills the daemon.
+      child.stdin?.on?.("error", (err) => {
+        this.logger.warn(`[Chorus] codex stdin error (ignored): ${err}`);
+      });
+
+      // Feed the prompt over stdin, then close it so the model runs.
+      try {
+        child.stdin?.write(prompt);
+        child.stdin?.end();
+      } catch (err) {
+        this.logger.warn(`[Chorus] failed writing prompt to codex stdin: ${err}`);
+      }
+    });
+  }
+}

--- a/cli/daemon-agent.mjs
+++ b/cli/daemon-agent.mjs
@@ -1,11 +1,12 @@
 // cli/daemon-agent.mjs
-// Pure resolution + validation of the daemon's `--agent <type>` selection. The
-// flag/env exist to RESERVE the extension point for future agent backends
-// (e.g. codex); only `claude-code` is implemented in this change. Resolving an
+// Pure resolution + validation of the daemon's `--agent <type>` selection.
+// `claude-code` (the default) and `codex` are both implemented backends
+// (add-daemon-codex-backend cashed in the reserved `codex` slot). Resolving an
 // unknown value is a hard error (no silent fallback). Zero dependencies.
 
-/** The agent backends the daemon recognizes. Only `claude-code` is implemented. */
-export const KNOWN_AGENTS = ["claude-code"];
+/** The agent backends the daemon recognizes. Both are implemented (claude-code
+ * via ClaudeSpawner, codex via CodexSpawner — see spawner-select.mjs). */
+export const KNOWN_AGENTS = ["claude-code", "codex"];
 
 /** The default agent backend when neither --agent nor CHORUS_AGENT is set. */
 export const DEFAULT_AGENT = "claude-code";
@@ -31,7 +32,7 @@ export function resolveAgentType(flags, env) {
       value: raw,
       error:
         `Unknown --agent "${raw}". Accepted: ${KNOWN_AGENTS.join(", ")}. ` +
-        `(Only ${DEFAULT_AGENT} is implemented; the flag reserves the slot for future agents.)`,
+        `(Default is ${DEFAULT_AGENT}.)`,
     };
   }
   return { ok: true, agent: raw };

--- a/cli/daemon-agent.mjs
+++ b/cli/daemon-agent.mjs
@@ -25,6 +25,18 @@ export function backendCli(agentType) {
 }
 
 /**
+ * Map the resolved agent backend to the `clientType` the daemon self-reports to
+ * the server (and that the connection registry + presence UI display). The server
+ * gates this against DAEMON_CLIENT_TYPES, so the values MUST match: `codex` →
+ * `codex`, `claude-code` → `claude_code`. Anything else falls back to claude_code.
+ * @param {string} agentType
+ * @returns {string}
+ */
+export function backendClientType(agentType) {
+  return agentType === "codex" ? "codex" : "claude_code";
+}
+
+/**
  * Resolve the agent type from flag → env → default, and validate it.
  * Precedence: explicit `--agent` flag > CHORUS_AGENT env > DEFAULT_AGENT.
  *

--- a/cli/daemon-agent.mjs
+++ b/cli/daemon-agent.mjs
@@ -12,6 +12,19 @@ export const KNOWN_AGENTS = ["claude-code", "codex"];
 export const DEFAULT_AGENT = "claude-code";
 
 /**
+ * Per-backend CLI descriptor: the executable name the daemon resolves/spawns and
+ * the env var that overrides its path. Drives the startup banner's "CLI" row and
+ * the not-found warning so they name the SELECTED backend (not always `claude`).
+ * Unknown / undefined falls back to the default (claude-code) descriptor.
+ * @param {string} agentType
+ * @returns {{ name: string, envVar: string }}
+ */
+export function backendCli(agentType) {
+  if (agentType === "codex") return { name: "codex", envVar: "CHORUS_CODEX_PATH" };
+  return { name: "claude", envVar: "CHORUS_CLAUDE_PATH" };
+}
+
+/**
  * Resolve the agent type from flag → env → default, and validate it.
  * Precedence: explicit `--agent` flag > CHORUS_AGENT env > DEFAULT_AGENT.
  *

--- a/cli/daemon-banner.mjs
+++ b/cli/daemon-banner.mjs
@@ -6,7 +6,10 @@
 //
 // SECURITY: the banner shows the credential SOURCE, never the raw API key
 // (owner decision: no masking needed because the key is simply not displayed).
-// Zero dependencies — ships in the npm package alongside chorus.mjs.
+// Zero dependencies (beyond the pure backendCli descriptor) — ships in the npm
+// package alongside chorus.mjs.
+
+import { backendCli } from "./daemon-agent.mjs";
 
 /**
  * @typedef {Object} BannerInfo
@@ -16,8 +19,8 @@
  * @property {string} agentUuid        authenticated agent uuid.
  * @property {"yolo"|"chorus"} permissionMode
  * @property {string} credentialSource resolved credential source (flag/env/login-file/…).
- * @property {string} agentType        local agent backend (e.g. claude-code).
- * @property {string|null} claudePath  resolved claude path, or null when not found.
+ * @property {string} agentType        local agent backend (claude-code | codex) — drives the CLI row label.
+ * @property {string|null} cliPath     resolved path of the SELECTED backend's CLI, or null when not found.
  * @property {string} [connection]     connection state line (default "connecting…").
  * @property {string} [configPath]     absolute path to the daemon.json the CLI reads.
  * @property {boolean} [configExists]  whether that daemon.json exists on disk.
@@ -39,7 +42,12 @@ export function bannerRows(info) {
     info.permissionMode === "yolo"
       ? "YOLO ⚠  (full autonomy — Bash/write/any command)"
       : "chorus-only (Chorus MCP tools only)";
-  const claude = info.claudePath ? `found: ${info.claudePath}` : "NOT FOUND — install `claude` or set CHORUS_CLAUDE_PATH";
+  // The CLI row names the SELECTED backend (claude-code → "claude", codex →
+  // "codex") so a `--agent codex` run never mislabels itself as claude.
+  const cli = backendCli(info.agentType);
+  const cliValue = info.cliPath
+    ? `found: ${info.cliPath}`
+    : `NOT FOUND — install \`${cli.name}\` or set ${cli.envVar}`;
   const rows = [
     ["Version", `chorus v${info.version}`],
     ["Server", info.url],
@@ -48,7 +56,7 @@ export function bannerRows(info) {
     ["Permission", permission],
     ["Credentials", `source: ${info.credentialSource}`],
     ["Connection", info.connection ?? "connecting…"],
-    ["claude CLI", claude],
+    [`${cli.name} CLI`, cliValue],
   ];
   // Config file row — shown only when the path is known. Tells the operator
   // exactly which daemon.json the CLI read (and whether it exists), so a
@@ -61,19 +69,33 @@ export function bannerRows(info) {
 }
 
 /**
- * The prominent warning shown at startup when the `claude` executable cannot be
- * resolved. Mirrors `yoloWarningLine()`'s loud single-line style so a missing
- * binary is visible in an unattended / systemd journal immediately, rather than
- * only when a wake later fails. The daemon stays non-fatal — it still subscribes.
+ * The prominent warning shown at startup when the SELECTED backend's executable
+ * cannot be resolved. Mirrors `yoloWarningLine()`'s loud single-line style so a
+ * missing binary is visible in an unattended / systemd journal immediately,
+ * rather than only when a wake later fails. The daemon stays non-fatal — it still
+ * subscribes. Names the backend's own binary + override env var (claude /
+ * CHORUS_CLAUDE_PATH, or codex / CHORUS_CODEX_PATH).
+ * @param {string} agentType
+ * @returns {string}
+ */
+export function agentNotFoundWarningLine(agentType) {
+  const { name, envVar } = backendCli(agentType);
+  return (
+    `⚠ ${name} CLI NOT FOUND on PATH — wakes will FAIL until you install \`${name}\` ` +
+    `or set ${envVar}. For a systemd/boot service, ensure the unit's PATH ` +
+    "includes the directory holding the binary (e.g. ~/.local/bin). The daemon will " +
+    "still subscribe, but every task dispatch errors until this is fixed."
+  );
+}
+
+/**
+ * Back-compat alias — the original claude-only warning. Delegates to
+ * {@link agentNotFoundWarningLine} for the default claude-code backend so older
+ * imports keep working.
  * @returns {string}
  */
 export function claudeNotFoundWarningLine() {
-  return (
-    "⚠ claude CLI NOT FOUND on PATH — wakes will FAIL until you install `claude` " +
-    "or set CHORUS_CLAUDE_PATH. For a systemd/boot service, ensure the unit's PATH " +
-    "includes the directory holding `claude` (e.g. ~/.local/bin). The daemon will " +
-    "still subscribe, but every task dispatch errors until this is fixed."
-  );
+  return agentNotFoundWarningLine("claude-code");
 }
 
 /**

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -18,7 +18,7 @@ import {
   resolvePermissionMode,
   yoloWarningLine,
 } from "./daemon-permission-mode.mjs";
-import { resolveAgentType } from "./daemon-agent.mjs";
+import { resolveAgentType, backendClientType } from "./daemon-agent.mjs";
 import { formatBanner, agentNotFoundWarningLine } from "./daemon-banner.mjs";
 import { ChorusClient, validateAndFetchIdentity } from "./chorus-client.mjs";
 import { SseListener } from "./sse-listener.mjs";
@@ -282,6 +282,9 @@ export function buildDaemon(creds, deps = {}) {
       makeSse({
         url: creds.url,
         apiKey: creds.apiKey,
+        // Self-report the SELECTED backend so the connection registry + presence UI
+        // label a codex daemon as `codex` (not the hardcoded `claude_code`).
+        clientType: backendClientType(agentType),
         // The working directory THIS connection serves (T3). `undefined` ⇒ the listener
         // reports its process cwd (single-path / HARD-1). It is just the served path.
         cwd,

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -19,7 +19,7 @@ import {
   yoloWarningLine,
 } from "./daemon-permission-mode.mjs";
 import { resolveAgentType } from "./daemon-agent.mjs";
-import { formatBanner, claudeNotFoundWarningLine } from "./daemon-banner.mjs";
+import { formatBanner, agentNotFoundWarningLine } from "./daemon-banner.mjs";
 import { ChorusClient, validateAndFetchIdentity } from "./chorus-client.mjs";
 import { SseListener } from "./sse-listener.mjs";
 import { createBackfill } from "./backfill.mjs";
@@ -28,6 +28,7 @@ import { WakeQueue } from "./wake-queue.mjs";
 import { Waker } from "./waker.mjs";
 import { LineageResolver } from "./lineage.mjs";
 import { resolveClaudePath } from "./claude-spawner.mjs";
+import { resolveCodexPath } from "./codex-spawner.mjs";
 import { selectSpawner } from "./spawner-select.mjs";
 import {
   createExecutionUploadHooks,
@@ -364,7 +365,11 @@ export async function runDaemon(flags = {}, deps = {}) {
   const askPrompt = deps.prompt ?? prompt;
   const writeCreds = deps.writeLoginFile ?? writeLoginFile;
   const version = deps.version ?? readVersion();
+  // Backend executable resolvers — injectable for tests. The SELECTED backend's
+  // resolver runs below (claude-code → findClaude, codex → findCodex), so the
+  // banner shows the right binary instead of always probing for `claude`.
   const findClaude = deps.resolveClaudePath ?? resolveClaudePath;
+  const findCodex = deps.resolveCodexPath ?? resolveCodexPath;
   const verbose = flags.verbose === true || env.CHORUS_VERBOSE === "1";
 
   // Resolve the agent backend (default claude-code). An unknown --agent /
@@ -418,10 +423,12 @@ export async function runDaemon(flags = {}, deps = {}) {
   if (typeof pf === "number") return pf;
   const { creds, identity, permissionMode } = pf;
 
-  // Detect the claude executable (non-fatal): the daemon still subscribes when
-  // it's missing; a wake surfaces the error visibly when one arrives. The
-  // resolved path (or absence) is shown in the banner below.
-  const claudePath = findClaude();
+  // Detect the SELECTED backend's executable (non-fatal): the daemon still
+  // subscribes when it's missing; a wake surfaces the error visibly when one
+  // arrives. The resolved path (or absence) is shown in the banner below. codex
+  // → resolveCodexPath, otherwise resolveClaudePath — so a `--agent codex` run
+  // probes (and the banner reports) `codex`, not `claude`.
+  const cliPath = agentType === "codex" ? findCodex() : findClaude();
 
   // The daemon.json the layered config readers (credentials, sigint timeout, cwds)
   // consult. Surfacing its absolute path + presence in the banner makes it obvious
@@ -440,7 +447,7 @@ export async function runDaemon(flags = {}, deps = {}) {
         permissionMode,
         credentialSource: creds.source,
         agentType,
-        claudePath,
+        cliPath,
         connection: "connecting…",
         configPath,
         configExists,
@@ -453,11 +460,13 @@ export async function runDaemon(flags = {}, deps = {}) {
   if (permissionMode === "yolo") {
     errLog(`[Chorus] ${yoloWarningLine()}`);
   }
-  // A missing `claude` binary is non-fatal (the daemon still subscribes), but the
+  // A missing backend binary is non-fatal (the daemon still subscribes), but the
   // banner row alone is easy to miss in a systemd journal — emit one loud ⚠ line
-  // on stderr so the operator sees it at startup, not only when a wake fails.
-  if (claudePath === null) {
-    errLog(`[Chorus] ${claudeNotFoundWarningLine()}`);
+  // on stderr so the operator sees it at startup, not only when a wake fails. The
+  // warning names the SELECTED backend (claude / CHORUS_CLAUDE_PATH or codex /
+  // CHORUS_CODEX_PATH).
+  if (cliPath === null) {
+    errLog(`[Chorus] ${agentNotFoundWarningLine(agentType)}`);
   }
 
   // Surface the served paths so an operator sees a multi-path daemon at a glance.

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -27,7 +27,8 @@ import { EventRouter } from "./event-router.mjs";
 import { WakeQueue } from "./wake-queue.mjs";
 import { Waker } from "./waker.mjs";
 import { LineageResolver } from "./lineage.mjs";
-import { ClaudeSpawner, resolveClaudePath } from "./claude-spawner.mjs";
+import { resolveClaudePath } from "./claude-spawner.mjs";
+import { selectSpawner } from "./spawner-select.mjs";
 import {
   createExecutionUploadHooks,
   createTranscriptUploadHooks,
@@ -95,9 +96,12 @@ function defaultLogger() {
 export function buildDaemon(creds, deps = {}) {
   const logger = deps.logger ?? defaultLogger();
   const permissionMode = deps.permissionMode ?? "chorus";
+  // The resolved agent backend selects which spawner the daemon injects
+  // (add-daemon-codex-backend). Defaults to claude-code, matching the prior
+  // hard-wired ClaudeSpawner. The spawn path below is backend-agnostic — it only
+  // ever calls the shared wake(...) contract.
+  const agentType = deps.agentType ?? "claude-code";
   // Per-wake verbose logging (daemon-startup-output), threaded into the Waker.
-  // agentType is currently display-only (banner/logs) — the spawn path is
-  // claude-code regardless (daemon-agent-selection reserves the slot only).
   const verbose = deps.verbose ?? false;
   // Escalation window for the interrupt killer (子3). Pre-resolved by runDaemon via
   // the layered resolver; falls back to the resolver's default here when not given,
@@ -112,7 +116,11 @@ export function buildDaemon(creds, deps = {}) {
   const lineage =
     deps.lineage ??
     new LineageResolver({ url: creds.url, apiKey: creds.apiKey, logger, fetchImpl: deps.fetchImpl });
-  const spawner = deps.spawner ?? new ClaudeSpawner({ logger, permissionMode });
+  // Inject the spawner for the resolved backend. claude-code → ClaudeSpawner
+  // (construction byte-identical to before); codex → CodexSpawner. `creds` are
+  // passed through so the Codex backend can export the daemon key into the woken
+  // process env (the Claude backend ignores creds — it gets its key via --mcp-config).
+  const spawner = deps.spawner ?? selectSpawner(agentType, { logger, permissionMode, creds });
   // The WakeQueue serializes per DIRECT idea (keyFor's key). It is shared across all
   // path-connections: serialization-per-idea still holds, and maxConcurrency caps the
   // whole process's in-flight wakes rather than per-cwd — the right global budget.

--- a/cli/spawner-select.mjs
+++ b/cli/spawner-select.mjs
@@ -1,0 +1,30 @@
+// cli/spawner-select.mjs
+// Backend selection seam: maps the resolved agent type (daemon-agent.mjs) to a
+// concrete Spawner instance. This is the ONLY place the daemon branches on the
+// backend — the wake pipeline above it (queue, waker, directed delivery, headless
+// guard, reporters) stays backend-agnostic and drives whichever spawner is
+// injected purely through the shared wake(...) contract.
+//
+// The function is TOTAL: resolveAgentType has already rejected unknown values
+// before this runs, so an unrecognized type here is not a user error path — we
+// fall back to the safe default (claude-code) rather than throw.
+
+import { ClaudeSpawner } from "./claude-spawner.mjs";
+import { CodexSpawner } from "./codex-spawner.mjs";
+
+/**
+ * Construct the spawner backend for `agentType`.
+ * @param {string} agentType  "claude-code" | "codex" (already validated upstream).
+ * @param {{ logger?: any, permissionMode?: "chorus"|"yolo", creds?: { url: string, apiKey: string } }} [opts]
+ * @returns {import("./codex-spawner.mjs").Spawner}
+ */
+export function selectSpawner(agentType, opts = {}) {
+  const { logger, permissionMode, creds } = opts;
+  if (agentType === "codex") {
+    return new CodexSpawner({ logger, permissionMode, creds });
+  }
+  // Default / "claude-code": construction byte-identical to the prior daemon
+  // (ClaudeSpawner takes only { logger, permissionMode } — creds are not used by
+  // the Claude backend, which gets its key via the --mcp-config file).
+  return new ClaudeSpawner({ logger, permissionMode });
+}

--- a/cli/sse-listener.mjs
+++ b/cli/sse-listener.mjs
@@ -108,8 +108,14 @@ export class SseListener {
     // cwd is supplied the daemon is single-path: report the process cwd (the directory
     // it was launched from), identical to today / an old daemon (HARD-1).
     this.cwd = opts.cwd ?? process.cwd();
+    // The daemon backend driving this connection (daemon-agent-selection): the
+    // server registers the row's `clientType` from this self-report, so a
+    // `--agent codex` daemon shows as `codex` instead of mislabelling itself
+    // `claude_code`. Defaults to claude_code (the default backend / an old
+    // single-backend daemon that never sets it).
+    this.clientType = opts.clientType ?? "claude_code";
     const params = new URLSearchParams({
-      clientType: "claude_code",
+      clientType: this.clientType,
       clientVersion: CLI_VERSION,
       host: hostname(),
       cwd: this.cwd,

--- a/cli/upload-hooks.mjs
+++ b/cli/upload-hooks.mjs
@@ -150,17 +150,41 @@ export function mergeUploadHooks(...args) {
 const CONVERSATION_TYPES = new Set(["user", "assistant"]);
 
 /**
- * Extract the plain user/assistant TEXT from one Claude Code stream-json object,
- * dropping everything that is not a conversation text block (system/result
- * envelopes, thinking, tool_use, tool_result). Returns null when the object is not a
- * keepable conversation message (so the caller can skip it). Never throws — a shape
- * it doesn't recognize yields null rather than an error (defensive against CLI drift).
+ * Extract the plain user/assistant TEXT from one stream object emitted by EITHER
+ * backend's headless stream, dropping everything that is not a conversation text
+ * block. Returns null when the object is not a keepable conversation message (so
+ * the caller can skip it). Never throws — a shape it doesn't recognize yields null
+ * rather than an error (defensive against CLI drift).
  *
- * @param {any} obj  One parsed stream-json NDJSON object.
+ * Two stream dialects are recognized (their top-level shapes are disjoint, so no
+ * backend flag is needed):
+ *  - Claude Code stream-json: `{ type: "user"|"assistant", message: { content … } }`.
+ *  - codex `codex exec --json`: conversation/tool output rides on `item.completed`
+ *    events discriminated by `item.type`; assistant text is an `agent_message`
+ *    item with a top-level `item.text` (verified against codex-cli 0.142.3). codex
+ *    does NOT echo the user prompt (the chat UI renders that from the turn's
+ *    promptText), and `reasoning` / `command_execution` / lifecycle envelopes are
+ *    not conversation text — all dropped.
+ *
+ * @param {any} obj  One parsed stream NDJSON object.
  * @returns {{ role: "user"|"assistant", text: string } | null}
  */
 export function extractTranscriptText(obj) {
   if (!obj || typeof obj !== "object") return null;
+
+  // ── codex `codex exec --json` dialect ──
+  // Only `item.completed` carries finished output; an `agent_message` item is the
+  // assistant's conversation text. Everything else (reasoning, command_execution,
+  // file_change, thread.started/turn.* lifecycle) is not user/assistant text.
+  if (obj.type === "item.completed") {
+    const item = obj.item;
+    if (!item || typeof item !== "object" || item.type !== "agent_message") return null;
+    const itemText = typeof item.text === "string" ? item.text : "";
+    if (!itemText.trim()) return null;
+    return { role: "assistant", text: itemText };
+  }
+
+  // ── Claude Code stream-json dialect ──
   if (!CONVERSATION_TYPES.has(obj.type)) return null;
 
   const message = obj.message;

--- a/docs/blogs/v2ex-daemon-remote-wake.zh.md
+++ b/docs/blogs/v2ex-daemon-remote-wake.zh.md
@@ -1,0 +1,54 @@
+# 我是怎么让远端的 Claude Code 自己接任务、把活干了的
+
+先看效果。在网页上把一条想法派给远端某台机器的某个目录，那边的 Claude Code 自己就醒了，接活、开干。我没在 prompt 里写一个字告诉它要做什么，那些它自己查出来的，全程我没碰终端：
+
+![远程唤醒 Claude Code](https://chorus-ai.dev/images/agent-daemon-wake.gif)
+
+我做了几个月一个开源项目 [Chorus](https://github.com/Chorus-AIDLC/Chorus)，简单说就是给 Claude Code 配了个带网页的任务后台：想法、提案、任务这一整条开发流程在服务端管着，Claude Code 在本地领活、干活、交活。
+
+但有个尴尬一直没解决：那半个 AI 平时根本不在线。我把任务派给一个 agent，它不会自己动，得等我哪天打开终端、跑起 Claude Code、把它领下来，才动一下。最近做的这个 daemon 就是来填这个坑的，让本地的 Claude Code 能自己接住服务端派来的任务。下面说说这套「派过去它自己就开干」的链路是怎么搭起来的。
+
+## 唤醒：订阅通知，spawn 一个 headless claude
+
+唤醒这步其实最简单。daemon 起来后订阅服务端的通知流（SSE），有任务派给这个 agent，就在本地 spawn 一个 headless 的 `claude -p` 去干。
+
+实现上有个选择：要不要接 Anthropic 的 Agent SDK。我选了直接 spawn 子进程。理由很现实，Chorus 要发到 npm，得在 linux、macOS、Windows 上都能跑，SDK 会拖进一串依赖，子进程这边零新增依赖。prompt 走 stdin 不走命令行参数，省掉转义和长度的麻烦，Windows 上自己找 `claude.cmd`。本地既然装了 Claude Code，直接调就完事了。
+
+## 醒来怎么知道干啥：给它一个认得路的环境
+
+唤醒不难，难的是它醒来得知道自己要干嘛。
+
+设想用 cron 唤起一个 `claude -p`，你得在 prompt 里贴上：任务描述、之前聊需求定下的几条结论、它依赖的前置任务上线了没、验收标准是什么。漏一条它就跑偏。而这堆东西你从哪复制？多半还是从你自己脑子里。喂少了它瞎做，喂多了你又退化成在工具之间搬运文本的人肉 adapter。
+
+Chorus 这边这些上下文本来就在库里。任务挂在哪条想法下、需求细化时聊出了什么结论、上游验收了没、AC 是什么，全是结构化存着的。所以唤起 claude 的时候，prompt 里只塞一个想法的 uuid 当线头，真正给它的是一套能去查这些的工具：daemon spawn claude 时带上 `--mcp-config`，指向 Chorus 的 MCP server（一个写在临时目录、用完即删的小 JSON，里面是服务端地址加这个 agent 的 key），claude 一起来就带着 `chorus_*` 这套工具。它进来先 `chorus_get_task` 看自己被派了啥，翻 elaboration 记录搞清楚为什么这么做，干完直接提交验收。
+
+它能自己接任务往前推、不用我一句句喂，靠的就是这个——醒在一个它认得路的环境里，而不是醒在一段干巴巴的 prompt 前。
+
+## 同一条想法，是同一场对话
+
+每次唤醒要是各干各的，agent 跨任务就失忆了。所以每个 session 锚在它对应那条想法的 uuid 上（没有归属想法的活，比如一个快速任务，就锚在它自己的 uuid 上）：同一条想法下的活，唤起的是同一个 session，`--resume` 接着上次往下走；想法和想法之间，session 互相隔开。
+
+这么锚还顺带解决了一件事，就是人能随时插回来。每次唤醒的日志里都打一句 `claude --resume <idea-uuid>`，你在 daemon 的工作目录里跑这句，就直接进到 agent 刚才那场对话里，不用翻 transcript 找会话 ID。它干到一半我想自己接手，跳进去就行。背后有个队列按锚点排，保证同一个 session 不会被两次唤醒同时 resume 撞上。
+
+## 后台跑的东西，得看得见也插得进话
+
+agent 在后台自己接任务跑，最怕变黑盒，连上没、在忙啥、干到哪，一概不知道。所以 transcript 通过 SSE 实时推到前端，每个 turn 它说了什么、跑了什么命令都看得到。
+
+光看还不够，跑偏了得能拦。我做了条反向的控制通道，服务端可以给 daemon 发不触发唤醒的控制信号。基于它做了三件事：你能在网页上给正在跑的 agent 插一句话，作为它的下一个 turn；能打断一个跑歪的 turn，daemon 收到信号会把那个 headless claude 的进程树两阶段干掉，先 SIGINT 留一截宽限窗口、不退再 SIGKILL；打断之后状态停在那，等你点恢复再 resume 接着原来那场往下续。能看、能拦、能插话，丢后台才放心。
+
+## 一个 daemon 守多个目录，还得能精确叫醒
+
+最新这版修的是我自己撞上的坑。daemon 守一个目录，可我代码散在好几个仓库里，前端一个后端一个。在前端目录起的 daemon，后端任务派过来，它就在前端目录里跑错了地方。
+
+于是让一个 daemon 能同时守多个目录（`--cwd` 可以重复传），每个目录是条独立连接，每个 `(agent、主机、目录)` 做成能单独点名的实例，派任务、@ 它的时候挑具体哪个。这里还有个不太起眼的坑：原来的唤醒是朝这个 agent 名下所有连接广播一个事件，钉了后端那个目录，前端那个也照样收到，谁先 resume 上算谁的。所以带钉的唤醒改成了定向投递，只发给算出来的那一个连接。钉哪个，就只醒哪个。
+
+## 小结
+
+整套链路拆开看就这么几样：订阅通知、spawn 一个 headless 子进程、给它一个能自查上下文的 MCP 环境、加一条反向控制通道，没给项目新增任何 npm 依赖。代码不复杂，真正费工夫的是边界：唤醒进哪个上下文、session 怎么锚、跑偏了怎么拦、多目录怎么不串。说到底想要的就一句话，把任务派过去，远端那个 Claude Code 自己就接着干了，不用我守在终端前。
+
+后来把 `--agent` 这个预留点兑现了，现在 `--agent codex` 能让本地 Codex 接活。Codex 跟 Claude Code 不太一样：它自己生成会话 id 不收外部指定的，所以每条想法的会话 id 我单独缓存了一份，下次唤醒拿它 `codex exec resume` 续上；没有 `--mcp-config` 这种东西，MCP 走它自己的 `~/.codex/config.toml`，daemon 只把自己的 key 通过环境变量喂进去；权限那边它是 sandbox 模式，yolo 就直接 `--dangerously-bypass-approvals-and-sandbox`。新唤醒、续会话、打断这几样都通了，打断复用的还是同一套进程组 kill。transcript 上传暂时只有 Claude Code 那条做了，Codex 的留到后面；模型认证（Bedrock 或 `codex login`）得你自己先配好。开源，AGPL-3.0，Next.js + Prisma + PostgreSQL，项目本身就是用 Chorus + Claude Code 开发的。
+
+- GitHub: https://github.com/Chorus-AIDLC/Chorus
+- v0.12.0 详细博文: https://chorus-ai.dev/zh/blog/chorus-v0.12.0-release/
+
+有问题欢迎 Issues 或 Discussions。

--- a/messages/en.json
+++ b/messages/en.json
@@ -1382,6 +1382,7 @@
     "unknownAgent": "Unknown agent",
     "clientClaudeCode": "Claude Code",
     "clientOpenclaw": "OpenClaw",
+    "clientCodex": "Codex",
     "clientUnknown": "Unknown client",
     "uptimeMonoDays": "{days}d {time}",
     "mobileBack": "Connections",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1383,6 +1383,7 @@
     "unknownAgent": "未命名智能体",
     "clientClaudeCode": "Claude Code",
     "clientOpenclaw": "OpenClaw",
+    "clientCodex": "Codex",
     "clientUnknown": "未知客户端",
     "uptimeMonoDays": "{days}天 {time}",
     "mobileBack": "返回连接列表",

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/README.md
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/README.md
@@ -1,0 +1,3 @@
+# add-daemon-codex-backend
+
+daemon Codex backend: wake codex on remote dispatch (cash in the --agent extension point)

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/design.md
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/design.md
@@ -1,0 +1,88 @@
+# Technical Design: daemon Codex backend
+
+## Overview
+
+Add a second spawner backend behind the daemon's existing `--agent` selection. The wake pipeline (SSE → EventRouter → WakeQueue → Waker) stays backend-agnostic; only the leaf that turns a wake into a subprocess changes. We extract the implicit `ClaudeSpawner.wake(...)` contract into an explicit interface and add a `CodexSpawner` that satisfies it against `codex exec`.
+
+The design is shaped by four verified divergences between Codex 0.142.3 and Claude Code (see proposal §Why). Everything below follows from them.
+
+## Architecture
+
+```
+resolveAgentType(flags, env)  →  "claude-code" | "codex"
+                                        │
+                  daemon.mjs spawner-injection seam
+                    (deps.spawner ?? selectSpawner(agentType, {logger, permissionMode}))
+                                        │
+              ┌─────────────────────────┴─────────────────────────┐
+        ClaudeSpawner                                         CodexSpawner
+   (claude -p --session-id/--resume,                  (codex exec --json / exec resume <id>,
+    transcript-file probe = new/resume,                id-map lookup = new/resume,
+    --allowedTools / --skip-permissions)               --sandbox / --dangerously-bypass…)
+              └──────── both implement Spawner.wake(params) → result ────────┘
+```
+
+The Waker is unchanged: it passes `sessionId` (the Chorus anchor — direct idea uuid, else entity uuid), `isNew` (its own transcript probe), `cwd`, `mcpConfigPath`, `onMessage`, `onChild`, and consumes `{ sessionId, exitCode, isNew }`. **Key move:** the waker's `isNew` and `mcpConfigPath` are *Claude-shaped*. To keep the waker backend-agnostic without a rewrite, the **spawner owns the final new-vs-resume decision and the MCP wiring** — the Claude spawner honors the passed `isNew`/`mcpConfigPath`; the Codex spawner ignores them and derives its own (id-map for new-vs-resume; user config for MCP). This is the smallest change that respects "each backend owns its session model" (Q2) and "rely on user config" (Q4).
+
+## Module Contracts
+
+### Spawner interface (the seam)
+
+```
+wake({
+  prompt: string,          // fed over stdin, NEVER argv
+  sessionId: string|null,  // Chorus anchor (direct idea uuid | entity uuid)
+  isNew: boolean,          // Claude: authoritative; Codex: advisory (spawner re-derives)
+  mcpConfigPath?: string,  // Claude: --mcp-config file; Codex: ignored
+  cwd?: string,            // spawn cwd (same value the waker probed)
+  onMessage?: (obj) => void,  // each parsed stream event
+  onChild?: (child) => void,  // live ChildProcess, sync, only on successful spawn
+}) → Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }>
+```
+
+Invariants both backends honor (carried over from `ClaudeSpawner`, all verified there):
+- **Never throw into the wake path.** A failed executable resolution / spawn / stdin EPIPE resolves with `exitCode: null` and a visible `logger.error`/`warn` — never an uncaught exception (one bad wake must not kill the daemon).
+- **`onChild` fires exactly once, synchronously, only on a successful spawn**, before the promise resolves — the waker registers the handle for the interrupt path.
+- **stdout parsed via `parseNdjsonChunk`** (already platform-neutral and shared) with a carry-over buffer; malformed lines warn-and-skip.
+- **POSIX `detached: true`** (process-group leader) so `killProcessTree` can group-kill descendants; Windows uses `taskkill /T /F`. stdio stays `["pipe","pipe","pipe"]`.
+- **Returned `sessionId`** is the id the daemon should anchor on going forward. Claude returns the same uuid it was given; **Codex returns its generated `thread_id`** (observed from the stream) — the waker already tracks `observedSessionId` from `onMessage`, so the return value reconciles.
+
+### `CodexSpawner` specifics
+
+- **buildArgs (new):** `["exec", "--json", sandboxFlag…]`, prompt via stdin. `--skip-git-repo-check` is included so a non-repo cwd still runs. The model/provider come from the user's config (not forced here).
+- **buildArgs (resume):** `["exec", "resume", "<thread_id>", "--json", sandboxFlag…]`.
+- **Sandbox flag from permission mode:** `yolo → ["--dangerously-bypass-approvals-and-sandbox"]`; `chorus → ["--sandbox", "read-only"]`. (Mirrors `ClaudeSpawner`'s `permissionMode` constructor option.)
+- **Thread-id capture:** on each `onMessage`, if the event carries the session/thread id (`session_meta.payload.id` or `thread.started.thread_id` — verify exact shape against installed version at impl time), record it as `observedThreadId`. On a successful, non-interrupted exit of a *new* run, persist `anchor (sessionId) → observedThreadId` via `codex-session-map`.
+- **new-vs-resume:** look up `sessionId` in the id map. Hit → resume with stored `thread_id`. Miss → new run. This *replaces* the waker's transcript-file probe for the Codex backend (the probe targets Claude's `~/.claude/projects/.../<id>.jsonl` layout, which does not apply).
+
+### `codex-session-map` (daemon-local persistence)
+
+- Single JSON file under the daemon config dir (same dir family as `~/.chorus/daemon.json`; exact path chosen at impl, e.g. `~/.chorus/codex-sessions.json`), shape `{ "<anchor-uuid>": "<codex-thread-id>" }`.
+- `getThreadId(anchor) → string|null` and `setThreadId(anchor, threadId)`; atomic write (temp + rename), never throws into the wake path (a write failure logs and degrades to "next wake starts fresh").
+- cwd/multi-path note: the map is keyed by the Chorus anchor (idea uuid), which is already globally unique, so it is safe across the daemon's multiple path-connections.
+
+### MCP authentication wiring (Q4 = c)
+
+The daemon does not write a Codex MCP config. Instead, before spawning, `CodexSpawner` ensures the child env carries the daemon's own resolved API key under the variable the user's `[mcp_servers.chorus]` references via `bearer_token_env_var` (default `CHORUS_API_KEY`): `env: { ...process.env, CHORUS_API_KEY: creds.apiKey, CHORUS_DAEMON_HEADLESS: "1" }`. Key via env, **never argv**. If the user has no `chorus` server configured, Codex starts without Chorus tools — logged once, not fatal. (The daemon's resolved `creds.apiKey` is already available at construction; pass it into the spawner like `permissionMode`.)
+
+## Risks & Mitigations
+
+- **Codex CLI drift.** Flags / event field names / config keys can change between releases. *Mitigation:* the implementation task MUST re-verify against the installed `codex --help` and `../codex` source; tests assert on our `buildArgs`, not on Codex's runtime behavior; unknown stream events are skipped, not fatal.
+- **Thread-id event shape uncertainty.** Docs say `thread.started.thread_id`; the on-disk rollout uses `session_meta.payload.id`. *Mitigation:* capture defensively — accept either, prefer the first id-bearing event; if none is seen, the run still completes (just won't be resumable, logged).
+- **Wrong-agent MCP key.** If the user's config hard-codes a different key instead of `bearer_token_env_var`, the woken Codex would act as that other agent. *Mitigation:* document that the daemon relies on `bearer_token_env_var`; the env-exported daemon key only takes effect when the config references it. Out of scope to rewrite the user's config.
+- **Interrupt reaching Codex's child shells.** Codex forks shells for tool calls. *Mitigation:* `detached` process-group + group-kill is exactly the mechanism `ClaudeSpawner` already proved for this; reused unchanged.
+- **claude-code regression.** *Mitigation:* `ClaudeSpawner` is left byte-equivalent; the interface extraction is type/doc-only; a test asserts the default agent still selects `ClaudeSpawner` and its argv is unchanged.
+
+## Implementation Plan
+
+1. Add `codex` to `KNOWN_AGENTS`; extract the `Spawner` interface typedef; add `selectSpawner(agentType, opts)` and wire it at the `daemon.mjs` injection seam (claude-code unchanged).
+2. `codex-session-map.mjs` — persistence with round-trip tests.
+3. `CodexSpawner` — executable resolution, buildArgs (new/resume + sandbox), spawn (detached, stdin, JSONL parse), thread-id capture + map write, env key export. Full unit tests.
+4. Integration check: a default-agent daemon still spawns Claude with identical argv; an `--agent codex` daemon selects `CodexSpawner` and (with a stub spawn) produces the expected `codex exec --json` argv for new and resume, with the prompt on stdin.
+
+## Verification notes for implementers (anti-hallucination)
+
+Before coding, run and read:
+- `codex exec --help` and `codex exec resume --help` (flags: `--json`, `--sandbox`, `--dangerously-bypass-approvals-and-sandbox`, `--skip-git-repo-check`, `--ephemeral`).
+- `../codex` source for the JSONL event carrying the thread/session id and for `bearer_token_env_var` handling in the MCP config loader.
+- The installed `~/.codex/config.toml` `[mcp_servers.chorus]` block as the reference shape the daemon relies on.

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/proposal.md
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: daemon Codex backend — cash in the `--agent` extension point so `--agent codex` wakes a local headless Codex
+
+## Why
+
+The daemon's remote-wake path today can spawn **only Claude Code**. The `--agent <type>` flag and `CHORUS_AGENT` env already exist (`cli/daemon-agent.mjs`), but `KNOWN_AGENTS = ["claude-code"]` and the comment is explicit: *"reserve the extension point for future agents (e.g. codex) … Only claude-code is implemented."* The existing `daemon-agent-selection` capability spec says the same. This change cashes that reservation in: `--agent codex` (or `CHORUS_AGENT=codex`) wakes a local **headless Codex** subprocess instead of Claude Code.
+
+The whole spawn path is Claude-specific (`cli/claude-spawner.mjs`): resolve executable → `buildArgs` → spawn headless → parse stream-json → feed prompt over stdin → process-group kill for interrupt. Codex's headless interface exists but **diverges structurally** from Claude's, so a clean abstraction is needed rather than a copy-paste.
+
+Verified on this host (Codex CLI **0.142.3**, source at `../codex`):
+
+1. **Non-interactive interface is sufficient.** `codex exec --json` emits JSONL events (`thread.started` / `turn.completed` / `item.*`); the prompt is read from **stdin** (`-` or no positional arg). `codex exec resume <SESSION_ID> [prompt]` continues a session. The stdin-not-argv security constraint is satisfiable.
+2. **Session id is *reversed*.** Claude accepts a client-supplied `--session-id`; **Codex generates its own `thread_id`** (surfaced in the first stream event — `session_meta.payload.id` in the rollout JSONL / `thread.started.thread_id` per the docs). The daemon's "anchor the session on the Chorus idea uuid" model therefore needs an extra **persisted `idea uuid → codex thread_id` map** to resume.
+3. **No `--mcp-config`.** Codex loads MCP from `~/.codex/config.toml` / `-c key=value` overrides / `CODEX_HOME`. HTTP MCP is supported (`[mcp_servers.<name>]` with `url` + `bearer_token_env_var`). **Trap:** relocating `CODEX_HOME` also moves Codex's *model* auth (this host authenticates the model via a Bedrock profile), so we must not naively swap `CODEX_HOME`.
+4. **No per-tool allowlist.** Claude's `--allowedTools mcp__chorus__*` has no Codex equivalent. Codex permission is a **sandbox mode** (`read-only` / `workspace-write` / `danger-full-access` / `--dangerously-bypass-approvals-and-sandbox`).
+
+> Provenance: idea `b8335370-3698-4944-92ae-b65620ebcb3f` (project Chorus 0.12.1), elaborated and **human-verified** (Round 1, 5 questions, resolved). The decisions below encode those answers verbatim. The elaboration dogfooded the headless flow — it ran from a daemon-woken headless session that routed its questions to the Chorus elaboration panel.
+
+## What Changes
+
+The verified elaboration answers set a deliberately scoped v1: **new wake + permission (yolo) + per-idea session-id cache for resume + interrupt**, with MCP injection **best-effort** (the user already configures the Chorus plugin's MCP, so the daemon need not inject it).
+
+- **Backend-agnostic spawner interface (Q1).** Extract the shape `ClaudeSpawner` and a new `CodexSpawner` both satisfy: `wake({ prompt, sessionId, isNew, mcpConfigPath, cwd, onMessage, onChild }) → { sessionId, exitCode, isNew }`. The daemon picks which spawner to inject from `resolveAgentType(flags, env)` — the upper layers (wake-queue, waker, directed delivery, headless guard, turn/transcript reporters) stay backend-agnostic. The contract is the **same JS interface already used at the `daemon.mjs` injection seam**; no waker rewrite.
+
+- **`codex` becomes a known backend (Q1).** `cli/daemon-agent.mjs` adds `codex` to `KNOWN_AGENTS` so `resolveAgentType` no longer rejects it; the startup banner shows the resolved backend (already wired). Selecting `claude-code` (explicitly or by default) behaves byte-for-byte as today.
+
+- **`CodexSpawner` — new wake (Q1).** Spawns `codex exec --json` headless: prompt over **stdin** (never argv), JSONL parsed from stdout (reusing the platform-neutral `parseNdjsonChunk`), `onMessage` fed each event, `onChild` handed the live child the instant it spawns. Cross-platform executable resolution mirrors `resolveClaudePath` (PATH walk + `.cmd`/`.bat` via `cmd.exe` on Windows + a `CHORUS_CODEX_PATH` override).
+
+- **Session anchoring via a persisted id map (Q2 = a).** Because Codex owns the id, `CodexSpawner` captures the generated `thread_id` from the first stream event and persists `idea uuid → thread_id` under the daemon's config dir. A subsequent wake for the same anchor resolves the stored `thread_id` and runs `codex exec resume <thread_id>`; with no mapping it starts fresh. **new-vs-resume is decided inside the spawner** (each backend owns its session model) — Claude probes the on-disk transcript, Codex consults the id map — so the waker passes its `sessionId` (the Chorus anchor) and lets the spawner translate.
+
+- **Permission posture: yolo first (Q3 = "先做 yolo").** Map the daemon's existing backend-agnostic permission switch: `yolo → codex exec --dangerously-bypass-approvals-and-sandbox` (full autonomy for code-writing AI-DLC work). The daemon default is already `yolo`. The restricted `chorus` posture maps to `--sandbox read-only` (MCP calls still work; no shell / file writes) so the switch stays meaningful, but yolo is the path this version targets and tests.
+
+- **MCP wiring: rely on the user's config, do not inject (Q4 = c).** The daemon does **not** synthesize a Codex MCP config. It relies on the user's existing `~/.codex/config.toml` carrying `[mcp_servers.chorus]` (the Chorus plugin / `codex mcp add` already sets this up with `bearer_token_env_var`). To make the woken Codex authenticate as **this daemon's agent**, the spawner exports the daemon's own resolved key into the child env under the variable the user's config references (default `CHORUS_API_KEY`) — key via **env, never argv**. If the user's config has no `chorus` MCP server, the woken Codex simply runs without Chorus tools (best-effort, logged, no crash) — acceptable for v1 per the answer ("mcp 看情况，不行就算了").
+
+- **Interrupt via process-group kill (Q5 = a).** `codex exec` forks child shells when running tools, so `CodexSpawner` spawns `detached: true` (POSIX process-group leader) exactly like `ClaudeSpawner`, and the existing two-stage `killProcessTree` (SIGINT → escalate → SIGKILL group; Windows `taskkill /T /F`) is reused unchanged. Post-interrupt resume rides on the Q2 id map (a re-wake after interrupt resumes the stored `thread_id`).
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-codex-backend`: the contract for the Codex spawn path — `codex exec --json` headless wake with prompt over stdin and JSONL stream parsing, cross-platform `codex` executable resolution with a `CHORUS_CODEX_PATH` override, the persisted `idea uuid → codex thread_id` map driving new-vs-`resume`, the permission-mode → sandbox-flag mapping (`yolo → --dangerously-bypass-approvals-and-sandbox`), the MCP-from-user-config posture with the daemon key exported via the configured `bearer_token_env_var`, and detached-process-group interrupt parity.
+- `daemon-spawner-interface`: the backend-agnostic `wake(...)` spawner contract and the `resolveAgentType`-driven selection of which spawner the daemon injects — the seam that keeps wake-queue / waker / directed-delivery / reporters backend-neutral.
+
+### Modified Capabilities
+
+- `daemon-agent-selection`: the existing requirement says only `claude-code` is implemented and the flag merely *reserves* the codex slot. This change implements `codex`, so the requirement is updated: `codex` is now a known, accepted backend that wakes a local headless Codex; unknown values are still rejected non-zero; `claude-code` remains the default and behaves exactly as before.
+
+## Impact
+
+- **Schema**: none. No migration, no Prisma model, no enum. The `idea→thread_id` map is a daemon-local JSON file under the daemon config dir, not a DB entity.
+- **Daemon client code** (in-repo, `cli/`):
+  - `cli/daemon-agent.mjs` — add `codex` to `KNOWN_AGENTS`.
+  - `cli/codex-spawner.mjs` *(new)* — `CodexSpawner` implementing the shared `wake(...)` contract: executable resolution, `buildArgs` (`exec --json` / `exec resume <id>` + sandbox flag), spawn (detached, stdin prompt, JSONL parse), thread-id capture.
+  - `cli/codex-session-map.mjs` *(new)* — persist/read the `idea uuid → codex thread_id` map under the daemon config dir (atomic write, never throws into the wake path).
+  - `cli/daemon.mjs` — at the spawner injection seam (`const spawner = deps.spawner ?? …`), choose `CodexSpawner` vs `ClaudeSpawner` from the resolved agent type; thread `permissionMode` through unchanged.
+  - `cli/claude-spawner.mjs` — no behavior change; if a shared interface typedef is extracted it lives here or in a small `spawner.mjs`, with `ClaudeSpawner` left byte-equivalent (claude-code must not regress).
+  - `cli/__tests__/` — unit tests for: agent resolution accepting `codex`; `CodexSpawner` argv (new vs resume, sandbox flag per mode, prompt never in argv); thread-id capture + map round-trip; permission-mode mapping; executable resolution incl. Windows `.cmd` and `CHORUS_CODEX_PATH`; spawner selection in `daemon.mjs`.
+- **Codex is an external dependency**: all `codex exec` flags, event field names (`thread_id`, `session_meta`), and config keys (`bearer_token_env_var`) MUST be verified against the installed `codex --help` and `../codex` source at implementation time, not assumed from this proposal (versions drift — verified here against 0.142.3).
+- **MCP tools / `docs/MCP_TOOLS.md`**: unchanged — no new Chorus tool.
+- **Skill docs / blog**: the daemon README/blog draft (`docs/blogs/v2ex-daemon-remote-wake.zh.md`) currently says "only Claude Code; `--agent` reserved for codex" — update the wording once shipped (tracked in the doc task, not blocking the backend).
+- **`docs/design.pen`**: not applicable — daemon CLI behavior change, no user-facing screen.
+- **Cross-platform / deps**: no new npm dependency (pitfall #9); spawn stays `shell:false` with argv arrays; Windows `.cmd` handled via `cmd.exe` like the Claude path; all new shell-free.
+
+## Out of Scope
+
+- **Transcript upload for Codex.** The Claude path uploads user/assistant text to `/api/daemon/transcript`. Codex's JSONL event shape differs; mapping it is deferred (the wake still runs and reports turn lifecycle). Tracked as a follow-up.
+- **Codex model authentication.** `codex login` / Bedrock profile setup is the user's responsibility (per Q4); the daemon does not manage model creds.
+- **Daemon-side synthesis of a Codex MCP config** (Q4 = c rejected option a/b): not done in v1.
+- **A non-`claude-code`/`codex` third backend.** The interface is general, but only these two are implemented.

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/specs/daemon-agent-selection/spec.md
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/specs/daemon-agent-selection/spec.md
@@ -1,9 +1,6 @@
-# daemon-agent-selection Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change improve-daemon-cli-ux. Update Purpose after archive.
-## Requirements
-### Requirement: `--agent` selection with claude-code and codex backends
+### Requirement: `--agent` selection with single implemented backend
 
 The daemon SHALL accept an `--agent <type>` flag and a `CHORUS_AGENT` environment variable selecting which local agent backend to wake, defaulting to `claude-code`. The daemon SHALL validate the resolved value against the set of known agent types — which SHALL include both `claude-code` and `codex` — and SHALL reject an unknown value with a clear, non-zero error naming the accepted values (it SHALL NOT silently fall back). The resolved agent type SHALL be displayed in the startup banner. The daemon SHALL select which spawner backend to inject based on the resolved agent type. Selecting `claude-code` (explicitly or by default) SHALL behave exactly as the current daemon spawn. Selecting `codex` SHALL wake a local headless Codex subprocess (see the `daemon-codex-backend` capability).
 
@@ -26,4 +23,3 @@ The daemon SHALL accept an `--agent <type>` flag and a `CHORUS_AGENT` environmen
 
 - **WHEN** the user passes `--agent <unknown>` (or sets `CHORUS_AGENT` to an unknown value)
 - **THEN** the daemon exits non-zero with a clear error naming the accepted agent types and does not start, rather than silently falling back to a default
-

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/specs/daemon-codex-backend/spec.md
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/specs/daemon-codex-backend/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Headless Codex wake over `codex exec --json`
+
+When the resolved backend is `codex`, the daemon SHALL wake the local Codex by spawning `codex exec --json` as a headless subprocess, feeding the wake prompt over **stdin** (never as a command-line argument), and parsing the JSONL event stream from stdout. The spawned child SHALL carry `CHORUS_DAEMON_HEADLESS=1` in its environment, matching the Claude backend's headless signal. The spawner SHALL resolve the `codex` executable without a shell (PATH walk for the platform's candidate names, a `.cmd`/`.bat` shim run via `cmd.exe` on Windows), honoring a `CHORUS_CODEX_PATH` override when set, and SHALL refuse to spawn with a visible log if it cannot locate the executable.
+
+#### Scenario: New wake spawns codex exec with the prompt on stdin
+
+- **WHEN** the daemon wakes the codex backend for an anchor that has no recorded Codex thread id
+- **THEN** it spawns `codex exec --json` (plus the resolved sandbox flag) with the prompt written to stdin, and no part of the prompt appears in the process arguments
+
+#### Scenario: Missing codex executable fails visibly without crashing
+
+- **WHEN** no `codex` executable can be resolved on PATH and `CHORUS_CODEX_PATH` is unset or invalid
+- **THEN** the wake resolves without spawning, emits a visible error log, and the daemon keeps running
+
+### Requirement: Codex session anchoring via a persisted idea→thread-id map
+
+Because Codex generates its own `thread_id` rather than accepting a client-supplied session id, the daemon SHALL capture the generated `thread_id` from the Codex event stream and SHALL persist a mapping from the Chorus session anchor (the direct idea uuid, or the entity uuid for an ad-hoc session) to that `thread_id` in a daemon-local store. On a subsequent wake for the same anchor, the daemon SHALL resume the existing Codex session via `codex exec resume <thread_id>`; when no mapping exists for the anchor, it SHALL start a fresh `codex exec` run. The new-vs-resume decision for the Codex backend SHALL be made from this map (not from the Claude on-disk transcript probe). The persistence SHALL be best-effort: a read/write failure SHALL degrade to starting a fresh session with a visible log, never throwing into the wake path.
+
+#### Scenario: Same anchor resumes the same Codex thread
+
+- **WHEN** a wake fires for an anchor whose `thread_id` was recorded by a prior successful Codex run
+- **THEN** the daemon runs `codex exec resume <thread_id>` so the conversation continues, rather than starting a new session
+
+#### Scenario: First wake for an anchor starts fresh and records the thread id
+
+- **WHEN** a wake fires for an anchor with no recorded `thread_id`
+- **THEN** the daemon starts a new `codex exec` run, captures the generated `thread_id` from the stream, and persists the anchor→thread-id mapping for future resumes
+
+### Requirement: Permission mode maps to a Codex sandbox posture, defaulting to YOLO
+
+The daemon's backend-agnostic permission mode SHALL map to a Codex sandbox posture: `yolo` SHALL run `codex exec` with `--dangerously-bypass-approvals-and-sandbox` (full autonomy for code-writing work), and the restricted `chorus` posture SHALL run with `--sandbox read-only` (MCP tool calls permitted; no shell execution or file writes). Consistent with the daemon's existing default, an unconfigured daemon SHALL wake Codex in `yolo`.
+
+#### Scenario: Default codex wake runs with full-autonomy sandbox bypass
+
+- **WHEN** the daemon wakes the codex backend with no permission flags overriding the default
+- **THEN** the `codex exec` invocation includes `--dangerously-bypass-approvals-and-sandbox`
+
+#### Scenario: Restricted posture runs codex read-only
+
+- **WHEN** the daemon is run in the restricted `chorus` posture and wakes the codex backend
+- **THEN** the `codex exec` invocation includes `--sandbox read-only` so the woken Codex can call MCP tools but cannot run shell commands or write files
+
+### Requirement: Codex MCP comes from the user config with the daemon key via env
+
+The daemon SHALL NOT synthesize a Codex MCP configuration. It SHALL rely on the user's existing `~/.codex/config.toml` to declare the Chorus MCP server (`[mcp_servers.chorus]`). To make the woken Codex authenticate as the daemon's own agent, the spawner SHALL export the daemon's resolved API key into the child process environment under the variable the user's config references via `bearer_token_env_var` (default `CHORUS_API_KEY`); the key SHALL be passed through the environment and SHALL NOT appear in the process arguments. When the user's config declares no Chorus MCP server, the woken Codex SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail.
+
+#### Scenario: Daemon key reaches the user-configured Chorus MCP server via env
+
+- **WHEN** the user's `~/.codex/config.toml` declares `[mcp_servers.chorus]` with `bearer_token_env_var = "CHORUS_API_KEY"` and the daemon wakes the codex backend
+- **THEN** the spawned Codex receives the daemon's resolved API key in its `CHORUS_API_KEY` environment variable (never in argv), so its Chorus MCP calls authenticate as the daemon's agent
+
+#### Scenario: No Chorus MCP configured still runs
+
+- **WHEN** the user's Codex config declares no Chorus MCP server
+- **THEN** the wake still spawns and completes, the woken Codex simply lacks Chorus tools, and the daemon logs the absence instead of crashing
+
+### Requirement: Codex interrupt via detached process-group kill
+
+The Codex backend SHALL spawn its subprocess in a detached POSIX process group (so it leads its own group and a group-directed signal reaches the child shells `codex exec` forks for tool calls), and the daemon's existing two-stage process-tree killer (graceful SIGINT, then forceful SIGKILL of the group after a timeout; `taskkill /T /F` on Windows) SHALL be reused unchanged to interrupt a running Codex wake. After an interrupt, a subsequent wake for the same anchor SHALL resume the recorded Codex `thread_id` when one was captured before the interrupt.
+
+#### Scenario: Interrupting a running Codex wake stops its process tree
+
+- **WHEN** an authorized interrupt is verified for a running Codex wake
+- **THEN** the daemon group-signals the detached Codex process so the Codex process and the child shells it spawned are stopped, escalating to a forceful kill if it does not exit within the timeout
+
+#### Scenario: Re-wake after interrupt resumes when a thread id was captured
+
+- **WHEN** a Codex wake was interrupted after its `thread_id` had been captured and persisted, and a new wake fires for the same anchor
+- **THEN** the daemon resumes that `thread_id` via `codex exec resume` rather than starting a fresh session

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/specs/daemon-spawner-interface/spec.md
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/specs/daemon-spawner-interface/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Backend-agnostic spawner interface and selection
+
+The daemon SHALL define a backend-agnostic spawner contract `wake({ prompt, sessionId, isNew, mcpConfigPath, cwd, onMessage, onChild }) → { sessionId, exitCode, isNew }` that both the Claude Code and Codex backends implement, and SHALL select which spawner instance to inject based on the agent type resolved from `--agent` / `CHORUS_AGENT`. The wake pipeline above the spawner (wake-queue, waker, directed delivery, headless guard, turn/transcript lifecycle reporters) SHALL remain backend-agnostic and SHALL NOT branch on the agent type. A spawner SHALL NOT throw into the wake path: any failure to resolve the executable, spawn, or write the prompt SHALL resolve with `exitCode: null` and a visible log line, so one failed wake never crashes the daemon. The spawner SHALL invoke `onChild` exactly once, synchronously, only on a successful spawn, before the wake promise resolves.
+
+#### Scenario: Default selection injects the Claude backend unchanged
+
+- **WHEN** the resolved agent type is `claude-code`
+- **THEN** the daemon injects the Claude spawner and its spawn argv and behavior are byte-for-byte the same as before this change
+
+#### Scenario: codex selection injects the Codex backend
+
+- **WHEN** the resolved agent type is `codex`
+- **THEN** the daemon injects the Codex spawner, and the waker drives it through the same `wake(...)` contract without any agent-type-specific branching in the waker
+
+#### Scenario: A spawn failure does not crash the daemon
+
+- **WHEN** a spawner cannot locate its backend executable or the spawn fails
+- **THEN** the wake resolves with `exitCode: null` and a visible error log, and the daemon continues serving subsequent notifications

--- a/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/tasks.md
+++ b/openspec/changes/archive/2026-06-27-add-daemon-codex-backend/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## 1. Spawner interface + agent selection + injection seam
+- [ ] Add `codex` to `KNOWN_AGENTS` in `cli/daemon-agent.mjs`
+- [ ] Extract the backend-agnostic `Spawner.wake(...)` interface typedef
+- [ ] Add `selectSpawner(agentType, { logger, permissionMode, creds })` and wire it at the `daemon.mjs` spawner-injection seam; claude-code path byte-equivalent
+- [ ] Tests: agent resolution accepts codex / rejects unknown; default + codex select the right spawner; Claude argv unchanged
+
+## 2. Codex session-id map (persistence)
+- [ ] `cli/codex-session-map.mjs`: get/set `anchor → thread_id`, atomic write, never throws
+- [ ] Tests: round-trip, missing-file, corrupt-file, write-failure degradation
+
+## 3. CodexSpawner
+- [ ] Executable resolution (PATH walk, Windows `.cmd` via cmd.exe, `CHORUS_CODEX_PATH` override)
+- [ ] buildArgs: new (`exec --json` + sandbox flag) and resume (`exec resume <id> --json` + sandbox flag); prompt over stdin
+- [ ] Permission mode → sandbox flag (`yolo → --dangerously-bypass-approvals-and-sandbox`, `chorus → --sandbox read-only`)
+- [ ] Spawn detached, JSONL parse via shared `parseNdjsonChunk`, `onMessage`/`onChild`, thread-id capture + map write on new-run success
+- [ ] Daemon key exported via `bearer_token_env_var` (default `CHORUS_API_KEY`) in child env, never argv; `CHORUS_DAEMON_HEADLESS=1`
+- [ ] Tests: argv (new/resume, sandbox per mode, prompt-not-in-argv), thread-id capture, env key export, exec resolution incl. Windows + override, no-throw on spawn failure
+
+## 4. Interrupt parity + integration check
+- [ ] Confirm detached process-group spawn so existing `killProcessTree` reaches Codex child shells (reused unchanged)
+- [ ] Integration: default daemon spawns Claude with identical argv; `--agent codex` produces expected `codex exec --json` argv for new and resume with prompt on stdin
+- [ ] Re-verify all `codex exec` flags / event field names / config keys against installed `codex --help` and `../codex` source
+
+## 5. Docs
+- [ ] Update `docs/blogs/v2ex-daemon-remote-wake.zh.md` wording ("only Claude Code; --agent reserved for codex" → codex implemented)

--- a/openspec/specs/daemon-codex-backend/spec.md
+++ b/openspec/specs/daemon-codex-backend/spec.md
@@ -1,0 +1,75 @@
+# daemon-codex-backend Specification
+
+## Purpose
+TBD - created by archiving change add-daemon-codex-backend. Update Purpose after archive.
+## Requirements
+### Requirement: Headless Codex wake over `codex exec --json`
+
+When the resolved backend is `codex`, the daemon SHALL wake the local Codex by spawning `codex exec --json` as a headless subprocess, feeding the wake prompt over **stdin** (never as a command-line argument), and parsing the JSONL event stream from stdout. The spawned child SHALL carry `CHORUS_DAEMON_HEADLESS=1` in its environment, matching the Claude backend's headless signal. The spawner SHALL resolve the `codex` executable without a shell (PATH walk for the platform's candidate names, a `.cmd`/`.bat` shim run via `cmd.exe` on Windows), honoring a `CHORUS_CODEX_PATH` override when set, and SHALL refuse to spawn with a visible log if it cannot locate the executable.
+
+#### Scenario: New wake spawns codex exec with the prompt on stdin
+
+- **WHEN** the daemon wakes the codex backend for an anchor that has no recorded Codex thread id
+- **THEN** it spawns `codex exec --json` (plus the resolved sandbox flag) with the prompt written to stdin, and no part of the prompt appears in the process arguments
+
+#### Scenario: Missing codex executable fails visibly without crashing
+
+- **WHEN** no `codex` executable can be resolved on PATH and `CHORUS_CODEX_PATH` is unset or invalid
+- **THEN** the wake resolves without spawning, emits a visible error log, and the daemon keeps running
+
+### Requirement: Codex session anchoring via a persisted idea→thread-id map
+
+Because Codex generates its own `thread_id` rather than accepting a client-supplied session id, the daemon SHALL capture the generated `thread_id` from the Codex event stream and SHALL persist a mapping from the Chorus session anchor (the direct idea uuid, or the entity uuid for an ad-hoc session) to that `thread_id` in a daemon-local store. On a subsequent wake for the same anchor, the daemon SHALL resume the existing Codex session via `codex exec resume <thread_id>`; when no mapping exists for the anchor, it SHALL start a fresh `codex exec` run. The new-vs-resume decision for the Codex backend SHALL be made from this map (not from the Claude on-disk transcript probe). The persistence SHALL be best-effort: a read/write failure SHALL degrade to starting a fresh session with a visible log, never throwing into the wake path.
+
+#### Scenario: Same anchor resumes the same Codex thread
+
+- **WHEN** a wake fires for an anchor whose `thread_id` was recorded by a prior successful Codex run
+- **THEN** the daemon runs `codex exec resume <thread_id>` so the conversation continues, rather than starting a new session
+
+#### Scenario: First wake for an anchor starts fresh and records the thread id
+
+- **WHEN** a wake fires for an anchor with no recorded `thread_id`
+- **THEN** the daemon starts a new `codex exec` run, captures the generated `thread_id` from the stream, and persists the anchor→thread-id mapping for future resumes
+
+### Requirement: Permission mode maps to a Codex sandbox posture, defaulting to YOLO
+
+The daemon's backend-agnostic permission mode SHALL map to a Codex sandbox posture: `yolo` SHALL run `codex exec` with `--dangerously-bypass-approvals-and-sandbox` (full autonomy for code-writing work), and the restricted `chorus` posture SHALL run with `--sandbox read-only` (MCP tool calls permitted; no shell execution or file writes). Consistent with the daemon's existing default, an unconfigured daemon SHALL wake Codex in `yolo`.
+
+#### Scenario: Default codex wake runs with full-autonomy sandbox bypass
+
+- **WHEN** the daemon wakes the codex backend with no permission flags overriding the default
+- **THEN** the `codex exec` invocation includes `--dangerously-bypass-approvals-and-sandbox`
+
+#### Scenario: Restricted posture runs codex read-only
+
+- **WHEN** the daemon is run in the restricted `chorus` posture and wakes the codex backend
+- **THEN** the `codex exec` invocation includes `--sandbox read-only` so the woken Codex can call MCP tools but cannot run shell commands or write files
+
+### Requirement: Codex MCP comes from the user config with the daemon key via env
+
+The daemon SHALL NOT synthesize a Codex MCP configuration. It SHALL rely on the user's existing `~/.codex/config.toml` to declare the Chorus MCP server (`[mcp_servers.chorus]`). To make the woken Codex authenticate as the daemon's own agent, the spawner SHALL export the daemon's resolved API key into the child process environment under the variable the user's config references via `bearer_token_env_var` (default `CHORUS_API_KEY`); the key SHALL be passed through the environment and SHALL NOT appear in the process arguments. When the user's config declares no Chorus MCP server, the woken Codex SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail.
+
+#### Scenario: Daemon key reaches the user-configured Chorus MCP server via env
+
+- **WHEN** the user's `~/.codex/config.toml` declares `[mcp_servers.chorus]` with `bearer_token_env_var = "CHORUS_API_KEY"` and the daemon wakes the codex backend
+- **THEN** the spawned Codex receives the daemon's resolved API key in its `CHORUS_API_KEY` environment variable (never in argv), so its Chorus MCP calls authenticate as the daemon's agent
+
+#### Scenario: No Chorus MCP configured still runs
+
+- **WHEN** the user's Codex config declares no Chorus MCP server
+- **THEN** the wake still spawns and completes, the woken Codex simply lacks Chorus tools, and the daemon logs the absence instead of crashing
+
+### Requirement: Codex interrupt via detached process-group kill
+
+The Codex backend SHALL spawn its subprocess in a detached POSIX process group (so it leads its own group and a group-directed signal reaches the child shells `codex exec` forks for tool calls), and the daemon's existing two-stage process-tree killer (graceful SIGINT, then forceful SIGKILL of the group after a timeout; `taskkill /T /F` on Windows) SHALL be reused unchanged to interrupt a running Codex wake. After an interrupt, a subsequent wake for the same anchor SHALL resume the recorded Codex `thread_id` when one was captured before the interrupt.
+
+#### Scenario: Interrupting a running Codex wake stops its process tree
+
+- **WHEN** an authorized interrupt is verified for a running Codex wake
+- **THEN** the daemon group-signals the detached Codex process so the Codex process and the child shells it spawned are stopped, escalating to a forceful kill if it does not exit within the timeout
+
+#### Scenario: Re-wake after interrupt resumes when a thread id was captured
+
+- **WHEN** a Codex wake was interrupted after its `thread_id` had been captured and persisted, and a new wake fires for the same anchor
+- **THEN** the daemon resumes that `thread_id` via `codex exec resume` rather than starting a fresh session
+

--- a/openspec/specs/daemon-spawner-interface/spec.md
+++ b/openspec/specs/daemon-spawner-interface/spec.md
@@ -1,0 +1,24 @@
+# daemon-spawner-interface Specification
+
+## Purpose
+TBD - created by archiving change add-daemon-codex-backend. Update Purpose after archive.
+## Requirements
+### Requirement: Backend-agnostic spawner interface and selection
+
+The daemon SHALL define a backend-agnostic spawner contract `wake({ prompt, sessionId, isNew, mcpConfigPath, cwd, onMessage, onChild }) → { sessionId, exitCode, isNew }` that both the Claude Code and Codex backends implement, and SHALL select which spawner instance to inject based on the agent type resolved from `--agent` / `CHORUS_AGENT`. The wake pipeline above the spawner (wake-queue, waker, directed delivery, headless guard, turn/transcript lifecycle reporters) SHALL remain backend-agnostic and SHALL NOT branch on the agent type. A spawner SHALL NOT throw into the wake path: any failure to resolve the executable, spawn, or write the prompt SHALL resolve with `exitCode: null` and a visible log line, so one failed wake never crashes the daemon. The spawner SHALL invoke `onChild` exactly once, synchronously, only on a successful spawn, before the wake promise resolves.
+
+#### Scenario: Default selection injects the Claude backend unchanged
+
+- **WHEN** the resolved agent type is `claude-code`
+- **THEN** the daemon injects the Claude spawner and its spawn argv and behavior are byte-for-byte the same as before this change
+
+#### Scenario: codex selection injects the Codex backend
+
+- **WHEN** the resolved agent type is `codex`
+- **THEN** the daemon injects the Codex spawner, and the waker drives it through the same `wake(...)` contract without any agent-type-specific branching in the waker
+
+#### Scenario: A spawn failure does not crash the daemon
+
+- **WHEN** a spawner cannot locate its backend executable or the spawn fails
+- **THEN** the wake resolves with `exitCode: null` and a visible error log, and the daemon continues serving subsequent notifications
+

--- a/src/components/agent-presence/hooks.ts
+++ b/src/components/agent-presence/hooks.ts
@@ -92,6 +92,8 @@ export function useClientTypeLabel() {
           return t("clientClaudeCode");
         case "openclaw":
           return t("clientOpenclaw");
+        case "codex":
+          return t("clientCodex");
         default:
           return t("clientUnknown");
       }

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -76,8 +76,8 @@ beforeEach(() => {
 
 // ===== Constants =====
 describe("constants", () => {
-  it("DAEMON_CLIENT_TYPES are exactly claude_code + openclaw", () => {
-    expect(DAEMON_CLIENT_TYPES).toEqual(["claude_code", "openclaw"]);
+  it("DAEMON_CLIENT_TYPES are claude_code + openclaw + codex", () => {
+    expect(DAEMON_CLIENT_TYPES).toEqual(["claude_code", "openclaw", "codex"]);
   });
 
   it("STALE_THRESHOLD_MS is 90s (3x the 30s heartbeat)", () => {
@@ -198,6 +198,17 @@ describe("registerConnection", () => {
       mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
       const result = await registerConnection(companyUuid, agentUuid, {
         clientType: "openclaw",
+        host: "linux-box",
+        cwd: "/srv/work",
+      });
+      expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+      expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+    });
+
+    it("registers a codex clientType (codex daemon backend)", async () => {
+      mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+      const result = await registerConnection(companyUuid, agentUuid, {
+        clientType: "codex",
         host: "linux-box",
         cwd: "/srv/work",
       });

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -21,7 +21,7 @@ import logger from "@/lib/logger";
 // The `clientType` column also reserves "browser" / "other" (see schema) so
 // browser registration can be added later without a migration, but only these
 // machine daemon types are registered now.
-export const DAEMON_CLIENT_TYPES = ["claude_code", "openclaw"] as const;
+export const DAEMON_CLIENT_TYPES = ["claude_code", "openclaw", "codex"] as const;
 export type DaemonClientType = (typeof DAEMON_CLIENT_TYPES)[number];
 
 // Staleness threshold for the liveness rule a downstream reader MUST apply:


### PR DESCRIPTION
## Summary
Cashes in the reserved `--agent codex` extension point: a remote-dispatched daemon wake can now spawn a local **headless Codex** (`codex exec --json`) instead of Claude Code. Implements idea `b8335370` (OpenSpec change `add-daemon-codex-backend`, archived).

The wake pipeline (queue, waker, directed delivery, headless guard, reporters) stays backend-agnostic — only the leaf that turns a wake into a subprocess changed. The `claude-code` path is byte-unchanged.

## What changed
| File | Change |
|------|--------|
| `cli/daemon-agent.mjs` | `KNOWN_AGENTS` now `["claude-code","codex"]`; error wording |
| `cli/spawner-select.mjs` (new) | `selectSpawner(agentType,{logger,permissionMode,creds})` |
| `cli/codex-spawner.mjs` (new) | `CodexSpawner`: `codex exec --json` headless wake, prompt via stdin, JSONL parse (shared `parseNdjsonChunk`), `thread.started` id capture, detached process group, key via env, never-throw-into-wake-path |
| `cli/codex-session-map.mjs` (new) | persisted `anchor → thread_id` (atomic write, best-effort) |
| `cli/daemon.mjs` | spawner injection seam uses `selectSpawner(agentType,…)` |
| `cli/__tests__/*` | 5 new test files; 2 updated (had used `codex` as the "unknown agent" example) |
| `docs/blogs/v2ex-daemon-remote-wake.zh.md` | closing paragraph reflects shipped scope |
| `openspec/specs/*`, `openspec/changes/archive/*` | new + updated capability specs; archived change |

## Key design points (verified against codex 0.142.3 + `../codex` source)
- **Session id is reversed**: Codex generates its own `thread_id` (no client `--session-id`). Captured from the `thread.started` event, persisted per idea anchor, resumed via `codex exec resume <id>`.
- **No `--mcp-config`**: MCP comes from the user's `~/.codex/config.toml`; the daemon key reaches it via the configured `bearer_token_env_var` (`CHORUS_API_KEY`) in child env, never argv.
- **Permission is subcommand-aware**: `yolo → --dangerously-bypass-approvals-and-sandbox` (valid on `exec` and `resume`); `chorus → --sandbox read-only` on `exec`, `-c sandbox_mode="read-only"` on `resume` (resume has no `--sandbox` flag — caught by e2e).
- **Interrupt parity**: detached POSIX process group reaped by the existing `killProcessTree` (no new killer).

## Out of scope (v1)
Codex transcript upload, daemon-side MCP config synthesis, Codex model auth (user-provided via Bedrock / `codex login`).

## Test plan
- [x] TDD unit tests for every new module; full CLI suite **485 tests pass** (`npx vitest run cli/`)
- [x] eslint clean on all new/changed files
- [x] **Strict local e2e against the real `codex` 0.142.3 binary** — 12/12 checks: new wake, **resume continuity** (model recalled turn-1 context via `codex exec resume`), real process-group interrupt (pid confirmed dead)
- [x] Two independent code reviews (PASS WITH NOTES, 0 blockers)
- [ ] Smoke test on a second machine with `chorus daemon --agent codex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)