### PR TITLE
feat(cli): `chorus daemon install` — correct systemd supervisor unit generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ The `chorus daemon` connects your local machine to a remote Chorus server as an 
 chorus login                     # Authenticate (opens browser)
 chorus daemon                    # Start daemon in foreground
 chorus daemon -d                 # Start daemon in background (detached)
-chorus daemon stop               # Stop background daemon
+chorus daemon install            # Install as a boot-autostart service (Linux) — recommended
+chorus daemon uninstall          # Remove the installed service
+chorus daemon stop               # Stop the daemon (delegates to systemd when installed)
 chorus daemon stop --force       # Force-clean the pidfile if a stuck pid blocks stop
 chorus daemon status             # Check daemon status
-chorus daemon restart            # Restart background daemon
+chorus daemon restart            # Restart the daemon
 chorus daemon logs               # View daemon logs
 ```
 
@@ -115,11 +117,21 @@ chorus daemon logs               # View daemon logs
 
 - **Claude Code & Codex backends** — Auto-detects the `claude` (or `codex`) CLI on your PATH; pick with `--agent codex`
 - **Background mode** — Run with `-d` flag; manage with `stop/restart/logs`
+- **Boot-autostart service** — `chorus daemon install` generates a correct `systemd --user` unit and starts it (see below); `status/stop/restart/logs` then transparently delegate to systemd
 - **Permission modes** — Default is full access (yolo); use `--chorus-only` to restrict to Chorus MCP tools only
 - **Multi-path** — Serve several working directories from one daemon with repeatable `--cwd` (see below)
 - **Interactive setup** — Prompts for credentials on first start if not already configured
 
 The daemon requires authentication. Run `chorus login` first, or it will prompt for credentials interactively on first start (if running in a terminal).
+
+#### Run at boot / login — `chorus daemon install`
+
+```bash
+chorus daemon install --cwd ~/work/repo-a --cwd ~/work/repo-b   # install + start now, autostart at login
+chorus daemon uninstall                                         # disable + remove the service
+```
+
+On Linux, `install` generates a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, no `-d`) so systemd owns the process directly, then `daemon-reload` + `enable --now`. It captures the `--cwd`/`--agent`/`--chorus-only` flags you pass. Do **not** hand-write a `Type=forking` unit around `chorus daemon -d` — the daemon self-daemonizes, which systemd can't track and which loops on restart; let `install` write the right unit. On macOS/Windows, `install` prints a correct template you install manually. Run `chorus login` first so the unit can see your credentials. See [docs/DAEMON.md](docs/DAEMON.md) for details.
 
 #### Serve multiple working directories
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -95,10 +95,12 @@ DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
 chorus login                     # 认证（打开浏览器）
 chorus daemon                    # 前台启动 daemon
 chorus daemon -d                 # 后台启动 daemon（分离模式）
-chorus daemon stop               # 停止后台 daemon
+chorus daemon install            # 安装为开机自启服务（Linux）—— 推荐
+chorus daemon uninstall          # 卸载已安装的服务
+chorus daemon stop               # 停止 daemon（已安装服务时委派给 systemd）
 chorus daemon stop --force       # pid 卡死时强制清理 pidfile
 chorus daemon status             # 查看 daemon 状态
-chorus daemon restart            # 重启后台 daemon
+chorus daemon restart            # 重启 daemon
 chorus daemon logs               # 查看 daemon 日志
 ```
 
@@ -106,11 +108,21 @@ chorus daemon logs               # 查看 daemon 日志
 
 - **Claude Code 与 Codex 后端** — 自动检测 PATH 中的 `claude`（或 `codex`）CLI；用 `--agent codex` 选择
 - **后台模式** — 使用 `-d` 标志后台运行；用 `stop/restart/logs` 管理
+- **开机自启服务** — `chorus daemon install` 生成正确的 `systemd --user` unit 并启动（见下文）；此后 `status/stop/restart/logs` 会自动委派给 systemd
 - **权限模式** — 默认完全访问（yolo）；使用 `--chorus-only` 限制为仅 Chorus MCP 工具
 - **多路径** — 用可重复的 `--cwd` 让单个 daemon 同时服务多个工作目录（见下文）
 - **交互式设置** — 首次启动时如未配置凭证会提示输入
 
 daemon 需要先认证。首次使用请先运行 `chorus login`，或者 daemon 会在首次启动时交互式提示输入凭证（如果在终端中运行）。
+
+#### 开机 / 登录时自启 —— `chorus daemon install`
+
+```bash
+chorus daemon install --cwd ~/work/repo-a --cwd ~/work/repo-b   # 立即安装并启动，登录时自启
+chorus daemon uninstall                                         # 停用并移除该服务
+```
+
+在 Linux 上，`install` 会生成一个 `systemd --user` unit，让 daemon 以**前台**方式运行（`Type=simple`，不带 `-d`），从而由 systemd 直接接管进程，然后 `daemon-reload` + `enable --now`。它会捕获你传入的 `--cwd`/`--agent`/`--chorus-only` 参数。**不要**手写 `Type=forking` + `chorus daemon -d` 的 unit —— daemon 会自我 daemon 化，systemd 追踪不到，重启时会陷入死循环；交给 `install` 写正确的 unit。在 macOS/Windows 上，`install` 会打印一份可手动安装的正确模板。请先运行 `chorus login`，让 unit 能读到凭证。详见 [docs/DAEMON.md](docs/DAEMON.md)。
 
 #### 服务多个工作目录
 

--- a/cli/__tests__/client-args.test.mjs
+++ b/cli/__tests__/client-args.test.mjs
@@ -91,8 +91,14 @@ describe("parseDaemonAction — lifecycle sub-actions", () => {
     expect(parseDaemonAction(["restart", "--verbose"])).toBe("restart");
   });
 
-  it("DAEMON_ACTIONS is exactly the four lifecycle verbs", () => {
-    expect([...DAEMON_ACTIONS].sort()).toEqual(["logs", "restart", "status", "stop"]);
+  it("DAEMON_ACTIONS is exactly the lifecycle + service verbs", () => {
+    expect([...DAEMON_ACTIONS].sort()).toEqual(["install", "logs", "restart", "status", "stop", "uninstall"]);
+  });
+
+  it("recognizes install / uninstall as leading actions", () => {
+    expect(parseDaemonAction(["install"])).toBe("install");
+    expect(parseDaemonAction(["install", "--cwd", "/a"])).toBe("install");
+    expect(parseDaemonAction(["uninstall"])).toBe("uninstall");
   });
 });
 
@@ -111,6 +117,8 @@ describe("daemonHelpText", () => {
       "restart",
       "logs",
       "stop --force",
+      "install",
+      "uninstall",
     ]) {
       expect(help).toContain(token);
     }

--- a/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
+++ b/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
@@ -15,6 +15,24 @@ function fakeLifecycle(over = {}) {
   };
 }
 
+/**
+ * A fake supervisor seam. Default: no supervisor installed (kind:none), so the
+ * control verbs fall through to the pidfile path — the pre-existing behavior.
+ * On a host that actually runs the chorus systemd unit the real detectSupervisor
+ * would fire, so every dispatch test injects this stub for isolation.
+ */
+function fakeService(over = {}) {
+  return {
+    detectSupervisor: vi.fn(() => ({ kind: "none" })),
+    installService: vi.fn(() => ({ platform: "linux", installed: true, unitPath: "/u", unitText: "", steps: ["wrote /u"] })),
+    uninstallService: vi.fn(() => ({ platform: "linux", removed: true, unitPath: "/u", steps: ["removed /u"] })),
+    systemctlUser: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
+    journalctlUser: vi.fn(() => ({ status: 0, stdout: "journal-body", stderr: "" })),
+    resolveServicePaths: vi.fn(() => ({ nodePath: "/node", scriptPath: "/x/chorus.mjs", path: "/bin" })),
+    ...over,
+  };
+}
+
 describe("runDaemon — lifecycle action dispatch", () => {
   it("status reports running pid and never builds the daemon", async () => {
     const logs = [];
@@ -22,7 +40,7 @@ describe("runDaemon — lifecycle action dispatch", () => {
     const lifecycle = fakeLifecycle({ isRunning: () => ({ running: true, pid: 77, stale: false }) });
     const code = await runDaemon(
       { action: "status" },
-      { lifecycle, build, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+      { lifecycle, service: fakeService(), build, log: (m) => logs.push(m), errLog: () => {}, env: {} }
     );
     expect(code).toBe(0);
     expect(logs.join("")).toMatch(/running \(pid 77\)/);
@@ -33,7 +51,7 @@ describe("runDaemon — lifecycle action dispatch", () => {
     const logs = [];
     const code = await runDaemon(
       { action: "status" },
-      { lifecycle: fakeLifecycle(), build: vi.fn(), log: (m) => logs.push(m), errLog: () => {}, env: {} }
+      { lifecycle: fakeLifecycle(), service: fakeService(), build: vi.fn(), log: (m) => logs.push(m), errLog: () => {}, env: {} }
     );
     expect(code).toBe(0);
     expect(logs.join("")).toMatch(/not running/i);
@@ -43,7 +61,7 @@ describe("runDaemon — lifecycle action dispatch", () => {
     const out = [];
     const ok = await runDaemon(
       { action: "logs" },
-      { lifecycle: fakeLifecycle(), log: (m) => out.push(m), errLog: (m) => out.push("E:" + m), env: {} }
+      { lifecycle: fakeLifecycle(), service: fakeService(), log: (m) => out.push(m), errLog: (m) => out.push("E:" + m), env: {} }
     );
     expect(ok).toBe(0);
     expect(out.join("")).toContain("log-body");
@@ -51,20 +69,20 @@ describe("runDaemon — lifecycle action dispatch", () => {
     const errs = [];
     const bad = await runDaemon(
       { action: "logs" },
-      { lifecycle: fakeLifecycle({ readLog: () => ({ ok: false, message: "no log file at /l" }) }), log: () => {}, errLog: (m) => errs.push(m), env: {} }
+      { lifecycle: fakeLifecycle({ readLog: () => ({ ok: false, message: "no log file at /l" }) }), service: fakeService(), log: () => {}, errLog: (m) => errs.push(m), env: {} }
     );
     expect(bad).toBe(1);
     expect(errs.join("")).toMatch(/no log file/);
   });
 
   it("stop returns 0 when it stopped, 1 (with clear message) when nothing ran", async () => {
-    const okCode = await runDaemon({ action: "stop" }, { lifecycle: fakeLifecycle(), log: () => {}, errLog: () => {}, env: {} });
+    const okCode = await runDaemon({ action: "stop" }, { lifecycle: fakeLifecycle(), service: fakeService(), log: () => {}, errLog: () => {}, env: {} });
     expect(okCode).toBe(0);
 
     const errs = [];
     const badCode = await runDaemon(
       { action: "stop" },
-      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: false, pid: null, reason: "not-running", message: "no daemon is running" }) }), log: () => {}, errLog: (m) => errs.push(m), env: {} }
+      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: false, pid: null, reason: "not-running", message: "no daemon is running" }) }), service: fakeService(), log: () => {}, errLog: (m) => errs.push(m), env: {} }
     );
     expect(badCode).toBe(1);
     expect(errs.join("")).toMatch(/no daemon/);
@@ -75,30 +93,30 @@ describe("runDaemon — lifecycle action dispatch", () => {
     // must not fail `chorus daemon stop && …` chains.
     const staleCode = await runDaemon(
       { action: "stop" },
-      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: false, pid: 9, reason: "stale-cleared", message: "no live daemon (cleared stale pidfile for pid 9)" }) }), log: () => {}, errLog: () => {}, env: {} }
+      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: false, pid: 9, reason: "stale-cleared", message: "no live daemon (cleared stale pidfile for pid 9)" }) }), service: fakeService(), log: () => {}, errLog: () => {}, env: {} }
     );
     expect(staleCode).toBe(0);
 
     const forcedCode = await runDaemon(
       { action: "stop" },
-      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: true, pid: 9, reason: "forced", message: "forced cleanup" }) }), log: () => {}, errLog: () => {}, env: {} }
+      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: true, pid: 9, reason: "forced", message: "forced cleanup" }) }), service: fakeService(), log: () => {}, errLog: () => {}, env: {} }
     );
     expect(forcedCode).toBe(0);
 
     const errCode = await runDaemon(
       { action: "stop" },
-      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: false, pid: 9, reason: "error", message: "failed to signal pid 9" }) }), log: () => {}, errLog: () => {}, env: {} }
+      { lifecycle: fakeLifecycle({ stopDaemon: () => ({ stopped: false, pid: 9, reason: "error", message: "failed to signal pid 9" }) }), service: fakeService(), log: () => {}, errLog: () => {}, env: {} }
     );
     expect(errCode).toBe(1);
   });
 
   it("stop threads --force into stopDaemon; plain stop does not", async () => {
     const lifecycle = fakeLifecycle();
-    await runDaemon({ action: "stop", force: true }, { lifecycle, log: () => {}, errLog: () => {}, env: {} });
+    await runDaemon({ action: "stop", force: true }, { lifecycle, service: fakeService(), log: () => {}, errLog: () => {}, env: {} });
     expect(lifecycle.stopDaemon).toHaveBeenCalledWith({ force: true });
 
     const lifecycle2 = fakeLifecycle();
-    await runDaemon({ action: "stop" }, { lifecycle: lifecycle2, log: () => {}, errLog: () => {}, env: {} });
+    await runDaemon({ action: "stop" }, { lifecycle: lifecycle2, service: fakeService(), log: () => {}, errLog: () => {}, env: {} });
     expect(lifecycle2.stopDaemon).toHaveBeenCalledWith({ force: false });
   });
 
@@ -107,7 +125,7 @@ describe("runDaemon — lifecycle action dispatch", () => {
     const ask = vi.fn();
     const code = await runDaemon(
       { action: "restart" },
-      { lifecycle, prompt: ask, log: () => {}, errLog: () => {}, env: {} }
+      { lifecycle, service: fakeService(), prompt: ask, log: () => {}, errLog: () => {}, env: {} }
     );
     expect(code).toBe(0);
     expect(lifecycle.stopDaemon).toHaveBeenCalledOnce();
@@ -119,9 +137,153 @@ describe("runDaemon — lifecycle action dispatch", () => {
 
   it("restart keeps non-forced stop semantics even with --force present", async () => {
     const lifecycle = fakeLifecycle();
-    await runDaemon({ action: "restart", force: true }, { lifecycle, log: () => {}, errLog: () => {}, env: {} });
+    await runDaemon({ action: "restart", force: true }, { lifecycle, service: fakeService(), log: () => {}, errLog: () => {}, env: {} });
     // restart must not silently discard a pidfile it couldn't verify.
     expect(lifecycle.stopDaemon).toHaveBeenCalledWith();
+  });
+});
+
+describe("runDaemon — supervisor (systemd) delegation", () => {
+  // When a systemd unit is installed+active, the control verbs must route to
+  // systemctl/journalctl instead of the pidfile — so a supervised daemon is
+  // never misreported as "not running" (the boot-storm confusion).
+  const installedActive = () => fakeService({
+    detectSupervisor: vi.fn(() => ({ kind: "systemd", installed: true, active: true, unitPath: "/u" })),
+  });
+
+  it("status delegates to systemctl and never touches the pidfile", async () => {
+    const logs = [];
+    const service = installedActive();
+    service.systemctlUser = vi.fn(() => ({ status: 0, stdout: "● chorus-daemon.service active", stderr: "" }));
+    const lifecycle = fakeLifecycle();
+    const code = await runDaemon(
+      { action: "status" },
+      { lifecycle, service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(logs.join("")).toMatch(/managed by systemd/);
+    expect(service.systemctlUser).toHaveBeenCalledWith(["status", "--no-pager", "chorus-daemon.service"]);
+    expect(lifecycle.isRunning).not.toHaveBeenCalled();
+  });
+
+  it("status returns 1 when the unit is installed but NOT active", async () => {
+    const service = fakeService({
+      detectSupervisor: () => ({ kind: "systemd", installed: true, active: false, unitPath: "/u" }),
+    });
+    const logs = [];
+    const code = await runDaemon(
+      { action: "status" },
+      { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(1);
+    expect(logs.join("")).toMatch(/NOT active/);
+  });
+
+  it("stop delegates to systemctl stop and does not signal the pidfile", async () => {
+    const service = installedActive();
+    const lifecycle = fakeLifecycle();
+    const logs = [];
+    const code = await runDaemon(
+      { action: "stop" },
+      { lifecycle, service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(service.systemctlUser).toHaveBeenCalledWith(["stop", "chorus-daemon.service"]);
+    expect(lifecycle.stopDaemon).not.toHaveBeenCalled();
+    expect(logs.join("")).toMatch(/stopped the daemon service/);
+  });
+
+  it("restart delegates to systemctl restart and does not re-detach", async () => {
+    const service = installedActive();
+    const lifecycle = fakeLifecycle();
+    const code = await runDaemon(
+      { action: "restart" },
+      { lifecycle, service, log: () => {}, errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(service.systemctlUser).toHaveBeenCalledWith(["restart", "chorus-daemon.service"]);
+    expect(lifecycle.startBackground).not.toHaveBeenCalled();
+  });
+
+  it("logs delegates to journalctl", async () => {
+    const service = installedActive();
+    service.journalctlUser = vi.fn(() => ({ status: 0, stdout: "journal-line", stderr: "" }));
+    const out = [];
+    const code = await runDaemon(
+      { action: "logs" },
+      { lifecycle: fakeLifecycle(), service, log: (m) => out.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(service.journalctlUser).toHaveBeenCalledWith(["-u", "chorus-daemon.service", "--no-pager", "-n", "200"]);
+    expect(out.join("")).toContain("journal-line");
+  });
+
+  it("a stop failure under systemd surfaces the error and returns 1", async () => {
+    const service = installedActive();
+    service.systemctlUser = vi.fn(() => ({ status: 1, stdout: "", stderr: "Failed to stop" }));
+    const errs = [];
+    const code = await runDaemon(
+      { action: "stop" },
+      { lifecycle: fakeLifecycle(), service, log: () => {}, errLog: (m) => errs.push(m), env: {} }
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toMatch(/failed to stop the service/i);
+  });
+});
+
+describe("runDaemon — install / uninstall", () => {
+  it("install passes the invoking --cwd/--agent/--chorus-only into the spec and reports success", async () => {
+    const service = fakeService();
+    const logs = [];
+    const code = await runDaemon(
+      { action: "install", cwd: ["/a", "/b"], agent: "claude-code", chorusOnly: true },
+      { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    const spec = service.installService.mock.calls[0][0];
+    expect(spec.cwds).toEqual(["/a", "/b"]);
+    expect(spec.agent).toBe("claude-code");
+    expect(spec.chorusOnly).toBe(true);
+    expect(logs.join("")).toMatch(/installed and started/);
+  });
+
+  it("install surfaces a Linux failure as exit 1", async () => {
+    const service = fakeService({
+      installService: () => ({ platform: "linux", installed: false, unitPath: "/u", unitText: "", steps: ["wrote /u"], error: "daemon-reload failed" }),
+    });
+    const errs = [];
+    const code = await runDaemon(
+      { action: "install" },
+      { lifecycle: fakeLifecycle(), service, log: () => {}, errLog: (m) => errs.push(m), env: {} }
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toMatch(/install failed: daemon-reload failed/);
+  });
+
+  it("install on macOS prints the template + steps and exits 0 without failing", async () => {
+    const service = fakeService({
+      installService: () => ({ platform: "darwin", installed: false, unitPath: "/p.plist", unitText: "<plist/>", steps: ["Save the plist below to /p.plist"] }),
+    });
+    const logs = [];
+    const code = await runDaemon(
+      { action: "install" },
+      { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(logs.join("\n")).toMatch(/Linux-only/);
+    expect(logs.join("\n")).toContain("<plist/>");
+  });
+
+  it("uninstall reports removal on Linux; 'nothing to remove' when absent", async () => {
+    const removed = fakeService();
+    const okLogs = [];
+    await runDaemon({ action: "uninstall" }, { lifecycle: fakeLifecycle(), service: removed, log: (m) => okLogs.push(m), errLog: () => {}, env: {} });
+    expect(okLogs.join("")).toMatch(/removed the daemon service/);
+
+    const none = fakeService({ uninstallService: () => ({ platform: "linux", removed: false, unitPath: "/u", steps: [] }) });
+    const noneLogs = [];
+    await runDaemon({ action: "uninstall" }, { lifecycle: fakeLifecycle(), service: none, log: (m) => noneLogs.push(m), errLog: () => {}, env: {} });
+    expect(noneLogs.join("")).toMatch(/nothing to remove/);
   });
 });
 

--- a/cli/__tests__/daemon-service.test.mjs
+++ b/cli/__tests__/daemon-service.test.mjs
@@ -56,6 +56,23 @@ describe("renderSystemdUnit (pure)", () => {
     expect(unit).not.toMatch(/ExecStop=/);
   });
 
+  it("quotes ExecStart tokens containing whitespace so systemd does not mis-split them", () => {
+    const u = renderSystemdUnit({ ...BASE, cwds: ["/home/u/My Projects/repo", "/plain"] });
+    const execLine = u.split("\n").find((l) => l.startsWith("ExecStart="));
+    // The spaced --cwd value must survive as ONE quoted token; the plain one bare.
+    expect(execLine).toContain('--cwd "/home/u/My Projects/repo"');
+    expect(execLine).toContain("--cwd /plain");
+    // Regression guard: the space inside the path must not appear unquoted (which
+    // systemd would tokenize into `--cwd /home/u/My` + stray `Projects/repo`).
+    expect(execLine).not.toMatch(/--cwd \/home\/u\/My Projects/);
+  });
+
+  it("quotes a node/script path that itself contains a space", () => {
+    const u = renderSystemdUnit({ ...BASE, nodePath: "/opt/My Tools/node", cwds: ["/a"] });
+    const execLine = u.split("\n").find((l) => l.startsWith("ExecStart="));
+    expect(execLine).toContain('ExecStart="/opt/My Tools/node"');
+  });
+
   it("carries Restart=on-failure, RestartSec, TimeoutStopSec, PATH, HOME, WantedBy", () => {
     expect(unit).toMatch(/^Restart=on-failure$/m);
     expect(unit).toMatch(/^RestartSec=10$/m);
@@ -153,7 +170,7 @@ describe("installService", () => {
     };
   }
 
-  it("writes the unit, daemon-reloads, and enable --now on Linux", () => {
+  it("writes the unit, daemon-reloads, enable --now, then restart on Linux", () => {
     const { io, calls } = linuxIO();
     const r = installService({ ...BASE }, io);
     expect(r).toMatchObject({ platform: "linux", installed: true });
@@ -161,11 +178,23 @@ describe("installService", () => {
     const [path, text] = io.writeFileSync.mock.calls[0];
     expect(path).toBe(systemdUnitPath({ home: "/home/u" }));
     expect(text).toMatch(/Type=simple/);
-    // ordered systemctl calls
+    // ordered systemctl calls — restart follows enable so a re-install with new
+    // flags actually applies to an already-running daemon (not just a no-op start).
     expect(calls).toEqual([
       ["systemctl", "--user", "daemon-reload"],
       ["systemctl", "--user", "enable", "--now", `${SERVICE_NAME}.service`],
+      ["systemctl", "--user", "restart", `${SERVICE_NAME}.service`],
     ]);
+  });
+
+  it("a failed restart does not fail an otherwise-good install", () => {
+    const { io } = linuxIO({
+      spawnSync: vi.fn((_cmd, args) => (args.includes("restart") ? { status: 1, stdout: "", stderr: "transient" } : { status: 0, stdout: "", stderr: "" })),
+    });
+    const r = installService({ ...BASE }, io);
+    expect(r.installed).toBe(true);
+    // restart step is best-effort — omitted from steps on failure, install still succeeds
+    expect(r.steps.some((s) => s.includes("restart"))).toBe(false);
   });
 
   it("returns installed:false + error when daemon-reload fails", () => {

--- a/cli/__tests__/daemon-service.test.mjs
+++ b/cli/__tests__/daemon-service.test.mjs
@@ -1,0 +1,265 @@
+// cli/__tests__/daemon-service.test.mjs
+// Unit tests for the supervisor-service module: pure unit/plist rendering, the
+// systemd detection probe, and the install/uninstall IO orchestration (all IO
+// injected — no real systemctl / disk).
+import { describe, it, expect, vi } from "vitest";
+import {
+  SERVICE_NAME,
+  systemdUnitPath,
+  launchdPlistPath,
+  buildServiceArgs,
+  renderSystemdUnit,
+  renderLaunchdPlist,
+  detectSupervisor,
+  installService,
+  uninstallService,
+  systemctlUser,
+  resolveServicePaths,
+} from "../daemon-service.mjs";
+
+const BASE = {
+  nodePath: "/usr/bin/node",
+  scriptPath: "/opt/chorus/chorus.mjs",
+  workingDir: "/home/u/dev/proj",
+  home: "/home/u",
+  path: "/home/u/.local/bin:/usr/bin:/bin",
+};
+
+describe("buildServiceArgs", () => {
+  it("emits the normal daemon argv WITHOUT -d, with repeated --cwd", () => {
+    const args = buildServiceArgs({ scriptPath: "/x/chorus.mjs", cwds: ["/a", "/b"] });
+    expect(args).toEqual(["/x/chorus.mjs", "daemon", "--cwd", "/a", "--cwd", "/b"]);
+    expect(args).not.toContain("-d");
+  });
+
+  it("includes --agent and --chorus-only when set; skips blank cwds", () => {
+    const args = buildServiceArgs({ scriptPath: "/x/chorus.mjs", cwds: ["/a", "", undefined], agent: "codex", chorusOnly: true });
+    expect(args).toEqual(["/x/chorus.mjs", "daemon", "--cwd", "/a", "--agent", "codex", "--chorus-only"]);
+  });
+});
+
+describe("renderSystemdUnit (pure)", () => {
+  const unit = renderSystemdUnit({ ...BASE, cwds: ["/a", "/b"] });
+
+  it("uses Type=simple and NO -d in ExecStart", () => {
+    expect(unit).toMatch(/^Type=simple$/m);
+    expect(unit).toMatch(/ExecStart=\/usr\/bin\/node \/opt\/chorus\/chorus\.mjs daemon --cwd \/a --cwd \/b$/m);
+    // The self-daemonize flag must never appear ON THE ExecStart LINE — that was
+    // the boot-loop cause. (Comment lines legitimately mention "-d".)
+    const execLine = unit.split("\n").find((l) => l.startsWith("ExecStart="));
+    expect(execLine).not.toMatch(/(\s)-d(\s|$)/);
+    expect(execLine).not.toMatch(/--detach/);
+    expect(unit).not.toMatch(/Type=forking/);
+  });
+
+  it("has NO ExecStop (Type=simple stop = SIGTERM to the graceful handler)", () => {
+    expect(unit).not.toMatch(/ExecStop=/);
+  });
+
+  it("carries Restart=on-failure, RestartSec, TimeoutStopSec, PATH, HOME, WantedBy", () => {
+    expect(unit).toMatch(/^Restart=on-failure$/m);
+    expect(unit).toMatch(/^RestartSec=10$/m);
+    expect(unit).toMatch(/^TimeoutStopSec=30$/m);
+    expect(unit).toMatch(/^Environment=PATH=\/home\/u\/\.local\/bin:\/usr\/bin:\/bin$/m);
+    expect(unit).toMatch(/^Environment=HOME=\/home\/u$/m);
+    expect(unit).toMatch(/^WantedBy=default\.target$/m);
+    expect(unit).toMatch(new RegExp(`^SyslogIdentifier=${SERVICE_NAME}$`, "m"));
+  });
+
+  it("respects custom restartSec / timeoutStopSec", () => {
+    const u = renderSystemdUnit({ ...BASE, restartSec: 5, timeoutStopSec: 45 });
+    expect(u).toMatch(/^RestartSec=5$/m);
+    expect(u).toMatch(/^TimeoutStopSec=45$/m);
+  });
+});
+
+describe("renderLaunchdPlist (pure)", () => {
+  const plist = renderLaunchdPlist({ ...BASE, cwds: ["/a"], logPath: "/home/u/.chorus/daemon.log" });
+
+  it("emits RunAtLoad + KeepAlive and the daemon argv without -d", () => {
+    expect(plist).toContain("<key>RunAtLoad</key>");
+    expect(plist).toContain("<key>KeepAlive</key>");
+    expect(plist).toContain("<string>/opt/chorus/chorus.mjs</string>");
+    expect(plist).toContain("<string>daemon</string>");
+    expect(plist).toContain("<string>--cwd</string>");
+    expect(plist).not.toContain("<string>-d</string>");
+    expect(plist).toContain("com.chorus.daemon");
+  });
+
+  it("xml-escapes special characters in paths", () => {
+    const p = renderLaunchdPlist({ ...BASE, workingDir: "/a & b/<x>", cwds: [], logPath: "/l" });
+    expect(p).toContain("/a &amp; b/&lt;x&gt;");
+  });
+});
+
+describe("detectSupervisor", () => {
+  function io(over = {}) {
+    return {
+      platform: "linux",
+      home: "/home/u",
+      existsSync: vi.fn(() => true),
+      spawnSync: vi.fn(() => ({ status: 0, stdout: "active\n", stderr: "" })),
+      ...over,
+    };
+  }
+
+  it("returns kind:none off Linux", () => {
+    expect(detectSupervisor(io({ platform: "darwin" }))).toEqual({ kind: "none" });
+    expect(detectSupervisor(io({ platform: "win32" }))).toEqual({ kind: "none" });
+  });
+
+  it("installed + active when the unit exists and is-active says active", () => {
+    const r = detectSupervisor(io());
+    expect(r.kind).toBe("systemd");
+    expect(r.installed).toBe(true);
+    expect(r.active).toBe(true);
+    expect(r.unitPath).toBe(systemdUnitPath({ home: "/home/u" }));
+  });
+
+  it("installed + inactive when the unit exists but is-active is not 'active'", () => {
+    const r = detectSupervisor(io({ spawnSync: () => ({ status: 3, stdout: "inactive\n", stderr: "" }) }));
+    expect(r).toMatchObject({ kind: "systemd", installed: true, active: false });
+  });
+
+  it("kind:none when neither the unit file nor an active service exists", () => {
+    const r = detectSupervisor(io({ existsSync: () => false, spawnSync: () => ({ status: 3, stdout: "inactive\n", stderr: "" }) }));
+    expect(r).toEqual({ kind: "none" });
+  });
+
+  it("still reports systemd when inactive but the unit file is present", () => {
+    const r = detectSupervisor(io({ existsSync: () => true, spawnSync: () => ({ status: 3, stdout: "unknown\n", stderr: "" }) }));
+    expect(r).toMatchObject({ kind: "systemd", installed: true, active: false });
+  });
+});
+
+describe("installService", () => {
+  function linuxIO(over = {}) {
+    const calls = [];
+    return {
+      io: {
+        platform: "linux",
+        home: "/home/u",
+        mkdirSync: vi.fn(),
+        writeFileSync: vi.fn(),
+        existsSync: vi.fn(() => true),
+        unlinkSync: vi.fn(),
+        spawnSync: vi.fn((cmd, args) => {
+          calls.push([cmd, ...args]);
+          return { status: 0, stdout: "", stderr: "" };
+        }),
+        ...over,
+      },
+      calls,
+    };
+  }
+
+  it("writes the unit, daemon-reloads, and enable --now on Linux", () => {
+    const { io, calls } = linuxIO();
+    const r = installService({ ...BASE }, io);
+    expect(r).toMatchObject({ platform: "linux", installed: true });
+    expect(io.writeFileSync).toHaveBeenCalledOnce();
+    const [path, text] = io.writeFileSync.mock.calls[0];
+    expect(path).toBe(systemdUnitPath({ home: "/home/u" }));
+    expect(text).toMatch(/Type=simple/);
+    // ordered systemctl calls
+    expect(calls).toEqual([
+      ["systemctl", "--user", "daemon-reload"],
+      ["systemctl", "--user", "enable", "--now", `${SERVICE_NAME}.service`],
+    ]);
+  });
+
+  it("returns installed:false + error when daemon-reload fails", () => {
+    const { io } = linuxIO({
+      spawnSync: vi.fn((_cmd, args) => (args.includes("daemon-reload") ? { status: 1, stdout: "", stderr: "boom" } : { status: 0, stdout: "", stderr: "" })),
+    });
+    const r = installService({ ...BASE }, io);
+    expect(r.installed).toBe(false);
+    expect(r.error).toMatch(/daemon-reload failed: boom/);
+  });
+
+  it("returns installed:false + error when enable --now fails", () => {
+    const { io } = linuxIO({
+      spawnSync: vi.fn((_cmd, args) => (args.includes("enable") ? { status: 1, stdout: "", stderr: "nope" } : { status: 0, stdout: "", stderr: "" })),
+    });
+    const r = installService({ ...BASE }, io);
+    expect(r.installed).toBe(false);
+    expect(r.error).toMatch(/enable --now failed: nope/);
+  });
+
+  it("darwin: does not write, returns a plist template + manual steps", () => {
+    const io = { platform: "darwin", home: "/home/u", writeFileSync: vi.fn(), mkdirSync: vi.fn(), spawnSync: vi.fn() };
+    const r = installService({ ...BASE }, io);
+    expect(r).toMatchObject({ platform: "darwin", installed: false });
+    expect(io.writeFileSync).not.toHaveBeenCalled();
+    expect(r.unitText).toContain("<plist");
+    expect(r.unitPath).toBe(launchdPlistPath({ home: "/home/u" }));
+    expect(r.steps.join(" ")).toMatch(/launchctl load/);
+  });
+
+  it("other platform: returns the foreground command with no -d and no write", () => {
+    const io = { platform: "win32", home: "C:/Users/u", writeFileSync: vi.fn(), spawnSync: vi.fn() };
+    const r = installService({ ...BASE, cwds: ["/a"] }, io);
+    expect(r.platform).toBe("other");
+    expect(r.installed).toBe(false);
+    expect(io.writeFileSync).not.toHaveBeenCalled();
+    expect(r.unitText).not.toMatch(/ -d(\s|$)/);
+    expect(r.unitText).toContain("daemon --cwd /a");
+  });
+});
+
+describe("uninstallService", () => {
+  it("disables, removes the unit, and reloads on Linux", () => {
+    const calls = [];
+    const io = {
+      platform: "linux",
+      home: "/home/u",
+      existsSync: vi.fn(() => true),
+      unlinkSync: vi.fn(),
+      spawnSync: vi.fn((cmd, args) => {
+        calls.push(args.join(" "));
+        return { status: 0, stdout: "", stderr: "" };
+      }),
+    };
+    const r = uninstallService(io);
+    expect(r).toMatchObject({ platform: "linux", removed: true });
+    expect(io.unlinkSync).toHaveBeenCalledWith(systemdUnitPath({ home: "/home/u" }));
+    expect(calls).toContain(`--user disable --now ${SERVICE_NAME}.service`);
+    expect(calls).toContain("--user daemon-reload");
+  });
+
+  it("is idempotent: reports removed:false when nothing was installed", () => {
+    const io = {
+      platform: "linux",
+      home: "/home/u",
+      existsSync: vi.fn(() => false),
+      unlinkSync: vi.fn(),
+      // disable of an absent unit returns non-zero; uninstall tolerates it.
+      spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "not loaded" })),
+    };
+    const r = uninstallService(io);
+    expect(r.removed).toBe(false);
+    expect(io.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("darwin: returns manual unload/rm steps", () => {
+    const r = uninstallService({ platform: "darwin", home: "/home/u" });
+    expect(r).toMatchObject({ platform: "darwin", removed: false });
+    expect(r.steps.join(" ")).toMatch(/launchctl unload/);
+  });
+});
+
+describe("systemctlUser / resolveServicePaths", () => {
+  it("systemctlUser never throws even when spawnSync throws", () => {
+    const io = { spawnSync: () => { throw new Error("no systemctl"); } };
+    const r = systemctlUser(["is-active", "x"], io);
+    expect(r.status).toBe(null);
+    expect(r.stderr).toMatch(/no systemctl/);
+  });
+
+  it("resolveServicePaths reflects the running node + PATH env", () => {
+    const r = resolveServicePaths({ PATH: "/custom/bin" }, "/my/node");
+    expect(r.nodePath).toBe("/my/node");
+    expect(r.path).toBe("/custom/bin");
+    expect(r.scriptPath).toMatch(/chorus\.mjs$/);
+  });
+});

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -11,7 +11,7 @@
  * default long-lived daemon) is intentionally NOT in this set — it is the
  * absence of a recognized sub-action token.
  */
-export const DAEMON_ACTIONS = new Set(["stop", "status", "restart", "logs"]);
+export const DAEMON_ACTIONS = new Set(["stop", "status", "restart", "logs", "install", "uninstall"]);
 
 /** Known agent backends. Only `claude-code` is implemented; the rest reserve
  * the extension point (see daemon-agent-selection). Exported for the resolver
@@ -78,7 +78,7 @@ export function parseClientFlags(argv) {
  * or an unknown leading token) is the normal long-lived daemon (`run`).
  *
  * @param {string[]} rest  argv after the `daemon` subcommand token
- * @returns {"run"|"stop"|"status"|"restart"|"logs"}
+ * @returns {"run"|"stop"|"status"|"restart"|"logs"|"install"|"uninstall"}
  */
 export function parseDaemonAction(rest) {
   const first = rest[0];
@@ -100,12 +100,18 @@ agent notification stream, and wake a local headless agent on task dispatch.
 USAGE
   chorus daemon [options]              Run the daemon (foreground)
   chorus daemon -d [options]           Run the daemon in the background (detached)
-  chorus daemon stop                   Stop the background daemon
+  chorus daemon install [options]      Install as a boot-autostart service and
+                                       start it now (Linux systemd --user;
+                                       macOS/Windows print a template + steps)
+  chorus daemon uninstall              Remove the installed service (Linux) /
+                                       print removal steps (macOS/Windows)
+  chorus daemon stop                   Stop the daemon (delegates to the service
+                                       manager when installed, else the pidfile)
   chorus daemon stop --force           Force-clean the pidfile when a stuck or
                                        unverifiable pid blocks a normal stop
-  chorus daemon status                 Show whether the background daemon is running
-  chorus daemon restart                Restart the background daemon
-  chorus daemon logs                   Show the background daemon log
+  chorus daemon status                 Show whether the daemon is running
+  chorus daemon restart                Restart the daemon
+  chorus daemon logs                   Show the daemon log (journal when installed)
 
 OPTIONS
   --url <url>              Remote Chorus server URL            (env: CHORUS_URL)
@@ -134,11 +140,23 @@ CREDENTIALS
   ~/.chorus/daemon.json (from 'chorus login') > Claude Code plugin config.
   On a TTY with no resolvable credentials, the daemon prompts to complete them.
 
+SERVICE (install)
+  'chorus daemon install' is the recommended way to run the daemon permanently.
+  On Linux it generates a systemd --user unit that runs the daemon in the
+  FOREGROUND (Type=simple, no -d) so systemd owns the process directly: it
+  starts at login, restarts on failure, and 'systemctl --user stop' shuts it
+  down gracefully. Do NOT hand-write a Type=forking unit around 'chorus daemon
+  -d' — the daemon self-daemonizes, which systemd cannot track and which loops
+  on restart. The install captures the --cwd / --agent / --chorus-only flags you
+  pass. On macOS/Windows install prints a correct template you install manually.
+
 EXAMPLES
   chorus daemon                        # Foreground, default yolo (TTY confirms once)
   chorus daemon --chorus-only          # Restrict the woken agent to Chorus tools
   chorus daemon -d                     # Background; see 'chorus daemon logs'
-  chorus daemon stop                   # Stop the background daemon
+  chorus daemon install --cwd ~/proj   # Install + start as a boot service (Linux)
+  chorus daemon uninstall              # Remove the installed service
+  chorus daemon stop                   # Stop the daemon
 `;
 }
 

--- a/cli/daemon-service.mjs
+++ b/cli/daemon-service.mjs
@@ -113,9 +113,11 @@ export function renderSystemdUnit(spec) {
     chorusOnly: spec.chorusOnly,
     scriptPath: spec.scriptPath,
   });
-  // ExecStart: continuation-line the --cwd pairs for readability, matching the
-  // hand-written units operators already have. systemd joins `\`-continued lines.
-  const execStart = [spec.nodePath, ...args].join(" ");
+  // systemd's ExecStart tokenizer splits on UNQUOTED whitespace, so a token
+  // with a space (an operator's `--cwd "/home/u/My Projects/repo"`, or a node/
+  // script path under such a dir) would be mis-split and the daemon would serve
+  // the wrong path silently. Quote every token so spaces survive.
+  const execStart = [spec.nodePath, ...args].map(systemdQuoteArg).join(" ");
   const restartSec = spec.restartSec ?? 10;
   const timeoutStopSec = spec.timeoutStopSec ?? 30;
   return `[Unit]
@@ -211,6 +213,19 @@ function xmlEscape(s) {
 }
 
 /**
+ * Quote a single token for a systemd `ExecStart=` line. systemd splits the line
+ * on unquoted whitespace and supports C-escaped double-quoted strings, so a
+ * token containing whitespace (or a quote/backslash) must be wrapped in `"…"`
+ * with `\` and `"` escaped. Tokens without whitespace are left bare to keep the
+ * common unit readable.
+ */
+function systemdQuoteArg(token) {
+  const s = String(token);
+  if (!/[\s"\\]/.test(s)) return s;
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
  * Detect whether a supervisor already manages the chorus daemon on this host.
  * Linux only (systemd --user); everything else reports `{ kind: "none" }`.
  *   - kind: "systemd" with installed (unit file present, `is-enabled` not
@@ -299,6 +314,12 @@ export function installService(spec, io = defaultIO()) {
         return { platform: "linux", installed: false, unitPath, unitText, steps, error: `systemctl --user enable --now failed: ${enable.stderr.trim() || `exit ${enable.status}`}` };
       }
       steps.push(`systemctl --user enable --now ${SERVICE_NAME}.service`);
+      // enable --now only STARTS an inactive service; on a re-install over an
+      // already-running daemon it is a no-op, leaving the old process on the old
+      // --cwd/--agent flags. Restart so a re-install always applies the new unit.
+      // Best-effort: a restart failure must not fail an otherwise-good install.
+      const restart = systemctlUser(["restart", `${SERVICE_NAME}.service`], io);
+      if (restart.status === 0) steps.push(`systemctl --user restart ${SERVICE_NAME}.service`);
       return { platform: "linux", installed: true, unitPath, unitText, steps };
     } catch (err) {
       return { platform: "linux", installed: false, unitPath, unitText, steps, error: err instanceof Error ? err.message : String(err) };
@@ -321,7 +342,10 @@ export function installService(spec, io = defaultIO()) {
   }
   // Windows / other: no first-class service model without native deps. Print the
   // foreground command an operator can wrap in their supervisor of choice.
-  const cmd = [spec.nodePath, ...buildServiceArgs(spec)].join(" ");
+  // Quote whitespace-bearing tokens so a copy-pasted path with a space survives.
+  const cmd = [spec.nodePath, ...buildServiceArgs(spec)]
+    .map((a) => (/\s/.test(String(a)) ? `"${a}"` : a))
+    .join(" ");
   return {
     platform: "other",
     installed: false,

--- a/cli/daemon-service.mjs
+++ b/cli/daemon-service.mjs
@@ -1,0 +1,398 @@
+// cli/daemon-service.mjs
+// `chorus daemon install` / `uninstall` — generate and install a CORRECT
+// supervisor unit for the long-lived daemon, and detect one so the lifecycle
+// subcommands (status/stop/restart/logs) can transparently delegate to it.
+//
+// WHY THIS EXISTS (root fix for the boot restart storm, idea e55ae33a follow-up):
+// operators hand-wrote a systemd unit as `Type=forking` + `ExecStart=… -d`.
+// `chorus daemon -d` SELF-daemonizes (detached + unref child + a JSON pidfile
+// systemd cannot parse), so systemd never adopts the forked child as MainPID,
+// treats the service as failed, and `Restart=on-failure` retries every few
+// seconds — each retry's `-d` preflight then finds the previous orphan alive
+// via the pidfile and refuses ("a daemon is already running"), an infinite
+// loop that also pins the server-side connection rows ("all declared paths
+// already served"). The correct model is a FOREGROUND `Type=simple` service:
+// systemd owns the process directly, `systemctl stop` delivers SIGTERM to the
+// daemon's existing graceful-shutdown handler, no pidfile is involved, and
+// there is nothing to double-start.
+//
+// Design (add-daemon-install-supervisor):
+//   - Linux: fully generate + install a `systemd --user` unit, daemon-reload,
+//     enable --now.
+//   - macOS (launchd) / Windows: PRINT a correct template + manual steps and
+//     exit 0 without writing (no auto-install off Linux — YAGNI + no native
+//     deps / platform service-manager coupling).
+//   - Rendering is PURE (no IO) so the correctness-critical unit text is unit
+//     testable; install / detect / delegate are thin injected-IO shells,
+//     mirroring the seam in daemon-lifecycle.mjs (all IO overridable per call).
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** The systemd --user unit name (also the launchd label stem). */
+export const SERVICE_NAME = "chorus-daemon";
+
+/** Default IO bundle — overridable per-call for tests (no real disk/process). */
+function defaultIO() {
+  return {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    unlinkSync,
+    writeFileSync,
+    spawnSync,
+    platform: process.platform,
+    home: homedir(),
+  };
+}
+
+/** ~/.config/systemd/user/chorus-daemon.service */
+export function systemdUnitPath(io = defaultIO()) {
+  return join(io.home ?? homedir(), ".config", "systemd", "user", `${SERVICE_NAME}.service`);
+}
+
+/** ~/Library/LaunchAgents/com.chorus.daemon.plist */
+export function launchdPlistPath(io = defaultIO()) {
+  return join(io.home ?? homedir(), "Library", "LaunchAgents", "com.chorus.daemon.plist");
+}
+
+/**
+ * Resolve the absolute path to this CLI's `chorus.mjs` entrypoint (one level up
+ * from cli/). Absolute so the generated unit does not depend on the operator's
+ * cwd or PATH at boot.
+ */
+export function resolveScriptPath() {
+  return join(dirname(dirname(fileURLToPath(import.meta.url))), "chorus.mjs");
+}
+
+/**
+ * Build the argv the SUPERVISED daemon runs — the normal long-lived daemon
+ * (NO `-d`: the supervisor owns the foreground process). Reflects the flags the
+ * operator passed to `install` so the boot-time daemon serves the same paths /
+ * agent / permission posture. Pure.
+ * @param {{ cwds?: string[], agent?: string, chorusOnly?: boolean, scriptPath: string }} spec
+ * @returns {string[]}  e.g. ["/x/chorus.mjs","daemon","--cwd","/a","--cwd","/b"]
+ */
+export function buildServiceArgs(spec) {
+  const args = [spec.scriptPath, "daemon"];
+  for (const cwd of spec.cwds ?? []) {
+    if (typeof cwd === "string" && cwd) args.push("--cwd", cwd);
+  }
+  if (spec.agent) args.push("--agent", spec.agent);
+  if (spec.chorusOnly) args.push("--chorus-only");
+  return args;
+}
+
+/**
+ * Render a `systemd --user` unit for the FOREGROUND daemon. Pure.
+ *
+ * Key correctness properties (the whole point of this module):
+ *   - Type=simple + ExecStart WITHOUT `-d` → systemd owns the node process as
+ *     MainPID; no self-fork, no pidfile.
+ *   - NO ExecStop → default stop is SIGTERM to the unit cgroup, which the
+ *     daemon already handles gracefully. A pidfile-based `ExecStop=chorus
+ *     daemon stop` would be a no-op here (foreground writes no pidfile).
+ *   - TimeoutStopSec gives graceful shutdown room before SIGKILL.
+ *   - PATH is captured so `node`/`claude`/`codex` resolve at boot the same way
+ *     they did in the operator's shell.
+ *
+ * @param {{
+ *   nodePath: string, scriptPath: string, cwds?: string[], agent?: string,
+ *   chorusOnly?: boolean, workingDir: string, home: string, path: string,
+ *   restartSec?: number, timeoutStopSec?: number,
+ * }} spec
+ * @returns {string}
+ */
+export function renderSystemdUnit(spec) {
+  const args = buildServiceArgs({
+    cwds: spec.cwds,
+    agent: spec.agent,
+    chorusOnly: spec.chorusOnly,
+    scriptPath: spec.scriptPath,
+  });
+  // ExecStart: continuation-line the --cwd pairs for readability, matching the
+  // hand-written units operators already have. systemd joins `\`-continued lines.
+  const execStart = [spec.nodePath, ...args].join(" ");
+  const restartSec = spec.restartSec ?? 10;
+  const timeoutStopSec = spec.timeoutStopSec ?? 30;
+  return `[Unit]
+Description=Chorus Daemon (multi-cwd)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# Type=simple: the daemon runs in the FOREGROUND (no -d). systemd owns this
+# process directly as MainPID, so 'systemctl stop' delivers SIGTERM straight to
+# the daemon's graceful-shutdown handler — no self-forked orphan, no pidfile
+# race, no restart storm. Do NOT add -d here: -d self-daemonizes and writes a
+# JSON pidfile systemd cannot parse (that was the boot-loop root cause).
+Type=simple
+WorkingDirectory=${spec.workingDir}
+ExecStart=${execStart}
+Restart=on-failure
+RestartSec=${restartSec}
+# Room for in-flight wakes to drain on SIGTERM before SIGKILL.
+TimeoutStopSec=${timeoutStopSec}
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=${SERVICE_NAME}
+Environment=HOME=${spec.home}
+Environment=PATH=${spec.path}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+/**
+ * Render a macOS launchd LaunchAgent plist for the FOREGROUND daemon. Pure.
+ * RunAtLoad + KeepAlive make launchd start it at login and restart on crash;
+ * ProgramArguments carries node + the daemon argv WITHOUT `-d` (launchd, like
+ * systemd, must own the foreground process). We print this for the operator to
+ * install manually (no auto-write off Linux).
+ * @param {{
+ *   nodePath: string, scriptPath: string, cwds?: string[], agent?: string,
+ *   chorusOnly?: boolean, workingDir: string, home: string, path: string,
+ *   logPath: string,
+ * }} spec
+ * @returns {string}
+ */
+export function renderLaunchdPlist(spec) {
+  const args = buildServiceArgs({
+    cwds: spec.cwds,
+    agent: spec.agent,
+    chorusOnly: spec.chorusOnly,
+    scriptPath: spec.scriptPath,
+  });
+  const programArgs = [spec.nodePath, ...args]
+    .map((a) => `    <string>${xmlEscape(a)}</string>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.chorus.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+${programArgs}
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${xmlEscape(spec.workingDir)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>${xmlEscape(spec.home)}</string>
+    <key>PATH</key>
+    <string>${xmlEscape(spec.path)}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(spec.logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(spec.logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+/** Minimal XML text escaping for plist string values. */
+function xmlEscape(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Detect whether a supervisor already manages the chorus daemon on this host.
+ * Linux only (systemd --user); everything else reports `{ kind: "none" }`.
+ *   - kind: "systemd" with installed (unit file present, `is-enabled` not
+ *     "not-found") and active (`is-active` == "active").
+ *   - kind: "none" otherwise (or when systemctl is unavailable).
+ * Used by the lifecycle subcommands to decide whether to delegate.
+ * @param {object} [io]
+ * @returns {{ kind: "systemd", installed: boolean, active: boolean, unitPath: string } | { kind: "none" }}
+ */
+export function detectSupervisor(io = defaultIO()) {
+  if (io.platform !== "linux") return { kind: "none" };
+  const unitPath = systemdUnitPath(io);
+  const installed = safeExists(unitPath, io);
+  // `is-active` is authoritative for "running under systemd right now". Query it
+  // even when the unit file is absent: a transient/unit-less path still returns
+  // non-active, and we never want to throw here.
+  const activeRes = systemctlUser(["is-active", `${SERVICE_NAME}.service`], io);
+  const active = (activeRes.stdout ?? "").trim() === "active";
+  if (!installed && !active) return { kind: "none" };
+  return { kind: "systemd", installed, active, unitPath };
+}
+
+function safeExists(path, io) {
+  try {
+    return io.existsSync(path);
+  } catch {
+    return false;
+  }
+}
+
+/** Run `systemctl --user <args>`, capturing output. Never throws. */
+export function systemctlUser(args, io = defaultIO()) {
+  try {
+    const r = io.spawnSync("systemctl", ["--user", ...args], { encoding: "utf8" });
+    return { status: r?.status ?? null, stdout: r?.stdout ?? "", stderr: r?.stderr ?? "" };
+  } catch (err) {
+    return { status: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Run `journalctl --user <args>`, capturing output. Never throws. */
+export function journalctlUser(args, io = defaultIO()) {
+  try {
+    const r = io.spawnSync("journalctl", ["--user", ...args], { encoding: "utf8" });
+    return { status: r?.status ?? null, stdout: r?.stdout ?? "", stderr: r?.stderr ?? "" };
+  } catch (err) {
+    return { status: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Install the systemd --user unit (Linux) or return the template to print
+ * (macOS/Windows). On Linux: write the unit, `daemon-reload`, `enable --now`.
+ * All IO injected. Never throws — errors surface in the return shape.
+ * @param {{
+ *   nodePath: string, scriptPath: string, cwds?: string[], agent?: string,
+ *   chorusOnly?: boolean, workingDir: string, path: string,
+ * }} spec
+ * @param {object} [io]
+ * @returns {{
+ *   platform: "linux"|"darwin"|"other",
+ *   installed: boolean,
+ *   unitPath?: string,
+ *   unitText: string,
+ *   steps: string[],
+ *   error?: string,
+ * }}
+ */
+export function installService(spec, io = defaultIO()) {
+  const home = io.home ?? homedir();
+  if (io.platform === "linux") {
+    const unitPath = systemdUnitPath(io);
+    const unitText = renderSystemdUnit({ ...spec, home });
+    const steps = [];
+    try {
+      io.mkdirSync(dirname(unitPath), { recursive: true });
+      io.writeFileSync(unitPath, unitText, { mode: 0o644 });
+      steps.push(`wrote ${unitPath}`);
+      const reload = systemctlUser(["daemon-reload"], io);
+      if (reload.status !== 0) {
+        return { platform: "linux", installed: false, unitPath, unitText, steps, error: `systemctl --user daemon-reload failed: ${reload.stderr.trim() || `exit ${reload.status}`}` };
+      }
+      steps.push("systemctl --user daemon-reload");
+      const enable = systemctlUser(["enable", "--now", `${SERVICE_NAME}.service`], io);
+      if (enable.status !== 0) {
+        return { platform: "linux", installed: false, unitPath, unitText, steps, error: `systemctl --user enable --now failed: ${enable.stderr.trim() || `exit ${enable.status}`}` };
+      }
+      steps.push(`systemctl --user enable --now ${SERVICE_NAME}.service`);
+      return { platform: "linux", installed: true, unitPath, unitText, steps };
+    } catch (err) {
+      return { platform: "linux", installed: false, unitPath, unitText, steps, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+  if (io.platform === "darwin") {
+    const plistPath = launchdPlistPath(io);
+    const unitText = renderLaunchdPlist({ ...spec, home, logPath: join(home, ".chorus", "daemon.log") });
+    return {
+      platform: "darwin",
+      installed: false,
+      unitPath: plistPath,
+      unitText,
+      steps: [
+        `Save the plist below to ${plistPath}`,
+        `launchctl load -w ${plistPath}`,
+        `Check: launchctl list | grep com.chorus.daemon`,
+      ],
+    };
+  }
+  // Windows / other: no first-class service model without native deps. Print the
+  // foreground command an operator can wrap in their supervisor of choice.
+  const cmd = [spec.nodePath, ...buildServiceArgs(spec)].join(" ");
+  return {
+    platform: "other",
+    installed: false,
+    unitText: cmd,
+    steps: [
+      "Automatic service install is only supported on Linux (systemd).",
+      "Run the daemon in the FOREGROUND under your supervisor of choice (NSSM, Task Scheduler, etc.) — do NOT use -d, let the supervisor own the process:",
+      `  ${cmd}`,
+    ],
+  };
+}
+
+/**
+ * Uninstall the systemd --user unit (Linux): `disable --now`, remove the unit
+ * file, `daemon-reload`. macOS/Windows: return manual removal steps. All IO
+ * injected. Never throws.
+ * @param {object} [io]
+ * @returns {{
+ *   platform: "linux"|"darwin"|"other",
+ *   removed: boolean,
+ *   unitPath?: string,
+ *   steps: string[],
+ *   error?: string,
+ * }}
+ */
+export function uninstallService(io = defaultIO()) {
+  if (io.platform === "linux") {
+    const unitPath = systemdUnitPath(io);
+    const steps = [];
+    const existed = safeExists(unitPath, io);
+    // disable --now stops + removes the autostart symlink; tolerate a missing
+    // unit (already gone) so uninstall is idempotent.
+    const disable = systemctlUser(["disable", "--now", `${SERVICE_NAME}.service`], io);
+    if (disable.status === 0) steps.push(`systemctl --user disable --now ${SERVICE_NAME}.service`);
+    try {
+      if (existed) {
+        io.unlinkSync(unitPath);
+        steps.push(`removed ${unitPath}`);
+      }
+    } catch (err) {
+      return { platform: "linux", removed: false, unitPath, steps, error: err instanceof Error ? err.message : String(err) };
+    }
+    systemctlUser(["daemon-reload"], io);
+    steps.push("systemctl --user daemon-reload");
+    return { platform: "linux", removed: existed || disable.status === 0, unitPath, steps };
+  }
+  if (io.platform === "darwin") {
+    const plistPath = launchdPlistPath(io);
+    return {
+      platform: "darwin",
+      removed: false,
+      unitPath: plistPath,
+      steps: [`launchctl unload -w ${plistPath}`, `rm ${plistPath}`],
+    };
+  }
+  return {
+    platform: "other",
+    removed: false,
+    steps: ["Automatic service uninstall is only supported on Linux (systemd). Remove the daemon from your supervisor manually."],
+  };
+}
+
+/**
+ * The absolute node + script paths for a freshly-rendered unit, derived from the
+ * running CLI. Kept here so callers don't reach into process internals.
+ * @returns {{ nodePath: string, scriptPath: string, path: string }}
+ */
+export function resolveServicePaths(env = process.env, execPath = process.execPath) {
+  return {
+    nodePath: execPath,
+    scriptPath: resolveScriptPath(),
+    path: env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+  };
+}

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -46,6 +46,15 @@ import {
   isRunning,
   readLog,
 } from "./daemon-lifecycle.mjs";
+import {
+  detectSupervisor,
+  installService,
+  uninstallService,
+  systemctlUser,
+  journalctlUser,
+  resolveServicePaths,
+  SERVICE_NAME,
+} from "./daemon-service.mjs";
 import { readFileSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -497,6 +506,17 @@ export async function runDaemon(flags = {}, deps = {}) {
     isRunning,
     readLog,
   };
+  // Supervisor (systemd --user) seam — install/uninstall the boot service and
+  // detect/delegate to it from the lifecycle subcommands. Injectable for tests
+  // (no real systemctl / disk). Defaults to the real daemon-service module.
+  const service = deps.service ?? {
+    detectSupervisor,
+    installService,
+    uninstallService,
+    systemctlUser,
+    journalctlUser,
+    resolveServicePaths: () => resolveServicePaths(env),
+  };
   // The preflight dep bundle — built from the same seams runDaemon resolved, so
   // the detach/restart paths run the SAME (injectable) preflight, not the real
   // implementations. Threaded into startDetached so tests can drive it offline.
@@ -504,7 +524,7 @@ export async function runDaemon(flags = {}, deps = {}) {
 
   const action = flags.action ?? "run";
   if (action !== "run") {
-    return handleLifecycleAction(action, { log, errLog, lifecycle, pfDeps });
+    return handleLifecycleAction(action, { log, errLog, lifecycle, service, pfDeps });
   }
 
   // `-d` / --detach: complete any interactive preflight in THIS foreground process
@@ -705,13 +725,82 @@ export async function preflight(ctx) {
 }
 
 /**
- * Dispatch a daemon lifecycle subcommand (stop/status/restart/logs) against the
- * pidfile/logfile-managed background daemon. Each reports clearly when nothing
- * is running (no silent failure). `restart` performs stop-then-detached-start.
+ * Dispatch a daemon lifecycle subcommand. Two families:
+ *   - install / uninstall — manage the boot-autostart supervisor service
+ *     (systemd --user on Linux; a printed template on macOS/Windows).
+ *   - status / stop / restart / logs — when a supervisor unit is installed and
+ *     active, DELEGATE to it (systemctl / journalctl) so a supervised daemon is
+ *     never misreported as "not running"; otherwise operate on the
+ *     pidfile/logfile-managed `-d` background daemon exactly as before.
+ * Each reports clearly (no silent failure). `restart` performs
+ * stop-then-detached-start on the pidfile path.
  * @returns {Promise<number>} exit code
  */
-export async function handleLifecycleAction(action, { log, errLog, lifecycle, pfDeps }) {
+export async function handleLifecycleAction(action, { log, errLog, lifecycle, service, pfDeps }) {
+  // The supervisor seam is optional (older test bundles inject only lifecycle);
+  // a no-op fallback keeps those callers on the pure pidfile path.
+  const svc = service ?? { detectSupervisor: () => ({ kind: "none" }) };
+
+  if (action === "install") {
+    const spec = {
+      ...svc.resolveServicePaths(),
+      cwds: pfDeps?.flags?.cwd ?? [],
+      agent: pfDeps?.flags?.agent,
+      chorusOnly: pfDeps?.flags?.chorusOnly === true,
+      workingDir: process.cwd(),
+    };
+    const r = svc.installService(spec);
+    if (r.installed) {
+      log(`[Chorus] installed and started the daemon service:`);
+      for (const s of r.steps) log(`[Chorus]   ${s}`);
+      log(`[Chorus] it will now start automatically at login. Manage it with:`);
+      log(`[Chorus]   chorus daemon status | stop | restart | logs`);
+      return 0;
+    }
+    if (r.platform === "linux") {
+      // Linux install actually failed (write / systemctl error) — surface it.
+      errLog(`[Chorus] service install failed: ${r.error}`);
+      for (const s of r.steps) errLog(`[Chorus]   (did: ${s})`);
+      return 1;
+    }
+    // macOS / Windows: not auto-installed by design — print the template + steps.
+    log(`[Chorus] automatic install is Linux-only. To run the daemon as a service on this platform:`);
+    for (const s of r.steps) log(`[Chorus]   ${s}`);
+    log("");
+    log(r.unitText);
+    return 0;
+  }
+  if (action === "uninstall") {
+    const r = svc.uninstallService();
+    if (r.platform === "linux") {
+      if (r.error) {
+        errLog(`[Chorus] service uninstall failed: ${r.error}`);
+        return 1;
+      }
+      if (r.removed) {
+        log(`[Chorus] removed the daemon service:`);
+        for (const s of r.steps) log(`[Chorus]   ${s}`);
+      } else {
+        log(`[Chorus] no installed daemon service found (nothing to remove).`);
+      }
+      return 0;
+    }
+    log(`[Chorus] automatic uninstall is Linux-only. To remove the service on this platform:`);
+    for (const s of r.steps) log(`[Chorus]   ${s}`);
+    return 0;
+  }
+
+  // For the control verbs, prefer a live supervisor unit over the pidfile.
+  const sup = svc.detectSupervisor();
+  const supervised = sup.kind === "systemd" && sup.installed;
+
   if (action === "status") {
+    if (supervised) {
+      log(`[Chorus] daemon is managed by systemd (${SERVICE_NAME}.service) — ${sup.active ? "active" : "installed but NOT active"}.`);
+      const r = svc.systemctlUser(["status", "--no-pager", `${SERVICE_NAME}.service`]);
+      if (r.stdout) log(r.stdout.trimEnd());
+      return sup.active ? 0 : 1;
+    }
     const s = lifecycle.isRunning();
     if (s.running) log(`[Chorus] daemon is running (pid ${s.pid}).`);
     else if (s.stale) log(`[Chorus] daemon is NOT running (stale pidfile for pid ${s.pid}).`);
@@ -719,6 +808,15 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, pf
     return 0;
   }
   if (action === "logs") {
+    if (supervised) {
+      const r = svc.journalctlUser(["-u", `${SERVICE_NAME}.service`, "--no-pager", "-n", "200"]);
+      if (r.status !== 0 && !r.stdout) {
+        errLog(`[Chorus] could not read the service journal: ${r.stderr.trim() || `exit ${r.status}`}`);
+        return 1;
+      }
+      log(r.stdout.trimEnd());
+      return 0;
+    }
     const r = lifecycle.readLog();
     if (!r.ok) {
       errLog(`[Chorus] ${r.message}`);
@@ -728,6 +826,16 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, pf
     return 0;
   }
   if (action === "stop") {
+    if (supervised) {
+      const r = svc.systemctlUser(["stop", `${SERVICE_NAME}.service`]);
+      if (r.status === 0) {
+        log(`[Chorus] stopped the daemon service (systemctl --user stop ${SERVICE_NAME}.service).`);
+        log(`[Chorus] note: it is still enabled and will start again at next login. To disable: chorus daemon uninstall`);
+        return 0;
+      }
+      errLog(`[Chorus] failed to stop the service: ${r.stderr.trim() || `exit ${r.status}`}`);
+      return 1;
+    }
     // --force: unconditional pidfile cleanup for stuck states the identity
     // probe cannot resolve. Threaded from the parsed client flags.
     const r = lifecycle.stopDaemon({ force: pfDeps?.flags?.force === true });
@@ -739,6 +847,15 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, pf
     return ok ? 0 : 1;
   }
   if (action === "restart") {
+    if (supervised) {
+      const r = svc.systemctlUser(["restart", `${SERVICE_NAME}.service`]);
+      if (r.status === 0) {
+        log(`[Chorus] restarted the daemon service (systemctl --user restart ${SERVICE_NAME}.service).`);
+        return 0;
+      }
+      errLog(`[Chorus] failed to restart the service: ${r.stderr.trim() || `exit ${r.status}`}`);
+      return 1;
+    }
     const r = lifecycle.stopDaemon();
     log(`[Chorus] ${r.message}`);
     // Start a fresh detached instance regardless of whether one was running.

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -755,6 +755,11 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
       for (const s of r.steps) log(`[Chorus]   ${s}`);
       log(`[Chorus] it will now start automatically at login. Manage it with:`);
       log(`[Chorus]   chorus daemon status | stop | restart | logs`);
+      // A --user service only survives logout with lingering enabled; and a
+      // separately-started `chorus daemon -d` would hold the same paths and make
+      // this service exit-and-retry. Surface both so neither is a silent gotcha.
+      log(`[Chorus] to keep it running after you log out: loginctl enable-linger "$USER"`);
+      log(`[Chorus] if you previously ran 'chorus daemon -d', stop it first ('chorus daemon stop') so it doesn't hold the same paths.`);
       return 0;
     }
     if (r.platform === "linux") {

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -6,8 +6,9 @@ Claude Code on task dispatch — so an assigned agent can act on work even when 
 one is at a terminal.
 
 ```bash
-npx @chorus-aidlc/chorus daemon        # foreground
-npx @chorus-aidlc/chorus daemon -d     # background (detached)
+npx @chorus-aidlc/chorus daemon          # foreground
+npx @chorus-aidlc/chorus daemon -d       # background (detached)
+npx @chorus-aidlc/chorus daemon install  # install as a boot service (Linux) — recommended
 ```
 
 See `chorus daemon --help` and `chorus login --help` for the full flag list.
@@ -146,18 +147,54 @@ chorus daemon stop --force  # force-clean the pidfile when a stuck/unverifiable
   interactive prompt.
 - Every lifecycle subcommand reports clearly when no daemon is running (it never
   fails silently).
+- **Under a supervisor (`chorus daemon install`)** these same subcommands
+  delegate to the service manager instead of the pidfile: `status`/`stop`/
+  `restart`/`logs` drive `systemctl`/`journalctl`. See "Auto-start on boot /
+  login" below — that is the recommended way to run the daemon permanently.
 
 ---
 
-## Auto-start on boot / login (manual setup)
+## Auto-start on boot / login
 
-Chorus does **not** install OS services for you. To start the daemon
-automatically, install one of the templates below by hand. (Windows: use Task
-Scheduler to run `chorus daemon` at logon — not templated here.)
+### Recommended: `chorus daemon install` (Linux)
+
+```bash
+chorus daemon install --cwd ~/proj          # generate the systemd --user unit,
+                                             # daemon-reload, enable --now
+chorus daemon install --cwd ~/a --cwd ~/b    # serve several paths at boot
+chorus daemon uninstall                      # disable + remove the unit
+```
+
+`install` generates a correct `systemd --user` unit and starts it — you never
+hand-write the file. It captures the `--cwd` / `--agent` / `--chorus-only` flags
+you pass, plus absolute `node` / `chorus.mjs` paths and your current `PATH`, and
+runs `systemctl --user daemon-reload` then `enable --now`. After install, the
+lifecycle subcommands **delegate to systemd** automatically — `chorus daemon
+status` / `stop` / `restart` / `logs` drive `systemctl` / `journalctl`, so a
+supervised daemon is never misreported as "not running".
+
+> **Why a command instead of a hand-written unit?** The generated unit runs the
+> daemon in the **foreground** (`Type=simple`, no `-d`) so systemd owns the
+> process directly. Hand-writing a `Type=forking` unit around `chorus daemon -d`
+> looks reasonable but breaks badly: `-d` self-daemonizes (it forks a detached
+> child and writes a JSON pidfile systemd can't parse), so systemd never adopts
+> the child as `MainPID`, marks the service failed, and `Restart=on-failure`
+> retries every few seconds — each retry's `-d` preflight then finds the previous
+> orphan alive via the pidfile and refuses, an infinite restart loop that also
+> pins the server-side connection rows. Let `install` write the right unit.
 
 > Pre-authorize YOLO before enabling auto-start: run `chorus daemon` once on a
-> terminal and confirm the `y/N` prompt (persists `yoloAckAt`), **or** set
-> `--chorus-only` in the template to keep the unattended daemon restricted.
+> terminal and confirm the `y/N` prompt (persists `yoloAckAt`), **or** pass
+> `--chorus-only` to `install` to keep the unattended daemon restricted.
+> `install` also needs credentials the unit can see — run `chorus login` first
+> so they land in `~/.chorus/daemon.json` (not just your shell env).
+
+### Manual setup (macOS, or advanced Linux customization)
+
+`chorus daemon install` is Linux-only; on macOS it prints the plist below for you
+to install by hand, and on Windows it prints the foreground command to wrap in
+Task Scheduler. Use these templates directly if you need to customize the unit.
+
 > Replace `/usr/local/bin/chorus` with your actual install path (`which chorus`).
 
 ### macOS — launchd LaunchAgent
@@ -248,7 +285,9 @@ unattended posture.
 |------|-------------------|
 | Start (foreground) | `chorus daemon` |
 | Start (background) | `chorus daemon -d` |
-| Stop / status / logs / restart | `chorus daemon stop` / `status` / `logs` / `restart` |
+| Install as a boot service (Linux) | `chorus daemon install [--cwd …]` |
+| Remove the boot service | `chorus daemon uninstall` |
+| Stop / status / logs / restart | `chorus daemon stop` / `status` / `logs` / `restart` (delegate to systemd when installed) |
 | Restrict the woken agent | `--chorus-only` / `CHORUS_CHORUS_ONLY=1` |
 | Force full autonomy | `--yolo` / `CHORUS_YOLO=1` (also the default) |
 | Verbose per-wake logs | `--verbose` / `CHORUS_VERBOSE=1` |

--- a/openspec/changes/add-daemon-install-supervisor/.openspec.yaml
+++ b/openspec/changes/add-daemon-install-supervisor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/add-daemon-install-supervisor/README.md
+++ b/openspec/changes/add-daemon-install-supervisor/README.md
@@ -1,0 +1,3 @@
+# add-daemon-install-supervisor
+
+chorus daemon install/uninstall generates a correct supervisor service (systemd --user) so operators never hand-write a broken Type=forking + -d unit

--- a/openspec/changes/add-daemon-install-supervisor/design.md
+++ b/openspec/changes/add-daemon-install-supervisor/design.md
@@ -1,0 +1,88 @@
+# Design — `chorus daemon install`
+
+## Context
+
+`chorus daemon -d` self-daemonizes (detached process-group leader, `unref`,
+JSON pidfile). That is correct for an ad-hoc background run driven by the
+lifecycle subcommands, but wrong under an OS supervisor: a supervisor must own
+the daemon process directly so it can track liveness and deliver a stop signal.
+Running `-d` under `Type=forking` breaks both — systemd cannot find the
+`MainPID`, and the pidfile double-start guard turns `Restart` into a loop.
+
+## Goals
+
+- One command installs a *correct* boot-autostart service; operators never
+  hand-write the unit.
+- The lifecycle verbs keep working after install, delegating to the supervisor
+  instead of the (now-absent) pidfile.
+- Linux-first, fully automated; macOS/Windows get a correct printed template
+  (no native-service coupling, no new dependencies).
+
+## Decisions
+
+### D1 — Foreground `Type=simple`, never `-d`
+
+The generated unit runs `node chorus.mjs daemon <--cwd …>` with **no** `-d`.
+systemd owns the node process as `MainPID`; `systemctl --user stop` sends
+SIGTERM to the cgroup, which the daemon's existing graceful-shutdown handler
+already drains (SSE close + in-flight wake drain) within `TimeoutStopSec`. No
+pidfile is involved, so there is nothing to double-start and no orphan.
+
+### D2 — No `ExecStop`
+
+For a `Type=simple` unit the default stop is SIGTERM to the unit's cgroup —
+exactly what the daemon handles. A pidfile-based `ExecStop=chorus daemon stop`
+would be a no-op here (a foreground daemon writes no pidfile) and is omitted.
+
+### D3 — `Restart=on-failure`, not `always`
+
+`on-failure` restarts on a crash (non-zero exit) but leaves a clean
+`systemctl stop` stopped, so an operator can actually stop the service. This is
+also what prevents the storm: a clean stop does not re-trigger a start.
+
+### D4 — Pure rendering, injected IO
+
+`renderSystemdUnit(spec)` / `renderLaunchdPlist(spec)` are pure string
+functions (all the correctness risk lives in the unit text, so it is unit
+tested exhaustively). `detectSupervisor` / `installService` / `uninstallService`
+and the `systemctlUser` / `journalctlUser` delegators take an injectable `io`
+bundle (`spawnSync`, fs, `platform`, `home`) — the same seam as
+`daemon-lifecycle.mjs`, so every branch is testable on one host with no real
+systemctl or disk.
+
+### D5 — Detection gates delegation
+
+`detectSupervisor(io)` returns `{ kind: "systemd", installed, active }` only on
+Linux when the unit file exists or `systemctl --user is-active` reports active;
+`{ kind: "none" }` otherwise. `handleLifecycleAction` treats
+`kind === "systemd" && installed` as *supervised* and routes
+status/stop/restart/logs to systemctl/journalctl; every other case falls
+through to the pre-existing pidfile path unchanged. The probe never throws
+(spawn failure → `{ kind: "none" }`), so a host without systemd degrades to the
+old behavior.
+
+### D6 — Capture the invoking flags
+
+`install` reads the parsed `--cwd` (array), `--agent`, `--chorus-only` from the
+client flags and bakes them into the unit's `ExecStart`, plus absolute
+node/script paths (`process.execPath`, resolved `chorus.mjs`) and the current
+`PATH` so `node`/`claude`/`codex` resolve at boot as they did in the operator's
+shell.
+
+## Alternatives considered
+
+- **Keep `-d` but add `PIDFile=` to a `Type=forking` unit.** Rejected: the
+  pidfile is JSON (`{"pid":…}`), which systemd cannot parse as a PID, and the
+  self-fork/`unref` still detaches the child out of the service cgroup.
+- **`Restart=always`.** Rejected: makes `systemctl stop` immediately restart,
+  reintroducing an "unkillable" feel.
+- **Auto-install launchd on macOS.** Deferred (YAGNI): the affected + primary
+  deployment target is Linux; a printed, correct plist template covers macOS
+  without coupling the CLI to `launchctl` semantics.
+
+## Risks
+
+- **PATH capture leaks a dev shell's PATH into the unit.** Acceptable: it is a
+  superset that still resolves the needed binaries; documented.
+- **`enable --now` on an already-active identical unit does not restart it.**
+  Correct and intended — install is idempotent and non-disruptive.

--- a/openspec/changes/add-daemon-install-supervisor/proposal.md
+++ b/openspec/changes/add-daemon-install-supervisor/proposal.md
@@ -1,0 +1,57 @@
+# Add `chorus daemon install` — correct supervisor unit generator
+
+## Why
+
+The daemon-background-lifecycle spec previously mandated that OS auto-start be
+**documentation templates only** — the CLI shipped no install command and left
+operators to hand-write a service unit. In practice that produced a
+catastrophic failure on a real AWS host (idea e55ae33a follow-up):
+
+An operator wrote a `systemd --user` unit as `Type=forking` +
+`ExecStart=… chorus daemon … -d` + `Restart=on-failure`. But `chorus daemon -d`
+**self-daemonizes**: it forks a detached, `unref`'d child and writes a JSON
+pidfile that systemd cannot parse as a PID. So systemd never adopts the forked
+child as `MainPID`, treats the service as failed, and `Restart=on-failure`
+retries every few seconds. Each retry's `-d` preflight then finds the previous
+orphan still alive via the pidfile and refuses to start
+(`a daemon is already running`) — an infinite loop. On the affected host the
+restart counter reached **1533** over ~4.5 hours in a single boot, and the
+orphaned daemon simultaneously held the pidfile and the server-side
+DaemonConnection rows for every declared path (`all declared paths are already
+served`), so neither `systemctl stop` (wrong `MainPID`) nor `chorus daemon stop`
+(defeated separately by an NTP false-stale) could kill it.
+
+The root cause is the integration model: a self-daemonizing `-d` process must
+never run under a `Type=forking` supervisor. The fix is to stop asking
+operators to hand-write units and instead **generate a correct one**.
+
+## What Changes
+
+- Add `chorus daemon install [--cwd … --agent … --chorus-only]` and
+  `chorus daemon uninstall`.
+- On Linux, `install` generates a `systemd --user` unit that runs the daemon in
+  the **foreground** (`Type=simple`, no `-d`) so systemd owns the process
+  directly, writes it to `~/.config/systemd/user/chorus-daemon.service`, then
+  `daemon-reload` + `enable --now` (immediate start + boot autostart). It
+  captures the `--cwd`/`--agent`/`--chorus-only` flags the operator passed.
+- On macOS/Windows, `install` prints a correct launchd plist / foreground
+  command template with manual steps and exits 0 without writing (no
+  auto-install off Linux — avoids native-service coupling; matches the
+  cross-platform-no-native-deps constraint).
+- `chorus daemon status`/`stop`/`restart`/`logs` detect an installed supervisor
+  unit and transparently delegate to `systemctl`/`journalctl`; otherwise they
+  fall back to the existing pidfile/logfile logic. A supervised daemon is thus
+  never misreported as "not running".
+- Supersede the "OS auto-start provided as documentation templates only"
+  requirement.
+
+## Capabilities
+
+- `daemon-background-lifecycle` (MODIFIED + ADDED requirements)
+
+## Impact
+
+- CLI-only change: new `cli/daemon-service.mjs` module, wiring in `cli/daemon.mjs`
+  and `cli/client-args.mjs`, docs in `docs/DAEMON.md`. No server, schema, or API
+  changes. The `-d` detached path is unchanged and still available for ad-hoc
+  background runs.

--- a/openspec/changes/add-daemon-install-supervisor/specs/daemon-background-lifecycle/spec.md
+++ b/openspec/changes/add-daemon-install-supervisor/specs/daemon-background-lifecycle/spec.md
@@ -1,0 +1,90 @@
+## REMOVED Requirements
+
+### Requirement: OS auto-start provided as documentation templates only
+
+## ADDED Requirements
+
+### Requirement: Supervisor service install / uninstall
+
+The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to manage the daemon as an OS-supervised, boot-autostart service, replacing the prior documentation-templates-only posture. On Linux the CLI SHALL generate a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, `ExecStart` invoking `chorus daemon` WITHOUT `-d`, so systemd owns the process directly as `MainPID`), SHALL capture the `--cwd` / `--agent` / `--chorus-only` flags passed to `install` plus absolute node and script paths and the current `PATH`, SHALL write it to `~/.config/systemd/user/chorus-daemon.service`, and SHALL then run `systemctl --user daemon-reload` followed by `systemctl --user enable --now` so the service starts immediately and at every login. The generated unit SHALL use `Restart=on-failure` (so a clean stop stays stopped) and SHALL NOT declare an `ExecStop` (a `Type=simple` stop is SIGTERM to the daemon's existing graceful-shutdown handler). The CLI SHALL NOT generate a `Type=forking` unit or an `ExecStart` containing `-d`. On macOS the CLI SHALL print a correct launchd LaunchAgent plist (foreground, `RunAtLoad` + `KeepAlive`, no `-d`) plus manual install steps and exit 0 without writing any file; on other platforms it SHALL print the foreground command to run under the operator's supervisor of choice. `uninstall` on Linux SHALL `disable --now` the unit, remove the unit file, and `daemon-reload`, reporting clearly when nothing was installed; off Linux it SHALL print the manual removal steps. The implementation SHALL be pure Node with no native-binding dependency and SHALL NOT use `shell:true`.
+
+#### Scenario: install generates a correct systemd unit and starts it
+
+- **WHEN** the user runs `chorus daemon install --cwd /a --cwd /b` on a Linux host with `systemctl --user` available
+- **THEN** the CLI writes `~/.config/systemd/user/chorus-daemon.service` with `Type=simple`, an `ExecStart` that runs `chorus daemon --cwd /a --cwd /b` with no `-d`, `Restart=on-failure`, and no `ExecStop`, then runs `daemon-reload` and `enable --now`, so systemd owns the node process as `MainPID` and the service starts at login
+
+#### Scenario: generated unit never self-daemonizes
+
+- **WHEN** the CLI renders the systemd unit for any set of flags
+- **THEN** the `ExecStart` line contains neither `-d` nor `--detach`, and the unit is not `Type=forking` — so systemd tracks the daemon directly and the boot-time restart loop cannot occur
+
+#### Scenario: install surfaces a failure instead of reporting success
+
+- **WHEN** `chorus daemon install` on Linux fails to write the unit or a `systemctl --user daemon-reload` / `enable --now` returns non-zero
+- **THEN** the CLI reports the failure with the underlying error and exits non-zero (no silent failure)
+
+#### Scenario: install off Linux prints a template and does not write
+
+- **WHEN** the user runs `chorus daemon install` on macOS or Windows
+- **THEN** the CLI prints a correct foreground service template (launchd plist on macOS) plus manual steps, writes no service file, and exits 0
+
+#### Scenario: uninstall removes the service or reports nothing to remove
+
+- **WHEN** the user runs `chorus daemon uninstall` on Linux
+- **THEN** the CLI disables and stops the unit, removes the unit file, and reloads systemd — or, when no unit is installed, reports that there was nothing to remove — and off Linux prints the manual removal steps
+
+## MODIFIED Requirements
+
+### Requirement: Lifecycle subcommands stop / status / restart / logs
+
+The CLI SHALL provide `chorus daemon stop`, `chorus daemon status`, `chorus daemon restart`, and `chorus daemon logs`, and SHALL, when an OS-supervised daemon service is installed, delegate these verbs to the service manager rather than the pidfile. When the CLI detects an installed supervisor unit (on Linux, a `systemd --user` `chorus-daemon.service` unit file present or reported active), `status` SHALL report the service state via `systemctl` (exiting non-zero when installed but not active), `stop` SHALL run `systemctl --user stop` (noting the service remains enabled for next login), `restart` SHALL run `systemctl --user restart`, and `logs` SHALL show the service journal via `journalctl --user`; a supervised daemon SHALL NOT be misreported as "not running". When no supervisor unit is detected, the subcommands SHALL operate on the pidfile/logfile managed by the `-d` path exactly as before: `stop` SHALL terminate the recorded daemon process and clean up the pidfile, `status` SHALL report whether the daemon is running (and its pid), `restart` SHALL stop any running instance and start a new detached one, and `logs` SHALL display `~/.chorus/daemon.log`. Whether a recorded pid counts as "running" on the pidfile path SHALL be decided by the identity-verified liveness probe (see "Identity-verified pidfile liveness"). Each subcommand SHALL behave sanely and report visibly when no daemon is running (no silent failure).
+
+#### Scenario: status delegates to the supervisor when installed
+
+- **WHEN** the user runs `chorus daemon status` while a `systemd --user` `chorus-daemon.service` is installed and active
+- **THEN** the CLI reports the daemon is managed by systemd and active (via `systemctl`), and does not consult the pidfile
+
+#### Scenario: stop delegates to the supervisor when installed
+
+- **WHEN** the user runs `chorus daemon stop` while the supervisor unit is installed and active
+- **THEN** the CLI runs `systemctl --user stop chorus-daemon.service`, reports the stop (noting the service is still enabled for next login), and does not signal via the pidfile
+
+#### Scenario: restart delegates to the supervisor when installed
+
+- **WHEN** the user runs `chorus daemon restart` while the supervisor unit is installed
+- **THEN** the CLI runs `systemctl --user restart chorus-daemon.service` and does not start a detached pidfile instance
+
+#### Scenario: logs delegates to the journal when installed
+
+- **WHEN** the user runs `chorus daemon logs` while the supervisor unit is installed
+- **THEN** the CLI shows the service journal via `journalctl --user -u chorus-daemon.service`
+
+#### Scenario: stop terminates the running daemon on the pidfile path
+
+- **WHEN** the user runs `chorus daemon stop` while a `-d` daemon is running and no supervisor unit is installed
+- **THEN** the recorded process is terminated and the pidfile is removed
+
+#### Scenario: stop self-heals a recycled-pid pidfile
+
+- **WHEN** the user runs `chorus daemon stop` while the pidfile's pid has been recycled to a process that fails identity verification and no supervisor unit is installed
+- **THEN** the CLI clears the stale pidfile and reports the cleanup instead of failing with a signal error
+
+#### Scenario: status reports running state on the pidfile path
+
+- **WHEN** the user runs `chorus daemon status` with no supervisor unit installed
+- **THEN** the CLI reports whether a `-d` daemon is running and, if so, its pid
+
+#### Scenario: restart cycles the daemon on the pidfile path
+
+- **WHEN** the user runs `chorus daemon restart` with no supervisor unit installed
+- **THEN** any running instance is stopped and a new detached instance is started
+
+#### Scenario: logs shows the daemon output on the pidfile path
+
+- **WHEN** the user runs `chorus daemon logs` with no supervisor unit installed
+- **THEN** the CLI displays the contents of `~/.chorus/daemon.log`
+
+#### Scenario: lifecycle commands report when nothing is running
+
+- **WHEN** the user runs `stop`, `status`, `restart`, or `logs` with no daemon running and no supervisor unit installed
+- **THEN** the CLI reports the absence clearly and does not fail silently


### PR DESCRIPTION
## Why

Follow-up to the daemon-stop NTP false-stale fix (idea e55ae33a, PR #401). That fix addressed only the **STOP** path. The real-world boot failure the owner hit had a **second, independent cause**: a hand-written systemd unit using `Type=forking` + `ExecStart=… chorus daemon … -d` + `Restart=on-failure`.

`chorus daemon -d` **self-daemonizes** (forks a detached, `unref`'d child and writes a JSON pidfile systemd cannot parse as a PID). So systemd never adopts the forked child as `MainPID`, treats the service as failed, and `Restart=on-failure` retries every ~10s — each retry's `-d` preflight then finds the previous orphan still alive via the pidfile and refuses (`a daemon is already running`), an infinite loop. On the affected host the restart counter reached **NRestarts=1533** in one boot, and the orphan simultaneously held the pidfile *and* the server-side DaemonConnection rows for every cwd (`all declared paths already served`), so neither `systemctl stop` (wrong MainPID) nor `chorus daemon stop` could kill it.

Root cause is the integration model: a self-daemonizing `-d` process must never run under a `Type=forking` supervisor. Fix: stop asking operators to hand-write units — **generate a correct one**.

## What changes

- **`chorus daemon install` / `uninstall`** (new `DAEMON_ACTIONS`). On Linux, `install` generates a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, no `-d`), writes it to `~/.config/systemd/user/chorus-daemon.service`, then `daemon-reload` + `enable --now`. It captures the invoking `--cwd`/`--agent`/`--chorus-only` flags plus absolute node/script paths and `PATH`. On macOS/Windows it prints a correct launchd plist / foreground template and exits 0 without writing.
- **Supervisor delegation**: `status`/`stop`/`restart`/`logs` detect an installed unit and transparently delegate to `systemctl`/`journalctl`; otherwise they fall back to the existing pidfile/logfile path **unchanged**. A supervised daemon is never misreported as "not running".
- New pure, injected-IO module `cli/daemon-service.mjs` (`renderSystemdUnit` / `renderLaunchdPlist` / `detectSupervisor` / `installService` / `uninstallService` / systemctl+journalctl delegators). Rendering is pure (all the correctness risk) → exhaustively unit-tested; install/detect/delegate use the same injectable seam as `daemon-lifecycle.mjs`.
- `docs/DAEMON.md` leads with `install` and explains the `Type=forking` trap; manual templates retained for macOS/advanced use.
- OpenSpec change `add-daemon-install-supervisor` (REMOVE the docs-only auto-start requirement, ADD install/uninstall, MODIFY the lifecycle requirement for delegation). `openspec validate --strict` passes.

The `-d` detached path is unchanged and still available for ad-hoc background runs.

## Testing

- `cli/__tests__/daemon-service.test.mjs` (23 tests): unit rendering (asserts `Type=simple`, no `-d`/`--detach`, no `Type=forking`), `detectSupervisor` across platforms, install/uninstall IO orchestration.
- `cli/__tests__/daemon-lifecycle-dispatch.test.mjs`: supervisor-delegation branch + install/uninstall dispatch; pidfile fallback preserved.
- Full CLI suite green; `npx tsc --noEmit` clean for the CLI change.
- **Live-verified on a real host** (independent session, not inside the daemon): `install` produced a `Type=simple` unit, systemd adopted the node process as `MainPID`, **NRestarts=0**, `stop`/`restart` delegated to systemctl with graceful shutdown, both cwd connections re-registered — **no restart storm, no `already running` / `already served` refusal**.

## Notes

- CLI-only; no server/schema/API changes. Base is `develop` (does not depend on #401 — the `daemon.mjs` change does not touch `processAlive`).
- Chorus task self-verified; independent `task-reviewer` returned **VERDICT: PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)