### PR TITLE
feat(mention): keyboard-complete @mention cwd picker

### DIFF
--- a/src/components/__tests__/mention-instance-picker-dialog.test.tsx
+++ b/src/components/__tests__/mention-instance-picker-dialog.test.tsx
@@ -170,7 +170,30 @@ describe("MentionInstancePickerDialog — mobile-safe layout", () => {
     expect(scroll.contains(header)).toBe(false);
   });
 
-  it("keeps the Pin button disabled until a cwd row is selected, then enables it", () => {
+  it("default-selects the first cwd row on open, so Pin is enabled with no click", () => {
+    // Keyboard-completeness: the picker opens with the FIRST instance pre-selected
+    // (radio checked, Pin enabled). This is what lets Up/Down navigate from a
+    // concrete row and Enter confirm without a preceding pointer click.
+    const instances = makeInstances(3);
+    render(
+      <MentionInstancePickerDialog
+        open
+        agentName="Test Agent"
+        instances={instances}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const pin = screen.getByRole("button", { name: "Pin instance" }) as HTMLButtonElement;
+    expect(pin.disabled).toBe(false);
+
+    // The first radio is the checked one; the rest are not.
+    const radios = screen.getAllByRole("radio") as HTMLElement[];
+    expect(radios[0].getAttribute("aria-checked")).toBe("true");
+    expect(radios[1].getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("lets a different cwd row be selected, then enables Pin for it", () => {
     render(
       <MentionInstancePickerDialog
         open
@@ -181,9 +204,7 @@ describe("MentionInstancePickerDialog — mobile-safe layout", () => {
       />,
     );
     const pin = screen.getByRole("button", { name: "Pin instance" }) as HTMLButtonElement;
-    expect(pin.disabled).toBe(true);
-
-    // Select the second row (multi-instance: no auto-select).
+    // Select the second row — Pin stays enabled and now targets that row.
     const radios = screen.getAllByRole("radio");
     fireEvent.click(radios[1]);
     expect(pin.disabled).toBe(false);
@@ -207,5 +228,68 @@ describe("MentionInstancePickerDialog — mobile-safe layout", () => {
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ connectionUuid: instances[2].connectionUuid }),
     );
+  });
+
+  it("confirms the current selection when Enter is pressed inside the list", () => {
+    // Enter is the keyboard counterpart of clicking Pin. On open the first row is
+    // pre-selected; arrow-select the second, then Enter confirms THAT one.
+    const onConfirm = vi.fn();
+    const instances = makeInstances(3);
+    render(
+      <MentionInstancePickerDialog
+        open
+        agentName="Test Agent"
+        instances={instances}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    const radios = screen.getAllByRole("radio");
+    fireEvent.click(radios[1]);
+    // Enter dispatched from within the radio group (bubbles to the list handler).
+    fireEvent.keyDown(radios[1], { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionUuid: instances[1].connectionUuid }),
+    );
+  });
+
+  it("Enter on open (first row pre-selected) confirms the first instance", () => {
+    const onConfirm = vi.fn();
+    const instances = makeInstances(3);
+    render(
+      <MentionInstancePickerDialog
+        open
+        agentName="Test Agent"
+        instances={instances}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(screen.getAllByRole("radio")[0], { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionUuid: instances[0].connectionUuid }),
+    );
+  });
+
+  it("does NOT confirm on Enter while an IME candidate is being composed", () => {
+    // CLAUDE.md IME rule: a CJK/JP/KR user pressing Enter to confirm an IME
+    // candidate must not accidentally pin. isComposing suppresses the confirm.
+    const onConfirm = vi.fn();
+    render(
+      <MentionInstancePickerDialog
+        open
+        agentName="Test Agent"
+        instances={makeInstances(3)}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(screen.getAllByRole("radio")[0], {
+      key: "Enter",
+      isComposing: true,
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
   });
 });

--- a/src/components/mention-editor.tsx
+++ b/src/components/mention-editor.tsx
@@ -472,10 +472,25 @@ export function MentionInstancePickerDialog({
   const t = useTranslations("mentionInstance");
   const [selected, setSelected] = useState<InstanceCandidate | null>(null);
 
-  // Reset the local selection whenever a new pick opens the dialog.
+  // Default-select the FIRST instance whenever a new pick opens the dialog, so
+  // the picker is keyboard-complete: Pin is enabled immediately (no click), and
+  // Radix RadioGroup's roving focus lands on a concrete row that Up/Down then
+  // move between. (The dialog only opens for 2+ instances — see selectMentionable.)
   useEffect(() => {
-    if (open) setSelected(null);
+    if (open) setSelected(instances[0] ?? null);
   }, [open, instances]);
+
+  // Enter confirms the current selection — the keyboard counterpart to clicking
+  // Pin. Scoped to the list region (below) so it never double-fires with the
+  // footer's Cancel / Pin buttons, which own their native Enter activation. The
+  // isImeComposing guard is mandatory (CLAUDE.md IME rule): a CJK/JP/KR user
+  // pressing Enter to CONFIRM an IME candidate must not accidentally pin.
+  const handleListKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "Enter" || isImeComposing(e)) return;
+    if (!selected) return;
+    e.preventDefault();
+    onConfirm(selected);
+  };
 
   const distinctHosts = new Set(instances.map((i) => i.host)).size;
 
@@ -500,7 +515,10 @@ export function MentionInstancePickerDialog({
             even when the instance list is tall or the soft keyboard shrinks the
             viewport. `min-h-0` lets this flex child shrink below its content height
             so it actually scrolls instead of pushing the footer off-screen. */}
-        <div className="min-h-0 flex-1 overflow-y-auto py-3">
+        <div
+          className="min-h-0 flex-1 overflow-y-auto py-3"
+          onKeyDown={handleListKeyDown}
+        >
           <InstancePicker
             instances={instances}
             selectedConnectionUuid={selected?.connectionUuid ?? null}


### PR DESCRIPTION
## Summary
The secondary cwd picker (`MentionInstancePickerDialog`), shown when an @-mentioned agent has 2+ online daemon instances, opened with **nothing selected** — so the keyboard couldn't drive it and **Pin** stayed disabled until a mouse click. This makes the picker keyboard-complete:

- **Default-select the first cwd** on open — Pin is enabled immediately, and Radix `RadioGroup` roving focus lands on a concrete row so Up/Down navigate from the start.
- **Up/Down** switch the selection — unchanged (Radix `RadioGroup` roving focus).
- **Enter confirms** the current selection — scoped to the list scroll region so it never double-fires with the footer's Cancel/Pin, and guarded by `isImeComposing()` per the CLAUDE.md IME rule (a CJK/JP/KR candidate-confirm Enter must not accidentally pin).

## Changed files
| File | Change |
|------|--------|
| `src/components/mention-editor.tsx` | `MentionInstancePickerDialog`: default-select `instances[0]` on open; add `handleListKeyDown` (IME-guarded Enter → `onConfirm`) on the list region |
| `src/components/__tests__/mention-instance-picker-dialog.test.tsx` | Invert "Pin disabled until selected" → "first row pre-selected"; add Enter-confirms / Enter-on-open / IME-suppressed cases |

## Test plan
- [x] `pnpm test` — mention-instance-picker-dialog (9) + instance-picker (11) = 20 passed
- [x] `npx tsc --noEmit` — exit 0
- [x] E2E in a real browser (seeded a 2-online-instance agent): default-select first row + Pin enabled; ArrowDown moves selection; Enter confirms the selected instance (`data-pinned-cwd` matches); IME `isComposing:true` Enter suppressed, normal Enter confirms; 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)