### PR TITLE
feat(idea-panel): reassign via assignee block + Yolo icon+label

### DIFF
--- a/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/README.md
+++ b/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/README.md
@@ -1,0 +1,3 @@
+# refine-idea-panel-action-row
+
+Move idea-tracker panel reassign entry onto the assignee block, drop the footer reassign icon button, and restore the Yolo button to icon+label

--- a/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/design.md
+++ b/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/design.md
@@ -1,0 +1,120 @@
+# Design — Refine idea-panel action row
+
+## Context
+
+Two twin idea-detail panels render the same stage-advance controls:
+
+- **Dashboard idea-tracker panel** — `dashboard/panels/idea-detail-panel.tsx`. Tabbed
+  (overview / elaboration / proposal / tasks / activity). The **assignee** is shown
+  only inside the **elaboration** tab via `AssigneeSection`
+  (`dashboard/panels/assignee-section.tsx`), rendered by `elaboration-view.tsx`. The
+  footer has a bottom-left icon-only reassign button gated by
+  `canAssign = idea.status !== "elaborated"`.
+- **`/ideas` panel** — `ideas/idea-detail-panel.tsx`. Single-scroll; shows its own
+  assignee block in the body and keeps its own footer reassign button.
+
+Both panels render the shared `YoloButton` (`src/components/yolo-button.tsx`) and
+`StartDevelopmentButton`. The last declutter pass (#406) turned both the footer
+reassign button and the Yolo button into icon-only controls with tooltips.
+
+This change touches **only the dashboard idea-tracker panel** for the reassign
+relocation, plus the **shared** `YoloButton` (which surfaces on both panels).
+
+## Goals / decisions (from elaboration round 1)
+
+| # | Decision |
+|---|----------|
+| q1 scope | Only the dashboard idea-tracker panel changes its reassign entry point; `/ideas` panel untouched. |
+| q2 placement | The assignee already displays in the elaboration tab (`AssigneeSection`); reuse it as the reassign trigger rather than adding a new block. |
+| q3 affordance | Minimal discoverability: `cursor-pointer` + tooltip only. No hover-background, no hover pencil icon. |
+| q4 gating | Keep the existing `canAssign` gating — assignee clickable while `open`/`elaborating`, read-only once `elaborated`. |
+| q5 Yolo | Rocket icon + "Yolo" label; **drop** the tooltip; keep purple styling and the confirm (AlertDialog) step. |
+
+## Change 1 — reassign moves onto the assignee block
+
+`AssigneeSection` currently takes only `assignee`. Extend it with two optional props so
+it can act as a reassign trigger without changing its default (read-only) behavior:
+
+```ts
+interface AssigneeSectionProps {
+  assignee: { type; uuid; name; instance? } | null;
+  onReassign?: () => void;   // when set AND editable, the block becomes a button
+  editable?: boolean;        // false → render as today (non-interactive)
+}
+```
+
+- When `onReassign` is set **and** `editable` is true: render the inner
+  avatar+name+instance box as a `<button type="button">` wrapper with
+  `cursor-pointer`, wrapped in a shadcn `Tooltip` whose content is
+  `common.reassign` (assigned) / `common.assign` (unassigned), and an `aria-label` to
+  match. Clicking calls `onReassign`. No hover-background or pencil icon (q3=b).
+- Otherwise: render exactly as today (a plain `<div>`), so the `/ideas` panel and any
+  read-only usage are unaffected.
+
+`elaboration-view.tsx` gains matching optional props and forwards them to
+`AssigneeSection`:
+
+```ts
+interface ElaborationViewProps {
+  // ...existing
+  onReassign?: () => void;
+  canReassign?: boolean;
+}
+```
+
+`idea-detail-panel.tsx` (dashboard):
+- Compute `canAssign = idea ? idea.status !== "elaborated" : false` (already present).
+- Pass `onReassign={() => setShowAssignModal(true)}` and `canReassign={canAssign}` into
+  `<ElaborationView>`.
+- **Remove** the footer `canAssign && (<TooltipProvider>…reassign icon Button…)` block
+  entirely. The `AssignIdeaModal` mount + `showAssignModal` state stay (the trigger
+  just moves).
+
+Editability parity: the footer button used `canAssign` (`status !== "elaborated"`); the
+assignee-block trigger uses the same predicate, so behavior is identical, only the
+trigger location changes (q4=a).
+
+## Change 2 — Yolo button icon + label
+
+In `src/components/yolo-button.tsx`, the primary trigger is currently
+`size="icon"` (h-8 w-8) wrapped in `TooltipProvider`/`Tooltip` with `aria-label` and a
+`Rocket`-only child. Change to:
+
+- Drop the `Tooltip`/`TooltipProvider`/`TooltipTrigger` wrappers and the tooltip import
+  usage around the trigger (keep them only if still used elsewhere in the file — they
+  are not).
+- Render a normal `Button` (default size) with purple classes retained
+  (`bg-[#7F5AF0] hover:bg-[#6D48DE] text-white`), child = `<Rocket className="mr-2 h-4 w-4" /> {t("button")}`.
+- Keep `AlertDialogTrigger asChild` around that Button so the confirm dialog still
+  fires; keep the whole AlertDialog confirm flow, disabled/offline logic, and the
+  `started`/`offlineHint` states unchanged.
+
+This mirrors `StartDevelopmentButton`'s icon+label shape, so the two primary
+stage-advance CTAs look consistent. Because `YoloButton` is shared, the label returns
+on the `/ideas` panel too — intended (q5, and the idea body says "no longer abbreviated").
+
+## Non-goals
+
+- No change to `/ideas` panel's footer reassign button.
+- No change to `StartDevelopmentButton`, the assign modal, gating predicates, or any
+  server action.
+- No new i18n keys (`common.reassign`, `common.assign`, `yolo.button` already exist).
+
+## Risks
+
+- **Discoverability**: a bare cursor+tooltip is subtle. Accepted by q3=b (minimal). The
+  tooltip + `aria-label` keep it accessible and self-documenting on hover/AT.
+- **Shared Yolo component**: the label change is intentionally global across both
+  panels; verified there is no third consumer that wanted icon-only.
+- **Elaboration-tab-only reach**: on the dashboard panel the reassign trigger is only
+  present on the elaboration tab (the only tab that renders the assignee). This is
+  self-consistent — `open`/`elaborating` ideas default to that tab, which is exactly
+  the editable window; once `elaborated` the block is read-only anyway.
+
+## Verification
+
+- `pnpm lint`, `npx tsc --noEmit`, `pnpm test` (yolo-button test updated for label).
+- Manual e2e (Playwright): open a dashboard idea panel on an `elaborating` idea →
+  elaboration tab → click assignee block → assign modal opens; footer no longer has the
+  reassign icon; Yolo shows rocket + "Yolo".
+- Update `docs/design.pen` for the modified panel footer + assignee affordance.

--- a/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/proposal.md
+++ b/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+On the dashboard idea-tracker detail panel, the footer's bottom-left **reassign**
+control was reduced to an icon-only button in the last declutter pass (#406). As a
+standalone icon it reads as clutter with weak affordance, and it crowds the footer
+so the **Yolo** button also had to shrink to an icon-only shortcut. The panel already
+shows the assignee (avatar + name + agent-instance line) in the elaboration tab, so
+the natural place to trigger reassignment is that assignee block itself — freeing the
+footer to let Yolo return to a full icon **+** label button.
+
+## What Changes
+
+- **Remove** the standalone reassign icon button from the footer action row of the
+  dashboard idea-tracker detail panel (`dashboard/panels/idea-detail-panel.tsx`).
+- **Make the existing assignee block clickable** (the `AssigneeSection` rendered in
+  the elaboration tab) so clicking it opens the reassign modal (`AssignIdeaModal`),
+  gated by the same `canAssign` predicate (`idea.status !== "elaborated"`): clickable
+  while `open` / `elaborating`, read-only once `elaborated`.
+- **Restore the Yolo button to icon + label** (rocket + "Yolo" text), dropping the
+  tooltip that stood in for the hidden label, while keeping its purple styling and the
+  confirm dialog. `YoloButton` is shared by both idea-detail panels, so this also
+  restores the label on the `/ideas` panel — matching the intent that Yolo is no
+  longer abbreviated anywhere.
+- **Scope:** only the dashboard idea-tracker panel changes its reassign entry point;
+  the `/ideas` panel keeps its own footer reassign button (per elaboration q1=b).
+
+## Capabilities
+
+### New Capabilities
+
+- `idea-panel-action-row`: how the dashboard idea-tracker detail panel exposes the
+  reassign entry point (on the assignee block, gated by editability) and how the Yolo
+  stage-advance button is presented (icon + label, no tooltip).
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+- **Code:**
+  - `src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx` —
+    remove footer reassign button; pass an `onReassign` affordance down to the
+    elaboration view / assignee section.
+  - `src/app/(dashboard)/projects/[uuid]/dashboard/panels/assignee-section.tsx` —
+    make the block a clickable trigger (cursor-pointer + tooltip) when editable.
+  - `src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx` —
+    thread the reassign click + editability through to `AssigneeSection`.
+  - `src/components/yolo-button.tsx` — icon + label, remove tooltip, keep confirm.
+- **Shared component:** the `YoloButton` change is visible on both idea-detail panels.
+- **i18n:** no new keys required (`common.reassign` / `common.assign`, `yolo.button`
+  already exist).
+- **Tests:** `src/components/__tests__/yolo-button.test.tsx` (label now rendered);
+  panel/assignee-section interaction.
+- **No API, schema, or data-model changes.**

--- a/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/specs/idea-panel-action-row/spec.md
+++ b/openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/specs/idea-panel-action-row/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Reassign entry on the assignee block
+
+The dashboard idea-tracker detail panel SHALL trigger reassignment from the assignee block shown in the elaboration tab, and SHALL NOT render a standalone reassign button in the footer action row.
+
+The assignee block acts as the reassign trigger only while the idea is editable — the same condition that previously gated the footer button (`idea.status !== "elaborated"`, i.e. `open` or `elaborating`). Once the idea is `elaborated` the block is read-only and does not open the reassign modal. The clickable affordance is minimal: a pointer cursor plus a tooltip (and an `aria-label`) reading "Reassign" when an assignee exists or "Assign" when unassigned. No hover-background tint or hover pencil icon is added.
+
+The `/ideas` idea-detail panel is out of scope for this change and keeps its own footer reassign button.
+
+#### Scenario: Clicking the assignee block on an elaborating idea opens the reassign modal
+
+- **WHEN** a user views the dashboard idea-tracker detail panel for an idea whose status is `open` or `elaborating`, on the elaboration tab, and clicks the assignee block
+- **THEN** the reassign modal (`AssignIdeaModal`) opens
+- **AND** the footer action row does not contain a standalone reassign button
+
+#### Scenario: Assignee block is read-only once the idea is elaborated
+
+- **WHEN** the idea's status is `elaborated`
+- **THEN** the assignee block is not clickable and clicking it does not open the reassign modal
+
+#### Scenario: Affordance is minimal
+
+- **WHEN** the assignee block is in its clickable (editable) state
+- **THEN** it shows a pointer cursor and a tooltip labelled "Reassign" (assigned) or "Assign" (unassigned)
+- **AND** it does not add a hover-background tint or a hover pencil icon
+
+### Requirement: Yolo button shows icon and label
+
+The Yolo stage-advance button SHALL render as a rocket icon followed by the "Yolo" text label, and SHALL NOT rely on a tooltip to convey its label.
+
+The button retains its purple styling and its two-step confirmation dialog. Because the Yolo button is a shared component rendered by both idea-detail panels, the icon+label presentation applies wherever the Yolo button appears.
+
+#### Scenario: Yolo button renders icon and text
+
+- **WHEN** the Yolo button is shown on an idea-detail panel for an eligible idea
+- **THEN** it displays a rocket icon together with the visible text "Yolo"
+- **AND** it does not depend on a hover tooltip to reveal its label
+
+#### Scenario: Confirmation dialog is preserved
+
+- **WHEN** a user clicks the Yolo button
+- **THEN** a confirmation dialog is shown before the yolo run is requested

--- a/openspec/specs/idea-panel-action-row/spec.md
+++ b/openspec/specs/idea-panel-action-row/spec.md
@@ -1,0 +1,47 @@
+# idea-panel-action-row Specification
+
+## Purpose
+TBD - created by archiving change refine-idea-panel-action-row. Update Purpose after archive.
+## Requirements
+### Requirement: Reassign entry on the assignee block
+
+The dashboard idea-tracker detail panel SHALL trigger reassignment from the assignee block shown in the elaboration tab, and SHALL NOT render a standalone reassign button in the footer action row.
+
+The assignee block acts as the reassign trigger only while the idea is editable — the same condition that previously gated the footer button (`idea.status !== "elaborated"`, i.e. `open` or `elaborating`). Once the idea is `elaborated` the block is read-only and does not open the reassign modal. The clickable affordance is minimal: a pointer cursor plus a tooltip (and an `aria-label`) reading "Reassign" when an assignee exists or "Assign" when unassigned. No hover-background tint or hover pencil icon is added.
+
+The `/ideas` idea-detail panel is out of scope for this change and keeps its own footer reassign button.
+
+#### Scenario: Clicking the assignee block on an elaborating idea opens the reassign modal
+
+- **WHEN** a user views the dashboard idea-tracker detail panel for an idea whose status is `open` or `elaborating`, on the elaboration tab, and clicks the assignee block
+- **THEN** the reassign modal (`AssignIdeaModal`) opens
+- **AND** the footer action row does not contain a standalone reassign button
+
+#### Scenario: Assignee block is read-only once the idea is elaborated
+
+- **WHEN** the idea's status is `elaborated`
+- **THEN** the assignee block is not clickable and clicking it does not open the reassign modal
+
+#### Scenario: Affordance is minimal
+
+- **WHEN** the assignee block is in its clickable (editable) state
+- **THEN** it shows a pointer cursor and a tooltip labelled "Reassign" (assigned) or "Assign" (unassigned)
+- **AND** it does not add a hover-background tint or a hover pencil icon
+
+### Requirement: Yolo button shows icon and label
+
+The Yolo stage-advance button SHALL render as a rocket icon followed by the "Yolo" text label, and SHALL NOT rely on a tooltip to convey its label.
+
+The button retains its purple styling and its two-step confirmation dialog. Because the Yolo button is a shared component rendered by both idea-detail panels, the icon+label presentation applies wherever the Yolo button appears.
+
+#### Scenario: Yolo button renders icon and text
+
+- **WHEN** the Yolo button is shown on an idea-detail panel for an eligible idea
+- **THEN** it displays a rocket icon together with the visible text "Yolo"
+- **AND** it does not depend on a hover tooltip to reveal its label
+
+#### Scenario: Confirmation dialog is preserved
+
+- **WHEN** a user clicks the Yolo button
+- **THEN** a confirmation dialog is shown before the yolo run is requested
+

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/assignee-section.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/assignee-section.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+//
+// UI tests for AssigneeSection (refine-idea-panel-action-row). The assignee
+// block doubles as the reassign trigger: when `editable && onReassign` are
+// both provided it renders as a clickable button (with an accessible
+// reassign/assign label) whose click invokes onReassign; otherwise it renders
+// as a non-interactive block (default render unchanged), so callers that omit
+// the props — and the elaborated (read-only) state — get no reassign entry.
+
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Radix has no bearing here (AssigneeSection uses a Tooltip), but its Popper
+// primitives touch ResizeObserver / pointer-capture — absent from jsdom.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+if (typeof Element !== "undefined" && !Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// AssigneeInstanceLine pulls in the agent-presence context; stub it to a bare
+// span so this stays a focused unit test of AssigneeSection's own behavior.
+vi.mock("@/components/agent-presence", () => ({
+  AssigneeInstanceLine: ({ host }: { host: string; cwd: string | null }) => (
+    <span>{host}</span>
+  ),
+}));
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolveKey(ns: string, key: string): string {
+    const path = ns ? `${ns}.${key}`.split(".") : key.split(".");
+    let node: unknown = en;
+    for (const p of path) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return `${ns ? ns + "." : ""}${key}`;
+      }
+    }
+    return typeof node === "string" ? node : `${ns ? ns + "." : ""}${key}`;
+  }
+  return {
+    useTranslations: (ns?: string) => (key: string) => resolveKey(ns ?? "", key),
+  };
+});
+
+import { AssigneeSection } from "../assignee-section";
+
+const agentAssignee = {
+  type: "agent",
+  uuid: "agent-1",
+  name: "Admin Claude",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AssigneeSection — reassign trigger", () => {
+  it("is a clickable button that invokes onReassign when editable + onReassign are set (assigned)", async () => {
+    const onReassign = vi.fn();
+    render(
+      <AssigneeSection assignee={agentAssignee} editable onReassign={onReassign} />
+    );
+    // Accessible name = "Reassign" (assignee present).
+    const btn = screen.getByRole("button", { name: /reassign/i });
+    await userEvent.click(btn);
+    expect(onReassign).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels the trigger 'Assign' when there is no assignee (unassigned state also wrapped)", async () => {
+    const onReassign = vi.fn();
+    render(<AssigneeSection assignee={null} editable onReassign={onReassign} />);
+    const btn = screen.getByRole("button", { name: /^assign$/i });
+    await userEvent.click(btn);
+    expect(onReassign).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders non-interactively when editable is false (elaborated / read-only)", () => {
+    const onReassign = vi.fn();
+    render(
+      <AssigneeSection assignee={agentAssignee} editable={false} onReassign={onReassign} />
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+    // The assignee name is still shown — only the click affordance is gone.
+    expect(screen.getByText("Admin Claude")).toBeTruthy();
+  });
+
+  it("renders non-interactively when the props are omitted (default render unchanged)", () => {
+    render(<AssigneeSection assignee={agentAssignee} />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("Admin Claude")).toBeTruthy();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
@@ -190,15 +190,17 @@ describe("dashboard IdeaDetailPanel — Verify Elaborate footer button", () => {
   it("does not render the button while a round is still pending", async () => {
     getElaborationActionMock.mockResolvedValue(elaborationResponse("pending_answers"));
     renderPanel();
-    // The idea loads (Reassign button proves the footer rendered) but no verify button.
-    await screen.findByRole("button", { name: "Reassign" });
+    // The idea loads (the stubbed elaboration view proves the panel body
+    // rendered — reassign now lives inside that view, not the footer) but no
+    // verify button.
+    await screen.findByTestId("elaboration-view");
     expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
   });
 
   it("does not render the button once elaboration is resolved", async () => {
     getIdeaActionMock.mockResolvedValue(ideaResponse({ elaborationStatus: "resolved" }));
     renderPanel();
-    await screen.findByRole("button", { name: "Reassign" });
+    await screen.findByTestId("elaboration-view");
     expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
   });
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/assignee-section.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/assignee-section.tsx
@@ -4,6 +4,12 @@ import { useTranslations } from "next-intl";
 import { Bot } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { AssigneeInstanceLine } from "@/components/agent-presence";
 import { isAgentAssignee } from "@/lib/assignee-identity";
 
@@ -15,60 +21,90 @@ interface AssigneeSectionProps {
     // Present only when type === "agent_instance": the pinned (host, cwd) place.
     instance?: { agentUuid: string; host: string; cwd: string | null };
   } | null;
+  // When both are set, the assignee box becomes the reassign trigger: clicking
+  // it calls onReassign (opens the assign modal). This replaces the panel's old
+  // footer reassign button — the entry point now lives on the assignee itself.
+  onReassign?: () => void;
+  // Gates the trigger the same way the removed footer button was gated
+  // (idea.status !== "elaborated"). When false/omitted the box is read-only.
+  editable?: boolean;
 }
 
-export function AssigneeSection({ assignee }: AssigneeSectionProps) {
+export function AssigneeSection({ assignee, onReassign, editable }: AssigneeSectionProps) {
   const tCommon = useTranslations("common");
+
+  // The reassign entry is active only while editable AND a handler is wired —
+  // read-only usages (e.g. an elaborated idea, or callers that omit the props)
+  // render exactly as before.
+  const interactive = editable === true && typeof onReassign === "function";
+  const actionLabel = assignee ? tCommon("reassign") : tCommon("assign");
+
+  // Shared inner content for both interactive and read-only renders.
+  const inner = assignee ? (
+    <>
+      <Avatar className="h-7 w-7">
+        <AvatarFallback
+          className={
+            isAgentAssignee(assignee)
+              ? "bg-[#C67A52] text-white"
+              : "bg-[#E5E0D8] text-[#6B6B6B]"
+          }
+        >
+          {isAgentAssignee(assignee) ? (
+            <Bot className="h-3.5 w-3.5" />
+          ) : (
+            assignee.name.charAt(0).toUpperCase()
+          )}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-[#2C2C2C]">{assignee.name}</div>
+        <div className="text-xs text-[#6B6B6B]">
+          {isAgentAssignee(assignee) ? tCommon("agent") : tCommon("user")}
+        </div>
+        {/* Pinned (host, cwd) place for an agent_instance assignee. */}
+        {assignee.type === "agent_instance" && assignee.instance && (
+          <div className="mt-1">
+            <AssigneeInstanceLine
+              cwd={assignee.instance.cwd}
+              host={assignee.instance.host}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  ) : (
+    <span className="text-sm text-[#9A9A9A]">{tCommon("unassigned")}</span>
+  );
+
+  const boxClass = "mt-2 flex items-center gap-2.5 rounded-lg bg-[#FAF8F4] p-3";
 
   return (
     <div>
       <Label className="text-[11px] font-medium uppercase tracking-wide text-[#9A9A9A]">
         {tCommon("assignee")}
       </Label>
-      <div className="mt-2 flex items-center gap-2.5 rounded-lg bg-[#FAF8F4] p-3">
-        {assignee ? (
-          <>
-            <Avatar className="h-7 w-7">
-              <AvatarFallback
-                className={
-                  isAgentAssignee(assignee)
-                    ? "bg-[#C67A52] text-white"
-                    : "bg-[#E5E0D8] text-[#6B6B6B]"
-                }
+      {interactive ? (
+        // Minimal affordance (elaboration q3=b): cursor-pointer + tooltip +
+        // aria-label. No hover-background tint, no hover pencil icon.
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onReassign}
+                aria-label={actionLabel}
+                className={`${boxClass} w-full cursor-pointer text-left`}
               >
-                {isAgentAssignee(assignee) ? (
-                  <Bot className="h-3.5 w-3.5" />
-                ) : (
-                  assignee.name.charAt(0).toUpperCase()
-                )}
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0">
-              <div className="text-sm font-medium text-[#2C2C2C]">
-                {assignee.name}
-              </div>
-              <div className="text-xs text-[#6B6B6B]">
-                {isAgentAssignee(assignee)
-                  ? tCommon("agent")
-                  : tCommon("user")}
-              </div>
-              {/* Pinned (host, cwd) place for an agent_instance assignee. */}
-              {assignee.type === "agent_instance" && assignee.instance && (
-                <div className="mt-1">
-                  <AssigneeInstanceLine
-                    cwd={assignee.instance.cwd}
-                    host={assignee.instance.host}
-                  />
-                </div>
-              )}
-            </div>
-          </>
-        ) : (
-          <span className="text-sm text-[#9A9A9A]">
-            {tCommon("unassigned")}
-          </span>
-        )}
-      </div>
+                {inner}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{actionLabel}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <div className={boxClass}>{inner}</div>
+      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/elaboration-view.tsx
@@ -19,9 +19,13 @@ interface ElaborationViewProps {
   elaboration: ElaborationResponse | null;
   isLoading: boolean;
   onRefresh: () => Promise<void> | void;
+  // Reassign entry: the panel wires these so the assignee block below becomes
+  // the reassign trigger (replaces the removed footer reassign button).
+  onReassign?: () => void;
+  canReassign?: boolean;
 }
 
-export function ElaborationView({ idea, elaboration, isLoading, onRefresh }: ElaborationViewProps) {
+export function ElaborationView({ idea, elaboration, isLoading, onRefresh, onReassign, canReassign }: ElaborationViewProps) {
   const t = useTranslations("ideaTracker");
   const tCommon = useTranslations("common");
 
@@ -35,8 +39,12 @@ export function ElaborationView({ idea, elaboration, isLoading, onRefresh }: Ela
 
   return (
     <motion.div variants={fadeIn} initial="initial" animate="animate">
-      {/* Assignee Section */}
-      <AssigneeSection assignee={idea.assignee} />
+      {/* Assignee Section — doubles as the reassign trigger (elaboration q2). */}
+      <AssigneeSection
+        assignee={idea.assignee}
+        onReassign={onReassign}
+        editable={canReassign}
+      />
 
       <Separator className="my-5 bg-[#F5F2EC]" />
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { X, Loader2, User, Trash2, ArrowRightLeft, Pencil, GitFork, CornerLeftUp, CornerDownRight, CheckCircle2 } from "lucide-react";
+import { X, Loader2, Trash2, ArrowRightLeft, Pencil, GitFork, CornerLeftUp, CornerDownRight, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
@@ -23,13 +23,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { PresenceIndicator } from "@/components/ui/presence-indicator";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
 import { ElaborationView } from "./elaboration-view";
 import { ProposalView, type ProposalData } from "./proposal-view";
@@ -935,6 +928,8 @@ export function IdeaDetailPanel({
                           await fetchElaboration();
                           await fetchIdea();
                         }}
+                        onReassign={() => setShowAssignModal(true)}
+                        canReassign={canAssign}
                       />
                     </div>
                   )}
@@ -1011,29 +1006,10 @@ export function IdeaDetailPanel({
               </div>
             ) : (
               <div className="flex items-center justify-between gap-3">
-                {canAssign && (
-                  // Icon-only (Option C — declutter the action row): the (re)assign
-                  // label rides a shadcn Tooltip (+ aria-label for a11y) so the
-                  // stage primary CTA stays the only full-text button.
-                  <TooltipProvider delayDuration={300}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="shrink-0 h-8 w-8 border-[#E5E0D8]"
-                          onClick={() => setShowAssignModal(true)}
-                          aria-label={idea.assignee ? t("common.reassign") : t("common.assign")}
-                        >
-                          <User className="h-4 w-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {idea.assignee ? t("common.reassign") : t("common.assign")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
+                {/* Reassign moved onto the assignee block in the elaboration tab
+                    (see ElaborationView onReassign/canReassign) — the footer no
+                    longer carries a standalone reassign button, which frees room
+                    for Yolo to render as a full icon+label CTA. */}
                 <div className="flex-1 min-w-0 flex flex-wrap items-center gap-2">
                   {/* Proposal-progression CTAs are hidden on a container idea:
                       a container may elaborate + derive children but MUST NOT

--- a/src/components/__tests__/yolo-button.test.tsx
+++ b/src/components/__tests__/yolo-button.test.tsx
@@ -5,6 +5,8 @@
 //    stage (incl. no proposal), hidden only when the idea is done or the
 //    assignee is not an agent,
 //  - AgentPresence-driven online state: offline disables with a hint,
+//  - icon + label presentation (refine-idea-panel-action-row): the button
+//    renders the visible "Yolo" text label, not an icon-only shortcut,
 //  - the CONFIRM step: clicking the button opens the dialog and does NOT call
 //    yoloRequestedAction until the user confirms,
 //  - server error codes surface as SPECIFIC i18n toasts (agent_offline distinct
@@ -15,10 +17,10 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-// The Yolo trigger is now wrapped in a shadcn (Radix) Tooltip, whose
-// PopperContent uses ResizeObserver — absent from jsdom. Without this stub,
-// opening the tooltip (focus/click) throws unhandled errors that Vitest flags
-// as potential false positives. Stub the browser APIs Radix's popper needs.
+// The Yolo confirm step uses a shadcn (Radix) AlertDialog, whose Popper-based
+// primitives use ResizeObserver + pointer-capture — absent from jsdom. Without
+// these stubs, opening the dialog throws unhandled errors that Vitest flags as
+// potential false positives. Stub the browser APIs Radix needs.
 if (typeof globalThis.ResizeObserver === "undefined") {
   globalThis.ResizeObserver = class {
     observe() {}
@@ -106,6 +108,16 @@ describe("YoloButton — render gating", () => {
     render(<YoloButton {...HAPPY_PROPS} />);
     const btn = screen.getByRole<HTMLButtonElement>("button", { name: "Yolo" });
     expect(btn.disabled).toBe(false);
+  });
+
+  it("renders the visible 'Yolo' text label (icon + label, not icon-only)", () => {
+    render(<YoloButton {...HAPPY_PROPS} />);
+    // The label is real button text now (no tooltip needed to convey it): the
+    // trigger's accessible name comes from its textContent, and the text node
+    // is present in the DOM.
+    const btn = screen.getByRole<HTMLButtonElement>("button", { name: "Yolo" });
+    expect(btn.textContent).toContain("Yolo");
+    expect(screen.getByText("Yolo")).toBeTruthy();
   });
 
   it("renders on a building-stage idea (approved proposal + unfinished task) — coexists with Start Development", () => {

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -26,12 +26,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
 import {
   canRequestYolo,
@@ -131,28 +125,18 @@ export function YoloButton({
   return (
     <>
       <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        {/* Icon-only (Option C — declutter the action row): the label rides a
-            shadcn Tooltip (+ aria-label for a11y) so the row stays compact while
-            the stage primary CTA keeps its full-text button. Both TooltipTrigger
-            and AlertDialogTrigger are asChild, so Radix merges their props onto
-            the single Button. */}
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <AlertDialogTrigger asChild>
-                <Button
-                  size="icon"
-                  className="h-8 w-8 bg-[#7F5AF0] hover:bg-[#6D48DE] text-white"
-                  disabled={!enabled}
-                  aria-label={t("button")}
-                >
-                  <Rocket className="h-4 w-4" />
-                </Button>
-              </AlertDialogTrigger>
-            </TooltipTrigger>
-            <TooltipContent>{t("button")}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        {/* Icon + label: the footer now has room (the standalone reassign button
+            moved onto the assignee block), so Yolo reads as a full text button
+            like Start Development rather than an icon-only shortcut. */}
+        <AlertDialogTrigger asChild>
+          <Button
+            className="bg-[#7F5AF0] hover:bg-[#6D48DE] text-white"
+            disabled={!enabled}
+          >
+            <Rocket className="mr-2 h-4 w-4" />
+            {t("button")}
+          </Button>
+        </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("confirmTitle")}</AlertDialogTitle>


### PR DESCRIPTION
## Summary
- Remove the dashboard idea-tracker detail panel's footer reassign icon button (added in #406 declutter).
- Make the assignee block (already shown in the elaboration tab) the reassign trigger — clicking it opens `AssignIdeaModal`, gated by the same `status !== "elaborated"` predicate the footer button used. Minimal affordance: `cursor-pointer` + tooltip + `aria-label` (no hover-bg tint, no pencil icon).
- Restore the shared `YoloButton` to a full rocket icon + "Yolo" label (tooltip dropped, purple styling + two-step confirm dialog kept).

## Scope
- **Dashboard idea-tracker panel only.** The `/ideas` twin panel is untouched and keeps its own footer reassign button.
- `YoloButton` is a shared component, so the icon+label restoration also applies to the `/ideas` panel's Yolo — intended ("no longer abbreviated anywhere").

## Changed files
| File | Change |
|------|--------|
| `src/components/yolo-button.tsx` | Icon-only trigger → default Button with `<Rocket>` + "Yolo"; removed Tooltip wrappers + import |
| `dashboard/panels/assignee-section.tsx` | Added optional `onReassign`/`editable`; box becomes a Tooltip-wrapped `<button>` (assigned + unassigned) when both set, else unchanged |
| `dashboard/panels/elaboration-view.tsx` | Forward `onReassign`/`canReassign` to `AssigneeSection` |
| `dashboard/panels/idea-detail-panel.tsx` | Wire `canReassign={canAssign}` + `onReassign`; remove footer reassign button and now-dead imports |
| `src/components/__tests__/yolo-button.test.tsx` | Assert the visible "Yolo" label; keep confirm-dialog gating coverage |
| `dashboard/panels/__tests__/assignee-section.test.tsx` | **New** — clickable-when-editable vs non-interactive-by-default |
| `dashboard/panels/__tests__/idea-detail-verify.test.tsx` | Re-anchor 2 cases off the removed footer "Reassign" button → stubbed `elaboration-view` testid |
| `openspec/changes/archive/2026-07-08-refine-idea-panel-action-row/`, `openspec/specs/idea-panel-action-row/` | OpenSpec change (archived) + emitted capability spec |

## Design decisions (from resolved elaboration)
- Scope = dashboard panel only (q1); reuse the existing assignee block rather than add one (q2); minimal cursor+tooltip affordance (q3); keep existing `elaborated` gating (q4); Yolo icon+label, drop tooltip (q5).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 254 files / 4038 tests pass, 0 failures
- [x] Deployed to the live env; `/login` → HTTP 200
- [ ] `docs/design.pen` update deferred (Pencil needs a GUI editor; not drivable headless) — follow-up
- [ ] Manual browser e2e (optional; behavior covered by component tests)

Chorus idea: `83f3d4fd-246b-41a2-b5f3-54455b42fb85`

🤖 Generated with [Claude Code](https://claude.com/claude-code)