### PR TITLE
fix(daemon): deterministic presence ordering so refreshes don't jitter

### DIFF
--- a/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-28

--- a/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/README.md
+++ b/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-agent-presence-order
+
+Stabilize daemon agent presence ordering across refreshes

--- a/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/design.md
+++ b/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/design.md
@@ -1,0 +1,97 @@
+# Design: Deterministic daemon presence ordering
+
+## Overview
+
+This fix moves ordering from "whatever the latest query/heartbeat produced" to an explicit deterministic contract. The server remains the authority for the API order, and the frontend applies the same defensive identity ordering before any derived grouping so a future local refactor cannot reintroduce array-order jitter.
+
+The important constraint is that not every layer has the same information:
+
+- The API projection knows `effectiveStatus`, `agentName`, `agentUuid`, `cwd`, `host`, `clientType`, `uuid`, and timestamps.
+- The presence UI also knows current executions, so it can identify running/queued/idle states for display.
+
+Therefore the shared rule is layered:
+
+1. Backend: deterministic connection order by `effectiveStatus` and stable identity fields.
+2. Frontend: deterministic connection/group order by status/activity rank where available, then the same stable identity fields.
+
+## Ordering Contract
+
+### Backend connection comparator
+
+For `ConnectionView[]` returned by `listConnectionsForOwner` and `listConnectionsForAgent`:
+
+1. `effectiveStatus` rank: `online` before `offline`.
+2. `agentName`, normalized for display sorting: trim, case-fold, missing name sorts after named agents.
+3. `agentUuid`.
+4. `cwd` path: known full path string ascending; `null` uses a deterministic sentinel and sorts after known paths.
+5. `host`: string ascending, with `""` as the existing unknown-host sentinel.
+6. `clientType`: string ascending.
+7. `uuid`: final stable tie-break.
+
+`lastSeenAt`, `connectedAt`, and `startedAt` remain display fields only. They must not decide primary order because heartbeats and reconnects can change them when the user-visible set is otherwise equivalent.
+
+Use a locale-stable comparison rather than browser/runtime-locale-dependent collation. A simple normalized string compare is sufficient because these fields are identifiers, not natural-language prose.
+
+### Frontend grouping comparator
+
+For agent-presence UI grouping:
+
+1. If execution-derived activity is available for an agent/instance, activity rank may be applied: `running`, `queued`, `online idle`, `offline`.
+2. Then apply the backend identity tie-breaks: agent name, agent uuid, cwd path, host, client type, uuid.
+3. Grouping must not preserve unsorted input order as a semantic decision. First appearance can only be used after the input has already been normalized by the comparator.
+
+This keeps "busy agents first" possible while preventing two equally-busy agents or two cwd entries from swapping on refresh.
+
+## Implementation Notes
+
+- Keep the comparator pure and unit-testable. The current `sortConnectionViews` in `src/services/daemon-connection.service.ts` is the backend hook point.
+- Prefer reusing one frontend helper from `src/components/agent-presence/instance-group.tsx` or a nearby utility so the popover and modal do not drift.
+- Do not mutate arrays in place; sort a copy.
+- Do not hide errors by returning empty arrays. Existing read-path error behavior should remain unchanged.
+- Do not remove `lastSeenAt` from `ConnectionView`; only stop using it as a primary sort key.
+
+## Test Strategy
+
+### Backend unit tests
+
+Seed multiple `DaemonConnection` rows with:
+
+- different raw database orders,
+- duplicate `agentName` values,
+- missing/null `agentName`,
+- multiple cwd values under one agent,
+- online and offline statuses,
+- different `lastSeenAt` values.
+
+Assert that two shuffled inputs map to byte-identical ordered `ConnectionView.uuid` sequences. Assert that heartbeat-only timestamp changes do not move rows unless status changes.
+
+### Frontend unit/component tests
+
+Cover `groupConnectionsByAgent` or the new sorting helper with:
+
+- same agent in multiple cwd paths, shuffled input,
+- same display name across two agent uuids,
+- unknown cwd plus known cwd,
+- running/queued/idle status ranks when execution data is part of the rendered surface.
+
+Existing tests in `src/components/agent-presence/__tests__/instance-group.test.ts` and `src/components/agent-presence/__tests__/presence-pill-drilldown.test.tsx` are the natural places.
+
+### Local E2E
+
+Add a local E2E check following the project's existing daemon/Claude local E2E style:
+
+1. Start the app against fixture or mocked connection data.
+2. Render the resident presence surface and expand the relevant agent/cwd list.
+3. Simulate repeated refreshes that return the same logical connection set in different raw array orders.
+4. Assert the visible agent row order and cwd sub-row order remain unchanged across refreshes.
+
+The E2E should prove the user-facing symptom is gone, not just that a pure comparator sorts correctly.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Users expect recency-first ordering because `lastSeenAt` used to influence order. | The idea explicitly prioritizes stable scanning over recency. Last-active remains visible in the detail panel. |
+| Backend and frontend comparators drift. | Document the same identity tie-break order in the spec and keep focused tests on both sides. |
+| Activity rank causes movement while work starts/stops. | That is a real state change and acceptable. Ties within the same activity rank remain deterministic. |
+| Locale-sensitive sorting differs across environments. | Use normalized string comparison for identifiers rather than default locale collation. |

--- a/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/proposal.md
+++ b/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/proposal.md
@@ -1,0 +1,51 @@
+# Proposal: Stabilize daemon agent presence ordering across refreshes
+
+## Why
+
+The daemon presence UI polls `GET /api/agent-connections` and also derives grouped agent/cwd rows locally. Today the server orders connections by `effectiveStatus` and `lastSeenAt` descending, while the frontend grouping preserves whatever order the current array happens to carry. That makes the UI visually unstable:
+
+1. A heartbeat refresh can change `lastSeenAt` without changing the set of agents or cwd entries, causing rows to move.
+2. Equal connection sets can arrive from the database in different raw orders, and the client preserves that accidental order.
+3. One agent's cwd rows inherit the same instability, so expanded content jumps even when the actual online state did not change.
+
+This breaks the main value of the resident presence surface: users need to scan and repeatedly target a known agent/cwd without the list moving underneath them.
+
+## What Changes
+
+- **Backend authoritative deterministic order.** `GET /api/agent-connections` returns a stable order for the same logical dataset. The server ranks by connection status first (`effectiveStatus: online` before `offline`), then by agent display name, agent uuid, cwd path string, host, client type, and connection uuid. `lastSeenAt` remains projected for display but is not a primary ordering key because it changes on heartbeat.
+
+- **Frontend defensive sort for derived views.** The agent-presence frontend adds a shared comparator/grouping helper and applies it before rendering the presence pill popover, the full connections modal, and any local agent/cwd grouping that can receive unsorted arrays. Where a view has local execution state and wants to show activity groups, it may rank `running` before `queued` before idle, but it must still tie-break by agent name/uuid and cwd/host so equivalent data renders identically.
+
+- **cwd rows sort by path string.** Within a given agent/status group, cwd entries sort by the full cwd path string ascending. `null` cwd uses the existing "unknown path" sentinel and sorts deterministically after known paths unless the existing formatter establishes a stricter local sentinel rule.
+
+- **Status changes may move rows; raw array order may not.** A row can move when its actual status/activity changes, because that is meaningful content. A row must not move solely because the API/database returned the same set in another order.
+
+- **Tests cover backend and local E2E behavior.** Unit tests cover the backend comparator against shuffled inputs. Frontend tests cover grouping/sorting of agent/cwd arrays. A local end-to-end test, using the project's existing daemon/Claude-style local E2E pattern, verifies repeated refreshes with equivalent connection sets do not reorder the visible agent and cwd rows.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agent-connection-observability`: adds deterministic ordering requirements for the daemon connection API and the resident presence UI.
+
+## Impact
+
+- **Schema**: none. No Prisma migration, no new model, no permission change.
+- **Backend code**:
+  - `src/services/daemon-connection.service.ts`: replace `lastSeenAt`-first ordering with a deterministic comparator and export or test the pure helper as appropriate.
+  - `src/services/__tests__/daemon-connection.service.test.ts`: add shuffled-input tests proving identical sets produce identical output.
+- **Frontend code**:
+  - `src/components/agent-presence/instance-group.tsx` and related presence helpers: sort defensively before grouping/rendering.
+  - `src/contexts/agent-presence-context.tsx` if needed: normalize connection arrays as they enter the shared data spine.
+  - Existing component tests under `src/components/agent-presence/__tests__/` and `src/contexts/__tests__/agent-presence-context.test.tsx`.
+- **Local E2E**:
+  - Add or extend the existing local Playwright/daemon E2E coverage so repeated refreshes with shuffled equivalent fixture data preserve DOM row order.
+- **Docs/design.pen**: not required unless implementation changes visible layout. This is a behavior/stability fix, not a new surface.
+
+## Out of Scope
+
+- Adding new presence states or changing the meaning of `effectiveStatus`.
+- Changing the daemon registry write path, heartbeat behavior, or `lastSeenAt` semantics.
+- Adding manual disconnect/delete actions.
+- Reworking the presence UI layout.
+- Making recency a user-selectable sort mode.

--- a/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/specs/agent-connection-observability/spec.md
+++ b/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/specs/agent-connection-observability/spec.md
@@ -1,0 +1,52 @@
+# agent-connection-observability Specification
+
+## ADDED Requirements
+
+### Requirement: Daemon connection lists SHALL render in a deterministic order across equivalent refreshes
+
+The `GET /api/agent-connections` read path and the resident agent-presence UI SHALL apply deterministic ordering so an equivalent set of daemon connections renders in the same order regardless of database row order, API array order, or heartbeat-only timestamp changes. The server SHALL be the authoritative source for the API's connection order. The frontend SHALL defensively normalize any locally derived agent/cwd grouping before rendering so it does not depend on accidental input order.
+
+The backend connection order SHALL rank `effectiveStatus = "online"` before `effectiveStatus = "offline"`, then tie-break by normalized `agentName`, `agentUuid`, cwd full path string, host, `clientType`, and connection `uuid`. Missing agent names and `null` cwd values SHALL use deterministic sentinels. `lastSeenAt`, `connectedAt`, and `startedAt` SHALL remain projected for display but SHALL NOT be primary ordering keys because they can change during refresh without changing the logical set of connections.
+
+When the frontend has local execution state, it MAY apply an activity rank before the stable identity tie-breaks, such as running before queued before online-idle before offline. Any such rank MUST still be deterministic and MUST still tie-break by agent identity and cwd identity. A row MAY move when its actual status or activity changes; it MUST NOT move solely because an equivalent array was returned in a different order.
+
+#### Scenario: API order is stable for shuffled equivalent rows
+
+- **GIVEN** two reads observe the same logical daemon connection set in different raw database orders
+- **WHEN** `GET /api/agent-connections` projects and sorts the rows
+- **THEN** both responses MUST return the same connection uuid sequence
+
+#### Scenario: Heartbeat-only timestamp changes do not reorder equivalent rows
+
+- **GIVEN** two online connections whose identity fields and statuses are unchanged
+- **WHEN** only `lastSeenAt` or other display timestamps change due to heartbeat refresh
+- **THEN** their relative order MUST remain determined by agent identity and cwd identity
+- **AND** the rows MUST NOT swap solely because one heartbeat timestamp is newer
+
+#### Scenario: Agent groups are ordered by status and stable identity
+
+- **GIVEN** the presence UI receives visible connections for multiple agents
+- **WHEN** the UI renders the popover or full connections modal
+- **THEN** agent groups MUST be ordered by status or activity rank first
+- **AND** groups with the same rank MUST be tie-broken by agent display name and agent uuid
+- **AND** repeated refreshes with the same logical set MUST preserve the same group order
+
+#### Scenario: cwd rows are ordered by full path string
+
+- **GIVEN** one agent has multiple visible cwd connections in the same status/activity rank
+- **WHEN** the UI renders the expanded cwd rows for that agent
+- **THEN** the cwd rows MUST be ordered by full cwd path string ascending with a deterministic `null` cwd sentinel
+- **AND** repeated refreshes with the same cwd set in different raw input order MUST preserve the same row order
+
+#### Scenario: Meaningful status changes may move a row
+
+- **GIVEN** an agent or cwd row changes from offline to online, online idle to running, or another supported status/activity rank transition
+- **WHEN** the UI refreshes
+- **THEN** the row MAY move to the appropriate status/activity group
+- **AND** rows within the same resulting group MUST still use deterministic identity tie-breaks
+
+#### Scenario: Local E2E verifies refresh stability
+
+- **GIVEN** a local end-to-end test renders the daemon presence surface with fixture daemon connections
+- **WHEN** repeated refreshes return the same logical agent/cwd set in different raw array orders
+- **THEN** the visible agent group order and cwd sub-row order MUST remain unchanged

--- a/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/tasks.md
+++ b/openspec/changes/archive/2026-06-28-fix-daemon-agent-presence-order/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+- [ ] Replace backend connection ordering with a deterministic comparator.
+  - [ ] Update `sortConnectionViews` in `src/services/daemon-connection.service.ts` to rank effective status first, then agent name, agent uuid, cwd, host, client type, and connection uuid.
+  - [ ] Keep timestamp fields projected but remove them as primary sort keys.
+  - [ ] Add unit tests proving shuffled equivalent inputs produce identical output order and heartbeat-only timestamp changes do not move rows.
+
+- [ ] Add frontend defensive ordering for agent/cwd presence groups.
+  - [ ] Add or extract a pure sorting helper near `src/components/agent-presence/instance-group.tsx`.
+  - [ ] Apply the helper before grouping/rendering in the presence popover and full connections modal paths.
+  - [ ] Cover multi-agent, duplicate-name, multi-cwd, and null-cwd cases in component/unit tests.
+
+- [ ] Add local E2E refresh-stability coverage.
+  - [ ] Follow the project's existing local daemon/Claude-style E2E pattern.
+  - [ ] Drive repeated refreshes with equivalent connection sets in different raw orders.
+  - [ ] Assert visible agent rows and cwd sub-rows keep the same DOM order.
+
+- [ ] Run verification.
+  - [ ] Run the targeted service/component tests.
+  - [ ] Run the new local E2E test.
+  - [ ] Run the relevant full test command used by this repo for frontend/service changes.

--- a/openspec/specs/agent-connection-observability/spec.md
+++ b/openspec/specs/agent-connection-observability/spec.md
@@ -377,3 +377,52 @@ a new permission bit.
 - **AND** it MUST NOT render the `interrupted` row (which remains modal-only)
 - **AND** a task row MUST still deep-link to its entity
 
+### Requirement: Daemon connection lists SHALL render in a deterministic order across equivalent refreshes
+
+The `GET /api/agent-connections` read path and the resident agent-presence UI SHALL apply deterministic ordering so an equivalent set of daemon connections renders in the same order regardless of database row order, API array order, or heartbeat-only timestamp changes. The server SHALL be the authoritative source for the API's connection order. The frontend SHALL defensively normalize any locally derived agent/cwd grouping before rendering so it does not depend on accidental input order.
+
+The backend connection order SHALL rank `effectiveStatus = "online"` before `effectiveStatus = "offline"`, then tie-break by normalized `agentName`, `agentUuid`, cwd full path string, host, `clientType`, and connection `uuid`. Missing agent names and `null` cwd values SHALL use deterministic sentinels. `lastSeenAt`, `connectedAt`, and `startedAt` SHALL remain projected for display but SHALL NOT be primary ordering keys because they can change during refresh without changing the logical set of connections.
+
+When the frontend has local execution state, it MAY apply an activity rank before the stable identity tie-breaks, such as running before queued before online-idle before offline. Any such rank MUST still be deterministic and MUST still tie-break by agent identity and cwd identity. A row MAY move when its actual status or activity changes; it MUST NOT move solely because an equivalent array was returned in a different order.
+
+#### Scenario: API order is stable for shuffled equivalent rows
+
+- **GIVEN** two reads observe the same logical daemon connection set in different raw database orders
+- **WHEN** `GET /api/agent-connections` projects and sorts the rows
+- **THEN** both responses MUST return the same connection uuid sequence
+
+#### Scenario: Heartbeat-only timestamp changes do not reorder equivalent rows
+
+- **GIVEN** two online connections whose identity fields and statuses are unchanged
+- **WHEN** only `lastSeenAt` or other display timestamps change due to heartbeat refresh
+- **THEN** their relative order MUST remain determined by agent identity and cwd identity
+- **AND** the rows MUST NOT swap solely because one heartbeat timestamp is newer
+
+#### Scenario: Agent groups are ordered by status and stable identity
+
+- **GIVEN** the presence UI receives visible connections for multiple agents
+- **WHEN** the UI renders the popover or full connections modal
+- **THEN** agent groups MUST be ordered by status or activity rank first
+- **AND** groups with the same rank MUST be tie-broken by agent display name and agent uuid
+- **AND** repeated refreshes with the same logical set MUST preserve the same group order
+
+#### Scenario: cwd rows are ordered by full path string
+
+- **GIVEN** one agent has multiple visible cwd connections in the same status/activity rank
+- **WHEN** the UI renders the expanded cwd rows for that agent
+- **THEN** the cwd rows MUST be ordered by full cwd path string ascending with a deterministic `null` cwd sentinel
+- **AND** repeated refreshes with the same cwd set in different raw input order MUST preserve the same row order
+
+#### Scenario: Meaningful status changes may move a row
+
+- **GIVEN** an agent or cwd row changes from offline to online, online idle to running, or another supported status/activity rank transition
+- **WHEN** the UI refreshes
+- **THEN** the row MAY move to the appropriate status/activity group
+- **AND** rows within the same resulting group MUST still use deterministic identity tie-breaks
+
+#### Scenario: Local E2E verifies refresh stability
+
+- **GIVEN** a local end-to-end test renders the daemon presence surface with fixture daemon connections
+- **WHEN** repeated refreshes return the same logical agent/cwd set in different raw array orders
+- **THEN** the visible agent group order and cwd sub-row order MUST remain unchanged
+

--- a/packages/openclaw-plugin/src/__tests__/daemon-loop.e2e.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/daemon-loop.e2e.test.ts
@@ -224,11 +224,10 @@ async function buildHarness(apiKey: string): Promise<Harness> {
     logger,
   });
 
-  let daemonClient: OpenClawDaemonClient;
   const redispatch = (req: WakeRequest): void => {
     void daemonClient.runWake(req);
   };
-  daemonClient = new OpenClawDaemonClient({
+  const daemonClient = new OpenClawDaemonClient({
     restClient,
     resolveRunContext: () => ({
       agent: fake.agent,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -107,7 +107,6 @@ export default definePluginEntry({
     //     into api.config/api.runtime (kept out of the client so it stays testable).
     //     `redispatch` resolves lineage for a synthetic resume so it continues the
     //     SAME session, then runs the wake; a delivered turn already carries its ids.
-    let daemonClient: OpenClawDaemonClient;
     const redispatch = (req: WakeRequest): void => {
       void (async () => {
         let enriched = req;
@@ -128,7 +127,7 @@ export default definePluginEntry({
         await daemonClient.runWake(enriched);
       })();
     };
-    daemonClient = new OpenClawDaemonClient({
+    const daemonClient = new OpenClawDaemonClient({
       restClient,
       resolveRunContext: () => resolveWakeRunContext(api, logger),
       redispatch,

--- a/src/components/agent-presence-pill.tsx
+++ b/src/components/agent-presence-pill.tsx
@@ -335,9 +335,11 @@ export function AgentPresencePill({ mobile = false }: { mobile?: boolean }) {
   // from presence rather than lingering as an all-offline row). Because every
   // grouped connection is now online, each group's onlineCount equals its
   // instance count, so the `> 0` filter is just defensive (a group can't be
-  // empty). The service's online-first sort still orders the rows.
+  // empty). `onlineConnectionsOnly` also applies the stable identity sort, so
+  // raw refresh array order cannot make the popover jump.
   const onlineAgentGroups = groupConnectionsByAgent(
-    onlineConnectionsOnly(connections),
+    onlineConnectionsOnly(connections, executionsByConnection),
+    executionsByConnection,
   ).filter((g) => g.onlineCount > 0);
 
   return (

--- a/src/components/agent-presence/__tests__/instance-group.test.ts
+++ b/src/components/agent-presence/__tests__/instance-group.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from "vitest";
 import {
   groupConnectionsByAgent,
   onlineConnectionsOnly,
+  sortConnectionsForPresence,
   deriveInstanceActivity,
 } from "../instance-group";
 import type { ConnectionView, ExecutionView } from "../types";
@@ -52,11 +53,11 @@ function exec(overrides: Partial<ExecutionView> & { uuid: string }): ExecutionVi
 }
 
 describe("groupConnectionsByAgent", () => {
-  it("groups connections by agent, preserving first-appearance order", () => {
+  it("groups connections by agent in deterministic identity order", () => {
     const groups = groupConnectionsByAgent([
-      conn({ uuid: "a1", agentUuid: "A", agentName: "Alpha" }),
       conn({ uuid: "b1", agentUuid: "B", agentName: "Beta" }),
-      conn({ uuid: "a2", agentUuid: "A", agentName: "Alpha" }),
+      conn({ uuid: "a2", agentUuid: "A", agentName: "Alpha", cwd: "/z" }),
+      conn({ uuid: "a1", agentUuid: "A", agentName: "Alpha", cwd: "/a" }),
     ]);
     expect(groups).toHaveLength(2);
     expect(groups[0].agentUuid).toBe("A");
@@ -110,13 +111,13 @@ describe("groupConnectionsByAgent", () => {
 });
 
 describe("onlineConnectionsOnly", () => {
-  it("keeps only effectively-online connections (drops offline)", () => {
+  it("keeps only effectively-online connections (drops offline) and returns them sorted", () => {
     const result = onlineConnectionsOnly([
-      conn({ uuid: "a1", effectiveStatus: "online" }),
+      conn({ uuid: "a1", effectiveStatus: "online", cwd: "/z" }),
       conn({ uuid: "a2", effectiveStatus: "offline" }),
-      conn({ uuid: "a3", effectiveStatus: "online" }),
+      conn({ uuid: "a3", effectiveStatus: "online", cwd: "/a" }),
     ]);
-    expect(result.map((c) => c.uuid)).toEqual(["a1", "a3"]);
+    expect(result.map((c) => c.uuid)).toEqual(["a3", "a1"]);
   });
 
   it("drops a legacy null-cwd OFFLINE 'unknown path' connection from presence", () => {
@@ -139,14 +140,173 @@ describe("onlineConnectionsOnly", () => {
     expect(groupConnectionsByAgent(offlineOnly)).toHaveLength(0);
   });
 
-  it("preserves input order of the surviving online connections", () => {
+  it("sorts surviving online connections instead of preserving raw input order", () => {
     const result = onlineConnectionsOnly([
-      conn({ uuid: "a1", effectiveStatus: "online" }),
+      conn({ uuid: "a1", effectiveStatus: "online", cwd: "/c" }),
       conn({ uuid: "a2", effectiveStatus: "offline" }),
-      conn({ uuid: "a3", effectiveStatus: "online" }),
-      conn({ uuid: "a4", effectiveStatus: "online" }),
+      conn({ uuid: "a3", effectiveStatus: "online", cwd: "/a" }),
+      conn({ uuid: "a4", effectiveStatus: "online", cwd: "/b" }),
     ]);
-    expect(result.map((c) => c.uuid)).toEqual(["a1", "a3", "a4"]);
+    expect(result.map((c) => c.uuid)).toEqual(["a3", "a4", "a1"]);
+  });
+});
+
+describe("sortConnectionsForPresence", () => {
+  it("sorts by effective status, agent name, agent uuid, cwd, host, client type, and uuid", () => {
+    const input = [
+      conn({
+        uuid: "offline-alpha",
+        agentUuid: "agent-a",
+        agentName: "Alpha",
+        effectiveStatus: "offline",
+        cwd: "/a",
+      }),
+      conn({
+        uuid: "online-beta",
+        agentUuid: "agent-b",
+        agentName: "Beta",
+        cwd: "/a",
+      }),
+      conn({
+        uuid: "online-alpha-null",
+        agentUuid: "agent-a",
+        agentName: "alpha",
+        cwd: null,
+      }),
+      conn({
+        uuid: "online-alpha-a",
+        agentUuid: "agent-a",
+        agentName: "  ALPHA ",
+        cwd: "/a",
+      }),
+      conn({
+        uuid: "online-missing",
+        agentUuid: "agent-0",
+        agentName: null,
+        cwd: "/a",
+      }),
+    ];
+
+    expect(sortConnectionsForPresence(input).map((c) => c.uuid)).toEqual([
+      "online-alpha-a",
+      "online-alpha-null",
+      "online-beta",
+      "online-missing",
+      "offline-alpha",
+    ]);
+    // Pure helper: original array was not mutated.
+    expect(input.map((c) => c.uuid)).toEqual([
+      "offline-alpha",
+      "online-beta",
+      "online-alpha-null",
+      "online-alpha-a",
+      "online-missing",
+    ]);
+  });
+
+  it("tie-breaks agents with duplicate display names by agent uuid", () => {
+    const result = sortConnectionsForPresence([
+      conn({
+        uuid: "same-name-b",
+        agentUuid: "agent-b",
+        agentName: "Same Name",
+      }),
+      conn({
+        uuid: "same-name-a",
+        agentUuid: "agent-a",
+        agentName: "same name",
+      }),
+    ]);
+
+    expect(result.map((c) => c.uuid)).toEqual(["same-name-a", "same-name-b"]);
+  });
+
+  it("ranks running before queued before online idle before offline, then stable identity", () => {
+    const running = conn({
+      uuid: "running-z",
+      agentUuid: "agent-z",
+      agentName: "Zeta",
+    });
+    const queued = conn({
+      uuid: "queued-a",
+      agentUuid: "agent-a",
+      agentName: "Alpha",
+    });
+    const idle = conn({
+      uuid: "idle-a",
+      agentUuid: "agent-a",
+      agentName: "Alpha",
+      cwd: "/idle",
+    });
+    const offline = conn({
+      uuid: "offline-a",
+      agentUuid: "agent-a",
+      agentName: "Alpha",
+      effectiveStatus: "offline",
+    });
+
+    const result = sortConnectionsForPresence(
+      [offline, idle, queued, running],
+      {
+        [running.uuid]: [exec({ uuid: "run", connectionUuid: running.uuid, status: "running" })],
+        [queued.uuid]: [exec({ uuid: "queue", connectionUuid: queued.uuid, status: "queued" })],
+        [idle.uuid]: [],
+        [offline.uuid]: [exec({ uuid: "offline-run", connectionUuid: offline.uuid, status: "running" })],
+      },
+    );
+
+    expect(result.map((c) => c.uuid)).toEqual([
+      "running-z",
+      "queued-a",
+      "idle-a",
+      "offline-a",
+    ]);
+  });
+
+  it("orders groups by highest instance activity when execution state is provided", () => {
+    const betaRunning = conn({
+      uuid: "beta-running",
+      agentUuid: "agent-b",
+      agentName: "Beta",
+    });
+    const alphaIdle = conn({
+      uuid: "alpha-idle",
+      agentUuid: "agent-a",
+      agentName: "Alpha",
+    });
+
+    const groups = groupConnectionsByAgent(
+      [alphaIdle, betaRunning],
+      {
+        [betaRunning.uuid]: [
+          exec({ uuid: "run", connectionUuid: betaRunning.uuid, status: "running" }),
+        ],
+      },
+    );
+
+    expect(groups.map((g) => g.agentUuid)).toEqual(["agent-b", "agent-a"]);
+  });
+
+  it("returns the same order for equivalent shuffled refresh payloads", () => {
+    const a = [
+      conn({ uuid: "z", agentUuid: "agent-z", agentName: "Zeta", cwd: "/z" }),
+      conn({ uuid: "a-null", agentUuid: "agent-a", agentName: "Alpha", cwd: null }),
+      conn({ uuid: "a-a", agentUuid: "agent-a", agentName: "Alpha", cwd: "/a" }),
+    ];
+    const b = [
+      conn({ uuid: "a-a", agentUuid: "agent-a", agentName: "Alpha", cwd: "/a" }),
+      conn({ uuid: "z", agentUuid: "agent-z", agentName: "Zeta", cwd: "/z" }),
+      conn({ uuid: "a-null", agentUuid: "agent-a", agentName: "Alpha", cwd: null }),
+    ];
+
+    expect(sortConnectionsForPresence(a).map((c) => c.uuid)).toEqual([
+      "a-a",
+      "a-null",
+      "z",
+    ]);
+    expect(sortConnectionsForPresence(b).map((c) => c.uuid)).toEqual(
+      sortConnectionsForPresence(a).map((c) => c.uuid),
+    );
   });
 });
 

--- a/src/components/agent-presence/__tests__/presence-refresh-stability.e2e.test.tsx
+++ b/src/components/agent-presence/__tests__/presence-refresh-stability.e2e.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+//
+// Local daemon-presence E2E guard: render the resident shell-level presence
+// provider + sidebar pill, then drive two poll refreshes whose connection
+// payloads are the same logical set in different raw orders. The visible agent
+// groups and expanded cwd rows must keep the same DOM order.
+//
+// Command:
+//   pnpm test src/components/agent-presence/__tests__/presence-refresh-stability.e2e.test.tsx
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ConnectionView } from "@/components/agent-presence";
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    let node: unknown = en;
+    for (const p of fullKey.split(".")) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations:
+      (namespace = "") =>
+      (key: string, params?: Record<string, string | number>) => {
+        let s = resolve(namespace, key);
+        if (params) {
+          for (const [k, v] of Object.entries(params)) {
+            s = s.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          }
+        }
+        return s;
+      },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const mockAuthFetch = vi.fn();
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
+vi.mock("@/lib/logger-client", () => ({
+  clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { AgentPresenceProvider } from "@/contexts/agent-presence-context";
+import { AgentPresencePill } from "@/components/agent-presence-pill";
+
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockEventSource.OPEN;
+  url: string;
+  constructor(url: string) {
+    this.url = url;
+  }
+  close() {
+    this.readyState = MockEventSource.CLOSED;
+  }
+}
+
+const NOW = "2026-06-23T12:00:00.000Z";
+
+function conn(overrides: Partial<ConnectionView> & Pick<ConnectionView, "uuid">): ConnectionView {
+  return {
+    agentUuid: "agent-alpha",
+    agentName: "Alpha Agent",
+    ownerUuid: null,
+    clientType: "claude_code",
+    clientVersion: "0.12.0",
+    host: "host-a",
+    cwd: "/work/a",
+    startedAt: NOW,
+    status: "online",
+    effectiveStatus: "online",
+    connectedAt: NOW,
+    lastSeenAt: NOW,
+    disconnectedAt: null,
+    ...overrides,
+  };
+}
+
+function agentLabelsInDomOrder(): string[] {
+  return screen
+    .getAllByRole("button", { name: /working directories/ })
+    .map((button) => button.textContent ?? "")
+    .map((text) => text.match(/Alpha Agent|Beta Agent/)?.[0])
+    .filter((name): name is string => Boolean(name));
+}
+
+function cwdTitlesInDomOrder(): string[] {
+  return Array.from(document.querySelectorAll<HTMLElement>("span[title^='/work/']"))
+    .map((el) => el.getAttribute("title"))
+    .filter((title): title is string => Boolean(title));
+}
+
+async function expandAllAgents() {
+  await waitFor(() =>
+    expect(
+      screen.getAllByRole("button", { name: /Show .*working directories/ }).length,
+    ).toBeGreaterThan(0),
+  );
+  for (const toggle of screen.getAllByRole("button", {
+    name: /Show .*working directories/,
+  })) {
+    fireEvent.click(toggle);
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  // @ts-expect-error inject mock EventSource
+  global.EventSource = MockEventSource;
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  mockAuthFetch.mockReset();
+});
+
+describe("daemon presence refresh stability E2E", () => {
+  it("keeps visible agent and cwd DOM order stable across shuffled refresh payloads", async () => {
+    const stableConnections = [
+      conn({
+        uuid: "alpha-z",
+        agentUuid: "agent-alpha",
+        agentName: "Alpha Agent",
+        cwd: "/work/z",
+      }),
+      conn({
+        uuid: "beta-b",
+        agentUuid: "agent-beta",
+        agentName: "Beta Agent",
+        host: "host-b",
+        cwd: "/work/b",
+      }),
+      conn({
+        uuid: "alpha-a",
+        agentUuid: "agent-alpha",
+        agentName: "Alpha Agent",
+        cwd: "/work/a",
+      }),
+    ];
+    const shuffledConnections = [
+      stableConnections[1],
+      stableConnections[0],
+      stableConnections[2],
+    ];
+    let connectionPolls = 0;
+    mockAuthFetch.mockImplementation((url: string) => {
+      if (url.startsWith("/api/daemon/executions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, data: { executions: [] } }),
+        });
+      }
+      const connections =
+        connectionPolls++ === 0 ? stableConnections : shuffledConnections;
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ success: true, data: { connections } }),
+      });
+    });
+
+    render(
+      <AgentPresenceProvider>
+        <AgentPresencePill />
+      </AgentPresenceProvider>,
+    );
+
+    await waitFor(() => expect(connectionPolls).toBe(1));
+    fireEvent.click(await screen.findByLabelText("Online agents — open details"));
+    await waitFor(() =>
+      expect(agentLabelsInDomOrder()).toEqual(["Alpha Agent", "Beta Agent"]),
+    );
+
+    await expandAllAgents();
+    await waitFor(() =>
+      expect(cwdTitlesInDomOrder()).toEqual(["/work/a", "/work/z", "/work/b"]),
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+    });
+    await waitFor(() => expect(connectionPolls).toBeGreaterThanOrEqual(2));
+
+    await waitFor(() =>
+      expect(agentLabelsInDomOrder()).toEqual(["Alpha Agent", "Beta Agent"]),
+    );
+    expect(cwdTitlesInDomOrder()).toEqual(["/work/a", "/work/z", "/work/b"]);
+  });
+});

--- a/src/components/agent-presence/connections-view.tsx
+++ b/src/components/agent-presence/connections-view.tsx
@@ -7,7 +7,7 @@
 // a presentational view that reads its dataset from the shell-level
 // `useAgentPresence()` spine instead of running its own poll + SSE. Capability
 // parity with the former page is a hard requirement:
-//   - master-detail connection list (online-first, as the service already sorts),
+//   - master-detail connection list (online-first with stable identity ties),
 //   - per-connection detail (client type + version, online/offline from
 //     `effectiveStatus`, host, last-active, uptime ONLY for online),
 //   - running/queued execution state + the `interrupted` executions the data
@@ -578,8 +578,8 @@ export function AgentConnectionsView() {
   // is still the source of `onlineCount`/`status` (the no-silent-error gate) and
   // of `selectedAgentOnlineConnections` (which independently filters online).
   const visibleConnections = useMemo(
-    () => onlineConnectionsOnly(connections),
-    [connections],
+    () => onlineConnectionsOnly(connections, executionsByConnection),
+    [connections, executionsByConnection],
   );
 
   // "loading" only on the very first poll before any data has settled. Once the

--- a/src/components/agent-presence/index.ts
+++ b/src/components/agent-presence/index.ts
@@ -25,6 +25,7 @@ export { IdentityBlock } from "./identity-block";
 export {
   groupConnectionsByAgent,
   onlineConnectionsOnly,
+  sortConnectionsForPresence,
   deriveInstanceActivity,
   useInstanceActivity,
   AgentGroupHeader,

--- a/src/components/agent-presence/instance-group.tsx
+++ b/src/components/agent-presence/instance-group.tsx
@@ -65,11 +65,55 @@ export interface AgentInstanceGroup {
   singleHost: string | undefined;
 }
 
+const MISSING_NAME_SORT_KEY = "\uffff";
+const NULL_CWD_SORT_KEY = "\uffff";
+
+function normalizedTextSortKey(value: string | null): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLocaleLowerCase("en-US") : MISSING_NAME_SORT_KEY;
+}
+
+function cwdSortKey(value: string | null): string {
+  return value === null ? NULL_CWD_SORT_KEY : value;
+}
+
+function compareText(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 /**
- * Group a flat, already-sorted (online-first, lastSeenAt desc — see
- * `sortConnectionViews`) list of connections into one entry per agent,
- * preserving the input order of agents (first appearance wins) and of
- * connections within an agent. Pure: no side effects, safe in render/test.
+ * Stable defensive ordering for frontend presence views. The backend already
+ * returns deterministic order, but local derived surfaces can receive arrays
+ * from tests, cached state, or future transforms; normalize before grouping so
+ * equivalent refreshes cannot jump because of raw array order.
+ */
+export function sortConnectionsForPresence(
+  connections: ConnectionView[],
+  executionsByConnection: Record<string, ExecutionView[]> = {},
+): ConnectionView[] {
+  return [...connections].sort((a, b) => {
+    const activityRankDiff =
+      connectionActivityRank(a, executionsByConnection[a.uuid] ?? []) -
+      connectionActivityRank(b, executionsByConnection[b.uuid] ?? []);
+    return (
+      activityRankDiff ||
+      compareText(normalizedTextSortKey(a.agentName), normalizedTextSortKey(b.agentName)) ||
+      compareText(a.agentUuid, b.agentUuid) ||
+      compareText(cwdSortKey(a.cwd), cwdSortKey(b.cwd)) ||
+      compareText(a.host, b.host) ||
+      compareText(a.clientType, b.clientType) ||
+      compareText(a.uuid, b.uuid)
+    );
+  });
+}
+
+/**
+ * Group a flat list of connections into one entry per agent after applying the
+ * stable presence comparator. Agent group order and connection order within an
+ * agent are therefore deterministic rather than inherited from raw API/cache
+ * array order. Pure: no side effects, safe in render/test.
  *
  * `multiHost` is derived from the count of DISTINCT non-empty-considered host
  * strings across the agent's connections (the empty-string host counts as its
@@ -79,10 +123,15 @@ export interface AgentInstanceGroup {
  */
 export function groupConnectionsByAgent(
   connections: ConnectionView[],
+  executionsByConnection: Record<string, ExecutionView[]> = {},
 ): AgentInstanceGroup[] {
+  const orderedConnections = sortConnectionsForPresence(
+    connections,
+    executionsByConnection,
+  );
   const order: string[] = [];
   const byAgent = new Map<string, ConnectionView[]>();
-  for (const conn of connections) {
+  for (const conn of orderedConnections) {
     if (!byAgent.has(conn.agentUuid)) {
       byAgent.set(conn.agentUuid, []);
       order.push(conn.agentUuid);
@@ -123,8 +172,22 @@ export function groupConnectionsByAgent(
  */
 export function onlineConnectionsOnly(
   connections: ConnectionView[],
+  executionsByConnection: Record<string, ExecutionView[]> = {},
 ): ConnectionView[] {
-  return connections.filter((c) => c.effectiveStatus === "online");
+  return sortConnectionsForPresence(
+    connections.filter((c) => c.effectiveStatus === "online"),
+    executionsByConnection,
+  );
+}
+
+function connectionActivityRank(
+  connection: ConnectionView,
+  executions: ExecutionView[],
+): number {
+  if (connection.effectiveStatus !== "online") return 3;
+  if (executions.some((e) => e.status === "running")) return 0;
+  if (executions.some((e) => e.status === "queued")) return 1;
+  return 2;
 }
 
 // The derived activity state of one instance, used to drive both the subline

--- a/src/services/__tests__/cwd-pin-chain.integration.test.ts
+++ b/src/services/__tests__/cwd-pin-chain.integration.test.ts
@@ -433,8 +433,8 @@ const OTHER_CONN = "conn-other-0002";
 // (add-agent-instance-addressing) references this uuid via assigneeType="agent_instance".
 const INSTANCE = "instance-pinned-0001";
 
-// A ConnectionView (the shape listConnectionsForAgent returns), online-first then
-// lastSeenAt desc per the registry contract. We build the list explicitly per test.
+// A ConnectionView (the shape listConnectionsForAgent returns), online-first with
+// stable identity ties per the registry contract. We build the list explicitly per test.
 function connView(overrides: Record<string, unknown> = {}) {
   return {
     uuid: PINNED_CONN,

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -47,9 +47,11 @@ import {
   touchConnection,
   listConnectionsForOwner,
   listConnectionsForAgent,
+  sortConnectionViews,
   resolveInstanceByTuple,
   resolveInstanceForConnection,
   listInstancesForAgent,
+  type ConnectionView,
   type SelfReport,
 } from "@/services/daemon-connection.service";
 
@@ -685,6 +687,8 @@ const ownerUuid = "owner-0000-0000-0000-000000000001";
 function makeRow(
   overrides: {
     uuid?: string;
+    agentUuid?: string;
+    clientType?: string;
     status?: string;
     agoMs?: number; // how long before NOW lastSeenAt was
     startedAt?: Date | null;
@@ -699,8 +703,8 @@ function makeRow(
   const agoMs = overrides.agoMs ?? 0;
   return {
     uuid: overrides.uuid ?? connectionUuid,
-    agentUuid,
-    clientType: "claude_code",
+    agentUuid: overrides.agentUuid ?? agentUuid,
+    clientType: overrides.clientType ?? "claude_code",
     // Use `in` (not `??`) for the nullable fields so an explicit null override
     // is honored rather than falling through to the default.
     clientVersion: "clientVersion" in overrides ? overrides.clientVersion : "0.11.0",
@@ -876,7 +880,7 @@ describe("T3 dispatch selection across multi-cwd + null-cwd connections", () => 
     });
   });
 
-  it("the dispatch chokepoint's 'first online' selection is unaffected by cwd (online-first sort)", async () => {
+  it("the dispatch chokepoint's 'first online' selection is unaffected by cwd (online-first deterministic sort)", async () => {
     // One OFFLINE repo-a row + two ONLINE rows (repo-b, then null). The first-online pick
     // must land an ONLINE connection regardless of cwd — selection is by online status,
     // never by cwd or project.
@@ -890,9 +894,9 @@ describe("T3 dispatch selection across multi-cwd + null-cwd connections", () => 
     const origin = result.find((c) => c.effectiveStatus === "online");
     expect(origin).toBeTruthy();
     expect(origin!.effectiveStatus).toBe("online");
-    // Online-first, then lastSeenAt desc: the freshest online (null-cwd, agoMs 1000) leads
-    // the offline repo-a row — i.e. a null-cwd connection is fully selectable as origin.
-    expect(origin!.uuid).toBe("conn-null-online");
+    // Online-first, then stable cwd identity: the real-cwd row leads the null-cwd
+    // row regardless of lastSeenAt, and both lead the offline row.
+    expect(origin!.uuid).toBe("conn-b-online");
   });
 
   it("a null-cwd (old daemon) connection is selectable as the sole online connection (HARD-1)", async () => {
@@ -962,27 +966,51 @@ describe("ordering", () => {
     vi.setSystemTime(NOW);
   });
 
-  it("sorts online-first, then lastSeenAt desc", async () => {
+  it("sorts online-first, then stable identity fields instead of lastSeenAt", async () => {
     // Build rows out of final order:
-    //  - offlineOld:  offline, lastSeenAt 1h ago
-    //  - onlineOld:   online + fresh, lastSeenAt 60s ago
-    //  - onlineNew:   online + fresh, lastSeenAt now
-    //  - offlineNew:  offline, lastSeenAt 30s ago
+    //  - offline zeta: newest timestamp, but name sorts after Alpha
+    //  - online beta:  newest timestamp, but name sorts after Alpha
+    //  - online alpha: older timestamp, but identity sorts first
+    //  - offline alpha: older timestamp, but identity sorts first in offline group
     mockPrisma.daemonConnection.findMany.mockResolvedValue([
-      makeRow({ uuid: "offline-old", status: "offline", agoMs: 60 * 60 * 1000 }),
-      makeRow({ uuid: "online-old", status: "online", agoMs: 60_000 }),
-      makeRow({ uuid: "online-new", status: "online", agoMs: 0 }),
-      makeRow({ uuid: "offline-new", status: "offline", agoMs: 30_000 }),
+      makeRow({
+        uuid: "offline-zeta-new",
+        status: "offline",
+        agoMs: 0,
+        agentUuid: "agent-z",
+        agent: { name: "Zeta", ownerUuid },
+      }),
+      makeRow({
+        uuid: "online-beta-new",
+        status: "online",
+        agoMs: 0,
+        agentUuid: "agent-b",
+        agent: { name: "Beta", ownerUuid },
+      }),
+      makeRow({
+        uuid: "online-alpha-old",
+        status: "online",
+        agoMs: 60_000,
+        agentUuid: "agent-a",
+        agent: { name: "Alpha", ownerUuid },
+      }),
+      makeRow({
+        uuid: "offline-alpha-old",
+        status: "offline",
+        agoMs: 30_000,
+        agentUuid: "agent-a",
+        agent: { name: "Alpha", ownerUuid },
+      }),
     ]);
 
     const result = await listConnectionsForOwner(companyUuid, ownerUuid);
 
-    // Online (newest lastSeenAt first), then offline (newest lastSeenAt first).
+    // Online first, then stable identity; timestamps do not drive the order.
     expect(result.map((v) => v.uuid)).toEqual([
-      "online-new",
-      "online-old",
-      "offline-new",
-      "offline-old",
+      "online-alpha-old",
+      "online-beta-new",
+      "offline-alpha-old",
+      "offline-zeta-new",
     ]);
     expect(result.map((v) => v.effectiveStatus)).toEqual([
       "online",
@@ -1002,6 +1030,178 @@ describe("ordering", () => {
     const result = await listConnectionsForOwner(companyUuid, ownerUuid);
     expect(result.map((v) => v.uuid)).toEqual(["fresh-online", "stale-online"]);
     expect(result.map((v) => v.effectiveStatus)).toEqual(["online", "offline"]);
+  });
+
+  it("returns identical order for shuffled equivalent inputs and heartbeat-only timestamp changes", async () => {
+    const first = [
+      makeRow({
+        uuid: "conn-z",
+        status: "online",
+        agoMs: 1_000,
+        agentUuid: "agent-z",
+        agent: { name: "Zeta", ownerUuid },
+        cwd: "/work/z",
+      }),
+      makeRow({
+        uuid: "conn-a",
+        status: "online",
+        agoMs: 60_000,
+        agentUuid: "agent-a",
+        agent: { name: "Alpha", ownerUuid },
+        cwd: "/work/a",
+      }),
+      makeRow({
+        uuid: "conn-null",
+        status: "online",
+        agoMs: 10_000,
+        agentUuid: "agent-a",
+        agent: { name: "Alpha", ownerUuid },
+        cwd: null,
+      }),
+      makeRow({
+        uuid: "conn-offline",
+        status: "offline",
+        agoMs: 0,
+        agentUuid: "agent-b",
+        agent: { name: "Beta", ownerUuid },
+        cwd: "/work/b",
+      }),
+    ];
+    const second = [
+      makeRow({
+        uuid: "conn-offline",
+        status: "offline",
+        agoMs: 70_000,
+        agentUuid: "agent-b",
+        agent: { name: "Beta", ownerUuid },
+        cwd: "/work/b",
+      }),
+      makeRow({
+        uuid: "conn-null",
+        status: "online",
+        agoMs: 5_000,
+        agentUuid: "agent-a",
+        agent: { name: "Alpha", ownerUuid },
+        cwd: null,
+      }),
+      makeRow({
+        uuid: "conn-a",
+        status: "online",
+        agoMs: 0,
+        agentUuid: "agent-a",
+        agent: { name: "Alpha", ownerUuid },
+        cwd: "/work/a",
+      }),
+      makeRow({
+        uuid: "conn-z",
+        status: "online",
+        agoMs: 30_000,
+        agentUuid: "agent-z",
+        agent: { name: "Zeta", ownerUuid },
+        cwd: "/work/z",
+      }),
+    ];
+
+    mockPrisma.daemonConnection.findMany.mockResolvedValueOnce(first);
+    const firstResult = await listConnectionsForOwner(companyUuid, ownerUuid);
+    mockPrisma.daemonConnection.findMany.mockResolvedValueOnce(second);
+    const secondResult = await listConnectionsForOwner(companyUuid, ownerUuid);
+
+    expect(firstResult.map((v) => v.uuid)).toEqual([
+      "conn-a",
+      "conn-null",
+      "conn-z",
+      "conn-offline",
+    ]);
+    expect(secondResult.map((v) => v.uuid)).toEqual(firstResult.map((v) => v.uuid));
+  });
+
+  it("tie-breaks duplicate and missing agent names by agent uuid, cwd, host, clientType, then uuid", () => {
+    const input = [
+      {
+        uuid: "conn-missing-name",
+        agentUuid: "agent-0",
+        agentName: null,
+        ownerUuid,
+        clientType: "codex",
+        clientVersion: null,
+        host: "host-b",
+        cwd: "/work/a",
+        startedAt: null,
+        status: "online",
+        effectiveStatus: "online",
+        connectedAt: NOW.toISOString(),
+        lastSeenAt: new Date(NOW.getTime() - 1_000).toISOString(),
+        disconnectedAt: null,
+        agentInstanceUuid: null,
+      },
+      {
+        uuid: "conn-agent-2",
+        agentUuid: "agent-2",
+        agentName: "Alpha",
+        ownerUuid,
+        clientType: "claude_code",
+        clientVersion: null,
+        host: "host-a",
+        cwd: "/work/a",
+        startedAt: null,
+        status: "online",
+        effectiveStatus: "online",
+        connectedAt: NOW.toISOString(),
+        lastSeenAt: NOW.toISOString(),
+        disconnectedAt: null,
+        agentInstanceUuid: null,
+      },
+      {
+        uuid: "conn-agent-1-null-cwd",
+        agentUuid: "agent-1",
+        agentName: "alpha",
+        ownerUuid,
+        clientType: "claude_code",
+        clientVersion: null,
+        host: "host-a",
+        cwd: null,
+        startedAt: null,
+        status: "online",
+        effectiveStatus: "online",
+        connectedAt: NOW.toISOString(),
+        lastSeenAt: NOW.toISOString(),
+        disconnectedAt: null,
+        agentInstanceUuid: null,
+      },
+      {
+        uuid: "conn-agent-1-a",
+        agentUuid: "agent-1",
+        agentName: "  ALPHA ",
+        ownerUuid,
+        clientType: "claude_code",
+        clientVersion: null,
+        host: "host-a",
+        cwd: "/work/a",
+        startedAt: null,
+        status: "online",
+        effectiveStatus: "online",
+        connectedAt: NOW.toISOString(),
+        lastSeenAt: NOW.toISOString(),
+        disconnectedAt: null,
+        agentInstanceUuid: null,
+      },
+    ] satisfies ConnectionView[];
+
+    const sorted = sortConnectionViews(input);
+
+    expect(sorted.map((v) => v.uuid)).toEqual([
+      "conn-agent-1-a",
+      "conn-agent-1-null-cwd",
+      "conn-agent-2",
+      "conn-missing-name",
+    ]);
+    expect(input.map((v) => v.uuid)).toEqual([
+      "conn-missing-name",
+      "conn-agent-2",
+      "conn-agent-1-null-cwd",
+      "conn-agent-1-a",
+    ]);
   });
 });
 

--- a/src/services/__tests__/daemon-multipath-e2e.integration.test.ts
+++ b/src/services/__tests__/daemon-multipath-e2e.integration.test.ts
@@ -327,22 +327,16 @@ describeReal("daemon multi-path E2E — REAL Postgres (T4 integration checkpoint
       expect(connA).not.toBeNull();
       expect(connB).not.toBeNull();
 
-      // listConnectionsForAgent sorts online-first then lastSeenAt desc. connB was
-      // registered last, so it is the freshest → the dispatch chokepoint would pin a
-      // NEW session to connB. To make the test deterministic about WHICH cwd is the
-      // origin, age connB slightly so connA is the freshest online row, pinning origin
-      // to cwdA. (This is the realistic case: the session began on cwdA.)
-      await realPrisma.daemonConnection.update({
-        where: { uuid: connB!.uuid },
-        data: { lastSeenAt: new Date(Date.now() - 5_000) },
-      });
+      // listConnectionsForAgent sorts online-first, then stable identity fields.
+      // The temp cwdA prefix sorts before cwdB, so the dispatch chokepoint pins a
+      // NEW session to cwdA without depending on heartbeat timestamps.
 
       // Drive the REAL dispatch chokepoint: it selects the origin connection by
       // (company, agent) only and stamps it on the session. The session id = DIRECT_IDEA.
       const turn = await maybeCreateTurnForWakeNotification(wakeCtx());
       expect(turn).not.toBeNull();
 
-      // The session was pinned to cwdA's connection (the freshest online row).
+      // The session was pinned to cwdA's connection (the first stable identity row).
       const session = await realPrisma.daemonSession.findFirst({
         where: { companyUuid, agentUuid, sessionId: DIRECT_IDEA },
         select: { uuid: true, originConnectionUuid: true },
@@ -433,12 +427,12 @@ describeReal("daemon multi-path E2E — REAL Postgres (T4 integration checkpoint
       });
       expect(session).not.toBeNull();
       // The chosen origin is one of the agent's real connections (deterministically the
-      // freshest online one) — never a fabricated / project-derived target.
+      // first stable identity row) — never a fabricated / project-derived target.
       const validUuids = [c1!.uuid, c2!.uuid, cNull!.uuid];
       expect(validUuids).toContain(session.originConnectionUuid);
-      // It is the LAST-registered (freshest) online row, confirming the online-first +
-      // lastSeenAt-desc selection still holds with mixed cwd/null rows present.
-      expect(session.originConnectionUuid).toBe(cNull!.uuid);
+      // It is the first cwd in deterministic path order, confirming online-first +
+      // stable identity selection with mixed cwd/null rows present.
+      expect(session.originConnectionUuid).toBe(c1!.uuid);
 
       // Structural guard against project→cwd inference: the chokepoint's selection input
       // never references a project; the Project model carries no cwd. We assert the
@@ -590,8 +584,8 @@ describeReal("daemon multi-path E2E — REAL Postgres (T4 integration checkpoint
       expect(upgradedRow.uuid).toBe(upgraded!.uuid);
 
       // (c) Functionality does NOT regress: a NEW session created after the upgrade pins
-      // to the upgraded (cwd-bearing) connection — it is the freshest online row — and
-      // resumes correctly off the real cwd.
+      // to the upgraded (cwd-bearing) connection — it sorts before the legacy null-cwd
+      // row by stable identity — and resumes correctly off the real cwd.
       DIRECT_IDEA = "idea-e2e-0000-0000-0000-00000000002"; // a distinct post-upgrade session
       const postTurn = await maybeCreateTurnForWakeNotification(wakeCtx());
       expect(postTurn).not.toBeNull();

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -206,17 +206,44 @@ function toConnectionView(row: DaemonConnectionRow): ConnectionView {
   };
 }
 
+const MISSING_NAME_SORT_KEY = "\uffff";
+const NULL_CWD_SORT_KEY = "\uffff";
+
+function normalizedTextSortKey(value: string | null): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLocaleLowerCase("en-US") : MISSING_NAME_SORT_KEY;
+}
+
+function cwdSortKey(value: string | null): string {
+  return value === null ? NULL_CWD_SORT_KEY : value;
+}
+
+function compareText(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 /**
- * Order the projected views online-first, then by `lastSeenAt` desc — the
- * most-relevant connections surface at the top. Sorts a copy; does not mutate
- * the input.
+ * Order the projected views deterministically for stable daemon presence UI.
+ *
+ * Timestamps remain display data only: `lastSeenAt` changes on heartbeat and
+ * therefore must not reorder an otherwise-equivalent connection set. Sorts a
+ * copy; never mutates the caller-owned array.
  */
-function sortConnectionViews(views: ConnectionView[]): ConnectionView[] {
+export function sortConnectionViews(views: ConnectionView[]): ConnectionView[] {
   return [...views].sort((a, b) => {
     if (a.effectiveStatus !== b.effectiveStatus) {
       return a.effectiveStatus === "online" ? -1 : 1;
     }
-    return b.lastSeenAt.localeCompare(a.lastSeenAt);
+    return (
+      compareText(normalizedTextSortKey(a.agentName), normalizedTextSortKey(b.agentName)) ||
+      compareText(a.agentUuid, b.agentUuid) ||
+      compareText(cwdSortKey(a.cwd), cwdSortKey(b.cwd)) ||
+      compareText(a.host, b.host) ||
+      compareText(a.clientType, b.clientType) ||
+      compareText(a.uuid, b.uuid)
+    );
   });
 }
 

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -414,8 +414,8 @@ type OriginSelection =
  *        treated as a plain agent, so the agent's online-first connection wakes. Never
  *        notify-only, never a hang.
  *  - With no pin: the online-first selection (`effectiveStatus === "online"`, first entry —
- *    the list is already sorted online-first then lastSeenAt desc) → `online_first`,
- *    exactly as before this change. None online → `none`.
+ *    the list is already sorted by stable daemon presence identity) → `online_first`.
+ *    None online → `none`.
  *
  * A `directed`/`online_first` result carries the chosen ONLINE `ConnectionView`. An
  * `offline_pin`/`none` result carries no connection: the caller creates NO turn and the
@@ -447,9 +447,9 @@ function selectOriginConnection(
     // SOFT-pin degrade → fall through to the online-first selection.
   }
 
-  // No pin (or a degraded soft pin) → online-first (the existing behavior). The list is
-  // pre-sorted online-first, so the first online entry is the freshest connection. None
-  // online → no turn.
+  // No pin (or a degraded soft pin) → online-first. The list is pre-sorted
+  // online-first with stable identity ties, so heartbeats do not reorder an
+  // otherwise-equivalent connection set. None online → no turn.
   const onlineFirst = connections.find((c) => c.effectiveStatus === "online");
   return onlineFirst
     ? { kind: "online_first", connection: onlineFirst }
@@ -589,7 +589,7 @@ export async function createTurnAndResolveTarget(
   try {
     // (3) Resolve the agent's connections, then select the ONLINE origin (cwd-bound
     // transcript owner) honoring any pinned target instance. listConnectionsForAgent is
-    // sorted online-first, then lastSeenAt desc.
+    // sorted online-first with stable identity ties.
     const connections = await listConnectionsForAgent(
       ctx.companyUuid,
       ctx.recipientUuid,


### PR DESCRIPTION
## Summary
The daemon presence UI re-sorted on every poll: backend connection order was driven by `lastSeenAt` (which changes on each heartbeat), and frontend derived groups inherited raw array order. Equivalent refreshes reshuffled the agent list and per-agent cwd rows, making the popover/modal visibly jump even when nothing actually changed.

This makes presence ordering **deterministic** end-to-end so identical-content refreshes never reorder.

## Changes
- **Backend** (`daemon-connection.service.ts`): `sortConnectionViews` now orders online-first then by stable identity (`agentName → agentUuid → cwd → host → clientType → uuid`). `lastSeenAt` is display-only and no longer drives order. Exported for reuse/testing.
- **Frontend** (`agent-presence/instance-group.tsx`): new `sortConnectionsForPresence` defensive comparator applied inside `groupConnectionsByAgent` / `onlineConnectionsOnly`, so cached/test/future transforms can't reintroduce jitter. Activity rank (running → queued → online idle → offline) is preserved, with stable identity tie-breaks.
- **notification-turn.ts**: comments updated — online-first origin selection now relies on stable identity ties, not `lastSeenAt` freshness.
- **E2E**: `presence-refresh-stability.e2e.test.tsx` renders the real `AgentPresenceProvider + AgentPresencePill`, fires two equivalent-but-shuffled refresh payloads, asserts agent + cwd DOM order is stable.
- **Cleanup**: removed stale `lastSeenAt desc / freshest` comments and integration-test expectations; fixed `prefer-const` lint in `openclaw-plugin`.
- **OpenSpec**: archived `fix-daemon-agent-presence-order` change; cumulative `agent-connection-observability` spec updated.

## Changed files
| File | Change |
|------|--------|
| `src/services/daemon-connection.service.ts` | Stable identity sort; `lastSeenAt` display-only |
| `src/components/agent-presence/instance-group.tsx` | `sortConnectionsForPresence` + activity-rank tie-breaks |
| `src/components/agent-presence-pill.tsx`, `connections-view.tsx`, `index.ts` | Wire defensive sort + executions |
| `src/services/notification-turn.ts` | Comment fixes for stable-identity origin selection |
| `src/components/agent-presence/__tests__/presence-refresh-stability.e2e.test.tsx` | New local E2E |
| `*.test.ts(x)`, `*.integration.test.ts` | Update expectations to stable order |
| `packages/openclaw-plugin/src/index.ts`, `daemon-loop.e2e.test.ts` | `prefer-const` lint fix |
| `openspec/...` | Archive change + cumulative spec |

## Test plan
- [x] `pnpm exec tsc --noEmit` → passes
- [x] `pnpm lint` → exit 0 (0 errors, pre-existing warnings only)
- [x] `pnpm test` presence + daemon-connection suites → 106 passed, 8 skipped (real-DB gate)
- [ ] Browser E2E acceptance of refresh stability (in progress)

Idea: `45b35509-8a25-43a2-abc4-77bd2632829c`

Generated with [Claude Code](https://claude.com/claude-code)