### PR TITLE
feat(openclaw-plugin): handle daemon stage-advance wake events

### DIFF
--- a/cli/__tests__/openclaw-plugin-wake-parity.test.mjs
+++ b/cli/__tests__/openclaw-plugin-wake-parity.test.mjs
@@ -1,0 +1,84 @@
+// cli/__tests__/openclaw-plugin-wake-parity.test.mjs
+//
+// LOCKSTEP GUARD (sync-openclaw-plugin-wake-events, elaboration q3=a): the CLI daemon
+// (cli/prompts.mjs) and the OpenClaw plugin (packages/openclaw-plugin/src/event-router.ts)
+// each maintain their OWN notification-action router — the plugin is a separately-published
+// npm package that cannot import from cli/, so the two cannot share code and drift apart in
+// practice (the plugin fell 3 wake actions behind the daemon, which this idea fixed).
+//
+// This guard makes the mirror ENFORCED, not merely documented: it asserts the plugin's
+// handled-action set is a SUPERSET of the daemon's wake-action set, minus the two actions the
+// plugin routes OFF the notification switch by design. It lives in cli/__tests__/ because the
+// root vitest.config.ts `include` covers `cli/**/__tests__/**/*.test.mjs` but its `exclude`
+// lists `packages` — so a guard here runs in the main CI and can read BOTH sources.
+//
+// It checks ACTION COVERAGE ONLY, never prompt-text equality: q4=c deliberately lets the two
+// hosts word their prompts differently (the plugin keeps its own voice; no headless preamble).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { WAKE_ACTIONS } from "../prompts.mjs";
+
+// Repo root is two levels up from cli/__tests__/. Resolve the plugin source path from the
+// test file's own URL so the test is CWD-independent (Vitest may run from repo root or cli/).
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROUTER = path.resolve(
+  HERE,
+  "..",
+  "..",
+  "packages",
+  "openclaw-plugin",
+  "src",
+  "event-router.ts",
+);
+
+// Actions the plugin handles OFF the notification `switch` by design, so they are NOT expected
+// as `case` labels in event-router.ts:
+//   - resource_resumed  → arrives on the reverse CONTROL channel (control-handler.ts `resume`),
+//     never as a persisted notification.
+//   - human_instruction → delivered via the `deliver_turn` / pending-turn sweep (daemon-client.ts),
+//     not the notification wake path.
+// Both are the deferred degraded-parity follow-up; excluding them keeps this guard focused on
+// the notification-router coverage invariant.
+const CONTROL_OR_TURN_DELIVERED = new Set(["resource_resumed", "human_instruction"]);
+
+/** Parse the plugin router's handled notification actions from its `case "<action>":` labels. */
+function parsePluginHandledActions(source) {
+  const handled = new Set();
+  const re = /case\s+"([a-z_]+)"\s*:/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    handled.add(m[1]);
+  }
+  return handled;
+}
+
+describe("OpenClaw plugin ↔ daemon wake-action parity (lockstep guard)", () => {
+  const source = readFileSync(PLUGIN_ROUTER, "utf8");
+  const pluginHandled = parsePluginHandledActions(source);
+
+  it("plugin handled-actions ⊇ daemon WAKE_ACTIONS minus the control/turn-delivered actions", () => {
+    const required = [...WAKE_ACTIONS].filter((a) => !CONTROL_OR_TURN_DELIVERED.has(a));
+    const missing = required.filter((a) => !pluginHandled.has(a));
+    expect(
+      missing,
+      `packages/openclaw-plugin/src/event-router.ts is missing wake actions the daemon handles: ${missing.join(", ")}. ` +
+        `Add a case + handler for each (or, if it is delivered off the notification switch, add it to CONTROL_OR_TURN_DELIVERED).`,
+    ).toEqual([]);
+  });
+
+  it("covers the three stage-advance actions this change added", () => {
+    for (const a of ["elaboration_verified", "start_development", "yolo_requested"]) {
+      expect(pluginHandled.has(a), `plugin router should handle "${a}"`).toBe(true);
+    }
+  });
+
+  it("sanity: the parser found the pre-existing handled actions too", () => {
+    // Guards against a broken regex silently making the superset check vacuous.
+    for (const a of ["task_assigned", "mentioned", "proposal_approved"]) {
+      expect(pluginHandled.has(a), `parser should have found "${a}"`).toBe(true);
+    }
+  });
+});

--- a/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/README.md
+++ b/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/README.md
@@ -1,0 +1,3 @@
+# sync-openclaw-plugin-wake-events
+
+Sync OpenClaw plugin event router with daemon: handle elaboration_verified, start_development, yolo_requested

--- a/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/design.md
+++ b/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/design.md
@@ -1,0 +1,113 @@
+# Design: Sync OpenClaw plugin wake events with the daemon
+
+## Context
+
+Two SSE→wake consumers, one server producer:
+
+```
+                     server (single producer)
+   src/services/notification-listener.ts  — activity → notification action
+   src/services/notification-turn.ts       — action → DaemonSessionTurn.trigger
+                     │  same SSE / control stream
+        ┌────────────┴─────────────┐
+        ▼                           ▼
+  CLI daemon                  OpenClaw plugin
+  cli/event-router.mjs        packages/openclaw-plugin/src/event-router.ts
+  cli/prompts.mjs             (in-process runEmbeddedAgent)
+  (headless claude -p)        clientType = "openclaw"
+  clientType = "claude_code"
+```
+
+The plugin cannot `import` from `cli/` (separate npm package, `rootDir: src`). So each path has its own router + prompts. The CLI's authoritative wake-action set is `WAKE_ACTIONS` in `cli/prompts.mjs`; its per-action prompt is `buildPromptBody(n)` in the same file.
+
+### The delta this change closes
+
+`WAKE_ACTIONS` (CLI) currently contains 14 entries. The plugin's `switch` handles 9. Categorizing the 5-action gap:
+
+| Action | CLI has it? | Plugin has it? | This change? |
+|---|---|---|---|
+| `elaboration_verified` | yes (`prompts.mjs`) | **no** → `default` log | **add** |
+| `start_development` | yes | **no** → `default` log | **add** |
+| `yolo_requested` | yes | **no** → `default` log | **add** |
+| `resource_resumed` | yes (control-channel synthetic) | routed elsewhere (control handler `resume`) | out of scope (follow-up) |
+| `human_instruction` | yes (turn-delivered) | routed elsewhere (`deliver_turn` / pending-turn) | out of scope (follow-up) |
+
+`resource_resumed` and `human_instruction` are **not** notification-`switch` actions in either host: the CLI routes them through `dispatchResume` / `dispatchPendingTurn`, and the plugin routes them through its control handler / daemon client. They are deliberately excluded from the notification router's parity set. Only the three stage-advance actions are truly missing from the plugin.
+
+## Goals / Non-Goals
+
+**Goals**
+- The plugin wakes the embedded agent for `elaboration_verified`, `start_development`, `yolo_requested` with an action-appropriate prompt.
+- The two routers cannot silently drift on wake-action coverage again.
+
+**Non-Goals**
+- Byte-identical prompt text between CLI and plugin (owner chose q4=c — keep the plugin's voice).
+- Fixing the two degraded paths, fan-out suppression, or extracting shared code (all deferred).
+
+## Decisions
+
+### D1 — Prompt bodies: contract-equivalent, plugin voice (q4=c)
+
+Each new handler mirrors the CLI prompt's **instructional contract**, written in the plugin's existing style. Concretely (the distinctive instruction each must carry, so a unit test can assert on it):
+
+- **`elaboration_verified`** (idea): "Elaboration for '<title>' was VERIFIED by a human (ideaUuid …, projectUuid …). The idea is now elaborated — do NOT answer elaboration questions. Proceed to WRITE THE PROPOSAL: gather context with chorus_get_idea + chorus_get_elaboration, then author it via the proposal flow (chorus_pm_create_proposal / the proposal skill)." + `buildMentionGuidance(n, "idea")`.
+- **`start_development`** (idea): "A human started DEVELOPMENT for '<title>' (ideaUuid …, projectUuid …). The proposal is approved and unfinished tasks remain. Claim and execute ALL remaining tasks in dependency order via the develop workflow: repeatedly chorus_get_unblocked_tasks → chorus_claim_task → implement → chorus_report_criteria_self_check → chorus_submit_for_verify, looping until NO claimable task remains. Do NOT stop after one task. Leave to_verify tasks and other sessions' tasks untouched. If nothing is claimable, post a brief status comment and end the turn." + `buildMentionGuidance(n, "idea")`.
+- **`yolo_requested`** (idea): "A human requested a YOLO run for '<title>' (ideaUuid …, projectUuid …). Drive this idea all the way to done following the yolo skill (Idea → Elaboration → Proposal → Execute → Verify). First read the current state (chorus_get_idea, chorus_get_elaboration, chorus_get_proposals) and RESUME from whatever phase it is in — do NOT assume a fixed stage. Complete through done + completion report, but do NOT merge or push a pull request without explicit human approval." + `buildMentionGuidance(n, "idea")`.
+
+All three are idea-anchored, so `entityType` is `idea` and the mention guidance targets the idea (matching `handleIdeaClaimed` / `handleElaborationAnswered`). Each uses `contextKeyFor("<action>", n.entityUuid)`.
+
+The `yolo_requested` prompt explicitly preserves the **"yolo never merges"** rule ("do NOT merge or push a pull request without explicit human approval") — the same clause the CLI prompt carries.
+
+### D2 — Wiring: three new `case` arms + three `handle*` methods
+
+Mirror the existing structure exactly. In `fetchAndRoute`'s `switch`, add three arms before `default`:
+
+```ts
+case "elaboration_verified":
+  this.handleElaborationVerified(notification, attribution);
+  break;
+case "start_development":
+  this.handleStartDevelopment(notification, attribution);
+  break;
+case "yolo_requested":
+  this.handleYoloRequested(notification, attribution);
+  break;
+```
+
+Each `handle*` method follows the `handleElaborationAnswered` shape: build `mentionGuidance = this.buildMentionGuidance(n, "idea")`, then `this.wake(message, this.contextKeyFor(action, n.entityUuid), attr)`. Attribution threading (lineage resolve → `{entityType, entityUuid, rootIdeaUuid, directIdeaUuid}`) is already done once in `fetchAndRoute` before the switch — the new handlers receive it unchanged, so idea lineage / session anchoring works identically to the existing idea handlers.
+
+### D3 — Lockstep guard location: `cli/__tests__/` (q3=a)
+
+The root `vitest.config.ts` `include` is `['src/**/__tests__/**/*.test.{ts,tsx}', 'cli/**/__tests__/**/*.test.mjs']` and `exclude` lists `packages`. So:
+
+- Plugin unit tests (`packages/openclaw-plugin/src/__tests__/*.test.ts`) run **only** in the plugin's own Vitest (its `pnpm --filter … test`), not in the root run.
+- A guard that must run in the **main CI** and read **both** files belongs in `cli/__tests__/`.
+
+The guard (`cli/__tests__/openclaw-plugin-wake-parity.test.mjs`) reads both source files as text and asserts set membership:
+
+1. Parse the CLI's `WAKE_ACTIONS` — import `{ WAKE_ACTIONS }` from `../prompts.mjs` (it's an exported `Set`, so no fragile regex).
+2. Parse the plugin's handled actions from `packages/openclaw-plugin/src/event-router.ts` — extract every `case "<action>":` label inside the router `switch` via regex over the file text (the plugin is TS and not importable from an `.mjs` test without a build, so text-scan is the pragmatic, dependency-free approach — and it is exactly what the "did someone add a case?" check needs).
+3. Define `CONTROL_OR_TURN_DELIVERED = new Set(["resource_resumed", "human_instruction"])` — the actions the plugin routes off the notification `switch` by design.
+4. Assert: for every `a` in `WAKE_ACTIONS` not in `CONTROL_OR_TURN_DELIVERED`, the plugin's parsed case-set includes `a`. On failure, list the missing actions so the next drift names itself.
+
+This makes the mirror **enforced**, not merely documented: the next time someone adds a wake action to `cli/prompts.mjs` without porting it to the plugin, the main CI fails with the exact missing action name. It does not assert prompt-text equality (q4=c allows divergent wording) — only action coverage.
+
+> Why not assert the reverse (plugin ⊆ CLI)? The plugin could legitimately handle a host-specific action the CLI never needs. The one-directional superset check (CLI-wake ⊆ plugin-handled, modulo the control/turn set) is the invariant that matters: "every server-minted wake the daemon acts on, the plugin acts on too."
+
+### D4 — Fetch path is unchanged
+
+The plugin's `fetchAndRoute` already fetches the notification, resolves lineage/attribution, and dispatches by action. The three new actions are idea-entity notifications exactly like `elaboration_answered`, so they flow through the existing fetch + attribution code with zero change — only the `switch` gains arms. No change to `sse-listener.ts`, `daemon-client.ts`, `control-handler.ts`, `lineage.ts`, or the SDK shim.
+
+## Risks / Trade-offs
+
+- **Mirror still duplicates prompt text.** Accepted (q3=a): the parity test guards *coverage*, not wording; wording drift is tolerated by design (q4=c). A future idea may extract a shared module (rejected here as too heavy for a 3-case sync).
+- **Text-scan parse of the plugin `switch`.** The regex keys on `case "<label>":`. If someone writes the case label via a computed expression it would miss — but every existing handler uses a string literal, and a new contributor copying the pattern will too. The failure mode is a false *pass* only if a case is added in a non-literal form, which no existing code does; the common drift (a case simply not added) is caught.
+- **No automated e2e.** Real OpenClaw + live SSE verification is manual (q5=a). Mitigated by the unit tests (message + contextKey per action) and the parity guard.
+
+## Migration Plan
+
+None. Additive code + tests only; no schema, no data, no config. Ships in the plugin's next publish (rebuilds `dist` from `src`).
+
+## Open Questions
+
+None — all five elaboration questions are resolved (q1=a scope, q2=a yolo in-scope, q3=a mirror+lockstep, q4=c plugin voice, q5=a unit+parity tests, manual e2e).

--- a/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/proposal.md
+++ b/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: Sync the OpenClaw plugin event router with the daemon's newly-added wake events
+
+## Why
+
+Chorus has **two independent "SSE event → wake an AI agent" paths** that consume the same server-side notification/control stream:
+
+1. **CLI daemon** — `cli/event-router.mjs` + `cli/prompts.mjs`, which turns a notification into a headless `claude -p` subprocess wake.
+2. **OpenClaw plugin** — `packages/openclaw-plugin/src/event-router.ts`, which wakes an in-process embedded agent via `runEmbeddedAgent`.
+
+The two paths share **no runtime code**: the plugin is a separately-published npm package (`@chorus-aidlc/chorus-openclaw-plugin`, `rootDir: src`) that cannot import from the monorepo's `cli/`. Each therefore reimplements its own `switch (notification.action)` router and its own per-action wake prompts. The shared producer is the server (`src/services/notification-listener.ts` mints the notification actions; `src/services/notification-turn.ts` classifies triggers).
+
+The server + CLI have grown three new **stage-advance** wake actions, all shipped:
+
+- `elaboration_verified` — a human clicked **Verify Elaborate** → wake the assigned agent to **write the proposal** (`add-elaboration-verify-wake`, PR merged).
+- `start_development` — a human clicked **Start Development** → wake the agent to **claim + execute all remaining tasks** in dependency order (`add-stage-advance-start-development`, PR merged).
+- `yolo_requested` — a human clicked **Yolo** → wake the agent to **drive the whole idea to done** via the yolo skill, stage-adaptively (`add-stage-advance-yolo`, PR #404 merged to `develop`).
+
+The CLI daemon handles all three (they are in `cli/prompts.mjs`'s `WAKE_ACTIONS` with dedicated prompt bodies). **The OpenClaw plugin's router has not been updated since 2026-06** and handles none of them — they fall through its `switch` to the `default` branch and are logged as `"Unhandled notification action"`. An OpenClaw-hosted agent whose human clicks Verify Elaborate / Start Development / Yolo is therefore **never woken** — the feature silently no-ops for that host.
+
+This change closes that gap for the three fully-missing events, and installs a lockstep guard so the two routers do not drift apart again.
+
+## What Changes
+
+- **Route the three stage-advance wake actions in the plugin.** Add `elaboration_verified`, `start_development`, and `yolo_requested` cases to `ChorusEventRouter`'s `switch (notification.action)` in `packages/openclaw-plugin/src/event-router.ts`, each waking the embedded agent with a dedicated prompt (a new `handle*` method mirroring the existing handlers). Contract-equivalent to the CLI's `cli/prompts.mjs` cases: `elaboration_verified` → "the idea is elaborated, write the proposal (do NOT answer questions)"; `start_development` → "claim and execute ALL remaining tasks in dependency order, loop until none claimable"; `yolo_requested` → "drive the whole idea to done via the yolo skill, resume from whatever phase it is in; never merge/push a PR without human approval."
+
+- **Keep the plugin's existing prompt voice (elaboration decision q4=c).** The new prompt bodies are written in the plugin router's own style (the existing `[Chorus] …` + `buildMentionGuidance` shape), not a byte-for-byte copy of `cli/prompts.mjs`. The CLI's `HEADLESS_PREAMBLE` is subprocess-specific and is **not** ported — the embedded agent needs no headless preamble. Each new wake carries the same `@mention` guidance the sibling idea-rooted handlers already emit, and a `contextKey` of `chorus:<action>:<entityUuid>` for burst dedup, exactly like every existing handler.
+
+- **Install a lockstep parity guard (elaboration decision q3=a — mirror, locked by a test).** Add a repo-level test under `cli/__tests__/` that asserts the plugin router's handled-action set is a superset of the daemon's wake-action set, minus the two actions the plugin deliberately routes elsewhere (`resource_resumed` via the reverse control channel; `human_instruction` via `deliver_turn` / pending-turn delivery). This test lives in `cli/__tests__/` because the root Vitest config includes `cli/**/__tests__` but **excludes** `packages/` — so a guard there runs in the main CI and can read both source files, catching the next drift automatically.
+
+- **Add plugin-side unit tests (elaboration decision q5=a).** Extend `packages/openclaw-plugin/src/__tests__/event-router.test.ts` with the three new actions in the existing `it.each` table (assert the wake message contains the action's distinctive instruction and the `contextKey` is `chorus:<action>:<entityUuid>`). These run in the plugin's own Vitest. Real-machine end-to-end verification (a running OpenClaw host + live SSE) is explicitly handed to a human — it cannot be automated from this headless session.
+
+- **No SDK shim change.** `packages/openclaw-plugin/src/openclaw-sdk.d.ts` already exposes `runEmbeddedAgent` and the wake plumbing; adding notification-action cases is pure routing/prompt work that needs no new runtime capability.
+
+- **No `dist/` edit.** `packages/openclaw-plugin/dist/` is gitignored (0 tracked files) and rebuilt at publish time from `src/` (`prepublishOnly` runs `typecheck` + `test` + `build`). The source edit is authoritative; the build step regenerates `dist`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `openclaw-event-bridge`: Extend the plugin's event-routing contract with a requirement that the router handles the three stage-advance wake actions (`elaboration_verified`, `start_development`, `yolo_requested`) by waking the embedded agent with an action-appropriate prompt, and a requirement that the plugin's handled-action set stays in lockstep with the daemon's wake-action set (superset minus the two control/turn-delivered actions).
+
+## Impact
+
+- **Schema**: **zero migrations.** No model, enum, or column touched. The server already mints all three actions.
+- **Plugin code** (`packages/openclaw-plugin/`, separately-published npm package):
+  - `src/event-router.ts` — three new `case` arms in `fetchAndRoute`'s `switch`, and three new private `handle*` methods.
+  - `src/__tests__/event-router.test.ts` — three new rows in the routing `it.each` table.
+- **Repo code** (`cli/`, main package — CI-run):
+  - `cli/__tests__/openclaw-plugin-wake-parity.test.mjs` (new) — the lockstep guard.
+- **Server code**: none — the notification actions and daemon triggers already exist.
+- **Docs**: none required. The daemon-vs-plugin wake parity is captured by the new spec requirement and the parity test; no MCP tool, skill, or `docs/MCP_TOOLS.md` change (the wake actions are server-minted, not agent-callable tools). No user-facing UI, so no `design.pen` change.
+- **Runtime**: no new dependencies, no migrations, no new permission bit, no new MCP tool.
+- **Backward compat**: fully additive. The nine existing plugin handlers are unchanged. Actions the plugin still does not route (`resource_resumed`, `human_instruction`) are unchanged — they are handled on the control / turn-delivery paths, not the notification `switch`, and remain out of scope here.
+
+## Out of Scope
+
+- The two **degraded** (not missing) parity gaps, deferred to a follow-up idea by explicit owner decision (elaboration q1=a):
+  - `resource_resumed` crash-vs-user (`resumedFrom`) prompt distinction in the plugin's control/resume path.
+  - The autonomous `deliver_turn` split (the plugin currently rebuilds every pending turn as a `human_instruction` prompt; the CLI re-reads the notification for directed autonomous turns).
+- Directed-delivery broadcast suppression in the plugin (`targetConnectionUuid` / `suppressWake`), also a follow-up.
+- Extracting a shared framework-agnostic action→prompt module, or build-time generation from a single source (elaboration q3 rejected b/c). This change keeps the mirror approach and guards it with a test.
+- Any change to how a proposal is written, how tasks are executed, or how the yolo pipeline runs — the new wakes reuse the existing flows exactly as the CLI's do.

--- a/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/specs/openclaw-event-bridge/spec.md
+++ b/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/specs/openclaw-event-bridge/spec.md
@@ -1,0 +1,57 @@
+# openclaw-event-bridge Specification
+
+## ADDED Requirements
+
+### Requirement: The plugin SHALL route the daemon's stage-advance wake actions to an embedded-agent wake
+
+The OpenClaw plugin's event router SHALL handle the three human-initiated stage-advance notification actions — `elaboration_verified`, `start_development`, and `yolo_requested` — by waking the embedded agent with an action-appropriate prompt, rather than letting them fall through to the unhandled-action default. Each wake SHALL be idea-anchored (the notification entity is the idea), SHALL carry a `contextKey` derived from the action and the entity UUID so duplicate deliveries collapse to one wake, and SHALL include `@mention` guidance addressing the actor. The prompt wording MAY differ from the CLI daemon's (`cli/prompts.mjs`) wording, but SHALL preserve each action's instructional contract:
+
+- `elaboration_verified` SHALL instruct the agent that the idea is now elaborated, that it MUST NOT answer elaboration questions, and that it SHALL write the proposal via the existing proposal flow.
+- `start_development` SHALL instruct the agent to claim and execute ALL remaining tasks of the idea's approved proposal in dependency order, looping until no claimable task remains, and SHALL NOT instruct it to stop after a single task.
+- `yolo_requested` SHALL instruct the agent to drive the whole idea to done via the yolo skill, resuming from the idea's current phase, and SHALL instruct it NOT to merge or push a pull request without explicit human approval.
+
+#### Scenario: elaboration_verified wakes the agent to write the proposal
+
+- **GIVEN** the plugin receives a `new_notification` SSE event whose notification action is `elaboration_verified` for an idea
+- **WHEN** the router dispatches it
+- **THEN** it MUST wake the embedded agent with a message instructing it to write the proposal (not to answer elaboration questions)
+- **AND** the wake's `contextKey` MUST be derived from the `elaboration_verified` action and the idea UUID
+
+#### Scenario: start_development wakes the agent to execute all remaining tasks
+
+- **GIVEN** the plugin receives a `new_notification` SSE event whose notification action is `start_development` for an idea
+- **WHEN** the router dispatches it
+- **THEN** it MUST wake the embedded agent with a message instructing it to claim and execute all remaining tasks in dependency order, looping until none are claimable
+- **AND** the wake's `contextKey` MUST be derived from the `start_development` action and the idea UUID
+
+#### Scenario: yolo_requested wakes the agent to drive the idea to done
+
+- **GIVEN** the plugin receives a `new_notification` SSE event whose notification action is `yolo_requested` for an idea
+- **WHEN** the router dispatches it
+- **THEN** it MUST wake the embedded agent with a message instructing it to drive the idea to done via the yolo skill, resuming from the idea's current phase
+- **AND** the message MUST instruct the agent not to merge or push a pull request without explicit human approval
+- **AND** the wake's `contextKey` MUST be derived from the `yolo_requested` action and the idea UUID
+
+#### Scenario: A stage-advance action is no longer treated as unhandled
+
+- **WHEN** the router dispatches any of `elaboration_verified`, `start_development`, or `yolo_requested`
+- **THEN** it MUST NOT log the action as an unhandled notification action
+- **AND** it MUST produce exactly one wake for that notification
+
+### Requirement: The plugin's handled wake actions SHALL stay in lockstep with the daemon's wake actions
+
+A repository-level test SHALL enforce that the set of notification actions the OpenClaw plugin's event router handles is a superset of the daemon's wake-action set (`WAKE_ACTIONS` exported from `cli/prompts.mjs`), excluding only the actions that are delivered off the notification `switch` by design — the reverse-control-channel resume (`resource_resumed`) and the turn-delivered instruction (`human_instruction`). The test SHALL live where the repository's main test runner collects it (a location the root Vitest `include` covers and its `packages` exclude does not), so it runs in the main CI and can read both the daemon and plugin sources. When a wake action exists in the daemon set (outside the excluded set) but is not handled by the plugin router, the test SHALL fail and SHALL name the missing action(s).
+
+#### Scenario: A new daemon wake action not ported to the plugin fails the guard
+
+- **GIVEN** the daemon's `WAKE_ACTIONS` gains a new action that is not in the control/turn-delivered exclusion set
+- **WHEN** that action is not added to the plugin router's handled cases
+- **THEN** the lockstep test MUST fail
+- **AND** the failure MUST identify the missing action by name
+
+#### Scenario: The current stage-advance actions satisfy the guard
+
+- **GIVEN** the plugin router handles `elaboration_verified`, `start_development`, and `yolo_requested`
+- **WHEN** the lockstep test runs
+- **THEN** it MUST pass
+- **AND** it MUST NOT require the plugin to handle `resource_resumed` or `human_instruction` (which are delivered off the notification switch)

--- a/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/tasks.md
+++ b/openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Sync OpenClaw plugin wake events with the daemon
+
+## 1. Route the three stage-advance wake actions in the plugin
+- [ ] 1.1 Add `elaboration_verified`, `start_development`, `yolo_requested` cases to `ChorusEventRouter`'s `switch` in `packages/openclaw-plugin/src/event-router.ts`, plus a `handleElaborationVerified` / `handleStartDevelopment` / `handleYoloRequested` method each, following the existing `handleElaborationAnswered` shape (idea-anchored, `buildMentionGuidance(n, "idea")`, `contextKeyFor(action, n.entityUuid)`). Preserve each action's instructional contract (write-proposal / execute-all-tasks / yolo-to-done-never-merge) in the plugin's own prompt voice; do not port the CLI `HEADLESS_PREAMBLE`.
+
+## 2. Plugin-side unit tests
+- [ ] 2.1 Extend `packages/openclaw-plugin/src/__tests__/event-router.test.ts` — add the three actions to the routing `it.each` table asserting the wake message carries the action's distinctive instruction and the `contextKey` is `chorus:<action>:<entityUuid>`; run the plugin Vitest green.
+
+## 3. Lockstep parity guard (repo CI)
+- [ ] 3.1 Add `cli/__tests__/openclaw-plugin-wake-parity.test.mjs` asserting the plugin router's handled-action set ⊇ `WAKE_ACTIONS` (from `cli/prompts.mjs`) minus `{resource_resumed, human_instruction}`; failure names the missing action(s). Run the root Vitest green.

--- a/openspec/specs/openclaw-event-bridge/spec.md
+++ b/openspec/specs/openclaw-event-bridge/spec.md
@@ -140,3 +140,57 @@ The OpenClaw plugin's SSE listener SHALL expose an `onControl` callback and SHAL
 - **WHEN** the control handler receives a verified `interrupt`, `resume`, or `deliver_turn` command for its own connection
 - **THEN** it MUST route `interrupt` to abort the matching in-flight run, `resume` to re-dispatch the entity's wake, and `deliver_turn` to the connection-scoped pending-turns sweep
 
+### Requirement: The plugin SHALL route the daemon's stage-advance wake actions to an embedded-agent wake
+
+The OpenClaw plugin's event router SHALL handle the three human-initiated stage-advance notification actions — `elaboration_verified`, `start_development`, and `yolo_requested` — by waking the embedded agent with an action-appropriate prompt, rather than letting them fall through to the unhandled-action default. Each wake SHALL be idea-anchored (the notification entity is the idea), SHALL carry a `contextKey` derived from the action and the entity UUID so duplicate deliveries collapse to one wake, and SHALL include `@mention` guidance addressing the actor. The prompt wording MAY differ from the CLI daemon's (`cli/prompts.mjs`) wording, but SHALL preserve each action's instructional contract:
+
+- `elaboration_verified` SHALL instruct the agent that the idea is now elaborated, that it MUST NOT answer elaboration questions, and that it SHALL write the proposal via the existing proposal flow.
+- `start_development` SHALL instruct the agent to claim and execute ALL remaining tasks of the idea's approved proposal in dependency order, looping until no claimable task remains, and SHALL NOT instruct it to stop after a single task.
+- `yolo_requested` SHALL instruct the agent to drive the whole idea to done via the yolo skill, resuming from the idea's current phase, and SHALL instruct it NOT to merge or push a pull request without explicit human approval.
+
+#### Scenario: elaboration_verified wakes the agent to write the proposal
+
+- **GIVEN** the plugin receives a `new_notification` SSE event whose notification action is `elaboration_verified` for an idea
+- **WHEN** the router dispatches it
+- **THEN** it MUST wake the embedded agent with a message instructing it to write the proposal (not to answer elaboration questions)
+- **AND** the wake's `contextKey` MUST be derived from the `elaboration_verified` action and the idea UUID
+
+#### Scenario: start_development wakes the agent to execute all remaining tasks
+
+- **GIVEN** the plugin receives a `new_notification` SSE event whose notification action is `start_development` for an idea
+- **WHEN** the router dispatches it
+- **THEN** it MUST wake the embedded agent with a message instructing it to claim and execute all remaining tasks in dependency order, looping until none are claimable
+- **AND** the wake's `contextKey` MUST be derived from the `start_development` action and the idea UUID
+
+#### Scenario: yolo_requested wakes the agent to drive the idea to done
+
+- **GIVEN** the plugin receives a `new_notification` SSE event whose notification action is `yolo_requested` for an idea
+- **WHEN** the router dispatches it
+- **THEN** it MUST wake the embedded agent with a message instructing it to drive the idea to done via the yolo skill, resuming from the idea's current phase
+- **AND** the message MUST instruct the agent not to merge or push a pull request without explicit human approval
+- **AND** the wake's `contextKey` MUST be derived from the `yolo_requested` action and the idea UUID
+
+#### Scenario: A stage-advance action is no longer treated as unhandled
+
+- **WHEN** the router dispatches any of `elaboration_verified`, `start_development`, or `yolo_requested`
+- **THEN** it MUST NOT log the action as an unhandled notification action
+- **AND** it MUST produce exactly one wake for that notification
+
+### Requirement: The plugin's handled wake actions SHALL stay in lockstep with the daemon's wake actions
+
+A repository-level test SHALL enforce that the set of notification actions the OpenClaw plugin's event router handles is a superset of the daemon's wake-action set (`WAKE_ACTIONS` exported from `cli/prompts.mjs`), excluding only the actions that are delivered off the notification `switch` by design — the reverse-control-channel resume (`resource_resumed`) and the turn-delivered instruction (`human_instruction`). The test SHALL live where the repository's main test runner collects it (a location the root Vitest `include` covers and its `packages` exclude does not), so it runs in the main CI and can read both the daemon and plugin sources. When a wake action exists in the daemon set (outside the excluded set) but is not handled by the plugin router, the test SHALL fail and SHALL name the missing action(s).
+
+#### Scenario: A new daemon wake action not ported to the plugin fails the guard
+
+- **GIVEN** the daemon's `WAKE_ACTIONS` gains a new action that is not in the control/turn-delivered exclusion set
+- **WHEN** that action is not added to the plugin router's handled cases
+- **THEN** the lockstep test MUST fail
+- **AND** the failure MUST identify the missing action by name
+
+#### Scenario: The current stage-advance actions satisfy the guard
+
+- **GIVEN** the plugin router handles `elaboration_verified`, `start_development`, and `yolo_requested`
+- **WHEN** the lockstep test runs
+- **THEN** it MUST pass
+- **AND** it MUST NOT require the plugin to handle `resource_resumed` or `human_instruction` (which are delivered off the notification switch)
+

--- a/packages/openclaw-plugin/src/__tests__/event-router.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/event-router.test.ts
@@ -104,6 +104,11 @@ describe("ChorusEventRouter.dispatch", () => {
     ["task_reopened", "task", "reopened"],
     ["elaboration_requested", "idea", "Elaboration requested"],
     ["elaboration_answered", "idea", "Elaboration answers submitted"],
+    // Stage-advance wakes (sync-openclaw-plugin-wake-events): mirror the daemon's
+    // cli/prompts.mjs contracts. The needle is the distinctive instruction of each.
+    ["elaboration_verified", "idea", "WRITE THE PROPOSAL"],
+    ["start_development", "idea", "ALL remaining tasks"],
+    ["yolo_requested", "idea", "yolo skill"],
   ])("routes action '%s' to a wake containing %j", async (action, entityType, needle) => {
     const { router } = build({
       chorus_get_notifications: {

--- a/packages/openclaw-plugin/src/event-router.ts
+++ b/packages/openclaw-plugin/src/event-router.ts
@@ -179,6 +179,20 @@ export class ChorusEventRouter {
         case "elaboration_answered":
           this.handleElaborationAnswered(notification, attribution);
           break;
+        // Stage-advance wakes (add-elaboration-verify-wake / add-stage-advance-*): a human
+        // clicked "Verify Elaborate" / "Start Development" / "Yolo" on the idea panel. These
+        // mirror the daemon's cli/prompts.mjs WAKE_ACTIONS cases — see the lockstep parity
+        // guard in cli/__tests__/openclaw-plugin-wake-parity.test.mjs, which fails if the
+        // daemon adds a wake action this switch does not handle.
+        case "elaboration_verified":
+          this.handleElaborationVerified(notification, attribution);
+          break;
+        case "start_development":
+          this.handleStartDevelopment(notification, attribution);
+          break;
+        case "yolo_requested":
+          this.handleYoloRequested(notification, attribution);
+          break;
         case "proposal_rejected":
           this.handleProposalRejected(notification, attribution);
           break;
@@ -313,6 +327,74 @@ export class ChorusEventRouter {
       `After reviewing, @mention the answerer to ask if they have any further questions before you proceed.\n` +
       mentionGuidance,
       this.contextKeyFor("elaboration_answered", n.entityUuid),
+      attr
+    );
+  }
+
+  /**
+   * A human clicked "Verify Elaborate" (add-elaboration-verify-wake). The elaboration
+   * is DONE and the idea is now `elaborated` — this is NOT a request to answer questions.
+   * The agent's job on this wake is to WRITE THE PROPOSAL via the existing proposal flow,
+   * anchored to the idea's session that ran elaboration. Mirrors the daemon's
+   * cli/prompts.mjs `elaboration_verified` case (plugin voice; no headless preamble).
+   */
+  private handleElaborationVerified(n: NotificationDetail, attr: WakeAttribution): void {
+    const mentionGuidance = this.buildMentionGuidance(n, "idea");
+
+    this.wake(
+      `[Chorus] Elaboration for idea '${n.entityTitle}' was VERIFIED by a human (ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). ` +
+      `The idea is now elaborated — do NOT answer elaboration questions. Proceed to WRITE THE PROPOSAL: gather context with ` +
+      `chorus_get_idea and chorus_get_elaboration, then author the proposal via the existing proposal flow ` +
+      `(chorus_pm_create_proposal / the proposal skill).\n${mentionGuidance}`,
+      this.contextKeyFor("elaboration_verified", n.entityUuid),
+      attr
+    );
+  }
+
+  /**
+   * A human clicked "Start Development" (add-stage-advance-start-development). The idea's
+   * proposal is approved and unfinished tasks remain. The agent's job on this wake is the
+   * WHOLE remaining execute stage — loop over every claimable task until none remain, never
+   * stopping after a single task. Mirrors the daemon's cli/prompts.mjs `start_development`
+   * case (plugin voice; no headless preamble).
+   */
+  private handleStartDevelopment(n: NotificationDetail, attr: WakeAttribution): void {
+    const mentionGuidance = this.buildMentionGuidance(n, "idea");
+
+    this.wake(
+      `[Chorus] A human started DEVELOPMENT for idea '${n.entityTitle}' (ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). ` +
+      `The idea's proposal is approved and unfinished tasks remain. Claim and execute ALL remaining tasks of that proposal in ` +
+      `dependency order, following the develop workflow: repeatedly find claimable tasks (chorus_get_unblocked_tasks with ` +
+      `projectUuid: "${n.projectUuid}"), claim one (chorus_claim_task), implement it, self-check its acceptance criteria ` +
+      `(chorus_report_criteria_self_check), and submit it (chorus_submit_for_verify) — then loop until NO claimable task remains. ` +
+      `Do NOT stop after one task. Leave tasks already in to_verify (awaiting human verification) and tasks claimed by other ` +
+      `sessions untouched. If nothing is claimable, post a brief status comment on the idea and end the turn.\n${mentionGuidance}`,
+      this.contextKeyFor("start_development", n.entityUuid),
+      attr
+    );
+  }
+
+  /**
+   * A human clicked "Yolo" (add-stage-advance-yolo). Unlike start_development (always the
+   * execute stage), this wake can land at ANY incomplete stage, so the prompt does NOT
+   * hard-code a stage — it points the agent at the yolo skill and lets it self-select the
+   * entry phase from the idea's current state. Honors the "yolo never merges" rule: drive
+   * through done + completion report, but never merge/push a PR without explicit human
+   * approval. Mirrors the daemon's cli/prompts.mjs `yolo_requested` case (plugin voice; no
+   * headless preamble).
+   */
+  private handleYoloRequested(n: NotificationDetail, attr: WakeAttribution): void {
+    const mentionGuidance = this.buildMentionGuidance(n, "idea");
+
+    this.wake(
+      `[Chorus] A human requested a YOLO run for idea '${n.entityTitle}' (ideaUuid: ${n.entityUuid}, projectUuid: ${n.projectUuid}). ` +
+      `Drive this idea all the way to done following the yolo skill (the full-auto AI-DLC pipeline: Idea → Elaboration → Proposal → ` +
+      `Execute → Verify). First read the idea's current state with chorus_get_idea (plus chorus_get_elaboration / ` +
+      `chorus_get_proposals as needed) and RESUME from whatever phase it is already in — do NOT assume a fixed stage: if ` +
+      `elaboration isn't resolved, self-elaborate then write the proposal; if a proposal is approved with open tasks, execute them; ` +
+      `and so on. Complete the pipeline through the final done state and completion report, but do NOT merge or push a pull request ` +
+      `without explicit human approval.\n${mentionGuidance}`,
+      this.contextKeyFor("yolo_requested", n.entityUuid),
       attr
     );
   }


### PR DESCRIPTION
## Summary
Syncs the OpenClaw plugin's SSE event router with the CLI daemon's newly-added human-initiated **stage-advance** wake actions. The plugin previously handled 9 of the daemon's wake actions but dropped `elaboration_verified`, `start_development`, and `yolo_requested` to its "Unhandled notification action" default — so an OpenClaw-hosted agent was **never woken** when a human clicked Verify Elaborate / Start Development / Yolo. This adds those three, and installs a lockstep guard so the two hand-mirrored routers can't drift on coverage again.

Implements idea `8f037434` (OpenSpec change `sync-openclaw-plugin-wake-events`).

## Changes
| File | Change |
|------|--------|
| `packages/openclaw-plugin/src/event-router.ts` | 3 new `switch` cases + `handleElaborationVerified` / `handleStartDevelopment` / `handleYoloRequested` methods. Plugin's own prompt voice (no `HEADLESS_PREAMBLE`), mirroring the daemon's `cli/prompts.mjs` contracts. |
| `packages/openclaw-plugin/src/__tests__/event-router.test.ts` | 3 new rows in the routing `it.each` table (needle + `contextKey` per action). |
| `cli/__tests__/openclaw-plugin-wake-parity.test.mjs` | **New** lockstep guard: asserts plugin-handled actions ⊇ daemon `WAKE_ACTIONS` minus `{resource_resumed, human_instruction}` (delivered off the notification switch by design); fails-and-names on drift. Lives in `cli/__tests__` so the root Vitest (which excludes `packages/`) runs it in CI. |
| `openspec/specs/openclaw-event-bridge/spec.md` + `openspec/changes/archive/2026-07-06-sync-openclaw-plugin-wake-events/` | OpenSpec change authored + archived; 2 new requirements merged into the capability spec. |

## Prompt contracts (mirror the daemon)
- `elaboration_verified` → idea is elaborated; **do NOT answer questions, write the proposal**.
- `start_development` → claim + execute **ALL** remaining tasks in dependency order, loop until none claimable.
- `yolo_requested` → drive the idea to done via the yolo skill, resume from current phase, **do NOT merge/push a PR without explicit human approval**.

## Out of scope (deferred follow-up)
The two *degraded* parity paths — `resource_resumed` crash-vs-user prompt, autonomous `deliver_turn` split — plus `targetConnectionUuid`/`suppressWake` fan-out suppression.

## Test plan
- [x] Plugin Vitest: **22 passed** (was 19; +3 rows, no regression) — `packages/openclaw-plugin` `npx vitest run src/__tests__/event-router.test.ts`
- [x] Parity guard: **3 passed** under root runner — `npx vitest run cli/__tests__/openclaw-plugin-wake-parity.test.mjs`
- [x] Guard proven to bite: temporarily removing the `yolo_requested` case → failed naming `yolo_requested` → reverted
- [x] `tsc --noEmit` clean in the plugin package
- [ ] Manual real-machine e2e (running OpenClaw host + live SSE, clicking the three buttons) — handed to a human

🤖 Generated with [Claude Code](https://claude.com/claude-code)