### PR TITLE
fix(daemon): reconcile orphan turns on new-generation daemon re-registration

### DIFF
--- a/src/app/api/daemon/turn-advance/__tests__/route.test.ts
+++ b/src/app/api/daemon/turn-advance/__tests__/route.test.ts
@@ -160,15 +160,13 @@ describe("POST /api/daemon/turn-advance", () => {
     expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
   });
 
-  it("accepts status=interrupted WITHOUT a reason (reason optional; column stays null)", async () => {
+  it("rejects status=interrupted WITHOUT a reason (non-null-iff-interrupted enforced at the boundary)", async () => {
     const res = await POST(
       postRequest({ connectionUuid, sessionId, status: "interrupted" }),
       emptyCtx,
     );
-    expect(res.status).toBe(200);
-    const arg = mockAdvanceTurnForWake.mock.calls[0][0];
-    expect(arg.status).toBe("interrupted");
-    expect(arg.interruptedReason).toBeUndefined();
+    expect(res.status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
   });
 
   it("rejects a bad status at the zod boundary (422)", async () => {

--- a/src/app/api/daemon/turn-advance/route.ts
+++ b/src/app/api/daemon/turn-advance/route.ts
@@ -34,9 +34,11 @@ import {
 // status, and the OPTIONAL wake-triggering entity (for the weak executionUuid link).
 // `startedAt`/`endedAt` are optional ISO-8601 strings (the service defaults them to the
 // transition time for the running/terminal edges when omitted). `interruptedReason`
-// accompanies `status = interrupted` and is restricted to the DAEMON-reportable subset
-// (`user`/`crash`/`shutdown`) — `offline` is the server reconcile's verdict about a
-// dead daemon, which a daemon alive enough to report cannot truthfully claim.
+// MUST accompany `status = interrupted` (and only that status) — the reason column's
+// "non-null iff interrupted" invariant is enforced at this boundary, not trusted to
+// clients — and is restricted to the DAEMON-reportable subset (`user`/`crash`/
+// `shutdown`): `offline` is the server reconcile's verdict about a dead daemon, which
+// a daemon alive enough to report cannot truthfully claim.
 const bodySchema = z
   .object({
     connectionUuid: z.string().min(1),
@@ -50,6 +52,10 @@ const bodySchema = z
   })
   .refine((b) => b.status === "interrupted" || b.interruptedReason == null, {
     message: "interruptedReason is only valid with status=interrupted",
+    path: ["interruptedReason"],
+  })
+  .refine((b) => b.status !== "interrupted" || b.interruptedReason != null, {
+    message: "interruptedReason is required with status=interrupted",
     path: ["interruptedReason"],
   });
 

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -38,6 +38,14 @@ const mockLogger = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/logger", () => ({ default: mockLogger }));
 
+// registerConnection lazily imports the session service to fire the new-generation
+// orphan-turn reconcile (restart-window seam). Mock it so this stays a unit test —
+// vi.mock applies to dynamic import() too.
+const mockReconcileOrphanTurns = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => 0));
+vi.mock("@/services/daemon-session.service", () => ({
+  reconcileOrphanTurns: (...args: unknown[]) => mockReconcileOrphanTurns(...args),
+}));
+
 import {
   DAEMON_CLIENT_TYPES,
   STALE_THRESHOLD_MS,
@@ -94,6 +102,12 @@ beforeEach(() => {
   // BEFORE any write. Default it to "no incumbent" so existing tests register as
   // before; the conflict suite overrides this per-case.
   mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
+  // The real-cwd path now ALSO issues a findFirst (the generation probe for the
+  // restart-window orphan-turn reconcile). Default to "no prior row"; tests that
+  // exercise the null-cwd lookup or the generation reconcile override per-case.
+  // (vi.clearAllMocks() clears calls but NOT implementations, so without this a
+  // prior test's mockRejectedValue on findFirst would leak into later suites.)
+  mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
 });
 
 // ===== Constants =====
@@ -183,8 +197,14 @@ describe("registerConnection", () => {
       const result = await registerConnection(companyUuid, agentUuid, report);
 
       expect(result).toEqual({ uuid: connectionUuid, connectedAt });
-      // The null-compat path must NOT be taken for a present cwd.
-      expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+      // A findFirst DOES run on the real-cwd path now — but it is the GENERATION
+      // PROBE (selects startedAt for the restart-window reconcile), not the
+      // null-compat row lookup. Assert its shape so the two can't be conflated.
+      expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.daemonConnection.findFirst.mock.calls[0][0].select).toEqual({
+        uuid: true,
+        startedAt: true,
+      });
       expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
       const arg = mockPrisma.daemonConnection.upsert.mock.calls[0][0];
       // The composite unique key now carries the REAL cwd (no more "" shim).
@@ -236,6 +256,100 @@ describe("registerConnection", () => {
       });
       expect(result).toEqual({ uuid: connectionUuid, connectedAt });
       expect(mockPrisma.daemonConnection.upsert).toHaveBeenCalledTimes(1);
+    });
+
+    // ===== New-generation orphan-turn reconcile (restart-window seam) =====
+    // A crashed daemon restarting within the staleness window reuses this row with a
+    // fresh lastSeenAt, so the age-only reconcile can never fire — the changed
+    // self-reported startedAt is the only evidence the previous process died.
+    describe("new-generation orphan-turn reconcile on re-registration", () => {
+      const report: SelfReport = {
+        clientType: "claude_code",
+        host: "mac.local",
+        cwd: "/Users/me/projects/alpha",
+        startedAt: new Date("2026-06-15T04:00:00.000Z"),
+      };
+      // Drain the fire-and-forget dynamic-import chain (a dynamic import resolves
+      // on a macrotask, so microtask-only draining is not enough).
+      const flush = async () => {
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      };
+
+      it("fires a FORCE reconcile when the row pre-exists with a DIFFERENT startedAt (restarted process)", async () => {
+        mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+          uuid: connectionUuid,
+          startedAt: new Date("2026-06-15T03:00:00.000Z"), // previous generation
+        });
+        mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+
+        await registerConnection(companyUuid, agentUuid, report);
+        await flush();
+
+        expect(mockReconcileOrphanTurns).toHaveBeenCalledTimes(1);
+        expect(mockReconcileOrphanTurns).toHaveBeenCalledWith(companyUuid, connectionUuid, {
+          force: true,
+        });
+      });
+
+      it("does NOT fire for the SAME startedAt (same process reconnecting after a transient drop)", async () => {
+        mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+          uuid: connectionUuid,
+          startedAt: new Date("2026-06-15T04:00:00.000Z"), // identical instant
+        });
+        mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+
+        await registerConnection(companyUuid, agentUuid, report);
+        await flush();
+        expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+      });
+
+      it("does NOT fire on first connect (no prior row)", async () => {
+        mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+        mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+
+        await registerConnection(companyUuid, agentUuid, report);
+        await flush();
+        expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+      });
+
+      it("does NOT fire when either generation is unprovable (null startedAt on either side)", async () => {
+        // Stored null (pre-feature row) + incoming non-null → conservative no-fire.
+        mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+          uuid: connectionUuid,
+          startedAt: null,
+        });
+        mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+        await registerConnection(companyUuid, agentUuid, report);
+        await flush();
+        expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+
+        // Stored non-null + incoming absent → conservative no-fire too.
+        mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+          uuid: connectionUuid,
+          startedAt: new Date("2026-06-15T03:00:00.000Z"),
+        });
+        await registerConnection(companyUuid, agentUuid, { ...report, startedAt: undefined });
+        await flush();
+        expect(mockReconcileOrphanTurns).not.toHaveBeenCalled();
+      });
+
+      it("registration succeeds even when the reconcile dispatch fails (fire-and-forget, logged)", async () => {
+        mockPrisma.daemonConnection.findFirst.mockResolvedValue({
+          uuid: connectionUuid,
+          startedAt: new Date("2026-06-15T03:00:00.000Z"),
+        });
+        mockPrisma.daemonConnection.upsert.mockResolvedValue({ uuid: connectionUuid, connectedAt });
+        mockReconcileOrphanTurns.mockRejectedValueOnce(new Error("reconcile blew up"));
+
+        const result = await registerConnection(companyUuid, agentUuid, report);
+        expect(result).toEqual({ uuid: connectionUuid, connectedAt });
+        await flush();
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.objectContaining({ companyUuid, connectionUuid }),
+          expect.stringMatching(/New-generation orphan-turn reconcile/),
+        );
+      });
     });
 
     it("upserts the same composite key on reconnect rather than inserting", async () => {

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -2076,6 +2076,89 @@ describe("reconcileOrphanTurns", () => {
       expect.stringMatching(/orphaned running turns/),
     );
   });
+
+  it("FORCE mode (new-generation registration) bypasses the age guard entirely", async () => {
+    // The restart-window seam: the restarted process's heartbeat keeps lastSeenAt
+    // fresh, so the age-only rule would no-op forever. force:true skips the
+    // eligibility read — the generation change is the caller's evidence.
+    runningTurnOnConnection();
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid, { force: true });
+    expect(count).toBe(1);
+    // The eligibility read is skipped entirely on the force path.
+    expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data.status).toBe("interrupted");
+    expect(data.interruptedReason).toBe("offline");
+  });
+
+  it("FORCE mode with no running turns is still a cheap no-op", async () => {
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
+    const count = await reconcileOrphanTurns(companyUuid, connectionUuid, { force: true });
+    expect(count).toBe(0);
+    expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+
+  it("RESTART-WINDOW REGRESSION: force-reconciling the orphan BEFORE the new wake keeps FIFO →ended on the correct turn", async () => {
+    // The seam this fix closes: an orphaned running turn (seq 1, from the dead
+    // generation) + a fresh wake creating turn seq 2. Without the generation
+    // reconcile, →ended's oldest-running FIFO resolution would target the ORPHAN,
+    // marking it cleanly ended and stranding the genuinely-finished seq-2 turn.
+    const orphanUuid = "turn-orphan-0000-0000-000000000001";
+    const newTurnUuid = "turn-new-0000-0000-0000-000000000002";
+
+    // Step 1 — new-generation registration fires the FORCE reconcile: only the
+    // orphan is `running` at this point (the new wake hasn't started).
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([{ uuid: orphanUuid }]);
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: orphanUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ uuid: orphanUuid, status: "interrupted", interruptedReason: "offline" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+    const reconciled = await reconcileOrphanTurns(companyUuid, connectionUuid, { force: true });
+    expect(reconciled).toBe(1);
+    expect(mockPrisma.daemonSessionTurn.update.mock.calls[0][0].where).toEqual({
+      uuid: orphanUuid,
+    });
+
+    vi.clearAllMocks();
+
+    // Step 2 — the new wake's turn (seq 2) runs and exits: →ended resolves by
+    // status=running, and with the orphan already interrupted the ONLY running
+    // turn is the new one — the report lands on it, never on the orphan.
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: newTurnUuid });
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: newTurnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ uuid: newTurnUuid, seq: 2, status: "ended" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "ended",
+    });
+    expect(res).toMatchObject({ ok: true });
+    // Resolution still queries status=running (FIFO oldest) — and the write hits
+    // the NEW turn, proving the orphan can no longer be mis-targeted.
+    expect(mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0].where).toEqual({
+      sessionUuid,
+      status: "running",
+    });
+    expect(mockPrisma.daemonSessionTurn.update.mock.calls[0][0].where).toEqual({
+      uuid: newTurnUuid,
+    });
+  });
 });
 
 // ===== Read-time orphan fallback on the session read paths =====

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -654,7 +654,8 @@ export async function registerConnection(
       // Postgres would never dedup two NULL-cwd rows on its own. So reuse the
       // existing null row by uuid when present; create one only on first connect.
       // This prevents null-row pileup on reconnect while keeping old daemons
-      // behaving exactly as before.
+      // behaving exactly as before. (No generation reconcile here: a cwd-less old
+      // daemon never self-reports startedAt, so a generation change is unprovable.)
       const existing = await prisma.daemonConnection.findFirst({
         where: { agentUuid, clientType: report.clientType, host, cwd: null },
         select: { uuid: true },
@@ -677,6 +678,17 @@ export async function registerConnection(
     }
 
     // ===== Current-daemon path: real cwd → clean compound-key upsert =====
+    // Generation probe (restart-window seam, fix-daemon-exit-orphan-running-turn):
+    // read the row's stored startedAt BEFORE the upsert refreshes it, so a NEW
+    // PROCESS GENERATION (different self-reported process start) is detectable. A
+    // crashed daemon that restarts within the staleness window reuses this row with
+    // a fresh lastSeenAt, which permanently defeats the age-only orphan-turn
+    // reconcile — the generation change is the only remaining evidence that the
+    // previous process (and any turn it left `running`) is dead.
+    const prior = await prisma.daemonConnection.findFirst({
+      where: { agentUuid, clientType: report.clientType, host, cwd },
+      select: { uuid: true, startedAt: true },
+    });
     const row = await prisma.daemonConnection.upsert({
       where: {
         agentUuid_clientType_host_cwd: {
@@ -690,6 +702,33 @@ export async function registerConnection(
       update: refreshData,
       select: { uuid: true, connectedAt: true },
     });
+
+    // New-generation orphan-turn reconcile: fire only when the row pre-existed AND
+    // both generations are provable (non-null startedAt on both sides) AND they
+    // differ. Same startedAt = the same process reconnecting (transient SSE drop) —
+    // nothing to reconcile. Null on either side is treated conservatively as
+    // unprovable (bias toward not interrupting). Fire-and-forget + lazily imported:
+    // registration must never fail, slow, or cycle on the session service
+    // (daemon-session.service imports this module for STALE_THRESHOLD_MS).
+    const incomingStartedAt = report.startedAt ?? null;
+    const priorStartedAt = prior?.startedAt instanceof Date ? prior.startedAt : null;
+    if (
+      prior &&
+      priorStartedAt !== null &&
+      incomingStartedAt !== null &&
+      priorStartedAt.getTime() !== incomingStartedAt.getTime()
+    ) {
+      void import("@/services/daemon-session.service")
+        .then(({ reconcileOrphanTurns }) =>
+          reconcileOrphanTurns(companyUuid, row.uuid, { force: true }),
+        )
+        .catch((err) => {
+          logger.error(
+            { err, companyUuid, connectionUuid: row.uuid },
+            "New-generation orphan-turn reconcile failed to dispatch",
+          );
+        });
+    }
     return { uuid: row.uuid, connectedAt: row.connectedAt };
   } catch (err) {
     logger.error(

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -627,10 +627,22 @@ function isOrphanEligible(
  * Fire-and-forget-safe: mirrors `daemon-execution.reconcileOffline` — swallows + logs
  * its own errors so a failing reconcile can never throw into SSE stream teardown or a
  * read path. Returns the number of turns finalized (0 on error/no-op).
+ *
+ * `opts.force` (restart-window seam): a crashed daemon that RESTARTS within the
+ * staleness window reuses the SAME connection row with a fresh `lastSeenAt`, making
+ * the age-only guard a permanent no-op for turns the DEAD generation orphaned — and
+ * the next wake's FIFO `→ended` resolution would then mis-target the orphan,
+ * stranding the genuinely-new turn on a LIVE connection (unhealable). When the
+ * registration path detects a NEW PROCESS GENERATION (self-reported `startedAt`
+ * changed), it calls with `force: true` to bypass the age guard: the safety evidence
+ * is the generation change itself — a `running` turn can only belong to the
+ * previous, dead process (same-session wakes are daemon-serialized and a freshly
+ * started process has no in-flight wakes yet). Every other caller keeps age-only.
  */
 export async function reconcileOrphanTurns(
   companyUuid: string,
   connectionUuid: string,
+  opts: { force?: boolean } = {},
 ): Promise<number> {
   try {
     const runningTurns = await prisma.daemonSessionTurn.findMany({
@@ -645,11 +657,15 @@ export async function reconcileOrphanTurns(
     // Re-verify eligibility AFTER finding candidates (the cheap read first would let
     // a racing heartbeat slip between check and write; candidates-first keeps the
     // stale window minimal and the age re-check is authoritative at write time).
-    const connection = await prisma.daemonConnection.findFirst({
-      where: { companyUuid, uuid: connectionUuid },
-      select: { lastSeenAt: true },
-    });
-    if (!isOrphanEligible(connection)) return 0;
+    // The force path (new-generation registration) skips the age guard — its
+    // evidence is the generation change, not staleness.
+    if (!opts.force) {
+      const connection = await prisma.daemonConnection.findFirst({
+        where: { companyUuid, uuid: connectionUuid },
+        select: { lastSeenAt: true },
+      });
+      if (!isOrphanEligible(connection)) return 0;
+    }
 
     const now = new Date();
     let finalized = 0;


### PR DESCRIPTION
## Summary

Fix for the code-review gateway round-1 BLOCKER on idea 489ade18 (comment 3cbe5021) — stacked on #397.

**The seam:** a crashed daemon restarting within the 90s staleness window reuses its connection row (same-tuple upsert) with fresh `lastSeenAt`, so the age-only orphan eligibility can never fire — and the next wake's FIFO `→ended` resolution mis-targets the orphaned turn, stranding the genuinely-new turn `running` on a LIVE connection (the original bug, unhealable).

**The fix:** `registerConnection` probes the stored `startedAt` before the upsert refreshes it. When the row pre-existed and both generations are provable (non-null both sides) and differ → fire-and-forget `reconcileOrphanTurns(company, conn, { force: true })`, a new explicit path that bypasses the age guard (evidence = the generation change: a running turn can only belong to the dead previous process, since wakes are daemon-serialized and a fresh process starts with none). Same `startedAt` (transient SSE reconnect), first connect, and null-on-either-side all conservatively never fire. Lazy import + swallow-and-log: registration never fails or slows. Age-only callers untouched.

**Round-1 NOTE also fixed:** the turn-advance zod boundary now REQUIRES `interruptedReason` with `status=interrupted` (non-null-iff-interrupted enforced server-side; the daemon always sends one — no compat break).

## Testing

- New: force-mode bypasses the age guard (eligibility read skipped) / cheap no-op without running turns; generation matrix at registration (different → force fire, same → nothing, first-connect → nothing, null-either-side → nothing, dispatch failure → logged + registration succeeds); **restart-window regression test**: orphan force-reconciled before the new wake → `→ended` FIFO lands on the correct turn.
- Updated: route rejects reason-less `interrupted` (422); real-cwd registration probe shape pinned.
- `pnpm test`: 3933 passed. `npx tsc --noEmit` clean. `pnpm lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)