### PR TITLE
fix(graph): compact the resource-graph control card

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1582,7 +1582,6 @@
     "expandAll": "Expand all",
     "collapseAll": "Collapse all",
     "filters": {
-      "heading": "Show",
       "idea": "Ideas",
       "proposal": "Proposals",
       "task": "Tasks",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1583,7 +1583,6 @@
     "expandAll": "全部展开",
     "collapseAll": "全部收起",
     "filters": {
-      "heading": "显示",
       "idea": "想法",
       "proposal": "提案",
       "task": "任务",

--- a/src/app/(dashboard)/projects/[uuid]/graph/resource-graph.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/resource-graph.tsx
@@ -59,6 +59,12 @@ import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { AnimatedEmptyState } from "@/components/animated-empty-state";
 import { usePanelUrl } from "@/hooks/use-panel-url";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -1037,10 +1043,10 @@ export function ResourceGraph({ projectUuid, currentUserUuid }: ResourceGraphPro
               <SlidersHorizontal className="h-4 w-4" />
             </Button>
           ) : (
-          <Card className="w-[224px] border-[#E5E0D8] bg-white/95 p-3 shadow-sm backdrop-blur">
+          <Card className="w-[208px] border-[#E5E0D8] bg-white/95 p-2.5 shadow-sm backdrop-blur">
             {/* Collapse control — mobile only; desktop keeps the panel pinned. */}
             {isMobile && (
-              <div className="mb-2 flex justify-end">
+              <div className="mb-1.5 flex justify-end">
                 <Button
                   type="button"
                   variant="ghost"
@@ -1057,41 +1063,78 @@ export function ResourceGraph({ projectUuid, currentUserUuid }: ResourceGraphPro
             {/* Node search (Tech Design D8). Hidden when empty — nothing to
                 search. Sits above the type filter on the same control card. */}
             {!isEmpty && (
-              <div className="mb-3" data-testid="graph-search">
-                <div className="relative">
-                  <Search
-                    className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#9A9A9A]"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    type="text"
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    onKeyDown={handleSearchKeyDown}
-                    placeholder={t("graph.search.placeholder")}
-                    aria-label={t("graph.search.placeholder")}
-                    data-testid="graph-search-input"
-                    className="h-8 pl-8 pr-8 text-xs"
-                  />
-                  {searchQuery !== "" && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={clearSearch}
-                      aria-label={t("graph.search.clear")}
-                      data-testid="graph-search-clear"
-                      className="absolute right-1 top-1/2 -translate-y-1/2 text-[#6B6B6B]"
-                    >
-                      <X className="h-3.5 w-3.5" />
-                    </Button>
-                  )}
+              <div className="mb-2" data-testid="graph-search">
+                {/* Search input + expand-all share one row: the input takes the
+                    remaining width and the expand-all / collapse-all toggle sits
+                    at its right. The action carries only an icon (no inline
+                    label) — a hover tooltip explains it, so the row stays short
+                    and we drop the separate "Show" heading entirely. */}
+                <div className="flex items-center gap-1.5">
+                  <div className="relative flex-1">
+                    <Search
+                      className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#9A9A9A]"
+                      aria-hidden="true"
+                    />
+                    <Input
+                      type="text"
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      onKeyDown={handleSearchKeyDown}
+                      placeholder={t("graph.search.placeholder")}
+                      aria-label={t("graph.search.placeholder")}
+                      data-testid="graph-search-input"
+                      className="h-8 pl-8 pr-8 text-xs"
+                    />
+                    {searchQuery !== "" && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={clearSearch}
+                        aria-label={t("graph.search.clear")}
+                        data-testid="graph-search-clear"
+                        className="absolute right-1 top-1/2 -translate-y-1/2 text-[#6B6B6B]"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </div>
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={anyExpanded ? collapseAll : expandAll}
+                          aria-label={
+                            anyExpanded
+                              ? t("graph.collapseAll")
+                              : t("graph.expandAll")
+                          }
+                          data-testid="graph-expand-toggle"
+                          className="shrink-0 text-[#6B6B6B]"
+                        >
+                          {anyExpanded ? (
+                            <Minimize2 className="h-3.5 w-3.5" />
+                          ) : (
+                            <Maximize2 className="h-3.5 w-3.5" />
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {anyExpanded
+                          ? t("graph.collapseAll")
+                          : t("graph.expandAll")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
 
                 {/* Count + prev/next + no-matches hint — only while searching. */}
                 {isSearching && (
                   <div
-                    className="mt-2 flex items-center justify-between gap-2"
+                    className="mt-1.5 flex items-center justify-between gap-2"
                     data-testid="graph-search-nav"
                   >
                     {totalMatches > 0 ? (
@@ -1141,22 +1184,24 @@ export function ResourceGraph({ projectUuid, currentUserUuid }: ResourceGraphPro
               </div>
             )}
 
-            <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-[#6B6B6B]">
-              {t("graph.filters.heading")}
-            </p>
-            <div className="flex flex-col gap-2">
+            {/* Type filter — a 2×2 grid (was a 4-row vertical stack) so the four
+                toggles read as a compact legend and halve the card's height. The
+                explanatory "Show" heading row was dropped: the color swatches +
+                labels are self-evident, and the expand-all action moved up onto
+                the search row, so no heading is needed here. */}
+            <div className="grid grid-cols-2 gap-x-2 gap-y-1.5">
               {(["idea", "proposal", "task", "document"] as NodeType[]).map((type) => {
                 const swatch = FILTER_SWATCH[type];
                 const id = `graph-filter-${type}`;
                 return (
-                  <div key={type} className="flex items-center gap-2">
+                  <div key={type} className="flex items-center gap-1.5">
                     <Checkbox
                       id={id}
                       checked={visible[type]}
                       onCheckedChange={() => toggleType(type)}
                     />
                     <span
-                      className="h-2 w-2 rounded-full"
+                      className="h-2 w-2 shrink-0 rounded-full"
                       style={{ backgroundColor: swatch.color }}
                     />
                     <Label htmlFor={id} className="cursor-pointer text-xs text-[#2C2C2C]">
@@ -1166,26 +1211,6 @@ export function ResourceGraph({ projectUuid, currentUserUuid }: ResourceGraphPro
                 );
               })}
             </div>
-            {/* Expand-all / collapse-all — flips mode based on current state.
-                Hidden when empty (nothing to expand). */}
-            {!isEmpty && (
-              <>
-                <div className="my-2 h-px bg-[#EFEAE2]" />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="w-full justify-center gap-2"
-                  onClick={anyExpanded ? collapseAll : expandAll}
-                >
-                  {anyExpanded ? (
-                    <Minimize2 className="h-3.5 w-3.5" />
-                  ) : (
-                    <Maximize2 className="h-3.5 w-3.5" />
-                  )}
-                  {anyExpanded ? t("graph.collapseAll") : t("graph.expandAll")}
-                </Button>
-              </>
-            )}
           </Card>
           )}
         </div>


### PR DESCRIPTION
## What

Compress the top-right control card on the project **Resource Graph** (mind-map) view. It combined the node search, the type filter/legend, and the expand-all action in a tall, loosely-spaced card that overlaid the canvas. This tightens it into a compact control while keeping Chorus's existing warm-cream / shadcn visual language (no redesign).

## Changes

- **Type filter → 2×2 grid** (was a 4-row vertical stack) — the biggest height cut; the swatch + label pairs read as a compact legend.
- **Expand-all / collapse-all** — was a full-width button + divider; now a compact **icon button sharing the search-input row**, to the right of the input. A Radix **hover tooltip** explains it (reusing `graph.expandAll` / `graph.collapseAll`), so no inline label is needed and the separate **"Show" heading row is dropped** entirely.
- Tighten paddings/margins and narrow the card **224px → 208px**. Card height drops **~178px → ~124px**.
- Remove the now-unused `graph.filters.heading` i18n key (en + zh).

Single component touched: `src/app/(dashboard)/projects/[uuid]/graph/resource-graph.tsx` (+ locale cleanup). Pure layout/spacing — no graph logic change.

## Contracts preserved

- All `graph-search-*` testids and the `graph-search` / `graph-search-nav` structure.
- The four type filters remain reachable via `getByLabelText("graph.filters.<type>")` as shadcn `Checkbox` with `aria-checked` semantics; color swatches kept.
- Mobile (`<768px`) still folds to a single `SlidersHorizontal` icon button and expands on tap.

## Verification

- `npx tsc --noEmit` — clean
- `pnpm lint` — 0 errors (pre-existing warnings only)
- `vitest run` graph suite — **48/48 pass**
- In-browser (dev:local, Graph Search Demo project): desktop card measured **208×124px** (was 208×178), tooltip shows on hover, search count/prev/next work, mobile folds correctly, no canvas occlusion.

This iteration was reviewed live and refined per feedback (drop the "Show" heading, move expand-all onto the search row with a tooltip). The build was also deployed to the live env for review.

> Note: `docs/design.pen` not updated — Pencil MCP needs the GUI editor, unavailable in this headless session. Recommend a follow-up in a GUI environment (density tweak to an existing control, not a new screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
