### PR TITLE
feat(cli): graceful daemon shutdown with outcome-aware turn exit reporting

### DIFF
--- a/cli/__tests__/daemon-integration.test.mjs
+++ b/cli/__tests__/daemon-integration.test.mjs
@@ -1126,3 +1126,96 @@ describe("integration checkpoint (子3): interrupt + resume + crash recovery", (
     await daemon.stop();
   });
 });
+
+describe("daemon graceful shutdown (fix-daemon-exit-orphan-running-turn)", () => {
+  it("stop() interrupts the in-flight wake, flushes its interrupted(shutdown) turn report, then disconnects MCP", async () => {
+    const order = [];
+    let releaseChild;
+    const childExited = new Promise((r) => (releaseChild = r));
+    const FAKE_CHILD = { pid: 4242 };
+
+    // A spawner whose subprocess blocks until "killed" (releaseChild), then exits 130.
+    const spawner = {
+      wake: vi.fn(async (params) => {
+        params.onChild?.(FAKE_CHILD);
+        await childExited;
+        return { sessionId: params.sessionId, exitCode: 130, isNew: true };
+      }),
+    };
+    const turnReports = [];
+    const mcp = mockMcp();
+    const daemon = buildDaemon(
+      { url: "https://chorus.example", apiKey: "cho_x" },
+      {
+        logger: silent,
+        mcpClient: mcp,
+        fetchImpl: lineageFetch(),
+        spawner,
+        cwd: "/nonexistent/chorus-daemon-shutdown-itest",
+        makeSseListener: (o) => new MockSse(o),
+        sigintTimeoutMs: 200,
+      }
+    );
+    // Spy on the primary waker's injected killer + turn reporter AFTER build. The
+    // killer releases the "child" (simulating the kill landing).
+    daemon.waker.killer = vi.fn(async () => {
+      order.push("killed");
+      releaseChild();
+      return { killed: true };
+    });
+    daemon.waker.advanceTurn = async (params) => {
+      turnReports.push(params);
+      order.push(`turn:${params.status}`);
+    };
+
+    await daemon.start();
+    daemon.sseListener.opts.onEvent({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 20)); // let the wake spawn (turn → running)
+
+    await daemon.stop();
+    order.push("stopped");
+
+    // The kill was dispatched, the wake's exit path reported interrupted(shutdown)
+    // BEFORE stop() returned, and MCP disconnected last.
+    expect(order).toEqual(["turn:running", "killed", "turn:interrupted", "stopped"]);
+    const last = turnReports.at(-1);
+    expect(last.status).toBe("interrupted");
+    expect(last.interruptedReason).toBe("shutdown");
+    expect(mcp.disconnected).toBe(true);
+  });
+
+  it("stop() is bounded: an unkillable wake does not hang the shutdown", async () => {
+    // A subprocess that NEVER exits, and a killer that does nothing.
+    const spawner = {
+      wake: vi.fn(async (params) => {
+        params.onChild?.({ pid: 1 });
+        await new Promise(() => {}); // never resolves
+      }),
+    };
+    const warns = [];
+    const daemon = buildDaemon(
+      { url: "https://chorus.example", apiKey: "cho_x" },
+      {
+        logger: { ...silent, warn: (m) => warns.push(m) },
+        mcpClient: mockMcp(),
+        fetchImpl: lineageFetch(),
+        spawner,
+        cwd: "/nonexistent/chorus-daemon-shutdown-itest2",
+        makeSseListener: (o) => new MockSse(o),
+        sigintTimeoutMs: 50, // drain bound = 50ms + 5s cap
+      }
+    );
+    daemon.waker.killer = vi.fn(async () => ({ killed: false }));
+
+    await daemon.start();
+    daemon.sseListener.opts.onEvent({ type: "new_notification", notificationUuid: "notif-1" });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const stopped = await Promise.race([
+      daemon.stop().then(() => true),
+      new Promise((r) => setTimeout(() => r(false), 8_000)),
+    ]);
+    expect(stopped).toBe(true); // returned within the bound, did not hang
+    expect(warns.join("")).toMatch(/did not finish within the bound/);
+  }, 15_000);
+});

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -539,6 +539,118 @@ describe("Waker interrupt / crash reporting (子3)", () => {
   });
 });
 
+describe("Waker graceful shutdown (fix-daemon-exit-orphan-running-turn)", () => {
+  const FAKE_CHILD = { pid: 5555 };
+
+  it("SUPPRESSES the execution crash report for a shutdown-killed subprocess (no stranded sticky rows)", async () => {
+    // A shutdown-kill looks exactly like a crash to the old logic: dirty exit, no
+    // user-interrupt flag. The !shuttingDown gate must keep reportInterrupt silent —
+    // the execution row is reconcileOffline's job when the stream drops.
+    const { waker, reportInterrupt } = makeWaker({
+      spawner: {
+        wake: vi.fn(async ({ sessionId, onChild }) => {
+          onChild?.(FAKE_CHILD);
+          waker.shuttingDown = true; // shutdown began mid-run
+          return { sessionId, exitCode: 130, isNew: true }; // SIGINT-killed
+        }),
+      },
+    });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+    expect(reportInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("a USER interrupt during shutdown still reports the execution (sticky resumability preserved)", async () => {
+    const { waker, reportInterrupt } = makeWaker({
+      spawner: {
+        wake: vi.fn(async ({ sessionId, onChild }) => {
+          onChild?.(FAKE_CHILD);
+          waker.markInterrupting("task", "task-1");
+          waker.shuttingDown = true;
+          return { sessionId, exitCode: 130, isNew: true };
+        }),
+      },
+    });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+    expect(reportInterrupt).toHaveBeenCalledWith("task", "task-1", "user");
+  });
+
+  it("outside shutdown the crash report is byte-for-byte unchanged", async () => {
+    const { waker, reportInterrupt } = makeWaker({
+      spawner: {
+        wake: vi.fn(async ({ sessionId, onChild }) => {
+          onChild?.(FAKE_CHILD);
+          return { sessionId, exitCode: 2, isNew: true };
+        }),
+      },
+    });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+    expect(reportInterrupt).toHaveBeenCalledWith("task", "task-1", "crash");
+  });
+
+  it("interruptAll sets shuttingDown and kills every live running child via the injected killer", async () => {
+    const killer = vi.fn(async () => ({ killed: true }));
+    let interruptAllRan;
+    const { waker } = makeWaker({
+      spawner: {
+        wake: vi.fn(async ({ sessionId, onChild }) => {
+          onChild?.(FAKE_CHILD);
+          // Simulate the daemon's stop() firing while this wake is live.
+          waker.interruptAll();
+          interruptAllRan = {
+            shuttingDown: waker.shuttingDown,
+            killerCalls: killer.mock.calls.length,
+          };
+          return { sessionId, exitCode: 130, isNew: true };
+        }),
+      },
+    });
+    waker.killer = killer;
+    waker.sigintTimeoutMs = 1234;
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(interruptAllRan.shuttingDown).toBe(true);
+    expect(interruptAllRan.killerCalls).toBe(1);
+    expect(killer).toHaveBeenCalledWith(
+      FAKE_CHILD,
+      expect.objectContaining({ sigintTimeoutMs: 1234 }),
+    );
+  });
+
+  it("interruptAll skips queued entries (no child yet) and is idempotent", async () => {
+    const killer = vi.fn(async () => ({ killed: true }));
+    const { waker } = makeWaker();
+    waker.killer = killer;
+    // A queued entry (no live child) — nothing to kill.
+    waker.markQueued(TASK_NOTIF, "idea:x", { rootIdeaUuid: null });
+    waker.interruptAll();
+    waker.interruptAll();
+    expect(waker.shuttingDown).toBe(true);
+    expect(killer).not.toHaveBeenCalled();
+  });
+
+  it("a rejecting killer never throws out of interruptAll (logged)", async () => {
+    const warns = [];
+    const { waker } = makeWaker();
+    waker.logger = { ...silent, warn: (m) => warns.push(m) };
+    waker.killer = vi.fn(() => Promise.reject(new Error("kill blew up")));
+    waker.executions.set("task:task-1", {
+      entityType: "task",
+      entityUuid: "task-1",
+      rootIdeaUuid: null,
+      status: "running",
+      startedAt: null,
+      child: FAKE_CHILD,
+    });
+    expect(() => waker.interruptAll()).not.toThrow();
+    await Promise.resolve(); // let the rejection propagate to the .catch
+    expect(warns.join("")).toMatch(/killProcessTree rejected/);
+  });
+});
+
 describe("EventRouter dispatch", () => {
   function makeRouter(notifications, waker, queue, seen) {
     const mcpClient = { callTool: vi.fn(async () => ({ notifications })) };

--- a/cli/__tests__/wake-queue.test.mjs
+++ b/cli/__tests__/wake-queue.test.mjs
@@ -127,3 +127,61 @@ describe("WakeQueue enqueue is non-blocking", () => {
     expect(ran).toBe(true);
   });
 });
+
+describe("WakeQueue graceful shutdown (stop + drain)", () => {
+  it("stop() prevents queued-but-unstarted tasks from ever starting", async () => {
+    const q = new WakeQueue({ maxConcurrency: 1, logger: silent });
+    const d1 = deferred();
+    const order = [];
+
+    q.enqueue("k1", async () => {
+      order.push("start-1");
+      await d1.promise;
+      order.push("end-1");
+    });
+    q.enqueue("k2", async () => {
+      order.push("start-2");
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(["start-1"]); // k2 waits on the concurrency slot
+
+    q.stop(); // shutdown begins — k2 must never start
+    d1.release();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(order).toEqual(["start-1", "end-1"]);
+  });
+
+  it("drain resolves true once in-flight tasks finish (pending ones don't block it)", async () => {
+    const q = new WakeQueue({ maxConcurrency: 1, logger: silent });
+    const d1 = deferred();
+    q.enqueue("k1", async () => {
+      await d1.promise;
+    });
+    q.enqueue("k2", async () => {}); // queued, never starts after stop()
+    await Promise.resolve();
+    q.stop();
+
+    const drainP = q.drain(2_000);
+    d1.release();
+    await expect(drainP).resolves.toBe(true);
+  });
+
+  it("drain resolves false when an in-flight task outlives the bound (shutdown never hangs)", async () => {
+    const q = new WakeQueue({ logger: silent });
+    const never = deferred(); // task that never finishes (unkillable wake)
+    q.enqueue("k1", async () => {
+      await never.promise;
+    });
+    await Promise.resolve();
+
+    await expect(q.drain(120)).resolves.toBe(false);
+    never.release(); // cleanup
+  });
+
+  it("drain on an idle queue resolves true immediately", async () => {
+    const q = new WakeQueue({ logger: silent });
+    await expect(q.drain(0)).resolves.toBe(true);
+  });
+});

--- a/cli/__tests__/waker-turn-lifecycle.test.mjs
+++ b/cli/__tests__/waker-turn-lifecycle.test.mjs
@@ -100,13 +100,57 @@ describe("Waker turn lifecycle (子1)", () => {
     expect(advanceTurn.mock.calls[1][0].status).toBe("ended");
   });
 
-  it("still advances running→ended on a NON-ZERO exit (a turn ends regardless of exit code)", async () => {
+  it("reports running→interrupted(crash) on a NON-ZERO exit with no interrupt requested (outcome-aware)", async () => {
     const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatSpawns(2) });
     const resolved = await waker.keyFor(TASK_NOTIF);
     await waker.wake(TASK_NOTIF, resolved.key, resolved);
 
     const statuses = advanceTurn.mock.calls.map((c) => c[0].status);
-    expect(statuses).toEqual(["running", "ended"]);
+    expect(statuses).toEqual(["running", "interrupted"]);
+    expect(advanceTurn.mock.calls[1][0].interruptedReason).toBe("crash");
+  });
+
+  it("reports running→interrupted(user) when the interrupt flag was set before exit", async () => {
+    const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatSpawns(130) });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    waker.markInterrupting("task", "task-1");
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const last = advanceTurn.mock.calls.at(-1)[0];
+    expect(last.status).toBe("interrupted");
+    expect(last.interruptedReason).toBe("user");
+  });
+
+  it("reports running→interrupted(shutdown) when the waker is shutting down", async () => {
+    const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatSpawns(130) });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    waker.shuttingDown = true;
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const last = advanceTurn.mock.calls.at(-1)[0];
+    expect(last.status).toBe("interrupted");
+    expect(last.interruptedReason).toBe("shutdown");
+  });
+
+  it("user-interrupt outranks shutdown in the turn reason", async () => {
+    const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatSpawns(130) });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    waker.markInterrupting("task", "task-1");
+    waker.shuttingDown = true;
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(advanceTurn.mock.calls.at(-1)[0].interruptedReason).toBe("user");
+  });
+
+  it("clean exit during shutdown still reports ended (the subprocess finished its work)", async () => {
+    const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatSpawns(0) });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    waker.shuttingDown = true;
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const last = advanceTurn.mock.calls.at(-1)[0];
+    expect(last.status).toBe("ended");
+    expect(last).not.toHaveProperty("interruptedReason");
   });
 
   it("does NOT attempt ended when the subprocess never spawned (turn stays pending; no illegal pending→ended)", async () => {

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -254,7 +254,20 @@ export function buildDaemon(creds, deps = {}) {
     // transcript (new-vs-resume) and to spawn, so they never diverge (Module Contract
     // 1 — resolveCwd is the single source). `cwd` is `undefined` for the single-path /
     // old-daemon default, which the Waker degrades to process.cwd() (HARD-1).
-    waker = new Waker({ creds, lineage, spawner, cwd, hooks, logger, reportInterrupt, advanceTurn, verbose });
+    waker = new Waker({
+      creds,
+      lineage,
+      spawner,
+      cwd,
+      hooks,
+      logger,
+      reportInterrupt,
+      advanceTurn,
+      verbose,
+      // Graceful-shutdown kill escalation (fix-daemon-exit-orphan-running-turn):
+      // interruptAll() reuses the SAME window the interrupt control handler uses.
+      sigintTimeoutMs,
+    });
     // The router reads THIS connection's own uuid lazily (same source the control handler
     // uses) to suppress a DIRECTED (pinned) wake stamped for a different connection
     // (fix-pinned-wake-directed-delivery, T2). Null until the SSE handshake assigns it — a
@@ -399,10 +412,30 @@ export function buildDaemon(creds, deps = {}) {
       }
     },
     async stop() {
+      // Graceful shutdown ordering (fix-daemon-exit-orphan-running-turn):
+      // 1. Stop taking new work: disconnect the SSE listeners (no new notifications)
+      //    and latch the queue (queued-but-unstarted wakes never spawn).
       for (const c of connections) {
         c.sseListener.disconnect?.();
       }
-      // The MCP client is process-wide (shared) — disconnect it once.
+      queue.stop();
+      // 2. Interrupt every in-flight wake subprocess via the shared kill escalation.
+      //    Each wake's exit path — seeing shuttingDown — reports its turn
+      //    interrupted(shutdown) and suppresses the execution crash report.
+      for (const c of connections) {
+        c.waker?.interruptAll?.();
+      }
+      // 3. Await the in-flight wakes so those turn-advance reports flush, BOUNDED:
+      //    the kill escalation window plus a hard 5s cap for the exit path's REST
+      //    reports. A wake that outlives this does NOT hang the shutdown — its
+      //    orphaned turn is the server-side offline reconcile's job (the backstop).
+      const drained = await queue.drain(sigintTimeoutMs + 5_000);
+      if (!drained) {
+        logger.warn(
+          "[Chorus] shutdown: in-flight wake(s) did not finish within the bound — exiting anyway (server reconcile will finalize their turns)",
+        );
+      }
+      // 4. The MCP client is process-wide (shared) — disconnect it once.
       await mcpClient.disconnect?.();
     },
   };

--- a/cli/wake-queue.mjs
+++ b/cli/wake-queue.mjs
@@ -30,6 +30,15 @@ export class WakeQueue {
     /** @type {string[]} keys waiting for a global concurrency slot. */
     this.readyKeys = [];
     this.activeCount = 0;
+    // Graceful-shutdown latch: once set, #pump starts NOTHING new — in-flight tasks
+    // finish (drain observes them) but queued work stays queued and dies with the
+    // process. Never cleared; a stopping queue is on its way out.
+    this.stopped = false;
+  }
+
+  /** Stop starting new tasks (graceful shutdown). In-flight tasks are unaffected. */
+  stop() {
+    this.stopped = true;
   }
 
   /**
@@ -75,8 +84,29 @@ export class WakeQueue {
     return [...this.pending.entries()].filter(([, q]) => q.length > 0).map(([k]) => k);
   }
 
+  /**
+   * Wait (bounded) for every in-flight task to finish — the graceful-shutdown drain
+   * (fix-daemon-exit-orphan-running-turn). Resolves `true` when the queue went idle
+   * (no active task) within `timeoutMs`, `false` on timeout — the caller exits
+   * anyway and leaves the rest to the server-side reconcile backstop. Pending
+   * (not-yet-started) tasks are NOT waited for: a shutting-down daemon stops
+   * starting new work, so only the in-flight subprocesses (and their exit reports)
+   * matter. Polling (50ms) keeps this zero-dep and independent of task internals.
+   * @param {number} timeoutMs
+   * @returns {Promise<boolean>}
+   */
+  async drain(timeoutMs) {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    while (this.activeCount > 0) {
+      if (Date.now() >= deadline) return false;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return true;
+  }
+
   /** Try to start as many ready keys as the concurrency cap allows. */
   #pump() {
+    if (this.stopped) return; // shutting down — start nothing new
     while (this.activeCount < this.maxConcurrency && this.readyKeys.length > 0) {
       const key = this.readyKeys.shift();
       if (this.running.has(key)) continue; // already running under another slot

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -19,6 +19,7 @@
 import { buildPrompt } from "./prompts.mjs";
 import { writeMcpConfig } from "./mcp-config.mjs";
 import { isNewSession } from "./claude-spawner.mjs";
+import { killProcessTree, DEFAULT_SIGINT_TIMEOUT_MS } from "./process-killer.mjs";
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
@@ -37,13 +38,17 @@ export class Waker {
    *     Injectable interrupt reporter (子3). Called when a wake's subprocess exits in
    *     an interrupted (user) or crashed (non-zero, no interrupt flag) state. Defaults
    *     to a no-op that logs — the daemon wires the REST reporter (interrupt-reporter.mjs).
-   *   advanceTurn?: (params: { sessionId: string, status: "running"|"ended", entityType?: string|null, entityUuid?: string|null }) => Promise<void>,
+   *   advanceTurn?: (params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown" }) => Promise<void>,
    *     Injectable turn-lifecycle reporter (子1 — daemon-session-conversation). Called
-   *     on spawn (→ running) and on subprocess exit (→ ended) to advance the server-side
+   *     on spawn (→ running) and on subprocess exit (→ ended on a clean exit, or
+   *     → interrupted with the classified reason otherwise) to advance the server-side
    *     DaemonSessionTurn the notification chokepoint created (status `pending`). The
    *     server resolves the turn by the session business key (`sessionId`) and stamps
    *     the weak executionUuid link from entityType/entityUuid. Defaults to a no-op that
    *     logs — the daemon wires the REST reporter (turn-reporter.mjs).
+   *   killer?: (child: any, opts: any) => Promise<any>,  Injectable kill escalation for
+   *     interruptAll(); defaults to process-killer.killProcessTree (cross-platform).
+   *   sigintTimeoutMs?: number,  Escalation window interruptAll passes the killer.
    * }} opts
    */
   constructor(opts) {
@@ -91,6 +96,17 @@ export class Waker {
     // wake's exit path reads + clears it to decide reason=user vs reason=crash.
     /** @type {Set<string>} */
     this.interrupting = new Set();
+    // Daemon graceful-shutdown flag (fix-daemon-exit-orphan-running-turn). Set once
+    // by interruptAll() and never cleared — a shutting-down Waker is on its way out.
+    // The wake exit path reads it to report the TURN as interrupted(shutdown), and to
+    // SUPPRESS the execution interrupt report (a shutdown-kill would otherwise read as
+    // a dirty exit → sticky interrupted(crash) execution row that reconcileOffline
+    // deliberately skips — stranded in the UI on every Ctrl-C).
+    this.shuttingDown = false;
+    // Injectable killer for interruptAll (defaults to the shared cross-platform
+    // escalation; tests inject a spy). Kill logic itself stays in process-killer.mjs.
+    this.killer = opts.killer ?? killProcessTree;
+    this.sigintTimeoutMs = opts.sigintTimeoutMs ?? DEFAULT_SIGINT_TIMEOUT_MS;
 
     // Per-resource execution registry — the source of truth for the execution
     // snapshot uploaded to the server. Keyed by `${entityType}:${entityUuid}`
@@ -138,6 +154,35 @@ export class Waker {
    */
   markInterrupting(entityType, entityUuid) {
     this.interrupting.add(this.#execKey(entityType, entityUuid));
+  }
+
+  /**
+   * Daemon graceful shutdown (fix-daemon-exit-orphan-running-turn): mark this Waker
+   * SHUTTING DOWN and kill every live wake subprocess via the shared graceful
+   * escalation (SIGINT → SIGKILL after `sigintTimeoutMs`). The in-flight wake()
+   * promises then run their normal exit path, which — seeing `shuttingDown` —
+   * reports each turn `interrupted(shutdown)` and suppresses the execution
+   * interrupt report. Idempotent; never throws (a failed kill is logged and left
+   * to the server-side offline reconcile as the backstop).
+   *
+   * Returns after the kill signals are DISPATCHED — completion of the subprocesses
+   * (and their turn reports) is observed by awaiting the wake promises, which the
+   * daemon's stop() does with a bounded cap.
+   */
+  interruptAll() {
+    this.shuttingDown = true;
+    for (const [key, entry] of this.executions) {
+      if (entry.status !== "running" || !entry.child) continue;
+      try {
+        Promise.resolve(
+          this.killer(entry.child, { sigintTimeoutMs: this.sigintTimeoutMs, logger: this.logger }),
+        ).catch((err) => {
+          this.logger.warn(`[Chorus] shutdown: killProcessTree rejected for ${key}: ${err}`);
+        });
+      } catch (err) {
+        this.logger.warn(`[Chorus] shutdown: kill dispatch failed for ${key}: ${err}`);
+      }
+    }
   }
 
   /** Recognized wake-triggering resource kinds the server's DaemonExecution accepts. */
@@ -397,30 +442,51 @@ export class Waker {
         );
       }
 
-      // Turn lifecycle (子1): the subprocess has exited — advance the server turn
-      // running→ended, regardless of exit code (a turn ends whether the run was clean,
-      // crashed, or interrupted). Only when it actually reached `running` (a never-
-      // spawned wake left the turn `pending`; a pending→ended skip is rejected server-
-      // side as invalid_transition). Swallow-safe; never throws into the wake path.
+      // Outcome classification for the exit reports below. Read the flags ONCE so the
+      // turn report and the execution report can never disagree on the outcome:
+      //   • clean exit (code 0)              → turn ended            (unchanged)
+      //   • interrupting flag (user)         → turn interrupted(user)
+      //   • shuttingDown (daemon SIGINT/TERM) → turn interrupted(shutdown)
+      //   • dirty exit otherwise             → turn interrupted(crash)
+      // User-interrupt outranks shutdown: the flag was set by an explicit authorized
+      // interrupt before the shutdown began, and its execution-row semantics (sticky,
+      // resumable) must be preserved.
+      const wasInterrupting = entity && execKey ? this.interrupting.has(execKey) : false;
+      const cleanExit = result && result.exitCode === 0;
+
+      // Turn lifecycle: the subprocess has exited — advance the server turn from
+      // `running` to its OUTCOME-AWARE terminal state (fix-daemon-exit-orphan-running-
+      // turn): `ended` on a clean exit, `interrupted` with the classified reason
+      // otherwise — mirroring what the execution row records, so the conversation
+      // history says WHY a turn stopped. Only when it actually reached `running` (a
+      // never-spawned wake left the turn `pending`; a pending→<terminal> skip is
+      // rejected server-side as invalid_transition). Swallow-safe; never throws.
       if (sessionId && turnAdvancedToRunning) {
-        await this.#advanceTurn(sessionId, "ended", entity);
+        if (cleanExit) {
+          await this.#advanceTurn(sessionId, "ended", entity);
+        } else {
+          const reason = wasInterrupting ? "user" : this.shuttingDown ? "shutdown" : "crash";
+          await this.#advanceTurn(sessionId, "interrupted", entity, reason);
+        }
       }
 
-      // Interrupt-vs-crash reporting (子3, Tech Design "Interrupt vs crash
-      // reporting"). Decide from the per-entity "interrupting" flag the control
-      // handler may have set while the subprocess was running:
+      // Interrupt-vs-crash EXECUTION reporting (子3, Tech Design "Interrupt vs crash
+      // reporting"). Decide from the same flags as the turn report above:
       //   • interrupting flag set            → interrupted(reason="user")
       //   • no flag AND non-zero/null exit    → interrupted(reason="crash")
       //   • clean exit (code 0)               → nothing (unchanged)
-      // The interrupted state is entity-generic — it lives on the DaemonExecution
-      // row (keyed connection+entity), so the reporter records it for ANY recognized
-      // wake resource (task/idea/proposal/document), not only tasks.
+      // EXCEPT during shutdown (fix-daemon-exit-orphan-running-turn, review blocker
+      // 2): a shutdown-killed subprocess exits dirty with no user flag, which would
+      // record the STICKY execution state interrupted(crash) — a state the execution
+      // offline-reconcile deliberately SKIPS and the read gate keeps showing, so
+      // every Ctrl-C would strand a crash-interrupted row in the UI. During shutdown
+      // report NO execution interrupt (user-interrupt still reports — its sticky
+      // resumability is the point); the row is left for reconcileOffline to flip
+      // `ended` when this connection's stream drops.
       if (entity && execKey) {
-        const wasInterrupting = this.interrupting.has(execKey);
-        const cleanExit = result && result.exitCode === 0;
         if (wasInterrupting) {
           await this.#report(entity, "user");
-        } else if (!cleanExit) {
+        } else if (!cleanExit && !this.shuttingDown) {
           // No interrupt requested but the subprocess did not exit cleanly (non-zero
           // code, or null from a spawn/transport failure) → treat as a crash.
           await this.#report(entity, "crash");
@@ -480,19 +546,22 @@ export class Waker {
    * Advance the server-side DaemonSessionTurn for this wake (子1) via the injected
    * reporter. Identified server-side by the session business key (`sessionId`); the
    * optional `entity` ({ entityType, entityUuid }) lets the server stamp the weak
-   * executionUuid link from the live execution row. Never throws into the wake path —
-   * a reporter failure is logged and swallowed (the REST reporter already swallows;
-   * this is belt-and-braces, matching #report).
-   * @param {string} sessionId @param {"running"|"ended"} status
+   * executionUuid link from the live execution row. An `interrupted` status carries
+   * its classified `interruptedReason` (user/crash/shutdown). Never throws into the
+   * wake path — a reporter failure is logged and swallowed (the REST reporter
+   * already swallows; this is belt-and-braces, matching #report).
+   * @param {string} sessionId @param {"running"|"ended"|"interrupted"} status
    * @param {{ entityType: string, entityUuid: string }|null} entity
+   * @param {"user"|"crash"|"shutdown"|null} [interruptedReason]
    */
-  async #advanceTurn(sessionId, status, entity) {
+  async #advanceTurn(sessionId, status, entity, interruptedReason = null) {
     try {
       await this.advanceTurn({
         sessionId,
         status,
         entityType: entity?.entityType ?? null,
         entityUuid: entity?.entityUuid ?? null,
+        ...(status === "interrupted" && interruptedReason ? { interruptedReason } : {}),
       });
     } catch (err) {
       this.logger.warn(


### PR DESCRIPTION
## Summary

Task 3 of 5 for idea 489ade18 — stacked on #393 (base: feat/turn-interrupted-state).

- **Graceful shutdown ordering** (`cli/daemon.mjs` `stop()`): disconnect SSE (no new notifications) → `queue.stop()` (queued-but-unstarted wakes never spawn) → `waker.interruptAll()` per connection → `queue.drain(sigintTimeoutMs + 5s)` so in-flight wakes' turn reports flush — bounded, an unkillable wake never hangs shutdown (server-side reconcile is the backstop, warned visibly) → MCP disconnect.
- **`Waker.interruptAll()`**: sets the `shuttingDown` latch and kills each live child via the existing cross-platform `killProcessTree` escalation (same `sigintTimeoutMs` as the interrupt control handler; kill logic stays in process-killer.mjs). Idempotent, never throws.
- **Outcome-aware turn exit report** (replaces unconditional `running→ended`): clean exit → `ended`; user interrupt → `interrupted(user)`; shutdown-killed → `interrupted(shutdown)`; dirty exit → `interrupted(crash)`. User-interrupt outranks shutdown. The `turnAdvancedToRunning` gate is preserved (never-spawned wakes report nothing).
- **Execution report gated during shutdown** (round-1 review blocker 2): a shutdown-kill looks like a crash (dirty exit, no user flag) and would record the STICKY execution state `interrupted(crash)` — which `reconcileOffline` deliberately skips, stranding a row on every Ctrl-C. The `!shuttingDown` gate suppresses it; the row is left `running` for the offline reconcile to flip `ended`. User interrupts still report (sticky resumability preserved); outside shutdown, execution reporting is unchanged.
- `WakeQueue` gains `stop()` (pump latch) and `drain(timeoutMs)` (bounded in-flight wait).

## Testing

- Waker: 4 outcome mappings + user-outranks-shutdown + clean-exit-during-shutdown; shutdown execution-report gate (suppressed on shutdown-kill, user still reports, unchanged outside shutdown); interruptAll (kills live children with the injected window, skips queued, idempotent, rejecting killer logged).
- WakeQueue: stop() prevents queued starts; drain true-on-finish / false-on-timeout / idle-immediate.
- Daemon integration: full stop() ordering (`turn:running → killed → turn:interrupted(shutdown) → stopped`, MCP disconnected) and bounded shutdown with an unkillable wake.
- `pnpm test`: 3904 passed (242 files). `npx tsc --noEmit` clean. `pnpm lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)