### PR TITLE
fix(daemon): route proposal approve/reject wakes to the idea's session origin

### DIFF
--- a/openspec/changes/fix-proposal-wake-session-origin/.openspec.yaml
+++ b/openspec/changes/fix-proposal-wake-session-origin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/fix-proposal-wake-session-origin/README.md
+++ b/openspec/changes/fix-proposal-wake-session-origin/README.md
@@ -1,0 +1,3 @@
+# fix-proposal-wake-session-origin
+
+Route proposal approve/reject daemon wakes to the idea's existing session origin (generalize the elaboration_verified session-origin upgrade to all idea-anchored autonomous wakes)

--- a/openspec/changes/fix-proposal-wake-session-origin/design.md
+++ b/openspec/changes/fix-proposal-wake-session-origin/design.md
@@ -1,0 +1,194 @@
+# Technical Design: Generalize the idea-session-origin wake upgrade
+
+## Overview
+
+`createTurnAndResolveTarget` (`src/services/notification-turn.ts:573`) is the single chokepoint
+that turns a wake notification into a `DaemonSessionTurn` and decides which connection to wake.
+Its connection selection runs in this order:
+
+1. `resolvePinnedTarget` → a hard mention pin or a soft assignment/idea-instance pin.
+2. `selectOriginConnection(connections, pin)` → classifies the result as `directed`,
+   `online_first`, `offline_pin`, or `none`.
+3. **(today, `elaboration_verified` only)** when the result is `online_first`, an upgrade re-points
+   it to the Idea's existing `DaemonSession.originConnectionUuid` if that origin is online.
+
+Step 3 is the fix that routes the "Verify Elaborate" proposal-writing wake to the cwd where the
+Idea's conversation already lives. It is gated on `trigger === "elaboration_verified"`
+(`notification-turn.ts:625`), so `proposal_approved` / `proposal_rejected` (mapped to
+`task_assigned`) never reach it and fall to `online_first` = arbitrary cwd.
+
+This change broadens the gate so step 3 applies to the **autonomous idea-anchored trigger
+family**, not just one trigger.
+
+## Architecture
+
+### The trigger taxonomy and which triggers get the upgrade
+
+`DaemonSessionTurn.trigger` is a 6-value enum (`notification-turn.ts:92-106`):
+`task_assigned | mentioned | elaboration | elaboration_verified | resume | human_instruction`.
+
+The action→trigger map (`NOTIFICATION_ACTION_TO_TURN_TRIGGER`, `notification-turn.ts:111-131`)
+collapses every wake action into one of these. The relevant collapses:
+
+| Notification action | Turn trigger | Idea-anchored? | Gets upgrade? |
+|---|---|---|---|
+| `proposal_approved`, `proposal_rejected` | `task_assigned` | yes (via `inputUuids[0]`) | **YES (new)** |
+| `idea_claimed` | `task_assigned` | yes | **YES (new)** |
+| `task_assigned`, `task_verified`, `task_reopened` | `task_assigned` | yes (via task→proposal→idea) | **YES (new)** |
+| `elaboration_requested`, `elaboration_answered` | `elaboration` | yes | **YES (new)** |
+| `elaboration_verified` | `elaboration_verified` | yes | yes (unchanged) |
+| `mentioned` | `mentioned` | maybe | **NO (excluded)** |
+| `human_instruction` | `human_instruction` | maybe | **NO (excluded)** |
+
+The upgrade set is therefore the **autonomous idea-anchored triggers**:
+`{ task_assigned, elaboration, elaboration_verified }`.
+
+### Why `mentioned` and `human_instruction` are excluded
+
+The owner's Q1=a answer is "generalize regardless of trigger, eliminate the special case." Read
+faithfully, that means *eliminate the per-trigger special-casing among the autonomous wakes* — it
+does not mean overriding the two triggers that already resolve their own explicit target:
+
+- **`mentioned`**: A pinned mention resolves to `directed` or `offline_pin` in
+  `selectOriginConnection`, so it never reaches the `online_first` branch the upgrade guards. An
+  **un-pinned** mention is contractually a broadcast → online-first wake — the existing
+  `daemon-cwd-instance-addressing` spec has an explicit scenario "An un-pinned mention still wakes
+  the online-first daemon" with "no target is stamped." Silently re-pointing an un-pinned mention
+  to some idea session origin would violate that contract. So `mentioned` is excluded on both
+  branches.
+
+- **`human_instruction`**: `daemon-instruction.service` already resolves the precise target session
+  and emits its own origin-pinned `deliver_turn` ping (`deliverTurnPing`). The chokepoint creating
+  a second, possibly-different directed target would double-deliver or mis-route. It is excluded.
+
+Excluding these two is not a new special case — it is the same boundary the directed-delivery
+design already draws: triggers that carry their own explicit target are never subject to the
+heuristic session-origin upgrade.
+
+### Priority is preserved by construction (owner Q5=a)
+
+The upgrade still runs **only inside the `selection.kind === "online_first"` branch**. Any
+higher-priority outcome short-circuits before it:
+
+- A **hard mention pin** → `directed` (online) or `offline_pin` (offline). Never `online_first`.
+- A **soft assignment / idea-instance pin** that is online → `directed`. Never `online_first`.
+- A soft pin whose instance is **offline** → degrades to `online_first` (R2 graceful un-pin) — and
+  then the session-origin upgrade legitimately applies, which is the desired "the pinned instance
+  is gone, so fall to where the conversation lives" behavior, identical to how
+  `elaboration_verified` already behaves for a degraded soft pin.
+
+So the upgrade can only ever replace an *otherwise-arbitrary* `online_first` choice with a
+*specific* idea-anchored origin. It never overrides a pin. This is exactly the invariant the
+existing `elaboration_verified` upgrade holds; we are widening *which triggers* reach it, not
+changing *when within the selection* it fires.
+
+## Implementation
+
+### 1. Rename the helper
+
+`resolveElaborationVerifiedTarget` → `resolveIdeaSessionOriginTarget`
+(`notification-turn.ts:477`). Body unchanged: given `directIdeaUuid`, find the idea-anchored
+`DaemonSession` (`sessionId === directIdeaUuid`), and return its `originConnectionUuid` connection
+iff it is online; else null. Update its doc comment to drop the "elaboration_verified"-specific
+language and describe it as the generic idea-session-origin resolver.
+
+### 2. Define the upgrade-eligible trigger set
+
+A module-level constant adjacent to the trigger map:
+
+```ts
+// The autonomous, idea-anchored triggers eligible for the idea-session-origin upgrade.
+// `mentioned` (carries its own pin / un-pinned-broadcast contract) and `human_instruction`
+// (resolves its own target + ping in daemon-instruction.service) are deliberately excluded.
+const IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS = new Set<TurnTrigger>([
+  "task_assigned",
+  "elaboration",
+  "elaboration_verified",
+]);
+```
+
+### 3. Broaden the gate
+
+At `notification-turn.ts:625`, replace:
+
+```ts
+if (trigger === "elaboration_verified" && selection.kind === "online_first") {
+  const ideaTarget = await resolveElaborationVerifiedTarget(...);
+  if (ideaTarget) selection = { kind: "directed", connection: ideaTarget };
+}
+```
+
+with:
+
+```ts
+if (
+  IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS.has(trigger) &&
+  selection.kind === "online_first"
+) {
+  const ideaTarget = await resolveIdeaSessionOriginTarget(
+    ctx.companyUuid,
+    ctx.recipientUuid,
+    directIdeaUuid,
+    connections,
+  );
+  if (ideaTarget) selection = { kind: "directed", connection: ideaTarget };
+}
+```
+
+`directIdeaUuid` is already resolved at `notification-turn.ts:608-615` for any lineage-walkable
+entity, and `resolveIdeaSessionOriginTarget` already returns null when it is null — so a
+non-idea-anchored `task_assigned` (e.g. a standalone task with no idea lineage) naturally
+no-ops and stays `online_first`. No extra guard needed.
+
+## Module Contracts
+
+- **Selection state machine unchanged.** `OriginSelection` kinds (`directed` / `online_first` /
+  `offline_pin` / `none`) and their downstream meaning are untouched. The change only adds more
+  transitions from `online_first → directed` via the existing upgrade path.
+- **Directed-delivery transport unchanged.** When the upgrade promotes to `directed`, the existing
+  step-7 logic emits the `deliver_turn` ping and surfaces `targetConnectionUuid`, so daemon-side
+  broadcast suppression already works for the newly-directed proposal/idea wakes — no daemon
+  client change.
+- **Cross-cwd per-instance session rule unchanged.** Step 5 (`notification-turn.ts:660-686`) only
+  forks a per-instance session when the `directed` target differs from the idea's existing session
+  origin. For the session-origin upgrade the target **is** that origin, so `existing.originConnectionUuid
+  === origin.uuid` and no fork happens — the wake lands on the canonical idea session. (Verified:
+  the upgrade sets `connection` to the very origin connection it looked up.)
+
+## Risks & Mitigations
+
+- **Risk: an autonomous `task_assigned` for a task whose idea session lives on a different,
+  now-online cwd than where the task "should" run.** Mitigation: this is the intended behavior —
+  the idea's conversation is the authoritative place for idea-anchored work; a task with its own
+  instance override takes the higher-priority soft pin and never reaches the upgrade.
+- **Risk: regressing the un-pinned mention broadcast contract.** Mitigation: `mentioned` is
+  explicitly excluded from `IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS`; a dedicated test asserts an
+  un-pinned mention with a resolvable idea session still stamps no target.
+- **Risk: double-delivery of `human_instruction`.** Mitigation: `human_instruction` is excluded;
+  its own `deliverTurnPing` remains the sole delivery.
+- **Risk: the idea session origin is online but stale (transcript moved).** Out of scope — this is
+  the same assumption the existing `elaboration_verified` upgrade already makes; the origin is the
+  recorded transcript owner and `claude --resume` correctness is governed by the existing
+  origin-pinning requirement.
+
+## Test Plan
+
+Extend `src/services/__tests__/notification-turn.test.ts`:
+
+1. `proposal_approved` (entity `proposal` whose `inputUuids[0]` → idea with an online session
+   origin, agent un-pinned) → selection becomes `directed` on that origin; `deliver_turn` fired.
+2. Same for `proposal_rejected`.
+3. `idea_claimed` (entity `idea` with an online session origin) → `directed` on the origin.
+4. **Priority:** idea is instance-pinned to an online instance → selection is `directed` on the
+   **pin**, not the session origin (upgrade skipped).
+5. **No session:** idea has no `DaemonSession` → stays `online_first`, no target.
+6. **Offline origin:** session origin connection offline → stays `online_first`, no target.
+7. **Exclusion:** un-pinned `mentioned` with a resolvable idea session → stays `online_first`, no
+   target stamped.
+8. **Exclusion:** `human_instruction` is not upgraded by the chokepoint (its target comes from
+   `daemon-instruction.service`).
+9. **Plain idea-anchored `task_assigned`** (entity resolves to an idea with an online session
+   origin) → `directed` on that origin, confirming the family is not proposal-only.
+10. **No-lineage no-op:** a `task_assigned` whose entity has NO idea lineage (`directIdeaUuid ===
+    null`) → stays `online_first`, no target — `resolveIdeaSessionOriginTarget`'s null-guard is
+    exercised so the widened gate cannot mis-fire for non-idea-anchored work.

--- a/openspec/changes/fix-proposal-wake-session-origin/proposal.md
+++ b/openspec/changes/fix-proposal-wake-session-origin/proposal.md
@@ -1,0 +1,136 @@
+# Proposal: Route proposal approve/reject daemon wakes to the idea's existing session origin
+
+## Why
+
+When a Proposal is **approved** or **rejected**, the daemon wake it triggers lands on an
+**arbitrary online connection (random cwd)** of the assigned agent — not the connection where
+that proposal's Idea conversation is actually running. A session started in cwd `A` to advance
+an Idea gets its approval/rejection answered by the agent in cwd `B`, where the context does
+not match.
+
+By contrast, `elaboration_verified` (the human "Verify Elaborate" handoff) routes correctly to
+the connection that owns the Idea's session. The two paths are inconsistent, and the
+inconsistency is not by design — it is an accident of how the upgrade was gated.
+
+Root cause (verified against the code, file:line):
+
+1. **Trigger mapping hides the upgrade from proposal events.** `proposal_approved` and
+   `proposal_rejected` are both mapped to the `task_assigned` turn trigger
+   (`src/services/notification-turn.ts:129-130`). The session-origin direction — the logic that
+   points a wake at the connection owning the Idea's session
+   (`resolveElaborationVerifiedTarget`, reading `DaemonSession.originConnectionUuid`) — is gated
+   on `trigger === "elaboration_verified"` (`src/services/notification-turn.ts:625`). So a
+   proposal event can **never** take that path.
+
+2. **Pin resolution is reachable for proposals but resolves to null in the common case.** The
+   lineage resolver **can** walk a proposal → root idea via `inputUuids[0]`
+   (`src/services/lineage.service.ts:171-218`; `LINEAGE_ENTITY_TYPES` includes `proposal` at
+   `notification-turn.ts:140`), so `resolvePinnedTarget` is reachable. But it only returns a pin
+   when the root Idea is **explicitly assigned to an `agent_instance`**
+   (`resolveIdeaInstancePin`, `notification-turn.ts:338-355`). Most Ideas are not instance-pinned
+   — they are merely being advanced by a daemon session in some cwd — so the pin is null and the
+   selection falls to `online_first` = **the agent's first online connection = arbitrary cwd**.
+
+The two facts compound: no pin **and** no session-origin upgrade ⇒ `online_first`. That is the
+random-cwd wake the user observed (`selectOriginConnection`, `notification-turn.ts:424`).
+
+The fix the owner approved (elaboration Round 1, all five questions answered): **stop gating the
+session-origin upgrade on a single trigger.** Apply it to every **autonomous, idea-anchored**
+wake whose selection is still `online_first` and whose entity resolves to an Idea anchor — which
+covers `proposal_approved` / `proposal_rejected` and, as a bonus, `idea_claimed` and the task
+wakes — eliminating the per-trigger special case rather than bolting on a second one.
+
+## What Changes
+
+- **Generalize the session-origin upgrade beyond `elaboration_verified`.** In
+  `createTurnAndResolveTarget`, the upgrade that re-points an `online_first` selection to the
+  Idea's existing `DaemonSession.originConnectionUuid` SHALL fire for the **autonomous
+  idea-anchored trigger family** — `task_assigned` (into which `proposal_approved`,
+  `proposal_rejected`, `idea_claimed`, `task_verified`, `task_reopened` all collapse) and
+  `elaboration` / `elaboration_verified` — not only `elaboration_verified`. The gating condition
+  becomes "the selection is `online_first` **and** a `directIdeaUuid` resolved **and** the trigger
+  is one of the autonomous idea-anchored triggers."
+
+- **Two triggers are deliberately excluded** from the upgrade because they carry their own target
+  resolution and have their own directed-delivery contracts:
+  - `mentioned` — an un-pinned mention is contractually a broadcast → online-first wake (see the
+    existing `daemon-cwd-instance-addressing` "un-pinned mention" scenario). A pinned mention
+    never reaches `online_first` (it resolves to `directed`/`offline_pin`). Either way the upgrade
+    must not touch it.
+  - `human_instruction` — the UI send-box resolves the exact target session and emits its own
+    `deliver_turn` ping in `daemon-instruction.service`. Letting the chokepoint also upgrade it
+    risks a divergent target / double delivery.
+
+- **Rename the helper to reflect its generalized role.** `resolveElaborationVerifiedTarget` →
+  `resolveIdeaSessionOriginTarget` (behavior unchanged: look up the idea-anchored
+  `DaemonSession`, return its origin connection iff online). The rename keeps the code honest now
+  that the function serves all autonomous idea-anchored wakes.
+
+- **Priority semantics preserved (owner Q5=a).** The upgrade still applies **only** when the
+  selection is `online_first` — i.e. only when no higher-priority pin matched. A hard mention pin
+  or a soft assignment / idea-instance pin still wins and the upgrade is skipped, exactly as
+  today. The resolved order remains: hard mention pin → soft assignment/idea-instance pin → idea
+  session origin → agent online-first.
+
+- **No-session / offline-origin fallback (owner Q4=a).** When the Idea has no existing daemon
+  session (e.g. it was elaborated entirely in the UI and the daemon was never woken on it), or
+  the session's origin connection is offline, the wake falls back to the existing `online_first`
+  selection — byte-identical to the pre-change behavior and identical to today's
+  `elaboration_verified` fallback.
+
+- **Scope: both `approved` and `rejected` (owner Q3=a).** Both proposal review outcomes share the
+  same root cause and are fixed together.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `daemon-cwd-instance-addressing`: The existing requirement "The proposal-writing wake SHALL be
+  directed to the idea's existing session origin" is generalized to "The autonomous idea-anchored
+  wake SHALL be directed to the idea's existing session origin" — the session-origin direction now
+  covers `proposal_approved` / `proposal_rejected` / `idea_claimed` / task wakes (the autonomous
+  idea-anchored trigger family), not only the `elaboration_verified` proposal-writing wake, while
+  preserving the pin-priority order and explicitly excluding the directed `mentioned` /
+  `human_instruction` triggers.
+
+## Impact
+
+- **Schema**: **zero migrations.** No model, column, enum, or permission-bit change. This is a
+  pure routing-logic change in one service function.
+- **Backend code**:
+  - `src/services/notification-turn.ts` — broaden the upgrade gate in
+    `createTurnAndResolveTarget` from `trigger === "elaboration_verified"` to the autonomous
+    idea-anchored trigger set; rename `resolveElaborationVerifiedTarget` →
+    `resolveIdeaSessionOriginTarget` and update its callers and doc comments.
+- **Tests**:
+  - `src/services/__tests__/notification-turn.test.ts` — add coverage asserting
+    `proposal_approved` / `proposal_rejected` / `idea_claimed` wakes route to the Idea's session
+    origin when `online_first`; that an instance-pinned Idea still takes the pin (priority
+    preserved); that the no-session and offline-origin cases fall back to `online_first`; and that
+    `mentioned` (un-pinned) and `human_instruction` are unaffected.
+- **Recipient resolution unchanged (owner Q2=a).** `proposal_approved` / `proposal_rejected`
+  continue to notify `proposal.createdByUuid` (`notification-listener.ts:277-287`). The
+  creator≠worker divergence is real but out of scope for this fix (see Out of Scope).
+- **Daemon client code**: none. The daemon's broadcast-suppression logic already keys off the
+  transport-only resolved target; a newly-directed proposal wake reuses that machinery with no
+  client change.
+- **Frontend / i18n / docs**: none.
+- **Backward compat**: additive and narrowing-safe. Un-pinned proposal/idea/task wakes that
+  previously fanned out to `online_first` are now directed to the idea's session origin **when one
+  exists and is online**; when none exists or it is offline, behavior is byte-identical to today.
+  Instance-pinned wakes, un-pinned mentions, and human instructions are unchanged.
+
+## Out of Scope
+
+- **Changing the proposal-event recipient** from `proposal.createdByUuid` to the Idea's worker
+  (owner chose Q2=a: keep `createdByUuid`). The session-origin query uses `recipientUuid` as the
+  `agentUuid`, so if a future scenario routinely has creator≠worker, both the woken agent and the
+  session lookup would be wrong — that is a separate behavior change, deliberately deferred to
+  avoid mixing two concerns in one bugfix.
+- **Adding an Idea pin column / instance picker for Ideas.** The Idea entity intentionally has no
+  pinned-instance columns; routing is derived from the existing session origin.
+- **The `mentioned` and `human_instruction` directed-delivery paths.** Their contracts are
+  unchanged.
+- **A durable queue / backfill for offline session origins.** Consistent with the existing
+  online-only wake policy, an offline origin falls back to `online_first`; there is no new
+  queue.

--- a/openspec/changes/fix-proposal-wake-session-origin/specs/daemon-cwd-instance-addressing/spec.md
+++ b/openspec/changes/fix-proposal-wake-session-origin/specs/daemon-cwd-instance-addressing/spec.md
@@ -1,0 +1,75 @@
+# daemon-cwd-instance-addressing Specification
+
+## MODIFIED Requirements
+
+### Requirement: The proposal-writing wake SHALL be directed to the idea's existing session origin
+
+An autonomous, idea-anchored wake SHALL be directed to the daemon instance where that idea's conversation already lives — its existing `DaemonSession.originConnectionUuid` for the idea-anchored session (`sessionId === directIdeaUuid`) — rather than fanning out to an arbitrary online instance of the agent, whenever the connection selection would otherwise fall to agent-overall online-first. This direction SHALL apply to the autonomous idea-anchored trigger family: the elaboration-resolve / "Verify Elaborate" handoff wake (`elaboration_verified`), the proposal-review wakes (`proposal_approved` and `proposal_rejected`), the idea-claimed wake (`idea_claimed`), the elaboration request/answer wakes (`elaboration_requested` / `elaboration_answered`), and the task-assignment wakes (`task_assigned` / `task_verified` / `task_reopened`) — every wake that resolves to an Idea anchor and is not already pinned. It SHALL NOT apply to a `mentioned` wake (an un-pinned mention is contractually a broadcast → online-first wake, and a pinned mention is resolved as a hard pin) nor to a `human_instruction` wake (whose exact target session and live delivery are resolved by the instruction send path, not the wake chokepoint).
+
+The `Idea` entity carries no pinned-instance columns, so the origin SHALL be taken from the idea's existing session. This direction SHALL apply ONLY when no higher-priority pin matched — that is, only when the connection selection is online-first; a hard mention pin or a soft assignment / idea-instance pin that resolves to an online connection takes priority and SHALL skip this upgrade, preserving the resolution order hard mention pin → soft assignment/idea-instance pin → idea session origin → agent online-first. When the idea has NO existing daemon session (it was elaborated entirely in the UI and the daemon was never woken on it), or that session's origin is offline, the wake SHALL fall back to the existing online-first selection. This wake SHALL reuse the same directed-delivery transport as the pinned `mentioned` / `task_assigned` wakes (the resolved target communicated to the daemon for broadcast suppression); it SHALL NOT introduce an Idea pin column, a new picker, a new permission bit, or a schema migration.
+
+#### Scenario: A proposal-approval wake targets the idea's session origin
+
+- **GIVEN** an idea with an existing daemon session whose origin is the ONLINE instance `(Laptop-Q3, dev/ai-pm)`
+- **AND** the same agent also has another online instance `(Laptop-Q3, dev/strands)`
+- **AND** the idea is NOT pinned to any `agent_instance`
+- **WHEN** that idea's proposal is approved and the `proposal_approved` wake is dispatched
+- **THEN** only the `dev/ai-pm` daemon MUST wake to handle the approval
+- **AND** the `dev/strands` daemon MUST suppress the wake
+
+#### Scenario: A proposal-rejection wake targets the idea's session origin
+
+- **GIVEN** an idea with an existing daemon session whose origin is an ONLINE instance, the agent having another online instance, and the idea not pinned to an `agent_instance`
+- **WHEN** that idea's proposal is rejected and the `proposal_rejected` wake is dispatched
+- **THEN** only the daemon at the idea's session origin MUST wake to handle the rejection
+- **AND** the agent's other online instance MUST suppress the wake
+
+#### Scenario: An idea-claimed wake targets the idea's session origin
+
+- **GIVEN** an idea with an existing online session origin and an un-pinned assignment, the agent having another online instance
+- **WHEN** the `idea_claimed` wake is dispatched
+- **THEN** the wake MUST be directed to the idea's session origin rather than agent-overall online-first
+
+#### Scenario: Verify Elaborate wakes the cwd where the idea conversation already lives
+
+- **GIVEN** an idea with an existing daemon session whose origin is the ONLINE instance `(Laptop-Q3, dev/ai-pm)`
+- **AND** the same agent also has another online instance `(Laptop-Q3, dev/strands)`
+- **WHEN** a human clicks "Verify Elaborate" and the `elaboration_verified` wake is dispatched
+- **THEN** only the `dev/ai-pm` daemon MUST wake to write the proposal
+- **AND** the `dev/strands` daemon MUST suppress the wake
+
+#### Scenario: An instance-pinned idea takes the pin over the session origin
+
+- **GIVEN** an idea pinned to the ONLINE `agent_instance` A
+- **AND** the idea's existing daemon session origin is a DIFFERENT online instance B of the same agent
+- **WHEN** a `proposal_approved` (or any autonomous idea-anchored) wake is dispatched
+- **THEN** the wake MUST target instance A (the higher-priority pin)
+- **AND** the session-origin upgrade MUST be skipped
+
+#### Scenario: Falls back to online-first when no session exists
+
+- **GIVEN** an idea that was elaborated entirely in the UI, with NO existing daemon session
+- **WHEN** an autonomous idea-anchored wake (e.g. `proposal_approved` or `elaboration_verified`) is dispatched
+- **THEN** the wake MUST fall back to the existing online-first selection (no target is stamped)
+- **AND** the behavior MUST match the pre-change wake exactly
+
+#### Scenario: Falls back when the idea's session origin is offline
+
+- **GIVEN** an idea whose existing session origin instance is OFFLINE
+- **AND** the agent has another online instance
+- **WHEN** an autonomous idea-anchored wake is dispatched
+- **THEN** it MUST fall back to online-first selection (the offline origin is not wakeable and is not queued)
+
+#### Scenario: An un-pinned mention is not redirected to the idea session origin
+
+- **GIVEN** an agent with two online instances, one of which is the origin of some idea's session
+- **AND** a `mentioned` notification that carries no pin
+- **WHEN** the wake selects a connection
+- **THEN** it MUST select the online-first connection with NO target stamped (broadcast), exactly as before this change
+- **AND** it MUST NOT be redirected to any idea's session origin
+
+#### Scenario: A human instruction is not re-targeted by the wake chokepoint
+
+- **WHEN** a `human_instruction` wake is processed at the notification chokepoint
+- **THEN** the chokepoint MUST NOT apply the idea-session-origin upgrade to it
+- **AND** its target and live delivery MUST come solely from the instruction send path

--- a/openspec/changes/fix-proposal-wake-session-origin/tasks.md
+++ b/openspec/changes/fix-proposal-wake-session-origin/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: fix-proposal-wake-session-origin
+
+## 1. Generalize the idea-session-origin wake upgrade
+- [ ] 1.1 Rename `resolveElaborationVerifiedTarget` → `resolveIdeaSessionOriginTarget` in `notification-turn.ts`; update its doc comment to the generic idea-session-origin resolver (behavior unchanged)
+- [ ] 1.2 Add `IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS = { task_assigned, elaboration, elaboration_verified }` set near the trigger map
+- [ ] 1.3 Broaden the gate at the upgrade site: from `trigger === "elaboration_verified" && online_first` to `IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS.has(trigger) && online_first`; call the renamed helper
+- [ ] 1.4 Confirm no daemon-client change needed (directed-delivery transport already keyed off resolved target)
+
+## 2. Tests
+- [ ] 2.1 `notification-turn.test.ts`: `proposal_approved` and `proposal_rejected` route to the idea's online session origin (un-pinned idea) and emit `deliver_turn`
+- [ ] 2.2 `idea_claimed` routes to the idea's session origin
+- [ ] 2.3 Priority preserved: an instance-pinned idea takes the pin, upgrade skipped
+- [ ] 2.4 Fallback: no idea session → `online_first`, no target; offline origin → `online_first`, no target
+- [ ] 2.5 Exclusions: un-pinned `mentioned` stamps no target (broadcast); `human_instruction` not upgraded by the chokepoint
+- [ ] 2.6 Plain idea-anchored `task_assigned` routes to the idea's session origin; standalone (no-lineage) `task_assigned` with `directIdeaUuid === null` stays `online_first` (null-guard exercised)
+- [ ] 2.7 `pnpm test` green for the file; `npx tsc --noEmit` clean
+
+## 3. Verify
+- [ ] 3.1 Local two-cwd daemon e2e (per idea verification suggestion): advance an idea to a proposal from cwd A, approve/reject → assert the woken connection is A's session origin, not B

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -1538,3 +1538,232 @@ describe("createTurnAndResolveTarget — instance-based pin lineage (T11)", () =
     expect(mockLoggerError).not.toHaveBeenCalled();
   });
 });
+
+// ===== Generalized idea-session-origin upgrade (fix-proposal-wake-session-origin) =====
+//
+// The session-origin upgrade — re-pointing an `online_first` selection to the idea's
+// existing DaemonSession origin — used to be gated on `trigger === "elaboration_verified"`
+// ONLY, so a proposal_approved / proposal_rejected wake (mapped to task_assigned) fanned out
+// to an arbitrary online cwd. It is now generalized to the AUTONOMOUS IDEA-ANCHORED trigger
+// family `{ task_assigned, elaboration, elaboration_verified }`, still gated on
+// `selection.kind === "online_first"` so it never overrides a hard/soft pin, and STILL
+// EXCLUDING `mentioned` (broadcast / no-target contract) and `human_instruction` (owns its
+// own directed delivery in daemon-instruction.service).
+describe("createTurnAndResolveTarget — generalized idea-session-origin upgrade", () => {
+  const ideaOriginConn = "conn-idea-origin";
+
+  // Two online connections; the idea's session lives on the SECOND (not online-first), so a
+  // correct upgrade must select it over the first entry.
+  function twoOnlineWithIdeaOrigin() {
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: ideaOriginConn, host: "host-B", cwd: "/home/u/dev/idea" }),
+    ]);
+    mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: ideaOriginConn });
+  }
+
+  // ----- proposal_approved / proposal_rejected → directed to the idea session origin -----
+
+  for (const action of ["proposal_approved", "proposal_rejected"]) {
+    it(`${action} routes an un-pinned idea's wake to its existing ONLINE session origin (ping + target)`, async () => {
+      twoOnlineWithIdeaOrigin();
+
+      const { turn, targetConnectionUuid, suppressWake } = await createTurnAndResolveTarget(
+        ctx({ action, entityType: "proposal", entityUuid: "proposal-1" }),
+      );
+
+      // The session lookup is keyed on the idea anchor derived from the proposal lineage.
+      expect(mockDaemonSessionFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ companyUuid, agentUuid, sessionId: ideaUuid }),
+        }),
+      );
+      // Directed to the idea's existing origin, NOT the online-first entry.
+      expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ originConnectionUuid: ideaOriginConn }),
+      );
+      expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+        expect.objectContaining({ originConnectionUuid: ideaOriginConn, turnUuid: turn?.uuid }),
+      );
+      expect(targetConnectionUuid).toBe(ideaOriginConn);
+      expect(suppressWake).toBe(false);
+      expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+  }
+
+  // ----- idea_claimed (no instance pin) → directed to the idea session origin -----
+
+  it("idea_claimed routes to the idea's existing session origin when the idea has no instance pin", async () => {
+    // idea entity, plain-agent assignee (default) → no pin → online_first → upgrade applies.
+    twoOnlineWithIdeaOrigin();
+
+    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "idea_claimed", entityType: "idea", entityUuid: ideaUuid }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: ideaOriginConn }),
+    );
+    expect(targetConnectionUuid).toBe(ideaOriginConn);
+  });
+
+  // ----- plain idea-anchored task_assigned → directed to the idea session origin -----
+
+  it("a plain idea-anchored task_assigned (task lineage → idea) routes to the idea's session origin", async () => {
+    // Task and root idea are both plain agents (defaults) → no pin → online_first → upgrade.
+    twoOnlineWithIdeaOrigin();
+
+    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", entityType: "task", entityUuid: taskUuid }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: ideaOriginConn }),
+    );
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: ideaOriginConn, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(ideaOriginConn);
+  });
+
+  // ----- PRIORITY PRESERVED: an instance pin still beats the session-origin upgrade -----
+
+  it("an instance-pinned idea takes the pin over the session origin for proposal_approved (upgrade skipped)", async () => {
+    // The root idea is pinned to an ONLINE instance; its existing session lives on a DIFFERENT
+    // online connection. The pin must win — selection is already `directed` so the upgrade is
+    // skipped (it only runs in the online_first branch).
+    const pinnedHost = "pin-host";
+    const pinnedCwd = "/home/u/dev/pinned";
+    const pinnedConnUuid = "conn-pinned";
+    pinIdeaToInstance(pinnedHost, pinnedCwd);
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "x", cwd: "/x" }),
+      onlineConn({ uuid: ideaOriginConn, host: "host-B", cwd: "/home/u/dev/idea" }),
+      onlineConn({ uuid: pinnedConnUuid, host: pinnedHost, cwd: pinnedCwd }),
+    ]);
+    mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: ideaOriginConn });
+
+    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "proposal_approved", entityType: "proposal", entityUuid: "proposal-1" }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: pinnedConnUuid }),
+    );
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: ideaOriginConn }),
+    );
+    expect(targetConnectionUuid).toBe(pinnedConnUuid);
+  });
+
+  // ----- FALLBACKS: no session / offline origin → online-first, no target -----
+
+  it("proposal_approved with NO existing idea session falls back to online-first (no ping, no target)", async () => {
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+    // Default mockDaemonSessionFindFirst → null (no existing idea session).
+
+    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "proposal_approved", entityType: "proposal", entityUuid: "proposal-1" }),
+    );
+
+    expect(turn?.status).toBe("pending");
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    expect(targetConnectionUuid).toBeNull();
+  });
+
+  it("proposal_approved whose idea session origin is OFFLINE falls back to online-first (no ping, no target)", async () => {
+    const onlineFirst = "conn-online-first";
+    const offlineOrigin = "conn-idea-origin-offline";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      offlineConn({ uuid: offlineOrigin, host: "host-B", cwd: "/home/u/dev/idea" }),
+    ]);
+    mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: offlineOrigin });
+
+    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "proposal_approved", entityType: "proposal", entityUuid: "proposal-1" }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    expect(targetConnectionUuid).toBeNull();
+  });
+
+  // ----- NO-LINEAGE NO-OP: a standalone task_assigned (directIdeaUuid null) stays online-first -----
+
+  it("a standalone task_assigned with NO idea lineage (directIdeaUuid null) stays online-first (null-guard)", async () => {
+    // The entity resolves to no idea anchor. Even with an (irrelevant) session row present,
+    // resolveIdeaSessionOriginTarget's null-guard short-circuits → online-first, no target.
+    mockResolveDirectIdeaUuid.mockResolvedValue(null);
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+
+    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", entityType: "task", entityUuid: taskUuid }),
+    );
+
+    expect(turn?.status).toBe("pending");
+    // Ad-hoc session keyed on the entity uuid, pinned online-first.
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: taskUuid, directIdeaUuid: null, originConnectionUuid: onlineFirst }),
+    );
+    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    expect(targetConnectionUuid).toBeNull();
+  });
+
+  // ----- EXCLUSIONS: mentioned + human_instruction are NOT upgraded even with a session -----
+
+  it("an un-pinned mentioned wake is NOT redirected to the idea session origin (broadcast, no target)", async () => {
+    // A resolvable idea session exists, but `mentioned` is excluded from the upgrade set: the
+    // wake must stay online-first with no target (the un-pinned broadcast contract).
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: ideaOriginConn, host: "host-B", cwd: "/home/u/dev/idea" }),
+    ]);
+    mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: ideaOriginConn });
+
+    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "mentioned", entityType: "idea", entityUuid: ideaUuid }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: ideaOriginConn }),
+    );
+    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    expect(targetConnectionUuid).toBeNull();
+  });
+
+  it("a human_instruction wake is NOT upgraded to the idea session origin even when one exists", async () => {
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: ideaOriginConn, host: "host-B", cwd: "/home/u/dev/idea" }),
+    ]);
+    mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: ideaOriginConn });
+
+    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "human_instruction", entityType: "idea", entityUuid: ideaUuid, instructionText: "do it" }),
+    );
+
+    // human_instruction resolves its own delivery elsewhere; the chokepoint must not upgrade it.
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    expect(targetConnectionUuid).toBeNull();
+  });
+});

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -140,6 +140,33 @@ export const NOTIFICATION_ACTION_TO_TURN_TRIGGER: Record<string, TurnTrigger> = 
 const LINEAGE_ENTITY_TYPES = new Set<string>(["task", "document", "proposal", "idea"]);
 
 /**
+ * The AUTONOMOUS, idea-anchored triggers eligible for the idea-session-origin upgrade
+ * (fix-proposal-wake-session-origin): when the connection selection is still
+ * `online_first` and the wake resolves to an idea anchor, the upgrade re-points it to the
+ * idea's existing `DaemonSession` origin (where that idea's conversation already lives)
+ * instead of fanning out to an arbitrary online cwd.
+ *
+ * These are exactly the wakes the daemon raises autonomously against idea-lineage work:
+ *   - `task_assigned` — the collapse target for `proposal_approved` / `proposal_rejected`
+ *     (the random-cwd defect being fixed), `idea_claimed`, `task_verified`, `task_reopened`.
+ *   - `elaboration` — elaboration request / answer wakes on an idea.
+ *   - `elaboration_verified` — the human "Verify Elaborate" → write-the-proposal wake (the
+ *     original, now-generalized, home of this upgrade).
+ *
+ * `mentioned` and `human_instruction` are DELIBERATELY EXCLUDED: an un-pinned `mentioned`
+ * wake is contractually a broadcast → online-first (stamping no target), a pinned mention
+ * is resolved as a HARD pin before this branch, and `human_instruction` resolves its own
+ * exact target + `deliver_turn` ping in `daemon-instruction.service` — upgrading it here
+ * would double-deliver or mis-route. Both carry their own target resolution, so the
+ * heuristic session-origin upgrade must never touch them.
+ */
+const IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS = new Set<TurnTrigger>([
+  "task_assigned",
+  "elaboration",
+  "elaboration_verified",
+]);
+
+/**
  * Resolve the trigger for a notification action, or null when the action is not
  * wake-triggering (so the caller skips turn creation entirely).
  */
@@ -457,7 +484,7 @@ function selectOriginConnection(
 }
 
 /**
- * Resolve the directed ONLINE target for an `elaboration_verified` wake: the connection
+ * Resolve the directed ONLINE target for an AUTONOMOUS IDEA-ANCHORED wake: the connection
  * that OWNS the idea's existing daemon session (`DaemonSession.originConnectionUuid` for
  * the idea-anchored session), when that connection is ONLINE.
  *
@@ -468,13 +495,21 @@ function selectOriginConnection(
  * online-first) selection and therefore SKIPS this upgrade. When no idea-anchored session
  * exists yet (the idea was elaborated entirely in the UI and the daemon was never woken on
  * it), or that origin is not currently online, this returns null → the caller falls back
- * to online-first (NO directed delivery), exactly as the pre-change proposal-writing wake.
+ * to online-first (NO directed delivery), byte-identical to the pre-change wake.
+ *
+ * Shared by every trigger in `IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS` — originally the
+ * `elaboration_verified` proposal-writing wake, now generalized so `proposal_approved` /
+ * `proposal_rejected` / `idea_claimed` / task wakes (all mapped to `task_assigned`) and the
+ * `elaboration` wakes land where the idea's conversation already runs instead of a random
+ * online cwd (fix-proposal-wake-session-origin).
  *
  * `directIdeaUuid` is the idea anchor (the session business key for an idea-anchored
- * session). `connections` is the agent's live registry, already resolved by the caller.
- * A query failure propagates to the caller's failure-isolation guard.
+ * session); a null anchor (a non-idea-anchored wake, e.g. a standalone task) short-circuits
+ * to null so the widened gate cannot mis-fire. `connections` is the agent's live registry,
+ * already resolved by the caller. A query failure propagates to the caller's
+ * failure-isolation guard.
  */
-async function resolveElaborationVerifiedTarget(
+async function resolveIdeaSessionOriginTarget(
   companyUuid: string,
   agentUuid: string,
   directIdeaUuid: string | null,
@@ -614,16 +649,24 @@ export async function createTurnAndResolveTarget(
       );
     }
 
-    // (4) elaboration_verified: the idea's `agent_instance` assignee is the HIGHER-priority
-    // soft pin already resolved in step 3 (resolvePinnedTarget reads the root idea's
-    // assignee). When the idea IS instance-pinned and that instance is online, selection is
-    // already `directed` — this upgrade is SKIPPED (the instance wins). ONLY when the idea
-    // has no assignee-instance (or its soft pin degraded because the instance is offline)
-    // does selection stay `online_first`, and THEN the LOWER-priority session-origin
-    // heuristic upgrades to the idea's existing ONLINE session origin (where the idea's
-    // conversation already lives). No session, or an offline origin → stays online-first.
-    if (trigger === "elaboration_verified" && selection.kind === "online_first") {
-      const ideaTarget = await resolveElaborationVerifiedTarget(
+    // (4) Idea-session-origin upgrade for AUTONOMOUS idea-anchored wakes (the family in
+    // IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS: task_assigned — into which proposal_approved /
+    // proposal_rejected / idea_claimed / task_* collapse — plus elaboration /
+    // elaboration_verified). The idea's `agent_instance` assignee is the HIGHER-priority soft
+    // pin already resolved in step 3 (resolvePinnedTarget reads the root/own idea's assignee).
+    // When the idea IS instance-pinned and that instance is online, selection is already
+    // `directed` — this upgrade is SKIPPED (the instance wins). ONLY when the idea has no
+    // assignee-instance (or its soft pin degraded because the instance is offline) does
+    // selection stay `online_first`, and THEN this LOWER-priority session-origin heuristic
+    // upgrades to the idea's existing ONLINE session origin (where the idea's conversation
+    // already lives), fixing the proposal approve/reject random-cwd wake. No session, an
+    // offline origin, or a non-idea-anchored wake (directIdeaUuid null) → stays online-first.
+    // `mentioned` / `human_instruction` are excluded from the set (they own their own target).
+    if (
+      IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS.has(trigger) &&
+      selection.kind === "online_first"
+    ) {
+      const ideaTarget = await resolveIdeaSessionOriginTarget(
         ctx.companyUuid,
         ctx.recipientUuid,
         directIdeaUuid,


### PR DESCRIPTION
## Summary
When a Proposal is **approved** or **rejected**, the daemon wake landed on an arbitrary online connection (random cwd) of the assigned agent instead of the connection where that proposal's Idea conversation runs. Root cause: `proposal_approved`/`proposal_rejected` map to the `task_assigned` turn trigger, so they never received the session-origin upgrade — which was gated on `trigger === "elaboration_verified"` — and fell through to `online_first`.

This generalizes the session-origin upgrade to the **autonomous idea-anchored trigger family** so proposal-review wakes (and `idea_claimed` / task wakes) route to the idea's existing `DaemonSession` origin.

## Changes
- Add `IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS = {task_assigned, elaboration, elaboration_verified}` and broaden the upgrade gate from `trigger === "elaboration_verified"` to `SET.has(trigger)` — still inside the `online_first` branch, so hard/soft pins are never overridden.
- Deliberately **exclude** `mentioned` (un-pinned broadcast / hard-pin contract) and `human_instruction` (resolves its own target + `deliver_turn` ping in `daemon-instruction.service`).
- Rename `resolveElaborationVerifiedTarget` → `resolveIdeaSessionOriginTarget` (body unchanged; null-anchor short-circuits).
- Fallback preserved: no idea session / offline origin → `online_first` (byte-identical to pre-change).

## Changed files
| File | Change |
|------|--------|
| `src/services/notification-turn.ts` | +58/−15 — trigger set, renamed helper, broadened gate |
| `src/services/__tests__/notification-turn.test.ts` | +229 — 10 new cases |
| `openspec/changes/fix-proposal-wake-session-origin/` | OpenSpec change (proposal/design/spec delta/tasks) |

## Test plan
- [x] `npx vitest run src/services/__tests__/notification-turn.test.ts` → 83/83
- [x] `npx tsc --noEmit` → clean
- [x] `eslint` on changed files → 0 errors
- [x] Full `pnpm test` green except a known-flaky, unrelated `cli/daemon-integration.test.mjs` timing case (passes 13/13 in isolation)
- [x] Independently re-verified by task-reviewer (PASS) and idea-level code-review gateway (PASS WITH NOTES)

## Notes
- Zero schema/migration/permission/daemon-client change.
- Out of scope (deliberate): proposal-event recipient stays `proposal.createdByUuid` — a separate concern if creator ≠ idea worker becomes common.
- Chorus idea: `b729713b-7f2b-4912-bf37-e458005fc272`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)