### PR TITLE
feat(graph): desktop hover tooltip on resource-graph nodes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1602,6 +1602,9 @@
     "outline": {
       "expand": "Expand {count} children",
       "collapse": "Collapse children"
+    },
+    "tooltip": {
+      "loading": "Loading…"
     }
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1603,6 +1603,9 @@
     "outline": {
       "expand": "展开 {count} 个子节点",
       "collapse": "收起子节点"
+    },
+    "tooltip": {
+      "loading": "加载中…"
     }
   }
 }

--- a/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/README.md
+++ b/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/README.md
@@ -1,0 +1,3 @@
+# add-graph-node-hover-tooltip
+
+Desktop hover tooltip on resource-graph nodes showing the full title and a status/type badge, fetched on demand per entity.

--- a/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/design.md
+++ b/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/design.md
@@ -1,0 +1,106 @@
+# Design — Resource-Graph Node Hover Tooltip
+
+## Context
+
+The desktop canvas (`mindmap-canvas.tsx`) already tracks the hovered node via
+`hoverId` (set from a pointer-move hit-test against the live rendered card
+rects) and knows each node's graph-space center plus the view transform
+(`viewRef = { scale, tx, ty }`). That's everything needed to anchor a DOM
+overlay beside the hovered card. The aggregation payload intentionally carries
+only `{ id, type, title, childCount, … }`, so the status/type for the tooltip
+comes from a per-entity fetch.
+
+## Goals / Non-Goals
+
+**Goals**
+- Desktop-only hover tooltip: full title + status (or document type) badge.
+- Fetch-on-hover, debounced + cached, with a loading state.
+- Anchored beside the card; appears after a short delay; clears on mouse-out.
+- Zero change to layout, tween, SSE, the aggregation service, or the mobile
+  outline. Additive to the existing hover lineage-highlight.
+
+**Non-Goals**
+- Mobile outline tooltip (no hover on touch; tap opens the panel).
+- Rich detail (description, assignee, dates, AC progress, presence) — explicitly
+  cut in elaboration; status is the only thing the graph can't already show.
+- Click-to-pin popover behavior (would collide with the click→side-panel
+  contract).
+
+## Decisions
+
+### D1 — DOM overlay, not canvas-drawn
+
+The tooltip is a React DOM element absolutely positioned over the canvas
+container, NOT painted into the canvas. Rich text + a styled badge +
+accessibility are trivial in DOM and impractical in Canvas 2D. The canvas
+container is already `position: absolute inset-0` inside a `relative` parent, so
+a sibling absolutely-positioned tooltip layers cleanly on top.
+
+### D2 — Anchor math
+
+When `hoverId` is set, compute the hovered node's **screen** position from its
+rendered graph-space center: `screenX = x * scale + tx`, `screenY = y * scale +
+ty` (the inverse of the painter's transform). Anchor the tooltip to the right
+edge of the card (`screenX + (CARD_W/2)*scale + gap`), vertically centered;
+flip to the left / clamp within the container when it would overflow the right
+edge. The tooltip reads the live rendered center (the same `renderedRef` source
+the hit-test uses) so it stays put while the card is settled.
+
+### D3 — Fetch-on-hover hook
+
+A `useNodeDetail(hoverId, type)` hook:
+- Debounces ~200ms after `hoverId` settles before fetching (a fast hover sweep
+  cancels the pending fetch — no request burst).
+- Caches results in a `Map<uuid, NodeDetail>` for the lifetime of the view, so
+  re-hovering a node is instant.
+- Exposes `{ detail, loading }`. While loading, the tooltip shows the title we
+  already have (from the node payload) + a small loading indicator for the
+  badge; when the fetch resolves, the badge fills in.
+- Reuses the existing REST endpoints — `GET /api/ideas/[uuid]`,
+  `/api/proposals/[uuid]`, `/api/tasks/[uuid]`, `/api/documents/[uuid]` — via
+  `fetch`, aborting an in-flight request when `hoverId` changes (same
+  AbortController idiom already used in `resource-graph.tsx`'s document fetch).
+
+### D4 — Status/type → badge
+
+A small mapping renders the badge per entity type:
+- **Idea** → `idea.status` (open / elaborating / elaborated).
+- **Proposal** → `proposal.status` (draft / approved / rejected / revised).
+- **Task** → `task.status` (open / assigned / in_progress / to_verify / done /
+  closed).
+- **Document** → `document.type` (prd / tech_design / adr / spec / guide /
+  report) — documents have no lifecycle status.
+
+Badge color/label reuses the existing badge conventions used in the
+tasks/proposals/ideas surfaces (shadcn `Badge` + the project's status-color
+helpers) so the tooltip reads consistently with the rest of the app. All
+user-facing labels go through `t()` (en + zh).
+
+### D5 — Interaction & lifecycle
+
+- The tooltip mounts only when `hoverId` is non-null AND the desktop canvas is
+  the active renderer (the parent already chooses canvas vs. outline by
+  viewport; the tooltip lives inside the canvas component, so it's desktop-only
+  by construction).
+- A short appear-delay (handled by the hook's debounce) avoids flicker on a
+  hover sweep; mouse-out clears `hoverId` → tooltip unmounts.
+- Pointer-events on the tooltip are disabled (`pointer-events-none`) so it never
+  intercepts a click meant for the canvas, and never blocks moving onto an
+  adjacent node.
+
+## Risks / Trade-offs
+
+- **Stale-while-revalidate:** a cached status could lag a live change. Acceptable
+  for a hover preview; the SSE live-update path still reconciles the graph
+  structure, and re-opening the side panel shows authoritative state. (Could
+  invalidate the cache on the existing entity-change SSE events as a later
+  refinement — not required for v1.)
+- **Anchor during tween:** while a card is mid-animation its rendered center
+  moves; reading the live `renderedRef` keeps the anchor attached, but a tooltip
+  is unlikely to be open mid-expand (hover and expand are distinct gestures).
+  Acceptable.
+
+## Migration
+
+Pure front-end addition. No data migration, no API change (reuses existing GET
+endpoints), no schema change.

--- a/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/proposal.md
+++ b/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/proposal.md
@@ -1,0 +1,67 @@
+# Add Desktop Hover Tooltip to Resource-Graph Nodes
+
+## Why
+
+The resource-graph node cards keep a compact layout: they show only a type
+eyebrow and a title, and the title is truncated to fit the card. On the desktop
+canvas a user who wants to know an entity's current state — or read a title that
+got cut off — has to click the node to open its side panel. A lightweight hover
+preview closes that gap without leaving the graph.
+
+The preview should surface what the graph itself does **not** already show. The
+graph already conveys structure (which idea derives what, how many children a
+hub has via its `+N` count, the dependency chain), so repeating derivative
+counts or document counts in a tooltip is redundant. The one thing not visible
+on a node card is its **lifecycle status**. So the tooltip is deliberately
+minimal: the full (untruncated) title plus a single status badge.
+
+## What Changes
+
+Add a hover tooltip to the desktop resource-graph canvas (`mindmap-canvas.tsx`).
+On hover (after a short delay) a tooltip anchored beside the hovered node card
+shows:
+
+- the entity's **full title** (untruncated), and
+- a **status badge**: for Idea / Proposal / Task the entity's lifecycle status;
+  for a Document (which has no status) its document type (e.g. `prd`,
+  `tech_design`). Badge styling reuses the existing per-entity badge
+  conventions.
+
+Details:
+
+- **Desktop canvas only.** The mobile vertical outline is out of scope — a touch
+  device has no hover semantics, and tapping an outline row already opens the
+  side panel.
+- **Fetch on hover.** The tooltip's data is fetched per entity on hover (reusing
+  the existing REST endpoints `GET /api/ideas|proposals|tasks|documents/[uuid]`),
+  not baked into the aggregation payload — keeping that payload lean and the
+  status always fresh. The fetch is debounced (so a fast hover sweep across
+  nodes doesn't fire a burst of requests) and cached per entity UUID for the
+  duration of the view.
+- **Anchored, not mouse-following.** The tooltip is positioned beside the node
+  card (not tracking the cursor), so it stays stable among dense nodes. It
+  appears after a short hover delay and disappears on mouse-out, and does not
+  occlude the hovered card.
+- **Coexists with the existing hover behavior.** Hover already drives the
+  lineage focus highlight; the tooltip is additive and does not change that.
+
+This is an **ADDED** capability requirement on `project-resource-graph`; no
+existing requirement changes. No aggregation/service change, no schema change.
+
+## Capabilities
+
+- `project-resource-graph` (ADDED) — a desktop hover tooltip that previews a
+  node's full title and status/type badge, fetched on demand.
+
+## Impact
+
+- **Code:** a small data hook (fetch-on-hover with debounce + per-uuid cache),
+  a tooltip overlay component (DOM, shadcn-style, absolutely positioned over the
+  canvas), and wiring in `mindmap-canvas.tsx` to map the existing `hoverId` +
+  node screen position to the tooltip anchor. No change to
+  `resource-graph.service.ts`, `resource-graph-tree-layout.ts`, or the mobile
+  outline.
+- **i18n:** any new user-facing strings (e.g. a loading label, status labels if
+  not already keyed) added to both `en` and `zh`.
+- **Tests:** unit/component coverage for the fetch hook (debounce + cache) and
+  the tooltip content mapping (title + correct badge per type).

--- a/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/specs/project-resource-graph/spec.md
+++ b/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/specs/project-resource-graph/spec.md
@@ -1,0 +1,47 @@
+# project-resource-graph Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Desktop hover tooltip previewing a node's title and status
+
+On the desktop (canvas) rendering of the resource graph, hovering a node SHALL,
+after a short delay, display a tooltip anchored beside that node's card. The
+tooltip SHALL show the entity's full (untruncated) title and a single badge
+conveying the entity's state: for an Idea, Proposal, or Task the badge SHALL
+show that entity's lifecycle status; for a Document, which has no lifecycle
+status, the badge SHALL show its document type. The tooltip's detail SHALL be
+fetched on demand per entity (reusing the existing per-entity read endpoints)
+rather than carried in the project aggregation payload, and repeated fetches for
+the same node SHALL be avoided (cached for the duration of the view) and a fast
+hover sweep across nodes SHALL NOT issue a request for every node passed over.
+The tooltip SHALL be anchored to the node card (not tracking the cursor), SHALL
+NOT occlude the hovered card, SHALL disappear when the pointer leaves the node,
+and SHALL NOT interfere with the existing hover lineage-highlight or with
+clicking a node. This tooltip is desktop-only; the mobile vertical outline SHALL
+NOT show it. All user-facing text in the tooltip SHALL be localized in both
+supported locales.
+
+#### Scenario: Hovering a node shows its title and status badge
+
+- **WHEN** a user hovers a node on the desktop graph canvas and pauses briefly
+- **THEN** a tooltip appears beside that node's card showing the entity's full title and a badge with its lifecycle status (or, for a Document, its document type)
+
+#### Scenario: Tooltip detail is fetched on demand and reused
+
+- **WHEN** a node is hovered for the first time
+- **THEN** the tooltip's status/type detail is fetched for that single entity via the existing per-entity read endpoint, and hovering the same node again reuses the cached detail without re-fetching
+
+#### Scenario: A fast hover sweep does not fire a request per node
+
+- **WHEN** the pointer moves quickly across many nodes without pausing
+- **THEN** no per-node detail request is issued for nodes merely passed over (the fetch is debounced until the hover settles)
+
+#### Scenario: Tooltip clears on mouse-out and does not block interaction
+
+- **WHEN** the pointer leaves the hovered node
+- **THEN** the tooltip disappears, and while shown it neither occludes the hovered card nor intercepts clicks intended for the canvas
+
+#### Scenario: Tooltip is desktop-only
+
+- **WHEN** the graph is rendered as the mobile vertical outline (narrow viewport)
+- **THEN** no hover tooltip is shown (tapping a row opens the entity's side panel instead)

--- a/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/tasks.md
+++ b/openspec/changes/archive/2026-06-30-add-graph-node-hover-tooltip/tasks.md
@@ -1,0 +1,8 @@
+# Tasks — Resource-Graph Node Hover Tooltip
+
+## 1. Fetch-on-hover data hook
+- [ ] 1.1 `useNodeDetail` hook: debounced fetch per hovered entity (GET /api/{ideas|proposals|tasks|documents}/[uuid]), per-uuid cache, AbortController on hover change, `{ detail, loading }` output, with unit tests for debounce + cache.
+
+## 2. Tooltip overlay + canvas wiring
+- [ ] 2.1 DOM tooltip overlay component (shadcn-style): full title + status/type badge per entity type, reusing existing badge conventions; `pointer-events-none`; i18n en+zh.
+- [ ] 2.2 Wire into `mindmap-canvas.tsx`: anchor from hoverId + rendered center + view transform (right edge, flip/clamp on overflow); short appear delay; clears on mouse-out; coexists with lineage highlight. Component test for content mapping + desktop-only behavior.

--- a/openspec/specs/project-resource-graph/spec.md
+++ b/openspec/specs/project-resource-graph/spec.md
@@ -238,3 +238,47 @@ lose the user's expansion.
 - **WHEN** a user activates a node's expand affordance, or activates the node body, in the vertical outline
 - **THEN** the affordance toggles that node's subtree, and activating the body opens the same per-entity side panel the desktop view opens
 
+### Requirement: Desktop hover tooltip previewing a node's title and status
+
+On the desktop (canvas) rendering of the resource graph, hovering a node SHALL,
+after a short delay, display a tooltip anchored beside that node's card. The
+tooltip SHALL show the entity's full (untruncated) title and a single badge
+conveying the entity's state: for an Idea, Proposal, or Task the badge SHALL
+show that entity's lifecycle status; for a Document, which has no lifecycle
+status, the badge SHALL show its document type. The tooltip's detail SHALL be
+fetched on demand per entity (reusing the existing per-entity read endpoints)
+rather than carried in the project aggregation payload, and repeated fetches for
+the same node SHALL be avoided (cached for the duration of the view) and a fast
+hover sweep across nodes SHALL NOT issue a request for every node passed over.
+The tooltip SHALL be anchored to the node card (not tracking the cursor), SHALL
+NOT occlude the hovered card, SHALL disappear when the pointer leaves the node,
+and SHALL NOT interfere with the existing hover lineage-highlight or with
+clicking a node. This tooltip is desktop-only; the mobile vertical outline SHALL
+NOT show it. All user-facing text in the tooltip SHALL be localized in both
+supported locales.
+
+#### Scenario: Hovering a node shows its title and status badge
+
+- **WHEN** a user hovers a node on the desktop graph canvas and pauses briefly
+- **THEN** a tooltip appears beside that node's card showing the entity's full title and a badge with its lifecycle status (or, for a Document, its document type)
+
+#### Scenario: Tooltip detail is fetched on demand and reused
+
+- **WHEN** a node is hovered for the first time
+- **THEN** the tooltip's status/type detail is fetched for that single entity via the existing per-entity read endpoint, and hovering the same node again reuses the cached detail without re-fetching
+
+#### Scenario: A fast hover sweep does not fire a request per node
+
+- **WHEN** the pointer moves quickly across many nodes without pausing
+- **THEN** no per-node detail request is issued for nodes merely passed over (the fetch is debounced until the hover settles)
+
+#### Scenario: Tooltip clears on mouse-out and does not block interaction
+
+- **WHEN** the pointer leaves the hovered node
+- **THEN** the tooltip disappears, and while shown it neither occludes the hovered card nor intercepts clicks intended for the canvas
+
+#### Scenario: Tooltip is desktop-only
+
+- **WHEN** the graph is rendered as the mobile vertical outline (narrow viewport)
+- **THEN** no hover tooltip is shown (tapping a row opens the entity's side panel instead)
+

--- a/src/app/(dashboard)/projects/[uuid]/graph/__tests__/node-tooltip.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/__tests__/node-tooltip.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+//
+// Component coverage for NodeTooltip (resource-graph hover tooltip, design
+// D1/D4). Verifies that the DOM overlay:
+//   - renders the entity's FULL (untruncated) title;
+//   - renders the correct single badge per entity type — lifecycle STATUS for
+//     idea/proposal/task, document TYPE for a document — reusing the existing
+//     status.*/documents.type* i18n keys;
+//   - shows a loading indicator (not a badge) while the detail fetch is in
+//     flight, with the title still visible;
+//   - carries pointer-events-none on its root so it never blocks a canvas click;
+//   - renders nothing meaningful (no badge) when there is no resolved detail.
+//
+// The "no hover" case (hoverId → null) is owned by the canvas, which simply does
+// not mount this component; here we cover the data-mapping + loading contract.
+//
+// next-intl is mocked with an echo translator so a label asserts as its key
+// (e.g. t("status.inProgress") → "status.inProgress"), exactly like the outline
+// suite — keeping the test independent of the actual translations.
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import { NodeTooltip } from "../node-tooltip";
+
+describe("NodeTooltip", () => {
+  it("renders the full untruncated title and an idea status badge", () => {
+    const longTitle =
+      "A deliberately very long idea title that the node card would have truncated to fit its 200px width";
+    const { getByTestId, getByText, queryByTestId } = render(
+      <NodeTooltip
+        title={longTitle}
+        type="idea"
+        detail={{ uuid: "idea-1", status: "elaborating" }}
+        loading={false}
+        x={120}
+        y={80}
+      />,
+    );
+
+    // FULL title (not truncated).
+    expect(getByText(longTitle)).toBeTruthy();
+    // Idea lifecycle status → the existing status.* key.
+    expect(getByText("status.elaborating")).toBeTruthy();
+    // No loading indicator once resolved.
+    expect(queryByTestId("node-tooltip-loading")).toBeNull();
+
+    // Anchored via inline left/top from the screen-anchor props.
+    const root = getByTestId("node-tooltip");
+    expect((root as HTMLElement).style.left).toBe("120px");
+    expect((root as HTMLElement).style.top).toBe("80px");
+    // pointer-events-none so it never intercepts a canvas click.
+    expect(root.className).toContain("pointer-events-none");
+  });
+
+  it("renders a task lifecycle status badge (snake_case enum → camelCase key)", () => {
+    const { getByText } = render(
+      <NodeTooltip
+        title="Task A"
+        type="task"
+        detail={{ uuid: "task-1", status: "in_progress" }}
+        loading={false}
+        x={0}
+        y={0}
+      />,
+    );
+    // task in_progress maps to the existing status.inProgress key.
+    expect(getByText("status.inProgress")).toBeTruthy();
+  });
+
+  it("renders a proposal status badge including the pending → pendingReview key", () => {
+    const { getByText } = render(
+      <NodeTooltip
+        title="Proposal one"
+        type="proposal"
+        detail={{ uuid: "prop-1", status: "pending" }}
+        loading={false}
+        x={0}
+        y={0}
+      />,
+    );
+    expect(getByText("status.pendingReview")).toBeTruthy();
+  });
+
+  it("renders a document TYPE badge (not a status) for a document node", () => {
+    const { getByText } = render(
+      <NodeTooltip
+        title="Tech Design doc"
+        type="document"
+        detail={{ uuid: "doc-1", docType: "tech_design" }}
+        loading={false}
+        x={0}
+        y={0}
+      />,
+    );
+    // document → its type, via the existing documents.type* key.
+    expect(getByText("documents.typeTechDesign")).toBeTruthy();
+  });
+
+  it("shows the title + a loading indicator (no badge) while detail is loading", () => {
+    const { getByText, getByTestId, queryByText } = render(
+      <NodeTooltip
+        title="Loading idea"
+        type="idea"
+        detail={null}
+        loading={true}
+        x={0}
+        y={0}
+      />,
+    );
+    // Title (already known from the node payload) stays visible.
+    expect(getByText("Loading idea")).toBeTruthy();
+    // Loading indicator shown in place of the badge.
+    expect(getByTestId("node-tooltip-loading")).toBeTruthy();
+    expect(getByText("graph.tooltip.loading")).toBeTruthy();
+    // No status/type badge yet.
+    expect(queryByText(/^status\./)).toBeNull();
+  });
+
+  it("renders no badge and no loading indicator when detail is unresolved and not loading", () => {
+    const { getByText, queryByText, queryByTestId } = render(
+      <NodeTooltip
+        title="No detail yet"
+        type="task"
+        detail={null}
+        loading={false}
+        x={0}
+        y={0}
+      />,
+    );
+    // Title still rendered; but no badge could be derived from a null detail,
+    // and we are no longer loading — so neither a badge nor the loading label
+    // shows (the slot stays empty rather than implying perpetual loading).
+    expect(getByText("No detail yet")).toBeTruthy();
+    expect(queryByText(/^status\./)).toBeNull();
+    expect(queryByTestId("node-tooltip-loading")).toBeNull();
+    expect(queryByText("graph.tooltip.loading")).toBeNull();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/graph/__tests__/use-node-detail.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/__tests__/use-node-detail.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+//
+// Unit coverage for useNodeDetail (fetch-on-hover node-detail hook, design D3).
+// Three behaviours under test:
+//   1. Debounce — rapidly changing hoverId across several ids then settling
+//      fires exactly ONE fetch, for the settled id (no request per id swept).
+//   2. Cache — hovering the same uuid a second time does not refetch.
+//   3. Abort / stale-safety — a stale earlier response can't overwrite the
+//      newer hovered id's detail.
+//
+// Fake timers drive the ~200ms debounce; fetch is stubbed. The hook is
+// framework-light (no canvas/DOM), so renderHook + rerender is enough.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNodeDetail } from "../use-node-detail";
+
+// Build a { success, data } envelope Response-like object.
+function ok(data: Record<string, unknown>) {
+  return {
+    ok: true,
+    json: async () => ({ success: true, data }),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("useNodeDetail", () => {
+  it("debounces a fast hover sweep into a single fetch for the settled id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({ status: "open" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useNodeDetail(id, "task"),
+      { initialProps: { id: "a" as string | null } },
+    );
+
+    // Sweep across several ids faster than the debounce window — each change
+    // cancels the prior pending timer, so no fetch fires for ids passed over.
+    rerender({ id: "b" });
+    rerender({ id: "c" });
+    rerender({ id: "d" });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Settle on "d" and let the debounce elapse.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/tasks/d",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    expect(result.current.detail).toEqual({ uuid: "d", status: "open" });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("does not refetch a uuid that is already cached", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({ status: "done" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useNodeDetail(id, "task"),
+      { initialProps: { id: "x" as string | null } },
+    );
+
+    // First hover of "x" → one fetch, result cached.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(result.current.detail).toEqual({ uuid: "x", status: "done" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Hover away, then back to "x" → cache hit, no second fetch, no loading.
+    rerender({ id: null });
+    rerender({ id: "x" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.detail).toEqual({ uuid: "x", status: "done" });
+  });
+
+  it("does not let a stale earlier response overwrite the newer hovered id", async () => {
+    // Hand back deferred promises keyed by url so the test controls which
+    // response resolves first. The first request (for the stale id) is made to
+    // resolve LAST, after we've already hovered & resolved a newer id.
+    const deferred = new Map<
+      string,
+      { resolve: (r: Response) => void; aborted: () => boolean }
+    >();
+    const fetchMock = vi.fn(
+      (url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((resolve) => {
+          deferred.set(url, {
+            resolve,
+            aborted: () => init?.signal?.aborted ?? false,
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useNodeDetail(id, "task"),
+      { initialProps: { id: "stale" as string | null } },
+    );
+
+    // Fire the fetch for "stale" (debounce elapses) but DON'T resolve it yet.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/tasks/stale", expect.anything());
+
+    // Move to a newer id "fresh"; this aborts the "stale" request and starts a
+    // new fetch once its debounce elapses.
+    rerender({ id: "fresh" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/tasks/fresh", expect.anything());
+
+    // The newer ("fresh") response resolves first.
+    await act(async () => {
+      deferred.get("/api/tasks/fresh")!.resolve(ok({ status: "in_progress" }));
+    });
+    expect(result.current.detail).toEqual({
+      uuid: "fresh",
+      status: "in_progress",
+    });
+
+    // Now the stale request's response arrives LATE. Its signal was aborted on
+    // the hover change, so the hook must ignore it and keep "fresh".
+    const staleEntry = deferred.get("/api/tasks/stale")!;
+    expect(staleEntry.aborted()).toBe(true);
+    await act(async () => {
+      staleEntry.resolve(ok({ status: "open" }));
+    });
+
+    expect(result.current.detail).toEqual({
+      uuid: "fresh",
+      status: "in_progress",
+    });
+  });
+
+  it("maps a document node to docType rather than status", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({ type: "prd" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useNodeDetail("doc1", "document"));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(result.current.detail).toEqual({ uuid: "doc1", docType: "prd" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/documents/doc1",
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx
@@ -50,6 +50,8 @@ import type {
   ResourceGraphNodeType as NodeType,
   ResourceGraphEdgeKind as EdgeKind,
 } from "@/services/resource-graph.service";
+import { useNodeDetail } from "./use-node-detail";
+import { NodeTooltip } from "./node-tooltip";
 
 // --- Public data shapes (Tech Design D5) ------------------------------------
 //
@@ -137,6 +139,17 @@ const BTN_W = 40;
 const TWEEN_MS = 300; // coordinate tween + fade duration (Tech Design D2)
 const BG = "#FAF8F4";
 
+// Hover-tooltip anchor geometry (screen pixels). The tooltip is anchored beside
+// the hovered card (Tech Design D2): preferred to the card's right edge with a
+// small gap, vertically centered; flipped to the left / clamped inside the
+// container on overflow. These are coarse layout estimates of the DOM tooltip's
+// box (its real size varies with the title) used only to choose a side and to
+// clamp — the tooltip itself is `max-w-[260px]`.
+const TOOLTIP_GAP = 12; // px gap between the card edge and the tooltip
+const TOOLTIP_EST_W = 260; // matches the tooltip's max width (for flip/clamp)
+const TOOLTIP_EST_H = 64; // approximate height (title + badge row)
+const TOOLTIP_MARGIN = 8; // keep this far from the container edges when clamping
+
 // --- Tween bookkeeping ------------------------------------------------------
 //
 // One animation record per visible node. `from`/`to` are graph-space target
@@ -190,6 +203,23 @@ export function MindMapCanvas({
 
   const [hoverId, setHoverId] = useState<string | null>(null);
 
+  // --- Hover tooltip (Tech Design D1/D2/D4) ---------------------------------
+  // Additive overlay: the hovered node's full title + a status/type badge,
+  // fetched on demand via useNodeDetail (debounced + cached). The anchor is a
+  // screen-pixel position recomputed from the live rendered center + the view
+  // transform on each paint while a node is hovered (see renderFrame). Stored as
+  // state so the DOM tooltip re-renders as the camera/card moves. This is purely
+  // additive — it does NOT touch hoverId-driven focusLineage below.
+  const [tooltipAnchor, setTooltipAnchor] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  // Mirror of tooltipAnchor read inside the rAF painter — lets the painter clear
+  // a stale anchor without listing tooltipAnchor as a renderFrame dependency
+  // (which would rebuild the painter every time the anchor nudges).
+  const tooltipAnchorRef = useRef(tooltipAnchor);
+  tooltipAnchorRef.current = tooltipAnchor;
+
   // --- Deterministic layout (Tech Design D1) --------------------------------
   // Pure: identical visible node/link sets + expand state → identical coords.
   const layout = useMemo(
@@ -202,6 +232,15 @@ export function MindMapCanvas({
     for (const n of nodes) m.set(n.id, n);
     return m;
   }, [nodes]);
+
+  // The hovered node + its type drive the tooltip's fetch-on-hover detail. The
+  // hook is debounced + cached + abort-safe; passing null when nothing is
+  // hovered clears it. The title shown comes straight from the node payload.
+  const hoveredNode = hoverId ? nodeById.get(hoverId) ?? null : null;
+  const { detail: hoverDetail, loading: hoverLoading } = useNodeDetail(
+    hoverId,
+    hoveredNode?.type ?? null,
+  );
 
   // --- Directed tree-spine maps -------------------------------------------
   // The layout resolves exactly one tree-spine parent per non-root node (idea
@@ -442,6 +481,47 @@ export function MindMapCanvas({
       });
     }
 
+    // 3) Hover-tooltip anchor (Tech Design D2). Compute the hovered card's
+    // SCREEN position from its LIVE rendered center + the view transform (the
+    // inverse of screenToGraph), then anchor the DOM tooltip beside the card:
+    // preferred to the right edge with a gap, vertically centered; flipped to
+    // the left and/or clamped inside the container when it would overflow.
+    // Reading the live `rendered` center keeps the anchor attached while the
+    // card tweens/pans/zooms. Written to React state only on meaningful change
+    // (epsilon-guarded) so the DOM tooltip follows without per-frame churn.
+    const hovered = hoverId ? rendered.get(hoverId) : undefined;
+    const hoveredExiting = hoverId ? anims.get(hoverId)?.exit : false;
+    if (hovered && !hoveredExiting) {
+      const centerX = hovered.x * view.scale + view.tx;
+      const centerY = hovered.y * view.scale + view.ty;
+      const halfW = (CARD_W / 2) * view.scale;
+      // Prefer the right side. Flip to the left if the right placement would run
+      // past the container's right edge.
+      const rightX = centerX + halfW + TOOLTIP_GAP;
+      const leftX = centerX - halfW - TOOLTIP_GAP - TOOLTIP_EST_W;
+      let ax =
+        rightX + TOOLTIP_EST_W <= width - TOOLTIP_MARGIN ? rightX : leftX;
+      // Final horizontal clamp inside the container (covers the degenerate case
+      // where neither side fully fits).
+      ax = Math.max(
+        TOOLTIP_MARGIN,
+        Math.min(ax, width - TOOLTIP_EST_W - TOOLTIP_MARGIN),
+      );
+      // Vertically centered on the card, then clamped inside the container.
+      let ay = centerY - TOOLTIP_EST_H / 2;
+      ay = Math.max(
+        TOOLTIP_MARGIN,
+        Math.min(ay, height - TOOLTIP_EST_H - TOOLTIP_MARGIN),
+      );
+      setTooltipAnchor((prev) =>
+        prev && Math.abs(prev.x - ax) < 0.5 && Math.abs(prev.y - ay) < 0.5
+          ? prev
+          : { x: ax, y: ay },
+      );
+    } else if (tooltipAnchorRef.current !== null) {
+      setTooltipAnchor(null);
+    }
+
     if (animating || hasActivePresence(getPresence, nodes)) {
       scheduleRender();
     }
@@ -626,6 +706,21 @@ export function MindMapCanvas({
         onPointerLeave={() => setHoverId(null)}
         onWheel={handleWheel}
       />
+      {/* Hover tooltip — a DOM overlay above the canvas (Tech Design D1).
+          Mounts only while a node is hovered AND its anchor is resolved; the
+          hook's debounce gives the short appear-delay, and a mouse-out
+          (hoverId → null) unmounts it. pointer-events-none lives on the tooltip
+          root so it never intercepts a canvas click. */}
+      {hoveredNode && tooltipAnchor && (
+        <NodeTooltip
+          title={hoveredNode.title}
+          type={hoveredNode.type}
+          detail={hoverDetail}
+          loading={hoverLoading}
+          x={tooltipAnchor.x}
+          y={tooltipAnchor.y}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/projects/[uuid]/graph/node-tooltip.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/node-tooltip.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+// Resource-graph hover tooltip overlay (desktop). Tech Design D1/D4.
+//
+// A DOM element absolutely positioned over the canvas container — NOT painted
+// into the canvas (rich text + a styled badge + a11y are trivial in DOM and
+// impractical in Canvas 2D). It previews the one thing the node card can't
+// already show: the entity's FULL (untruncated) title + a single badge —
+// lifecycle STATUS for idea/proposal/task, or document TYPE for a Document
+// (which has no status).
+//
+// Badge styling/colors and i18n labels are REUSED verbatim from the existing
+// per-entity surfaces (tasks kanban-board, proposals proposal-kanban, ideas
+// idea-detail-panel, documents doc-type-config) — the tooltip must read the
+// same as the rest of the app. The status sets are derived from the real
+// Prisma enums (Idea: open|elaborating|elaborated; Proposal: draft|pending|
+// approved|rejected|revised; Task: open|assigned|in_progress|to_verify|done|
+// closed), NOT the design doc's (intentionally incomplete) enumeration.
+//
+// The data ({ status?, docType? }) is supplied by useNodeDetail (debounced +
+// cached fetch-on-hover). While `loading`, the title is shown with a small
+// spinner in place of the badge. The root carries `pointer-events-none` so it
+// never intercepts a click meant for the canvas, and renders nothing when there
+// is no hovered node.
+
+import { useTranslations } from "next-intl";
+import { Loader2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import type { NodeDetail, NodeType } from "./use-node-detail";
+
+// --- Status → badge color (verbatim from the existing per-entity surfaces) ---
+//
+// Each entry copies the surface's own inline `statusColors` map so the tooltip
+// badge matches that surface exactly. Where a real enum value isn't colored by
+// its surface (proposal `rejected`/`revised`), we reuse the shared palette
+// already used elsewhere for the same semantics (rejected → destructive red of
+// status.rejected; revised → the neutral draft chip).
+const IDEA_STATUS_COLOR: Record<string, string> = {
+  open: "bg-[#FFF3E0] text-[#E65100]",
+  elaborating: "bg-[#E3F2FD] text-[#1976D2]",
+  elaborated: "bg-[#E0F2F1] text-[#00796B]",
+};
+
+const PROPOSAL_STATUS_COLOR: Record<string, string> = {
+  draft: "bg-[#F5F5F5] text-[#6B6B6B]",
+  pending: "bg-[#FFF3E0] text-[#E65100]",
+  approved: "bg-[#E8F5E9] text-[#2E7D32]",
+  rejected: "bg-[#FFEBEE] text-[#C62828]",
+  revised: "bg-[#F5F5F5] text-[#6B6B6B]",
+  closed: "bg-[#F5F5F5] text-[#9A9A9A]",
+};
+
+const TASK_STATUS_COLOR: Record<string, string> = {
+  open: "bg-[#FFF3E0] text-[#E65100]",
+  assigned: "bg-[#E3F2FD] text-[#1976D2]",
+  in_progress: "bg-[#E8F5E9] text-[#5A9E6F]",
+  to_verify: "bg-[#F3E5F5] text-[#7B1FA2]",
+  done: "bg-[#E0F2F1] text-[#00796B]",
+  closed: "bg-[#F5F5F5] text-[#9A9A9A]",
+};
+
+// --- Status → i18n label key suffix (reuses the existing `status.*` keys) -----
+//
+// The surfaces map a raw status to a `status.<suffix>` key (camelCased where the
+// enum is snake_cased). We mirror that so we reuse the keys already present in
+// both locales rather than adding new ones.
+const STATUS_I18N: Record<string, string> = {
+  open: "open",
+  // idea
+  elaborating: "elaborating",
+  elaborated: "elaborated",
+  // proposal
+  draft: "draft",
+  pending: "pendingReview",
+  approved: "approved",
+  rejected: "rejected",
+  revised: "draft", // no dedicated key; surfaces don't color it either
+  // task
+  assigned: "assigned",
+  in_progress: "inProgress",
+  to_verify: "toVerify",
+  done: "done",
+  closed: "closed",
+};
+
+// --- Document type → badge color + label key ---------------------------------
+//
+// doc-type-config.ts only configures prd/spec/design/note/report/other, but the
+// real Document.type enum (and the graph) also include tech_design/adr/guide.
+// The `documents.type*` i18n keys for ALL of these already exist in both
+// locales, so we map every value here (colors reuse the doc-type palette).
+const DOC_TYPE_COLOR: Record<string, string> = {
+  prd: "bg-[#E3F2FD] text-[#1976D2]",
+  tech_design: "bg-[#F3E5F5] text-[#7B1FA2]",
+  adr: "bg-[#FFF8E1] text-[#9A6B00]",
+  spec: "bg-[#E8F5E9] text-[#5A9E6F]",
+  guide: "bg-[#E0F2F1] text-[#00796B]",
+  report: "bg-[#FFF8E1] text-[#9A6B00]",
+  design: "bg-[#F3E5F5] text-[#7B1FA2]",
+  note: "bg-[#FFF3E0] text-[#E65100]",
+  other: "bg-[#F5F5F5] text-[#6B6B6B]",
+};
+
+const DOC_TYPE_I18N: Record<string, string> = {
+  prd: "documents.typePrd",
+  tech_design: "documents.typeTechDesign",
+  adr: "documents.typeAdr",
+  spec: "documents.typeSpec",
+  guide: "documents.typeGuide",
+  report: "documents.typeReport",
+  design: "documents.typeDesign",
+  note: "documents.typeNote",
+  other: "documents.typeOther",
+};
+
+const STATUS_COLOR_BY_TYPE: Record<NodeType, Record<string, string>> = {
+  idea: IDEA_STATUS_COLOR,
+  proposal: PROPOSAL_STATUS_COLOR,
+  task: TASK_STATUS_COLOR,
+  document: {}, // documents use DOC_TYPE_COLOR, not a status map
+};
+
+const NEUTRAL_COLOR = "bg-[#F5F5F5] text-[#6B6B6B]";
+
+export interface NodeTooltipProps {
+  /** The hovered node's full (untruncated) title — already known from the node payload. */
+  title: string;
+  /** The hovered node's entity type. */
+  type: NodeType;
+  /** Resolved detail (status / docType) from useNodeDetail; null while loading or unresolved. */
+  detail: NodeDetail | null;
+  /** True while the per-entity detail fetch is in flight (show a spinner for the badge). */
+  loading: boolean;
+  /** Absolute screen position of the tooltip's top-left, in container pixels. */
+  x: number;
+  y: number;
+}
+
+// Resolve the badge's { color, label } for a node type + its detail. Returns
+// null when there is nothing to show yet (no detail → caller renders a spinner).
+function resolveBadge(
+  type: NodeType,
+  detail: NodeDetail | null,
+  t: ReturnType<typeof useTranslations>,
+): { color: string; label: string } | null {
+  if (!detail) return null;
+  if (type === "document") {
+    const value = detail.docType;
+    if (!value) return null;
+    const color = DOC_TYPE_COLOR[value] ?? NEUTRAL_COLOR;
+    const key = DOC_TYPE_I18N[value];
+    return { color, label: key ? t(key) : value };
+  }
+  const value = detail.status;
+  if (!value) return null;
+  const color = STATUS_COLOR_BY_TYPE[type][value] ?? NEUTRAL_COLOR;
+  const suffix = STATUS_I18N[value];
+  return { color, label: suffix ? t(`status.${suffix}`) : value };
+}
+
+export function NodeTooltip({
+  title,
+  type,
+  detail,
+  loading,
+  x,
+  y,
+}: NodeTooltipProps) {
+  const t = useTranslations();
+  const badge = resolveBadge(type, detail, t);
+
+  return (
+    <div
+      data-testid="node-tooltip"
+      role="tooltip"
+      // pointer-events-none: the tooltip never intercepts a click meant for the
+      // canvas, and never blocks moving the pointer onto an adjacent node.
+      className="pointer-events-none absolute z-20 max-w-[260px] rounded-lg border border-[#EAE4DB] bg-white px-3 py-2 shadow-lg"
+      style={{ left: x, top: y }}
+    >
+      <p className="text-sm font-medium leading-snug text-[#2C2C2C]">{title}</p>
+      <div className="mt-1.5 flex items-center">
+        {badge ? (
+          <Badge className={badge.color}>{badge.label}</Badge>
+        ) : loading ? (
+          // While the detail fetch is in flight (or hasn't resolved yet) show a
+          // small spinner in place of the badge; the title (already known from
+          // the node payload) stays visible above it.
+          <span
+            data-testid="node-tooltip-loading"
+            className="inline-flex items-center gap-1 text-xs text-[#9A9A9A]"
+          >
+            <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+            {t("graph.tooltip.loading")}
+          </span>
+        ) : (
+          // Resolved with no badge to show (e.g. an unknown/failed detail): keep
+          // the slot empty rather than implying a perpetual "loading" state.
+          <span data-testid="node-tooltip-no-badge" className="sr-only">
+            {/* no badge */}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/projects/[uuid]/graph/use-node-detail.ts
+++ b/src/app/(dashboard)/projects/[uuid]/graph/use-node-detail.ts
@@ -1,0 +1,130 @@
+"use client";
+
+// Fetch-on-hover node-detail hook for the resource-graph tooltip (desktop).
+//
+// Per design.md D3: when a node is hovered the tooltip needs the one thing the
+// graph itself can't show — its lifecycle status (or, for a Document, its
+// document type). That detail is NOT carried in the lean aggregation payload,
+// so it's fetched per entity on demand from the existing per-entity REST read
+// endpoints. To keep a fast hover sweep from firing a request burst the fetch
+// is debounced ~200ms after `hoverId` settles, the in-flight request is aborted
+// when the hover moves on (so a slower earlier response can't clobber a newer
+// id's detail), and every resolved detail is cached per-uuid for the hook's
+// lifetime so re-hovering is instant.
+//
+// This hook is intentionally framework-light and unit-testable: no canvas, no
+// DOM, no UI. The tooltip overlay + canvas wiring is a separate task.
+
+import { useEffect, useRef, useState } from "react";
+import type { ResourceGraphNodeType } from "@/services/resource-graph.service";
+import { clientLogger } from "@/lib/logger-client";
+
+export type NodeType = ResourceGraphNodeType;
+
+// What the tooltip badge needs. The title already comes from the node payload,
+// so the hook only resolves the badge dimension: a lifecycle `status` for
+// idea/proposal/task, or `docType` for a Document (which has no status).
+export type NodeDetail = {
+  uuid: string;
+  status?: string;
+  docType?: string;
+};
+
+// Map each node type to its existing per-entity REST read endpoint. Note the
+// pluralized path segments (idea → /api/ideas/...).
+const ENDPOINT: Record<NodeType, string> = {
+  idea: "/api/ideas",
+  proposal: "/api/proposals",
+  task: "/api/tasks",
+  document: "/api/documents",
+};
+
+// Debounce window after `hoverId` settles before a fetch fires (ms). A hoverId
+// change inside this window cancels the pending fetch.
+const DEBOUNCE_MS = 200;
+
+type DetailEnvelope = {
+  success: boolean;
+  data?: { status?: string; type?: string };
+  error?: string;
+};
+
+export function useNodeDetail(
+  hoverId: string | null,
+  type: NodeType | null,
+): { detail: NodeDetail | null; loading: boolean } {
+  const [detail, setDetail] = useState<NodeDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Per-uuid cache for the lifetime of the hook. A cache hit returns instantly
+  // with no refetch and no loading flash.
+  const cacheRef = useRef<Map<string, NodeDetail>>(new Map());
+
+  useEffect(() => {
+    // No hover (or no type) → nothing to show, nothing in flight.
+    if (!hoverId || !type) {
+      setDetail(null);
+      setLoading(false);
+      return;
+    }
+
+    // Cache hit → show immediately, no fetch, no loading.
+    const cached = cacheRef.current.get(hoverId);
+    if (cached) {
+      setDetail(cached);
+      setLoading(false);
+      return;
+    }
+
+    // Cache miss → debounce, then fetch. The cleanup clears the pending timer
+    // (so a fast sweep fires no request for ids merely passed over) and aborts
+    // the in-flight request (so a slower earlier response can't overwrite the
+    // newer hovered id's detail). Mirror the document-fetch AbortController
+    // idiom in resource-graph.tsx.
+    setDetail(null);
+    setLoading(true);
+
+    const ac = new AbortController();
+    const timer = setTimeout(() => {
+      (async () => {
+        try {
+          const res = await fetch(`${ENDPOINT[type]}/${hoverId}`, {
+            signal: ac.signal,
+          });
+          const json: DetailEnvelope = await res.json();
+          if (ac.signal.aborted) return;
+          if (!res.ok || !json.success || !json.data) {
+            clientLogger.error(
+              "Failed to load node detail for graph tooltip:",
+              json.error,
+            );
+            setLoading(false);
+            return;
+          }
+          // Document has no lifecycle status — surface its type as docType.
+          const next: NodeDetail =
+            type === "document"
+              ? { uuid: hoverId, docType: json.data.type }
+              : { uuid: hoverId, status: json.data.status };
+          cacheRef.current.set(hoverId, next);
+          setDetail(next);
+          setLoading(false);
+        } catch (err) {
+          if (ac.signal.aborted) return;
+          clientLogger.error(
+            "Failed to load node detail for graph tooltip:",
+            err,
+          );
+          setLoading(false);
+        }
+      })();
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      ac.abort();
+    };
+  }, [hoverId, type]);
+
+  return { detail, loading };
+}


### PR DESCRIPTION
## Summary

Adds a **desktop-only hover tooltip** to the resource-graph mind-map. Hovering a node card shows a DOM overlay with the entity's **full (untruncated) title + a single status badge** — Idea/Proposal/Task lifecycle status, or document type for Documents. The compact card can't show lifecycle status, so the tooltip is deliberately minimal (title + status); derivative/document counts are already visible on the graph and would be redundant.

Follows the just-merged mind-map redesign (#376); branches off `develop`.

## What's in it

- **`use-node-detail.ts`** (new) — fetch-on-hover hook: ~200ms debounce (a fast hover sweep fires no request), per-uuid `Map` cache, `AbortController` stale-safety. Reuses the existing `GET /api/{ideas|proposals|tasks|documents}/[uuid]` endpoints, keeping the aggregation payload lean and the status fresh. Returns `{ detail, loading }`.
- **`node-tooltip.tsx`** (new) — DOM overlay (`pointer-events-none`) with a shadcn `Badge` whose colors/labels are reused **verbatim** from the tasks/proposals/ideas surfaces (derived from the real Prisma enums, not invented). Loading state shows the already-known title + spinner.
- **`mindmap-canvas.tsx`** (edit) — wires the hook, anchors the tooltip beside the card from the live rendered center + view transform (`screenX = x*scale + tx`; flip/clamp on overflow). Purely additive — the existing hover lineage-highlight (`focusLineage`) is untouched (+95/−0).
- **i18n** — `graph.tooltip.loading` added to en + zh.
- **OpenSpec** — `add-graph-node-hover-tooltip` (ADDED requirement on `project-resource-graph`) archived; cumulative spec updated + mirrored.
- **Tests** — `use-node-detail.test.tsx` (debounce/cache/abort) + `node-tooltip.test.tsx` (title + per-type badge + loading/empty).

## Decisions (from elaboration, idea `10d8acf3`)

Content converged over 3 rounds from "many fields" → **just title + status**. Fetch-on-hover (not aggregation-baked) for freshness + lean payload. Anchored (not mouse-following) for stability among dense nodes. Desktop-only — touch has no hover and the mobile outline taps to open the panel.

## Testing

`npx tsc --noEmit` 0, `pnpm lint` 0 errors, `pnpm test resource-graph use-node-detail node-tooltip` → 8 files / 71 tests pass. Code-review gateway: PASS WITH NOTES (no blockers).

## Follow-ups (not in this PR)

- Cache invalidation on SSE entity-change is deferred (design D-Risks): a cached status can briefly lag a live change; the side panel shows authoritative state. Optional v2.
- `docs/design.pen` hover-tooltip screen not added (Pencil MCP needs the file open in-editor; headless this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)