### PR TITLE
feat(daemon): server-side orphan-turn reconcile for dead daemons

### DIFF
--- a/src/app/api/events/__tests__/route.test.ts
+++ b/src/app/api/events/__tests__/route.test.ts
@@ -19,6 +19,7 @@ const mockReconcileOffline = vi.fn();
 const mockPublishExecutionChange = vi.fn();
 const mockListVisibleConnectionUuids = vi.fn();
 const mockIsSessionVisibleToCaller = vi.fn();
+const mockReconcileOrphanTurns = vi.fn();
 
 vi.mock("@/lib/auth", () => ({
   getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
@@ -37,6 +38,7 @@ vi.mock("@/services/daemon-connection.service", () => ({
     result !== null && typeof result === "object" && "conflict" in (result as object),
   touchConnection: (...args: unknown[]) => mockTouchConnection(...args),
   markDisconnected: (...args: unknown[]) => mockMarkDisconnected(...args),
+  STALE_THRESHOLD_MS: 90_000,
 }));
 
 // The route now also resolves the caller's visible connections (to subscribe to
@@ -59,6 +61,7 @@ vi.mock("@/services/daemon-execution.service", () => ({
 vi.mock("@/services/daemon-session.service", () => ({
   isSessionVisibleToCaller: (...args: unknown[]) => mockIsSessionVisibleToCaller(...args),
   transcriptEventName: (sessionUuid: string) => `transcript:${sessionUuid}`,
+  reconcileOrphanTurns: (...args: unknown[]) => mockReconcileOrphanTurns(...args),
 }));
 
 import { GET } from "@/app/api/events/route";
@@ -122,6 +125,7 @@ beforeEach(() => {
   mockPublishExecutionChange.mockResolvedValue(undefined);
   // Default: the requested session (when one is given) is visible to the caller.
   mockIsSessionVisibleToCaller.mockResolvedValue(true);
+  mockReconcileOrphanTurns.mockResolvedValue(0);
 });
 
 afterEach(() => {
@@ -177,6 +181,44 @@ describe("GET /api/events (change events SSE)", () => {
 
     expect(mockMarkDisconnected).toHaveBeenCalledTimes(1);
     expect(mockMarkDisconnected).toHaveBeenCalledWith(companyUuid, connHandle);
+  });
+
+  it("arms a DEFERRED orphan-turn reconcile on abort that fires only after the staleness window", async () => {
+    vi.useFakeTimers();
+    const ac = new AbortController();
+    const res = await GET(makeRequest("clientType=claude_code", ac.signal));
+    await startStream(res);
+
+    ac.abort();
+    await flush();
+
+    // Executions reconcile immediately; turns do NOT — they get the full window.
+    expect(mockReconcileOffline).toHaveBeenCalledTimes(1);
+    expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+
+    // One tick before the window: still not fired.
+    await vi.advanceTimersByTimeAsync(90_000 - 1);
+    expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+
+    // Window elapsed: the deferred reconcile fires for this connection. (The age-only
+    // no-op-when-reconnected verdict lives inside reconcileOrphanTurns itself.)
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockReconcileOrphanTurns).toHaveBeenCalledTimes(1);
+    expect(mockReconcileOrphanTurns).toHaveBeenCalledWith(companyUuid, connectionUuid);
+  });
+
+  it("does NOT arm the orphan reconcile for a non-daemon (browser) stream abort", async () => {
+    vi.useFakeTimers();
+    mockParseSelfReport.mockReturnValue(null);
+    mockRegisterConnection.mockResolvedValue(null);
+    const ac = new AbortController();
+    const res = await GET(makeRequest("", ac.signal));
+    await startStream(res);
+
+    ac.abort();
+    await flush();
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
   });
 
   it("preserves projectUuid filtering: cross-project change events are dropped", async () => {

--- a/src/app/api/events/notifications/__tests__/route.test.ts
+++ b/src/app/api/events/notifications/__tests__/route.test.ts
@@ -14,6 +14,7 @@ const mockParseSelfReport = vi.fn();
 const mockRegisterConnection = vi.fn();
 const mockTouchConnection = vi.fn();
 const mockMarkDisconnected = vi.fn();
+const mockReconcileOrphanTurns = vi.fn();
 
 vi.mock("@/lib/auth", () => ({
   getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
@@ -35,6 +36,13 @@ vi.mock("@/services/daemon-connection.service", () => ({
     result !== null && typeof result === "object" && "conflict" in (result as object),
   touchConnection: (...args: unknown[]) => mockTouchConnection(...args),
   markDisconnected: (...args: unknown[]) => mockMarkDisconnected(...args),
+  STALE_THRESHOLD_MS: 90_000,
+}));
+
+// The route now defers an orphan-turn reconcile by the staleness window on abort.
+// Mock the session service so this stays a unit test.
+vi.mock("@/services/daemon-session.service", () => ({
+  reconcileOrphanTurns: (...args: unknown[]) => mockReconcileOrphanTurns(...args),
 }));
 
 import { GET } from "@/app/api/events/notifications/route";
@@ -215,6 +223,24 @@ describe("GET /api/events/notifications (notification SSE)", () => {
       `notification:agent:${actorUuid}`,
       expect.any(Function),
     );
+  });
+
+  it("arms a DEFERRED orphan-turn reconcile on abort that fires only after the staleness window", async () => {
+    vi.useFakeTimers();
+    const ac = new AbortController();
+    const res = await GET(makeRequest("clientType=openclaw", ac.signal));
+    await startStream(res);
+
+    ac.abort();
+    await flush();
+    expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(90_000 - 1);
+    expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockReconcileOrphanTurns).toHaveBeenCalledTimes(1);
+    expect(mockReconcileOrphanTurns).toHaveBeenCalledWith(companyUuid, connectionUuid);
   });
 
   describe("registration conflict (a live different-process daemon holds this (agent,host,cwd))", () => {

--- a/src/app/api/events/notifications/route.ts
+++ b/src/app/api/events/notifications/route.ts
@@ -10,11 +10,13 @@ import {
   isConnectionConflict,
   touchConnection,
   markDisconnected,
+  STALE_THRESHOLD_MS,
 } from "@/services/daemon-connection.service";
 import {
   reconcileOffline,
   publishExecutionChange,
 } from "@/services/daemon-execution.service";
+import { reconcileOrphanTurns } from "@/services/daemon-session.service";
 import { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -133,6 +135,17 @@ export async function GET(request: NextRequest) {
           void reconcileOffline(auth.companyUuid, conn.uuid).then(() =>
             publishExecutionChange(auth.companyUuid, conn.uuid),
           );
+          // Deferred orphan-turn reconcile: unlike executions (flipped immediately
+          // above), a running TURN gets the full staleness window before being
+          // declared interrupted — SSE streams reconnect transiently, and
+          // reconcileOrphanTurns re-verifies age-only eligibility at fire time, so a
+          // reconnected daemon (fresh lastSeenAt) makes this a no-op. Per-instance
+          // best-effort: unref'd so it never holds the process; a timer lost to a
+          // server restart is covered by the read-time fallback.
+          const orphanTimer = setTimeout(() => {
+            void reconcileOrphanTurns(auth.companyUuid, conn.uuid);
+          }, STALE_THRESHOLD_MS);
+          orphanTimer.unref?.();
         }
       });
     },

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -10,6 +10,7 @@ import {
   isConnectionConflict,
   touchConnection,
   markDisconnected,
+  STALE_THRESHOLD_MS,
 } from "@/services/daemon-connection.service";
 import {
   reconcileOffline,
@@ -20,6 +21,7 @@ import {
 } from "@/services/daemon-execution.service";
 import {
   isSessionVisibleToCaller,
+  reconcileOrphanTurns,
   transcriptEventName,
   type TranscriptEvent,
 } from "@/services/daemon-session.service";
@@ -191,6 +193,17 @@ export async function GET(request: NextRequest) {
           void reconcileOffline(auth.companyUuid, conn.uuid).then(() =>
             publishExecutionChange(auth.companyUuid, conn.uuid),
           );
+          // Deferred orphan-turn reconcile: unlike executions (flipped immediately
+          // above), a running TURN gets the full staleness window before being
+          // declared interrupted — SSE streams reconnect transiently, and
+          // reconcileOrphanTurns re-verifies age-only eligibility at fire time, so a
+          // reconnected daemon (fresh lastSeenAt) makes this a no-op. Per-instance
+          // best-effort: unref'd so it never holds the process; a timer lost to a
+          // server restart is covered by the read-time fallback.
+          const orphanTimer = setTimeout(() => {
+            void reconcileOrphanTurns(auth.companyUuid, conn.uuid);
+          }, STALE_THRESHOLD_MS);
+          orphanTimer.unref?.();
         }
       });
     },

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -78,6 +78,7 @@ import {
   appendTranscriptMessages,
   advanceTurnForWake,
   getPendingTurnsForConnection,
+  reconcileOrphanTurns,
   SessionReadOnlyError,
   transcriptEventName,
 } from "@/services/daemon-session.service";
@@ -944,8 +945,10 @@ describe("getSessionDetail", () => {
       orderBy: [{ turnUuid: "asc" }, { seq: "asc" }],
     });
     // Candidate turns are read seq DESC; with NO cursor there is no take cap (the page
-    // window is computed in memory over the message stream) and no seq filter.
-    const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
+    // window is computed in memory over the message stream) and no seq filter. The
+    // candidate query is the LAST turn findMany (the read-time orphan-reconcile probe
+    // runs first on this path).
+    const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls.at(-1)![0];
     expect(turnArgs.orderBy).toEqual({ seq: "desc" });
     expect(turnArgs.where).toEqual({ sessionUuid });
   });
@@ -1030,8 +1033,9 @@ describe("getSessionDetail", () => {
     );
 
     // Candidate turn query fenced `seq <= beforeTurnSeq` (the cursor turn itself stays in
-    // so its older messages can be returned).
-    const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
+    // so its older messages can be returned). The candidate query is the LAST turn
+    // findMany (the read-time orphan-reconcile probe runs first on this path).
+    const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls.at(-1)![0];
     expect(turnArgs.where).toEqual({ sessionUuid, seq: { lte: 3 } });
     // Only messages strictly older than (turnSeq 3, msgSeq 2): t3's seq 1 (and its slot
     // seq 0), plus all of t2 and t1's slots. t3's seq 2 and 3 are at/after the cursor →
@@ -1941,6 +1945,231 @@ describe("advanceTurnForWake", () => {
     });
     expect(res).toMatchObject({ ok: false, reason: "invalid_transition", from: "ended", to: "running" });
     expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+});
+
+// ===== reconcileOrphanTurns (server-side escape hatch for a daemon dead mid-turn) =====
+describe("reconcileOrphanTurns", () => {
+  const STALE = STALE_THRESHOLD_MS; // 90_000 (mocked to the real literal above)
+
+  // A running turn owned (via its session's originConnectionUuid) by the connection,
+  // plus the advanceTurn-chokepoint mocks for a successful → interrupted write.
+  function runningTurnOnConnection() {
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([{ uuid: turnUuid }]);
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ status: "interrupted", interruptedReason: "offline" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+  }
+
+  it("finalizes a stale connection's running turns as interrupted(offline) via the chokepoint (SSE emitted)", async () => {
+    runningTurnOnConnection();
+    // lastSeenAt aged past the threshold → orphan-eligible.
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+      lastSeenAt: new Date(Date.now() - STALE - 1_000),
+    });
+
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid);
+
+    expect(count).toBe(1);
+    // The candidate query is fenced to running turns of THIS connection's sessions.
+    const findArg = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
+    expect(findArg.where).toEqual({
+      status: "running",
+      session: { companyUuid, originConnectionUuid: connectionUuid },
+    });
+    // Written through advanceTurn: status + reason + endedAt.
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data.status).toBe("interrupted");
+    expect(data.interruptedReason).toBe("offline");
+    expect(data.endedAt).toBeInstanceOf(Date);
+    // SSE published by the chokepoint (not reimplemented here).
+    expect(mockEventBus.emit).toHaveBeenCalledTimes(1);
+    expect(mockEventBus.emit.mock.calls[0][1].trigger).toBe("turn_status_changed");
+  });
+
+  it("AGE-ONLY rule: a fresh lastSeenAt is NOT eligible even when status is 'offline' (abort→reconnect gap)", async () => {
+    // The connection row just aborted (status flipped offline) but its lastSeenAt is
+    // fresh — the daemon may be reconnecting. The reconcile must write NOTHING; the
+    // stored status is deliberately not consulted (blocker-1 regression guard).
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([{ uuid: turnUuid }]);
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+      status: "offline",
+      lastSeenAt: new Date(Date.now() - 5_000), // 5s ago — well within 90s
+    });
+
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid);
+
+    expect(count).toBe(0);
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+    expect(mockEventBus.emit).not.toHaveBeenCalled();
+    // Eligibility read selects only lastSeenAt — status cannot influence the verdict.
+    expect(mockPrisma.daemonConnection.findFirst.mock.calls[0][0].select).toEqual({
+      lastSeenAt: true,
+    });
+  });
+
+  it("a stale lastSeenAt IS eligible even while status still reads 'online' (kill -9, no abort)", async () => {
+    runningTurnOnConnection();
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+      status: "online", // never marked offline — the daemon died without an abort
+      lastSeenAt: new Date(Date.now() - STALE - 60_000),
+    });
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid);
+    expect(count).toBe(1);
+  });
+
+  it("a deleted connection row is eligible (a gone connection cannot report)", async () => {
+    runningTurnOnConnection();
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid);
+    expect(count).toBe(1);
+  });
+
+  it("no running turns → no eligibility read, no writes (cheap no-op)", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid);
+    expect(count).toBe(0);
+    expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("PENDING turns are untouched — the candidate query filters status=running only", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
+    await reconcileOrphanTurns(companyUuid, connectionUuid);
+    expect(mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0].where.status).toBe("running");
+  });
+
+  it("RACE: a turn the daemon terminally reported meanwhile loses as a LOGGED invalid_transition (no crash)", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([{ uuid: turnUuid }]);
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+      lastSeenAt: new Date(Date.now() - STALE - 1_000),
+    });
+    // By the time advanceTurn re-reads the turn, the daemon's own running→ended landed.
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "ended",
+    });
+
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid);
+
+    expect(count).toBe(0);
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ turnUuid, from: "ended", to: "interrupted" }),
+      expect.stringMatching(/lost the race/),
+    );
+  });
+
+  it("SWALLOWS + LOGS its own errors (fire-and-forget-safe, returns 0)", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockRejectedValue(new Error("db down"));
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid);
+    expect(count).toBe(0);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ companyUuid, connectionUuid }),
+      expect.stringMatching(/orphaned running turns/),
+    );
+  });
+});
+
+// ===== Read-time orphan fallback on the session read paths =====
+describe("read-time orphan-turn fallback", () => {
+  const staleDate = new Date(Date.now() - STALE_THRESHOLD_MS - 10_000);
+
+  it("getVisibleSessions converges a stale connection's running turn before returning", async () => {
+    const userAuth = { type: "user", companyUuid, actorUuid: ownerUuid };
+    mockPrisma.daemonSession.findMany.mockResolvedValue([sessionRow()]);
+    // Probe: this session has a running turn; reconcile re-reads candidates the same way.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      { uuid: turnUuid, sessionUuid },
+    ]);
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({ lastSeenAt: staleDate });
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ status: "interrupted", interruptedReason: "offline" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    const sessions = await getVisibleSessions(userAuth);
+
+    expect(sessions).toHaveLength(1);
+    // The orphaned turn was written through (interrupted persisted in the DB).
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data.status).toBe("interrupted");
+    expect(data.interruptedReason).toBe("offline");
+  });
+
+  it("getVisibleSessions read SURVIVES a fallback failure (best-effort, logged, never breaks the read)", async () => {
+    const userAuth = { type: "user", companyUuid, actorUuid: ownerUuid };
+    mockPrisma.daemonSession.findMany.mockResolvedValue([sessionRow()]);
+    // The probe itself explodes — the read must still return its sessions, with the
+    // failure logged (no-silent-errors) rather than propagated.
+    mockPrisma.daemonSessionTurn.findMany.mockRejectedValue(new Error("probe down"));
+
+    const sessions = await getVisibleSessions(userAuth);
+
+    expect(sessions).toHaveLength(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ companyUuid }),
+      expect.stringMatching(/fallback failed/),
+    );
+  });
+
+  it("getSessionDetail converges the open session's orphaned running turn on read", async () => {
+    const userAuth = { type: "user", companyUuid, actorUuid: ownerUuid };
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    // First findMany = probe (running turn present); later calls = candidate window.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ status: "running" }),
+    ]);
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({ lastSeenAt: staleDate });
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ status: "interrupted", interruptedReason: "offline" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    const detail = await getSessionDetail(userAuth, sessionUuid);
+
+    expect(detail).not.toBeNull();
+    // Write-through happened before the view was built.
+    expect(mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data.status).toBe(
+      "interrupted",
+    );
+  });
+
+  it("getSessionDetail during the abort→reconnect gap does NOT interrupt the live turn", async () => {
+    const userAuth = { type: "user", companyUuid, actorUuid: ownerUuid };
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(sessionRow());
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ status: "running" }),
+    ]);
+    // status=offline (stream just aborted) but lastSeenAt fresh → NOT eligible.
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+      status: "offline",
+      lastSeenAt: new Date(Date.now() - 3_000),
+    });
+
+    const detail = await getSessionDetail(userAuth, sessionUuid);
+
+    expect(detail).not.toBeNull();
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+    // The running band renders as-is — still the daemon's live turn.
+    expect(detail!.turns.some((t) => t.status === "running")).toBe(true);
   });
 });
 

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -586,6 +586,152 @@ export async function advanceTurn(
   return { ok: true, turn: view };
 }
 
+// ===== Orphan-turn reconcile (daemon died mid-turn) =====
+
+/**
+ * Is this connection ORPHAN-ELIGIBLE — dead long enough that its `running` turns can
+ * be declared interrupted? The rule is AGE-ONLY: `lastSeenAt` older than the
+ * registry's single `STALE_THRESHOLD_MS` (90s). It is deliberately NOT the OR-rule
+ * (`status !== "online" || stale`) the execution read gate uses: `markDisconnected`
+ * flips `status` to "offline" the instant an SSE stream aborts, so under the OR-rule
+ * a session read landing in a transient abort→reconnect gap would falsely finalize a
+ * genuinely live turn — whose daemon's later `running → ended` report would then be
+ * rejected. Age-only is safe in both directions: a live daemon's 30s heartbeat keeps
+ * `lastSeenAt` fresh (never eligible), and a daemon that died WITHOUT an abort (kill
+ * -9, machine sleep) goes stale within 90s even while `status` still reads "online".
+ * A connection that no longer exists is eligible (a deleted connection cannot report).
+ */
+function isOrphanEligible(
+  connection: { lastSeenAt: Date } | null,
+  now: number = Date.now(),
+): boolean {
+  if (!connection) return true;
+  return now - connection.lastSeenAt.getTime() > STALE_THRESHOLD_MS;
+}
+
+/**
+ * Finalize the orphaned `running` turns of every session ORIGINATING on
+ * `connectionUuid` as `interrupted(offline)` — the server-side escape hatch for a
+ * daemon that died mid-turn and will never send its `running → ended` report. The
+ * turn's owner is `session.originConnectionUuid` (continuation is origin-pinned),
+ * NOT the execution row's connection.
+ *
+ * Steps: find the connection's sessions' `running` turns → RE-VERIFY the connection
+ * is orphan-eligible (age-only rule above — the guard that makes every caller safe,
+ * so a deferred timer or read-path call after the daemon reconnected is a no-op) →
+ * advance each turn through the `advanceTurn` chokepoint (legality + SSE publish come
+ * free; `pending` turns are deliberately untouched — they are the reconnect
+ * backfill's job). A turn the daemon terminally reported in the meantime loses the
+ * race here as a harmless invalid_transition (logged).
+ *
+ * Fire-and-forget-safe: mirrors `daemon-execution.reconcileOffline` — swallows + logs
+ * its own errors so a failing reconcile can never throw into SSE stream teardown or a
+ * read path. Returns the number of turns finalized (0 on error/no-op).
+ */
+export async function reconcileOrphanTurns(
+  companyUuid: string,
+  connectionUuid: string,
+): Promise<number> {
+  try {
+    const runningTurns = await prisma.daemonSessionTurn.findMany({
+      where: {
+        status: "running",
+        session: { companyUuid, originConnectionUuid: connectionUuid },
+      },
+      select: { uuid: true },
+    });
+    if (runningTurns.length === 0) return 0;
+
+    // Re-verify eligibility AFTER finding candidates (the cheap read first would let
+    // a racing heartbeat slip between check and write; candidates-first keeps the
+    // stale window minimal and the age re-check is authoritative at write time).
+    const connection = await prisma.daemonConnection.findFirst({
+      where: { companyUuid, uuid: connectionUuid },
+      select: { lastSeenAt: true },
+    });
+    if (!isOrphanEligible(connection)) return 0;
+
+    const now = new Date();
+    let finalized = 0;
+    for (const turn of runningTurns) {
+      const result = await advanceTurn(turn.uuid, "interrupted", {
+        interruptedReason: "offline",
+        endedAt: now,
+      });
+      if (result.ok) {
+        finalized += 1;
+      } else if (result.reason === "invalid_transition") {
+        // The daemon's own terminal report (or a concurrent reconcile) won the race —
+        // the turn is already terminal. Log for visibility, never crash.
+        const { default: logger } = await import("@/lib/logger");
+        logger.info(
+          { turnUuid: turn.uuid, from: result.from, to: result.to },
+          "Orphan-turn reconcile lost the race to a concurrent terminal transition",
+        );
+      }
+    }
+    return finalized;
+  } catch (err) {
+    const { default: logger } = await import("@/lib/logger");
+    logger.error(
+      { err, companyUuid, connectionUuid },
+      "Failed to reconcile orphaned running turns",
+    );
+    return 0;
+  }
+}
+
+/**
+ * Read-time fallback: converge any orphaned `running` turns among `sessions` before
+ * the caller builds its view. For each DISTINCT origin connection whose sessions have
+ * a `running` turn, run `reconcileOrphanTurns` (which re-verifies the age-only
+ * eligibility itself — a fresh connection is a no-op). Write-through, not a view-only
+ * mask: turns are durable conversation history and must converge in the DB — this is
+ * also what heals legacy dirty rows (pre-dating the interrupted state) and the
+ * lost-deferred-timer case (server restarted between SSE abort and timer fire), with
+ * zero migration DML.
+ *
+ * Best-effort END TO END: the probe query here AND the per-connection reconcile
+ * (which swallows its own errors) are both inside this function's try — a fallback
+ * hiccup can never break the read that hosts it (the read's own queries keep their
+ * propagate-don't-swallow contract untouched). Returns the number of turns finalized.
+ */
+async function reconcileOrphanTurnsForSessions(
+  companyUuid: string,
+  sessions: { uuid: string; originConnectionUuid: string }[],
+): Promise<number> {
+  if (sessions.length === 0) return 0;
+  try {
+    // Only origin connections that actually have a running turn among these sessions —
+    // avoids a per-connection no-op query storm on every list read.
+    const withRunning = await prisma.daemonSessionTurn.findMany({
+      where: { status: "running", sessionUuid: { in: sessions.map((s) => s.uuid) } },
+      select: { sessionUuid: true },
+    });
+    if (withRunning.length === 0) return 0;
+    const runningSessionUuids = new Set(withRunning.map((t) => t.sessionUuid));
+    const connectionUuids = [
+      ...new Set(
+        sessions
+          .filter((s) => runningSessionUuids.has(s.uuid))
+          .map((s) => s.originConnectionUuid),
+      ),
+    ];
+    let finalized = 0;
+    for (const connectionUuid of connectionUuids) {
+      finalized += await reconcileOrphanTurns(companyUuid, connectionUuid);
+    }
+    return finalized;
+  } catch (err) {
+    const { default: logger } = await import("@/lib/logger");
+    logger.error(
+      { err, companyUuid },
+      "Read-time orphan-turn fallback failed (read continues unconverged)",
+    );
+    return 0;
+  }
+}
+
 // ===== Owner-scoped reads =====
 //
 // As with the connection/execution registries' read functions, these deliberately do
@@ -613,6 +759,10 @@ export async function getVisibleSessions(auth: {
     where: { companyUuid: auth.companyUuid, ...ownerScope(auth) },
     orderBy: { lastTurnAt: "desc" },
   });
+  // Read-time orphan-turn fallback: converge running turns whose origin daemon is
+  // stale-dead BEFORE the caller derives per-session running indicators. Best-effort
+  // (never breaks the read); the session rows themselves are unaffected.
+  await reconcileOrphanTurnsForSessions(auth.companyUuid, rows);
   return rows.map(toSessionView);
 }
 
@@ -775,6 +925,12 @@ export async function getSessionDetail(
     where: { uuid: sessionUuid, companyUuid: auth.companyUuid, ...ownerScope(auth) },
   });
   if (!sessionRow) return null; // not visible → 404 non-disclosure
+
+  // Read-time orphan-turn fallback: a `running` turn whose origin daemon is stale-dead
+  // is finalized `interrupted(offline)` BEFORE the turn window below is loaded, so this
+  // very read returns the converged state (no forever-running band). Best-effort — a
+  // reconcile failure never degrades the read.
+  await reconcileOrphanTurnsForSessions(auth.companyUuid, [sessionRow]);
 
   // Clamp the page size: at least 1, at most 200 messages per page (a hard ceiling so a
   // hostile `limit` can't ask for an unbounded scan; also the session retention cap).


### PR DESCRIPTION
## Summary

Task 2 of 5 for idea 489ade18 — stacked on #393 (base: feat/turn-interrupted-state).

- New `reconcileOrphanTurns(companyUuid, connectionUuid)`: finalizes `running` turns of the connection's sessions (owner = `session.originConnectionUuid`, the origin-pinned anchor) as `interrupted(offline)` through the `advanceTurn` chokepoint — legality check + `turn_status_changed` SSE come free. `pending` turns untouched (backfill's job). Fire-and-forget-safe (swallow+log, mirrors execution `reconcileOffline`).
- **Age-only orphan eligibility** (round-1 review blocker): a connection is orphan-eligible only when `lastSeenAt` is older than the registry's single `STALE_THRESHOLD_MS` (90s) — never the stored `status` alone, which flips on every transient SSE abort. The eligibility read selects only `lastSeenAt`, so status cannot influence the verdict.
- **Trigger 1 — deferred abort:** both SSE routes (`/api/events`, `/api/events/notifications`) arm an unref'd `setTimeout(STALE_THRESHOLD_MS)` on daemon stream abort; the age re-check at fire time makes it a no-op when the daemon reconnected.
- **Trigger 2 — read-time fallback:** `getVisibleSessions` + `getSessionDetail` converge orphaned running turns write-through before building views — this also heals legacy dirty rows and the lost-timer (server restart) case with zero migration DML. The fallback is best-effort end-to-end (a probe failure is logged, the read continues).
- Race with the daemon's own terminal report: loser gets a logged `invalid_transition`, writes nothing.

## Testing

- New suites: `reconcileOrphanTurns` (stale verdict; fresh-lastSeenAt no-op **regardless of status** — abort→reconnect-gap regression test; kill-9 eligibility while status still 'online'; deleted connection; pending untouched; race → logged invalid_transition; swallow+log) and read-time fallback (list + detail converge; gap read doesn't interrupt; read survives fallback failure).
- Both SSE route tests: deferred timer fires exactly at the window, not before; browser streams never arm it.
- `pnpm test`: 3903 passed (242 files). `npx tsc --noEmit` clean. `pnpm lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)