### PR TITLE
fix(cli): stop first-run P1000 when embedded PGlite port is occupied (#379)

### DIFF
--- a/chorus.mjs
+++ b/chorus.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync, fork } from "node:child_process";
+import { fork, spawn } from "node:child_process";
 import { randomBytes, createHash } from "node:crypto";
 import {
   existsSync,
@@ -38,6 +38,15 @@ import {
 // (`chorus daemon` / `chorus login`) never registers the server's handlers.
 // Pure module → unit-testable without this entry's import-time side effects.
 import { installServerSignalHandlers } from "./cli/server-signal-handlers.mjs";
+// Embedded-PGlite launch (child-exit capture + port-conflict fail-fast). Extracted
+// into a pure, dependency-injected module so it is unit-testable with fakes — see
+// cli/embedded-db.mjs and its __tests__ (GitHub #379).
+import {
+  launchEmbeddedPglite,
+  isPrismaAuthFailure,
+  formatMigrationAuthDiagnostic,
+  maskDbUrl,
+} from "./cli/embedded-db.mjs";
 
 /** Read the package version once for help/version output. */
 function pkgVersion() {
@@ -247,6 +256,27 @@ function waitForTcp(host, tcpPort, maxRetries = 30, intervalMs = 500) {
   });
 }
 
+// Quick one-shot probe: is something ALREADY listening on host:port right now?
+// Used as a pre-flight before forking embedded PGlite so we never fork onto a port
+// held by a foreign process (e.g. a real Postgres) and then mistake it for our own
+// PGlite. Resolves true if a TCP connection succeeds, false otherwise. (GitHub #379)
+function isPortOccupied(host, tcpPort, timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port: tcpPort });
+    let settled = false;
+    const done = (occupied) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(occupied);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+  });
+}
+
 function ensureSecret() {
   const secretPath = join(dataDir, ".secret");
   if (process.env.NEXTAUTH_SECRET) return;
@@ -311,34 +341,52 @@ async function main() {
     const pgliteSocketEntry = resolveOrDie("@electric-sql/pglite-socket");
     const serverScript = resolve(dirname(pgliteSocketEntry), "scripts", "server.js");
 
-    pgliteProcess = fork(serverScript, [
-      `--db=${join(dataDir, "pglite")}`,
-      `--port=${PGLITE_PORT}`,
-      "--max-connections=10",
-    ], { stdio: "ignore", detached: false });
-
-    pgliteProcess.on("error", (err) => {
-      // MODULE_NOT_FOUND is unreachable after the resolveOrDie fix above, but
-      // guard against regressions (see issue #214).
-      if (err.code === "MODULE_NOT_FOUND") {
-        console.error(`PGlite server script unreachable: ${err.message}`);
-      } else {
-        console.error("PGlite process error:", err.message);
-      }
-      process.exit(1);
+    // Launch via the pure, dependency-injected module so a foreign listener on
+    // PGLITE_PORT can never be mistaken for our PGlite (GitHub #379): it pre-flights
+    // the port, then treats the child exiting before ready as fatal (any exit code,
+    // incl. the reproduced EADDRINUSE -> exit 0), instead of trusting "someone is
+    // listening". `waitForTcp`/`isPortOccupied` are injected so the logic unit-tests
+    // with fakes (see cli/embedded-db.mjs + __tests__).
+    const launch = await launchEmbeddedPglite({
+      host: "localhost",
+      port: PGLITE_PORT,
+      fork: () =>
+        fork(serverScript, [
+          `--db=${join(dataDir, "pglite")}`,
+          `--port=${PGLITE_PORT}`,
+          "--max-connections=10",
+        ], { stdio: "ignore", detached: false }),
+      waitForTcp,
+      preflightCheck: isPortOccupied,
+      logger: console,
     });
 
-    try {
-      await waitForTcp("localhost", PGLITE_PORT);
-    } catch (err) {
-      console.error(`\nERROR: ${err.message}`);
-      console.error(`\nPossible causes:`);
-      console.error(`  - Port ${PGLITE_PORT} is already in use`);
-      console.error(`  - Corrupt data in ${join(dataDir, "pglite")}/`);
+    if (!launch.ok) {
+      if (launch.reason === "child-exited") {
+        // The child (our PGlite) exited before the port was confirmed ready. The most
+        // common cause is the port being occupied by another process the child could
+        // not bind (EADDRINUSE), which PGlite catches and exits 0 — so key the message
+        // off the failure, not the exit code.
+        console.error(
+          `\nERROR: Embedded PostgreSQL (PGlite) exited before it was ready ` +
+            `(exit code ${launch.exitInfo?.code ?? "unknown"}).`
+        );
+        console.error(`\nMost likely port ${PGLITE_PORT} is already in use by another process`);
+        console.error(`(e.g. a real PostgreSQL). Free the port, or run on a different one:`);
+        console.error(`  chorus --pglite-port <port>`);
+      } else if (launch.reason === "not-ready") {
+        console.error(`\nERROR: ${launch.error?.message ?? "PGlite failed to start."}`);
+        console.error(`\nPossible causes:`);
+        console.error(`  - Port ${PGLITE_PORT} is already in use`);
+        console.error(`  - Corrupt data in ${join(dataDir, "pglite")}/`);
+      } else if (launch.reason === "child-error") {
+        console.error("PGlite process error:", launch.error?.message ?? String(launch.error));
+      }
+      // reason === "port-occupied" already logged the actionable message in the module.
       process.exit(1);
     }
 
-    console.log(`PGlite ready on port ${PGLITE_PORT}.`);
+    pgliteProcess = launch.child;
     process.env.DATABASE_URL = `postgresql://postgres:postgres@localhost:${PGLITE_PORT}/postgres?sslmode=disable`;
   }
 
@@ -350,14 +398,49 @@ async function main() {
   // 3. Run database migrations
   console.log("Running database migrations...");
   const prismaBin = resolveOrDie("prisma/build/index.js");
-  try {
-    execSync(`"${process.execPath}" "${prismaBin}" migrate deploy`, {
+  // Tee the migrate output: stream each chunk to the parent's stdout/stderr LIVE (so
+  // "Applying migration …" progress appears as it happens, not batched at the end) AND
+  // buffer it so an authentication failure can be classified and rewritten into an
+  // actionable Chorus diagnostic (GitHub #379).
+  const migrateResult = await new Promise((resolveMigrate) => {
+    const child = spawn(process.execPath, [prismaBin, "migrate", "deploy"], {
       cwd: __dirname,
-      stdio: "inherit",
       env: { ...process.env },
+      stdio: ["inherit", "pipe", "pipe"],
     });
-  } catch {
-    console.error("ERROR: Database migration failed.");
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (chunk) => {
+      out += chunk;
+      process.stdout.write(chunk); // live echo
+    });
+    child.stderr.on("data", (chunk) => {
+      err += chunk;
+      process.stderr.write(chunk); // live echo
+    });
+    child.on("error", (e) => resolveMigrate({ status: 1, stdout: out, stderr: `${err}\n${e.message}` }));
+    child.on("close", (code, signal) => {
+      // A null exit code means the migrate process was killed by a signal — treat that
+      // as a failure (status 1), never as success, so we don't start the server against
+      // a half-migrated database.
+      resolveMigrate({ status: code === null ? 1 : code, stdout: out, stderr: err });
+    });
+  });
+  if (migrateResult.status !== 0) {
+    const combined = `${migrateResult.stdout ?? ""}\n${migrateResult.stderr ?? ""}`;
+    if (isPrismaAuthFailure(combined)) {
+      // Replace the bare Prisma P1000 (the last thing the user would otherwise see)
+      // with a self-explaining, path-appropriate diagnostic.
+      console.error(
+        formatMigrationAuthDiagnostic({
+          effectiveUrl: process.env.DATABASE_URL,
+          startedEmbedded: startEmbeddedPglite,
+          pglitePort: PGLITE_PORT,
+        })
+      );
+    } else {
+      console.error("ERROR: Database migration failed.");
+    }
     process.exit(1);
   }
   console.log("Migrations completed.");
@@ -389,11 +472,12 @@ async function main() {
   console.log("");
   console.log(`  URL:       http://${hostname === "0.0.0.0" ? "localhost" : hostname}:${port}`);
   console.log(`  Data:      ${dataDir}`);
-  const dbLabel = usePglite
-    ? (startEmbeddedPglite
-        ? "PGlite (embedded, pg.Pool max=1)"
-        : "PGlite (external, pg.Pool max=1)")
-    : "external PostgreSQL";
+  // When embedded PGlite was skipped, DATABASE_URL is what we actually connected to —
+  // name its host:port (credentials masked) so a residual/unintended export is visible
+  // rather than silent (GitHub #379, D4). Precedence semantics are unchanged.
+  const dbLabel = startEmbeddedPglite
+    ? "PGlite (embedded, pg.Pool max=1)"
+    : `${usePglite ? "PGlite (external, pg.Pool max=1)" : "external PostgreSQL"} (from DATABASE_URL: ${maskDbUrl(process.env.DATABASE_URL)})`;
   console.log(`  Database:  ${dbLabel}`);
   console.log(`  Redis:     ${process.env.REDIS_URL ? "connected" : "disabled (in-memory EventBus)"}`);
   const maskedPassword = process.env.DEFAULT_PASSWORD === "chorus"

--- a/cli/__tests__/embedded-db-integration.test.mjs
+++ b/cli/__tests__/embedded-db-integration.test.mjs
@@ -1,0 +1,211 @@
+// cli/__tests__/embedded-db-integration.test.mjs
+//
+// INTEGRATION CHECKPOINT for GitHub #379 — the DAG convergence point. Unlike the pure
+// unit tests in embedded-db.test.mjs (fake spawner/socket), this drives the REAL
+// chorus.mjs entry with a REAL forked PGlite and a REAL foreign Postgres, reproducing
+// the exact scenarios that produced the reported P1000 and asserting they can no longer
+// be reached silently.
+//
+// Three paths (design.md):
+//   A. Foreign Postgres occupies the PGlite port  -> fail fast, no "PGlite ready", no P1000.
+//   B. Residual bad DATABASE_URL                   -> rewritten Chorus diagnostic + banner
+//                                                     names the external source (not bare P1000).
+//   C. Clean env                                   -> happy path unchanged (migrations apply,
+//                                                     banner prints), then shuts down cleanly.
+//
+// Hermetic + self-cleaning: a uniquely-named container, isolated high ports (NEVER the dev
+// DB on 5433 or dev server on 8637), a throwaway data-dir, and guaranteed teardown.
+//
+// The foreign-Postgres legs (A, B) need docker + the postgres image. If docker is
+// unavailable we SKIP with a visible console.warn (never a silent skip — project policy).
+// Path C needs no docker and always runs.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHORUS_ENTRY = resolve(__dirname, "..", "..", "chorus.mjs");
+
+// Isolated, unlikely-to-collide resources. Deliberately far from 5433 (dev DB) / 8637 (dev server).
+const FOREIGN_PG_PORT = 5468; // real Postgres occupies this
+const CLEAN_PGLITE_PORT = 5469; // Path C embedded PGlite
+const HTTP_PORT_A = 8781;
+const HTTP_PORT_B = 8782;
+const HTTP_PORT_C = 8783;
+const CONTAINER = "chorus-379-integration-pg";
+const FOREIGN_PASSWORD = "notchorus"; // != "postgres", so postgres/postgres is rejected
+
+/** True if `docker` runs and the postgres image is usable. */
+function dockerAvailable() {
+  const v = spawnSync("docker", ["version", "--format", "{{.Server.Version}}"], {
+    encoding: "utf8",
+    timeout: 8000,
+  });
+  return v.status === 0 && !!(v.stdout || "").trim();
+}
+
+/**
+ * Run chorus.mjs to completion-or-banner, capturing combined output.
+ * Resolves when the process exits (fail-fast paths) OR the banner appears (happy path),
+ * whichever comes first; then ensures the process is dead.
+ */
+function runChorus({ args, env, waitForBanner, timeoutMs = 90000 }) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(process.execPath, [CHORUS_ENTRY, ...args], {
+      cwd: resolve(__dirname, "..", ".."),
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    const done = (reason) => {
+      if (child.exitCode === null && !child.killed) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* already gone */
+        }
+      }
+      resolvePromise({ output: out, reason, exitCode: child.exitCode });
+    };
+    const onData = (chunk) => {
+      out += chunk;
+      // Wait for the FULL banner block, not just the version line: the `Login:` field is
+      // the last banner row printed after `Database:`, so matching it guarantees the
+      // whole banner (incl. the Database line we assert on) is in `out`. Resolve then and
+      // tear down — the post-banner Next.js server start is out of scope for this
+      // DB-focused checkpoint.
+      if (waitForBanner && /Login:\s+/.test(out)) {
+        done("banner");
+      }
+    };
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
+    child.on("exit", () => done("exit"));
+    child.on("error", () => done("error"));
+    const t = setTimeout(() => done("timeout"), timeoutMs);
+    if (t.unref) t.unref();
+  });
+}
+
+const hasDocker = dockerAvailable();
+const describeForeign = hasDocker ? describe : describe.skip;
+
+if (!hasDocker) {
+  // Visible skip — never silent (project "no silent errors" policy).
+  console.warn(
+    "[embedded-db-integration] SKIPPING the foreign-Postgres legs (Path A + Path B): " +
+      "docker is not available. Path C (clean env) still runs. Run with docker to exercise " +
+      "the full #379 reproduction."
+  );
+}
+
+describeForeign("embedded-db integration — foreign Postgres (Paths A & B, docker)", () => {
+  beforeAll(() => {
+    spawnSync("docker", ["rm", "-f", CONTAINER], { stdio: "ignore" });
+    const up = spawnSync(
+      "docker",
+      [
+        "run", "-d", "--name", CONTAINER,
+        "-e", `POSTGRES_PASSWORD=${FOREIGN_PASSWORD}`,
+        "-p", `127.0.0.1:${FOREIGN_PG_PORT}:5432`,
+        "postgres:16-alpine",
+      ],
+      { encoding: "utf8", timeout: 60000 }
+    );
+    if (up.status !== 0) {
+      throw new Error(`failed to start foreign Postgres container: ${up.stderr || up.stdout}`);
+    }
+    // Wait for readiness so the port is genuinely LISTENing before the tests run.
+    let ready = false;
+    for (let i = 0; i < 30; i++) {
+      const r = spawnSync("docker", ["exec", CONTAINER, "pg_isready", "-U", "postgres"], {
+        stdio: "ignore",
+        timeout: 8000,
+      });
+      if (r.status === 0) {
+        ready = true;
+        break;
+      }
+      spawnSync("sleep", ["1"]);
+    }
+    if (!ready) throw new Error("foreign Postgres did not become ready in time");
+  }, 120000);
+
+  afterAll(() => {
+    spawnSync("docker", ["rm", "-f", CONTAINER], { stdio: "ignore" });
+  });
+
+  it("Path A: foreign Postgres on the PGlite port -> fail fast, no 'PGlite ready', no bare P1000", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "chorus-379-A-"));
+    try {
+      const { output } = await runChorus({
+        args: ["--pglite-port", String(FOREIGN_PG_PORT), "--port", String(HTTP_PORT_A), "--data-dir", dataDir],
+        env: { DATABASE_URL: "" }, // ensure no residual DATABASE_URL — this is the embedded path
+        waitForBanner: false,
+      });
+      // Fail-fast with an actionable port-conflict message…
+      expect(output).toMatch(/--pglite-port/);
+      expect(output).toMatch(new RegExp(String(FOREIGN_PG_PORT)));
+      // …and crucially NOT a false readiness claim, and NOT a bare Prisma P1000.
+      expect(output).not.toMatch(/PGlite ready/i);
+      expect(output).not.toMatch(/P1000/);
+      // It must not have reached / gotten past migrations against the foreign DB.
+      expect(output).not.toMatch(/Migrations completed/);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  it("Path B: residual bad DATABASE_URL -> rewritten Chorus diagnostic (not bare P1000)", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "chorus-379-B-"));
+    try {
+      const badUrl = `postgresql://postgres:postgres@localhost:${FOREIGN_PG_PORT}/postgres?sslmode=disable`;
+      const { output } = await runChorus({
+        args: ["--port", String(HTTP_PORT_B), "--data-dir", dataDir],
+        env: { DATABASE_URL: badUrl },
+        waitForBanner: false,
+      });
+      // The rewritten Chorus diagnostic names the external host:port and the remedy…
+      expect(output).toMatch(new RegExp(`localhost:${FOREIGN_PG_PORT}`));
+      expect(output).toMatch(/unset DATABASE_URL/);
+      // …credentials are masked (the cleartext password must not appear)…
+      expect(output).not.toMatch(/postgres:postgres@/);
+      // …and it did NOT start embedded PGlite (DATABASE_URL was honored).
+      expect(output).not.toMatch(/Starting embedded PostgreSQL/);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  }, 120000);
+});
+
+describe("embedded-db integration — clean env (Path C, no docker)", () => {
+  it("clean env: migrations apply, banner prints, then shuts down cleanly", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "chorus-379-C-"));
+    try {
+      const { output } = await runChorus({
+        args: ["--pglite-port", String(CLEAN_PGLITE_PORT), "--port", String(HTTP_PORT_C), "--data-dir", dataDir],
+        env: { DATABASE_URL: "" },
+        waitForBanner: true,
+      });
+      // AC-3 success signal for the DB-launch fix is: embedded PGlite came up, migrations
+      // applied, and the startup banner printed. (The post-banner Next.js server start is
+      // out of scope here — in a source checkout it depends on a `next build` having run
+      // to produce .next/standalone/.next/static, which this DB-focused test does not.)
+      expect(output).toMatch(/PGlite ready on port/);
+      expect(output).toMatch(/Migrations completed/);
+      expect(output).toMatch(/Chorus v\d/);
+      // Happy path uses embedded PGlite — banner must NOT be tainted with a DATABASE_URL source.
+      expect(output).toMatch(/Database:\s+PGlite \(embedded/);
+      expect(output).not.toMatch(/P1000/);
+      // The DB-launch path itself must not have failed fast.
+      expect(output).not.toMatch(/could not start/);
+    } finally {
+      // Free the embedded PGlite port in case a child lingered.
+      spawnSync("pkill", ["-f", `port=${CLEAN_PGLITE_PORT}`], { stdio: "ignore" });
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  }, 120000);
+});

--- a/cli/__tests__/embedded-db.test.mjs
+++ b/cli/__tests__/embedded-db.test.mjs
@@ -1,0 +1,348 @@
+// cli/__tests__/embedded-db.test.mjs
+// Regression tests for GitHub #379 — the embedded PGlite launch used to mistake a
+// foreign process listening on the PGlite port (default 5433) for our own PGlite:
+// it forked the child with stdio:"ignore", attached only .on("error") (spawn
+// failure), then trusted waitForTcp ("is *someone* listening?"). A real Postgres
+// on the port therefore produced a false "PGlite ready", a connection to the wrong
+// DB, and a Prisma P1000 at migrate time.
+//
+// The hardened launcher (cli/embedded-db.mjs) is PURE + dependency-injected so we
+// can drive it with a fake spawner + fake TCP probe — no real process spawning, no
+// import-time side effects (server-signal-handlers.test.mjs pattern). Two layered
+// guards: (1) a pre-flight port-occupancy probe that fails fast BEFORE forking onto
+// an occupied port; (2) an exit-latch that treats the child exiting before the port
+// is ready as fatal for ANY exit code (incl. the reproduced EADDRINUSE -> exit 0).
+import { describe, it, expect, vi } from "vitest";
+import {
+  launchEmbeddedPglite,
+  formatPortConflictMessage,
+  isPrismaAuthFailure,
+  maskDbUrl,
+  formatMigrationAuthDiagnostic,
+} from "../embedded-db.mjs";
+
+/** A minimal ChildProcess-like fake: records listeners, lets tests fire events. */
+function fakeChild() {
+  const listeners = {};
+  return {
+    exitCode: null,
+    killed: false,
+    on(event, fn) {
+      (listeners[event] ||= []).push(fn);
+      return this;
+    },
+    /** test helper: how many listeners are attached for an event */
+    _listenerCount(event) {
+      return (listeners[event] || []).length;
+    },
+    kill() {
+      this.killed = true;
+      return true;
+    },
+    /** test helper: simulate the child exiting */
+    _emitExit(code, signal = null) {
+      this.exitCode = code;
+      for (const fn of listeners.exit || []) fn(code, signal);
+    },
+    /** test helper: simulate a spawn error */
+    _emitError(err) {
+      for (const fn of listeners.error || []) fn(err);
+    },
+  };
+}
+
+/**
+ * Wait until the launcher has attached at least one listener for `event` on the
+ * child — i.e. it has passed `await preflightCheck` and `fork()`. Polls the fake's
+ * recorded listeners across microtasks so tests fire child events at a realistic
+ * point (a real child dies AFTER fork + listener attach, never before).
+ */
+async function waitForListeners(child, event) {
+  for (let i = 0; i < 50; i++) {
+    if (child._listenerCount(event) > 0) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error(`timed out waiting for a '${event}' listener to attach`);
+}
+
+/** A fake logger recording every line. */
+function fakeLogger() {
+  const lines = [];
+  return {
+    lines,
+    log: (m) => lines.push(String(m)),
+    error: (m) => lines.push(String(m)),
+    text: () => lines.join("\n"),
+  };
+}
+
+const HOST = "localhost";
+const PORT = 5433;
+
+describe("launchEmbeddedPglite", () => {
+  it("pre-flight: fails fast when the port is already occupied, WITHOUT forking", async () => {
+    const fork = vi.fn(() => fakeChild());
+    const logger = fakeLogger();
+    // preflight true => a foreign process (e.g. a real Postgres) already holds the port
+    const preflightCheck = vi.fn(async () => true);
+    const waitForTcp = vi.fn(async () => {});
+
+    const result = await launchEmbeddedPglite({
+      host: HOST,
+      port: PORT,
+      fork,
+      waitForTcp,
+      preflightCheck,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("port-occupied");
+    expect(result.port).toBe(PORT);
+    // The whole point: do NOT fork onto an occupied port, and never claim readiness.
+    expect(fork).not.toHaveBeenCalled();
+    expect(waitForTcp).not.toHaveBeenCalled();
+    expect(logger.text()).not.toMatch(/PGlite ready/i);
+  });
+
+  it("healthy start: port free, child alive when ready -> ok, emits 'PGlite ready'", async () => {
+    const child = fakeChild();
+    const fork = vi.fn(() => child);
+    const logger = fakeLogger();
+    const preflightCheck = vi.fn(async () => false);
+    const waitForTcp = vi.fn(async () => {}); // resolves => ready
+
+    const result = await launchEmbeddedPglite({
+      host: HOST,
+      port: PORT,
+      fork,
+      waitForTcp,
+      preflightCheck,
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.child).toBe(child);
+    expect(fork).toHaveBeenCalledTimes(1);
+    expect(logger.text()).toMatch(/PGlite ready on port 5433/);
+    expect(child.killed).toBe(false);
+  });
+
+  it("EADDRINUSE -> exit(0): child exits code 0 before ready -> FATAL (keys off exited-before-ready, not exit code)", async () => {
+    const child = fakeChild();
+    const fork = vi.fn(() => child);
+    const logger = fakeLogger();
+    const preflightCheck = vi.fn(async () => false);
+    // waitForTcp never resolves during the test window; the child's exit must decide the outcome.
+    const waitForTcp = vi.fn(() => new Promise(() => {}));
+
+    const promise = launchEmbeddedPglite({
+      host: HOST,
+      port: PORT,
+      fork,
+      waitForTcp,
+      preflightCheck,
+      logger,
+    });
+    // Simulate the reproduced case: PGlite catches EADDRINUSE and shuts down cleanly
+    // with code 0. Fire it after the async preflight has resolved and the launcher has
+    // forked + attached its listeners (mirrors a real child dying during startup).
+    await waitForListeners(child, "exit");
+    child._emitExit(0);
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("child-exited");
+    expect(result.exitInfo).toMatchObject({ code: 0 });
+    // A non-zero-only check would have MISSED this — the assertion guards that.
+    expect(logger.text()).not.toMatch(/PGlite ready/i);
+  });
+
+  it("non-zero exit: child exits code 1 before ready -> FATAL", async () => {
+    const child = fakeChild();
+    const fork = vi.fn(() => child);
+    const logger = fakeLogger();
+    const preflightCheck = vi.fn(async () => false);
+    const waitForTcp = vi.fn(() => new Promise(() => {}));
+
+    const promise = launchEmbeddedPglite({
+      host: HOST,
+      port: PORT,
+      fork,
+      waitForTcp,
+      preflightCheck,
+      logger,
+    });
+    await waitForListeners(child, "exit");
+    child._emitExit(1);
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("child-exited");
+    expect(result.exitInfo).toMatchObject({ code: 1 });
+  });
+
+  it("spawn error before ready -> FATAL", async () => {
+    const child = fakeChild();
+    const fork = vi.fn(() => child);
+    const logger = fakeLogger();
+    const preflightCheck = vi.fn(async () => false);
+    const waitForTcp = vi.fn(() => new Promise(() => {}));
+
+    const promise = launchEmbeddedPglite({
+      host: HOST,
+      port: PORT,
+      fork,
+      waitForTcp,
+      preflightCheck,
+      logger,
+    });
+    await waitForListeners(child, "error");
+    child._emitError(new Error("spawn ENOENT"));
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("child-error");
+  });
+
+  it("ordering race: ready wins but child already exited -> still FATAL (double-check)", async () => {
+    const child = fakeChild();
+    const fork = vi.fn(() => child);
+    const logger = fakeLogger();
+    const preflightCheck = vi.fn(async () => false);
+    // waitForTcp resolves immediately (as if a foreign listener answered), but the
+    // child has ALSO exited — a dead child must not be accepted as success even when
+    // the port probe succeeds. Set exitCode so the post-fork liveness check catches it.
+    child.exitCode = 0;
+    const waitForTcp = vi.fn(async () => {});
+
+    const result = await launchEmbeddedPglite({
+      host: HOST,
+      port: PORT,
+      fork,
+      waitForTcp,
+      preflightCheck,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("child-exited");
+    expect(logger.text()).not.toMatch(/PGlite ready/i);
+  });
+
+  it("readiness times out (waitForTcp rejects), child still alive -> FATAL and child killed", async () => {
+    const child = fakeChild();
+    const fork = vi.fn(() => child);
+    const logger = fakeLogger();
+    const preflightCheck = vi.fn(async () => false);
+    const waitForTcp = vi.fn(async () => {
+      throw new Error("PGlite failed to start within 15 seconds.");
+    });
+
+    const result = await launchEmbeddedPglite({
+      host: HOST,
+      port: PORT,
+      fork,
+      waitForTcp,
+      preflightCheck,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("not-ready");
+    // Don't leak the child if it's still running after a readiness timeout.
+    expect(child.killed).toBe(true);
+  });
+});
+
+describe("formatPortConflictMessage", () => {
+  it("names the occupied port and suggests --pglite-port", () => {
+    const msg = formatPortConflictMessage(5433);
+    expect(msg).toMatch(/5433/);
+    expect(msg).toMatch(/--pglite-port/);
+    // Actionable: mentions the likely cause (another process / PostgreSQL on the port).
+    expect(msg).toMatch(/occupied|in use|another/i);
+  });
+});
+
+describe("isPrismaAuthFailure", () => {
+  // Exact surface text captured from the installed Prisma 7.3.0 `migrate deploy`
+  // (see task #379): `Error: P1000: Authentication failed against database server, the
+  // provided database credentials for `postgres` are not valid.`
+  const P1000 =
+    'Error: P1000: Authentication failed against database server, the provided ' +
+    "database credentials for `postgres` are not valid.\n\nPlease make sure to " +
+    "provide valid database credentials for the database server at the configured address.";
+
+  it("recognizes a real Prisma P1000 auth failure (by code token)", () => {
+    expect(isPrismaAuthFailure(P1000)).toBe(true);
+  });
+
+  it("recognizes the auth phrase even without the P1000 token", () => {
+    expect(
+      isPrismaAuthFailure("Authentication failed against database server")
+    ).toBe(true);
+  });
+
+  it("does NOT misfire on a non-auth migration error (P3009 / failed migration)", () => {
+    const p3009 =
+      "Error: P3009: migrate found failed migrations in the target database.\n" +
+      "The `20260101_init` migration started but failed.";
+    expect(isPrismaAuthFailure(p3009)).toBe(false);
+  });
+
+  it("does NOT misfire on a connectivity error (P1001 can't reach server)", () => {
+    const p1001 =
+      "Error: P1001: Can't reach database server at `localhost:5433`.\n" +
+      "Please make sure your database server is running.";
+    expect(isPrismaAuthFailure(p1001)).toBe(false);
+  });
+
+  it("tolerates empty/undefined output", () => {
+    expect(isPrismaAuthFailure("")).toBe(false);
+    expect(isPrismaAuthFailure(undefined)).toBe(false);
+  });
+});
+
+describe("maskDbUrl", () => {
+  it("masks credentials but keeps host:port", () => {
+    const masked = maskDbUrl("postgresql://postgres:secretpw@localhost:5433/postgres?sslmode=disable");
+    expect(masked).not.toMatch(/secretpw/);
+    expect(masked).toMatch(/localhost:5433/);
+  });
+
+  it("handles a URL without credentials", () => {
+    expect(maskDbUrl("postgresql://localhost:5433/postgres")).toMatch(/localhost:5433/);
+  });
+
+  it("returns a placeholder for empty input", () => {
+    expect(maskDbUrl("")).toBeTruthy();
+  });
+});
+
+describe("formatMigrationAuthDiagnostic", () => {
+  it("embedded-PGlite path: blames port occupancy, suggests --pglite-port, masks creds", () => {
+    const msg = formatMigrationAuthDiagnostic({
+      effectiveUrl: "postgresql://postgres:postgres@localhost:5433/postgres?sslmode=disable",
+      startedEmbedded: true,
+      pglitePort: 5433,
+    });
+    expect(msg).toMatch(/localhost:5433/);
+    expect(msg).toMatch(/--pglite-port/);
+    expect(msg).toMatch(/occupied|another PostgreSQL|in use/i);
+    // Should NOT tell the embedded-path user to unset DATABASE_URL (they didn't set one).
+    expect(msg).not.toMatch(/unset DATABASE_URL/);
+  });
+
+  it("external DATABASE_URL path: names host:port, tells user to unset DATABASE_URL, masks creds", () => {
+    const msg = formatMigrationAuthDiagnostic({
+      effectiveUrl: "postgresql://admin:hunter2@db.example.com:5432/prod",
+      startedEmbedded: false,
+      pglitePort: 5433,
+    });
+    expect(msg).not.toMatch(/hunter2/);
+    expect(msg).toMatch(/db\.example\.com:5432/);
+    expect(msg).toMatch(/unset DATABASE_URL/);
+    expect(msg).toMatch(/DATABASE_URL/);
+  });
+});

--- a/cli/embedded-db.mjs
+++ b/cli/embedded-db.mjs
@@ -1,0 +1,234 @@
+// cli/embedded-db.mjs
+// Embedded PGlite launch logic, extracted out of chorus.mjs (GitHub #379).
+//
+// Why this module exists — the bug:
+//   chorus.mjs used to fork the PGlite child with { stdio: "ignore" }, attach only
+//   .on("error") (which fires ONLY on spawn failure), then trust waitForTcp — which
+//   answers "is *someone* listening on this port?", NOT "is it *our* PGlite?". When a
+//   real Postgres already occupied the port (default 5433), the forked PGlite child
+//   died of EADDRINUSE — but it catches that and exits with code 0 (a clean shutdown),
+//   so .on("error") never fired and its output was swallowed by stdio:"ignore". The
+//   launcher then connected to the FOREIGN Postgres, printed a false "PGlite ready",
+//   and `prisma migrate deploy` failed authentication with a bare Prisma P1000.
+//
+// The fix is defense-in-depth, both layers pure + dependency-injected so they unit-test
+// with fakes (server-signal-handlers.mjs precedent — no real process spawning, no
+// import-time side effects):
+//   1. Pre-flight port-occupancy probe — before forking, check whether the port is
+//      already held. If so, FAIL FAST with an actionable message (no fork, no false
+//      "ready", no silent mis-connect).
+//   2. Exit-latch — after forking, race the child's "exit"/"error" against port-ready.
+//      If the child exits before readiness is confirmed, for ANY exit code (including
+//      the reproduced EADDRINUSE -> exit 0), the launch is FATAL. "someone is listening"
+//      is no longer sufficient evidence that our embedded PGlite is up.
+//
+// No automatic port bumping (out of scope for #379 — elaboration chose fail-fast).
+
+/**
+ * Format the fail-fast message shown when the embedded PGlite port is occupied.
+ * @param {number} port
+ * @returns {string}
+ */
+export function formatPortConflictMessage(port) {
+  return (
+    `ERROR: Embedded PostgreSQL (PGlite) could not start — port ${port} is already in use.\n` +
+    `Another process (often a real PostgreSQL) is occupying it. Free the port, or run\n` +
+    `Chorus on a different embedded port:  chorus --pglite-port <port>`
+  );
+}
+
+/** True when a child process has already terminated (exit code recorded). */
+function childHasExited(child) {
+  return child.exitCode !== null && child.exitCode !== undefined;
+}
+
+/**
+ * Classify migrate output as a Prisma authentication failure (P1000).
+ *
+ * Matches the stable error CODE token first, then the human phrase as a fallback,
+ * so it survives message drift across Prisma versions. Deliberately narrow: it must
+ * NOT fire on other migration errors (P3009 failed migration, P1001 can't-reach, etc.)
+ * — those keep chorus.mjs's existing generic "Database migration failed" path.
+ * Verified against the installed Prisma 7.3.0 surface text (GitHub #379).
+ *
+ * @param {string|undefined|null} output  combined stdout+stderr of `prisma migrate deploy`
+ * @returns {boolean}
+ */
+export function isPrismaAuthFailure(output) {
+  if (!output) return false;
+  const text = String(output);
+  // P1000 is Prisma's dedicated auth-failure code — the most stable signal.
+  if (/\bP1000\b/.test(text)) return true;
+  // Fallback phrase (covers adapter-surfaced errors that omit the bare code token).
+  if (/Authentication failed against (the )?database server/i.test(text)) return true;
+  return false;
+}
+
+/**
+ * Mask credentials in a Postgres connection URL, preserving host:port (+db) for
+ * diagnostics. Falls back to a naive user:pass@ strip if URL parsing fails, and to a
+ * placeholder for empty input.
+ *
+ * @param {string|undefined|null} url
+ * @returns {string}
+ */
+export function maskDbUrl(url) {
+  if (!url) return "(unknown database)";
+  const raw = String(url);
+  try {
+    const u = new URL(raw);
+    const auth = u.username ? `${u.username}:***@` : "";
+    const db = u.pathname && u.pathname !== "/" ? u.pathname : "";
+    return `${u.protocol}//${auth}${u.host}${db}`;
+  } catch {
+    // Best-effort: strip a user:pass@ segment if present.
+    return raw.replace(/\/\/[^@/]*@/, "//***@");
+  }
+}
+
+/** Extract just host:port from a connection URL for terse messages. */
+function hostPortOf(url) {
+  if (!url) return "the database";
+  try {
+    return new URL(String(url)).host || "the database";
+  } catch {
+    const m = String(url).match(/@([^/?]+)/);
+    return m ? m[1] : "the database";
+  }
+}
+
+/**
+ * Build the Chorus-friendly diagnostic shown (as the FINAL output) when
+ * `prisma migrate deploy` fails authentication. The remedy depends on WHY we're
+ * pointed at that database:
+ *   - embedded path (no external DATABASE_URL): the port is likely occupied by another
+ *     PostgreSQL — suggest `chorus --pglite-port <port>`.
+ *   - external path (DATABASE_URL set): name the external host:port and suggest
+ *     `unset DATABASE_URL` if it was unintended.
+ * Credentials are always masked.
+ *
+ * @param {object} params
+ * @param {string}  params.effectiveUrl    the DATABASE_URL actually used for migration
+ * @param {boolean} params.startedEmbedded  true if we launched embedded PGlite ourselves
+ * @param {number}  params.pglitePort       the embedded port (for the --pglite-port hint)
+ * @returns {string}
+ */
+export function formatMigrationAuthDiagnostic({ effectiveUrl, startedEmbedded, pglitePort }) {
+  const masked = maskDbUrl(effectiveUrl);
+  const hostPort = hostPortOf(effectiveUrl);
+  const lines = [
+    "",
+    "ERROR: Database migration failed — the database server rejected the credentials.",
+    `Connected to ${masked}, but authentication failed (Prisma P1000).`,
+    "",
+  ];
+  if (startedEmbedded) {
+    lines.push(
+      `This usually means port ${pglitePort} is occupied by another PostgreSQL, so Chorus`,
+      `connected to it instead of its own embedded database. Free the port, or run on a`,
+      `different one:  chorus --pglite-port <port>`
+    );
+  } else {
+    lines.push(
+      `Chorus used the DATABASE_URL from your environment (${hostPort}) instead of its`,
+      `embedded database. If that was not intended, clear it and re-run:  unset DATABASE_URL`
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Launch the embedded PGlite child and confirm it is genuinely OUR process that is
+ * ready — not a foreign listener on the same port.
+ *
+ * Pure w.r.t. its injected dependencies: `fork`, `waitForTcp`, `preflightCheck`,
+ * `logger`. No process global is touched here; the caller (chorus.mjs) wires the real
+ * implementations and decides how to exit on failure.
+ *
+ * @param {object} params
+ * @param {string}   params.host            host to probe for readiness (e.g. "localhost")
+ * @param {number}   params.port            embedded PGlite port
+ * @param {() => { on: Function, kill?: Function, exitCode: number|null, killed?: boolean }} params.fork
+ *   forks the PGlite server child and returns a ChildProcess-like object
+ * @param {(host: string, port: number) => Promise<void>} params.waitForTcp
+ *   resolves when the port accepts a TCP connection, rejects on timeout
+ * @param {(host: string, port: number) => Promise<boolean>} params.preflightCheck
+ *   resolves true if the port is ALREADY occupied before we fork (foreign listener)
+ * @param {{ log: Function, error: Function }} params.logger
+ * @returns {Promise<
+ *   | { ok: true, child: object }
+ *   | { ok: false, reason: "port-occupied", port: number }
+ *   | { ok: false, reason: "child-exited", exitInfo: { code: number|null, signal: string|null } }
+ *   | { ok: false, reason: "child-error", error: Error }
+ *   | { ok: false, reason: "not-ready", error: Error }
+ * >}
+ */
+export async function launchEmbeddedPglite({ host, port, fork, waitForTcp, preflightCheck, logger }) {
+  // Layer 1 — pre-flight: never fork onto an already-occupied port.
+  const occupied = await preflightCheck(host, port);
+  if (occupied) {
+    logger.error(formatPortConflictMessage(port));
+    return { ok: false, reason: "port-occupied", port };
+  }
+
+  const child = fork();
+
+  // The child may have died synchronously during/just after fork (its exit code is
+  // then already recorded even if our "exit" listener attaches a tick too late).
+  if (childHasExited(child)) {
+    return {
+      ok: false,
+      reason: "child-exited",
+      exitInfo: { code: child.exitCode, signal: null },
+    };
+  }
+
+  // Layer 2 — latch the child's terminal events, then race them against readiness.
+  // A dead child ALWAYS beats a "someone is listening" probe: that is the #379 guard.
+  let exitInfo = null; // { code, signal } once the child exits
+  let spawnError = null;
+  let readyError = null;
+
+  const childDied = new Promise((resolve) => {
+    child.on("exit", (code, signal) => {
+      exitInfo = { code, signal };
+      resolve("exit");
+    });
+    child.on("error", (err) => {
+      spawnError = err;
+      resolve("error");
+    });
+  });
+
+  const readied = waitForTcp(host, port).then(
+    () => "ready",
+    (err) => {
+      readyError = err;
+      return "not-ready";
+    }
+  );
+
+  const outcome = await Promise.race([childDied, readied]);
+
+  // Re-check the latches regardless of who won the race — the child dying is fatal
+  // even if the port-ready probe also resolved (e.g. against a foreign listener).
+  if (exitInfo || childHasExited(child)) {
+    return {
+      ok: false,
+      reason: "child-exited",
+      exitInfo: exitInfo || { code: child.exitCode ?? null, signal: null },
+    };
+  }
+  if (spawnError) {
+    return { ok: false, reason: "child-error", error: spawnError };
+  }
+  if (outcome === "not-ready") {
+    // Readiness timed out but the child is (as far as we know) still alive — don't leak it.
+    if (child.kill && !child.killed) child.kill("SIGTERM");
+    return { ok: false, reason: "not-ready", error: readyError };
+  }
+
+  // outcome === "ready" AND the child has not exited → genuinely our PGlite.
+  logger.log(`PGlite ready on port ${port}.`);
+  return { ok: true, child };
+}

--- a/openspec/changes/fix-embedded-pglite-port-conflict/.openspec.yaml
+++ b/openspec/changes/fix-embedded-pglite-port-conflict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/fix-embedded-pglite-port-conflict/README.md
+++ b/openspec/changes/fix-embedded-pglite-port-conflict/README.md
@@ -1,0 +1,3 @@
+# fix-embedded-pglite-port-conflict
+
+Fix P1000 on first chorus run when the PGlite port is occupied or DATABASE_URL is residual (GitHub #379)

--- a/openspec/changes/fix-embedded-pglite-port-conflict/design.md
+++ b/openspec/changes/fix-embedded-pglite-port-conflict/design.md
@@ -1,0 +1,83 @@
+## Context
+
+`chorus.mjs` is the standalone server entry (`#!/usr/bin/env node`). On the server-launch path (no `daemon`/`login` subcommand) its `main()` decides how to obtain a database:
+
+- `usePglite` defaults to `true`; `startEmbeddedPglite = usePglite && !process.env.DATABASE_URL` (`chorus.mjs:287`).
+- When starting embedded PGlite it `fork()`s `@electric-sql/pglite-socket`'s `server.js` with `{ stdio: "ignore" }` (`:314–318`), attaches only `pgliteProcess.on("error", …)` (`:320`, fires on **spawn** failure only), then `await waitForTcp("localhost", PGLITE_PORT)` (`:332`) which resolves as soon as a TCP connect succeeds. On success it hardcodes `process.env.DATABASE_URL = postgresql://postgres:postgres@localhost:${PGLITE_PORT}/postgres` (`:342`).
+- Then `execSync("… prisma … migrate deploy", { stdio: "inherit" })` (`:354`); on throw it prints `ERROR: Database migration failed.` and `exit(1)` (`:360`).
+
+**Reproduced failure modes (real hardware, 2026-07-01):**
+- **A:** a real Postgres already on `PGLITE_PORT`. The forked PGlite child logs `EADDRINUSE` and **exits 0** (clean shutdown after catching the listen error); `stdio:"ignore"` hides it; `.on("error")` never fires (no spawn failure). `waitForTcp` connects to the *foreign* Postgres → prints `PGlite ready` → `DATABASE_URL` points at the foreign DB → `migrate deploy` → **P1000**.
+- **B:** `DATABASE_URL` already exported → embedded PGlite skipped → connect to that DB → **P1000**.
+
+The existing `cli/server-signal-handlers.mjs` (+ its `__tests__`) establishes the codebase pattern: **extract a pure, dependency-injected helper out of the side-effectful entry so it can be unit-tested with fakes.** This design follows that precedent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A foreign listener on `PGLITE_PORT` can never be mistaken for our embedded PGlite (kill Path A's silent mis-connect).
+- The PGlite child exiting for *any* reason before the port is confirmed ready is detected and fatal (not just spawn failure).
+- When the DB connection fails at migration time, the user sees an actionable, self-explaining diagnostic (host:port connected, credential mismatch, remedies) instead of a bare Prisma P1000.
+- When `DATABASE_URL` causes embedded PGlite to be skipped, that provenance is visible in the banner and in any failure message.
+- The launch/diagnostic logic is unit-testable without spawning real processes or importing the entry module's import-time side effects.
+- Clean happy path (no occupant, no `DATABASE_URL`) is byte-for-byte unchanged in behavior.
+
+**Non-Goals:**
+- **Automatic port bumping** (5433→5434→…). Elaboration chose fail-fast (`--pglite-port` is the manual remedy). Deferred.
+- **Passing the PGlite child's stderr through** to the console. Elaboration chose `capture_exit` only; the rewritten P1000 diagnostic (Q3) carries the actionable information, so raw child stderr is not required. Deferred.
+- Changing `DATABASE_URL`-wins precedence semantics (kept as-is; only made visible).
+- Deep protocol/handshake validation of the peer (e.g., confirming it speaks PGlite's wire dialect). Child-liveness + fail-fast is sufficient for the MVP; handshake probing is a possible future hardening.
+
+## Decisions
+
+### D1 — Detect child exit, don't trust "someone is listening"
+
+Replace the spawn-only `.on("error")` with a launch routine that treats **the PGlite child exiting before the port is confirmed** as fatal. Concretely, race two conditions after `fork`:
+
+- **child exit** — attach `pgliteProcess.on("exit", (code, signal) => …)`. If the child exits (any code, including the observed `EADDRINUSE → exit 0`) before we've confirmed readiness, the launch **fails fatally**.
+- **port ready** — `waitForTcp` resolving.
+
+Whichever fires first wins. If child-exit wins → fatal error (the port is either occupied by a foreign process or PGlite couldn't start). If port-ready wins first **and the child is still alive**, we accept it. This closes the Path A gap: a foreign listener no longer counts as success, because our own child having exited is now an independent, sufficient failure signal.
+
+> Implementation note (verify against the installed Node): a `fork`ed child that exits fires `"exit"` even under `stdio:"ignore"`. The child's own `EADDRINUSE` handler exits 0, so we must key off *"exited before ready"*, **not** *"exited with non-zero code"* — a non-zero-only check would miss the reproduced case. Task AC must assert exactly this.
+
+### D2 — Fail-fast message on port conflict
+
+When D1 declares the launch failed (child exited before ready), print a clear, actionable error and `exit(1)`:
+
+> `Embedded PostgreSQL (PGlite) could not start on port <PORT>. The port may be occupied by another process (e.g. a real PostgreSQL). Free the port, or choose another with: chorus --pglite-port <port>.`
+
+No auto-bump. This replaces the misleading `PGlite ready` line for the conflict case.
+
+### D3 — Rewrite Prisma P1000 into a Chorus diagnostic
+
+Wrap `migrate deploy` so an authentication failure is intercepted and re-presented. Because `stdio:"inherit"` streams Prisma's output live, detection must not rely on swallowing it: capture the migrate step's output (or re-run classification) enough to recognize the auth-failure signature, then append/emit a Chorus diagnostic as the **final** message so it's the last thing the user sees. The diagnostic states:
+
+- which host:port was connected (derive from the effective `DATABASE_URL`, credentials masked),
+- that the server rejected the `postgres` credentials,
+- the two remedies, chosen by *why* we're pointed there:
+  - embedded-PGlite path (no external `DATABASE_URL`): "port `<PORT>` is likely occupied by another PostgreSQL — retry with `chorus --pglite-port <free port>`",
+  - external path (`DATABASE_URL` set): "Chorus is using your `DATABASE_URL` (`<host:port>`); if that is unintended, `unset DATABASE_URL` and re-run."
+
+Detection should match Prisma's P1000 robustly (code token `P1000` and/or the "Authentication failed against database server" phrase) and must not misfire on unrelated migration errors — non-auth failures keep today's generic `Database migration failed` path. Verify the exact P1000 surface text against the installed Prisma version rather than trusting memory.
+
+### D4 — DATABASE_URL provenance in the banner
+
+The banner already prints a `Database:` line. Extend the skip-PGlite case so it names the external target: `Database: external PostgreSQL (from DATABASE_URL: <host:port>)` (credentials masked). Semantics unchanged — only visibility. The D3 external-path diagnostic reuses the same host:port formatting helper.
+
+### D5 — Extract a pure, injectable module (testing seam)
+
+Following `cli/server-signal-handlers.mjs`: move the embedded-PGlite launch + diagnostic logic into a new pure module under `cli/` (e.g. `cli/embedded-db.mjs`) exporting small functions that take injected dependencies — a `fork`-like spawner, a `waitForTcp`-like readiness probe, a `logger`/`console`, and an `exit` callback — so unit tests drive them with fakes (mirroring the fake-`process` recorder in `server-signal-handlers.test.mjs`). `chorus.mjs` becomes a thin caller. Pure functions to cover:
+
+- **launch outcome resolver** — given (child-exit event vs port-ready event ordering, child alive flag) → `{ ok }` or `{ fatal, reason }` (D1).
+- **P1000 classifier** — given migrate stdout/stderr + exit status → `isAuthFailure: boolean` (D3).
+- **diagnostic formatter** — given `{ effectiveUrl, startedEmbedded, pglitePort }` → the exact remedy string (D2/D3/D4), credentials masked.
+
+This keeps the fix honest (assert the exact reproduced case) and avoids flaky process-spawning tests in the unit layer; a separate integration test exercises the real `fork`.
+
+## Risks / Trade-offs
+
+- **Race semantics (D1):** the child could exit *microseconds after* `waitForTcp` resolves against the real PGlite — acceptable: that's a genuinely-started PGlite that then crashed, still worth surfacing, but the common healthy path resolves port-ready first with a live child. Keep the "still alive at ready-time" check narrow to avoid false fatals on a healthy start. Cover ordering in unit tests.
+- **P1000 detection brittleness (D3):** matching on Prisma's message/code risks drift across Prisma versions. Mitigate by matching the stable `P1000` token first, phrase second, and falling back to the generic error path when unsure (never *hide* a real failure). Pin behavior with a unit test over a captured P1000 sample and re-verify against the installed Prisma.
+- **`stdio:"inherit"` vs capturing output (D3):** to classify the migrate failure we may need to capture rather than pure-inherit its streams; must preserve live progress visibility (users expect to see migrations applying). Trade-off: tee/capture, or run classification on a captured buffer while still echoing. Chosen approach must not regress the visible migration progress on the happy path.
+- **Foreign PGlite on the port:** if the occupant genuinely *is* another Chorus PGlite with matching `postgres/postgres`, migration could succeed against it (data goes to the wrong instance). Out of scope to fully disambiguate here; D1 only guarantees we don't treat a *dead* child as success. Handshake/identity probing is future work.

--- a/openspec/changes/fix-embedded-pglite-port-conflict/proposal.md
+++ b/openspec/changes/fix-embedded-pglite-port-conflict/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+A first-time user who runs `chorus` after a global install can hit Prisma **P1000** ("Authentication failed against database server, the provided credentials for `postgres` are not valid") — an out-of-the-box CLI should never require the user to supply their own Postgres. This was reported as GitHub #379 and **reproduced on real hardware** via two paths:
+
+- **Path A (port occupied):** the embedded PGlite is forked on a hardcoded port (default 5433). If a *real* Postgres already listens there, the forked PGlite child dies of `EADDRINUSE` — but it **exits with code 0** (it catches the error and shuts down cleanly), and its output is swallowed by `stdio: "ignore"`. The current `.on("error")` handler only catches *spawn* failure, so nothing is caught. `waitForTcp` then probes only "is *someone* listening?" — the foreign Postgres is — so it prints a misleading **`PGlite ready`**, sets `DATABASE_URL=postgres:postgres@localhost:5433`, and the next step (`prisma migrate deploy`) hands the wrong credentials to the foreign DB → **P1000**.
+- **Path B (residual env):** if the user's shell already exports `DATABASE_URL` (common on developer machines), embedded PGlite is skipped entirely and Chorus connects straight to that DB; wrong credentials → **P1000**.
+
+Correction over the original report: P1000 surfaces at the **`prisma migrate deploy`** step, *before* the Next.js server starts — the process `exit(1)`s and the user never reaches a login screen. (Ruled out by experiment: a stale `.next/standalone/.env` does **not** ship to npm; `bun` vs `npm` install is irrelevant — the runtime is always node.)
+
+## What Changes
+
+Scope is the agreed MVP (elaboration Round 1): make the failure **impossible to hit silently**, and make any residual failure **self-explaining**. No automatic port bumping.
+
+- **Capture PGlite child-process exit (any exit code), not just spawn error.** If the forked PGlite process exits before `waitForTcp` reports the port ready, treat it as **fatal** and stop with a clear message — never let a foreign listener on the port be mistaken for our PGlite. This closes Path A at the root: `waitForTcp` alone ("someone is listening") is no longer sufficient evidence that our embedded DB is up.
+- **Rewrite the bare Prisma P1000 into a Chorus-friendly diagnostic.** When `prisma migrate deploy` fails with an authentication error, intercept it and print an actionable message: which host:port was connected, that credentials did not match, and the two remedies (`--pglite-port <free port>` if the default port is occupied, or `unset DATABASE_URL` if it points at the wrong DB). The raw P1000 is no longer the last thing the user sees.
+- **Surface `DATABASE_URL` provenance explicitly.** When embedded PGlite is skipped because `DATABASE_URL` is set, say so in the startup banner and in the failure diagnostic ("Using external DATABASE_URL <host:port>; embedded PGlite not started"), so a *residual* export is visible rather than silent. Existing `DATABASE_URL`-wins semantics are unchanged.
+
+Explicitly **out of scope** for this change (deferred): automatic port bumping (5433→5434→…), and passing the PGlite child's stderr through to the console.
+
+## Capabilities
+
+### New Capabilities
+- `embedded-db-launch`: how the standalone `chorus` server launches (or declines to launch) the embedded PGlite database — child-process liveness detection, port-conflict fail-fast, DATABASE_URL provenance in the banner, and actionable diagnostics when the database connection fails at migration time.
+
+### Modified Capabilities
+<!-- none — no existing spec capability covers the embedded-DB launch path -->
+
+## Impact
+
+- **Code:** `chorus.mjs` (embedded-PGlite launch block ~L303–L343, `.on("error")` handler L320, `waitForTcp` L225–L248, migration block L350–L363, banner L385–L411). Following the existing `cli/server-signal-handlers.mjs` precedent, the launch/diagnostic logic is extracted into a **pure, dependency-injected `cli/*.mjs` module** so it can be unit-tested with fake process/socket objects without importing the side-effectful entry.
+- **Tests:** new `cli/__tests__/*.test.mjs` covering child-exit capture, port-conflict fail-fast, and P1000 rewrite; plus a real end-to-end reproduction (foreign Postgres on the PGlite port; residual bad `DATABASE_URL`).
+- **No schema/API/dependency changes.** No behavioral change on the clean happy path (no port occupant, no `DATABASE_URL`) — verified still working during reproduction.
+- **Docs:** the `--pglite-port` remedy and the `DATABASE_URL` provenance note may warrant a line in the CLI `--help` / setup docs.

--- a/openspec/changes/fix-embedded-pglite-port-conflict/specs/embedded-db-launch/spec.md
+++ b/openspec/changes/fix-embedded-pglite-port-conflict/specs/embedded-db-launch/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Embedded PGlite launch detects child-process exit
+The standalone `chorus` server SHALL treat the embedded PGlite child process exiting before its port is confirmed ready as a fatal launch failure, regardless of the child's exit code. Detecting that a TCP port is listening SHALL NOT by itself be accepted as evidence that the embedded PGlite is running.
+
+#### Scenario: PGlite child exits with code 0 after EADDRINUSE
+- **WHEN** the embedded PGlite child process is forked on a port already bound by another process and the child exits (observed exit code 0 after catching `EADDRINUSE`) before readiness is confirmed
+- **THEN** the launch is treated as failed and the server does not proceed to run migrations against whatever is listening on that port
+
+#### Scenario: PGlite child exits with a non-zero code
+- **WHEN** the embedded PGlite child process exits with any non-zero code before readiness is confirmed
+- **THEN** the launch is treated as failed and a fatal error is reported
+
+#### Scenario: Healthy embedded PGlite start
+- **WHEN** no other process occupies the port and the forked PGlite child is still alive at the moment the port reports ready
+- **THEN** the launch succeeds and the server proceeds to migrations, unchanged from the prior happy-path behavior
+
+### Requirement: Port-conflict failure is actionable and never a silent mis-connect
+When the embedded PGlite launch fails because its port is occupied, the standalone `chorus` server SHALL exit with a non-zero status and print an actionable message naming the port and offering `--pglite-port` as the remedy. It SHALL NOT print a success line (e.g. "PGlite ready") when its own PGlite child did not start, and it SHALL NOT silently connect to a foreign database listening on that port.
+
+#### Scenario: Default port occupied by a foreign PostgreSQL
+- **WHEN** a real PostgreSQL is listening on the default embedded port and the user runs `chorus` with no `DATABASE_URL` set
+- **THEN** the server prints a message identifying the occupied port and instructing the user to free it or pass `chorus --pglite-port <port>`, and exits non-zero without attempting migrations against the foreign PostgreSQL
+
+#### Scenario: No misleading readiness line on conflict
+- **WHEN** the embedded PGlite child fails to bind its port
+- **THEN** the console output does not contain a "PGlite ready" confirmation for that port
+
+### Requirement: Database authentication failure is rewritten into a Chorus diagnostic
+When a database connection used for migrations fails authentication (Prisma P1000), the standalone `chorus` server SHALL present a Chorus-authored diagnostic as the final output. The diagnostic SHALL name the connected host and port (with credentials masked), state that the server rejected the credentials, and give a remedy appropriate to why that database was chosen. Migration failures that are NOT authentication failures SHALL retain the existing generic error path.
+
+#### Scenario: P1000 on the embedded-PGlite path
+- **WHEN** migrations fail with an authentication error and no external `DATABASE_URL` was set (embedded PGlite path)
+- **THEN** the diagnostic explains the port is likely occupied by another PostgreSQL and instructs the user to retry with `chorus --pglite-port <free port>`
+
+#### Scenario: P1000 on the external DATABASE_URL path
+- **WHEN** migrations fail with an authentication error and `DATABASE_URL` was set in the environment
+- **THEN** the diagnostic names the external host:port from `DATABASE_URL` and instructs the user to `unset DATABASE_URL` if that target was unintended
+
+#### Scenario: Non-authentication migration failure
+- **WHEN** migrations fail for a reason other than authentication (e.g. a schema or connectivity error unrelated to credentials)
+- **THEN** the server reports the failure via the existing generic migration-failure path without falsely attributing it to credentials
+
+### Requirement: DATABASE_URL provenance is visible when embedded PGlite is skipped
+When the standalone `chorus` server skips launching embedded PGlite because `DATABASE_URL` is set, it SHALL make that provenance visible in the startup banner and in any subsequent connection-failure diagnostic, naming the external host and port (credentials masked). The precedence semantics (a set `DATABASE_URL` takes priority over embedded PGlite) SHALL remain unchanged.
+
+#### Scenario: Banner shows external DATABASE_URL source
+- **WHEN** `chorus` starts with `DATABASE_URL` set in the environment
+- **THEN** the startup banner's database line indicates the database comes from `DATABASE_URL` and names its host:port with credentials masked
+
+#### Scenario: Residual DATABASE_URL is not silently honored
+- **WHEN** `DATABASE_URL` is set and the resulting connection fails
+- **THEN** the failure diagnostic points out that `DATABASE_URL` selected the target database, so a residual/unintended export is visible rather than hidden

--- a/openspec/changes/fix-embedded-pglite-port-conflict/tasks.md
+++ b/openspec/changes/fix-embedded-pglite-port-conflict/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## 1. Extract & harden embedded-PGlite launch (child-exit capture + fail-fast)
+- [ ] Extract embedded-PGlite launch + diagnostic logic from `chorus.mjs` into a pure, dependency-injected `cli/embedded-db.mjs` (precedent: `cli/server-signal-handlers.mjs`).
+- [ ] Detect child exit before port-ready as fatal (any exit code, incl. EADDRINUSE→exit 0); remove misleading "PGlite ready" on conflict; print `--pglite-port` remedy; exit non-zero.
+- [ ] Unit tests with fake spawner/socket for: EADDRINUSE→exit 0, non-zero exit, healthy start, ordering race.
+
+## 2. Rewrite P1000 into a Chorus diagnostic + DATABASE_URL provenance
+- [ ] Classify migrate auth-failure (P1000 token / phrase) without misfiring on other errors; keep generic path otherwise.
+- [ ] Emit final diagnostic (embedded path → --pglite-port; external path → unset DATABASE_URL); mask creds.
+- [ ] Banner names external DATABASE_URL host:port when embedded PGlite skipped.
+- [ ] Unit tests for classifier + formatter over captured P1000 sample.
+
+## 3. End-to-end reproduction test (integration checkpoint)
+- [ ] Real foreign Postgres on the PGlite port → assert fail-fast, no P1000, no false "PGlite ready".
+- [ ] Residual bad DATABASE_URL → assert rewritten diagnostic, not bare P1000.
+- [ ] Clean env → assert happy path unchanged (migrations apply, server starts).


### PR DESCRIPTION
## Summary
Fixes GitHub #379 — a first-time `chorus` run hit Prisma **P1000** when the embedded PGlite port (default 5433) was already held by a foreign Postgres, or when a residual `DATABASE_URL` pointed at the wrong DB. Reproduced on real hardware: the forked PGlite child dies of `EADDRINUSE` but **exits code 0**, so `waitForTcp` mistook the foreign listener for our PGlite, printed a false `PGlite ready`, and `migrate deploy` failed auth — before the server ever started.

## What changed
- **Root cause (defense-in-depth):** extracted the embedded-PGlite launch into a pure, dependency-injected `cli/embedded-db.mjs` with (1) a **pre-flight port-occupancy probe** that fails fast before forking and (2) a **child-exit latch** that is fatal if the child exits before port-ready — for **any** exit code (incl. the reproduced `EADDRINUSE → exit 0`). "Someone is listening" is no longer accepted as proof it's our PGlite.
- **Diagnosability:** the bare Prisma P1000 is rewritten into an actionable Chorus diagnostic — embedded path → `chorus --pglite-port <port>`, external path → `unset DATABASE_URL` — with credentials masked. The startup banner now names the external `DATABASE_URL` host:port (masked) when embedded PGlite is skipped.
- **No regression:** the migrate step moved from `execSync(stdio:inherit)` to an async `spawn` **streaming tee** — live "Applying migration …" progress is preserved while output is buffered for classification. `DATABASE_URL`-wins precedence unchanged.

Scope is the elaborated MVP: fail-fast (no automatic port bumping) and no child-stderr passthrough — both deferred by design.

## Changed files
| File | Change |
|------|--------|
| `chorus.mjs` | Thin caller of the new module; `isPortOccupied` pre-flight; async `spawn` streaming tee for migrate + P1000-rewrite branch; banner DATABASE_URL provenance |
| `cli/embedded-db.mjs` | **New** pure/DI module: `launchEmbeddedPglite`, `formatPortConflictMessage`, `isPrismaAuthFailure`, `maskDbUrl`, `formatMigrationAuthDiagnostic` |
| `cli/__tests__/embedded-db.test.mjs` | **New** 18 unit tests (fake spawner/socket) |
| `cli/__tests__/embedded-db-integration.test.mjs` | **New** 3 integration tests driving real `chorus.mjs` (docker Postgres) across all 3 repro paths; docker-unavailable → visible logged skip |
| `openspec/changes/fix-embedded-pglite-port-conflict/` | **New** OpenSpec change (proposal/design/spec) |

## Test plan
- [x] `npx vitest run cli/` → 542 pass (44 files)
- [x] `pnpm test` (full suite) → 3713 pass, 2 pre-existing live-DB skips
- [x] `npx tsc --noEmit` → 0
- [x] `pnpm lint` → 0 errors
- [x] Real docker end-to-end: foreign-PG-on-port → fail-fast (no false "PGlite ready", no P1000); residual DATABASE_URL → rewritten diagnostic; clean env → 28 migrations apply + banner prints
- [x] Authored + verified through the Chorus AI-DLC pipeline (proposal-reviewer + 3 task-reviewers + idea code-review gateway, all PASS / PASS WITH NOTES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)