### PR TITLE
fix(idea-panel): declutter action row — icon-ify Reassign + Yolo with shadcn Tooltip

### DIFF
--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -23,6 +23,12 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { PresenceIndicator } from "@/components/ui/presence-indicator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
 import { ElaborationView } from "./elaboration-view";
 import { ProposalView, type ProposalData } from "./proposal-view";
@@ -906,14 +912,27 @@ export function IdeaDetailPanel({
             ) : (
               <div className="flex items-center justify-between gap-3">
                 {canAssign && (
-                  <Button
-                    variant="outline"
-                    className="shrink-0 border-[#E5E0D8] rounded-md px-4 py-2 text-[13px] font-medium"
-                    onClick={() => setShowAssignModal(true)}
-                  >
-                    <User className="mr-2 h-4 w-4" />
-                    {idea.assignee ? t("common.reassign") : t("common.assign")}
-                  </Button>
+                  // Icon-only (Option C — declutter the action row): the (re)assign
+                  // label rides a shadcn Tooltip (+ aria-label for a11y) so the
+                  // stage primary CTA stays the only full-text button.
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="shrink-0 h-8 w-8 border-[#E5E0D8]"
+                          onClick={() => setShowAssignModal(true)}
+                          aria-label={idea.assignee ? t("common.reassign") : t("common.assign")}
+                        >
+                          <User className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {idea.assignee ? t("common.reassign") : t("common.assign")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )}
                 <div className="flex-1 min-w-0 flex flex-wrap items-center gap-2">
                   {/* Verify Elaborate — human "elaboration confirmed, agent

--- a/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
@@ -22,6 +22,12 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { AssigneeInstanceLine } from "@/components/agent-presence";
 import { isAssignedToActor, isAgentAssignee } from "@/lib/assignee-identity";
 import { UnifiedComments } from "@/components/unified-comments";
@@ -643,14 +649,27 @@ export function IdeaDetailPanel({
             ) : (
               <>
                 {canAssign && (
-                  <Button
-                    variant="outline"
-                    className="shrink-0 border-[#E5E0D8] rounded-md px-4 py-2 text-[13px] font-medium"
-                    onClick={() => setShowAssignModal(true)}
-                  >
-                    <User className="mr-2 h-4 w-4" />
-                    {idea.assignee ? t("common.reassign") : t("common.assign")}
-                  </Button>
+                  // Icon-only (Option C — declutter the action row): the (re)assign
+                  // label rides a shadcn Tooltip (+ aria-label for a11y) so the
+                  // stage primary CTA stays the only full-text button.
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="shrink-0 h-8 w-8 border-[#E5E0D8]"
+                          onClick={() => setShowAssignModal(true)}
+                          aria-label={idea.assignee ? t("common.reassign") : t("common.assign")}
+                        >
+                          <User className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {idea.assignee ? t("common.reassign") : t("common.assign")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )}
                 {/* Middle area: help text or action buttons */}
                 <div className="flex-1 min-w-0 flex flex-wrap items-center gap-2">

--- a/src/components/__tests__/yolo-button.test.tsx
+++ b/src/components/__tests__/yolo-button.test.tsx
@@ -15,6 +15,24 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+// The Yolo trigger is now wrapped in a shadcn (Radix) Tooltip, whose
+// PopperContent uses ResizeObserver — absent from jsdom. Without this stub,
+// opening the tooltip (focus/click) throws unhandled errors that Vitest flags
+// as potential false positives. Stub the browser APIs Radix's popper needs.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+if (typeof Element !== "undefined" && !Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+}
+
 const { yoloRequestedActionMock, toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
   yoloRequestedActionMock: vi.fn(),
   toastSuccessMock: vi.fn(),

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -26,6 +26,12 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
 import {
   canRequestYolo,
@@ -125,15 +131,28 @@ export function YoloButton({
   return (
     <>
       <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <AlertDialogTrigger asChild>
-          <Button
-            className="bg-[#7F5AF0] hover:bg-[#6D48DE] text-white"
-            disabled={!enabled}
-          >
-            <Rocket className="mr-2 h-4 w-4" />
-            {t("button")}
-          </Button>
-        </AlertDialogTrigger>
+        {/* Icon-only (Option C — declutter the action row): the label rides a
+            shadcn Tooltip (+ aria-label for a11y) so the row stays compact while
+            the stage primary CTA keeps its full-text button. Both TooltipTrigger
+            and AlertDialogTrigger are asChild, so Radix merges their props onto
+            the single Button. */}
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <AlertDialogTrigger asChild>
+                <Button
+                  size="icon"
+                  className="h-8 w-8 bg-[#7F5AF0] hover:bg-[#6D48DE] text-white"
+                  disabled={!enabled}
+                  aria-label={t("button")}
+                >
+                  <Rocket className="h-4 w-4" />
+                </Button>
+              </AlertDialogTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{t("button")}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("confirmTitle")}</AlertDialogTitle>


### PR DESCRIPTION
## Summary
Follow-up UI polish for the Yolo button feature (#404). The idea-detail action row stacked three full-text buttons (Reassign + Verify Elaborate + Yolo) during the elaborating stage and read as too crowded. This demotes the two secondary actions to icon-only buttons, keeping only the stage primary CTA (Verify Elaborate / Start Development) as full text.

- **Reassign** → icon-only in both idea-detail panels.
- **Yolo** → icon-only in `yolo-button.tsx`.
- Both carry their label via the shadcn `<Tooltip>` component (matching the `resource-graph.tsx` idiom) + `aria-label` for accessibility — **not** the native `title` attribute (per CLAUDE.md's shadcn-only UI rule).
- The Yolo button nests `TooltipTrigger` + `AlertDialogTrigger` (both `asChild`) onto the single Button, so its confirm dialog still opens.
- Test infra: added a jsdom `ResizeObserver` stub to `yolo-button.test.tsx` (Radix Tooltip's PopperContent needs it) so opening the tooltip no longer throws Vitest-flagged unhandled errors.

## Changed files
| File | Change |
|------|--------|
| `src/components/yolo-button.tsx` | Yolo trigger → icon-only + shadcn Tooltip (nested asChild triggers) |
| `src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx` | Reassign → icon-only + shadcn Tooltip |
| `src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx` | Reassign → icon-only + shadcn Tooltip |
| `src/components/__tests__/yolo-button.test.tsx` | jsdom ResizeObserver/pointer-capture stub |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full suite green (3995 passing; yolo-button 10/10 with **zero** unhandled errors)
- [x] eslint on changed files clean
- [x] Live browser check: hovering Yolo/Reassign shows the shadcn tooltip (dark pill, `data-slot=tooltip-content`), not a native title; clicking Yolo still opens the confirm dialog
- [x] Already deployed to production (working-tree build) and verified 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)