### PR TITLE
feat(daemon): add terminal interrupted state to DaemonSessionTurn

### DIFF
--- a/cli/__tests__/turn-reporter.test.mjs
+++ b/cli/__tests__/turn-reporter.test.mjs
@@ -3,7 +3,7 @@
 // daemon-session-conversation): REST POST to /api/daemon/turn-advance, Bearer auth,
 // zero new deps, fire-and-forget never-throws.
 import { describe, it, expect, vi } from "vitest";
-import { createTurnReporter, TURN_STATUSES } from "../turn-reporter.mjs";
+import { createTurnReporter, TURN_STATUSES, TURN_INTERRUPT_REASONS } from "../turn-reporter.mjs";
 
 const silent = { info() {}, warn() {}, error() {} };
 
@@ -123,6 +123,62 @@ describe("createTurnReporter", () => {
   });
 
   it("TURN_STATUSES is the strict lifecycle set", () => {
-    expect([...TURN_STATUSES].sort()).toEqual(["ended", "pending", "running"]);
+    expect([...TURN_STATUSES].sort()).toEqual(["ended", "interrupted", "pending", "running"]);
+  });
+
+  it("TURN_INTERRUPT_REASONS is the daemon-reportable subset (no offline)", () => {
+    expect([...TURN_INTERRUPT_REASONS].sort()).toEqual(["crash", "shutdown", "user"]);
+  });
+
+  it("sends interruptedReason alongside status=interrupted", async () => {
+    const fetchImpl = okFetch();
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: silent,
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "interrupted", interruptedReason: "shutdown" });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body).toEqual({
+      connectionUuid: "conn-1",
+      sessionId: "idea-1",
+      status: "interrupted",
+      interruptedReason: "shutdown",
+    });
+  });
+
+  it("refuses interruptedReason=offline (server-reconcile verdict) — logged, no fetch", async () => {
+    const fetchImpl = okFetch();
+    const warns = [];
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "interrupted", interruptedReason: "offline" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(warns.join("")).toMatch(/bad interruptedReason/);
+  });
+
+  it("refuses an interruptedReason on a non-interrupted status — logged, no fetch", async () => {
+    const fetchImpl = okFetch();
+    const warns = [];
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "ended", interruptedReason: "crash" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(warns.join("")).toMatch(/bad interruptedReason/);
   });
 });

--- a/cli/daemon-rest-client.mjs
+++ b/cli/daemon-rest-client.mjs
@@ -134,10 +134,12 @@ export function createDaemonRestClient(opts) {
     /**
      * POST /api/daemon/turn-advance — advance a wake's DaemonSessionTurn lifecycle. The
      * server resolves the turn by the session BUSINESS KEY (`sessionId`); the optional
-     * `entityType`/`entityUuid` stamp the weak executionUuid link. Requires the
+     * `entityType`/`entityUuid` stamp the weak executionUuid link. An `interrupted`
+     * status may carry `interruptedReason` (`user`/`crash`/`shutdown` — the server
+     * rejects `offline`, which is its own reconcile verdict). Requires the
      * connectionUuid (the server addresses the turn against a connection the agent owns).
      */
-    async turnAdvance({ sessionId, status, entityType, entityUuid }) {
+    async turnAdvance({ sessionId, status, entityType, entityUuid, interruptedReason }) {
       const connectionUuid = getConnectionUuid();
       if (!connectionUuid) {
         const error = `cannot advance turn for session ${sessionId} → ${status} — no connection uuid yet`;
@@ -150,6 +152,8 @@ export function createDaemonRestClient(opts) {
         status,
         // Only sent when BOTH are present, so the server never gets a partial linkage.
         ...(entityType && entityUuid ? { entityType, entityUuid } : {}),
+        // Only meaningful alongside status=interrupted; never sent otherwise.
+        ...(status === "interrupted" && interruptedReason ? { interruptedReason } : {}),
       };
       return post(
         "turn-advance",

--- a/cli/turn-reporter.mjs
+++ b/cli/turn-reporter.mjs
@@ -4,7 +4,7 @@
 // persistent conversation; the server creates that turn (status `pending`) at the
 // notification chokepoint, and the daemon advances it:
 //   • on spawn      → pending → running
-//   • on subprocess exit → running → ended
+//   • on subprocess exit → running → ended (clean) | interrupted (user/crash/shutdown)
 //
 // The daemon does NOT know the server-side turn uuid. It identifies the turn the SAME
 // way the transcript ingest does — by the session BUSINESS KEY (`sessionId` = the
@@ -27,7 +27,10 @@ import { createDaemonRestClient } from "./daemon-rest-client.mjs";
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
 /** Turn lifecycle states the server's turn-advance endpoint accepts. */
-export const TURN_STATUSES = new Set(["pending", "running", "ended"]);
+export const TURN_STATUSES = new Set(["pending", "running", "ended", "interrupted"]);
+
+/** Interrupt reasons a DAEMON may report (`offline` is server-reconcile-only). */
+export const TURN_INTERRUPT_REASONS = new Set(["user", "crash", "shutdown"]);
 
 /**
  * Build an `advanceTurn(params)` function the waker invokes on a wake's spawn (→
@@ -43,7 +46,7 @@ export const TURN_STATUSES = new Set(["pending", "running", "ended"]);
  *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
  *   fetchImpl?: typeof fetch,             Injectable for tests.
  * }} opts
- * @returns {(params: { sessionId: string, status: "running"|"ended", entityType?: string|null, entityUuid?: string|null }) => Promise<void>}
+ * @returns {(params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown"|null }) => Promise<void>}
  */
 export function createTurnReporter(opts) {
   const logger = opts.logger ?? NOOP_LOGGER;
@@ -58,18 +61,36 @@ export function createTurnReporter(opts) {
     logger,
   });
 
-  return async function advanceTurn({ sessionId, status, entityType, entityUuid }) {
+  return async function advanceTurn({
+    sessionId,
+    status,
+    entityType,
+    entityUuid,
+    interruptedReason,
+  }) {
     if (typeof sessionId !== "string" || !sessionId || !TURN_STATUSES.has(status)) {
       logger.warn(
         `[Chorus] refusing to advance turn: bad sessionId/status (${sessionId}, ${status})`,
       );
       return;
     }
+    // Domain guard mirroring the server's: a reason travels only with `interrupted`
+    // and only from the daemon-reportable vocabulary (`offline` is the server's own
+    // reconcile verdict). Refusing here keeps a bad caller visible in daemon logs
+    // instead of as a server 400.
+    if (interruptedReason != null) {
+      if (status !== "interrupted" || !TURN_INTERRUPT_REASONS.has(interruptedReason)) {
+        logger.warn(
+          `[Chorus] refusing to advance turn: bad interruptedReason (${interruptedReason}) for status ${status}`,
+        );
+        return;
+      }
+    }
     // The client resolves the connectionUuid lazily, validates it (logging
     // "no connection uuid yet" when absent), POSTs the exact server payload — sending
     // entityType/entityUuid only when both are present — and logs the failure cause on a
     // network error / non-2xx. We swallow the structured result so a failed report can
     // never crash the wake path.
-    await client.turnAdvance({ sessionId, status, entityType, entityUuid });
+    await client.turnAdvance({ sessionId, status, entityType, entityUuid, interruptedReason });
   };
 }

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/.openspec.yaml
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/README.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-exit-orphan-running-turn
+
+Fix: daemon exit mid-turn leaves the turn stuck running forever

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/design.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/design.md
@@ -1,0 +1,98 @@
+# Technical Design: Fix daemon-exit orphan `running` turns
+
+## Overview
+
+Give `DaemonSessionTurn` a terminal `interrupted` state and make sure every path a daemon can die on converges an in-flight turn to a terminal state:
+
+- **Daemon-reported** (graceful shutdown, user interrupt, subprocess crash): the waker's existing exit report becomes outcome-aware and can report `interrupted` with a reason.
+- **Server-inferred** (`kill -9`, machine sleep, network loss, daemon never comes back): server-side reconcile finalizes `running` turns whose owning connection is effectively offline, as `interrupted(offline)`.
+
+No turn is ever auto-re-dispatched (elaboration q2): `interrupted` is terminal; the human decides whether to re-send. `pending` turns are deliberately untouched — they are the reconnect-backfill's job and re-deliver correctly today.
+
+## Data Model
+
+`DaemonSessionTurn` changes (DDL-only migration via `pnpm db:migrate:dev`):
+
+```prisma
+status            String  @default("pending") // pending | running | ended | interrupted
+interruptedReason String? // null | user | crash | shutdown | offline — set iff status == interrupted
+```
+
+`status` is already a free-form string column (comment-documented enum), so only `interruptedReason` is a new column. `endedAt` is set on the `interrupted` transition too — an interrupted turn has a definite end time (used by elapsed rendering).
+
+Reason vocabulary (superset of `DaemonExecution.interruptedReason`):
+
+| reason | set by | meaning |
+|---|---|---|
+| `user` | daemon | authorized user interrupt stopped the subprocess |
+| `crash` | daemon | subprocess exited dirty (non-zero / null) with no interrupt requested |
+| `shutdown` | daemon | daemon graceful shutdown (SIGINT/SIGTERM) killed the subprocess |
+| `offline` | server | connection went effectively offline with the turn still `running` |
+
+## State machine (`daemon-session.service.ts`)
+
+`NEXT_TURN_STATUS` becomes a set-valued edge map:
+
+```
+pending     → { running }
+running     → { ended, interrupted }
+ended       → {}          (terminal)
+interrupted → {}          (terminal)
+```
+
+All other rules are unchanged: no skips (`pending → interrupted` is illegal — a pending turn is recoverable via backfill and must stay pending), no backward moves, same-status re-apply rejected, `invalid_transition` writes nothing. `advanceTurn` gains `interruptedReason` in its opts, persisted only on the `→ interrupted` edge; the `turn_status_changed` SSE trigger fires exactly as for `ended`.
+
+**Late-report convergence:** if the server already finalized a turn `interrupted(offline)` and the daemon later reports `running → ended` (e.g. a >90s network partition where the subprocess actually finished), the report is rejected as `invalid_transition` and logged — the existing daemon-side rule (log, never crash the run) applies. Both sides are terminal; the turn stays `interrupted`. Transcript ingest does NOT check turn status, so messages that arrive late still append (history preserved).
+
+## Server-side orphan reconcile
+
+Liveness anchor: a turn's owner is `turn.session.originConnectionUuid` (continuation is origin-pinned), NOT the execution row's connection.
+
+**Orphan-eligibility rule (stricter than the read API's "effectively offline"):** a turn is orphan-eligible only when its origin connection's `lastSeenAt` is older than `STALE_THRESHOLD_MS` (90s, the registry's single constant — no second timeout). The rule is **age-only, deliberately NOT the OR-rule** (`status !== "online" || stale`) the execution read gate uses: `markDisconnected` flips `status` to `offline` the instant an SSE stream aborts, so under the OR-rule a session read landing in a transient abort→reconnect gap would falsely finalize a genuinely live turn (whose daemon then gets its `running → ended` rejected). Age-only is safe in both directions: a live daemon's 30s heartbeat keeps `lastSeenAt` fresh (never eligible), and a daemon that died without an abort (hard kill, sleep) goes stale within 90s even while `status` still reads `online`. Both reconcile triggers below use this same rule.
+
+New service function `reconcileOrphanTurns(companyUuid, connectionUuid)` in `daemon-session.service.ts`:
+
+1. Find sessions with `originConnectionUuid = connectionUuid` that have `running` turns.
+2. Re-check the connection is orphan-eligible (age-only rule above) — the guard that makes every caller safe.
+3. For each such turn, `advanceTurn(turn, "interrupted", { interruptedReason: "offline", endedAt: now })` — routing through the chokepoint keeps SSE emission and legality checks in one place.
+4. Swallow-and-log its own errors when called from fire-and-forget paths (mirrors `reconcileOffline`).
+
+Two triggers (elaboration q3 = event-driven + read-time fallback):
+
+- **Deferred abort trigger:** the SSE abort handlers (`/api/events`, `/api/events/notifications`) — where `markDisconnected` + execution `reconcileOffline` already fire — additionally schedule `reconcileOrphanTurns` after `STALE_THRESHOLD_MS`. The delay (vs. executions' immediate flip) exists because SSE streams reconnect transiently; step 2's age-only re-check makes the deferred run a no-op when the daemon came back (a reconnected daemon's heartbeat refreshed `lastSeenAt`). A lost timer (server restart) is covered by the read-time fallback.
+- **Read-time fallback:** the session read paths (single-session transcript read and session list) detect `running` turns whose origin connection is orphan-eligible (age-only: `lastSeenAt` stale past 90s — NEVER on `status` alone, see the rule above) and invoke the same reconcile inline (write-through, not a view-only mask — unlike executions' read-time gate, because turns are durable conversation history and must converge in the DB). This also converges pre-existing dirty rows on next access with zero migration DML (q5, entailed by the q3 read-time-fallback choice).
+
+## CLI daemon graceful shutdown (elaboration q4 = interrupt-and-report)
+
+- `cli/waker.mjs` gains a shutdown mode: a `shuttingDown` flag plus `interruptAll()` that marks every running entry as shutdown-interrupted and kills each live child via the existing `killProcessTree` escalation (SIGINT → SIGKILL, existing `sigintTimeoutMs`).
+- The waker's exit report (currently always `running → ended`) becomes **outcome-aware**, mirroring what the execution row already records:
+  - clean exit (code 0) → `ended`
+  - `interrupting` flag (user interrupt) → `interrupted(user)`
+  - `shuttingDown` flag → `interrupted(shutdown)`
+  - otherwise (dirty exit) → `interrupted(crash)`
+- `cli/daemon.mjs` `stop()` orders: stop taking new wakes (disconnect SSE first) → `waker.interruptAll()` → await in-flight wake promises (bounded by the kill escalation, plus a hard cap) so their turn-advance reports flush → disconnect MCP → exit. The signal handler awaits `stop()` as today.
+- **Execution-row report gated during shutdown:** a shutdown-killed subprocess exits dirty with no user-interrupt flag, which the waker's existing exit logic would report as execution `interrupted(crash)` — a STICKY state that `reconcileOffline` deliberately skips and the read gate keeps showing, so every Ctrl-C would strand a crash-interrupted execution row. Therefore the waker's execution interrupt report gains a `!shuttingDown` gate: during shutdown, no execution interrupt is reported at all; the row is left `running` and the existing execution `reconcileOffline` flips it `ended` when the stream drops. Outside shutdown, execution reporting is byte-for-byte unchanged (sticky user-interrupt resumability, crash reporting).
+- `cli/turn-reporter.mjs` + `cli/daemon-rest-client.mjs`: `advanceTurn` payload gains optional `interruptedReason`; `/api/daemon/turn-advance` route validates `status ∈ {running, ended, interrupted}` and `interruptedReason ∈ {user, crash, shutdown}` (daemon may not claim `offline` — that verdict is the server's).
+
+## UI
+
+`interrupted` is a terminal state with a distinct, quiet presentation (elaboration q6 — reuse the existing "interrupted" vocabulary, no new interaction):
+
+- `turn-band.tsx`: `interrupted` renders like `ended` structurally (no pulse, no spinner, quiet spine) with an "Interrupted" badge in a warning-muted tone; reason is available for the label/tooltip (`offline`/`shutdown`/`crash`/`user` can share one generic "Interrupted" label — per-reason copy optional).
+- `transcript-view.tsx` header badge: unchanged logic — an interrupted turn is simply not `running`; the `turns.find(running)` probe naturally stops matching once reconciled.
+- `conversation-list.tsx`: running-dot logic unchanged (`status === "running"` only).
+- i18n: `daemonChat.turnStatusInterrupted` (+ any reason strings) in **both** `messages/en.json` and `messages/zh.json`.
+
+## Module Contracts
+
+- `advanceTurn(turnUuid, status, opts)` — opts gains `interruptedReason?: string | null`; persisted only on `→ interrupted`. Return shape unchanged (`AdvanceTurnResult`).
+- `reconcileOrphanTurns(companyUuid, connectionUuid): Promise<number>` — returns count finalized; never throws on the fire-and-forget path.
+- REST `/api/daemon/turn-advance` body: `{ connectionUuid, sessionId, status, entityType?, entityUuid?, interruptedReason? }`.
+- `TurnView` gains `interruptedReason: string | null` (serialized to the UI and in SSE `turn_status_changed`).
+
+## Risks & Mitigations
+
+- **False interrupt on transient disconnect** → both triggers use the age-only orphan-eligibility rule (`lastSeenAt` stale past 90s, never `status` alone) re-verified at write time; the abort trigger is additionally deferred by the same window.
+- **Duplicate reconcile racing the daemon's own report** → all writes go through `advanceTurn`'s legality check; whichever terminal write lands first wins, the loser gets `invalid_transition` (logged, harmless).
+- **Multi-instance servers** → the deferred timer is per-instance and best-effort; the read-time fallback is instance-independent and authoritative. Both are idempotent through the state machine.
+- **Turn/execution divergence** (turn `interrupted(crash)` vs execution sticky `interrupted`) → intentional: turn = conversation history fact, execution = live resumability fact; they already diverge for `ended`.

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/proposal.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/proposal.md
@@ -1,0 +1,39 @@
+# Fix: daemon exit mid-turn leaves the turn stuck `running` forever
+
+## Why
+
+When a daemon process exits while a turn is in flight — whether killed hard (`kill -9`, crash, machine sleep) or stopped gracefully (Ctrl-C / SIGTERM) — the server is left with dirty state: the `DaemonSessionTurn` stays `running` forever. The UI (transcript header badge, turn band, conversation list) renders "Running" straight off `turn.status`, so the agent looks permanently busy on a turn that will never end.
+
+Root cause (verified in code):
+
+- The turn state machine is strict `pending → running → ended` (`src/services/daemon-session.service.ts` `NEXT_TURN_STATUS`), and the **only** writer of `running → ended` is the daemon's own `POST /api/daemon/turn-advance` call, sent from `cli/waker.mjs` after the headless subprocess exits. No server-side path ever finalizes a turn.
+- The daemon's graceful shutdown (`cli/daemon.mjs` `stop()`) only disconnects the SSE listeners and MCP client — it neither stops in-flight subprocesses nor reports any turn terminal state. So even a clean Ctrl-C mid-turn orphans the turn.
+- The existing offline reconcile (`reconcileOffline`, fired on SSE abort) flips only `DaemonExecution` rows to `ended`; it never touches `DaemonSessionTurn`.
+- Reconnect backfill (`getPendingTurnsForConnection`) reads only `status = "pending"` turns, so a turn orphaned in `running` is invisible to every recovery path.
+
+## What Changes
+
+Per the resolved elaboration (idea `489ade18`, round 1):
+
+1. **New terminal turn state `interrupted`** (elaboration q1: reuse the existing "interrupted" concept, aligned with `DaemonExecution`). Turn state machine becomes `pending → running → ended | interrupted`, with a nullable `interruptedReason` discriminator (`user` | `crash` | `shutdown` | `offline`). `interrupted` is terminal — an orphaned turn is finalized, never auto-retried (q2: finalize only; a turn may have partially executed, so automatic re-dispatch risks duplicate side effects).
+2. **Server-side orphan-turn reconcile** (q3: event-driven + read-time fallback). When a daemon connection's `lastSeenAt` goes stale past the existing 90s threshold (age-only rule — never the stored `status` alone, which flips on every transient SSE abort), its sessions' `running` turns are finalized to `interrupted(offline)`: (a) the SSE-abort path arms a deferred reconcile after the staleness window, and (b) session read paths lazily finalize orphaned running turns on access — covering `kill -9`, server restarts, and (as an entailed side effect of the read-time fallback) converging any pre-existing dirty rows.
+3. **Daemon graceful shutdown finalizes in-flight turns** (q4: interrupt-and-report). `stop()` interrupts in-flight subprocesses via the existing kill escalation, and the waker's exit path reports the turn terminal state before the process exits — `interrupted(shutdown)` on shutdown; and while touching this path, the exit report becomes outcome-aware generally (`ended` on clean exit, `interrupted(user)` on a user interrupt, `interrupted(crash)` on a dirty exit), matching what the execution row already records.
+4. **UI renders interrupted turns distinctly** (q6: reuse the existing "interrupted" presentation vocabulary). Turn band / transcript header / conversation list treat `interrupted` as a terminal, visually quiet state with an "Interrupted" label — no more infinite spinner.
+5. **No dedicated legacy-data cleanup** (q5: "不处理存量" — no migration DML, no admin sweep, no extra mechanism built for legacy rows). The convergence of old dirty rows is not a dedicated cleanup: it falls out of the q3 read-time fallback for free, so it is specified and tested as a property of that mechanism rather than as separate legacy-data work.
+
+## Capabilities
+
+- `daemon-session-conversation` (MODIFIED + ADDED): turn state machine gains `interrupted`; server-side orphan reconcile requirements.
+- `daemon-rest-client` (MODIFIED): `turn-advance` payload carries the new status and optional reason.
+- `cli-daemon` (ADDED): graceful shutdown finalizes in-flight turns before exit.
+- `daemon-session-transcript-read` (ADDED): interrupted turn presentation.
+
+## Impact
+
+- **Schema**: `DaemonSessionTurn` gains nullable `interruptedReason` (DDL-only migration via `prisma migrate dev`; `status` is already a free-form string column).
+- **Server**: `daemon-session.service.ts` (state machine, reconcile, read-path fallback), `daemon-connection.service.ts` (abort hook wiring), `/api/daemon/turn-advance` route.
+- **CLI**: `cli/daemon.mjs` (`stop()`), `cli/waker.mjs` (exit reporting, interrupt-all), `cli/turn-reporter.mjs` / `cli/daemon-rest-client.mjs` (reason field).
+- **UI**: `transcript-view.tsx`, `turn-band.tsx`, `conversation-list.tsx`, both locale files.
+- **Compat**: a late `running → ended` report arriving after a turn was already finalized `interrupted` is rejected as `invalid_transition` (existing behavior for illegal edges) and logged — both sides converge on a terminal state, no crash.
+
+OpenSpec change slug: fix-daemon-exit-orphan-running-turn

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/cli-daemon/spec.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/cli-daemon/spec.md
@@ -1,0 +1,42 @@
+# cli-daemon — delta: graceful shutdown finalizes in-flight turns
+
+## ADDED Requirements
+
+### Requirement: Daemon graceful shutdown SHALL interrupt in-flight wakes and report their turn terminal state before exiting
+
+On SIGINT/SIGTERM, the daemon SHALL stop accepting new wakes, interrupt every in-flight wake subprocess via the existing graceful kill escalation (SIGINT first, SIGKILL after the configured escalation window), and flush each interrupted wake's turn terminal report (`running → interrupted`, reason `shutdown`) to the server before the process exits. Shutdown SHALL be bounded — a wake that cannot be killed or reported within the escalation window plus a hard cap SHALL NOT hang the shutdown indefinitely; server-side offline reconcile remains the backstop for anything left behind. The waker's turn exit report SHALL be outcome-aware generally: a clean subprocess exit reports `ended`; a user-interrupted subprocess reports `interrupted(user)`; a shutdown-killed subprocess reports `interrupted(shutdown)`; a dirty exit with no interrupt requested reports `interrupted(crash)`.
+
+During shutdown, the waker SHALL NOT report a `DaemonExecution` interrupt for the subprocesses it killed: a shutdown-kill is a dirty exit with no user-interrupt flag, which the unchanged crash path would record as the STICKY execution state `interrupted(crash)` — a state the execution offline-reconcile deliberately skips, so every graceful shutdown would strand crash-interrupted execution rows. Instead the execution row is left as-is and the existing execution offline-reconcile flips it `ended` when the connection drops. Outside shutdown, `DaemonExecution` reporting semantics (sticky user-interrupt resumability, crash reporting, offline reconcile) SHALL be unchanged.
+
+#### Scenario: Ctrl-C mid-turn leaves no orphan running turn
+
+- **GIVEN** a daemon with one wake subprocess running (its turn is `running`)
+- **WHEN** the daemon receives SIGINT and completes shutdown
+- **THEN** the subprocess MUST have been killed via the graceful escalation
+- **AND** the turn MUST have been reported `interrupted` with reason `shutdown` before the daemon process exits
+
+#### Scenario: Clean exits still report ended
+
+- **GIVEN** a wake subprocess that exits with code 0 during normal operation
+- **WHEN** the waker reports the turn's exit
+- **THEN** the report MUST be `running → ended` (unchanged behavior)
+
+#### Scenario: A crashed subprocess reports an interrupted turn
+
+- **GIVEN** a wake subprocess that exits non-zero with no interrupt requested and no shutdown in progress
+- **WHEN** the waker reports the turn's exit
+- **THEN** the report MUST be `running → interrupted` with reason `crash`
+
+#### Scenario: Shutdown does not strand a sticky crash-interrupted execution row
+
+- **GIVEN** a wake subprocess killed by the shutdown escalation (dirty exit, no user interrupt)
+- **WHEN** the waker handles the exit during shutdown
+- **THEN** it MUST NOT report the execution as `interrupted(crash)`
+- **AND** the execution row MUST be left for the existing offline reconcile to flip `ended` when the connection drops
+
+#### Scenario: Shutdown does not hang on an unkillable wake
+
+- **GIVEN** a wake subprocess that survives the kill escalation
+- **WHEN** the shutdown's hard cap elapses
+- **THEN** the daemon MUST exit anyway
+- **AND** the orphaned turn is left to server-side offline reconcile

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/daemon-rest-client/spec.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/daemon-rest-client/spec.md
@@ -1,0 +1,30 @@
+# daemon-rest-client — delta: turn-advance carries interrupted status + reason
+
+## MODIFIED Requirements
+
+### Requirement: A shared host-agnostic client SHALL own the `/api/daemon/*` reporting payload shapes
+
+The system SHALL provide a single shared module that encapsulates every daemon→server report — `turn-advance`, `transcript`, `execution-state`, `report-interrupt`, and the `pending-turns` read — and SHALL be the single source of truth for those request/response shapes. The module SHALL be constructed from only host-agnostic inputs (`url`, `apiKey`, a `getConnectionUuid` accessor, an injectable `fetchImpl`, and an optional logger) and SHALL authenticate every request with the agent `Authorization: Bearer <apiKey>` header and no other mechanism. The module SHALL NOT import or reference any daemon-host-specific facility (no child-process spawning, no `claude` invocation, no stream-json parsing, no OpenClaw SDK), so that both the chorus CLI daemon and the OpenClaw plugin can consume it unchanged.
+
+#### Scenario: The client exposes the five daemon reporting operations
+
+- **WHEN** the shared client is constructed with `{ url, apiKey, getConnectionUuid, fetchImpl }`
+- **THEN** it MUST expose operations that POST to `/api/daemon/turn-advance`, `/api/daemon/transcript`, `/api/daemon/execution-state`, and `/api/daemon/report-interrupt`, and that GET `/api/daemon/pending-turns`
+- **AND** every request MUST carry the `Authorization: Bearer <apiKey>` header
+
+#### Scenario: The payload shapes match the existing server contract
+
+- **WHEN** the client issues each operation
+- **THEN** the `turn-advance` body MUST carry `{ connectionUuid, sessionId, status }` (with optional `entityType`/`entityUuid`, and — when `status` is `interrupted` — an `interruptedReason` of `user`, `crash`, or `shutdown`), the `transcript` body MUST carry `{ sessionId, messages: [{ role, text }] }`, the `execution-state` body MUST carry `{ connectionUuid, executions: [{ taskUuid, rootIdeaUuid|null, status, startedAt|null }] }`, the `report-interrupt` body MUST carry `{ connectionUuid, entityType, entityUuid, reason }`, and the `pending-turns` read MUST be `GET /api/daemon/pending-turns?connectionUuid=<uuid>`
+- **AND** these MUST be the exact shapes the server endpoints accept
+
+#### Scenario: The client has zero daemon-host coupling
+
+- **WHEN** the shared module's source is inspected
+- **THEN** it MUST NOT import `child_process`, spawn `claude`, parse stream-json, or import any OpenClaw SDK symbol
+- **AND** its only outbound effect MUST be HTTP calls via the injected `fetchImpl`
+
+#### Scenario: The server rejects a daemon claiming the offline reason
+
+- **WHEN** a turn-advance report carries `status = "interrupted"` with `interruptedReason = "offline"`
+- **THEN** the server MUST reject it (the `offline` verdict is reserved to server-side reconcile)

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/daemon-session-conversation/spec.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,102 @@
+# daemon-session-conversation — delta: orphan running turns get a terminal `interrupted` state
+
+## MODIFIED Requirements
+
+### Requirement: Every daemon wake SHALL be recorded as a turn on its DaemonSession
+
+The server SHALL define a Prisma model `DaemonSessionTurn` representing one wake on a conversation. It SHALL carry at least: `uuid`, `sessionUuid` (referencing `DaemonSession.uuid`), `seq` (monotonic per session), `trigger` (one of `task_assigned`, `mentioned`, `elaboration`, `elaboration_verified`, `start_development`, `resume`, `human_instruction`), `promptText` (nullable — the free-text instruction body for a `human_instruction` turn, null for autonomous triggers), `status` (`pending` | `running` | `ended` | `interrupted`), `interruptedReason` (nullable — `user` | `crash` | `shutdown` | `offline`, set if and only if `status = "interrupted"`), `startedAt` (nullable), `endedAt` (nullable), and `createdAt`. Every wake-triggering event — whether an autonomous dispatch (task assignment, @mention, elaboration request, elaboration verified, start development, resume) or a human-typed instruction — SHALL produce exactly one turn on the corresponding `DaemonSession`, distinguished only by `trigger`. A turn SHALL reference the live execution it corresponds to (so the conversation turn and the `DaemonExecution` row are linked) without altering `DaemonExecution` reconcile semantics. The `trigger` field is a free-form string column; extending the enumeration SHALL NOT require a data-mutating migration.
+
+The turn status state machine SHALL be: `pending → running`, `running → ended`, `running → interrupted`; `ended` and `interrupted` are terminal. Skips (including `pending → interrupted` — a pending turn is recoverable via backfill and stays pending), backward moves, and same-status re-application SHALL be rejected as invalid transitions that write nothing. The `interrupted` transition SHALL record `endedAt` (an interrupted turn has a definite end time) and persist the supplied `interruptedReason`. An interrupted turn SHALL NOT be automatically re-dispatched or reverted to `pending` — resending is a human decision.
+
+#### Scenario: An autonomous task dispatch records a turn
+
+- **GIVEN** a task is assigned to a daemon agent, producing a wake on session I
+- **WHEN** the server records the wake
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "task_assigned"`
+
+#### Scenario: A human instruction records a turn carrying its text
+
+- **GIVEN** a human submits a free-text instruction to session I
+- **WHEN** the server records it
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "human_instruction"` and `promptText` set to the submitted text
+
+#### Scenario: An elaboration-verified wake records a turn
+
+- **GIVEN** a human verifies the elaboration of an idea-anchored session I
+- **WHEN** the server records the wake
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "elaboration_verified"`
+
+#### Scenario: A start-development wake records a turn
+
+- **GIVEN** a human clicks Start Development for an idea anchored to session I
+- **WHEN** the server records the wake
+- **THEN** a `DaemonSessionTurn` MUST be created on session I with `trigger = "start_development"`
+
+#### Scenario: Turn trigger distinguishes wake kinds on one conversation
+
+- **GIVEN** session I has received a task assignment, an @mention, and a human instruction
+- **WHEN** the session's turns are listed
+- **THEN** all three MUST appear as turns on the same `DaemonSession`, distinguished by their `trigger` values
+
+#### Scenario: A turn links to its execution without changing execution semantics
+
+- **WHEN** a turn begins running and a `DaemonExecution` row reflects the running entity
+- **THEN** the turn MUST reference that execution
+- **AND** the `DaemonExecution` snapshot-reconcile behavior MUST be unchanged by the turn linkage
+
+#### Scenario: A running turn can be finalized as interrupted with a reason
+
+- **GIVEN** a turn in status `running`
+- **WHEN** it is advanced to `interrupted` with reason `shutdown`
+- **THEN** the turn MUST persist `status = "interrupted"`, `interruptedReason = "shutdown"`, and a non-null `endedAt`
+- **AND** the `turn_status_changed` SSE trigger MUST be published exactly as for an `ended` transition
+
+#### Scenario: Interrupted and ended are both terminal
+
+- **GIVEN** a turn in status `interrupted` (or `ended`)
+- **WHEN** any further status transition is attempted (including a late `running → ended` report from a daemon that reconnected after the server already finalized the turn)
+- **THEN** the transition MUST be rejected as invalid, writing nothing
+- **AND** the rejection MUST be logged visibly, never crash the reporting side
+
+#### Scenario: A pending turn is never interrupted
+
+- **GIVEN** a turn in status `pending` whose connection goes offline
+- **WHEN** orphan reconcile runs
+- **THEN** the turn MUST remain `pending` (it stays recoverable via reconnect backfill)
+
+## ADDED Requirements
+
+### Requirement: The server SHALL finalize a running turn whose origin connection is stale
+
+The server SHALL reconcile orphaned `running` turns — turns whose owning session's `originConnectionUuid` resolves to a connection whose `lastSeenAt` is older than the registry's single staleness threshold — by finalizing them to `interrupted` with `interruptedReason = "offline"`, routing through the same status-transition chokepoint (legality check + SSE emission) as every other transition. Orphan eligibility SHALL be judged by `lastSeenAt` age ONLY — never by the connection's stored `status` alone — because `status` flips to `offline` the instant an SSE stream aborts, and a read landing in a transient abort→reconnect gap would otherwise falsely interrupt a genuinely live turn. Two triggers SHALL exist: (1) an event-driven trigger armed from the daemon SSE stream's abort path that runs after the staleness window elapses and re-verifies age-based staleness before writing (so a transient reconnect, whose heartbeat refreshed `lastSeenAt`, makes it a no-op), and (2) a read-time fallback on the daemon-session read paths that detects and finalizes such turns inline when a session is read, so daemon deaths that never fired an abort (hard kill, server restart losing the timer) and pre-existing dirty rows converge without any data-mutating migration. Both triggers SHALL be idempotent through the state machine (a concurrent daemon report or duplicate reconcile loses the race as a logged invalid transition, harmless). Reconcile failures on fire-and-forget paths SHALL be logged, never thrown into stream teardown.
+
+#### Scenario: Daemon killed hard, turn converges on next read
+
+- **GIVEN** a daemon is killed with SIGKILL while a turn is `running`, so no abort fires and no daemon report will ever arrive
+- **WHEN** the session is next read after the connection's `lastSeenAt` has aged past the staleness threshold
+- **THEN** the turn MUST be finalized `interrupted` with reason `offline` and the read MUST return it in that state
+
+#### Scenario: Transient SSE reconnect does not interrupt a live turn
+
+- **GIVEN** a daemon's SSE stream aborts while a turn is `running` and the daemon reconnects within the staleness window
+- **WHEN** the deferred reconcile armed by the abort runs
+- **THEN** it MUST re-verify age-based staleness and write nothing (the turn stays `running`)
+
+#### Scenario: A session read during the abort→reconnect gap does not interrupt a live turn
+
+- **GIVEN** a daemon's SSE stream just aborted (connection `status` = `offline`) but its `lastSeenAt` is younger than the staleness threshold
+- **WHEN** the session is read
+- **THEN** the read-time fallback MUST NOT finalize the running turn (age-only rule; `status` alone is not evidence of death)
+
+#### Scenario: Legacy dirty rows converge without migration DML
+
+- **GIVEN** turns left permanently `running` by daemon exits that predate this change
+- **WHEN** their sessions are read
+- **THEN** the read-time fallback MUST finalize them `interrupted(offline)`
+- **AND** no data-mutating migration is required for this convergence
+
+#### Scenario: Reconcile loses the race to the daemon's own report
+
+- **GIVEN** the daemon reports `running → ended` at the same moment the server reconcile attempts `running → interrupted`
+- **WHEN** both writes reach the transition chokepoint
+- **THEN** exactly one MUST win and the loser MUST be rejected as an invalid transition that writes nothing

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/specs/daemon-session-transcript-read/spec.md
@@ -1,0 +1,20 @@
+# daemon-session-transcript-read — delta: interrupted turn presentation
+
+## ADDED Requirements
+
+### Requirement: An interrupted turn SHALL render as a distinct terminal state, never as running
+
+The conversation surface SHALL treat `status = "interrupted"` as a terminal turn state. An interrupted turn's band SHALL show an explicit "Interrupted" status label (localized in every supported locale), styled distinctly from both `running` (no spinner, no pulse, no elapsed-running timer) and plain `ended` (visually distinguishable as an abnormal termination). The transcript header's running probe and the conversation list's running indicator SHALL NOT match an interrupted turn. The `turn_status_changed` SSE event for a `running → interrupted` transition SHALL update the open conversation in place, exactly like the other status transitions, and the turn view payload SHALL carry `interruptedReason` so the UI can surface it.
+
+#### Scenario: A turn interrupted by daemon exit stops rendering as running
+
+- **GIVEN** an open conversation whose latest turn is `running`
+- **WHEN** a `turn_status_changed` event arrives finalizing it `interrupted(offline)`
+- **THEN** the turn band MUST switch to the "Interrupted" presentation without a page refresh
+- **AND** the header running badge and the conversation list's running indicator MUST clear
+
+#### Scenario: Interrupted is visually distinct from ended
+
+- **WHEN** a transcript renders one `ended` turn and one `interrupted` turn
+- **THEN** the two MUST be distinguishable (the interrupted band carries the "Interrupted" label)
+- **AND** neither shows a spinner or running pulse

--- a/openspec/changes/fix-daemon-exit-orphan-running-turn/tasks.md
+++ b/openspec/changes/fix-daemon-exit-orphan-running-turn/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [ ] 1. Turn `interrupted` terminal state — schema + state machine + turn-advance route
+- [ ] 2. Server-side orphan-turn reconcile — deferred abort trigger + read-time fallback
+- [ ] 3. CLI daemon graceful shutdown + outcome-aware turn exit reporting
+- [ ] 4. UI interrupted-turn presentation + i18n
+- [ ] 5. Integration checkpoint — daemon-exit e2e across kill modes

--- a/prisma/migrations/20260704023331_add_turn_interrupted_state/migration.sql
+++ b/prisma/migrations/20260704023331_add_turn_interrupted_state/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DaemonSessionTurn" ADD COLUMN     "interruptedReason" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -595,7 +595,14 @@ model DaemonSessionTurn {
   seq           Int // monotonic per session
   trigger       String // task_assigned | mentioned | elaboration | elaboration_verified | resume | human_instruction
   promptText    String? // free-text body for human_instruction; null otherwise (canonical source)
-  status        String                    @default("pending") // pending | running | ended
+  status        String                    @default("pending") // pending | running | ended | interrupted
+  // Discriminator for the `interrupted` status: `user` = user-requested interrupt,
+  // `crash` = subprocess exited dirty, `shutdown` = daemon graceful shutdown killed
+  // the wake, `offline` = server-side reconcile of a turn whose origin connection
+  // went stale. Non-null iff status == interrupted. Unlike DaemonExecution's sticky
+  // `interrupted` (resumable), a turn's `interrupted` is TERMINAL — it is durable
+  // conversation history, never resumed or auto-retried.
+  interruptedReason String?
   // Weak ref to the live DaemonExecution row this turn corresponds to (no DB FK;
   // execution rows are reconciled/transient).
   executionUuid String?

--- a/src/app/api/daemon/turn-advance/__tests__/route.test.ts
+++ b/src/app/api/daemon/turn-advance/__tests__/route.test.ts
@@ -17,9 +17,11 @@ vi.mock("@/services/daemon-execution.service", () => ({
   connectionBelongsToAgent: (...args: unknown[]) => mockConnectionBelongsToAgent(...args),
 }));
 
-// daemon-session.service: TURN_STATUSES re-exported for the route's zod enum.
+// daemon-session.service: TURN_STATUSES + the daemon-reportable interrupt-reason
+// subset, re-exported for the route's zod enums.
 vi.mock("@/services/daemon-session.service", () => ({
-  TURN_STATUSES: ["pending", "running", "ended"],
+  TURN_STATUSES: ["pending", "running", "ended", "interrupted"],
+  DAEMON_REPORTABLE_INTERRUPT_REASONS: ["user", "crash", "shutdown"],
   advanceTurnForWake: (...args: unknown[]) => mockAdvanceTurnForWake(...args),
 }));
 
@@ -127,6 +129,46 @@ describe("POST /api/daemon/turn-advance", () => {
     expect(res.status).toBe(409);
     expect(body.error.code).toBe("CONFLICT");
     expect(body.error.message).toMatch(/ended → running/);
+  });
+
+  it("accepts status=interrupted with a daemon-reportable reason and passes it through", async () => {
+    const res = await POST(
+      postRequest({ connectionUuid, sessionId, status: "interrupted", interruptedReason: "shutdown" }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(200);
+    const arg = mockAdvanceTurnForWake.mock.calls[0][0];
+    expect(arg.status).toBe("interrupted");
+    expect(arg.interruptedReason).toBe("shutdown");
+  });
+
+  it("rejects interruptedReason=offline (server-reconcile verdict, not daemon-reportable) at the zod boundary", async () => {
+    const res = await POST(
+      postRequest({ connectionUuid, sessionId, status: "interrupted", interruptedReason: "offline" }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
+  it("rejects an interruptedReason accompanying a non-interrupted status (422)", async () => {
+    const res = await POST(
+      postRequest({ connectionUuid, sessionId, status: "ended", interruptedReason: "crash" }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
+  it("accepts status=interrupted WITHOUT a reason (reason optional; column stays null)", async () => {
+    const res = await POST(
+      postRequest({ connectionUuid, sessionId, status: "interrupted" }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(200);
+    const arg = mockAdvanceTurnForWake.mock.calls[0][0];
+    expect(arg.status).toBe("interrupted");
+    expect(arg.interruptedReason).toBeUndefined();
   });
 
   it("rejects a bad status at the zod boundary (422)", async () => {

--- a/src/app/api/daemon/turn-advance/route.ts
+++ b/src/app/api/daemon/turn-advance/route.ts
@@ -2,7 +2,7 @@
 // Daemon → server turn lifecycle advance (子1 — daemon-session-conversation).
 //
 // POST — the daemon advances the lifecycle of the turn it is executing
-// (`pending → running → ended`) on ONE of its OWN sessions. It identifies the turn by
+// (`pending → running → ended | interrupted`) on ONE of its OWN sessions. It identifies the turn by
 // the session BUSINESS KEY (`sessionId` = the directIdeaUuid for an idea-anchored
 // session, or the entity uuid for an ad-hoc one — the deterministic Claude session
 // anchor the daemon already computes), NOT the server-side turn uuid, which the daemon
@@ -24,21 +24,34 @@ import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
 import { getAuthContext } from "@/lib/auth";
 import { connectionBelongsToAgent, EXECUTION_ENTITY_TYPES } from "@/services/daemon-execution.service";
-import { TURN_STATUSES, advanceTurnForWake } from "@/services/daemon-session.service";
+import {
+  TURN_STATUSES,
+  DAEMON_REPORTABLE_INTERRUPT_REASONS,
+  advanceTurnForWake,
+} from "@/services/daemon-session.service";
 
 // Body: the connection reporting the advance, the session business key, the target
 // status, and the OPTIONAL wake-triggering entity (for the weak executionUuid link).
 // `startedAt`/`endedAt` are optional ISO-8601 strings (the service defaults them to the
-// transition time for the running/ended edges when omitted).
-const bodySchema = z.object({
-  connectionUuid: z.string().min(1),
-  sessionId: z.string().min(1),
-  status: z.enum([...TURN_STATUSES]),
-  entityType: z.enum([...EXECUTION_ENTITY_TYPES]).optional(),
-  entityUuid: z.string().min(1).optional(),
-  startedAt: z.coerce.date().nullish(),
-  endedAt: z.coerce.date().nullish(),
-});
+// transition time for the running/terminal edges when omitted). `interruptedReason`
+// accompanies `status = interrupted` and is restricted to the DAEMON-reportable subset
+// (`user`/`crash`/`shutdown`) — `offline` is the server reconcile's verdict about a
+// dead daemon, which a daemon alive enough to report cannot truthfully claim.
+const bodySchema = z
+  .object({
+    connectionUuid: z.string().min(1),
+    sessionId: z.string().min(1),
+    status: z.enum([...TURN_STATUSES]),
+    entityType: z.enum([...EXECUTION_ENTITY_TYPES]).optional(),
+    entityUuid: z.string().min(1).optional(),
+    startedAt: z.coerce.date().nullish(),
+    endedAt: z.coerce.date().nullish(),
+    interruptedReason: z.enum([...DAEMON_REPORTABLE_INTERRUPT_REASONS]).nullish(),
+  })
+  .refine((b) => b.status === "interrupted" || b.interruptedReason == null, {
+    message: "interruptedReason is only valid with status=interrupted",
+    path: ["interruptedReason"],
+  });
 
 // POST /api/daemon/turn-advance — advance a turn's lifecycle by session business key.
 export const POST = withErrorHandler(async (request: NextRequest) => {
@@ -58,8 +71,16 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   if (!parsed.success) {
     return errors.validationError(parsed.error.flatten());
   }
-  const { connectionUuid, sessionId, status, entityType, entityUuid, startedAt, endedAt } =
-    parsed.data;
+  const {
+    connectionUuid,
+    sessionId,
+    status,
+    entityType,
+    entityUuid,
+    startedAt,
+    endedAt,
+    interruptedReason,
+  } = parsed.data;
 
   // Ownership fence: the connection must belong to the authenticated agent within its
   // company. A connection owned by another agent (or non-existent) is 404 — never 403
@@ -80,6 +101,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     entityUuid: entityUuid ?? null,
     startedAt: startedAt ?? undefined,
     endedAt: endedAt ?? undefined,
+    interruptedReason: interruptedReason ?? undefined,
   });
 
   if (!result.ok) {

--- a/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
+++ b/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
@@ -27,6 +27,7 @@ function turn(
     trigger: "task_assigned",
     promptText: null,
     status: "pending",
+    interruptedReason: null,
     executionUuid: null,
     startedAt: null,
     endedAt: null,

--- a/src/contexts/__tests__/agent-presence-context.test.tsx
+++ b/src/contexts/__tests__/agent-presence-context.test.tsx
@@ -120,6 +120,7 @@ function transcriptEvent(over: Partial<TranscriptEvent> = {}): TranscriptEvent {
       trigger: "task_assigned",
       promptText: null,
       status: "running",
+      interruptedReason: null,
       executionUuid: null,
       startedAt: null,
       endedAt: null,

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -116,6 +116,7 @@ function turnRow(overrides: Partial<Record<string, unknown>> = {}) {
     trigger: "task_assigned",
     promptText: null,
     status: "pending",
+    interruptedReason: null,
     executionUuid: null,
     startedAt: null,
     endedAt: null,
@@ -189,8 +190,8 @@ describe("constants", () => {
     expect(TURN_TRIGGERS).toContain("task_assigned");
   });
 
-  it("TURN_STATUSES are the strict forward lifecycle pending/running/ended", () => {
-    expect([...TURN_STATUSES]).toEqual(["pending", "running", "ended"]);
+  it("TURN_STATUSES are the strict forward lifecycle pending/running/ended|interrupted", () => {
+    expect([...TURN_STATUSES]).toEqual(["pending", "running", "ended", "interrupted"]);
   });
 
   it("SESSION_STATUSES are active/ended", () => {
@@ -453,8 +454,107 @@ describe("createPendingTurn", () => {
   });
 });
 
-// ===== advanceTurn (strict pending → running → ended) =====
+// ===== advanceTurn (strict pending → running → ended | interrupted) =====
 describe("advanceTurn", () => {
+  it("running → interrupted: persists status + interruptedReason + endedAt, emits turn_status_changed", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    const endedAt = new Date("2026-06-15T05:00:00.000Z");
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ status: "interrupted", interruptedReason: "shutdown", endedAt }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    const res = await advanceTurn(turnUuid, "interrupted", {
+      endedAt,
+      interruptedReason: "shutdown",
+    });
+    expect(res).toMatchObject({ ok: true });
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data.status).toBe("interrupted");
+    expect(data.interruptedReason).toBe("shutdown");
+    expect(data.endedAt).toBe(endedAt);
+
+    // The SSE trigger fires exactly as for ended, carrying the reason in the view.
+    expect(mockEventBus.emit).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = mockEventBus.emit.mock.calls[0];
+    expect(eventName).toBe(`transcript:${sessionUuid}`);
+    expect(payload.trigger).toBe("turn_status_changed");
+    expect(payload.turn.status).toBe("interrupted");
+    expect(payload.turn.interruptedReason).toBe("shutdown");
+  });
+
+  it("REJECTS pending → interrupted (a pending turn stays recoverable via backfill)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "pending",
+    });
+    const res = await advanceTurn(turnUuid, "interrupted", { interruptedReason: "offline" });
+    expect(res).toEqual({
+      ok: false,
+      reason: "invalid_transition",
+      from: "pending",
+      to: "interrupted",
+    });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("REJECTS any transition out of the terminal interrupted state (incl. a late running→ended report)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "interrupted",
+    });
+    // The daemon finished the subprocess after the server already reconciled the turn
+    // interrupted(offline) — its late `ended` report must lose the race, writing nothing.
+    const res = await advanceTurn(turnUuid, "ended");
+    expect(res).toMatchObject({ ok: false, reason: "invalid_transition", from: "interrupted", to: "ended" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("REJECTS ended → interrupted (terminal states never cross)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "ended",
+    });
+    const res = await advanceTurn(turnUuid, "interrupted", { interruptedReason: "offline" });
+    expect(res).toMatchObject({ ok: false, reason: "invalid_transition", from: "ended", to: "interrupted" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("REJECTS re-applying interrupted → interrupted", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "interrupted",
+    });
+    const res = await advanceTurn(turnUuid, "interrupted", { interruptedReason: "offline" });
+    expect(res).toMatchObject({ ok: false, reason: "invalid_transition" });
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("DROPS interruptedReason on a non-interrupted edge (invariant: reason iff interrupted)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow({ status: "ended" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+    // A stray reason alongside a legal → ended must not decorate the ended turn.
+    await advanceTurn(turnUuid, "ended", { interruptedReason: "crash" });
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data.status).toBe("ended");
+    expect(data).not.toHaveProperty("interruptedReason");
+  });
+
   it("pending → running: updates status, records startedAt + executionUuid, emits turn_status_changed", async () => {
     mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
       uuid: turnUuid,
@@ -1773,6 +1873,28 @@ describe("advanceTurnForWake", () => {
     expect(updateArg.data.endedAt).toBeInstanceOf(Date);
     // executionUuid is left untouched (undefined) when no entity is supplied.
     expect(updateArg.data).not.toHaveProperty("executionUuid");
+  });
+
+  it("running→interrupted resolves the RUNNING turn, defaults endedAt, and persists the reason", async () => {
+    ownedSessionWithLatestTurn("running");
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "interrupted",
+      interruptedReason: "shutdown",
+    });
+
+    expect(res).toMatchObject({ ok: true });
+    // → interrupted leaves from the same state as → ended: the running turn.
+    const resolve = mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0];
+    expect(resolve.where).toEqual({ sessionUuid, status: "running" });
+    const updateArg = mockPrisma.daemonSessionTurn.update.mock.calls[0][0];
+    expect(updateArg.data.status).toBe("interrupted");
+    expect(updateArg.data.interruptedReason).toBe("shutdown");
+    expect(updateArg.data.endedAt).toBeInstanceOf(Date);
   });
 
   it("returns not_found when the agent has no such session (non-disclosure)", async () => {

--- a/src/services/daemon-instruction.service.ts
+++ b/src/services/daemon-instruction.service.ts
@@ -790,6 +790,7 @@ export async function createConversationalIdeaSession(
     trigger: turnRow.trigger,
     promptText: turnRow.promptText,
     status: turnRow.status,
+    interruptedReason: turnRow.interruptedReason,
     executionUuid: turnRow.executionUuid,
     startedAt: turnRow.startedAt ? turnRow.startedAt.toISOString() : null,
     endedAt: turnRow.endedAt ? turnRow.endedAt.toISOString() : null,

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -55,11 +55,24 @@ export const TURN_TRIGGERS = [
 ] as const;
 export type TurnTrigger = (typeof TURN_TRIGGERS)[number];
 
-// A turn's lifecycle states, in strict forward order. The daemon advances a turn
-// `pending → running → ended`; this service enforces that ordering (no skips, no
-// backward transitions) in `advanceTurn`.
-export const TURN_STATUSES = ["pending", "running", "ended"] as const;
+// A turn's lifecycle states. A turn advances `pending → running`, then terminates as
+// either `ended` (the subprocess completed) or `interrupted` (the wake was stopped —
+// by a user, a crash, a daemon shutdown, or server-side offline reconcile); this
+// service enforces that ordering (no skips, no backward transitions) in `advanceTurn`.
+// Both `ended` and `interrupted` are terminal. Unlike DaemonExecution's sticky
+// `interrupted` (a live, resumable fact), a turn's `interrupted` is durable
+// conversation history — never resumed, never auto-retried.
+export const TURN_STATUSES = ["pending", "running", "ended", "interrupted"] as const;
 export type TurnStatus = (typeof TURN_STATUSES)[number];
+
+// Discriminator vocabulary for `status = interrupted`. `user`/`crash`/`shutdown` are
+// daemon-reported outcomes; `offline` is reserved to SERVER-side reconcile of a turn
+// whose origin connection went stale — the turn-advance route rejects a daemon
+// claiming it (the daemon being alive to report contradicts the verdict).
+export const TURN_INTERRUPT_REASONS = ["user", "crash", "shutdown", "offline"] as const;
+export type TurnInterruptReason = (typeof TURN_INTERRUPT_REASONS)[number];
+// The subset a daemon may self-report over `/api/daemon/turn-advance`.
+export const DAEMON_REPORTABLE_INTERRUPT_REASONS = ["user", "crash", "shutdown"] as const;
 
 // The two session lifecycle states. A session is `active` until explicitly ended;
 // it stays readable (its turns/transcript) regardless of state — `ended` is history,
@@ -123,7 +136,8 @@ export interface TurnView {
   seq: number;
   trigger: string;
   promptText: string | null;
-  status: string; // pending | running | ended
+  status: string; // pending | running | ended | interrupted
+  interruptedReason: string | null; // user | crash | shutdown | offline; set iff interrupted
   executionUuid: string | null;
   startedAt: string | null; // ISO-8601
   endedAt: string | null; // ISO-8601
@@ -182,6 +196,7 @@ interface DaemonSessionTurnRow {
   trigger: string;
   promptText: string | null;
   status: string;
+  interruptedReason: string | null;
   executionUuid: string | null;
   startedAt: Date | null;
   endedAt: Date | null;
@@ -213,6 +228,7 @@ function toTurnView(row: DaemonSessionTurnRow): TurnView {
     trigger: row.trigger,
     promptText: row.promptText,
     status: row.status,
+    interruptedReason: row.interruptedReason,
     executionUuid: row.executionUuid,
     startedAt: row.startedAt ? row.startedAt.toISOString() : null,
     endedAt: row.endedAt ? row.endedAt.toISOString() : null,
@@ -457,30 +473,40 @@ export type AdvanceTurnResult =
   | { ok: false; reason: "not_found" }
   | { ok: false; reason: "invalid_transition"; from: string; to: string };
 
-// The single legal forward edge for each status. Enforces strict
-// pending → running → ended with no skips and no backward moves. A status with no
-// outgoing edge (`ended`) is terminal. Re-applying the SAME status is also rejected
-// (an idempotent no-op would otherwise hide a double-report bug and re-emit SSE).
-const NEXT_TURN_STATUS: Record<TurnStatus, TurnStatus | null> = {
-  pending: "running",
-  running: "ended",
-  ended: null,
+// The legal forward edges for each status. Enforces strict
+// pending → running → ended | interrupted with no skips and no backward moves — in
+// particular `pending → interrupted` is illegal: a pending turn never started, is
+// recoverable via reconnect backfill, and must stay pending. A status with no
+// outgoing edges (`ended`, `interrupted`) is terminal — a late daemon report against
+// an already-reconciled turn (or vice versa) loses the race here as a harmless
+// invalid_transition. Re-applying the SAME status is also rejected (an idempotent
+// no-op would otherwise hide a double-report bug and re-emit SSE).
+const NEXT_TURN_STATUS: Record<TurnStatus, readonly TurnStatus[]> = {
+  pending: ["running"],
+  running: ["ended", "interrupted"],
+  ended: [],
+  interrupted: [],
 };
 
 /**
  * Advance a turn through its lifecycle — the SINGLE turn-status chokepoint. Enforces
- * strict `pending → running → ended`: only the one legal forward edge from the turn's
- * current status is allowed; a skip (`pending → ended`), a backward move
- * (`running → pending`), or re-applying the same status is rejected as
- * `invalid_transition` and writes nothing. A turn that does not exist is `not_found`.
+ * strict `pending → running → ended | interrupted`: only a legal forward edge from
+ * the turn's current status is allowed; a skip (`pending → ended`,
+ * `pending → interrupted`), a backward move (`running → pending`), a transition out
+ * of a terminal status (`ended`/`interrupted`), or re-applying the same status is
+ * rejected as `invalid_transition` and writes nothing. A turn that does not exist is
+ * `not_found`.
  *
  * On a legal transition it:
  *  - sets the new `status`, and optionally records `startedAt` (the daemon's spawn
- *    time, typically on → running), `endedAt` (subprocess exit, on → ended), and the
- *    weak `executionUuid` link to the live `DaemonExecution` row (recorded without
- *    altering execution-state reconcile semantics), and
+ *    time, typically on → running), `endedAt` (subprocess exit / interrupt time, on
+ *    either terminal edge), `interruptedReason` (persisted ONLY on → interrupted;
+ *    ignored on every other edge so a stray value can never decorate an `ended`
+ *    turn), and the weak `executionUuid` link to the live `DaemonExecution` row
+ *    (recorded without altering execution-state reconcile semantics), and
  *  - PUBLISHES the `turn_status_changed` SSE trigger on `transcript:{sessionUuid}` so
- *    a viewer sees the turn flip pending → running → ended live, for any caller.
+ *    a viewer sees the turn flip live, for any caller and any edge — including
+ *    → interrupted, which is how a viewer's forever-spinner clears.
  *
  * A query/write failure propagates (no silent swallow). The session lookup supplies
  * the companyUuid the SSE event carries.
@@ -488,7 +514,12 @@ const NEXT_TURN_STATUS: Record<TurnStatus, TurnStatus | null> = {
 export async function advanceTurn(
   turnUuid: string,
   status: TurnStatus,
-  opts: { startedAt?: Date | null; endedAt?: Date | null; executionUuid?: string | null } = {},
+  opts: {
+    startedAt?: Date | null;
+    endedAt?: Date | null;
+    executionUuid?: string | null;
+    interruptedReason?: string | null;
+  } = {},
 ): Promise<AdvanceTurnResult> {
   const turn = await prisma.daemonSessionTurn.findUnique({
     where: { uuid: turnUuid },
@@ -496,11 +527,11 @@ export async function advanceTurn(
   });
   if (!turn) return { ok: false, reason: "not_found" };
 
-  // The turn's persisted status must be a known lifecycle value to have a legal edge;
-  // a foreign value (should never happen) has no outgoing edge → invalid_transition.
+  // The turn's persisted status must be a known lifecycle value to have legal edges;
+  // a foreign value (should never happen) has no outgoing edges → invalid_transition.
   const current = turn.status as TurnStatus;
-  const legalNext = NEXT_TURN_STATUS[current] ?? null;
-  if (status !== legalNext) {
+  const legalNext = NEXT_TURN_STATUS[current] ?? [];
+  if (!legalNext.includes(status)) {
     return { ok: false, reason: "invalid_transition", from: turn.status, to: status };
   }
 
@@ -511,10 +542,16 @@ export async function advanceTurn(
     startedAt?: Date | null;
     endedAt?: Date | null;
     executionUuid?: string | null;
+    interruptedReason?: string | null;
   } = { status };
   if (opts.startedAt !== undefined) data.startedAt = opts.startedAt;
   if (opts.endedAt !== undefined) data.endedAt = opts.endedAt;
   if (opts.executionUuid !== undefined) data.executionUuid = opts.executionUuid;
+  // The reason is meaningful only on the → interrupted edge; dropping it elsewhere
+  // keeps the "non-null iff interrupted" column invariant without trusting callers.
+  if (status === "interrupted" && opts.interruptedReason !== undefined) {
+    data.interruptedReason = opts.interruptedReason;
+  }
 
   const updated = await prisma.daemonSessionTurn.update({
     where: { uuid: turnUuid },
@@ -1293,10 +1330,12 @@ export type AdvanceTurnForWakeResult =
  * When `entityType`/`entityUuid` are supplied AND the live `DaemonExecution` row for
  * `(companyUuid, connectionUuid, entity)` resolves, its uuid is stamped onto the turn
  * as the weak `executionUuid` link — recorded WITHOUT touching execution-state
- * reconcile semantics. `startedAt`/`endedAt` default to the transition time for the
- * `running`/`ended` edges respectively (the daemon's spawn/exit moment) unless the
- * caller passes explicit timestamps. A query/write failure propagates (no swallow):
- * a lost transition would strand a turn's lifecycle.
+ * reconcile semantics. `startedAt` defaults to the transition time on the `running`
+ * edge and `endedAt` on either terminal edge (`ended`/`interrupted`) — the daemon's
+ * spawn/exit/stop moment — unless the caller passes explicit timestamps.
+ * `interruptedReason` is passed through to `advanceTurn` (persisted only on the
+ * → interrupted edge). A query/write failure propagates (no swallow): a lost
+ * transition would strand a turn's lifecycle.
  */
 export async function advanceTurnForWake(params: {
   companyUuid: string;
@@ -1308,6 +1347,7 @@ export async function advanceTurnForWake(params: {
   entityUuid?: string | null;
   startedAt?: Date | null;
   endedAt?: Date | null;
+  interruptedReason?: string | null;
 }): Promise<AdvanceTurnForWakeResult> {
   // Resolve the agent's OWN session by its business key (company + agent fenced).
   const session = await prisma.daemonSession.findFirst({
@@ -1328,11 +1368,17 @@ export async function advanceTurnForWake(params: {
   // the running turn's `→ended` would mis-target the newer pending turn (rejected as an
   // invalid transition), stranding the real turn `running` forever. Status-based FIFO
   // resolution fixes that without the daemon needing to learn the server turn uuid:
-  //   • → running : the OLDEST still-`pending` turn (the next queued wake to start).
-  //   • → ended   : the `running` turn (the one whose subprocess just exited).
+  //   • → running     : the OLDEST still-`pending` turn (the next queued wake to start).
+  //   • → ended       : the `running` turn (the one whose subprocess just exited).
+  //   • → interrupted : the `running` turn too (the one whose subprocess was stopped —
+  //                     both terminal edges leave from the same state).
   // For any other target status, fall back to the oldest turn in the prior state.
   const fromStatus =
-    params.status === "running" ? "pending" : params.status === "ended" ? "running" : null;
+    params.status === "running"
+      ? "pending"
+      : params.status === "ended" || params.status === "interrupted"
+        ? "running"
+        : null;
   const turn = await prisma.daemonSessionTurn.findFirst({
     where: {
       sessionUuid: session.uuid,
@@ -1374,7 +1420,7 @@ export async function advanceTurnForWake(params: {
   const endedAt =
     params.endedAt !== undefined
       ? params.endedAt
-      : params.status === "ended"
+      : params.status === "ended" || params.status === "interrupted"
         ? now
         : undefined;
 
@@ -1382,6 +1428,9 @@ export async function advanceTurnForWake(params: {
     ...(startedAt !== undefined ? { startedAt } : {}),
     ...(endedAt !== undefined ? { endedAt } : {}),
     ...(executionUuid !== undefined ? { executionUuid } : {}),
+    ...(params.interruptedReason !== undefined
+      ? { interruptedReason: params.interruptedReason }
+      : {}),
   });
 
   if (result.ok) return { ok: true, turn: result.turn };


### PR DESCRIPTION
## Summary

Task 1 of 5 for idea 489ade18 (fix: daemon exit mid-turn leaves the turn stuck `running` forever) — the state-machine foundation the other tasks build on.

- `DaemonSessionTurn` gains nullable `interruptedReason` (`user` | `crash` | `shutdown` | `offline`) via a CLI-generated DDL-only migration; status enum documented as `pending | running | ended | interrupted`.
- `advanceTurn` enforces `pending → running → ended | interrupted`; both terminal states reject any further transition (a late `running → ended` report after server reconcile loses the race as a logged `invalid_transition`). The `→ interrupted` edge persists the reason and stamps `endedAt`; a stray reason on any other edge is dropped (invariant: reason non-null iff interrupted). `turn_status_changed` SSE fires on the new edge exactly as for `ended`.
- `POST /api/daemon/turn-advance` accepts `status=interrupted` (target resolution picks the `running` turn, same as `ended`) with `interruptedReason ∈ {user, crash, shutdown}` — `offline` is rejected at the zod boundary (server-reconcile-only verdict).
- Shared CLI REST client + turn-reporter pass `interruptedReason` through, with a mirrored daemon-side domain guard (bad reason → logged, no fetch).
- `TurnView` serializes `interruptedReason` (SSE + REST reads).
- Includes the OpenSpec change folder `fix-daemon-exit-orphan-running-turn` (proposal/design/4 spec deltas, validated `--strict`).

## Testing

- `pnpm test`: 3888 passed (242 files), including new coverage: every legal/illegal edge (skips incl. `pending→interrupted`, backward, terminal-cross, re-apply), reason-drop invariant, `advanceTurnForWake` interrupted resolution + endedAt default, route zod boundary (offline rejected, reason-without-interrupted rejected, reason optional), CLI reporter passthrough + guards.
- `npx tsc --noEmit`: clean. `pnpm lint`: 0 errors.
- Migration verified DDL-only (single `ALTER TABLE ... ADD COLUMN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)