### PR TITLE
fix(daemon): exclude harness-injected synthetic content (skill bodies) from transcript sync

### DIFF
--- a/cli/__tests__/transcript-upload-hooks.test.mjs
+++ b/cli/__tests__/transcript-upload-hooks.test.mjs
@@ -55,6 +55,57 @@ const USER_TEXT_STRING = {
 };
 const RESULT_ENVELOPE = { type: "result", subtype: "success", session_id: SID, result: "done" };
 
+// ── Harness-injected synthetic content (Claude Code 2.1.195) ──
+// A loaded skill body is delivered to the model as a synthetic user turn. On the live
+// `claude -p --output-format stream-json --verbose` stdout the daemon reads, it is a
+// `type:"user"` envelope carrying a `text` block, marked `isSynthetic:true`. (The
+// on-disk JSONL marks the same message `isMeta:true` — a DIFFERENT field name; the
+// daemon reads the stream, so the guard keys on `isSynthetic`. Verified by capturing
+// real stdout from the installed CLI, not from memory.)
+const USER_SKILL_BODY_SYNTHETIC = {
+  type: "user",
+  session_id: SID,
+  isSynthetic: true,
+  message: {
+    role: "user",
+    content: [{ type: "text", text: "Base directory for this skill: /home/u/.claude/plugins/...\n\n# Idea Skill\n..." }],
+  },
+};
+// A human wake instruction is a NON-synthetic user text message — must still sync.
+const USER_HUMAN_INSTRUCTION = {
+  type: "user",
+  session_id: SID,
+  message: { role: "user", content: [{ type: "text", text: "[Chorus] New instruction from a human: please claim it." }] },
+};
+// A genuine assistant reply that merely QUOTES a skill string — must NOT be dropped
+// (proves the filter is structural on isSynthetic, not content-sniffing).
+const ASSISTANT_QUOTES_SKILL = {
+  type: "assistant",
+  session_id: SID,
+  message: {
+    role: "assistant",
+    content: [{ type: "text", text: 'I read the "Base directory for this skill" line and proceeded.' }],
+  },
+};
+// A retained, non-synthetic text block that wraps a <system-reminder> alongside real text.
+const USER_TEXT_WITH_REMINDER = {
+  type: "user",
+  session_id: SID,
+  message: {
+    role: "user",
+    content: [{ type: "text", text: "Real instruction.<system-reminder>internal note</system-reminder> Keep going." }],
+  },
+};
+// A message that is ONLY a system-reminder — nothing real remains after stripping.
+const USER_REMINDER_ONLY = {
+  type: "user",
+  session_id: SID,
+  message: {
+    role: "user",
+    content: [{ type: "text", text: "<system-reminder>ambient context, not user input</system-reminder>" }],
+  },
+};
+
 describe("extractTranscriptText — keep user/assistant text, drop everything else", () => {
   it("keeps an assistant text message", () => {
     expect(extractTranscriptText(ASSISTANT_TEXT)).toEqual({
@@ -132,6 +183,48 @@ describe("extractTranscriptText — keep user/assistant text, drop everything el
   it("falls back to the envelope type when message.role is absent", () => {
     const noRole = { type: "user", message: { content: [{ type: "text", text: "hi" }] } };
     expect(extractTranscriptText(noRole)).toEqual({ role: "user", text: "hi" });
+  });
+});
+
+describe("extractTranscriptText — exclude harness-injected synthetic content", () => {
+  it("drops a type:user isSynthetic:true skill-body message (no body leaks)", () => {
+    expect(extractTranscriptText(USER_SKILL_BODY_SYNTHETIC)).toBeNull();
+  });
+
+  it("keeps a NON-synthetic [Chorus] human instruction", () => {
+    expect(extractTranscriptText(USER_HUMAN_INSTRUCTION)).toEqual({
+      role: "user",
+      text: "[Chorus] New instruction from a human: please claim it.",
+    });
+  });
+
+  it("does NOT drop an assistant reply that merely quotes a skill string (structural, not content-sniffing)", () => {
+    expect(extractTranscriptText(ASSISTANT_QUOTES_SKILL)).toEqual({
+      role: "assistant",
+      text: 'I read the "Base directory for this skill" line and proceeded.',
+    });
+  });
+
+  it("does NOT drop a synthetic ASSISTANT message — the guard is gated on type:user only", () => {
+    // An assistant envelope marked isSynthetic must still be kept (real assistant text);
+    // the synthetic drop is scoped to user envelopes (where injected content rides).
+    const synthAssistant = {
+      type: "assistant",
+      isSynthetic: true,
+      message: { role: "assistant", content: [{ type: "text", text: "still my reply" }] },
+    };
+    expect(extractTranscriptText(synthAssistant)).toEqual({ role: "assistant", text: "still my reply" });
+  });
+
+  it("strips a <system-reminder> span from retained text but keeps the real text", () => {
+    expect(extractTranscriptText(USER_TEXT_WITH_REMINDER)).toEqual({
+      role: "user",
+      text: "Real instruction. Keep going.",
+    });
+  });
+
+  it("drops a message that is only a <system-reminder> after stripping", () => {
+    expect(extractTranscriptText(USER_REMINDER_ONLY)).toBeNull();
   });
 });
 

--- a/cli/upload-hooks.mjs
+++ b/cli/upload-hooks.mjs
@@ -145,9 +145,39 @@ export function mergeUploadHooks(...args) {
 // top-level type — otherwise a tool-result-only user message would leak. The server
 // ingest stores ONLY `user`/`assistant` text (see /api/daemon/transcript), so this
 // filter mirrors exactly what the server will persist.
+//
+// Harness-injected synthetic content: when the model loads a skill, the skill's full
+// markdown body is delivered as a SYNTHETIC user turn. On the live stream-json stdout
+// (verified against Claude Code CLI 2.1.195 by capturing real `claude -p
+// --output-format stream-json --verbose` output) that envelope is
+// `{ type:"user", isSynthetic:true, message:{ content:[{type:"text", text:"Base
+// directory for this skill: …"}] } }`. Because it's a plain `text` block, the
+// block-level filter alone would KEEP it and leak the whole skill body to Chorus, so
+// we drop `type:"user"` envelopes flagged `isSynthetic:true` outright. ⚠️ FIELD NAME:
+// the live stream marks this `isSynthetic`; the on-disk transcript JSONL
+// (~/.claude/projects/.../*.jsonl, which the daemon does NOT read) marks the SAME
+// message `isMeta` — keying on `isMeta` here would be a silent no-op. Genuine human
+// instructions and the agent's own replies never carry `isSynthetic`, so this is a
+// purely structural match (no size/content heuristic) and cannot drop real content.
+// MCP-server instructions, CLAUDE.md context, and the deferred-tool listing are folded
+// into the dropped `type:"system"` init envelope and never reach this filter. Scope is
+// the Claude Code dialect only — the codex (`item.completed`) path is unaffected.
 
 /** Top-level stream-json envelope types that carry a conversation message. */
 const CONVERSATION_TYPES = new Set(["user", "assistant"]);
+
+/**
+ * Remove `<system-reminder>…</system-reminder>` spans from a retained text block
+ * (defense-in-depth for harness-injected reminders that ride inside a kept text
+ * block). Structural tag match — not a size/content heuristic. Non-reminder text is
+ * left untouched; a message that is only a reminder collapses to empty and is then
+ * dropped by the caller's emptiness check.
+ * @param {string} s
+ * @returns {string}
+ */
+function stripSystemReminders(s) {
+  return s.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "");
+}
 
 /**
  * Extract the plain user/assistant TEXT from one stream object emitted by EITHER
@@ -187,6 +217,12 @@ export function extractTranscriptText(obj) {
   // ── Claude Code stream-json dialect ──
   if (!CONVERSATION_TYPES.has(obj.type)) return null;
 
+  // Drop harness-injected synthetic content (e.g. a loaded skill body). Claude Code
+  // marks these user turns `isSynthetic:true` on the live stream (NOT the on-disk
+  // `isMeta` field). Gated on `type:"user"` so a synthetic *assistant* envelope, if one
+  // ever appears, is still treated as real assistant text. Structural match only.
+  if (obj.type === "user" && obj.isSynthetic === true) return null;
+
   const message = obj.message;
   if (!message || typeof message !== "object") return null;
   // The persisted role is the message's role; fall back to the envelope type (they
@@ -214,8 +250,13 @@ export function extractTranscriptText(obj) {
     return null;
   }
 
-  // A message with no text (e.g. a user message that was purely a tool_result, or an
-  // assistant message that was purely tool_use/thinking) is dropped — nothing to store.
+  // Strip any wrapped <system-reminder> spans (defense-in-depth) before deciding
+  // emptiness, so a reminder-only message collapses to nothing and is dropped.
+  text = stripSystemReminders(text);
+
+  // A message with no text (e.g. a user message that was purely a tool_result, an
+  // assistant message that was purely tool_use/thinking, or text that was only a
+  // system-reminder) is dropped — nothing to store.
   if (!text.trim()) return null;
   return { role, text };
 }

--- a/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-29

--- a/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/README.md
+++ b/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/README.md
@@ -1,0 +1,3 @@
+# daemon-skip-synthetic-transcript
+
+Daemon excludes harness-injected synthetic transcript content (skill bodies) from Chorus sync, structurally via the stream-json isSynthetic marker

--- a/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/design.md
+++ b/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/design.md
@@ -1,0 +1,117 @@
+# Technical Design: Exclude synthetic content from daemon transcript sync
+
+## Overview
+
+The fix lives entirely in the daemon's transcript extractor
+(`cli/upload-hooks.mjs` → `extractTranscriptText`), the single chokepoint every
+stream-json object passes through on its way to `POST /api/daemon/transcript`. We add a
+structural guard that drops harness-injected synthetic messages, keyed on Claude Code's
+own `isSynthetic` stream marker. No server, schema, or API change.
+
+## Evidence — what the daemon actually reads
+
+The daemon spawns `claude -p --output-format stream-json --verbose`
+(`cli/claude-spawner.mjs:172`) and hands every parsed NDJSON object to
+`onTranscriptMessage`, which calls `extractTranscriptText`. The relevant shapes were
+captured from real stdout (Claude Code CLI, this machine):
+
+| Logical content | Stream-json envelope | Current filter outcome |
+|---|---|---|
+| Loaded skill body | `type:"user"`, `isSynthetic:true`, `content:[{type:"text", text:"Base directory for this skill: …"}]` | **KEPT → leaks** |
+| Skill tool result | `type:"user"`, `content:[{type:"tool_result", …"Launching skill: …"}]` | dropped (not a `text` block) |
+| Human wake instruction | `type:"user"`, `isSynthetic` absent, `content:[{type:"text", …"[Chorus] …"}]` | kept (correct) |
+| Agent reply | `type:"assistant"`, `isSynthetic` absent, `text` block | kept (correct) |
+| `CLAUDE.md` / MCP-server instructions / deferred-tool listing | folded into `type:"system"` `subtype:"init"` | dropped (system envelope) |
+| Mid-turn `<system-reminder>` | rides inside a `tool_result` block | dropped (not a `text` block) |
+
+Key facts established by capture:
+
+1. **`isSynthetic`, not `isMeta`.** The on-disk JSONL marks the skill body with
+   `isMeta:true`; the live stream marks it with `isSynthetic:true`. The daemon reads the
+   stream, so the guard MUST key on `isSynthetic`. (`isMeta` does not appear anywhere in
+   stream-json top-level keys.)
+2. **The skill body is the only large injected blob that reaches the conversation
+   filter** in the headless stream. System/init-folded context (MCP instructions,
+   `CLAUDE.md`, tool listings) and `tool_result`-wrapped system-reminders are already
+   dropped by the existing `text`-only block filter.
+3. **A content heuristic would be unsafe.** The agent's own genuine replies sometimes
+   quote skill strings (e.g. "Base directory for this skill") while discussing the work;
+   those carry no `isSynthetic` flag. Only the structural flag separates injected text
+   from authored text — which is why the chosen mechanism is structural-match-only.
+
+## Architecture / the change
+
+In `extractTranscriptText`, Claude Code branch, **before** extracting text from a
+`type:"user"` envelope:
+
+```js
+// Drop harness-injected synthetic content (e.g. loaded skill bodies). Claude Code's
+// stream-json marks these user envelopes with isSynthetic:true; genuine human
+// instructions and the agent's own messages never carry it. Structural match only —
+// no size/content heuristic, so real replies/tool summaries/errors are never dropped.
+if (obj.type === "user" && obj.isSynthetic === true) return null;
+```
+
+Placement: after the `item.completed` (codex) branch and the
+`CONVERSATION_TYPES` check, but before/at the point where the `user` message's content
+is read. It is gated on `obj.type === "user"` so it cannot affect assistant messages.
+
+### Defense-in-depth: strip wrapped system-reminders
+
+For any retained `text` block, strip `<system-reminder>…</system-reminder>` spans (and
+drop the message if nothing but a reminder remains). This is a structural tag match, not
+a size heuristic, and covers the case where a reminder is concatenated into an otherwise
+kept text block. Implemented as a small helper applied to the joined text before the
+final `text.trim()` emptiness check.
+
+```js
+function stripSystemReminders(s) {
+  // Remove <system-reminder>…</system-reminder> spans (non-greedy, dotall).
+  return s.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "");
+}
+```
+
+## Module Contracts
+
+- `extractTranscriptText(obj)` keeps its contract: returns `{ role, text }` or `null`;
+  never throws. The two additions only ever turn a would-be-kept message into `null`
+  (synthetic user) or shrink its `text` (reminder strip). No new return shape.
+- The codex (`item.completed`) branch is untouched — scope is Claude Code only.
+- The server ingest endpoint and its existing requirement are unchanged; this strictly
+  reduces what the daemon sends.
+
+## Implementation Plan
+
+1. Add the `isSynthetic` drop and `stripSystemReminders` helper to
+   `cli/upload-hooks.mjs`; update the dialect doc-comment to record the `isSynthetic`
+   vs `isMeta` distinction so the next reader doesn't regress to the on-disk field.
+2. Unit tests in `cli/__tests__/` for `extractTranscriptText`:
+   - `type:"user"` + `isSynthetic:true` + text block → `null` (skill body dropped).
+   - `type:"user"` + no `isSynthetic` + `[Chorus]` text → kept (human instruction).
+   - `type:"assistant"` + text that *contains* "Base directory for this skill" → kept
+     (genuine reply not dropped — guards against content-sniffing regression).
+   - `text` block wrapping `<system-reminder>…</system-reminder>` → reminder stripped;
+     reminder-only message → dropped.
+   - codex `item.completed` `agent_message` → unchanged.
+3. Local e2e verification (the acceptance gate the requester asked for): run a local
+   Chorus server + daemon, wake a session that loads a skill, and assert the stored
+   transcript contains the agent's reply but not the skill body, and that a human
+   instruction and an error message both still sync. Because the elaboration scope is
+   "skill + injected context" (q2), the e2e ALSO verifies — not merely assumes — that the
+   other named injected categories (MCP-server instructions, `CLAUDE.md` context, the
+   deferred-tool/agent listing) are absent from the stored transcript. The evidence
+   above predicts they never reach the conversation filter (folded into the dropped
+   `type:"system"` init envelope); if the live run shows any of them leaking, that is a
+   finding and the filter must extend beyond the `isSynthetic` drop to cover it.
+
+## Risks & Mitigations
+
+- **`isSynthetic` semantics drift across CLI versions.** Mitigation: the guard is
+  additive and fail-safe — if the flag stops appearing, behavior reverts to today's
+  (over-sync), not data loss; the e2e test pins the current behavior and will flag a
+  regression. The doc-comment records the captured CLI version.
+- **Future legitimate synthetic content we *do* want.** None today; the decision is
+  drop-completely. If that changes, the guard is a single line to relax.
+- **Over-stripping reminders.** The regex is anchored to the literal
+  `<system-reminder>` tag pair; non-reminder text is untouched. Covered by a kept-text
+  test case.

--- a/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/proposal.md
+++ b/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/proposal.md
@@ -1,0 +1,85 @@
+# Proposal: Exclude harness-injected synthetic content from daemon transcript sync
+
+## Why
+
+When the Chorus daemon wakes a headless `claude -p` session, it streams the session
+transcript back to Chorus. Loading a skill in that session injects the **full skill
+markdown body** (often 4k–20k characters) into the conversation. Today that body is
+synced to Chorus verbatim, so the daemon session stream fills with low-value,
+repetitive, internal-implementation text that drowns out the things a human actually
+wants to read: agent progress, questions, results, and errors.
+
+This is observable right now: a single idea-elaboration turn that loads `chorus:idea`,
+`chorus:proposal`, and `chorus:openspec-aware` injects three 13k–20k-character skill
+bodies into the Chorus transcript.
+
+The root cause is structural, and it was pinned by capturing the real
+`claude -p --output-format stream-json --verbose` stdout the daemon consumes:
+
+- A loaded skill body arrives as a `type:"user"` envelope carrying a `text` block,
+  marked **`isSynthetic: true`** — Claude Code's own flag for harness-injected,
+  non-human content.
+- The daemon's transcript filter (`cli/upload-hooks.mjs` → `extractTranscriptText`)
+  keeps **all** `text` blocks from `user`/`assistant` messages and has **no synthetic
+  check**, so the injected skill body passes straight through to
+  `POST /api/daemon/transcript`.
+- Genuine content — the human's wake instruction, the agent's own replies, tool-result
+  summaries the agent writes — never carries `isSynthetic`, so it is distinguishable by
+  structure alone.
+
+> **Field-name caveat (verified):** the on-disk transcript JSONL
+> (`~/.claude/projects/.../*.jsonl`) marks the same message with `isMeta: true`, but the
+> daemon does **not** read that file — it reads the live stream-json stdout, where the
+> field is `isSynthetic`. A fix keyed on `isMeta` would be a silent no-op in production.
+> This change keys on `isSynthetic`.
+
+## What Changes
+
+- The daemon's `extractTranscriptText` (Claude Code stream-json dialect) **drops any
+  `type:"user"` envelope whose `isSynthetic === true`** before extracting text. This is
+  a pure structural match — no size threshold, no content sniffing — so it can never
+  accidentally drop a real agent reply, tool-result summary, human instruction, or error
+  message.
+- Defense-in-depth: where any retained `text` block still wraps a
+  `<system-reminder>…</system-reminder>` injection, that wrapped block is stripped from
+  the stored text. (In the headless stream, MCP-server instructions, `CLAUDE.md`
+  context, and the deferred-tool listing are folded into the already-dropped
+  `type:"system"` init envelope and never reach the conversation filter, so no extra
+  handling is needed for them.)
+- Behavior is **always on** with no configuration knob.
+- Scope is the **Claude Code daemon backend only**. The Codex backend
+  (`codex exec --json`, `item.completed` dialect) is unchanged by this change and will be
+  addressed separately if needed.
+- Verification is a **local end-to-end test**: run a real local Chorus server + daemon,
+  wake a session that loads a skill, and assert that (a) the skill body never appears in
+  the session's stored transcript, while (b) the agent's replies, tool-result summaries,
+  human instructions, and key errors still sync.
+
+## Capabilities
+
+- `daemon-session-conversation` (MODIFIED) — the transcript-ingest requirement is
+  extended so the daemon-side filter excludes harness-injected synthetic content, stated
+  as a backend-agnostic guarantee about what reaches the ingest endpoint.
+
+## Impact
+
+- **Code:** `cli/upload-hooks.mjs` (`extractTranscriptText`, Claude Code branch) — add
+  the `isSynthetic` drop and the `<system-reminder>` strip. Tests in
+  `cli/__tests__/` for the new filter cases.
+- **No schema change**, no new permission bit, no API contract change. The server ingest
+  already stores only `user`/`assistant` text and is the second line of defense; this
+  change reduces what the daemon sends rather than changing what the server accepts.
+- **No migration.** Existing already-synced skill text is not retro-cleaned by this
+  change (out of scope; the rolling-window cap will age it out).
+- **Boundary:** the sibling idea "修复 Codex daemon UI 指令处理中间消息重复同步到 Chorus"
+  owns the duplicate-intermediate-message problem. This change owns only the skill-body /
+  verbose-injection leak.
+
+## Non-goals
+
+- Showing a short "loaded skill X" marker in the stream. The decision was to drop
+  synthetic content **completely**, with no replacement event.
+- Retro-cleaning skill text already persisted in existing sessions.
+- Any change to the Codex backend.
+- A configuration flag or verbose/debug mode to re-enable full sync.
+- UI-side collapsing of skill content (rejected in favor of never sending it).

--- a/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/specs/daemon-session-conversation/spec.md
+++ b/openspec/changes/archive/2026-06-29-daemon-skip-synthetic-transcript/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: The daemon SHALL exclude harness-injected synthetic content from the transcript it syncs
+
+The Claude Code daemon backend SHALL NOT sync harness-injected synthetic conversation
+content (for example, the full body of a loaded skill) to Chorus. The daemon's
+stream-json transcript extractor SHALL drop any `type:"user"` stream envelope marked as
+synthetic by Claude Code (the `isSynthetic: true` field on the live
+`claude -p --output-format stream-json` stdout) before any text is extracted from it, so
+that such content is never posted to `POST /api/daemon/transcript`. The exclusion SHALL
+be a purely structural match on the synthetic marker — it SHALL NOT use a size threshold
+or content/text-pattern heuristic — so that genuine human instructions, the agent's own
+replies, tool-result summaries the agent authors, and error messages (none of which
+carry the synthetic marker) are never dropped. The behavior SHALL be always on with no
+configuration knob. This requirement SHALL apply to the Claude Code backend only; the
+codex (`codex exec --json` / `item.completed`) backend extraction SHALL be unchanged.
+
+As defense-in-depth, where a retained `text` block still wraps a
+`<system-reminder>…</system-reminder>` span, the daemon SHALL strip that span from the
+stored text, and SHALL drop the message entirely if no non-reminder text remains. The
+extractor SHALL continue to never throw on an unrecognized shape (returning "not a
+keepable message" instead).
+
+#### Scenario: A loaded skill body is not synced
+
+- **GIVEN** a Claude Code daemon session whose stream-json stdout contains a
+  `type:"user"` envelope with `isSynthetic: true` carrying a `text` block with a skill
+  body (e.g. text beginning "Base directory for this skill: …")
+- **WHEN** the daemon's transcript extractor processes that envelope
+- **THEN** the extractor MUST yield no message for it
+- **AND** no skill-body text MUST be posted to `POST /api/daemon/transcript`
+
+#### Scenario: A human instruction is still synced
+
+- **GIVEN** a `type:"user"` envelope with no synthetic marker carrying a `text` block
+  with a human wake instruction (e.g. text beginning "[Chorus] …")
+- **WHEN** the daemon's transcript extractor processes that envelope
+- **THEN** the extractor MUST yield a `user` message with that instruction text
+- **AND** that text MUST be eligible to sync to Chorus
+
+#### Scenario: A genuine agent reply that quotes injected text is not dropped
+
+- **GIVEN** a `type:"assistant"` envelope with no synthetic marker whose `text` block
+  happens to contain a phrase that also appears in injected content (e.g. the agent
+  discusses "Base directory for this skill" in its own words)
+- **WHEN** the daemon's transcript extractor processes that envelope
+- **THEN** the extractor MUST yield an `assistant` message with the reply text
+  (the structural match on the synthetic marker MUST NOT classify a non-synthetic
+  message as injected based on its content)
+
+#### Scenario: A wrapped system-reminder is stripped from retained text
+
+- **GIVEN** a retained, non-synthetic `text` block that contains a
+  `<system-reminder>…</system-reminder>` span alongside other text
+- **WHEN** the daemon's transcript extractor processes it
+- **THEN** the stored text MUST have the system-reminder span removed
+- **AND** if removing the span leaves no non-whitespace text, the extractor MUST yield
+  no message
+
+#### Scenario: The codex backend extraction is unaffected
+
+- **GIVEN** a codex `item.completed` `agent_message` stream item
+- **WHEN** the daemon's transcript extractor processes it
+- **THEN** the extractor MUST yield the assistant text exactly as it did before this
+  change (the synthetic-content exclusion MUST NOT alter the codex dialect path)

--- a/openspec/specs/daemon-session-conversation/spec.md
+++ b/openspec/specs/daemon-session-conversation/spec.md
@@ -191,3 +191,67 @@ The server SHALL scope session/turn reads so that a user caller sees only the se
 - **WHEN** a caller in company C1 reads daemon sessions
 - **THEN** the result MUST NOT include that session
 
+### Requirement: The daemon SHALL exclude harness-injected synthetic content from the transcript it syncs
+
+The Claude Code daemon backend SHALL NOT sync harness-injected synthetic conversation
+content (for example, the full body of a loaded skill) to Chorus. The daemon's
+stream-json transcript extractor SHALL drop any `type:"user"` stream envelope marked as
+synthetic by Claude Code (the `isSynthetic: true` field on the live
+`claude -p --output-format stream-json` stdout) before any text is extracted from it, so
+that such content is never posted to `POST /api/daemon/transcript`. The exclusion SHALL
+be a purely structural match on the synthetic marker — it SHALL NOT use a size threshold
+or content/text-pattern heuristic — so that genuine human instructions, the agent's own
+replies, tool-result summaries the agent authors, and error messages (none of which
+carry the synthetic marker) are never dropped. The behavior SHALL be always on with no
+configuration knob. This requirement SHALL apply to the Claude Code backend only; the
+codex (`codex exec --json` / `item.completed`) backend extraction SHALL be unchanged.
+
+As defense-in-depth, where a retained `text` block still wraps a
+`<system-reminder>…</system-reminder>` span, the daemon SHALL strip that span from the
+stored text, and SHALL drop the message entirely if no non-reminder text remains. The
+extractor SHALL continue to never throw on an unrecognized shape (returning "not a
+keepable message" instead).
+
+#### Scenario: A loaded skill body is not synced
+
+- **GIVEN** a Claude Code daemon session whose stream-json stdout contains a
+  `type:"user"` envelope with `isSynthetic: true` carrying a `text` block with a skill
+  body (e.g. text beginning "Base directory for this skill: …")
+- **WHEN** the daemon's transcript extractor processes that envelope
+- **THEN** the extractor MUST yield no message for it
+- **AND** no skill-body text MUST be posted to `POST /api/daemon/transcript`
+
+#### Scenario: A human instruction is still synced
+
+- **GIVEN** a `type:"user"` envelope with no synthetic marker carrying a `text` block
+  with a human wake instruction (e.g. text beginning "[Chorus] …")
+- **WHEN** the daemon's transcript extractor processes that envelope
+- **THEN** the extractor MUST yield a `user` message with that instruction text
+- **AND** that text MUST be eligible to sync to Chorus
+
+#### Scenario: A genuine agent reply that quotes injected text is not dropped
+
+- **GIVEN** a `type:"assistant"` envelope with no synthetic marker whose `text` block
+  happens to contain a phrase that also appears in injected content (e.g. the agent
+  discusses "Base directory for this skill" in its own words)
+- **WHEN** the daemon's transcript extractor processes that envelope
+- **THEN** the extractor MUST yield an `assistant` message with the reply text
+  (the structural match on the synthetic marker MUST NOT classify a non-synthetic
+  message as injected based on its content)
+
+#### Scenario: A wrapped system-reminder is stripped from retained text
+
+- **GIVEN** a retained, non-synthetic `text` block that contains a
+  `<system-reminder>…</system-reminder>` span alongside other text
+- **WHEN** the daemon's transcript extractor processes it
+- **THEN** the stored text MUST have the system-reminder span removed
+- **AND** if removing the span leaves no non-whitespace text, the extractor MUST yield
+  no message
+
+#### Scenario: The codex backend extraction is unaffected
+
+- **GIVEN** a codex `item.completed` `agent_message` stream item
+- **WHEN** the daemon's transcript extractor processes it
+- **THEN** the extractor MUST yield the assistant text exactly as it did before this
+  change (the synthetic-content exclusion MUST NOT alter the codex dialect path)
+


### PR DESCRIPTION
## What

The Claude Code daemon was syncing the **full body of every loaded skill** (4k–20k chars) into Chorus session transcripts, drowning out real progress, questions, and results. This drops that harness-injected synthetic content.

Implements idea `24ce103f` (Chorus 0.12.1) via OpenSpec change `daemon-skip-synthetic-transcript`.

## Root cause (verified, not assumed)

Captured real `claude -p --output-format stream-json --verbose` stdout (the stream the daemon actually reads, CLI 2.1.195): a loaded skill body arrives as a `type:"user"` envelope with **`isSynthetic: true`** carrying a `text` block. `extractTranscriptText` kept all `text` blocks with no synthetic check, so it leaked the body.

> ⚠️ Field-name trap: the on-disk transcript JSONL marks the same message `isMeta`, but the daemon does **not** read that file. Keying on `isMeta` would be a silent no-op. The fix keys on `isSynthetic`.

## Change (`cli/upload-hooks.mjs`)

- Drop `type:"user"` + `isSynthetic === true` envelopes before text extraction — **structural match only**, no size/content heuristic (a heuristic would false-positive on the agent's own replies that quote skill strings).
- Add `stripSystemReminders()` — removes `<system-reminder>…</system-reminder>` spans from retained text (defense-in-depth); a reminder-only message is dropped.
- **Claude Code dialect only** — the codex `item.completed` path is untouched.
- Always on, no config knob. No server / schema / API change.

## Verification

- 6 new unit tests (synthetic drop, human-instruction kept, quoted-skill-string-in-reply kept, synthetic-assistant kept, reminder strip, reminder-only drop). Full suite 49/49, `tsc --noEmit` clean, `lint` 0 errors.
- **Local e2e with before/after control:** a real captured skill-loading stream driven through the real upload pipeline → real local server → real PGlite → real read-back API. Pre-fix kept the 13.9KB skill body (leaks); the fix stored 435 chars of genuine content, skill body absent, while human instruction + replies + error all synced. q2 scope (MCP instructions / CLAUDE.md / deferred-tool listing) verified absent.
- Reviews: proposal-reviewer PASS (round 2), task-reviewer PASS (filter) + PASS WITH NOTES (e2e), code-reviewer gateway PASS WITH NOTES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)