### PR TITLE
feat(daemon): warn + skip conflicting daemon connections instead of silent takeover

### DIFF
--- a/cli/__tests__/daemon-multipath.test.mjs
+++ b/cli/__tests__/daemon-multipath.test.mjs
@@ -77,6 +77,7 @@ class MockSse {
   deliver(event) {
     if (event?.type === "connection_registered") return this.opts.onConnectionId?.(event.connectionUuid);
     if (event?.type === "control") return this.opts.onControl?.(event);
+    if (event?.type === "connection_conflict") return this.opts.onConflict?.(event);
     this.opts.onEvent(event);
   }
 }
@@ -385,5 +386,123 @@ describe("back-compat: deps.cwd (single value) maps to a one-element cwd set", (
     expect(daemon.connections).toHaveLength(1);
     expect(daemon.waker).toBe(daemon.connections[0].waker); // primary alias
     expect(daemon.waker.resolveCwd()).toBe("/legacy/single");
+  });
+});
+
+// ===== add-daemon-connection-conflict-skip: warn + skip + all-conflict exit =====
+describe("connection conflict — warn, skip, no-retry, all-conflict exit", () => {
+  /** Build a daemon over the given cwd set, capturing each MockSse + logger warns + wake spy. */
+  function buildWithConflict(cwds) {
+    const warns = [];
+    const wake = vi.fn(async (p) => ({ sessionId: p.sessionId, exitCode: 0, isNew: p.isNew }));
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger: { ...silent, warn: (m) => warns.push(m) },
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner: { wake },
+        cwds,
+        makeSseListener: (o) => new MockSse(o),
+      }
+    );
+    return { daemon, warns, wake };
+  }
+
+  it("AC#1: on conflict the daemon warns (host+cwd), disconnects that listener, and never spawns", async () => {
+    const { daemon, warns, wake } = buildWithConflict(["/dev/repo-a"]);
+    const conn = daemon.connections[0];
+    expect(conn.sseListener.connected).toBe(false);
+    await daemon.start();
+    expect(conn.sseListener.connected).toBe(true);
+
+    conn.sseListener.deliver({ type: "connection_conflict", host: "mac.local", cwd: "/dev/repo-a" });
+
+    // Warned with host + cwd, listener torn down (no reconnect), path marked skipped.
+    expect(warns.join("")).toMatch(/conflict/i);
+    expect(warns.join("")).toContain("mac.local");
+    expect(warns.join("")).toContain("/dev/repo-a");
+    expect(conn.sseListener.connected).toBe(false);
+    expect(conn.outcome.skipped).toBe(true);
+    // A conflict is never a wake — no subprocess spawned.
+    expect(wake).not.toHaveBeenCalled();
+  });
+
+  it("AC#2: partial conflict — C1 conflicts (skipped) while C2 registers and still serves wakes", async () => {
+    const { daemon, wake } = buildWithConflict(["/dev/repo-a", "/dev/repo-b"]);
+    await daemon.start();
+    const [c1, c2] = daemon.connections;
+
+    c1.sseListener.deliver({ type: "connection_conflict", host: "h", cwd: "/dev/repo-a" });
+    c2.sseListener.deliver({ type: "connection_registered", connectionUuid: "conn-B" });
+
+    // C1 surrendered; C2 alive and owns its connection uuid.
+    expect(c1.outcome.skipped).toBe(true);
+    expect(c1.sseListener.connected).toBe(false);
+    expect(c2.outcome.skipped).toBe(false);
+    expect(c2.sseListener.connected).toBe(true);
+    expect(c2.connectionState.connectionUuid).toBe("conn-B");
+
+    // C2 still dispatches a wake (its serving path is undisturbed by C1's skip).
+    c2.sseListener.deliver({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(wake).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC#2: a partial conflict does NOT settle allConflict (the daemon keeps running)", async () => {
+    const { daemon } = buildWithConflict(["/dev/repo-a", "/dev/repo-b"]);
+    await daemon.start();
+    const [c1, c2] = daemon.connections;
+
+    let settled = false;
+    daemon.allConflict.then(() => { settled = true; });
+
+    c1.sseListener.deliver({ type: "connection_conflict", host: "h", cwd: "/dev/repo-a" });
+    c2.sseListener.deliver({ type: "connection_registered", connectionUuid: "conn-B" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // One conflicted, one registered → at least one path serves → must NOT settle.
+    expect(settled).toBe(false);
+  });
+
+  it("AC#3: allConflict settles ONLY after EVERY path conflicts (not while one is mid-handshake)", async () => {
+    const { daemon } = buildWithConflict(["/dev/repo-a", "/dev/repo-b"]);
+    await daemon.start();
+    const [c1, c2] = daemon.connections;
+
+    let settled = false;
+    daemon.allConflict.then(() => { settled = true; });
+
+    // First path conflicts; second still handshaking → latch must NOT fire yet (R5).
+    c1.sseListener.deliver({ type: "connection_conflict", host: "h", cwd: "/dev/repo-a" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(settled).toBe(false);
+
+    // Second path also conflicts → now all resolved + none registered → settles.
+    c2.sseListener.deliver({ type: "connection_conflict", host: "h", cwd: "/dev/repo-b" });
+    await daemon.allConflict; // resolves, or the test times out if the latch is broken
+    expect(settled).toBe(true);
+  });
+
+  it("a reconnect's repeated connection_registered does not double-count the latch", async () => {
+    // Two paths: one registers (twice, simulating a reconnect), the other conflicts.
+    // The repeated registration must not flip the bookkeeping into a premature/incorrect
+    // all-conflict (it stays a partial → never settles).
+    const { daemon } = buildWithConflict(["/dev/repo-a", "/dev/repo-b"]);
+    await daemon.start();
+    const [c1, c2] = daemon.connections;
+
+    let settled = false;
+    daemon.allConflict.then(() => { settled = true; });
+
+    c1.sseListener.deliver({ type: "connection_registered", connectionUuid: "conn-A" });
+    c1.sseListener.deliver({ type: "connection_registered", connectionUuid: "conn-A" }); // reconnect re-emit
+    c2.sseListener.deliver({ type: "connection_conflict", host: "h", cwd: "/dev/repo-b" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // One real registration survives → never an all-conflict.
+    expect(settled).toBe(false);
+    expect(c1.outcome.skipped).toBe(false);
+    expect(c2.outcome.skipped).toBe(true);
   });
 });

--- a/cli/__tests__/daemon-permission-wiring.test.mjs
+++ b/cli/__tests__/daemon-permission-wiring.test.mjs
@@ -69,6 +69,40 @@ describe("runDaemon — TTY yolo starts without confirmation", () => {
   });
 });
 
+describe("runDaemon — all-conflict non-zero exit (add-daemon-connection-conflict-skip)", () => {
+  it("returns 1 and warns when daemon.allConflict settles (every path already served)", async () => {
+    const errs = [];
+    const stop = vi.fn(async () => {});
+    // A fake daemon whose allConflict is ALREADY settled → the all-paths-conflicted case.
+    const build = vi.fn(() => ({ async start() {}, stop, allConflict: Promise.resolve() }));
+    const code = await runDaemon(
+      {},
+      baseDeps({
+        isTTY: false,
+        build,
+        errLog: (m) => errs.push(m),
+        // waitForever never resolves, so the only way out is the allConflict branch.
+        waitForever: () => new Promise(() => {}),
+      })
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toMatch(/already served by a live daemon/i);
+    // Cleanly stops the (zero-serving) daemon before exiting.
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 0 when allConflict never settles and the subscription ends normally (no false exit)", async () => {
+    // A serving daemon: allConflict never settles; waitForever resolving (e.g. test
+    // teardown) must yield a clean 0, never the conflict exit.
+    const build = vi.fn(() => ({ async start() {}, async stop() {}, allConflict: new Promise(() => {}) }));
+    const code = await runDaemon(
+      {},
+      baseDeps({ isTTY: false, build, waitForever: async () => {} })
+    );
+    expect(code).toBe(0);
+  });
+});
+
 describe("recordYoloAck — preserves credentials, adds ack", () => {
   it("merges yoloAckAt into the existing file without touching creds", () => {
     const existing = { url: "u", apiKey: "cho_x", agentUuid: "a", agentName: "n" };

--- a/cli/__tests__/sse-listener.test.mjs
+++ b/cli/__tests__/sse-listener.test.mjs
@@ -167,6 +167,84 @@ describe("SseListener parsing", () => {
     listener.disconnect();
   });
 
+  it("forks a type:connection_conflict event to onConflict and NEVER to onEvent (no wake)", async () => {
+    const events = [];
+    const conflicts = [];
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse([
+        ": connected\n\n",
+        'data: {"type":"connection_conflict","host":"mac.local","cwd":"/work/alpha"}\n\n',
+        'data: {"type":"new_notification","notificationUuid":"n1"}\n\n',
+      ])
+    );
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (e) => events.push(e),
+      onConflict: (e) => conflicts.push(e),
+      logger: silentLogger,
+      fetchImpl,
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The conflict event went to onConflict ONLY, carrying host + cwd.
+    expect(conflicts).toEqual([
+      { type: "connection_conflict", host: "mac.local", cwd: "/work/alpha" },
+    ]);
+    // onEvent saw the real notification but NEVER the conflict event (no wake path).
+    expect(events).toEqual([{ type: "new_notification", notificationUuid: "n1" }]);
+    listener.disconnect();
+  });
+
+  it("a throwing onConflict callback does not crash the stream", async () => {
+    const warns = [];
+    const events = [];
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse([
+        'data: {"type":"connection_conflict","host":"h","cwd":"/w"}\n\n',
+        'data: {"type":"new_notification","notificationUuid":"after"}\n\n',
+      ])
+    );
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (e) => events.push(e),
+      onConflict: () => { throw new Error("conflict boom"); },
+      logger: { ...silentLogger, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 10));
+    // The next event still flows despite the throwing conflict handler.
+    expect(events).toEqual([{ type: "new_notification", notificationUuid: "after" }]);
+    expect(warns.join("")).toMatch(/onConflict callback error/);
+    listener.disconnect();
+  });
+
+  it("defaults onConflict to a no-op: a connection_conflict with no handler does not crash or reach onEvent", async () => {
+    const events = [];
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse([
+        'data: {"type":"connection_conflict","host":"h","cwd":"/w"}\n\n',
+        'data: {"type":"new_notification","notificationUuid":"n1"}\n\n',
+      ])
+    );
+    // No onConflict supplied → constructor defaults it to a no-op.
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (e) => events.push(e),
+      logger: silentLogger,
+      fetchImpl,
+    });
+    await listener.connect();
+    await new Promise((r) => setTimeout(r, 10));
+    // Conflict is swallowed by the default no-op; only the real notification reaches onEvent.
+    expect(events).toEqual([{ type: "new_notification", notificationUuid: "n1" }]);
+    listener.disconnect();
+  });
+
   it("tolerates malformed data line without throwing", async () => {
     const events = [];
     const warns = [];

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -140,6 +140,40 @@ export function buildDaemon(creds, deps = {}) {
       ? deps.cwds
       : [deps.cwd];
 
+  // ===== All-conflict exit latch (add-daemon-connection-conflict-skip, Q3) =====
+  // Each declared connection resolves to exactly one terminal outcome: REGISTERED
+  // (saw connection_registered → onConnectionId) or CONFLICTED (saw
+  // connection_conflict → onConflict). When EVERY declared connection has resolved
+  // AND none registered (≥1 conflicted, 0 survived), the daemon has nothing to serve,
+  // so we settle `allConflict` — runDaemon races this against waitForever and returns
+  // a non-zero exit. The latch is evaluated only after all connections resolve (R5):
+  // a path still mid-handshake leaves `resolved < total`, so a partial conflict never
+  // triggers the exit. A connection that registers (even after some conflicted) flips
+  // `anyRegistered`, so the exit never fires while at least one path serves.
+  const totalConnections = cwdSet.length;
+  let resolvedConnections = 0;
+  let anyRegistered = false;
+  let settleAllConflict; // resolver, wired into the promise below
+  // A promise that settles ONLY in the all-paths-conflicted case. It never rejects and
+  // never settles otherwise (a serving daemon simply keeps waiting on waitForever).
+  const allConflict = new Promise((resolve) => {
+    settleAllConflict = resolve;
+  });
+  // Record one connection's terminal outcome and, once all have resolved, decide whether
+  // the whole daemon should exit. Idempotent per connection BY CONSTRUCTION: the guard
+  // lives here (flips the connection's own `outcome.resolved`) so a reconnect's repeated
+  // connection_registered — or any future caller — can never double-count, no matter the
+  // call site. The first terminal signal for a connection wins; later ones are no-ops.
+  function recordConnectionOutcome(outcome, registered) {
+    if (outcome.resolved) return;
+    outcome.resolved = true;
+    resolvedConnections += 1;
+    if (registered) anyRegistered = true;
+    if (resolvedConnections === totalConnections && !anyRegistered) {
+      settleAllConflict();
+    }
+  }
+
   /**
    * Build ONE independent path-connection bound to `cwd` (one SSE stream → one
    * DaemonConnection row, keyed by that cwd server-side). All per-connection state —
@@ -157,6 +191,13 @@ export function buildDaemon(creds, deps = {}) {
     // doesn't matter. Per-connection so each path's wakes report against the right row.
     /** @type {{ connectionUuid: string|null }} */
     const connectionState = { connectionUuid: null };
+
+    // Per-connection terminal-outcome bookkeeping (add-daemon-connection-conflict-skip).
+    // `resolved` guards recordConnectionOutcome against double-counting a reconnect's
+    // repeated connection_registered. `skipped` marks a cwd surrendered to a live
+    // different-process daemon — purely informational (the listener is torn down, so it
+    // simply never reconnects), kept on the returned object for inspection/tests.
+    const outcome = { resolved: false, skipped: false };
 
     // Interrupt reporter (子3): REST POST with the daemon's Bearer key. Injectable for
     // tests (shared across connections when injected — tests use a single connection).
@@ -295,13 +336,37 @@ export function buildDaemon(creds, deps = {}) {
             `[Chorus] registered as connection ${connectionUuid}` +
               (cwd ? ` (cwd=${cwd})` : "")
           );
+          // Terminal outcome: this path registered. recordConnectionOutcome is idempotent
+          // per connection, so a reconnect's repeated connection_registered counts once.
+          recordConnectionOutcome(outcome, true);
+        },
+        // Connection conflict (add-daemon-connection-conflict-skip, Q3/Q4): the server
+        // refused to register THIS cwd because a live different-process daemon already
+        // holds the same (agent, host, cwd). Warn prominently, tear the listener down
+        // (disconnect clears the reconnect timer + aborts), and mark the path skipped —
+        // it is never reconnected/re-probed for the process lifetime. Takeover happens
+        // only on the NEXT daemon start/restart. Independent closures mean skipping this
+        // path never disturbs another connection's dispatch/control.
+        onConflict: (event) => {
+          const conflictCwd = (event && event.cwd) ?? cwd ?? process.cwd();
+          const conflictHost = (event && event.host) || "this host";
+          logger.warn(
+            `[Chorus] ⚠ connection conflict: a live daemon already serves ` +
+              `(host=${conflictHost}, cwd=${conflictCwd}) — skipping this path. ` +
+              `Stop the other daemon (or wait for it to go offline) and restart to take it over.`
+          );
+          outcome.skipped = true;
+          // Tear down THIS path's listener: no reconnect, no re-probe (Q4).
+          sseListener.disconnect?.();
+          // Terminal outcome: this path conflicted (idempotent — counts once).
+          recordConnectionOutcome(outcome, false);
         },
         onControl,
         onReconnect: backfill,
         logger,
       });
 
-    return { cwd, connectionState, waker, router, backfill, sseListener, hooks };
+    return { cwd, connectionState, waker, router, backfill, sseListener, hooks, outcome };
   }
 
   // Build one connection per declared cwd. The order is the declaration order; the
@@ -321,6 +386,10 @@ export function buildDaemon(creds, deps = {}) {
     router: primary.router,
     sseListener: primary.sseListener,
     connections,
+    // Settles ONLY when every declared connection resolved and none registered
+    // (all paths already served by a live daemon — Q3). runDaemon races this against
+    // waitForever to exit non-zero. Never settles for a serving daemon.
+    allConflict,
     async start() {
       // Connect every path-connection. Each fires its own onConnect hook + SSE connect;
       // the daemon process cwd is untouched (NFR-3).
@@ -502,8 +571,32 @@ export async function runDaemon(flags = {}, deps = {}) {
   await daemon.start();
   log("[Chorus] daemon running. Waiting for task dispatches (Ctrl+C to stop).");
 
-  // Keep the process alive for the long-lived SSE subscription.
-  await (deps.waitForever ?? (() => new Promise(() => {})))();
+  // Keep the process alive for the long-lived SSE subscription, but exit non-zero if
+  // EVERY declared path turns out to be already served by a live daemon
+  // (add-daemon-connection-conflict-skip, Q3). `daemon.allConflict` settles only in
+  // that all-paths-conflicted case; otherwise we wait forever on the subscription. A
+  // sentinel distinguishes the two so a waitForever that never settles can't be mistaken
+  // for the conflict exit.
+  const ALL_CONFLICT = Symbol("all-conflict");
+  const waitForever = deps.waitForever ?? (() => new Promise(() => {}));
+  // `daemon.allConflict` is present on the real buildDaemon output; guard for injected
+  // test fakes that don't provide it (those never settle the conflict branch). A
+  // never-settling fallback keeps the race purely waitForever-driven in that case.
+  const allConflictSignal =
+    daemon.allConflict ?? new Promise(() => {});
+  const outcome = await Promise.race([
+    waitForever().then(() => 0),
+    allConflictSignal.then(() => ALL_CONFLICT),
+  ]);
+  if (outcome === ALL_CONFLICT) {
+    const n = servedPaths.length;
+    errLog(
+      `[Chorus] all ${n} declared ${n === 1 ? "path is" : "paths are"} already served by a live daemon — nothing to do. ` +
+        `Stop the other daemon(s) or remove the conflicting path(s), then restart.`
+    );
+    await daemon.stop();
+    return 1;
+  }
   return 0;
 }
 

--- a/cli/sse-listener.mjs
+++ b/cli/sse-listener.mjs
@@ -69,6 +69,13 @@ const PROCESS_STARTED_AT = new Date();
  *   wake: the control event is forked here BEFORE `onEvent`, so the router / WakeQueue
  *   never sees it and it can never spawn a new Claude. The handler verifies the target
  *   connection + entity and interrupts the running subprocess (see control-handler.mjs).
+ * @property {(event: Record<string, unknown>) => void} [onConflict]  Called for a
+ *   `type:"connection_conflict"` data event (add-daemon-connection-conflict-skip): the
+ *   server refused to register THIS cwd because a live different-process daemon already
+ *   holds the same (agent, host, cwd). Like `control`, it is forked BEFORE `onEvent` so
+ *   it can NEVER reach the router / WakeQueue — a conflict is not a wake. The daemon's
+ *   handler warns and permanently tears down this cwd's listener (it does not reconnect).
+ *   The event carries `{ host, cwd }` of the conflicting identity.
  * @property {() => Promise<void>} [onReconnect]  Called after a reconnect so the
  *   caller can back-fill notifications missed during the gap.
  * @property {string} [cwd]  The working directory THIS connection serves (T3 — 单
@@ -91,6 +98,7 @@ export class SseListener {
     this.onEvent = opts.onEvent;
     this.onConnectionId = opts.onConnectionId ?? (() => {});
     this.onControl = opts.onControl ?? (() => {});
+    this.onConflict = opts.onConflict ?? (() => {});
     this.onReconnect = opts.onReconnect ?? (async () => {});
     /** @type {string|null} The connection this stream registered as (once reported). */
     this.connectionUuid = null;
@@ -258,6 +266,20 @@ export class SseListener {
             this.onControl(event);
           } catch (err) {
             this.logger.warn(`[Chorus] onControl callback error: ${err}`);
+          }
+          continue;
+        }
+        // Connection conflict (add-daemon-connection-conflict-skip): the server refused
+        // to register THIS cwd because a live different-process daemon already holds the
+        // same (agent, host, cwd). Like `control`, fork it to onConflict and `continue`
+        // — it MUST NEVER fall through to onEvent (the router / WakeQueue), or a conflict
+        // would be mistaken for a wake and could spawn a subprocess. A conflict is not a
+        // wake; the daemon's handler warns and tears down this cwd's listener.
+        if (event && event.type === "connection_conflict") {
+          try {
+            this.onConflict(event);
+          } catch (err) {
+            this.logger.warn(`[Chorus] onConflict callback error: ${err}`);
           }
           continue;
         }

--- a/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-28

--- a/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/README.md
+++ b/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/README.md
@@ -1,0 +1,3 @@
+# add-daemon-connection-conflict-skip
+
+Warn + skip on conflicting live daemon connections at the same (agent, host, cwd); never silently take over

--- a/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/design.md
+++ b/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/design.md
@@ -1,0 +1,196 @@
+# Design: Daemon connection conflict — warn + skip
+
+## Overview
+
+The `DaemonConnection` registry keys a row on the composite unique
+`(agentUuid, clientType, host, cwd)`. A second daemon started under the *same*
+key issues a byte-identical upsert `where`, so today `registerConnection`
+silently refreshes (takes over) the incumbent's row. The problem: at the key
+level, **"another live daemon process is preempting"** and **"the same daemon
+dropped and reconnected"** are indistinguishable — so we cannot reject on
+"key exists and is fresh" alone without breaking normal reconnect.
+
+The discriminator is a **process identity**: the self-reported `startedAt`
+(`PROCESS_STARTED_AT`, captured once at daemon module load and re-sent verbatim
+on every reconnect). Detection therefore reduces to a small truth table over
+`(incumbent freshness, startedAt equality)`.
+
+Two decisions from elaboration shape this design and are treated as fixed:
+
+- **DEC-1 (Q1 = startedAt only).** Process identity is `startedAt` alone — no new
+  `instanceId` column, no pid. Minimal change; accepted cost is that two daemons
+  started in the *same millisecond* are indistinguishable and the later one is
+  allowed to refresh (treated as a reconnect). This is vanishingly rare and
+  fails safe toward today's behavior.
+- **DEC-2 (Q2 = `(agent, host, cwd)` triple, clientType-agnostic).** Conflict is
+  judged across **all** client types at the same `(agent, host, cwd)`, not just
+  the same `(agent, clientType, host, cwd)` row. Running two backends
+  (claude_code + codex) in the *same* cwd under the *same* agent is therefore
+  **not a supported configuration** — both would be woken by the same
+  `notification:agent:<uuid>` batch and double-execute, which is exactly the
+  harm this change exists to prevent. This grain is consistent with the existing
+  `AgentInstance` unique key `(companyUuid, agentUuid, host, cwd)`, which already
+  omits `clientType` — from the addressing/wake perspective the two backends are
+  already "the same instance."
+
+## Detection rule (server, `registerConnection`)
+
+Applied **only on the real-cwd path** (`cwd !== null`). Let the incoming report
+carry `startedAt = S_new` for identity `(agent, host, cwd)`.
+
+1. Query for any existing connection row at `(agentUuid, host, cwd)` — **across
+   all clientTypes** (DEC-2) — that is **effectively online**: `status = "online"`
+   AND `now - lastSeenAt <= STALE_THRESHOLD_MS` (90s; reuse the exported constant,
+   never re-derive it).
+2. Branch:
+   - **No fresh incumbent** → not a conflict. Proceed with the normal upsert /
+     instance-link path exactly as today (this covers both first-connect and
+     **stale takeover** — the incumbent dead/`>90s` silent).
+   - **Fresh incumbent, `startedAt === S_new`** → **same process reconnect**.
+     Not a conflict; proceed with the normal refresh. (Preserves reconnect
+     semantics 1:1.)
+   - **Fresh incumbent, `startedAt !== S_new`** (including incumbent
+     `startedAt = null` vs. a non-null `S_new`, and vice-versa) → **CONFLICT**.
+     Return a conflict signal and **write nothing**.
+
+### Truth table
+
+| Incumbent at (agent,host,cwd) | startedAt vs incoming | Verdict |
+|---|---|---|
+| none | — | register (first connect) |
+| stale (`>90s` or `status≠online`) | any | register (takeover) |
+| fresh | equal | refresh (same-process reconnect) |
+| fresh | different (incl. one null) | **conflict → skip, write nothing** |
+
+> **Null-startedAt edge (confirmed with requester):** a fresh incumbent whose
+> `startedAt` is null, faced with a non-null incoming `startedAt` (or the
+> reverse), counts as **different → conflict → skip**. Rationale: prefer
+> non-preemption; a fresh row we cannot prove is "us" is treated as someone
+> else's. In practice every current daemon self-reports `startedAt`, so this is a
+> defensive corner, not a common path.
+
+## Load-bearing invariant — a skipped registration writes nothing
+
+This is the crux and the easiest thing to get subtly wrong. Because the only
+discriminator is `startedAt` (DEC-1), the incumbent's own reconnect must keep
+matching itself. If a *rejected* second daemon were allowed to write or refresh
+the row (even just `lastSeenAt`), it would pollute the very comparison the
+incumbent relies on. Therefore:
+
+- The conflict branch returns a distinct result **before any `upsert` / `update`
+  / `create`** — no row mutation, no `AgentInstance` upsert, nothing.
+- `registerConnection`'s return type widens to express three outcomes without
+  conflating them:
+  - **success** → `ConnectionHandle { uuid, connectedAt }` (unchanged shape);
+  - **conflict** → a sentinel the route can distinguish from success (e.g.
+    `{ conflict: true, host, cwd }`), so the route emits `connection_conflict`
+    and the existing lifecycle (heartbeat `touch`, `markDisconnected`,
+    execution reconcile) is **not** wired up for a connection that was never
+    registered;
+  - **null** → unchanged: not a daemon clientType, or a swallowed write failure.
+- The existing **swallow-and-log** contract for genuine write *failures* is
+  unchanged. A conflict is **not** an error — it is a normal, expected outcome
+  with its own signal; it must not be logged as a failure, but it **does** get a
+  structured `warn` (Q6) so it is diagnosable.
+
+## Server → daemon signal: `connection_conflict`
+
+- The notification route (`/api/events/notifications`) today emits a
+  `connection_registered` data event once the row is registered. When
+  `registerConnection` returns the **conflict** sentinel, the route instead emits
+  a single `connection_conflict` data event:
+  `{ type: "connection_conflict", host, cwd }`. It does **not** emit
+  `connection_registered`, does **not** subscribe the control channel, and does
+  **not** start the heartbeat for that stream (there is no row to touch).
+- Symmetric handling is added to `/api/events` for consistency, though the daemon
+  only uses the notification endpoint.
+- The event is a normal SSE `data:` line; browser `EventSource` clients ignore
+  the unrecognized `type`, exactly as they already ignore `connection_registered`
+  and `control`.
+
+## Daemon side: warn, skip, no-retry, conditional exit
+
+In `cli/sse-listener.mjs`, mirror the existing fork for `connection_registered` /
+`control`: a `connection_conflict` event is parsed and routed to a new
+`onConflict(event)` callback **before** `onEvent`, so it can never reach the wake
+router / WakeQueue (Module Contract: a conflict is not a wake).
+
+In `cli/daemon.mjs`'s per-connection closure (`buildConnection(cwd, index)`):
+
+- **Warn + skip (Q3 partial / Q4 no-retry).** `onConflict` logs a prominent
+  WARNING naming `host` + `cwd` and the fact that a live daemon already serves
+  this path, then calls the listener's `disconnect()` (which clears the reconnect
+  timer and aborts) and marks this connection **permanently skipped** — it is
+  never reconnected or re-probed for the life of the process. Stale-takeover of
+  this path happens only on the **next daemon start / restart** (a fresh process
+  with a fresh `startedAt`), never via background re-probe.
+- **Non-conflicting paths unaffected (Q3).** Each connection is an independent
+  closure with its own listener/router/backfill, so skipping one cwd leaves the
+  others serving normally.
+- **All-conflict exit (Q3).** A small process-level latch counts how many of the
+  declared connections ended in a conflict vs. successfully registered. When the
+  set of declared paths resolves such that **none** registered and **at least
+  one** conflicted, the daemon prints a clear "all N paths are already served by
+  a live daemon — nothing to do" line and exits **non-zero**. Because conflict is
+  reported asynchronously over SSE (not at `start()` return), the latch resolves
+  after each connection reaches a terminal state (registered or conflict); the
+  exit fires once every declared connection has resolved and none survived.
+- **Banner / startup output.** The served-paths line already printed at startup
+  is complemented by a per-skip WARNING; skipped cwds are named so an operator
+  sees at a glance which path was surrendered and why.
+
+## cwd = null exemption (Q5 / HARD-1)
+
+The legacy `cwd = null` branch in `registerConnection` (old daemons that don't
+self-report cwd) is **explicitly exempt** from conflict detection — it keeps
+today's `findFirst → update / create` refresh-or-takeover behavior verbatim.
+Justification: a daemon carrying this feature always self-reports a real cwd and
+never lands on the null branch; an old daemon neither sends `startedAt` nor can
+act on a `connection_conflict` event, so adding detection there could only break
+its reconnect. The null branch is left untouched.
+
+## Module contracts
+
+1. **`registerConnection` outcome is tri-state.** Callers MUST distinguish
+   success / conflict / null and MUST NOT treat conflict as either a handle or a
+   failure. Only success wires up `touch` / `markDisconnected` / execution
+   reconcile.
+2. **Conflict signal is forked before the wake path.** `connection_conflict`,
+   like `connection_registered` and `control`, MUST be consumed in
+   `#processMessage` and MUST NOT fall through to `onEvent`.
+3. **Skip is terminal for that cwd.** Once a path-connection is marked
+   conflicted, the daemon MUST NOT reconnect or re-probe it within the process
+   lifetime (Q4).
+4. **Liveness threshold is shared.** Conflict freshness MUST use the exported
+   `STALE_THRESHOLD_MS` and the same `status === "online" && fresh` rule the read
+   projection (`toConnectionView`) uses — producer and consumer never drift.
+
+## Risks & mitigations
+
+- **R1 — Rejected daemon pollutes the comparison row.** Mitigated by the
+  load-bearing invariant: the conflict branch returns before any write. Covered
+  by a test asserting the incumbent row's `connectedAt` / `lastSeenAt` are
+  unchanged after a conflicting registration.
+- **R2 — Breaking normal reconnect.** Same-`startedAt` fresh incumbent is
+  explicitly the reconnect path and refreshes as before. Covered by a regression
+  test (fresh + same startedAt → refresh, not conflict).
+- **R3 — Breaking crash-restart.** A crashed daemon's row goes stale within the
+  90s window; stale incumbents are always takeable. Covered by a test
+  (stale incumbent + different startedAt → register/takeover).
+- **R4 — Same-millisecond start collision (DEC-1 cost).** Accepted and
+  documented; fails safe toward refresh. No mitigation beyond documentation,
+  since adding an `instanceId` was explicitly declined.
+- **R5 — All-conflict exit racing async SSE.** The exit latch only fires after
+  every declared connection has reached a terminal state; a connection still
+  awaiting its handshake does not trigger a premature exit.
+- **R6 — Cross-tenant / cross-agent false positive.** The conflict query is
+  scoped by `agentUuid` (and implicitly company via the authenticated context),
+  so a different agent or company on the same host+cwd never collides.
+
+## Out of scope
+
+- Adding an `instanceId` / pid to the registry (declined — DEC-1).
+- Auto-takeover of a conflicting path by background re-probe (declined — Q4).
+- Supporting two backends in the same cwd as a first-class configuration
+  (explicitly unsupported — DEC-2).
+- Any change to the daemon.json field-merge / auto-start behavior (orthogonal).

--- a/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/proposal.md
+++ b/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+When a second `chorus daemon` is started on the **same machine, same cwd, and same agent identity** (a forgotten resident daemon, a systemd unit racing a manual start, or a second terminal), the server `registerConnection` upsert silently **overwrites (takes over)** the existing connection row — `connectedAt` / `lastSeenAt` / `status` are all refreshed with **no warning** and **no liveness check**. Two daemon processes then both believe they hold the connection and race for the same task-dispatch / reverse-control channel, causing duplicate wakes, duplicate execution, and tangled transcripts. The operator gets no signal that they started a second, conflicting daemon. The fix is to detect a still-alive incumbent and **warn + skip** instead of silently preempting it.
+
+## What Changes
+
+- **Server-side conflict detection in `registerConnection`.** Before writing, the server checks for an existing **fresh** (effectively-online) connection at the same `(agentUuid, host, cwd)` triple — **regardless of `clientType`** — whose self-reported process identity (`startedAt`) **differs** from the incoming report. When that holds, the registration is a **conflict**: the server returns a conflict signal and **writes nothing** (no upsert, no row refresh).
+- **A new `connection_conflict` SSE data event.** On a detected conflict the notification route emits a `connection_conflict` event (distinct from `connection_registered`) carrying the conflicting `host` / `cwd`, instead of the usual `connection_registered`.
+- **Daemon warn + skip per cwd.** On receiving `connection_conflict` for one of its path-connections, the daemon prints a prominent **WARNING** (naming host + cwd + that a live daemon already serves it), tears that one cwd's SSE listener down, and **does not reconnect or re-probe it** for the life of the process.
+- **Partial vs. total conflict.** A multi-path daemon keeps serving its **non-conflicting** cwds normally; only the conflicting paths are skipped. If **every** declared path conflicts (no connection survives), the daemon process **exits non-zero** with a clear message rather than lingering as a zombie that serves nothing.
+- **Server-side structured log** on each rejected (conflicting) registration, carrying `companyUuid` / `agentUuid` / `host` / `cwd` / incumbent-vs-incoming `startedAt`, so a conflict is diagnosable even when the second daemon's stderr lands in a different journal.
+- **Preserved paths (no regression):** stale-connection takeover (incumbent dead / `>90s` no heartbeat) and same-process reconnect (same `startedAt`) both continue to refresh the row as today. The legacy `cwd = null` branch (old daemons that don't self-report cwd, HARD-1) is **explicitly exempt** from conflict detection.
+- **No schema migration.** Detection reuses the already-persisted `startedAt`, `status`, and `lastSeenAt` columns — no new column, no `instanceId`.
+
+## Capabilities
+
+### New Capabilities
+- _(none)_ — this change extends two existing capabilities; it introduces no new spec.
+
+### Modified Capabilities
+- `daemon-connection-registry`: adds a conflict-detection requirement to the registration lifecycle — a fresh, different-process incumbent at the same `(agent, host, cwd)` causes the registration to be skipped (nothing written) and a conflict signalled, while stale takeover and same-process reconnect are preserved and the `cwd = null` branch is exempt. Adds the server-side structured conflict log.
+- `cli-daemon`: adds a requirement that the daemon warns and permanently skips a conflicting path-connection (no reconnect/re-probe), keeps serving non-conflicting paths, and exits non-zero when all declared paths conflict.
+
+## Impact
+
+- **Code:**
+  - `src/services/daemon-connection.service.ts` — conflict pre-check in `registerConnection` (real-cwd path only); a typed conflict result distinct from a successful `ConnectionHandle`; structured warn log.
+  - `src/app/api/events/notifications/route.ts` (and, for symmetry, `src/app/api/events/route.ts`) — emit `connection_conflict` instead of `connection_registered` when registration reports a conflict.
+  - `cli/sse-listener.mjs` — parse the `connection_conflict` event and surface it via a new `onConflict` callback (forked before `onEvent`, like `connection_registered` / `control`, so it never reaches the wake router).
+  - `cli/daemon.mjs` — per-connection conflict handler that disconnects that cwd's listener without scheduling a reconnect; process-level bookkeeping that exits non-zero when no connection survives; banner/log lines that name skipped cwds.
+- **APIs / contracts:** no REST or MCP surface change; only a new SSE data-event `type`. Browser `EventSource` clients ignore the unrecognized `type` (same as `connection_registered` / `control` today).
+- **Data:** no Prisma schema change; no migration.
+- **Behavioral compatibility:** old daemons (no `startedAt`, `cwd = null`) behave exactly as before; single-daemon reconnect and crash-restart takeover are unchanged.
+- **Adjacency:** orthogonal to the daemon.json field-merge / auto-start series (`2fbef34d`, `e6ecb2c`), which guard "config not lost"; this idea guards "duplicate process does not silently preempt."

--- a/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/specs/cli-daemon/spec.md
+++ b/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/specs/cli-daemon/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: The daemon SHALL warn and permanently skip a path-connection the server reports as conflicting
+
+When the server reports a `connection_conflict` event for one of the daemon's path-connections (a live daemon already holds the same `(agent, host, cwd)`), the daemon SHALL print a prominent WARNING that names the `host` and `cwd` and states that a live daemon already serves that path, SHALL tear down that path-connection's SSE listener (clearing any pending reconnect), and SHALL NOT reconnect or re-probe that path for the remaining lifetime of the process. The `connection_conflict` event SHALL be consumed before the wake-routing path so it can never be mistaken for a notification and can never spawn a subprocess. Takeover of a conflicting path SHALL occur only on a subsequent daemon start or restart, never via in-process background re-probe.
+
+#### Scenario: A conflicting path is warned and dropped without retry
+
+- **GIVEN** a daemon path-connection for cwd C receives a `connection_conflict` event from the server
+- **WHEN** the daemon handles the event
+- **THEN** it MUST emit a WARNING naming the host and cwd C and the reason (a live daemon already serves it)
+- **AND** it MUST stop that path's SSE listener and MUST NOT schedule a reconnect or re-probe for cwd C for the life of the process
+
+#### Scenario: A conflict event never reaches the wake path
+
+- **WHEN** a `connection_conflict` event arrives on a path-connection's stream
+- **THEN** it MUST be handled by the conflict path and MUST NOT be dispatched to the event router / wake queue
+- **AND** no Claude/Codex subprocess MUST be spawned as a result of the conflict event
+
+### Requirement: A daemon serving multiple paths SHALL skip only the conflicting paths and keep serving the rest
+
+When a daemon serves multiple cwds and only some of them conflict with a live daemon, the daemon process SHALL continue running and SHALL keep serving its non-conflicting path-connections normally; only the conflicting paths SHALL be skipped. Each path-connection is independent, so a skip of one cwd SHALL NOT disrupt task dispatch or the reverse-control channel of another cwd's connection.
+
+#### Scenario: Partial conflict leaves non-conflicting paths serving
+
+- **GIVEN** a daemon declared to serve cwds C1 and C2, where C1 conflicts with a live daemon and C2 does not
+- **WHEN** the daemon starts and the server reports a conflict for C1
+- **THEN** the daemon MUST warn and skip C1
+- **AND** the daemon process MUST stay running and MUST continue serving C2 (its dispatch and control channel intact)
+
+### Requirement: A daemon SHALL exit non-zero when every declared path conflicts
+
+When every declared path-connection of the daemon ends in a conflict (none registers successfully), the daemon SHALL print a clear message that all declared paths are already served by a live daemon and there is nothing to do, and SHALL exit with a non-zero status rather than lingering as a process that serves no connection. The exit SHALL fire only after every declared path-connection has reached a terminal outcome (registered or conflicted), so a path still completing its handshake does not trigger a premature exit.
+
+#### Scenario: All paths conflict — daemon exits non-zero
+
+- **GIVEN** a daemon declared to serve only cwds that are each already served by a live daemon
+- **WHEN** the server reports a conflict for every one of the daemon's path-connections
+- **THEN** the daemon MUST print a clear "all N paths already served — nothing to do" message
+- **AND** the process MUST exit with a non-zero status
+
+#### Scenario: Exit waits for all paths to resolve
+
+- **GIVEN** a daemon serving cwds C1 and C2 where C1 is reported conflicting before C2 has completed its handshake
+- **WHEN** C1's conflict is handled
+- **THEN** the daemon MUST NOT exit yet
+- **AND** the all-conflict exit MUST be evaluated only once C2 has also reached a terminal outcome

--- a/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/specs/daemon-connection-registry/spec.md
+++ b/openspec/changes/archive/2026-06-28-add-daemon-connection-conflict-skip/specs/daemon-connection-registry/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Registration SHALL skip and signal a conflict when a live different-process daemon already holds the same (agent, host, cwd)
+
+When registering a connection on the real-cwd path (`cwd` is not null), the server SHALL first check for an existing **effectively-online** `DaemonConnection` at the same `(agentUuid, host, cwd)` identity — **across all `clientType` values**, not only the same `clientType` row — where "effectively online" uses the shared liveness rule (`status = "online"` AND `lastSeenAt` within `STALE_THRESHOLD_MS`). The server SHALL compare the incumbent's self-reported process identity (`startedAt`) against the incoming report and SHALL treat the registration as a **conflict** when a fresh incumbent exists whose `startedAt` differs from the incoming `startedAt` (two `startedAt` values count as differing when one is null and the other is not). On a conflict the server SHALL NOT write, upsert, refresh, or otherwise mutate any `DaemonConnection` or `AgentInstance` row, and SHALL return a conflict result that the caller can distinguish from both a successful registration handle and a failure. A conflict SHALL NOT be reported as a registry write failure.
+
+Because the only discriminator is `startedAt`, a rejected registration writing to the row would corrupt the incumbent's own reconnect comparison; the conflict branch therefore MUST return before any persistence operation.
+
+#### Scenario: A fresh same-process reconnect refreshes, not conflicts
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, host H, cwd C)` with `startedAt = T`
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` reporting the same `startedAt = T`
+- **THEN** the existing row MUST be refreshed (status online, `connectedAt` / `lastSeenAt` advanced) exactly as a normal reconnect
+- **AND** the call MUST return a success handle, not a conflict
+
+#### Scenario: A fresh different-process daemon is a conflict and writes nothing
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, host H, cwd C)` with `startedAt = T1`
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` reporting a different `startedAt = T2`
+- **THEN** the call MUST return a conflict result
+- **AND** no `DaemonConnection` or `AgentInstance` row MUST be created, upserted, or refreshed — the incumbent row's `connectedAt`, `lastSeenAt`, and `status` MUST be unchanged
+
+#### Scenario: A stale incumbent is taken over, never treated as a conflict
+
+- **GIVEN** a `DaemonConnection` for `(agent A, host H, cwd C)` that is not effectively online (status not `online`, or `lastSeenAt` older than `STALE_THRESHOLD_MS`)
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` with any `startedAt`
+- **THEN** the registration MUST proceed as a normal takeover (refresh / upsert), regardless of `startedAt`
+- **AND** the call MUST return a success handle
+
+#### Scenario: Conflict detection is cross-clientType at the same (agent, host, cwd)
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, clientType claude_code, host H, cwd C)` with `startedAt = T1`
+- **WHEN** a registration arrives for `(agent A, clientType codex, host H, cwd C)` with a different `startedAt = T2`
+- **THEN** the call MUST return a conflict result and MUST NOT write a second row
+- **AND** running two backends in the same cwd under the same agent is thereby treated as a conflict, not two coexisting connections
+
+#### Scenario: A fresh incumbent with a null startedAt conflicts with a self-reporting daemon
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, host H, cwd C)` whose `startedAt` is null
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` reporting a non-null `startedAt`
+- **THEN** the call MUST return a conflict result and MUST NOT mutate the incumbent row
+
+### Requirement: The cwd-null registration branch SHALL be exempt from conflict detection
+
+The legacy compatibility branch for an old daemon that does not self-report `cwd` (the `cwd = null` row, HARD-1) SHALL retain its existing find-then-update-or-create refresh/takeover behavior unchanged and SHALL NOT apply conflict detection. A daemon carrying this feature always self-reports a real cwd and never reaches the null branch; an old daemon neither sends `startedAt` nor can act on a conflict signal, so applying detection there would only break its reconnect.
+
+#### Scenario: An old cwd-null daemon reconnects without conflict
+
+- **GIVEN** a `DaemonConnection` row for `(agent A, clientType claude_code, host H, cwd = null)`
+- **WHEN** an old daemon that does not self-report cwd reconnects for the same `(agent A, clientType claude_code, host H, cwd = null)`
+- **THEN** the existing null-cwd row MUST be refreshed exactly as before this change
+- **AND** no conflict result MUST be produced for the null-cwd branch
+
+### Requirement: The SSE notification route SHALL emit a connection_conflict event instead of connection_registered on a conflict
+
+When `registerConnection` returns a conflict result, the `/api/events/notifications` route SHALL send a single SSE data event of the form `{ "type": "connection_conflict", "host": <host>, "cwd": <cwd> }` to the connecting stream and SHALL NOT send a `connection_registered` event for that stream. For a conflicted stream the route SHALL NOT subscribe the per-connection reverse-control channel and SHALL NOT run the per-connection heartbeat touch or disconnect/reconcile lifecycle, because no row was registered. The same conflict handling SHALL be applied symmetrically by the `/api/events` route. Browser `EventSource` clients, which ignore unrecognized event `type` values, SHALL be unaffected.
+
+#### Scenario: Conflict emits connection_conflict and omits connection_registered
+
+- **GIVEN** a daemon opens the notification SSE stream for an identity that conflicts with a fresh different-process incumbent
+- **WHEN** the server processes the registration
+- **THEN** the stream MUST receive a `connection_conflict` data event carrying the `host` and `cwd`
+- **AND** the stream MUST NOT receive a `connection_registered` event
+- **AND** no per-connection control subscription or heartbeat-driven row touch MUST be wired up for that stream
+
+### Requirement: The server SHALL emit a structured log when it rejects a conflicting registration
+
+On each rejected (conflicting) registration the server SHALL emit a single structured log at warn level carrying at least `companyUuid`, `agentUuid`, `host`, `cwd`, and both the incumbent and incoming `startedAt` values, so a duplicate-daemon conflict is diagnosable server-side even when the second daemon's local stderr is captured in a separate journal. This log SHALL be distinct from the error log used for genuine registry write failures (a conflict is an expected outcome, not a failure).
+
+#### Scenario: A rejected conflict is logged with identifying fields
+
+- **WHEN** the server rejects a registration as a conflict
+- **THEN** a structured warn log MUST be written including `companyUuid`, `agentUuid`, `host`, `cwd`, and the incumbent-vs-incoming `startedAt`
+- **AND** the conflict MUST NOT be logged via the registry write-failure error path

--- a/openspec/specs/cli-daemon/spec.md
+++ b/openspec/specs/cli-daemon/spec.md
@@ -266,3 +266,49 @@ fatal signal.
   SSE subscription and the MCP client and logging `[Chorus] shutting down daemon...` — and
   does NOT print the server's bare `Shutting down...` line
 
+### Requirement: The daemon SHALL warn and permanently skip a path-connection the server reports as conflicting
+
+When the server reports a `connection_conflict` event for one of the daemon's path-connections (a live daemon already holds the same `(agent, host, cwd)`), the daemon SHALL print a prominent WARNING that names the `host` and `cwd` and states that a live daemon already serves that path, SHALL tear down that path-connection's SSE listener (clearing any pending reconnect), and SHALL NOT reconnect or re-probe that path for the remaining lifetime of the process. The `connection_conflict` event SHALL be consumed before the wake-routing path so it can never be mistaken for a notification and can never spawn a subprocess. Takeover of a conflicting path SHALL occur only on a subsequent daemon start or restart, never via in-process background re-probe.
+
+#### Scenario: A conflicting path is warned and dropped without retry
+
+- **GIVEN** a daemon path-connection for cwd C receives a `connection_conflict` event from the server
+- **WHEN** the daemon handles the event
+- **THEN** it MUST emit a WARNING naming the host and cwd C and the reason (a live daemon already serves it)
+- **AND** it MUST stop that path's SSE listener and MUST NOT schedule a reconnect or re-probe for cwd C for the life of the process
+
+#### Scenario: A conflict event never reaches the wake path
+
+- **WHEN** a `connection_conflict` event arrives on a path-connection's stream
+- **THEN** it MUST be handled by the conflict path and MUST NOT be dispatched to the event router / wake queue
+- **AND** no Claude/Codex subprocess MUST be spawned as a result of the conflict event
+
+### Requirement: A daemon serving multiple paths SHALL skip only the conflicting paths and keep serving the rest
+
+When a daemon serves multiple cwds and only some of them conflict with a live daemon, the daemon process SHALL continue running and SHALL keep serving its non-conflicting path-connections normally; only the conflicting paths SHALL be skipped. Each path-connection is independent, so a skip of one cwd SHALL NOT disrupt task dispatch or the reverse-control channel of another cwd's connection.
+
+#### Scenario: Partial conflict leaves non-conflicting paths serving
+
+- **GIVEN** a daemon declared to serve cwds C1 and C2, where C1 conflicts with a live daemon and C2 does not
+- **WHEN** the daemon starts and the server reports a conflict for C1
+- **THEN** the daemon MUST warn and skip C1
+- **AND** the daemon process MUST stay running and MUST continue serving C2 (its dispatch and control channel intact)
+
+### Requirement: A daemon SHALL exit non-zero when every declared path conflicts
+
+When every declared path-connection of the daemon ends in a conflict (none registers successfully), the daemon SHALL print a clear message that all declared paths are already served by a live daemon and there is nothing to do, and SHALL exit with a non-zero status rather than lingering as a process that serves no connection. The exit SHALL fire only after every declared path-connection has reached a terminal outcome (registered or conflicted), so a path still completing its handshake does not trigger a premature exit.
+
+#### Scenario: All paths conflict — daemon exits non-zero
+
+- **GIVEN** a daemon declared to serve only cwds that are each already served by a live daemon
+- **WHEN** the server reports a conflict for every one of the daemon's path-connections
+- **THEN** the daemon MUST print a clear "all N paths already served — nothing to do" message
+- **AND** the process MUST exit with a non-zero status
+
+#### Scenario: Exit waits for all paths to resolve
+
+- **GIVEN** a daemon serving cwds C1 and C2 where C1 is reported conflicting before C2 has completed its handshake
+- **WHEN** C1's conflict is handled
+- **THEN** the daemon MUST NOT exit yet
+- **AND** the all-conflict exit MUST be evaluated only once C2 has also reached a terminal outcome
+

--- a/openspec/specs/daemon-connection-registry/spec.md
+++ b/openspec/specs/daemon-connection-registry/spec.md
@@ -195,3 +195,76 @@ the requirement binds the consumer (`f2fe9a7f`) that adds one.
 - **THEN** it MUST return that connection only to user U (the agent's owner)
 - **AND** it MUST NOT return that connection's `host` or `clientVersion` to other members of U's company
 
+### Requirement: Registration SHALL skip and signal a conflict when a live different-process daemon already holds the same (agent, host, cwd)
+
+When registering a connection on the real-cwd path (`cwd` is not null), the server SHALL first check for an existing **effectively-online** `DaemonConnection` at the same `(agentUuid, host, cwd)` identity — **across all `clientType` values**, not only the same `clientType` row — where "effectively online" uses the shared liveness rule (`status = "online"` AND `lastSeenAt` within `STALE_THRESHOLD_MS`). The server SHALL compare the incumbent's self-reported process identity (`startedAt`) against the incoming report and SHALL treat the registration as a **conflict** when a fresh incumbent exists whose `startedAt` differs from the incoming `startedAt` (two `startedAt` values count as differing when one is null and the other is not). On a conflict the server SHALL NOT write, upsert, refresh, or otherwise mutate any `DaemonConnection` or `AgentInstance` row, and SHALL return a conflict result that the caller can distinguish from both a successful registration handle and a failure. A conflict SHALL NOT be reported as a registry write failure.
+
+Because the only discriminator is `startedAt`, a rejected registration writing to the row would corrupt the incumbent's own reconnect comparison; the conflict branch therefore MUST return before any persistence operation.
+
+#### Scenario: A fresh same-process reconnect refreshes, not conflicts
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, host H, cwd C)` with `startedAt = T`
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` reporting the same `startedAt = T`
+- **THEN** the existing row MUST be refreshed (status online, `connectedAt` / `lastSeenAt` advanced) exactly as a normal reconnect
+- **AND** the call MUST return a success handle, not a conflict
+
+#### Scenario: A fresh different-process daemon is a conflict and writes nothing
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, host H, cwd C)` with `startedAt = T1`
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` reporting a different `startedAt = T2`
+- **THEN** the call MUST return a conflict result
+- **AND** no `DaemonConnection` or `AgentInstance` row MUST be created, upserted, or refreshed — the incumbent row's `connectedAt`, `lastSeenAt`, and `status` MUST be unchanged
+
+#### Scenario: A stale incumbent is taken over, never treated as a conflict
+
+- **GIVEN** a `DaemonConnection` for `(agent A, host H, cwd C)` that is not effectively online (status not `online`, or `lastSeenAt` older than `STALE_THRESHOLD_MS`)
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` with any `startedAt`
+- **THEN** the registration MUST proceed as a normal takeover (refresh / upsert), regardless of `startedAt`
+- **AND** the call MUST return a success handle
+
+#### Scenario: Conflict detection is cross-clientType at the same (agent, host, cwd)
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, clientType claude_code, host H, cwd C)` with `startedAt = T1`
+- **WHEN** a registration arrives for `(agent A, clientType codex, host H, cwd C)` with a different `startedAt = T2`
+- **THEN** the call MUST return a conflict result and MUST NOT write a second row
+- **AND** running two backends in the same cwd under the same agent is thereby treated as a conflict, not two coexisting connections
+
+#### Scenario: A fresh incumbent with a null startedAt conflicts with a self-reporting daemon
+
+- **GIVEN** an effectively-online `DaemonConnection` for `(agent A, host H, cwd C)` whose `startedAt` is null
+- **WHEN** a registration arrives for the same `(agent A, host H, cwd C)` reporting a non-null `startedAt`
+- **THEN** the call MUST return a conflict result and MUST NOT mutate the incumbent row
+
+### Requirement: The cwd-null registration branch SHALL be exempt from conflict detection
+
+The legacy compatibility branch for an old daemon that does not self-report `cwd` (the `cwd = null` row, HARD-1) SHALL retain its existing find-then-update-or-create refresh/takeover behavior unchanged and SHALL NOT apply conflict detection. A daemon carrying this feature always self-reports a real cwd and never reaches the null branch; an old daemon neither sends `startedAt` nor can act on a conflict signal, so applying detection there would only break its reconnect.
+
+#### Scenario: An old cwd-null daemon reconnects without conflict
+
+- **GIVEN** a `DaemonConnection` row for `(agent A, clientType claude_code, host H, cwd = null)`
+- **WHEN** an old daemon that does not self-report cwd reconnects for the same `(agent A, clientType claude_code, host H, cwd = null)`
+- **THEN** the existing null-cwd row MUST be refreshed exactly as before this change
+- **AND** no conflict result MUST be produced for the null-cwd branch
+
+### Requirement: The SSE notification route SHALL emit a connection_conflict event instead of connection_registered on a conflict
+
+When `registerConnection` returns a conflict result, the `/api/events/notifications` route SHALL send a single SSE data event of the form `{ "type": "connection_conflict", "host": <host>, "cwd": <cwd> }` to the connecting stream and SHALL NOT send a `connection_registered` event for that stream. For a conflicted stream the route SHALL NOT subscribe the per-connection reverse-control channel and SHALL NOT run the per-connection heartbeat touch or disconnect/reconcile lifecycle, because no row was registered. The same conflict handling SHALL be applied symmetrically by the `/api/events` route. Browser `EventSource` clients, which ignore unrecognized event `type` values, SHALL be unaffected.
+
+#### Scenario: Conflict emits connection_conflict and omits connection_registered
+
+- **GIVEN** a daemon opens the notification SSE stream for an identity that conflicts with a fresh different-process incumbent
+- **WHEN** the server processes the registration
+- **THEN** the stream MUST receive a `connection_conflict` data event carrying the `host` and `cwd`
+- **AND** the stream MUST NOT receive a `connection_registered` event
+- **AND** no per-connection control subscription or heartbeat-driven row touch MUST be wired up for that stream
+
+### Requirement: The server SHALL emit a structured log when it rejects a conflicting registration
+
+On each rejected (conflicting) registration the server SHALL emit a single structured log at warn level carrying at least `companyUuid`, `agentUuid`, `host`, `cwd`, and both the incumbent and incoming `startedAt` values, so a duplicate-daemon conflict is diagnosable server-side even when the second daemon's local stderr is captured in a separate journal. This log SHALL be distinct from the error log used for genuine registry write failures (a conflict is an expected outcome, not a failure).
+
+#### Scenario: A rejected conflict is logged with identifying fields
+
+- **WHEN** the server rejects a registration as a conflict
+- **THEN** a structured warn log MUST be written including `companyUuid`, `agentUuid`, `host`, `cwd`, and the incumbent-vs-incoming `startedAt`
+- **AND** the conflict MUST NOT be logged via the registry write-failure error path
+

--- a/src/app/api/events/__tests__/route.test.ts
+++ b/src/app/api/events/__tests__/route.test.ts
@@ -31,6 +31,10 @@ vi.mock("@/lib/event-bus", () => ({
 vi.mock("@/services/daemon-connection.service", () => ({
   parseSelfReport: (...args: unknown[]) => mockParseSelfReport(...args),
   registerConnection: (...args: unknown[]) => mockRegisterConnection(...args),
+  // Faithful re-implementation of the real guard: a conflict result carries a
+  // `conflict` key (the route uses it to skip the per-connection lifecycle).
+  isConnectionConflict: (result: unknown) =>
+    result !== null && typeof result === "object" && "conflict" in (result as object),
   touchConnection: (...args: unknown[]) => mockTouchConnection(...args),
   markDisconnected: (...args: unknown[]) => mockMarkDisconnected(...args),
 }));
@@ -207,6 +211,43 @@ describe("GET /api/events (change events SSE)", () => {
     handler({ companyUuid: "other-company", type: "x" });
     await flush();
     expect(chunks.length).toBe(before);
+  });
+
+  describe("registration conflict (symmetric with the notification route)", () => {
+    const conflictResult = { conflict: true, host: "mac.local", cwd: "/work/alpha" };
+    beforeEach(() => {
+      mockParseSelfReport.mockReturnValue({
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/work/alpha",
+        startedAt: new Date("2026-06-15T09:00:00.000Z"),
+      });
+      mockRegisterConnection.mockResolvedValue(conflictResult);
+    });
+
+    it("emits a connection_conflict event (with host+cwd) on conflict", async () => {
+      const res = await GET(makeRequest("clientType=claude_code&host=mac.local&cwd=/work/alpha"));
+      const { chunks } = await startStream(res);
+      const joined = chunks.join("");
+      expect(joined).toContain(": connected");
+      expect(joined).toContain('"type":"connection_conflict"');
+      expect(joined).toContain('"host":"mac.local"');
+      expect(joined).toContain('"cwd":"/work/alpha"');
+    });
+
+    it("skips the per-connection lifecycle on conflict (no heartbeat touch, no markDisconnected)", async () => {
+      vi.useFakeTimers();
+      const ac = new AbortController();
+      const res = await GET(makeRequest("clientType=claude_code", ac.signal));
+      await startStream(res);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(mockTouchConnection).not.toHaveBeenCalled();
+
+      ac.abort();
+      await Promise.resolve();
+      expect(mockMarkDisconnected).not.toHaveBeenCalled();
+    });
   });
 
   describe("no-clientType / browser connection", () => {

--- a/src/app/api/events/notifications/__tests__/route.test.ts
+++ b/src/app/api/events/notifications/__tests__/route.test.ts
@@ -29,6 +29,10 @@ vi.mock("@/lib/event-bus", () => ({
 vi.mock("@/services/daemon-connection.service", () => ({
   parseSelfReport: (...args: unknown[]) => mockParseSelfReport(...args),
   registerConnection: (...args: unknown[]) => mockRegisterConnection(...args),
+  // Faithful re-implementation of the real guard: a conflict result carries a
+  // `conflict` key (the route uses it to skip the per-connection lifecycle).
+  isConnectionConflict: (result: unknown) =>
+    result !== null && typeof result === "object" && "conflict" in (result as object),
   touchConnection: (...args: unknown[]) => mockTouchConnection(...args),
   markDisconnected: (...args: unknown[]) => mockMarkDisconnected(...args),
 }));
@@ -211,6 +215,64 @@ describe("GET /api/events/notifications (notification SSE)", () => {
       `notification:agent:${actorUuid}`,
       expect.any(Function),
     );
+  });
+
+  describe("registration conflict (a live different-process daemon holds this (agent,host,cwd))", () => {
+    const conflictResult = { conflict: true, host: "mac.local", cwd: "/work/alpha" };
+    beforeEach(() => {
+      mockParseSelfReport.mockReturnValue({
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/work/alpha",
+        startedAt: new Date("2026-06-15T09:00:00.000Z"),
+      });
+      mockRegisterConnection.mockResolvedValue(conflictResult);
+    });
+
+    it("emits a single connection_conflict event (with host+cwd) and NOT connection_registered", async () => {
+      const res = await GET(makeRequest("clientType=claude_code&host=mac.local&cwd=/work/alpha"));
+      const { chunks } = await startStream(res);
+      const joined = chunks.join("");
+
+      expect(joined).toContain(": connected");
+      expect(joined).toContain('"type":"connection_conflict"');
+      expect(joined).toContain('"host":"mac.local"');
+      expect(joined).toContain('"cwd":"/work/alpha"');
+      // Must NOT also tell the daemon it registered — no row was written.
+      expect(joined).not.toContain("connection_registered");
+    });
+
+    it("wires up NO per-connection lifecycle on conflict (no control sub, no heartbeat touch, no markDisconnected)", async () => {
+      vi.useFakeTimers();
+      const ac = new AbortController();
+      const res = await GET(makeRequest("clientType=claude_code", ac.signal));
+      await startStream(res);
+
+      // No control channel subscription (that is keyed on a real connection uuid).
+      const controlOn = mockEventBus.on.mock.calls.find((c) => String(c[0]).startsWith("control:"));
+      expect(controlOn).toBeUndefined();
+
+      // Heartbeat frame still flows (keep-alive) but it must NOT touch a registry row.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(mockTouchConnection).not.toHaveBeenCalled();
+
+      // Abort must not mark a (nonexistent) row disconnected.
+      ac.abort();
+      await Promise.resolve();
+      expect(mockMarkDisconnected).not.toHaveBeenCalled();
+      const controlOff = mockEventBus.off.mock.calls.find((c) => String(c[0]).startsWith("control:"));
+      expect(controlOff).toBeUndefined();
+    });
+
+    it("still subscribes the per-user notification channel on conflict (the user keeps getting notifications)", async () => {
+      const res = await GET(makeRequest("clientType=claude_code"));
+      await startStream(res);
+      const onCall = mockEventBus.on.mock.calls.find((c) =>
+        String(c[0]).startsWith("notification:"),
+      );
+      expect(onCall).toBeDefined();
+      expect(onCall![0]).toBe(`notification:agent:${actorUuid}`);
+    });
   });
 
   describe("no-clientType / browser connection", () => {

--- a/src/app/api/events/notifications/route.ts
+++ b/src/app/api/events/notifications/route.ts
@@ -7,6 +7,7 @@ import { eventBus, controlEventName } from "@/lib/event-bus";
 import {
   parseSelfReport,
   registerConnection,
+  isConnectionConflict,
   touchConnection,
   markDisconnected,
 } from "@/services/daemon-connection.service";
@@ -30,7 +31,16 @@ export async function GET(request: NextRequest) {
   // null, the lifecycle below is skipped and the route behaves exactly as before
   // (no DaemonConnection row is written).
   const report = parseSelfReport(request.nextUrl.searchParams);
-  const conn = await registerConnection(auth.companyUuid, auth.actorUuid, report);
+  const registration = await registerConnection(auth.companyUuid, auth.actorUuid, report);
+  // Split the tri-state result into two narrow bindings:
+  //  - `conflict`: a live different-process daemon already holds this (agent, host, cwd).
+  //    NO row was written, so we wire up NO per-connection lifecycle; instead the stream
+  //    emits a single `connection_conflict` event so the daemon can warn + skip that cwd.
+  //  - `conn`: a real registered connection (handle) — the full lifecycle is wired as
+  //    before. `null` registration (non-daemon clientType / swallowed write failure)
+  //    leaves both null and the route behaves exactly as before this change.
+  const conflict = isConnectionConflict(registration) ? registration : null;
+  const conn = isConnectionConflict(registration) ? null : registration;
 
   const userKey = `${auth.type}:${auth.actorUuid}`;
   const encoder = new TextEncoder();
@@ -48,13 +58,21 @@ export async function GET(request: NextRequest) {
       // Send initial connection confirmation
       send(": connected\n\n");
 
-      // Tell a self-reporting daemon which DaemonConnection it registered as, so
-      // it can attribute its execution-state snapshots to this connection
-      // (POST /api/daemon/execution-state requires the connectionUuid). Emitted
-      // as a normal data event the daemon's SSE listener parses; browser clients
-      // ignore the unrecognized `type`. Only sent when a connection row was
-      // actually registered (conn is null for non-daemon clientTypes).
-      if (conn) {
+      // First data event tells the daemon how its registration resolved. Exactly
+      // one of three outcomes:
+      //  - conflict → a single `connection_conflict` event carrying the conflicting
+      //    host + cwd, so the daemon warns and skips that cwd (it must NOT also get a
+      //    `connection_registered`, since no row was written).
+      //  - registered → the usual `connection_registered` with the connectionUuid the
+      //    daemon attributes its execution-state snapshots to.
+      //  - neither (non-daemon clientType) → no handshake event at all, as before.
+      // Browser clients ignore both unrecognized `type`s (same as today's
+      // connection_registered / control).
+      if (conflict) {
+        send(
+          `data: ${JSON.stringify({ type: "connection_conflict", host: conflict.host, cwd: conflict.cwd })}\n\n`,
+        );
+      } else if (conn) {
         send(
           `data: ${JSON.stringify({ type: "connection_registered", connectionUuid: conn.uuid })}\n\n`,
         );

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -7,6 +7,7 @@ import { eventBus, type RealtimeEvent, type PresenceEvent } from "@/lib/event-bu
 import {
   parseSelfReport,
   registerConnection,
+  isConnectionConflict,
   touchConnection,
   markDisconnected,
 } from "@/services/daemon-connection.service";
@@ -40,7 +41,12 @@ export async function GET(request: NextRequest) {
   // null, the lifecycle below is skipped and the route behaves exactly as before
   // (no DaemonConnection row is written).
   const report = parseSelfReport(request.nextUrl.searchParams);
-  const conn = await registerConnection(auth.companyUuid, auth.actorUuid, report);
+  const registration = await registerConnection(auth.companyUuid, auth.actorUuid, report);
+  // Tri-state split (mirrors /api/events/notifications): a conflict wrote NO row, so
+  // it gets a single `connection_conflict` event and NO per-connection lifecycle; a
+  // handle gets the full lifecycle as before; a null registration leaves both null.
+  const conflict = isConnectionConflict(registration) ? registration : null;
+  const conn = isConnectionConflict(registration) ? null : registration;
 
   // Resolve which daemon connections this caller may see (owner/self scoped) so
   // the stream can forward their per-connection `execution:{uuid}` events. The
@@ -82,6 +88,17 @@ export async function GET(request: NextRequest) {
 
       // Send initial connection confirmation
       send(": connected\n\n");
+
+      // On a registration conflict (a live different-process daemon already holds this
+      // (agent, host, cwd)), emit a single `connection_conflict` event so a daemon on
+      // this endpoint warns + skips that cwd. No row was written, so NO per-connection
+      // execution/transcript lifecycle is wired below (all gated on `conn`). Browser
+      // clients ignore the unrecognized `type`. Symmetric with the notification route.
+      if (conflict) {
+        send(
+          `data: ${JSON.stringify({ type: "connection_conflict", host: conflict.host, cwd: conflict.cwd })}\n\n`,
+        );
+      }
 
       // Subscribe to change events
       const handler = (event: RealtimeEvent) => {

--- a/src/services/__tests__/daemon-connection-conflict.integration.test.ts
+++ b/src/services/__tests__/daemon-connection-conflict.integration.test.ts
@@ -1,0 +1,237 @@
+// src/services/__tests__/daemon-connection-conflict.integration.test.ts
+// Integration checkpoint for add-daemon-connection-conflict-skip (Task 5).
+//
+// Exercises the SERVER half end-to-end against a STATEFUL in-memory prisma fake (so
+// it runs in CI without a real Postgres, unlike the T2_REAL_DB_URL-gated suite): the
+// REAL `registerConnection` decides conflict vs refresh vs takeover across a sequence
+// of registrations, and we assert the persisted rows + returned verdicts. This proves
+// the layered truth table holds when state actually accumulates, not just per-call.
+//
+// Maps to the delta-spec acceptance scenarios:
+//   • Scenario A (core bug) → daemon-connection-registry "Registration SHALL skip and
+//     signal a conflict …": a live incumbent + a different-process second registration
+//     yields a conflict AND the incumbent row is byte-for-byte untouched (write-nothing).
+//   • Scenario C → "A stale incumbent is taken over": after the incumbent goes stale,
+//     a new process registers (takeover), not a conflict.
+//   • Scenario D → "A fresh same-process reconnect refreshes, not conflicts".
+//   • cross-clientType + null-cwd exemption rows complete the registry-side coverage.
+// Scenarios B (partial-conflict survivor) and E (all-conflict exit) are daemon-process
+// behavior and are covered end-to-end in cli/__tests__/daemon-multipath.test.mjs +
+// daemon-permission-wiring.test.mjs; the daemon-side `onConflict` consumption of the
+// server's `connection_conflict` signal is covered in cli/__tests__/sse-listener.test.mjs.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ===== Stateful in-memory prisma fake =====
+// Models just enough of daemonConnection + agentInstance for registerConnection's
+// real-cwd path: findMany (conflict probe), upsert (compound-key), findFirst/create/
+// update (null-cwd compat). Rows live in module-level arrays reset per test.
+interface ConnRow {
+  uuid: string;
+  companyUuid: string;
+  agentUuid: string;
+  clientType: string;
+  clientVersion: string | null;
+  host: string;
+  cwd: string | null;
+  startedAt: Date | null;
+  status: string;
+  connectedAt: Date;
+  lastSeenAt: Date;
+  disconnectedAt: Date | null;
+  agentInstanceUuid: string | null;
+}
+
+// Hoisted so the vi.mock factory (itself hoisted above imports) can reference it.
+// `store` holds the mutable row arrays + uuid counter, reset per test in beforeEach.
+const { mockPrisma, mockLogger, store } = vi.hoisted(() => {
+  const store: {
+    connRows: ConnRow[];
+    instanceRows: { uuid: string; companyUuid: string; agentUuid: string; host: string; cwd: string | null }[];
+    uuidSeq: number;
+  } = { connRows: [], instanceRows: [], uuidSeq: 0 };
+  const nextUuid = (p: string) => `${p}-${++store.uuidSeq}`;
+  const matchesWhere = (row: Record<string, unknown>, where: Record<string, unknown>): boolean =>
+    Object.entries(where).every(([k, v]) => row[k] === v);
+
+  const mockPrisma = {
+    daemonConnection: {
+      findMany: vi.fn(async ({ where }: { where: Record<string, unknown> }) =>
+        store.connRows.filter((r) => matchesWhere(r as unknown as Record<string, unknown>, where)),
+      ),
+      upsert: vi.fn(
+        async ({
+          where,
+          create,
+          update,
+        }: {
+          where: { agentUuid_clientType_host_cwd: { agentUuid: string; clientType: string; host: string; cwd: string } };
+          create: Omit<ConnRow, "uuid">;
+          update: Partial<ConnRow>;
+        }) => {
+          const key = where.agentUuid_clientType_host_cwd;
+          const existing = store.connRows.find(
+            (r) =>
+              r.agentUuid === key.agentUuid &&
+              r.clientType === key.clientType &&
+              r.host === key.host &&
+              r.cwd === key.cwd,
+          );
+          if (existing) {
+            Object.assign(existing, update);
+            return { uuid: existing.uuid, connectedAt: existing.connectedAt };
+          }
+          const row: ConnRow = { uuid: nextUuid("conn"), ...create };
+          store.connRows.push(row);
+          return { uuid: row.uuid, connectedAt: row.connectedAt };
+        },
+      ),
+      findFirst: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+        const r = store.connRows.find((row) => matchesWhere(row as unknown as Record<string, unknown>, where));
+        return r ? { uuid: r.uuid, connectedAt: r.connectedAt } : null;
+      }),
+      update: vi.fn(async ({ where, data }: { where: { uuid: string }; data: Partial<ConnRow> }) => {
+        const r = store.connRows.find((row) => row.uuid === where.uuid)!;
+        Object.assign(r, data);
+        return { uuid: r.uuid, connectedAt: r.connectedAt };
+      }),
+      create: vi.fn(async ({ data }: { data: Omit<ConnRow, "uuid"> }) => {
+        const row: ConnRow = { uuid: nextUuid("conn"), ...data };
+        store.connRows.push(row);
+        return { uuid: row.uuid, connectedAt: row.connectedAt };
+      }),
+    },
+    agentInstance: {
+      upsert: vi.fn(async ({ create }: { create: { companyUuid: string; agentUuid: string; host: string; cwd: string | null } }) => {
+        const existing = store.instanceRows.find(
+          (r) => r.companyUuid === create.companyUuid && r.agentUuid === create.agentUuid && r.host === create.host && r.cwd === create.cwd,
+        );
+        if (existing) return { uuid: existing.uuid };
+        const row = { uuid: nextUuid("inst"), ...create };
+        store.instanceRows.push(row);
+        return { uuid: row.uuid };
+      }),
+      findFirst: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+        const r = store.instanceRows.find((row) => matchesWhere(row as unknown as Record<string, unknown>, where));
+        return r ? { uuid: r.uuid } : null;
+      }),
+      create: vi.fn(async ({ data }: { data: { companyUuid: string; agentUuid: string; host: string; cwd: string | null } }) => {
+        const row = { uuid: nextUuid("inst"), ...data };
+        store.instanceRows.push(row);
+        return { uuid: row.uuid };
+      }),
+      update: vi.fn(async ({ where }: { where: { uuid: string } }) => ({ uuid: where.uuid })),
+    },
+  };
+  const mockLogger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+  return { mockPrisma, mockLogger, store };
+});
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/logger", () => ({ default: mockLogger }));
+
+import {
+  registerConnection,
+  isConnectionConflict,
+  STALE_THRESHOLD_MS,
+  type SelfReport,
+} from "@/services/daemon-connection.service";
+
+const companyUuid = "co-1";
+const agentUuid = "ag-1";
+const host = "mac.local";
+const cwd = "/work/alpha";
+
+const report = (over: Partial<SelfReport> = {}): SelfReport => ({
+  clientType: "claude_code",
+  host,
+  cwd,
+  startedAt: new Date("2026-06-15T03:00:00.000Z"),
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.connRows = [];
+  store.instanceRows = [];
+  store.uuidSeq = 0;
+});
+
+// Terse accessor for the live connection rows (reassigned each test in beforeEach).
+const conns = () => store.connRows;
+
+describe("conflict integration checkpoint (real registerConnection over a stateful store)", () => {
+  it("Scenario A: a live incumbent + a different-process second registration → conflict, incumbent row UNTOUCHED", async () => {
+    // First daemon registers and is heartbeating (fresh).
+    const first = await registerConnection(companyUuid, agentUuid, report({ startedAt: new Date("2026-06-15T03:00:00.000Z") }));
+    expect(isConnectionConflict(first)).toBe(false);
+    expect(conns()).toHaveLength(1);
+    const incumbent = { ...conns()[0] }; // snapshot
+
+    // Second daemon, SAME (agent, host, cwd), DIFFERENT startedAt → conflict.
+    const second = await registerConnection(companyUuid, agentUuid, report({ startedAt: new Date("2026-06-15T09:00:00.000Z") }));
+    expect(isConnectionConflict(second)).toBe(true);
+    expect(second).toEqual({ conflict: true, host, cwd });
+
+    // Write-nothing: still exactly one row, byte-for-byte unchanged.
+    expect(conns()).toHaveLength(1);
+    expect(conns()[0]).toEqual(incumbent);
+    // A structured warn was emitted; no error path.
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("Scenario A (cross-clientType): a fresh claude_code incumbent makes a codex registration a conflict (no 2nd row)", async () => {
+    await registerConnection(companyUuid, agentUuid, report({ clientType: "claude_code", startedAt: new Date("2026-06-15T03:00:00.000Z") }));
+    const second = await registerConnection(companyUuid, agentUuid, report({ clientType: "codex", startedAt: new Date("2026-06-15T09:00:00.000Z") }));
+    expect(isConnectionConflict(second)).toBe(true);
+    expect(conns()).toHaveLength(1);
+    expect(conns()[0].clientType).toBe("claude_code");
+  });
+
+  it("Scenario D: the SAME process reconnecting (startedAt unchanged) refreshes the row — never a conflict", async () => {
+    const started = new Date("2026-06-15T03:00:00.000Z");
+    const first = await registerConnection(companyUuid, agentUuid, report({ startedAt: started }));
+    expect(isConnectionConflict(first)).toBe(false);
+    const firstUuid = conns()[0].uuid;
+
+    // Same startedAt → reconnect refresh. Still one row, same uuid.
+    const again = await registerConnection(companyUuid, agentUuid, report({ startedAt: started }));
+    expect(isConnectionConflict(again)).toBe(false);
+    expect(conns()).toHaveLength(1);
+    expect(conns()[0].uuid).toBe(firstUuid);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("Scenario C: a STALE incumbent is taken over by a new process — not misjudged as a conflict (crash-restart)", async () => {
+    await registerConnection(companyUuid, agentUuid, report({ startedAt: new Date("2026-06-15T03:00:00.000Z") }));
+    // Simulate the first daemon crashing: its row goes stale (lastSeenAt well past the threshold).
+    conns()[0].lastSeenAt = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000);
+
+    // Restart with a fresh process identity → takeover (refresh of the same compound-key row).
+    const restart = await registerConnection(companyUuid, agentUuid, report({ startedAt: new Date("2026-06-15T12:00:00.000Z") }));
+    expect(isConnectionConflict(restart)).toBe(false);
+    expect(conns()).toHaveLength(1);
+    expect(conns()[0].status).toBe("online");
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("null-cwd (old daemon) is exempt: detection findMany never runs, reconnect refreshes the null row", async () => {
+    const oldReport = report({ cwd: null, startedAt: null });
+    const a = await registerConnection(companyUuid, agentUuid, oldReport);
+    expect(isConnectionConflict(a)).toBe(false);
+    // A second old-daemon report with a DIFFERENT startedAt would conflict on the real-cwd
+    // path, but the null branch is exempt: it reuses the single null row, no conflict.
+    const b = await registerConnection(companyUuid, agentUuid, report({ cwd: null, startedAt: new Date("2026-06-15T09:00:00.000Z") }));
+    expect(isConnectionConflict(b)).toBe(false);
+    expect(conns().filter((r) => r.cwd === null)).toHaveLength(1);
+    // The conflict probe (findMany) is real-cwd-only — never consulted for cwd=null.
+    expect(mockPrisma.daemonConnection.findMany).not.toHaveBeenCalled();
+  });
+
+  it("a different AGENT at the same host+cwd never collides (scope is per-agent)", async () => {
+    await registerConnection(companyUuid, agentUuid, report({ startedAt: new Date("2026-06-15T03:00:00.000Z") }));
+    const other = await registerConnection(companyUuid, "ag-2", report({ startedAt: new Date("2026-06-15T09:00:00.000Z") }));
+    expect(isConnectionConflict(other)).toBe(false);
+    expect(conns()).toHaveLength(2);
+  });
+});

--- a/src/services/__tests__/daemon-connection-registration.integration.test.ts
+++ b/src/services/__tests__/daemon-connection-registration.integration.test.ts
@@ -52,7 +52,14 @@ type RegisterConnection = typeof import("@/services/daemon-connection.service")[
 type ListConnectionsForAgent =
   typeof import("@/services/daemon-connection.service")["listConnectionsForAgent"];
 type ParseSelfReport = typeof import("@/services/daemon-connection.service")["parseSelfReport"];
-let registerConnection: RegisterConnection;
+// Narrowed to the handle|null result: every scenario in THIS file is a
+// non-conflict registration (reports carry no startedAt, so a null-vs-null
+// incumbent refreshes rather than conflicts). The wrapper asserts that and
+// returns the handle|null shape so existing `.uuid` assertions keep compiling.
+type RegisterConnectionNarrowed = (
+  ...args: Parameters<RegisterConnection>
+) => Promise<{ uuid: string; connectedAt: Date } | null>;
+let registerConnection: RegisterConnectionNarrowed;
 let listConnectionsForAgent: ListConnectionsForAgent;
 let parseSelfReport: ParseSelfReport;
 
@@ -80,7 +87,13 @@ describeReal("registerConnection — REAL Postgres (cwd-aware registry)", () => 
     }));
 
     const svc = await import("@/services/daemon-connection.service");
-    registerConnection = svc.registerConnection;
+    registerConnection = async (...args) => {
+      const result = await svc.registerConnection(...args);
+      if (svc.isConnectionConflict(result)) {
+        throw new Error(`unexpected conflict result in a non-conflict test: ${JSON.stringify(result)}`);
+      }
+      return result;
+    };
     listConnectionsForAgent = svc.listConnectionsForAgent;
     parseSelfReport = svc.parseSelfReport;
 

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -42,7 +42,8 @@ import {
   DAEMON_CLIENT_TYPES,
   STALE_THRESHOLD_MS,
   parseSelfReport,
-  registerConnection,
+  registerConnection as registerConnectionRaw,
+  isConnectionConflict,
   markDisconnected,
   touchConnection,
   listConnectionsForOwner,
@@ -62,6 +63,21 @@ const connectionUuid = "conn-0000-0000-0000-000000000001";
 const connectedAt = new Date("2026-06-15T03:00:00.000Z");
 const handle = { uuid: connectionUuid, connectedAt };
 
+// registerConnection now returns a tri-state (handle | conflict | null). Every
+// pre-existing test below exercises a non-conflict path, so this wrapper asserts
+// "not a conflict" once and narrows the result back to `handle | null` for those
+// call sites. The dedicated conflict-detection suite calls `registerConnectionRaw`
+// directly to assert the conflict outcome.
+const registerConnection = async (
+  ...args: Parameters<typeof registerConnectionRaw>
+): Promise<{ uuid: string; connectedAt: Date } | null> => {
+  const result = await registerConnectionRaw(...args);
+  if (isConnectionConflict(result)) {
+    throw new Error(`unexpected conflict result in a non-conflict test: ${JSON.stringify(result)}`);
+  }
+  return result;
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useRealTimers();
@@ -74,6 +90,10 @@ beforeEach(() => {
   mockPrisma.agentInstance.findFirst.mockResolvedValue({ uuid: instanceUuid });
   mockPrisma.agentInstance.create.mockResolvedValue({ uuid: instanceUuid });
   mockPrisma.agentInstance.update.mockResolvedValue({ uuid: instanceUuid });
+  // Conflict detection (real-cwd path) issues a findMany over (agentUuid, host, cwd)
+  // BEFORE any write. Default it to "no incumbent" so existing tests register as
+  // before; the conflict suite overrides this per-case.
+  mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
 });
 
 // ===== Constants =====
@@ -410,6 +430,179 @@ describe("registerConnection", () => {
       expect(mockPrisma.agentInstance.findFirst).not.toHaveBeenCalled();
       expect(mockPrisma.agentInstance.create).not.toHaveBeenCalled();
     });
+  });
+});
+
+// ===== Conflict detection: warn + skip a live different-process daemon =====
+//
+// add-daemon-connection-conflict-skip. Before any write, on the REAL-cwd path only,
+// registerConnection refuses to silently take over a connection a DIFFERENT live
+// daemon process already holds at the same (agentUuid, host, cwd) — judged across
+// ALL clientTypes (Q2/DEC-2), discriminated by the self-reported startedAt (Q1/DEC-1).
+// Truth table: none/stale → register; fresh+same startedAt → refresh (reconnect);
+// fresh+different startedAt (incl. null-vs-non-null) → conflict (skip, write nothing).
+describe("registerConnection → conflict detection (warn + skip)", () => {
+  const host = "mac.local";
+  const cwd = "/work/alpha";
+  const incumbentStartedAt = new Date("2026-06-15T03:00:00.000Z");
+  const incomingStartedAt = new Date("2026-06-15T09:00:00.000Z");
+  const freshLastSeen = new Date(); // now → within STALE_THRESHOLD_MS
+
+  // Build an incumbent row as returned by the detection findMany (only the selected
+  // liveness fields). `lastSeenAt` defaults to "now" (fresh); pass an old date for stale.
+  const incumbent = (over: Partial<{ status: string; lastSeenAt: Date; startedAt: Date | null; clientType: string }> = {}) => ({
+    status: "online",
+    lastSeenAt: freshLastSeen,
+    startedAt: incumbentStartedAt,
+    clientType: "claude_code",
+    ...over,
+  });
+
+  const report = (over: Partial<SelfReport> = {}): SelfReport => ({
+    clientType: "claude_code",
+    host,
+    cwd,
+    startedAt: incomingStartedAt,
+    ...over,
+  });
+
+  const expectNoWrite = () => {
+    expect(mockPrisma.daemonConnection.upsert).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonConnection.update).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonConnection.create).not.toHaveBeenCalled();
+    // The AgentInstance must also be untouched — conflict returns BEFORE upsertAgentInstance.
+    expect(mockPrisma.agentInstance.upsert).not.toHaveBeenCalled();
+    expect(mockPrisma.agentInstance.create).not.toHaveBeenCalled();
+    expect(mockPrisma.agentInstance.update).not.toHaveBeenCalled();
+  };
+
+  it("AC#1: fresh incumbent + DIFFERENT startedAt → conflict sentinel, writes NOTHING", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([incumbent()]);
+
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report());
+
+    expect(isConnectionConflict(result)).toBe(true);
+    expect(result).toEqual({ conflict: true, host, cwd });
+    expectNoWrite();
+    // The detection query targets the (agentUuid, host, cwd) SUBSET (cross-clientType),
+    // NOT the unique (agent, clientType, host, cwd) row.
+    expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledWith({
+      where: { agentUuid, host, cwd },
+      select: { status: true, lastSeenAt: true, startedAt: true, clientType: true },
+    });
+  });
+
+  it("AC#1: incumbent startedAt=null vs incoming non-null → conflict (the null-startedAt edge)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([incumbent({ startedAt: null })]);
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report());
+    expect(result).toEqual({ conflict: true, host, cwd });
+    expectNoWrite();
+  });
+
+  it("AC#1: incumbent non-null vs incoming startedAt=null → conflict (null edge, other direction)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([incumbent()]);
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report({ startedAt: null }));
+    expect(result).toEqual({ conflict: true, host, cwd });
+    expectNoWrite();
+  });
+
+  it("AC#2: cross-clientType — a fresh claude_code incumbent makes a codex registration a conflict", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([incumbent({ clientType: "claude_code" })]);
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report({ clientType: "codex" }));
+    expect(result).toEqual({ conflict: true, host, cwd });
+    expectNoWrite();
+  });
+
+  it("AC#4: conflict emits ONE structured warn (not the write-failure error path)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([incumbent()]);
+    await registerConnectionRaw(companyUuid, agentUuid, report());
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    const [ctx] = mockLogger.warn.mock.calls[0];
+    expect(ctx).toMatchObject({
+      companyUuid,
+      agentUuid,
+      host,
+      cwd,
+      incumbentStartedAt,
+      incomingStartedAt,
+      incumbentClientType: "claude_code",
+      incomingClientType: "claude_code",
+    });
+  });
+
+  it("AC#3: fresh incumbent + SAME startedAt → NOT a conflict, refreshes (reconnect)", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([incumbent({ startedAt: incomingStartedAt })]);
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report());
+
+    expect(isConnectionConflict(result)).toBe(false);
+    expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("AC#3: STALE incumbent (lastSeenAt older than threshold) → takeover regardless of startedAt", async () => {
+    const stale = new Date(Date.now() - STALE_THRESHOLD_MS - 1_000);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      incumbent({ lastSeenAt: stale, startedAt: incumbentStartedAt }),
+    ]);
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report());
+
+    expect(isConnectionConflict(result)).toBe(false);
+    expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC#3: incumbent status=offline (fresh lastSeenAt) → takeover, not a conflict", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      incumbent({ status: "offline", startedAt: incumbentStartedAt }),
+    ]);
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report());
+    expect(isConnectionConflict(result)).toBe(false);
+    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC#3: NO incumbent at all → first-connect registers normally", async () => {
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report());
+    expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+    expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("a stale + a fresh-same-process row coexisting → still NOT a conflict (reconnect wins over the stale ghost)", async () => {
+    const stale = new Date(Date.now() - STALE_THRESHOLD_MS - 1_000);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      incumbent({ lastSeenAt: stale, startedAt: new Date("2000-01-01T00:00:00.000Z") }),
+      incumbent({ startedAt: incomingStartedAt }), // fresh, same process as incoming
+    ]);
+    mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+    const result = await registerConnectionRaw(companyUuid, agentUuid, report());
+    expect(isConnectionConflict(result)).toBe(false);
+  });
+
+  it("AC#3 (Q5): the cwd=null branch is EXEMPT — never runs detection, refreshes the old-daemon row", async () => {
+    // An old daemon: no cwd. Detection must NOT run (findMany not called on the null path);
+    // the existing findFirst→update/create compatibility path handles it.
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "old-null-row" });
+    mockPrisma.daemonConnection.update.mockResolvedValue({ uuid: "old-null-row", connectedAt });
+
+    const result = await registerConnectionRaw(companyUuid, agentUuid, {
+      clientType: "claude_code",
+      host,
+      cwd: null,
+      startedAt: null,
+    });
+
+    expect(isConnectionConflict(result)).toBe(false);
+    expect(result).toEqual({ uuid: "old-null-row", connectedAt });
+    // Detection's findMany is real-cwd-only — it must not be consulted for cwd=null.
+    expect(mockPrisma.daemonConnection.findMany).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/__tests__/daemon-multipath-e2e.integration.test.ts
+++ b/src/services/__tests__/daemon-multipath-e2e.integration.test.ts
@@ -91,7 +91,14 @@ type AssertContinuable = typeof import("@/services/daemon-session.service")["ass
 type SessionReadOnlyErrorT = typeof import("@/services/daemon-session.service")["SessionReadOnlyError"];
 type StaleThreshold = typeof import("@/services/daemon-connection.service")["STALE_THRESHOLD_MS"];
 
-let registerConnection: RegisterConnection;
+// Narrowed to handle|null: every registration in this e2e is a non-conflict
+// path (distinct cwds, no competing same-cwd live process), so the wrapper
+// asserts "not a conflict" and returns the handle|null shape the `.uuid`
+// assertions below expect.
+type RegisterConnectionNarrowed = (
+  ...args: Parameters<RegisterConnection>
+) => Promise<{ uuid: string; connectedAt: Date } | null>;
+let registerConnection: RegisterConnectionNarrowed;
 let listConnectionsForAgent: ListConnectionsForAgent;
 let parseSelfReport: ParseSelfReport;
 let maybeCreateTurnForWakeNotification: MaybeCreateTurn;
@@ -165,7 +172,13 @@ describeReal("daemon multi-path E2E — REAL Postgres (T4 integration checkpoint
     }));
 
     const connSvc = await import("@/services/daemon-connection.service");
-    registerConnection = connSvc.registerConnection;
+    registerConnection = async (...args) => {
+      const result = await connSvc.registerConnection(...args);
+      if (connSvc.isConnectionConflict(result)) {
+        throw new Error(`unexpected conflict result in a non-conflict test: ${JSON.stringify(result)}`);
+      }
+      return result;
+    };
     listConnectionsForAgent = connSvc.listConnectionsForAgent;
     parseSelfReport = connSvc.parseSelfReport;
     STALE_THRESHOLD_MS = connSvc.STALE_THRESHOLD_MS;

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -66,6 +66,43 @@ export interface ConnectionHandle {
 }
 
 /**
+ * Returned by `registerConnection` when the registration is REJECTED because a
+ * live, different-process daemon already holds the same `(agentUuid, host, cwd)`
+ * identity (add-daemon-connection-conflict-skip). This is NOT an error and NOT a
+ * handle — it is a third, distinct outcome the caller (the SSE route) must
+ * recognize so it can emit a `connection_conflict` event instead of wiring up the
+ * per-connection lifecycle for a connection that was never written.
+ *
+ * The crucial contract: when this is returned, NOTHING was written — no
+ * `DaemonConnection` row was created/upserted/refreshed and no `AgentInstance`
+ * was materialized. Because the only process-identity discriminator is the
+ * self-reported `startedAt` (DEC-1), a rejected registration that wrote even
+ * `lastSeenAt` would corrupt the incumbent's own reconnect comparison.
+ *
+ * `host`/`cwd` echo the conflicting identity so the route can forward them to the
+ * daemon (which names them in its WARNING). `cwd` is always a real string here —
+ * conflict detection runs only on the real-cwd path; the `cwd=null` HARD-1 branch
+ * is exempt (Q5).
+ */
+export interface ConnectionConflict {
+  conflict: true;
+  host: string;
+  cwd: string;
+}
+
+/**
+ * Narrow a `registerConnection` result to the conflict sentinel. Callers use this
+ * to distinguish the three outcomes (success handle | conflict | null) without
+ * leaning on structural truthiness — a conflict object is truthy, so a naive
+ * `if (result)` would mistake it for a handle.
+ */
+export function isConnectionConflict(
+  result: ConnectionHandle | ConnectionConflict | null,
+): result is ConnectionConflict {
+  return result !== null && "conflict" in result;
+}
+
+/**
  * Read projection of a `DaemonConnection` row returned to callers of the read
  * API. The raw `status` and the timestamps are passed through so a client can
  * render uptime and last-active without re-implementing liveness; the
@@ -181,9 +218,22 @@ interface DaemonConnectionRow {
  * (this read path) can never drift. The boundary is inclusive: elapsed exactly
  * equal to the threshold still counts as fresh → "online".
  */
+/**
+ * The single liveness predicate shared by every consumer (the read projection,
+ * the instance-online derivation, AND the registration conflict check), so
+ * producer and consumer can never drift (Module Contract 4). A connection is
+ * *effectively online* iff its raw `status` is the literal "online" AND its
+ * `lastSeenAt` is within `STALE_THRESHOLD_MS` of `now`. The boundary is
+ * inclusive: elapsed exactly equal to the threshold still counts as fresh.
+ * `now` is injected (defaulting to `Date.now()`) so callers that already
+ * captured a timestamp can pass it for internal consistency.
+ */
+function isEffectivelyOnline(status: string, lastSeenAt: Date, now: number = Date.now()): boolean {
+  return status === "online" && now - lastSeenAt.getTime() <= STALE_THRESHOLD_MS;
+}
+
 function toConnectionView(row: DaemonConnectionRow): ConnectionView {
-  const fresh = Date.now() - row.lastSeenAt.getTime() <= STALE_THRESHOLD_MS;
-  const effectiveStatus = row.status === "online" && fresh ? "online" : "offline";
+  const effectiveStatus = isEffectivelyOnline(row.status, row.lastSeenAt) ? "online" : "offline";
 
   return {
     uuid: row.uuid,
@@ -415,11 +465,93 @@ async function upsertAgentInstance(
   }
 }
 
+/**
+ * Result of the conflict pre-check: identifies the fresh incumbent that blocks the
+ * registration, so the caller can log it. `null` from `detectRegistrationConflict`
+ * means "no conflict — proceed to register".
+ */
+interface ConflictDetail {
+  incumbentStartedAt: Date | null;
+  incumbentClientType: string;
+}
+
+/**
+ * Decide whether registering at `(agentUuid, host, cwd)` would silently preempt a
+ * different live daemon process (add-daemon-connection-conflict-skip). Returns a
+ * `ConflictDetail` when it WOULD (the caller must skip + signal), or `null` when
+ * registration may proceed.
+ *
+ * Truth table over the existing rows at the `(agentUuid, host, cwd)` TRIPLE —
+ * evaluated ACROSS ALL clientTypes (Q2/DEC-2), so a fresh claude_code incumbent
+ * blocks a codex registration at the same path and vice-versa:
+ *  - no effectively-online incumbent → null (first connect OR stale takeover — a
+ *    stale/offline row is always takeable, regardless of startedAt);
+ *  - a fresh incumbent whose startedAt EQUALS the incoming startedAt → null (this
+ *    is the same process reconnecting; preserve reconnect semantics 1:1);
+ *  - a fresh incumbent whose startedAt DIFFERS from the incoming startedAt
+ *    (including the null-vs-non-null asymmetry in either direction) → CONFLICT.
+ *
+ * Liveness uses the shared `isEffectivelyOnline` predicate (Module Contract 4) so
+ * it can never drift from the read projection. `now` is the registration timestamp
+ * already captured by the caller, passed in for internal consistency.
+ *
+ * Read-only: this issues a single `findMany` and never writes — it runs before any
+ * mutation so the write-nothing invariant holds. It is invoked inside
+ * `registerConnection`'s try/catch, so a query failure propagates to that catch and
+ * degrades to the existing swallow-and-log "return null" (treated as "no conflict,
+ * but the subsequent write will also fail and be swallowed") rather than throwing.
+ */
+async function detectRegistrationConflict(
+  agentUuid: string,
+  host: string,
+  cwd: string,
+  incomingStartedAt: Date | null,
+  now: number,
+): Promise<ConflictDetail | null> {
+  // The composite unique is (agentUuid, clientType, host, cwd); querying the
+  // (agentUuid, host, cwd) SUBSET is intentionally non-unique so it spans every
+  // clientType at this path. Only liveness-relevant fields are selected.
+  const rows = await prisma.daemonConnection.findMany({
+    where: { agentUuid, host, cwd },
+    select: { status: true, lastSeenAt: true, startedAt: true, clientType: true },
+  });
+
+  for (const row of rows) {
+    if (!isEffectivelyOnline(row.status, row.lastSeenAt, now)) {
+      // Stale / offline incumbent — always takeable, never a conflict.
+      continue;
+    }
+    // Fresh incumbent. Same startedAt ⇒ same process reconnecting (not a conflict).
+    // - Both non-null and equal instants → same process → refresh.
+    // - One null, one non-null (either direction) → DIFFERENT → conflict (the
+    //   confirmed null-startedAt edge: a fresh row we cannot prove is "us" is
+    //   treated as someone else's, biasing toward non-preemption).
+    // - Both null → treated as "same" → refresh. This biases toward preserving
+    //   reconnect (DEC-1 fails safe toward today's behavior) and is practically
+    //   unreachable: this branch only runs on the real-cwd path, where every
+    //   feature-carrying daemon always self-reports startedAt, so an incoming
+    //   null here is not a real CLI. Two genuinely-different startedAt-less
+    //   daemons at one real cwd would be required to hit the preempt case — which
+    //   the real client never produces.
+    const bothNonNullEqual =
+      incomingStartedAt !== null &&
+      row.startedAt !== null &&
+      row.startedAt.getTime() === incomingStartedAt.getTime();
+    const bothNull = incomingStartedAt === null && row.startedAt === null;
+    if (bothNonNullEqual || bothNull) {
+      continue;
+    }
+    // Fresh + different process identity → conflict. Return the first such incumbent.
+    return { incumbentStartedAt: row.startedAt, incumbentClientType: row.clientType };
+  }
+  return null;
+}
+
 export async function registerConnection(
   companyUuid: string,
   agentUuid: string,
   report: SelfReport,
-): Promise<ConnectionHandle | null> {
+): Promise<ConnectionHandle | ConnectionConflict | null> {
   if (!isDaemonClientType(report.clientType)) {
     return null;
   }
@@ -431,6 +563,50 @@ export async function registerConnection(
   const now = new Date();
 
   try {
+    // ===== Conflict detection (add-daemon-connection-conflict-skip) =====
+    // Before writing ANYTHING, on the real-cwd path only, refuse to silently take
+    // over a connection that a *different live daemon process* already holds at the
+    // same (agentUuid, host, cwd). This is the one new branch; it must return BEFORE
+    // upsertAgentInstance and before any connection write (the write-nothing
+    // invariant — a rejected write would corrupt the incumbent's startedAt-based
+    // reconnect comparison, since startedAt is the only process discriminator, DEC-1).
+    //
+    // Scope is the (agentUuid, host, cwd) TRIPLE across ALL clientTypes (Q2/DEC-2),
+    // not the (agent, clientType, host, cwd) unique row — two backends in the same
+    // cwd would be woken by the same notification batch and double-execute, the very
+    // harm this guards. The cwd=null HARD-1 branch is EXEMPT (Q5): an old daemon
+    // neither self-reports startedAt nor can act on a conflict signal, so detecting
+    // there could only break its reconnect.
+    if (cwd !== null) {
+      const conflict = await detectRegistrationConflict(
+        agentUuid,
+        host,
+        cwd,
+        report.startedAt ?? null,
+        now.getTime(),
+      );
+      if (conflict) {
+        // Structured WARN (Q6) — distinct from the write-failure logger.error below;
+        // a conflict is an expected outcome, not a failure. Carries enough identity to
+        // diagnose a duplicate daemon even when the second process's stderr lands in a
+        // different journal.
+        logger.warn(
+          {
+            companyUuid,
+            agentUuid,
+            host,
+            cwd,
+            incumbentStartedAt: conflict.incumbentStartedAt,
+            incomingStartedAt: report.startedAt ?? null,
+            incumbentClientType: conflict.incumbentClientType,
+            incomingClientType: report.clientType,
+          },
+          "Skipping daemon connection registration: a live daemon already holds this (agent, host, cwd)",
+        );
+        return { conflict: true, host, cwd };
+      }
+    }
+
     // Materialize / reuse the durable AgentInstance for this identity FIRST, so we
     // can link the connection to it in the SAME write path. upsertAgentInstance
     // swallows its own errors and returns `null` on failure: an instance-table write
@@ -695,9 +871,7 @@ export async function listInstancesForAgent(
   });
 
   const views: InstanceView[] = rows.map((row) => {
-    const online = row.connections.some(
-      (c) => c.status === "online" && now - c.lastSeenAt.getTime() <= STALE_THRESHOLD_MS,
-    );
+    const online = row.connections.some((c) => isEffectivelyOnline(c.status, c.lastSeenAt, now));
     return {
       uuid: row.uuid,
       agentUuid: row.agentUuid,


### PR DESCRIPTION
## Summary
When a second `chorus daemon` registers at the same `(agent, host, cwd)` as a **live different-process** daemon, the server previously upserted (silently took over) the existing connection row — so two processes raced the same task-dispatch / reverse-control channel (duplicate wakes, duplicate execution, tangled transcripts). This change detects the live incumbent and **warns + skips** instead of silently preempting.

Implements OpenSpec change `add-daemon-connection-conflict-skip` (idea `137c3bc3`). No DB migration; no MCP/UI surface change (only a new SSE data-event `type`).

## How it works
- **Server** (`registerConnection`): on the real-cwd path, before any write, probe for a fresh effectively-online connection at the same `(agentUuid, host, cwd)` **across all clientTypes**, discriminated by the self-reported `startedAt`. Fresh + different `startedAt` → **conflict**: return a sentinel and **write nothing** (the load-bearing invariant — `startedAt` is the only process discriminator, so a stray write would poison the incumbent's reconnect comparison). No-incumbent / stale → register (first-connect + takeover); fresh + same `startedAt` → refresh (reconnect).
- **Routes**: emit `{type:"connection_conflict",host,cwd}` instead of `connection_registered`, and wire up no per-connection lifecycle for a stream that registered nothing.
- **Daemon**: `sse-listener.mjs` forks `connection_conflict` to `onConflict` *before* the wake path; `daemon.mjs` warns (host+cwd), tears that cwd's listener down (no reconnect/re-probe), and keeps serving non-conflicting paths. When every declared path conflicts, the daemon exits non-zero.

## Elaboration decisions honored
Q1 `startedAt`-only discriminator (no new column/migration) · Q2 `(agent,host,cwd)` cross-clientType scope · Q3 non-zero exit on all-conflict · Q4 permanent skip / no in-process retry · Q5 `cwd=null` (old daemon) exempt · Q6 server-side structured warn. Plus: a fresh null-`startedAt` incumbent vs a non-null incoming → treated as a conflict.

## Changed files
| File | Change |
|------|--------|
| `src/services/daemon-connection.service.ts` | `detectRegistrationConflict` + tri-state `registerConnection` return + `isConnectionConflict` guard + shared `isEffectivelyOnline` |
| `src/app/api/events/notifications/route.ts`, `src/app/api/events/route.ts` | emit `connection_conflict`, skip lifecycle on conflict |
| `cli/sse-listener.mjs` | `onConflict` fork before `onEvent` |
| `cli/daemon.mjs` | per-connection warn/skip + all-conflict non-zero exit latch |
| `openspec/specs/{cli-daemon,daemon-connection-registry}/spec.md` | merged ADDED requirements (change archived) |

## Test plan
- [x] `pnpm test` — 3547 passed / 0 failed
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` — 0 errors
- [x] `openspec validate --strict` valid
- [x] New `daemon-connection-conflict.integration.test.ts` drives the real `registerConnection` over a stateful fake (Scenarios A/C/D + null-cwd exempt + per-agent isolation); daemon-side Scenarios B/E in `daemon-multipath` + `daemon-permission-wiring`
- [ ] Strict local e2e acceptance (in progress)

## Follow-up
The long-term `daemon-connection-registry` spec still has pre-cwd `(agent,clientType,host)` key wording + a recognized-types list missing `codex` (pre-existing, orthogonal). Flagged for a separate MODIFIED-delta change rather than touched in this append-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)