### PR TITLE
feat(graph): trackpad zoom & pan gestures for project graph views

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1653,6 +1653,11 @@
     "tooltip": {
       "loading": "Loading…"
     },
+    "zoom": {
+      "in": "Zoom in",
+      "out": "Zoom out",
+      "fit": "Fit to view"
+    },
     "status": {
       "unknown": "Unknown"
     }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1654,6 +1654,11 @@
     "tooltip": {
       "loading": "加载中…"
     },
+    "zoom": {
+      "in": "放大",
+      "out": "缩小",
+      "fit": "适应视图"
+    },
     "status": {
       "unknown": "未知"
     }

--- a/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/README.md
+++ b/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/README.md
@@ -1,0 +1,3 @@
+# add-graph-trackpad-gestures
+
+Trackpad zoom/pan gestures for the project graph views

--- a/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/design.md
+++ b/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/design.md
@@ -1,0 +1,132 @@
+# Design: Trackpad zoom & pan gestures for the project graph views
+
+## Context
+
+Two independent graph renderers exist and must both be addressed (elaboration Q1=b):
+
+| Surface | File(s) | Tech | Zoom/pan today |
+|---|---|---|---|
+| `/graph` mind-map | `mindmap-canvas.tsx` | hand-rolled `<canvas>` 2D | custom `handleWheel` (zoom-only), pointer drag pan, touch pinch/double-tap |
+| Task-dependency DAG | `task-dag.tsx`, `dag-view.tsx`, `proposal-editor.tsx` | `@xyflow/react` v12 | @xyflow defaults (`zoomOnScroll`, `panOnDrag`) |
+
+They share **no** code, so this change has two implementation halves with intentionally different mechanisms but a single user-facing model: **two-finger swipe pans, pinch (or Ctrl/⌘+scroll) zooms, mouse wheel zooms** (elaboration Q2=a, Q3=a). Non-functional stance is "solid & responsive, no inertia" (Q5=a); on-screen `+`/`−`/fit controls are added to the canvas (Q4=a). The DAG already ships `<Controls>`.
+
+## Goals / Non-goals
+
+- **Goal:** a trackpad user can pan the graph by two-finger swipe and zoom by pinch, on both surfaces, without learning a modifier key.
+- **Goal:** mouse users keep wheel-to-zoom on the canvas; on the DAG, mouse users zoom via Ctrl/⌘+wheel, pinch, or the Controls buttons.
+- **Goal:** page never scrolls while the pointer is over a graph and gesturing.
+- **Non-goal:** momentum/inertia physics; a MiniMap; touch-device changes (the existing touch pinch/double-tap path is untouched); any layout/data change.
+
+## Decision 1 — Canvas wheel classifier (`mindmap-canvas.tsx`)
+
+Replace `handleWheel` (currently `deltaY`→zoom only) with a pure classifier + a native, non-passive `wheel` listener.
+
+### D1.1 The classifier (pure, exported, unit-tested)
+
+```ts
+export type WheelGesture =
+  | { kind: "zoom"; scaleFactor: number }   // pinch or mouse-wheel notch
+  | { kind: "pan"; dx: number; dy: number }; // two-finger swipe
+
+export function classifyWheel(ev: {
+  ctrlKey: boolean;
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number; // 0 = pixel, 1 = line, 2 = page
+}): WheelGesture;
+```
+
+Classification order:
+
+1. **`ctrlKey === true` → zoom.** This is exactly how browsers surface a trackpad **pinch** (synthetic ctrl+wheel) *and* the explicit Ctrl/⌘+wheel zoom shortcut. `scaleFactor = Math.exp(-deltaY * ZOOM_PINCH_SENSITIVITY)`. Pinch deltas are pixel-mode and fine, so a smaller sensitivity constant than the mouse notch keeps pinch from over-zooming.
+2. **Else if the event looks like a trackpad swipe → pan.** A plain wheel is treated as a two-finger pan when it carries a horizontal component (`deltaX !== 0`) OR it is a fine-grained pixel-mode vertical scroll (`deltaMode === 0` and `abs(deltaY)` below `MOUSE_NOTCH_MIN` px). `dx = deltaX`, `dy = deltaY`. Panning applies `tx -= dx; ty -= dy` (content follows the fingers).
+3. **Else → zoom** (classic mouse wheel: coarse, vertical-only, often line-mode). `scaleFactor = Math.exp(-deltaY * ZOOM_WHEEL_SENSITIVITY)` — the current `0.0015` constant, preserving today's mouse feel exactly.
+
+> **Heuristic honesty.** No web API cleanly separates "mouse wheel" from "trackpad two-finger scroll"; both are `WheelEvent`s. The `deltaX`-present / fine-pixel-vertical test is the same signal Figma, tldraw, and Excalidraw use. Edge case: a plain (no-ctrl) vertical two-finger trackpad swipe with pixel deltas at or above `MOUSE_NOTCH_MIN` is indistinguishable from a mouse notch and will zoom. This is the accepted, documented trade-off of Q3=a ("mouse wheel still zooms"); the pinch and horizontal-swipe paths cover the common trackpad zoom/pan intents, and the on-screen controls + Ctrl+wheel are the unambiguous fallbacks. Constants live next to `SCALE_MIN`/`SCALE_MAX` with a comment.
+
+### D1.2 Native non-passive listener
+
+React's `onWheel` is registered passively in some browsers, so `preventDefault()` inside it can be ignored (and logs a console warning). Attach the handler via `addEventListener("wheel", handler, { passive: false })` in an effect on the canvas element and `preventDefault()` on every classified graph gesture, so the page does not scroll while the cursor is over the canvas. Remove on cleanup. The current JSX `onWheel` prop is dropped. This keeps `touch-none` (already present) doing the touch-side job and adds the wheel-side job.
+
+Pan and zoom both mutate `viewRef.current` and call `scheduleRender()` — the same transform channel the drag-pan and pinch paths already use — and zoom clamps to `[SCALE_MIN, SCALE_MAX]` via the existing cursor-anchored math extracted into a small `zoomAround(scaleFactor, sx, sy)` helper (shared by the wheel-zoom and the new `+`/`−` buttons).
+
+## Decision 2 — Canvas on-screen controls (Q4=a)
+
+Add a bottom-left (mirroring ReactFlow's Controls placement, but on the opposite side from the top-right search card) vertical cluster of three shadcn `<Button size="icon">` in a rounded card, over the canvas:
+
+- **Zoom in** (`Plus`) → `zoomAround(ZOOM_BUTTON_STEP, cx, cy)` centered on the viewport center.
+- **Zoom out** (`Minus`) → `zoomAround(1 / ZOOM_BUTTON_STEP, cx, cy)`.
+- **Fit / reset** (`Maximize`/`Frame` lucide icon) → set `viewRef.current = fitTransformFor(layout, dims)` (the existing pure fit helper) and repaint.
+
+These render in `mindmap-canvas.tsx` as sibling DOM over the `<canvas>` (like the existing tooltip overlay), so they participate in normal layout and are keyboard/pointer accessible. Each carries an `aria-label` and a shadcn `<Tooltip>`, all i18n-driven (`graph.zoom.in` / `graph.zoom.out` / `graph.zoom.fit`). `data-testid`s: `graph-zoom-in`, `graph-zoom-out`, `graph-zoom-fit`. The buttons are hidden while the layout is empty (nothing to zoom), consistent with the search row.
+
+> The buttons live in the canvas component (not the parent `resource-graph.tsx`) because the zoom math, `viewRef`, `layout`, and `dims` are all canvas-local; lifting them to the parent would mean exporting the transform. Keeping them here reuses `zoomAround` + `fitTransformFor` directly.
+
+## Decision 3 — ReactFlow DAG configuration (two full-canvas mounts only)
+
+@xyflow/react v12 supports the Figma model declaratively — no custom wheel handling. The target prop set:
+
+```tsx
+panOnScroll                       // two-finger / wheel scroll pans
+panOnScrollMode={PanOnScrollMode.Free}  // pan on both axes
+zoomOnScroll={false}              // scroll no longer zooms…
+zoomOnPinch                       // …pinch still zooms (default true; set explicit)
+zoomActivationKeyCode={["Meta", "Control"]}  // …and Ctrl/⌘+scroll zooms (cross-platform)
+panOnDrag                         // drag still pans (default true)
+```
+
+### D3.0 Scope: which mounts get this (BLOCKER fix, review round 1)
+
+There are **three** `<ReactFlow>` instances, but only **two** get `DAG_PAN_ZOOM_PROPS`:
+
+| Mount | Renders `<Controls>`? | Gets pan-on-scroll? |
+|---|---|---|
+| `dag-view.tsx` (tasks view) | yes, unconditional | **yes** |
+| `proposal-editor.tsx` (proposal editor) | yes, unconditional | **yes** |
+| `task-dag.tsx`'s own `<ReactFlow>` (readonly dashboard preview) | **no** — gated behind `!readonly`, and it is only ever mounted `readonly` (dashboard `proposal-view.tsx`) | **no — excluded** |
+
+The `task-dag.tsx` `<ReactFlow>` is a small, height-bounded thumbnail embedded inside a scrollable dashboard panel, always mounted `readonly`, and it deliberately hides `<Controls>` when readonly. Applying `zoomOnScroll={false}` there would strip its **only** zoom affordance (no Controls, no Ctrl+wheel discoverability for a preview), and making its wheel pan-the-graph would hijack the dashboard's page scroll. So it keeps its current defaults. `task-dag.tsx` still **owns** the exported `DAG_PAN_ZOOM_PROPS` constant (one source of truth for the DAG code), it just doesn't spread it into its own preview `<ReactFlow>`.
+
+The `task-dag-navigation` capability's "On-screen controls still zoom and fit" scenario is therefore satisfiable on both in-scope mounts (both render Controls); the excluded preview is not covered by that capability.
+
+Behavior this yields (on the two in-scope mounts):
+- **Two-finger trackpad swipe →** `panOnScroll` pans (Free = x+y).
+- **Trackpad pinch →** `zoomOnPinch` zooms (unaffected by `zoomOnScroll=false`).
+- **Ctrl/⌘+scroll →** while `zoomActivationKeyCode` is held, scroll zooms even though `zoomOnScroll` is false.
+- **`<Controls>` buttons →** zoom in/out/fit, already present and unconditional on both in-scope mounts.
+- **Mouse-only user (no pinch) →** zoom via Ctrl+wheel or the Controls buttons. This is the accepted DAG-side consequence of the Figma model (documented for the reviewer): unlike the canvas, ReactFlow's `panOnScroll` applies to *all* wheel events with no mouse-vs-trackpad heuristic, so a plain mouse wheel pans rather than zooms here. We accept the small canvas/DAG divergence (canvas: plain mouse wheel zooms; DAG: plain mouse wheel pans) in exchange for not fighting the library; both surfaces share the same *trackpad* model, which is the idea's goal.
+
+### D3.1 Single source of truth for the props
+
+`dag-view.tsx` and `proposal-editor.tsx` construct their own `<ReactFlow>` (they are not thin wrappers over `task-dag.tsx`). To avoid drifting copies, export a shared constant from `task-dag.tsx`:
+
+```ts
+export const DAG_PAN_ZOOM_PROPS = {
+  panOnScroll: true,
+  panOnScrollMode: PanOnScrollMode.Free,
+  zoomOnScroll: false,
+  zoomOnPinch: true,
+  zoomActivationKeyCode: ["Meta", "Control"],
+  panOnDrag: true,
+} as const;
+```
+
+and spread `{...DAG_PAN_ZOOM_PROPS}` into the **two in-scope** `<ReactFlow>` mounts (`dag-view.tsx`, `proposal-editor.tsx`) — NOT into `task-dag.tsx`'s own readonly preview mount (D3.0). `minZoom`/`maxZoom`/`fitView` stay per-mount as they are.
+
+> `zoomActivationKeyCode={["Meta","Control"]}` activates on ⌘ (macOS) **and** Ctrl (Windows/Linux), covering the `task-dag-navigation` spec's "Ctrl or Command + scroll zooms" scenario cross-platform (addresses review round-1 NOTE). @xyflow/react v12 accepts a `KeyCode` array here.
+
+## Decision 4 — Testing strategy
+
+- **`classifyWheel` unit tests** (new, pure — mirrors how `pinchTransform`/`fitTransformFor` are already tested): ctrl+wheel → zoom; horizontal wheel → pan; fine pixel vertical → pan; coarse/line vertical → zoom; zoom `scaleFactor` sign matches scroll direction.
+- **Canvas control cluster tests** (extend the jsdom canvas harness in `mindmap-canvas-touch.test.tsx` or a sibling): clicking `+`/`−` changes the recorded `setTransform` scale; clicking fit resets toward the fit scale; buttons carry their `aria-label`s.
+- **Existing `mindmap-canvas-touch.test.tsx`** must stay green (touch pinch/double-tap/drag contract unchanged).
+- **DAG props:** a light render/prop assertion that the three mounts receive `panOnScroll` + `zoomOnScroll=false` (guards against a future edit dropping the shared spread). No behavioral ReactFlow simulation — @xyflow's own tests cover the mechanics.
+- **Type check + lint + full `pnpm test`** green.
+- **E2E:** manual browser verification (Playwright MCP) of the `/graph` canvas — the on-screen zoom/fit buttons visibly work and the page doesn't scroll on a wheel gesture — is the human/browser AC on the integration task, since trackpad `deltaX`/pinch cannot be synthesized headlessly with fidelity.
+
+## Risks
+
+- **Heuristic false-classify (canvas):** a plain vertical trackpad swipe with large pixel deltas zooms instead of panning. Mitigated by the horizontal-component test catching most two-finger pans and by the explicit controls. Documented, accepted (Q3=a).
+- **`preventDefault` scope:** the non-passive listener must be scoped to the canvas element only, never the document, so normal page scrolling elsewhere is unaffected. Cleanup on unmount required.
+- **Canvas/DAG divergence:** plain mouse wheel zooms on the canvas but pans on the DAG. Accepted trade-off of not custom-writing ReactFlow wheel handling (D3). The shared model is the *trackpad* model.

--- a/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/proposal.md
+++ b/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/proposal.md
@@ -1,0 +1,49 @@
+# Trackpad zoom & pan gestures for the project graph views
+
+## Why
+
+The project graph views do not behave the way a trackpad user expects.
+
+- The `/projects/[uuid]/graph` canvas mind-map (`mindmap-canvas.tsx`) maps **every** `wheel` event to a zoom (`handleWheel` reads only `deltaY`, ignores `deltaX` and `ctrlKey`). A two-finger trackpad swipe — which the browser reports as a `wheel` event with `deltaX`/`deltaY` — therefore zooms instead of panning, and there is no way to pan except a single-finger/mouse drag. A trackpad pinch, which the browser reports as `wheel` with `ctrlKey=true`, is treated as an ordinary zoom by accident rather than by design and its granularity is wrong.
+- The canvas page has **no on-screen zoom or reset controls** at all, so a user on a device without a usable scroll-to-zoom (or who does not know the Ctrl+wheel convention) has no discoverable way to zoom or return to the full view.
+- The ReactFlow task-dependency DAG (rendered by `task-dag.tsx`, `dag-view.tsx`, and `proposal-editor.tsx`) relies on @xyflow defaults (`zoomOnScroll=true`, `panOnScroll=false`), so a two-finger trackpad swipe zooms there too instead of panning — the same mismatch, in a second surface.
+
+The net effect is that the industry-standard trackpad interaction of design/whiteboard tools (two-finger swipe pans, pinch zooms) is unavailable in Chorus's graph views.
+
+## What Changes
+
+Adopt a **Figma/Miro-style** trackpad interaction model across **both** graph surfaces, keeping mouse users fully supported:
+
+1. **Canvas mind-map (`/graph`):** replace the zoom-only wheel handler with a gesture classifier that distinguishes, on the raw `WheelEvent`:
+   - **pinch-zoom** — `ctrlKey === true` (how browsers report a trackpad pinch, and the explicit Ctrl/⌘+wheel zoom convention) → zoom around the cursor.
+   - **two-finger pan** — a plain wheel event that carries a horizontal component or reads as a fine-grained trackpad scroll → pan the canvas by `(deltaX, deltaY)`.
+   - **mouse-wheel zoom** — a plain, coarse, vertical-only wheel event (a classic mouse wheel notch) → zoom around the cursor, exactly as today.
+   The listener is attached natively (non-passive) so it can `preventDefault()` inside the graph region and stop the page from scrolling during a gesture. Pan and zoom reuse the existing `viewRef` transform and the shared `SCALE_MIN`/`SCALE_MAX` clamp.
+
+2. **Canvas on-screen controls:** add a small control cluster to the `/graph` canvas — zoom-in (`+`), zoom-out (`−`), and reset/fit-to-view — as a fallback zoom entry point that does not depend on any gesture or the Ctrl convention. These reuse the canvas's existing zoom-around-center and `fitTransformFor` math.
+
+3. **ReactFlow DAG (the two full-canvas surfaces):** configure the tasks-view DAG (`dag-view.tsx`) and the proposal-editor DAG (`proposal-editor.tsx`) so a two-finger scroll pans (`panOnScroll` + `panOnScrollMode="free"`, `zoomOnScroll={false}`), while zoom stays available via pinch (`zoomOnPinch`, on by default), Ctrl/⌘+scroll (ReactFlow zooms on scroll while `zoomActivationKeyCode` is held even when `zoomOnScroll` is off), and the already-present `<Controls>` buttons that both surfaces render unconditionally. Node dragging and selection are unchanged. The shared config constant lives in `task-dag.tsx` (so all DAG code has one source of truth) and is spread into those two mounts.
+
+   The **compact readonly DAG preview** rendered by `task-dag.tsx` in the dashboard `proposal-view` panel is intentionally **excluded** from the pan-on-scroll model. It is a small, height-bounded thumbnail embedded in a scrollable dashboard; making its wheel pan-the-graph would hijack page scroll, and it deliberately hides `<Controls>` (gated behind `!readonly`), so flipping `zoomOnScroll` off there would strip its only zoom path. It keeps its current behavior unchanged.
+
+### Explicitly out of scope
+
+- Inertia / momentum / damping animation on the canvas gestures — the non-functional decision (elaboration Q5=a) is "solid & responsive," not native-app polish. Gestures track the input frame-for-frame; no fling physics.
+- The MiniMap (none exists today; not added here).
+- Any change to the graph's data model, layout, expand/collapse, search, or side panels.
+
+## Capabilities
+
+- `project-resource-graph` (MODIFIED) — the canvas mind-map gains trackpad pan / pinch-zoom gesture classification and an on-screen zoom/fit control cluster; the existing touch and mouse behavior is preserved.
+- `task-dag-navigation` (ADDED) — a new capability describing the ReactFlow task-dependency DAG's trackpad-first pan/zoom navigation configuration, shared across the two full-canvas interactive mounts (tasks view + proposal editor); the compact readonly dashboard preview is explicitly out of scope.
+
+## Impact
+
+- **Code:**
+  - `src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx` — wheel classifier + native non-passive listener + on-screen control cluster.
+  - `src/components/task-dag.tsx` — export the shared `DAG_PAN_ZOOM_PROPS` constant (the `task-dag.tsx` `<ReactFlow>` itself, being the readonly dashboard preview, does **not** apply it).
+  - `src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx`, `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx` — spread the shared ReactFlow pan/zoom props into their `<ReactFlow>` mounts.
+  - `messages/en.json`, `messages/zh.json` — i18n keys for the new control buttons' labels/tooltips.
+- **Tests:** new unit coverage for the wheel classifier (pinch vs. pan vs. mouse-zoom) and the canvas control cluster; the existing `mindmap-canvas-touch.test.tsx` touch contract stays green.
+- **Docs:** `docs/design.pen` updated for the `/graph` canvas control cluster.
+- **No** database, API, MCP, or permission changes.

--- a/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/specs/project-resource-graph/spec.md
+++ b/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/specs/project-resource-graph/spec.md
@@ -1,0 +1,56 @@
+# project-resource-graph — Trackpad gestures & on-screen zoom controls (delta)
+
+## ADDED Requirements
+
+### Requirement: Trackpad two-finger pan and pinch-zoom on the canvas
+
+The canvas mind-map SHALL support a trackpad (touchpad) two-finger swipe to pan the tree and a trackpad pinch to zoom it, following the Figma/Miro interaction model, while preserving the existing mouse-wheel-to-zoom behavior. Wheel events over the canvas SHALL be classified as follows: a wheel event carrying `ctrlKey` (how a browser reports a trackpad pinch, and also the explicit Ctrl/⌘+wheel zoom shortcut) SHALL zoom the tree around the cursor; a plain wheel event that carries a horizontal component or reads as a fine-grained trackpad scroll SHALL pan the tree by the event's horizontal and vertical deltas; and a plain, coarse, vertical-only wheel event (a mouse-wheel notch) SHALL zoom the tree around the cursor exactly as it did before this change. Panning and zooming SHALL reuse the existing view transform and SHALL clamp the resulting scale to the same minimum and maximum bounds the touch and prior wheel paths use. While the pointer is over the canvas and a gesture is classified, the graph SHALL prevent the browser's default page scroll so the page does not move during a pan or zoom. These wheel-gesture changes SHALL NOT alter the existing touch gestures (two-finger pinch, double-tap, single-finger drag) or the single-pointer drag-to-pan behavior.
+
+#### Scenario: Two-finger trackpad swipe pans the tree
+
+- **WHEN** a user performs a two-finger swipe on a trackpad while the pointer is over the canvas
+- **THEN** the tree pans in the direction of the swipe (both horizontally and vertically) and the browser page does not scroll
+
+#### Scenario: Trackpad pinch zooms around the cursor
+
+- **WHEN** a user performs a pinch gesture on a trackpad over the canvas (reported by the browser as a wheel event with the control modifier)
+- **THEN** the tree zooms in or out around the cursor position, clamped to the same minimum and maximum zoom bounds as the other zoom paths
+
+#### Scenario: Ctrl or Command plus wheel zooms
+
+- **WHEN** a user holds Ctrl or Command and scrolls the wheel over the canvas
+- **THEN** the tree zooms around the cursor rather than panning
+
+#### Scenario: Mouse wheel still zooms
+
+- **WHEN** a user scrolls a plain mouse wheel (a coarse, vertical-only notch with no modifier) over the canvas
+- **THEN** the tree zooms around the cursor exactly as it did before this change
+
+#### Scenario: Existing touch and drag behavior unchanged
+
+- **WHEN** a user uses a two-finger touch pinch, a double-tap, a single-finger touch drag, or a single-pointer mouse drag on the canvas
+- **THEN** those gestures behave exactly as they did before the trackpad wheel gestures were added
+
+### Requirement: On-screen zoom and fit controls on the graph canvas
+
+The graph canvas SHALL present an on-screen control cluster offering zoom-in, zoom-out, and fit-to-view (reset) actions, so a user can change the zoom and re-frame the whole tree without relying on any trackpad gesture, mouse wheel, or modifier key. Zoom-in and zoom-out SHALL step the zoom by a fixed factor centered on the viewport, clamped to the same minimum and maximum zoom bounds as the gesture paths. Fit-to-view SHALL re-frame the entire tree centered in the viewport, using the same fit computation the first-load fit and the double-tap reset use. Each control SHALL carry an accessible label and a tooltip, and all of its user-facing text SHALL be internationalized in both supported locales. The control cluster SHALL be hidden when the graph is empty (there is nothing to zoom or fit).
+
+#### Scenario: Zoom-in and zoom-out buttons change the zoom
+
+- **WHEN** a user clicks the zoom-in or zoom-out control
+- **THEN** the tree zooms in or out by a fixed step centered on the viewport, staying within the minimum and maximum zoom bounds
+
+#### Scenario: Fit control re-frames the whole tree
+
+- **WHEN** a user clicks the fit-to-view control
+- **THEN** the view re-frames the entire tree centered in the viewport, matching the first-load fit
+
+#### Scenario: Controls are accessible and localized
+
+- **WHEN** the control cluster is shown
+- **THEN** each button exposes an accessible label and a tooltip whose text is internationalized in both supported locales
+
+#### Scenario: Controls hidden when the graph is empty
+
+- **WHEN** the project has no Ideas, Proposals, Tasks, or Documents to graph
+- **THEN** the zoom/fit control cluster is not shown

--- a/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/specs/task-dag-navigation/spec.md
+++ b/openspec/changes/archive/2026-07-07-add-graph-trackpad-gestures/specs/task-dag-navigation/spec.md
@@ -1,0 +1,37 @@
+# task-dag-navigation — Trackpad-first pan/zoom for the ReactFlow task DAG (delta)
+
+## ADDED Requirements
+
+### Requirement: Trackpad-first pan and zoom on the interactive task-dependency DAG
+
+The interactive, full-canvas task-dependency DAG — the ReactFlow graph rendered on the tasks view and in the proposal editor — SHALL adopt a Figma/Miro-style trackpad navigation model, applied consistently across those mounts. A two-finger trackpad swipe (and, generally, a scroll gesture) SHALL pan the graph freely on both axes rather than zoom it. Zooming SHALL remain available through a trackpad pinch, through holding Ctrl or Command while scrolling, and through the on-screen zoom controls that these mounts display. Dragging SHALL continue to pan the graph, and node dragging, selection, and connection behavior SHALL be unchanged. The pan/zoom configuration SHALL be defined once as a single shared constant and applied to every in-scope mount so the surfaces cannot drift apart. The compact, readonly DAG preview embedded in the dashboard proposal panel (which hides the on-screen controls and lives inside a scrollable page) SHALL be excluded from this model and SHALL retain its existing wheel-zoom / drag-pan behavior, so that its only zoom affordance is not removed and it does not hijack page scroll.
+
+#### Scenario: Two-finger swipe pans the DAG
+
+- **WHEN** a user performs a two-finger trackpad swipe over the tasks-view or proposal-editor DAG
+- **THEN** the graph pans on both axes rather than zooming
+
+#### Scenario: Pinch and Ctrl/Command+scroll still zoom the DAG
+
+- **WHEN** a user pinches on a trackpad, or holds Ctrl or Command while scrolling, over the tasks-view or proposal-editor DAG
+- **THEN** the graph zooms in or out
+
+#### Scenario: On-screen controls still zoom and fit
+
+- **WHEN** a user clicks the on-screen zoom-in, zoom-out, or fit controls on the tasks-view or proposal-editor DAG
+- **THEN** the graph zooms or re-frames as before
+
+#### Scenario: Consistent across the in-scope mounts via one shared config
+
+- **WHEN** the DAG is shown on the tasks view or in the proposal editor
+- **THEN** both use the same shared pan-on-scroll / zoom configuration constant
+
+#### Scenario: Readonly dashboard preview is excluded
+
+- **WHEN** the compact readonly DAG preview is shown in the dashboard proposal panel
+- **THEN** it retains its existing wheel-zoom and drag-pan behavior and is not switched to pan-on-scroll, so its zoom affordance is preserved and it does not hijack page scroll
+
+#### Scenario: Node interaction unchanged
+
+- **WHEN** a user drags a node, selects a node, or (in an editable DAG) creates a connection
+- **THEN** those interactions behave exactly as they did before the navigation model changed

--- a/openspec/specs/project-resource-graph/spec.md
+++ b/openspec/specs/project-resource-graph/spec.md
@@ -381,3 +381,56 @@ When a search ends, the graph SHALL keep every currently expanded node expanded 
 - **WHEN** the user clears a search and then collapses a hub that had been expanded to reveal a match
 - **THEN** that hub collapses normally, because expansion is now ordinary user-controlled state with no search snapshot overriding it
 
+### Requirement: Trackpad two-finger pan and pinch-zoom on the canvas
+
+The canvas mind-map SHALL support a trackpad (touchpad) two-finger swipe to pan the tree and a trackpad pinch to zoom it, following the Figma/Miro interaction model, while preserving the existing mouse-wheel-to-zoom behavior. Wheel events over the canvas SHALL be classified as follows: a wheel event carrying `ctrlKey` (how a browser reports a trackpad pinch, and also the explicit Ctrl/⌘+wheel zoom shortcut) SHALL zoom the tree around the cursor; a plain wheel event that carries a horizontal component or reads as a fine-grained trackpad scroll SHALL pan the tree by the event's horizontal and vertical deltas; and a plain, coarse, vertical-only wheel event (a mouse-wheel notch) SHALL zoom the tree around the cursor exactly as it did before this change. Panning and zooming SHALL reuse the existing view transform and SHALL clamp the resulting scale to the same minimum and maximum bounds the touch and prior wheel paths use. While the pointer is over the canvas and a gesture is classified, the graph SHALL prevent the browser's default page scroll so the page does not move during a pan or zoom. These wheel-gesture changes SHALL NOT alter the existing touch gestures (two-finger pinch, double-tap, single-finger drag) or the single-pointer drag-to-pan behavior.
+
+#### Scenario: Two-finger trackpad swipe pans the tree
+
+- **WHEN** a user performs a two-finger swipe on a trackpad while the pointer is over the canvas
+- **THEN** the tree pans in the direction of the swipe (both horizontally and vertically) and the browser page does not scroll
+
+#### Scenario: Trackpad pinch zooms around the cursor
+
+- **WHEN** a user performs a pinch gesture on a trackpad over the canvas (reported by the browser as a wheel event with the control modifier)
+- **THEN** the tree zooms in or out around the cursor position, clamped to the same minimum and maximum zoom bounds as the other zoom paths
+
+#### Scenario: Ctrl or Command plus wheel zooms
+
+- **WHEN** a user holds Ctrl or Command and scrolls the wheel over the canvas
+- **THEN** the tree zooms around the cursor rather than panning
+
+#### Scenario: Mouse wheel still zooms
+
+- **WHEN** a user scrolls a plain mouse wheel (a coarse, vertical-only notch with no modifier) over the canvas
+- **THEN** the tree zooms around the cursor exactly as it did before this change
+
+#### Scenario: Existing touch and drag behavior unchanged
+
+- **WHEN** a user uses a two-finger touch pinch, a double-tap, a single-finger touch drag, or a single-pointer mouse drag on the canvas
+- **THEN** those gestures behave exactly as they did before the trackpad wheel gestures were added
+
+### Requirement: On-screen zoom and fit controls on the graph canvas
+
+The graph canvas SHALL present an on-screen control cluster offering zoom-in, zoom-out, and fit-to-view (reset) actions, so a user can change the zoom and re-frame the whole tree without relying on any trackpad gesture, mouse wheel, or modifier key. Zoom-in and zoom-out SHALL step the zoom by a fixed factor centered on the viewport, clamped to the same minimum and maximum zoom bounds as the gesture paths. Fit-to-view SHALL re-frame the entire tree centered in the viewport, using the same fit computation the first-load fit and the double-tap reset use. Each control SHALL carry an accessible label and a tooltip, and all of its user-facing text SHALL be internationalized in both supported locales. The control cluster SHALL be hidden when the graph is empty (there is nothing to zoom or fit).
+
+#### Scenario: Zoom-in and zoom-out buttons change the zoom
+
+- **WHEN** a user clicks the zoom-in or zoom-out control
+- **THEN** the tree zooms in or out by a fixed step centered on the viewport, staying within the minimum and maximum zoom bounds
+
+#### Scenario: Fit control re-frames the whole tree
+
+- **WHEN** a user clicks the fit-to-view control
+- **THEN** the view re-frames the entire tree centered in the viewport, matching the first-load fit
+
+#### Scenario: Controls are accessible and localized
+
+- **WHEN** the control cluster is shown
+- **THEN** each button exposes an accessible label and a tooltip whose text is internationalized in both supported locales
+
+#### Scenario: Controls hidden when the graph is empty
+
+- **WHEN** the project has no Ideas, Proposals, Tasks, or Documents to graph
+- **THEN** the zoom/fit control cluster is not shown
+

--- a/openspec/specs/task-dag-navigation/spec.md
+++ b/openspec/specs/task-dag-navigation/spec.md
@@ -1,0 +1,39 @@
+# task-dag-navigation Specification
+
+## Purpose
+TBD - created by archiving change add-graph-trackpad-gestures. Update Purpose after archive.
+## Requirements
+### Requirement: Trackpad-first pan and zoom on the interactive task-dependency DAG
+
+The interactive, full-canvas task-dependency DAG — the ReactFlow graph rendered on the tasks view and in the proposal editor — SHALL adopt a Figma/Miro-style trackpad navigation model, applied consistently across those mounts. A two-finger trackpad swipe (and, generally, a scroll gesture) SHALL pan the graph freely on both axes rather than zoom it. Zooming SHALL remain available through a trackpad pinch, through holding Ctrl or Command while scrolling, and through the on-screen zoom controls that these mounts display. Dragging SHALL continue to pan the graph, and node dragging, selection, and connection behavior SHALL be unchanged. The pan/zoom configuration SHALL be defined once as a single shared constant and applied to every in-scope mount so the surfaces cannot drift apart. The compact, readonly DAG preview embedded in the dashboard proposal panel (which hides the on-screen controls and lives inside a scrollable page) SHALL be excluded from this model and SHALL retain its existing wheel-zoom / drag-pan behavior, so that its only zoom affordance is not removed and it does not hijack page scroll.
+
+#### Scenario: Two-finger swipe pans the DAG
+
+- **WHEN** a user performs a two-finger trackpad swipe over the tasks-view or proposal-editor DAG
+- **THEN** the graph pans on both axes rather than zooming
+
+#### Scenario: Pinch and Ctrl/Command+scroll still zoom the DAG
+
+- **WHEN** a user pinches on a trackpad, or holds Ctrl or Command while scrolling, over the tasks-view or proposal-editor DAG
+- **THEN** the graph zooms in or out
+
+#### Scenario: On-screen controls still zoom and fit
+
+- **WHEN** a user clicks the on-screen zoom-in, zoom-out, or fit controls on the tasks-view or proposal-editor DAG
+- **THEN** the graph zooms or re-frames as before
+
+#### Scenario: Consistent across the in-scope mounts via one shared config
+
+- **WHEN** the DAG is shown on the tasks view or in the proposal editor
+- **THEN** both use the same shared pan-on-scroll / zoom configuration constant
+
+#### Scenario: Readonly dashboard preview is excluded
+
+- **WHEN** the compact readonly DAG preview is shown in the dashboard proposal panel
+- **THEN** it retains its existing wheel-zoom and drag-pan behavior and is not switched to pan-on-scroll, so its zoom affordance is preserved and it does not hijack page scroll
+
+#### Scenario: Node interaction unchanged
+
+- **WHEN** a user drags a node, selects a node, or (in an editable DAG) creates a connection
+- **THEN** those interactions behave exactly as they did before the navigation model changed
+

--- a/src/app/(dashboard)/projects/[uuid]/graph/__tests__/mindmap-canvas-wheel.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/__tests__/mindmap-canvas-wheel.test.tsx
@@ -1,0 +1,283 @@
+// @vitest-environment jsdom
+//
+// Trackpad wheel-gesture coverage for MindMapCanvas (Task: "Canvas: trackpad
+// wheel classifier + non-passive listener", Spec Delta "Trackpad two-finger pan
+// and pinch-zoom on the canvas"). Two layers, mirroring mindmap-canvas-touch:
+//
+//   1. Pure math — `classifyWheel` is an exported pure helper, so the
+//      pan/pinch/mouse-zoom heuristic is asserted directly without a canvas:
+//      ctrl+wheel → zoom, horizontal wheel → pan, fine pixel vertical → pan,
+//      coarse/line vertical → zoom, and the zoom scaleFactor sign.
+//
+//   2. Behavior — a mounted canvas is driven with a native (non-passive) wheel
+//      event to prove (a) the listener calls preventDefault so the page does not
+//      scroll, and (b) a ctrl+wheel zoom mutates the view transform scale.
+//
+// Canvas 2D is mocked the same way as mindmap-canvas-touch.test.tsx.
+
+import React from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, act, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("@/hooks/use-presence", () => ({
+  usePresence: () => ({ getPresence: () => [] }),
+}));
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// Records the horizontal scale of every setTransform(a, …) call — the painter
+// writes `dpr * view.scale` as `a`, so with dpr=1 the last recorded value is
+// the live view scale.
+const setTransformScales: number[] = [];
+
+function stubCanvas2D(): CanvasRenderingContext2D {
+  const ctx = {
+    setTransform: (a?: number) => {
+      if (typeof a === "number") setTransformScales.push(a);
+    },
+    fillRect: () => {},
+    save: () => {},
+    restore: () => {},
+    translate: () => {},
+    scale: () => {},
+    rotate: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    bezierCurveTo: () => {},
+    quadraticCurveTo: () => {},
+    arcTo: () => {},
+    closePath: () => {},
+    fill: () => {},
+    stroke: () => {},
+    arc: () => {},
+    fillText: () => {},
+    measureText: (text: string) => ({ width: text.length * 6 }) as TextMetrics,
+    setLineDash: () => {},
+    clearRect: () => {},
+    drawImage: () => {},
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    lineCap: "butt",
+    lineJoin: "miter",
+    font: "",
+    textAlign: "left" as CanvasTextAlign,
+    textBaseline: "alphabetic" as CanvasTextBaseline,
+    globalAlpha: 1,
+    shadowColor: "",
+    shadowBlur: 0,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.useFakeTimers();
+  setTransformScales.length = 0;
+  (window as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+    StubResizeObserver as unknown as typeof ResizeObserver;
+  if (typeof (globalThis as { Path2D?: unknown }).Path2D === "undefined") {
+    (globalThis as { Path2D: unknown }).Path2D = function (_d?: string) {
+      void _d;
+    } as unknown as typeof Path2D;
+  }
+  HTMLCanvasElement.prototype.getContext = vi.fn(
+    () => stubCanvas2D(),
+  ) as unknown as HTMLCanvasElement["getContext"];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    return setTimeout(() => cb(0), 0) as unknown as number;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+  HTMLCanvasElement.prototype.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return 800;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return 600;
+    },
+  });
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+import {
+  MindMapCanvas,
+  classifyWheel,
+  type ForceNode,
+} from "../mindmap-canvas";
+
+describe("classifyWheel (pure) — Q2=a / Q3=a pan vs zoom heuristic", () => {
+  it("ctrl+wheel (trackpad pinch OR Ctrl/⌘+wheel) → zoom", () => {
+    const g = classifyWheel({ ctrlKey: true, deltaX: 0, deltaY: -10, deltaMode: 0 });
+    expect(g.kind).toBe("zoom");
+    if (g.kind === "zoom") expect(g.scaleFactor).toBeGreaterThan(1); // scroll up = zoom in
+  });
+
+  it("a wheel event with a horizontal component → pan", () => {
+    const g = classifyWheel({ ctrlKey: false, deltaX: 40, deltaY: 5, deltaMode: 0 });
+    expect(g).toEqual({ kind: "pan", dx: 40, dy: 5 });
+  });
+
+  it("a fine pixel-mode vertical wheel (below the mouse-notch threshold) → pan", () => {
+    const g = classifyWheel({ ctrlKey: false, deltaX: 0, deltaY: 12, deltaMode: 0 });
+    expect(g).toEqual({ kind: "pan", dx: 0, dy: 12 });
+  });
+
+  it("a coarse pixel-mode vertical wheel (at/above the threshold) → zoom (mouse notch)", () => {
+    const g = classifyWheel({ ctrlKey: false, deltaX: 0, deltaY: 120, deltaMode: 0 });
+    expect(g.kind).toBe("zoom");
+    if (g.kind === "zoom") expect(g.scaleFactor).toBeLessThan(1); // scroll down = zoom out
+  });
+
+  it("a line-mode vertical wheel → zoom (classic mouse wheel)", () => {
+    const g = classifyWheel({ ctrlKey: false, deltaX: 0, deltaY: -3, deltaMode: 1 });
+    expect(g.kind).toBe("zoom");
+    if (g.kind === "zoom") expect(g.scaleFactor).toBeGreaterThan(1);
+  });
+
+  it("zoom scaleFactor sign matches scroll direction", () => {
+    const inGesture = classifyWheel({ ctrlKey: true, deltaX: 0, deltaY: -20, deltaMode: 0 });
+    const outGesture = classifyWheel({ ctrlKey: true, deltaX: 0, deltaY: 20, deltaMode: 0 });
+    if (inGesture.kind === "zoom") expect(inGesture.scaleFactor).toBeGreaterThan(1);
+    if (outGesture.kind === "zoom") expect(outGesture.scaleFactor).toBeLessThan(1);
+  });
+});
+
+function buildNodes(): ForceNode[] {
+  return [{ id: "idea-1", type: "idea", title: "Idea one", status: "building" }];
+}
+
+describe("MindMapCanvas — native non-passive wheel listener", () => {
+  it("calls preventDefault so the page does not scroll during a gesture", () => {
+    const { container } = render(
+      <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    const canvas = container.querySelector("canvas")!;
+    act(() => {
+      vi.advanceTimersByTime(50); // settle the one-time fit
+    });
+    const ev = new WheelEvent("wheel", {
+      deltaX: 30,
+      deltaY: 0,
+      ctrlKey: false,
+      cancelable: true,
+      bubbles: true,
+    });
+    act(() => {
+      canvas.dispatchEvent(ev);
+    });
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("a ctrl+wheel zoom mutates the view transform scale", () => {
+    const { container } = render(
+      <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    const canvas = container.querySelector("canvas")!;
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    const scaleBefore = setTransformScales.at(-1)!;
+    expect(Number.isFinite(scaleBefore)).toBe(true);
+    act(() => {
+      canvas.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaX: 0,
+          deltaY: -100, // scroll up with ctrl → zoom in
+          ctrlKey: true,
+          clientX: 400,
+          clientY: 300,
+          cancelable: true,
+          bubbles: true,
+        }),
+      );
+      vi.advanceTimersByTime(50); // let the repaint run
+    });
+    const scaleAfter = setTransformScales.at(-1)!;
+    expect(scaleAfter).toBeGreaterThan(scaleBefore);
+  });
+});
+
+describe("MindMapCanvas — on-screen zoom / fit control cluster (Q4=a)", () => {
+  it("renders zoom-in / zoom-out / fit controls with accessible labels when there are nodes", () => {
+    const { getByTestId } = render(
+      <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    // The mocked useTranslations returns the key, so aria-label === the i18n key.
+    expect(getByTestId("graph-zoom-in").getAttribute("aria-label")).toBe("graph.zoom.in");
+    expect(getByTestId("graph-zoom-out").getAttribute("aria-label")).toBe("graph.zoom.out");
+    expect(getByTestId("graph-zoom-fit").getAttribute("aria-label")).toBe("graph.zoom.fit");
+  });
+
+  it("hides the control cluster when the graph is empty", () => {
+    const { queryByTestId } = render(
+      <MindMapCanvas nodes={[]} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    expect(queryByTestId("graph-zoom-in")).toBeNull();
+    expect(queryByTestId("graph-zoom-fit")).toBeNull();
+  });
+
+  it("zoom-in raises the view scale and zoom-out lowers it (centered on the viewport)", () => {
+    const { getByTestId } = render(
+      <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(50); // settle the one-time fit
+    });
+    const scaleAfterFit = setTransformScales.at(-1)!;
+    act(() => {
+      fireEvent.click(getByTestId("graph-zoom-in"));
+      vi.advanceTimersByTime(50);
+    });
+    const scaleAfterZoomIn = setTransformScales.at(-1)!;
+    expect(scaleAfterZoomIn).toBeGreaterThan(scaleAfterFit);
+    act(() => {
+      fireEvent.click(getByTestId("graph-zoom-out"));
+      fireEvent.click(getByTestId("graph-zoom-out"));
+      vi.advanceTimersByTime(50);
+    });
+    const scaleAfterZoomOut = setTransformScales.at(-1)!;
+    expect(scaleAfterZoomOut).toBeLessThan(scaleAfterZoomIn);
+  });
+
+  it("fit re-frames the tree back toward the first-load fit scale", () => {
+    const { getByTestId } = render(
+      <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    const scaleAfterFit = setTransformScales.at(-1)!;
+    // Zoom in a couple of times, then fit — the scale should return to the fit.
+    act(() => {
+      fireEvent.click(getByTestId("graph-zoom-in"));
+      fireEvent.click(getByTestId("graph-zoom-in"));
+      vi.advanceTimersByTime(50);
+    });
+    expect(setTransformScales.at(-1)!).toBeGreaterThan(scaleAfterFit);
+    act(() => {
+      fireEvent.click(getByTestId("graph-zoom-fit"));
+      vi.advanceTimersByTime(50);
+    });
+    expect(setTransformScales.at(-1)!).toBeCloseTo(scaleAfterFit, 5);
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx
@@ -38,7 +38,15 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
+import { Plus, Minus, Maximize } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { usePresence } from "@/hooks/use-presence";
 import { getAgentColor } from "@/lib/agent-color";
 import {
@@ -213,6 +221,68 @@ export function centerTransformFor(
 // clamp scale identically (Tech Design D1/D3).
 const SCALE_MIN = 0.2;
 const SCALE_MAX = 2.5;
+
+// --- Trackpad wheel-gesture tuning (Tech Design D1) -------------------------
+//
+// The `/graph` canvas classifies raw `wheel` events into a Figma/Miro-style
+// model: a trackpad pinch (reported by browsers as ctrl+wheel) or Ctrl/⌘+wheel
+// zooms; a plain two-finger trackpad swipe pans; a classic mouse-wheel notch
+// still zooms (elaboration Q2=a / Q3=a). See `classifyWheel`.
+//
+// Heuristic honesty: no web API cleanly separates "mouse wheel" from "trackpad
+// two-finger scroll" — both are `WheelEvent`s. We treat a plain wheel as a PAN
+// when it carries a horizontal component (`deltaX`) OR reads as a fine-grained
+// pixel-mode vertical scroll (below MOUSE_NOTCH_MIN px); otherwise (coarse,
+// vertical-only, often line-mode) it is a mouse notch → ZOOM. This is the same
+// signal Figma / tldraw / Excalidraw use. The one accepted ambiguity: a plain
+// vertical two-finger trackpad swipe with pixel deltas at/above MOUSE_NOTCH_MIN
+// is indistinguishable from a mouse notch and will zoom — covered by the pinch
+// path, the on-screen controls, and Ctrl+wheel as unambiguous fallbacks.
+const ZOOM_WHEEL_SENSITIVITY = 0.0015; // mouse-notch zoom feel (unchanged from the old handler)
+const ZOOM_PINCH_SENSITIVITY = 0.01; // pinch/ctrl+wheel deltas are fine pixels — a larger factor keeps them responsive without over-zooming
+const MOUSE_NOTCH_MIN = 30; // px: a pixel-mode vertical wheel below this reads as a fine trackpad scroll (pan), not a mouse notch
+
+// The fixed multiplier the on-screen +/- zoom buttons step by (Tech Design D2).
+const ZOOM_BUTTON_STEP = 1.3;
+
+/** The classified intent of a wheel event over the canvas (Tech Design D1). */
+export type WheelGesture =
+  | { kind: "zoom"; scaleFactor: number }
+  | { kind: "pan"; dx: number; dy: number };
+
+/**
+ * Classify a raw wheel event into a pan or a zoom (pure + exported so the
+ * heuristic is unit-testable without a canvas — mirrors pinchTransform). See
+ * the tuning-constant block above for the heuristic rationale.
+ *
+ *   1. ctrlKey → zoom. Browsers report a trackpad PINCH as a synthetic
+ *      ctrl+wheel, and Ctrl/⌘+wheel is the explicit zoom shortcut. Uses the
+ *      finer ZOOM_PINCH_SENSITIVITY.
+ *   2. else a horizontal component OR a fine pixel-mode vertical scroll → pan
+ *      (a two-finger trackpad swipe). dx/dy are the raw deltas.
+ *   3. else → zoom (a classic mouse-wheel notch), preserving the old feel via
+ *      ZOOM_WHEEL_SENSITIVITY.
+ *
+ * `scaleFactor` is a multiplier on the current scale; scrolling up (negative
+ * deltaY) yields a factor > 1 (zoom in), matching the prior handler.
+ */
+export function classifyWheel(ev: {
+  ctrlKey: boolean;
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number; // 0 = pixel, 1 = line, 2 = page
+}): WheelGesture {
+  if (ev.ctrlKey) {
+    return { kind: "zoom", scaleFactor: Math.exp(-ev.deltaY * ZOOM_PINCH_SENSITIVITY) };
+  }
+  const isPixelMode = ev.deltaMode === 0;
+  const looksLikeTrackpadSwipe =
+    ev.deltaX !== 0 || (isPixelMode && Math.abs(ev.deltaY) < MOUSE_NOTCH_MIN);
+  if (looksLikeTrackpadSwipe) {
+    return { kind: "pan", dx: ev.deltaX, dy: ev.deltaY };
+  }
+  return { kind: "zoom", scaleFactor: Math.exp(-ev.deltaY * ZOOM_WHEEL_SENSITIVITY) };
+}
 
 // Double-tap disambiguation window (Tech Design D2). A second tap within this
 // time AND distance of the first is a double-tap (zoom), not a node click.
@@ -1039,16 +1109,16 @@ export function MindMapCanvas({
     }
   }, []);
 
-  const handleWheel = useCallback(
-    (ev: React.WheelEvent) => {
-      const rect = canvasRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      const sx = ev.clientX - rect.left;
-      const sy = ev.clientY - rect.top;
+  // Zoom by a scale factor while keeping the graph point under (sx, sy) fixed
+  // (cursor/viewport anchor). Shared by the wheel-zoom path and the on-screen
+  // zoom buttons (Tech Design D1/D2). Clamps to [SCALE_MIN, SCALE_MAX].
+  const zoomAround = useCallback(
+    (scaleFactor: number, sx: number, sy: number) => {
       const v = viewRef.current;
-      const factor = Math.exp(-ev.deltaY * 0.0015);
-      const nextScale = Math.min(SCALE_MAX, Math.max(SCALE_MIN, v.scale * factor));
-      // Zoom around the cursor: keep the graph point under the cursor fixed.
+      const nextScale = Math.min(
+        SCALE_MAX,
+        Math.max(SCALE_MIN, v.scale * scaleFactor),
+      );
       const gx = (sx - v.tx) / v.scale;
       const gy = (sy - v.ty) / v.scale;
       viewRef.current = {
@@ -1060,6 +1130,62 @@ export function MindMapCanvas({
     },
     [scheduleRender],
   );
+  // Keep a live ref to zoomAround so the native (non-React) wheel listener below
+  // can call the latest closure without re-attaching on every render.
+  const zoomAroundRef = useRef(zoomAround);
+  zoomAroundRef.current = zoomAround;
+
+  // Native, NON-PASSIVE wheel listener (Tech Design D1). React's onWheel is
+  // passive in some browsers, so preventDefault() there is ignored (and warns).
+  // Attaching manually with { passive: false } lets us stop the page from
+  // scrolling while the cursor is over the canvas and a gesture is classified.
+  // classifyWheel splits the raw event into a two-finger PAN (trackpad swipe)
+  // or a ZOOM (pinch / ctrl+wheel / mouse notch); see classifyWheel above.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const onWheel = (ev: WheelEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const sx = ev.clientX - rect.left;
+      const sy = ev.clientY - rect.top;
+      const gesture = classifyWheel(ev);
+      // Stop the page from scrolling under any classified graph gesture.
+      ev.preventDefault();
+      if (gesture.kind === "pan") {
+        // Content follows the fingers: swiping down/right moves the view up/left.
+        viewRef.current = {
+          ...viewRef.current,
+          tx: viewRef.current.tx - gesture.dx,
+          ty: viewRef.current.ty - gesture.dy,
+        };
+        scheduleRender();
+      } else {
+        zoomAroundRef.current(gesture.scaleFactor, sx, sy);
+      }
+    };
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    return () => canvas.removeEventListener("wheel", onWheel);
+  }, [scheduleRender]);
+
+  // --- On-screen zoom / fit controls (Tech Design D2, Q4=a) -----------------
+  // A fallback zoom entry point that needs no gesture, wheel, or modifier key.
+  // The +/- buttons step the zoom centered on the viewport (reusing zoomAround);
+  // fit re-frames the whole tree via the same fitTransformFor the first-load fit
+  // and double-tap reset use. Hidden while the layout is empty (nothing to zoom).
+  const zoomInByButton = useCallback(() => {
+    zoomAround(ZOOM_BUTTON_STEP, dims.width / 2, dims.height / 2);
+  }, [zoomAround, dims.width, dims.height]);
+  const zoomOutByButton = useCallback(() => {
+    zoomAround(1 / ZOOM_BUTTON_STEP, dims.width / 2, dims.height / 2);
+  }, [zoomAround, dims.width, dims.height]);
+  const fitByButton = useCallback(() => {
+    const next = fitTransformFor(layout, dims);
+    if (next) {
+      viewRef.current = next;
+      scheduleRender();
+    }
+  }, [layout, dims, scheduleRender]);
+  const hasNodes = layout.positions.size > 0;
 
   return (
     <div ref={containerRef} className="absolute inset-0">
@@ -1072,7 +1198,6 @@ export function MindMapCanvas({
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
         onPointerLeave={() => setHoverId(null)}
-        onWheel={handleWheel}
       />
       {/* Hover tooltip — a DOM overlay above the canvas (Tech Design D3).
           Title-only: shows the hovered node's FULL untruncated title (the one
@@ -1086,6 +1211,64 @@ export function MindMapCanvas({
           x={tooltipAnchor.x}
           y={tooltipAnchor.y}
         />
+      )}
+      {/* On-screen zoom / fit control cluster (Tech Design D2, Q4=a). A DOM
+          overlay in the bottom-left (opposite the top-right search card),
+          giving a gesture-free zoom/reframe fallback. Hidden while the graph
+          is empty. All labels are i18n-driven (graph.zoom.*). */}
+      {hasNodes && (
+        <TooltipProvider delayDuration={300}>
+          <div className="absolute bottom-3 left-3 flex flex-col gap-1 rounded-lg border border-[#EAE4DB] bg-white/95 p-1 shadow-sm backdrop-blur-sm">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={zoomInByButton}
+                  aria-label={t("graph.zoom.in")}
+                  data-testid="graph-zoom-in"
+                  className="text-[#6B6B6B]"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right">{t("graph.zoom.in")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={zoomOutByButton}
+                  aria-label={t("graph.zoom.out")}
+                  data-testid="graph-zoom-out"
+                  className="text-[#6B6B6B]"
+                >
+                  <Minus className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right">{t("graph.zoom.out")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={fitByButton}
+                  aria-label={t("graph.zoom.fit")}
+                  data-testid="graph-zoom-fit"
+                  className="text-[#6B6B6B]"
+                >
+                  <Maximize className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right">{t("graph.zoom.fit")}</TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
       )}
     </div>
   );

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx
@@ -23,6 +23,7 @@ import { usePresence, injectPresence } from "@/hooks/use-presence";
 import { PresenceIndicator } from "@/components/ui/presence-indicator";
 import { useRealtimeEntityEvent } from "@/contexts/realtime-context";
 import { findNew, findDeleted, shouldRefresh } from "./draft-diff";
+import { DAG_PAN_ZOOM_PROPS } from "@/components/task-dag";
 import { ExportDropdown } from "@/components/export-dropdown";
 import { getProposalDraftsAction } from "./actions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -750,6 +751,7 @@ export function ProposalEditor({
                   minZoom={0.3}
                   maxZoom={1.5}
                   proOptions={{ hideAttribution: true }}
+                  {...DAG_PAN_ZOOM_PROPS}
                 >
                   <Background color="#E5E0D8" gap={20} />
                   <Controls

--- a/src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx
@@ -20,6 +20,7 @@ import {
   nodeTypes,
   defaultEdgeStyle,
   getLayoutedElements,
+  DAG_PAN_ZOOM_PROPS,
   type TaskNodeData,
 } from "@/components/task-dag";
 import { getProjectDependenciesAction } from "./actions";
@@ -156,6 +157,7 @@ export function DagView({ projectUuid, onTaskSelect, refreshKey }: DagViewProps)
         minZoom={0.3}
         maxZoom={1.5}
         proOptions={{ hideAttribution: true }}
+        {...DAG_PAN_ZOOM_PROPS}
       >
         <Background color="#E5E0D8" gap={20} />
         <Controls

--- a/src/components/__tests__/task-dag-pan-zoom.test.tsx
+++ b/src/components/__tests__/task-dag-pan-zoom.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// Regression guard for the shared trackpad pan/zoom config on the ReactFlow
+// task-dependency DAG (Task: "ReactFlow DAG: shared trackpad pan-on-scroll
+// config on the two full-canvas mounts", Spec Delta "task-dag-navigation").
+//
+// Three checks, matching the tech design's "no behavioral ReactFlow simulation
+// — assert the shared props are applied" strategy (Decision 4 / D3.0):
+//   1. DAG_PAN_ZOOM_PROPS has the exact intended shape (Figma model).
+//   2. The readonly dashboard-preview <ReactFlow> in TaskDag does NOT receive
+//      the pan-on-scroll props — it keeps its own inline zoomOnScroll (the
+//      BLOCKER-fix regression guard: applying zoomOnScroll=false to a mount
+//      that hides <Controls> would strip its only zoom path).
+//   3. The two in-scope mounts (dag-view.tsx, proposal-editor.tsx) spread
+//      {...DAG_PAN_ZOOM_PROPS} into their <ReactFlow> (guards a future edit
+//      dropping the shared spread).
+
+import React from "react";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+// Capture the props handed to <ReactFlow> so we can assert what the readonly
+// TaskDag preview passes (and does not pass).
+const reactFlowProps: Array<Record<string, unknown>> = [];
+
+vi.mock("@xyflow/react", () => ({
+  // ReactFlow records its props and renders its children so <Controls> gating
+  // stays observable if needed.
+  ReactFlow: (props: Record<string, unknown>) => {
+    reactFlowProps.push(props);
+    return React.createElement("div", { "data-testid": "reactflow" }, props.children as React.ReactNode);
+  },
+  Background: () => null,
+  Controls: () => React.createElement("div", { "data-testid": "controls" }),
+  Handle: () => null,
+  Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+  PanOnScrollMode: { Free: "free", Vertical: "vertical", Horizontal: "horizontal" },
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+beforeEach(() => {
+  reactFlowProps.length = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+import { TaskDag, DAG_PAN_ZOOM_PROPS } from "../task-dag";
+
+describe("DAG_PAN_ZOOM_PROPS — shared Figma-model config", () => {
+  it("has the exact intended shape", () => {
+    expect(DAG_PAN_ZOOM_PROPS).toEqual({
+      panOnScroll: true,
+      panOnScrollMode: "free",
+      zoomOnScroll: false,
+      zoomOnPinch: true,
+      zoomActivationKeyCode: ["Meta", "Control"],
+      panOnDrag: true,
+    });
+  });
+});
+
+describe("TaskDag readonly dashboard preview — excluded from pan-on-scroll", () => {
+  it("does NOT receive panOnScroll and keeps its own inline zoomOnScroll=true", () => {
+    render(
+      <TaskDag
+        readonly
+        tasks={[{ uuid: "t1", title: "T1", status: "open", priority: "high" }]}
+        edges={[]}
+      />,
+    );
+    expect(reactFlowProps).toHaveLength(1);
+    const props = reactFlowProps[0];
+    // The BLOCKER-fix invariant: the readonly preview must NOT be switched to
+    // pan-on-scroll (it hides <Controls>, so it would lose its only zoom path).
+    expect(props.panOnScroll).toBeUndefined();
+    expect(props.zoomOnScroll).toBe(true); // its own inline value, unchanged
+  });
+});
+
+describe("the two in-scope mounts spread {...DAG_PAN_ZOOM_PROPS}", () => {
+  const mounts = [
+    "app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx",
+    "app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx",
+  ];
+  for (const rel of mounts) {
+    it(`${rel} imports and spreads the shared config`, () => {
+      const src = fs.readFileSync(path.join(process.cwd(), "src", rel), "utf8");
+      expect(src).toContain("DAG_PAN_ZOOM_PROPS");
+      expect(src).toContain("{...DAG_PAN_ZOOM_PROPS}");
+    });
+  }
+
+  it("task-dag.tsx does NOT spread the config into its own preview ReactFlow", () => {
+    const src = fs.readFileSync(
+      path.join(process.cwd(), "src", "components", "task-dag.tsx"),
+      "utf8",
+    );
+    // It exports the const…
+    expect(src).toContain("export const DAG_PAN_ZOOM_PROPS");
+    // …but never spreads it (the readonly preview keeps its own inline props).
+    expect(src).not.toContain("{...DAG_PAN_ZOOM_PROPS}");
+  });
+});

--- a/src/components/task-dag.tsx
+++ b/src/components/task-dag.tsx
@@ -5,6 +5,7 @@ import {
   ReactFlow,
   Background,
   Controls,
+  PanOnScrollMode,
   type Node,
   type Edge,
   type NodeProps,
@@ -124,6 +125,28 @@ const compactEdgeStyle = {
   animated: true,
   style: { stroke: "#C67A52", strokeWidth: 1.5 },
   markerEnd: { type: "arrowclosed" as const, color: "#C67A52" },
+};
+
+// Shared Figma/Miro-style trackpad pan/zoom config for the interactive,
+// full-canvas DAG mounts (tasks view + proposal editor). A two-finger scroll
+// pans freely (both axes); zoom stays available via pinch, Ctrl/⌘+scroll, and
+// the <Controls> buttons those mounts render unconditionally.
+//
+// NOTE (Tech Design D3.0): this is intentionally NOT applied to the readonly
+// dashboard-preview <ReactFlow> below — that mount hides <Controls> (gated
+// behind !readonly) and lives inside a scrollable dashboard, so flipping
+// zoomOnScroll off there would strip its only zoom affordance and its wheel
+// would hijack page scroll. It keeps its own inline zoomOnScroll/panOnDrag.
+// This module owns the constant; the two in-scope mounts import and spread it.
+export const DAG_PAN_ZOOM_PROPS = {
+  panOnScroll: true,
+  panOnScrollMode: PanOnScrollMode.Free,
+  zoomOnScroll: false,
+  zoomOnPinch: true,
+  // Mutable string[] (not `as const`) so it matches ReactFlow's KeyCode type,
+  // which rejects a readonly tuple. ⌘ (macOS) + Ctrl (Windows/Linux)+wheel zoom.
+  zoomActivationKeyCode: ["Meta", "Control"] as string[],
+  panOnDrag: true,
 };
 
 function getLayoutedElements(


### PR DESCRIPTION
## Summary
Adopt a Figma/Miro-style trackpad interaction model across both project graph surfaces (idea `a6a1289c`, proposal `5378eba5`): a two-finger swipe pans and a pinch zooms, while mouse users stay fully supported. Deployed to the live env and tested by the owner before this PR.

## Changes
| File | Change |
|------|--------|
| `src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx` | Pure `classifyWheel` (pan / pinch-zoom / mouse-notch-zoom) on a non-passive wheel listener that `preventDefault`s so the page never scrolls during a gesture; extracted `zoomAround`; on-screen +/− / fit control cluster |
| `src/components/task-dag.tsx` | Exported shared `DAG_PAN_ZOOM_PROPS` (Figma pan-on-scroll config); readonly dashboard preview intentionally excluded (keeps its only zoom path) |
| `src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx`, `.../proposals/[proposalUuid]/proposal-editor.tsx` | Spread the shared config into the two full-canvas ReactFlow mounts |
| `messages/en.json`, `messages/zh.json` | `graph.zoom.{in,out,fit}` i18n keys |
| `openspec/specs/{project-resource-graph,task-dag-navigation}/spec.md` + archive | OpenSpec change `add-graph-trackpad-gestures` archived; capability specs updated |
| `*/__tests__/mindmap-canvas-wheel.test.tsx`, `*/__tests__/task-dag-pan-zoom.test.tsx` | New unit coverage (17 tests) |

## Design notes / accepted trade-offs
- **Canvas** owns a custom wheel heuristic (mouse-vs-trackpad); the **DAG** uses ReactFlow's declarative props (no such heuristic) — so plain mouse-wheel zooms on the canvas but pans on the DAG. Both share the same *trackpad* model.
- The **readonly dashboard DAG preview** is deliberately excluded from pan-on-scroll: it hides `<Controls>`, so switching `zoomOnScroll` off would strip its only zoom path (this was a proposal-review BLOCKER fix).
- No inertia/momentum (solid & responsive per elaboration Q5=a).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` — 0 errors on changed files
- [x] `pnpm test` — 4012 passed (17 new; only the known-flaky `cli daemon-integration` case failed once under full-suite load, passes 16/16 isolated)
- [x] Proposal-reviewer + 3 task-reviewers + ship-time code-reviewer all PASS / PASS WITH NOTES
- [x] Deployed to live env and tested by owner
- [ ] design.pen update (deferred — non-required; needs a GUI Pencil session)

Generated with [Claude Code](https://claude.com/claude-code)