### PR TITLE
fix(graph): plain wheel always zooms; remove flaky device classifier

### DIFF
--- a/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/README.md
+++ b/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/README.md
@@ -1,0 +1,3 @@
+# fix-graph-wheel-device-classification
+
+Replace the magnitude-based mouse/trackpad wheel heuristic on the graph canvas with device inference so a slow mouse wheel still zooms; align the task DAG

--- a/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/design.md
+++ b/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/design.md
@@ -1,0 +1,118 @@
+# Technical Design: Device-inferred wheel classification for the graph surfaces
+
+## Overview
+
+Both graph surfaces need the same rule: **a mouse wheel zooms at any speed; a trackpad two-finger swipe pans (both axes, including a purely vertical swipe).** Today they diverge and both get it partly wrong for a mouse:
+
+- **`/graph` canvas** (`mindmap-canvas.tsx`) classifies each wheel event in isolation with a magnitude threshold `MOUSE_NOTCH_MIN = 30px`: a pixel-mode wheel with `|deltaY| < 30` is treated as a trackpad pan. A slow / high-resolution / smooth-scroll mouse notch is < 30px, so it pans — the reported bug.
+- **Task DAG** (`task-dag.tsx`, ReactFlow) uses `panOnScroll: true, zoomOnScroll: false` (from #408): **every** plain wheel pans, including a mouse wheel. No magnitude bug, but a mouse wheel never zooms — the same principle, violated the other way.
+
+The fix is a single shared, stateful **device classifier** that infers the pointing device from the *rhythm and continuity of the recent wheel stream* (elaboration Q2=b), not from any one event's size or fractionality. Both surfaces consume it (Q3=b). It preserves the mouse-zoom / trackpad-pan split (Q1=b), including a **vertical** trackpad swipe still panning.
+
+## Why magnitude / fractionality / ramping are the WRONG signals (the Round-1 blocker)
+
+The reported device is a **high-resolution or smooth-scroll mouse**. Its notches are small (< 30px), often **fractional**, and **ramp** in magnitude within a notch. A trackpad two-finger scroll produces the *same* per-event shape — small, fractional, ramping. Therefore **none of {delta magnitude, fractional deltas, per-event ramp} can separate the two devices**; keying "trackpad" on any of them (as the threshold does, and as a naive stream heuristic would) re-breaks the exact device that filed the bug. This is the mistake Round 1 caught and this design must not repeat.
+
+What actually differs is the **shape of the event stream over time**, plus two hard device tells:
+
+| Signal | Mouse wheel | Trackpad two-finger scroll | Reliable? |
+|---|---|---|---|
+| `deltaMode` | sometimes line/page (`1`/`2`) | always pixel (`0`) | **line/page ⇒ mouse** (hard tell) |
+| `deltaX` (horizontal component) | ~always `0` (no tilt) | frequently non-zero | **horizontal ⇒ trackpad** (hard tell) |
+| stream continuity / duration | **short bounded bursts** — a notch (or a few events) then a gap; even fast scrolling is repeated discrete notches | **one sustained, uninterrupted run** — many closely-spaced events over a long gesture, typically with an inertial **momentum decay tail** after the fingers lift | primary vertical separator |
+| delta magnitude / fractionality / per-event ramp | small, fractional, ramping on hi-res mice | small, fractional, ramping | **NOT reliable — do not use** |
+
+So the axis is **"short bounded burst vs sustained continuous run,"** not "coarse vs fine."
+
+## Module contract — `src/lib/wheel-gesture.ts`
+
+A pure, framework-agnostic classifier so both a raw DOM `wheel` listener (canvas) and a ReactFlow wrapper (DAG) can share it and it stays unit-testable without a browser.
+
+```ts
+export type WheelGesture =
+  | { kind: "zoom"; deltaY: number }   // caller maps deltaY→scaleFactor with its own sensitivity
+  | { kind: "pan"; dx: number; dy: number };
+
+export interface WheelSample {
+  ctrlKey: boolean;
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number;   // 0 pixel, 1 line, 2 page
+  timeStamp: number;   // ev.timeStamp (ms); monotonic within a document
+}
+
+// Opaque rolling state. Create one per surface instance; feed every wheel event.
+export interface WheelClassifierState { /* device, lastTs, run bookkeeping */ }
+export function createWheelClassifierState(): WheelClassifierState;
+
+// Pure: returns the gesture AND the next state (no mutation of the input),
+// so tests can drive a scripted event stream and assert each classification.
+// Field name is `state` everywhere (contract + call sites + ACs) — no `nextState`.
+export function classifyWheelStream(
+  state: WheelClassifierState,
+  sample: WheelSample,
+): { gesture: WheelGesture; state: WheelClassifierState };
+```
+
+The `zoom` variant carries raw `deltaY` (not a pre-multiplied `scaleFactor`) — the classifier is device-only; each surface keeps its own zoom sensitivity (the canvas already has `ZOOM_WHEEL_SENSITIVITY` / `ZOOM_PINCH_SENSITIVITY`; the DAG uses a fixed zoom step). One classifier, two feels.
+
+### Decision procedure (precedence order)
+
+Given the current `state` and a new `sample`, in order:
+
+1. **`ctrlKey` → `zoom`.** A browser reports a trackpad pinch as a synthetic ctrl+wheel, and Ctrl/⌘+wheel is the explicit zoom shortcut. Device-agnostic; does not touch the mouse/trackpad decision. (Unchanged from today.)
+2. **Idle reset.** If `sample.timeStamp - state.lastTs > IDLE_RESET_MS`, clear the inferred device to `unknown` and reset the run bookkeeping (count, first/last timestamps): a new gesture is classified on its own evidence, never a stale one.
+3. **Hard tell — line/page mode** (`deltaMode !== 0`) → device = **mouse**, sticky → `zoom`.
+4. **Hard tell — horizontal component** (`deltaX !== 0`) → device = **trackpad**, sticky → `pan`. (A tilt-wheel horizontal scroll is a deliberate horizontal-pan intent anyway, so treating it as pan is correct even on the rare mouse that has one.)
+5. **Continuity — sustained run ⇒ trackpad.** Track the current run: increment a count and remember timestamps while successive events stay within `CONTINUITY_GAP_MS` of each other. When the run reaches `CONTINUITY_MIN_EVENTS` **and** has lasted at least `CONTINUITY_MIN_MS`, mark device = **trackpad**, sticky → `pan`. A mouse notch is a short bounded burst that does not reach a sustained-run of this length; a trackpad swipe is one continuous run and does. **Crucially, magnitude/fractionality/ramping are never inspected here** — only cadence and duration.
+6. **Default while `unknown` → `zoom`** (mouse). This is the deliberate inversion that fixes the bug and sets the *safe* bias: an ambiguous pure-vertical event — including the leading events of any gesture before continuity is established — is treated as a mouse-wheel **zoom**, not a pan. The old code defaulted small vertical deltas to *pan*; we invert that.
+7. Emit `pan {dx, dy}` iff device resolved to `trackpad`; otherwise `zoom {deltaY}`.
+
+Constants (tunable, exported for tests): `IDLE_RESET_MS ≈ 400`, `CONTINUITY_GAP_MS ≈ 60`, `CONTINUITY_MIN_EVENTS ≈ 5`, `CONTINUITY_MIN_MS ≈ 120`. All live in the module; no magic numbers at call sites.
+
+### Accepted residual ambiguity (documented honestly)
+
+Two bounded, self-correcting residuals — both err toward the *safe* direction (zoom) and neither is the reported bug:
+
+- **Leading edge of a vertical trackpad swipe:** its first few pure-vertical events (before the run crosses the continuity thresholds, or before any horizontal drift) classify as `zoom`, then flip to `pan` once the run is established. Bounded to `CONTINUITY_MIN_EVENTS` events; in practice trackpad swipes drift horizontally almost immediately (step 4 fires sooner). This is the Q1=b trade the user accepted.
+- **A fast free-spinning mouse wheel** that produces one long uninterrupted dense run with no gaps *could* cross the continuity thresholds and reclassify to `pan` mid-spin. The **slow / notched mouse — the reported device — never does** (short bounded bursts stay `zoom` by the step-6 default), so the filed bug is definitively fixed. `CONTINUITY_MIN_EVENTS`/`_MS` are tuned to require a genuinely sustained run so ordinary mouse scrolling stays zoom; pinch, Ctrl/⌘+wheel, and the on-screen controls remain unambiguous zoom paths regardless.
+
+The key contrast with the Round-1 design: we no longer read magnitude/fractionality/ramping at all, and the default flips to zoom — so a small, fractional, ramping mouse notch (the reported shape) is zoom, not pan.
+
+## Surface integration
+
+### `/graph` canvas (`mindmap-canvas.tsx`)
+- Replace the pure `classifyWheel(ev)` + `MOUSE_NOTCH_MIN` with a per-mount `WheelClassifierState` held in a ref, fed from the existing non-passive `wheel` listener (already `{ passive: false }`, already `preventDefault()`s classified gestures).
+- `pan` → the existing `viewRef` translate; `zoom` → existing `zoomAroundRef.current(scaleFactor, sx, sy)`, where `scaleFactor = Math.exp(-deltaY * ZOOM_WHEEL_SENSITIVITY)` (unchanged feel). Pinch/ctrl path uses `ZOOM_PINCH_SENSITIVITY` as today.
+- Delete `MOUSE_NOTCH_MIN` and the old `classifyWheel`/single-event `WheelGesture` export; update `mindmap-canvas-wheel.test.tsx` to drive the new stream classifier.
+
+### Task DAG (interactive mounts) — CORRECTED file locations
+Round-1 note: the interactive `<ReactFlow>` mounts are **NOT** in `task-dag.tsx`. Verified against code:
+- Interactive mounts that spread `DAG_PAN_ZOOM_PROPS`: **`src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx:160`** and **`src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx:754`**.
+- `src/components/task-dag.tsx`'s own `<ReactFlow>` (`zoomOnScroll={true}`, exported `TaskDag`) is the **readonly/compact preview** rendered by `dashboard/panels/proposal-view.tsx`. It **must stay unchanged** (Round-1 note; also the existing `task-dag-navigation` "readonly preview excluded" scenario).
+
+ReactFlow has no per-event classifier hook, so own the wheel on the two interactive mounts:
+- Replace the shared `DAG_PAN_ZOOM_PROPS` (which lives in `task-dag.tsx` and is *imported* by the two mounts) with a new shared helper — a small hook/props bundle (e.g. `useDagWheelNav()` exported from a shared module) that sets `zoomOnScroll={false}` and `panOnScroll={false}` while keeping `zoomOnPinch: true`, `zoomActivationKeyCode: ["Meta","Control"]`, and `panOnDrag: true`, and attaches a non-passive `wheel` listener running the shared classifier. Both mounts consume the one helper so they cannot drift.
+- In the listener: for a `pan`, `preventDefault()` and pan via the ReactFlow instance API (`setViewport({ x: x - dx, y: y - dy, zoom })`); for a mouse `zoom`, `preventDefault()` and zoom around the cursor by a fixed step clamped to the DAG's existing `minZoom=0.3`/`maxZoom=1.5`; leave `ctrlKey` events to ReactFlow (do NOT `preventDefault`, so its native pinch/⌘-wheel zoom still runs — avoids double-handling).
+- **Implementer note (hallucination guard):** verify the exact ReactFlow 12 (`@xyflow/react`) instance-API names (`useReactFlow`, `setViewport`, `zoomTo`, `getViewport`, `screenToFlowPosition`) against the installed version's types/docs before wiring — do not trust memory.
+
+## Testing
+
+- `wheel-gesture.test.ts` (new) — scripted streams, one assertion per event. Must include streams that would have tripped the Round-1 design:
+  - **REPORTED-DEVICE regression guard:** a short, bounded, pure-vertical stream of **small fractional ramping** deltas (a hi-res/smooth mouse slow notch: e.g. 3–4 events like 3.4, 6.1, 8.2 px then a gap) → **every event `zoom`**. This is the exact shape the Round-1 classifier mis-panned.
+  - slow single mouse notch from idle (small px, vertical-only) → `zoom`.
+  - classic line-mode notch → `zoom`.
+  - fast repeated notches with inter-notch gaps → `zoom` (bursts, not one sustained run).
+  - trackpad horizontal / diagonal swipe → `pan` (step-4 horizontal tell).
+  - trackpad pure-vertical sustained swipe → `zoom` for the leading events, then `pan` once the run crosses `CONTINUITY_MIN_EVENTS`/`_MS`; momentum tail stays `pan` (sticky).
+  - `ctrlKey` wheel → `zoom` regardless of device.
+  - idle gap (> `IDLE_RESET_MS`) between two gestures re-classifies the second independently.
+- Update `mindmap-canvas-wheel.test.tsx` and `task-dag-pan-zoom.test.tsx` to the new module.
+
+## Risks & Mitigations
+
+- **R1 (Round-1 blocker) — hi-res/smooth-scroll mouse re-broken.** Eliminated by construction: the classifier never inspects magnitude/fractionality/ramping; the default is zoom; only a horizontal component or a genuinely sustained continuous run flips to pan, neither of which a slow/notched mouse produces. Covered by the explicit REPORTED-DEVICE regression-guard test above.
+- **R2 — ReactFlow wheel takeover regresses pinch/drag/node interaction.** Mitigated by leaving `ctrlKey` (pinch) to ReactFlow, keeping `panOnDrag`, and covering the DAG with the updated pan-zoom test; the readonly preview is untouched.
+- **R3 — editing the wrong DAG mount.** Round-1 note corrected: edits target `dag-view.tsx` + `proposal-editor.tsx`; `task-dag.tsx`'s `<ReactFlow>` (readonly `TaskDag`) is explicitly out of scope.
+- **R4 — `timeStamp` source.** Use `ev.timeStamp` consistently; the classifier uses only *differences*, so the epoch is irrelevant as long as one source is used per stream.
+- **R5 — fast free-spin mouse reclassified to pan.** See residual: bounded, err-toward-safe, not the reported bug; continuity thresholds tuned so ordinary mouse scrolling stays zoom.

--- a/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/proposal.md
+++ b/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The trackpad pan gestures added in #408 introduced a mouse-wheel regression on the project graph canvas (`/graph`): a **slow** mouse-wheel notch now pans the tree up/down instead of zooming, and only a **fast** notch zooms. The cause is a per-event magnitude threshold (`MOUSE_NOTCH_MIN = 30px`) in `classifyWheel` — a pixel-mode wheel below 30px is assumed to be a trackpad swipe. High-resolution and smooth-scroll mice emit sub-30px pixel deltas per notch, so slow scrolling is misclassified as a pan. This is the exact "accepted ambiguity" the code comments flagged, but it degrades ordinary mouse use.
+
+## What Changes
+
+- Replace the single-event magnitude heuristic with a **stateful device classifier** that infers the device from the **rhythm and continuity** of recent wheel events — a mouse produces short bounded bursts (or line/page deltas), a trackpad produces a horizontal component or a sustained continuous run (swipe + momentum tail) — so a mouse-wheel notch zooms at **any** scroll speed while a two-finger trackpad swipe still pans. It deliberately does **not** use delta magnitude, fractional value, or per-event ramp as a device signal, because a high-resolution/smooth-scroll mouse (the reported device) produces exactly those and would otherwise be re-misclassified as a trackpad. Extracted into one shared, unit-tested module both graph surfaces consume.
+- **`/graph` mind-map canvas**: route its non-passive wheel handler through the shared classifier. Slow mouse wheel zooms again; trackpad two-finger swipe pans; trackpad pinch and Ctrl/⌘+wheel still zoom; on-screen +/- / fit controls unchanged.
+- **Task-dependency DAG** (ReactFlow — tasks view + proposal editor): align its wheel behavior with the fixed canvas via the same classifier so **mouse wheel zooms** and **trackpad two-finger swipe pans**, resolving the cross-surface inconsistency where #408 left the DAG panning on every wheel. Pinch, Ctrl/⌘+wheel, drag-pan, node interaction, and the on-screen Controls are preserved; the compact readonly dashboard preview stays excluded (unchanged).
+
+## Capabilities
+
+### New Capabilities
+_(none — this is a fix to existing gesture behavior)_
+
+### Modified Capabilities
+- `project-resource-graph`: the "Trackpad two-finger pan and pinch-zoom on the canvas" requirement changes its wheel classification from a single-event magnitude threshold to a recent-stream device inference, so a slow mouse-wheel notch still zooms.
+- `task-dag-navigation`: the interactive DAG's trackpad-first pan/zoom requirement changes so a mouse wheel zooms (any speed) and a trackpad two-finger swipe pans, via the same shared classifier, instead of ReactFlow's blanket pan-on-scroll.
+
+## Impact
+
+- Code: `src/lib/wheel-gesture.ts` (new shared classifier + its tests), `src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx` (rewire `classifyWheel`), and the two **interactive** DAG mounts — `src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx` and `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx` — which currently spread `DAG_PAN_ZOOM_PROPS` (defined in `task-dag.tsx`); that blanket pan-on-scroll config is replaced by a shared classifier-driven wheel handler. The `<ReactFlow>` inside `task-dag.tsx` itself is the **readonly compact preview** (`TaskDag`, used by `dashboard/panels/proposal-view.tsx`) and stays unchanged.
+- Tests: existing `mindmap-canvas-wheel.test.tsx` and `task-dag-pan-zoom.test.tsx` updated; new coverage for the device classifier.
+- No API, DB, or dependency changes. Behavior-only, front-end only.
+- `docs/design.pen`: the graph interaction notes are updated to reflect the device-inference model.

--- a/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/specs/project-resource-graph/spec.md
+++ b/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/specs/project-resource-graph/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Trackpad two-finger pan and pinch-zoom on the canvas
+
+The canvas mind-map SHALL support a trackpad (touchpad) two-finger swipe to pan the tree and a trackpad pinch to zoom it, following the Figma/Miro interaction model, while preserving the existing mouse-wheel-to-zoom behavior at ANY scroll speed. Wheel events over the canvas SHALL be classified by inferring the pointing device from the rhythm and continuity of the recent stream of wheel events, and SHALL NOT use any single event's delta magnitude, fractional value, or per-event magnitude ramp as a mouse-versus-trackpad signal (because a high-resolution or smooth-scroll mouse produces small, fractional, ramping deltas indistinguishable per-event from a trackpad). The classification SHALL behave as follows: a wheel event carrying `ctrlKey` (how a browser reports a trackpad pinch, and also the explicit Ctrl/⌘+wheel zoom shortcut) SHALL zoom the tree around the cursor; a wheel event with a line or page delta mode SHALL be treated as a mouse wheel and zoom; a wheel event carrying a horizontal component SHALL be treated as a trackpad swipe and pan; a stream that becomes a sustained continuous run (many closely-spaced events over a minimum duration, as a two-finger swipe and its momentum tail produce) SHALL be treated as a trackpad and pan by the event's horizontal and vertical deltas; and an otherwise-ambiguous vertical wheel event — including a slow mouse-wheel notch and the leading events of any gesture before a device is inferred — SHALL default to a mouse-wheel zoom around the cursor. A slow mouse-wheel notch SHALL zoom, not pan. After a brief idle gap the inferred device SHALL reset so a new gesture is classified on its own evidence. Panning and zooming SHALL reuse the existing view transform and SHALL clamp the resulting scale to the same minimum and maximum bounds the touch and prior wheel paths use. While the pointer is over the canvas and a gesture is classified, the graph SHALL prevent the browser's default page scroll so the page does not move during a pan or zoom. These wheel-gesture changes SHALL NOT alter the existing touch gestures (two-finger pinch, double-tap, single-finger drag) or the single-pointer drag-to-pan behavior.
+
+#### Scenario: Two-finger trackpad swipe pans the tree
+
+- **WHEN** a user performs a two-finger swipe on a trackpad while the pointer is over the canvas
+- **THEN** the tree pans in the direction of the swipe (both horizontally and vertically) and the browser page does not scroll
+
+#### Scenario: Trackpad pinch zooms around the cursor
+
+- **WHEN** a user performs a pinch gesture on a trackpad over the canvas (reported by the browser as a wheel event with the control modifier)
+- **THEN** the tree zooms in or out around the cursor position, clamped to the same minimum and maximum zoom bounds as the other zoom paths
+
+#### Scenario: Ctrl or Command plus wheel zooms
+
+- **WHEN** a user holds Ctrl or Command and scrolls the wheel over the canvas
+- **THEN** the tree zooms around the cursor rather than panning
+
+#### Scenario: Slow mouse wheel zooms
+
+- **WHEN** a user scrolls a plain mouse wheel slowly over the canvas, so each notch reports a small vertical pixel delta separated by gaps
+- **THEN** the tree zooms around the cursor rather than panning, because a short bounded vertical burst is not a sustained continuous run and defaults to a mouse-wheel zoom
+
+#### Scenario: High-resolution or smooth-scroll mouse wheel zooms
+
+- **WHEN** a user scrolls a high-resolution or smooth-scroll mouse whose vertical notch reports small, fractional, ramping pixel deltas over the canvas
+- **THEN** the tree zooms around the cursor rather than panning, because the classifier does not treat small, fractional, or ramping deltas as a trackpad signal and the short vertical burst defaults to zoom
+
+#### Scenario: Fast mouse wheel still zooms
+
+- **WHEN** a user scrolls a plain mouse wheel quickly over the canvas (a coarse or rapidly repeated vertical-only notch with no modifier)
+- **THEN** the tree zooms around the cursor exactly as it did before this change
+
+#### Scenario: Existing touch and drag behavior unchanged
+
+- **WHEN** a user uses a two-finger touch pinch, a double-tap, a single-finger touch drag, or a single-pointer mouse drag on the canvas
+- **THEN** those gestures behave exactly as they did before the wheel-classification change

--- a/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/specs/task-dag-navigation/spec.md
+++ b/openspec/changes/archive/2026-07-08-fix-graph-wheel-device-classification/specs/task-dag-navigation/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Trackpad-first pan and zoom on the interactive task-dependency DAG
+
+The interactive, full-canvas task-dependency DAG — the ReactFlow graph rendered on the tasks view and in the proposal editor — SHALL adopt a Figma/Miro-style trackpad navigation model, applied consistently across those mounts, using the SAME shared device-inference wheel classifier the resource-graph canvas uses, with the same rule that a single event's delta magnitude, fractional value, or per-event ramp SHALL NOT be used as a mouse-versus-trackpad signal. A wheel stream inferred to come from a trackpad (a horizontal component, or a sustained continuous run such as a two-finger swipe and its momentum tail) SHALL pan the graph freely on both axes rather than zoom it. A wheel stream inferred to come from a mouse wheel (a line/page delta mode, or an otherwise-ambiguous vertical wheel event that defaults to mouse) SHALL zoom the graph around the cursor at any scroll speed. Zooming SHALL also remain available through a trackpad pinch, through holding Ctrl or Command while scrolling, and through the on-screen zoom controls that these mounts display. Dragging SHALL continue to pan the graph, and node dragging, selection, and connection behavior SHALL be unchanged. The classifier and the wheel handling SHALL be defined once and applied to every in-scope mount so the surfaces cannot drift apart, and the resulting scale SHALL clamp to the DAG's existing minimum and maximum zoom bounds. The compact, readonly DAG preview embedded in the dashboard proposal panel (which hides the on-screen controls and lives inside a scrollable page) SHALL be excluded from this model and SHALL retain its existing wheel-zoom / drag-pan behavior, so that its only zoom affordance is not removed and it does not hijack page scroll.
+
+#### Scenario: Two-finger swipe pans the DAG
+
+- **WHEN** a user performs a two-finger trackpad swipe over the tasks-view or proposal-editor DAG
+- **THEN** the graph pans on both axes rather than zooming
+
+#### Scenario: Mouse wheel zooms the DAG at any speed
+
+- **WHEN** a user scrolls a plain mouse wheel (a vertical-only notch with no modifier), whether slowly or quickly, and including a high-resolution/smooth-scroll mouse with small fractional deltas, over the tasks-view or proposal-editor DAG
+- **THEN** the graph zooms in or out around the cursor rather than panning, because a short bounded vertical burst defaults to a mouse-wheel zoom and small/fractional/ramping deltas are not treated as a trackpad signal
+
+#### Scenario: Pinch and Ctrl/Command+scroll still zoom the DAG
+
+- **WHEN** a user pinches on a trackpad, or holds Ctrl or Command while scrolling, over the tasks-view or proposal-editor DAG
+- **THEN** the graph zooms in or out
+
+#### Scenario: On-screen controls still zoom and fit
+
+- **WHEN** a user clicks the on-screen zoom-in, zoom-out, or fit controls on the tasks-view or proposal-editor DAG
+- **THEN** the graph zooms or re-frames as before
+
+#### Scenario: Consistent across the in-scope mounts via one shared classifier
+
+- **WHEN** the DAG is shown on the tasks view or in the proposal editor
+- **THEN** both use the same shared device-inference wheel classifier and wheel-handling wrapper
+
+#### Scenario: Readonly dashboard preview is excluded
+
+- **WHEN** the compact readonly DAG preview is shown in the dashboard proposal panel
+- **THEN** it retains its existing wheel-zoom and drag-pan behavior and is not switched to the shared classifier, so its zoom affordance is preserved and it does not hijack page scroll
+
+#### Scenario: Node interaction unchanged
+
+- **WHEN** a user drags a node, selects a node, or (in an editable DAG) creates a connection
+- **THEN** those interactions behave exactly as they did before the navigation model changed

--- a/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/README.md
+++ b/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/README.md
@@ -1,0 +1,3 @@
+# graph-wheel-always-zooms
+
+Plain mouse wheel always zooms the graph (protect wheel-zoom); pinch zooms, drag pans; remove the device classifier

--- a/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/design.md
+++ b/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/design.md
@@ -1,0 +1,64 @@
+# Technical Design: Plain wheel always zooms (protect mouse-wheel zoom)
+
+## Overview
+
+Return to the pre-#408 deterministic model, chosen in idea elaboration round 3:
+
+- **any wheel over the graph → ZOOM around the cursor** (no modifier needed, any speed).
+- **trackpad pinch → ZOOM** (browsers deliver a pinch as a synthetic `ctrlKey` wheel, which is still a wheel → zoom).
+- **panning → drag** (single-pointer drag on the canvas; `panOnDrag` on the DAG).
+
+No device inference, no pan-on-wheel, no stream state. The accepted cost (elaboration r3): a trackpad two-finger vertical swipe now zooms instead of panning; trackpad users pan by dragging and zoom by pinch. This is unambiguous and eliminates the flaky mis-scroll for good.
+
+## `/graph` canvas (`mindmap-canvas.tsx`)
+
+Replace the classifier-backed listener with an unconditional zoom:
+
+```ts
+const onWheel = (ev: WheelEvent) => {
+  const rect = canvas.getBoundingClientRect();
+  const sx = ev.clientX - rect.left;
+  const sy = ev.clientY - rect.top;
+  ev.preventDefault();                       // never let the page scroll under the canvas
+  // A trackpad pinch arrives as a synthetic ctrlKey wheel with fine pixel deltas,
+  // so it uses the finer pinch sensitivity; a plain mouse wheel uses the notch feel.
+  const sensitivity = ev.ctrlKey ? ZOOM_PINCH_SENSITIVITY : ZOOM_WHEEL_SENSITIVITY;
+  zoomAroundRef.current(Math.exp(-ev.deltaY * sensitivity), sx, sy);
+};
+```
+
+- Remove `wheelStateRef`, the `classifyWheelStream`/`createWheelClassifierState`/`WheelClassifierState` import, and every pan branch / continuity bookkeeping.
+- `zoomAround`, `ZOOM_WHEEL_SENSITIVITY`, `ZOOM_PINCH_SENSITIVITY` are kept as-is.
+- Panning stays via the existing single-pointer drag (`handlePointerDown/Move` → `viewRef` translate) — untouched. Touch pinch/double-tap/drag paths — untouched (they never went through the wheel listener).
+- This is effectively the pre-#408 wheel handler (which was `zoomAround(Math.exp(-deltaY * ZOOM_WHEEL_SENSITIVITY), …)` on every wheel), plus the pinch-sensitivity split.
+
+## Interactive task DAG (`task-dag.tsx` + two mounts)
+
+Delete `dag-wheel-nav.tsx`; the interactive mounts adopt ReactFlow's default wheel-zoom — the SAME inline props the readonly preview already uses (`task-dag.tsx`'s own `<ReactFlow>` has `panOnDrag={true}` + `zoomOnScroll={true}`):
+
+On both `tasks/dag-view.tsx` and `proposals/[proposalUuid]/proposal-editor.tsx` `<ReactFlow>`:
+- set `zoomOnScroll={true}`, `panOnDrag={true}`, `zoomOnPinch={true}` (inline);
+- remove `{...DAG_INTERACTIVE_PAN_ZOOM_PROPS}` and `<DagWheelNav/>` (+ their imports).
+
+`zoomOnScroll:true` is ReactFlow's default: a plain wheel zooms around the cursor, a pinch zooms, and drag pans — exactly the model. No custom listener, no `zoomActivationKeyCode`, no `panOnScroll`. Remove the now-unused `DAG_INTERACTIVE_PAN_ZOOM_PROPS` export from `task-dag.tsx`. The readonly compact dashboard preview keeps its identical inline props (already correct) — all three mounts converge.
+
+> Net effect: the interactive DAG returns to ReactFlow defaults (its pre-#408 behavior), and the classifier layer both surfaces briefly shared is gone.
+
+## Deletion ordering (compile-safe)
+
+Learned from the prior proposal's review: drop a module only after its importers are gone, so every task ends tsc-green.
+
+- **Task 1 (canvas):** rewrite `mindmap-canvas.tsx` to remove its `@/lib/wheel-gesture` import. Do NOT delete `wheel-gesture.ts` yet (`dag-wheel-nav.tsx` still imports it). Repo compiles at task-1 end.
+- **Task 2 (DAG + deletions):** de-import `<DagWheelNav/>` from both mounts → delete `dag-wheel-nav.tsx` (+test) → then delete `wheel-gesture.ts` (+test), since nothing imports it anymore → grep clean. Repo compiles at task-2 end.
+
+## Testing
+
+- `mindmap-canvas-wheel.test.tsx` — rewrite: every wheel zooms. A plain vertical wheel changes the view scale (not just translate); a `ctrlKey` wheel zooms (pinch); scrolling up zooms in / down zooms out; `preventDefault` always called; a plain wheel does NOT pan (no translate-only change). No classifier import.
+- `task-dag-pan-zoom.test.tsx` — assert both interactive mounts pass `zoomOnScroll:true` + `panOnDrag:true` and render neither `<DagWheelNav/>` nor a `panOnScroll`/`DAG_INTERACTIVE_PAN_ZOOM_PROPS`; readonly preview unchanged.
+- Delete `wheel-gesture.test.ts` and `dag-wheel-nav.test.tsx` with their modules.
+
+## Risks & Mitigations
+
+- **R1 — trackpad users lose two-finger-swipe pan.** Explicitly accepted (elaboration r3): pan via drag, zoom via pinch. Deterministic and matches pre-#408.
+- **R2 — dangling importers after deletion.** Enforced by the task ordering above + a final grep for `wheel-gesture` / `classifyWheelStream` / `createWheelClassifierState` / `DagWheelNav` / `DAG_INTERACTIVE_PAN_ZOOM_PROPS`, guarded by tsc + full test run.
+- **R3 — supersedes archived + closed prior work.** The `fix-graph-wheel-device-classification` change is archived; the `graph-wheel-scroll-pans-ctrl-zooms` proposal was closed unbuilt. This change modifies the same two capability specs to the final always-zoom model; the delta specs overwrite the relevant requirements.

--- a/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/proposal.md
+++ b/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The device-inference wheel classifier shipped for idea 9d326265 still intermittently mis-scrolls (a smooth-scroll mouse is indistinguishable from a trackpad on the event stream), and the interim "scroll pans / Ctrl+wheel zooms" model was reversed by the user. The final decision (idea elaboration round 3, 2026-07-09): **protect mouse-wheel zoom** — a plain wheel ALWAYS ZOOMS at any speed (no modifier), the trackpad two-finger-pan optimization is abandoned, a trackpad pinch zooms, and panning is via drag. This is a return to the pre-#408 behavior and is fully deterministic (no device guessing → no flakiness).
+
+## What Changes
+
+- **Remove the device-inference classifier entirely.** Delete `src/lib/wheel-gesture.ts` + test, and `src/components/dag-wheel-nav.tsx` + test — the whole "infer mouse vs trackpad" layer is abandoned.
+- **`/graph` mind-map canvas** (`mindmap-canvas.tsx`): the non-passive wheel handler always ZOOMS around the cursor — `ev.preventDefault()` then `zoomAround(Math.exp(-ev.deltaY * sensitivity), sx, sy)`. No pan branch, no stream state, no modifier requirement. A trackpad pinch (synthetic ctrlKey wheel) uses the finer ZOOM_PINCH_SENSITIVITY; a plain wheel uses ZOOM_WHEEL_SENSITIVITY. Panning stays available via the existing single-pointer drag path (unchanged). Existing touch pinch/double-tap/drag are untouched.
+- **Interactive task DAG** (tasks view + proposal editor): use ReactFlow's default wheel-zoom — `zoomOnScroll:true`, `panOnDrag:true`, `zoomOnPinch:true` (drop `panOnScroll`, drop `zoomActivationKeyCode`, drop the custom `<DagWheelNav/>` listener). This is exactly the config the readonly dashboard preview already uses, so all three DAG mounts converge on ReactFlow defaults. The readonly preview stays unchanged.
+
+## Capabilities
+
+### New Capabilities
+_(none)_
+
+### Modified Capabilities
+- `project-resource-graph`: the canvas wheel requirement becomes "a plain wheel always zooms around the cursor; pinch zooms; drag pans" — no device inference, no pan-on-wheel.
+- `task-dag-navigation`: the interactive DAG's wheel requirement becomes ReactFlow default wheel-zoom (drag pans, pinch zooms), dropping the shared pan-on-scroll config.
+
+## Impact
+
+- Code: DELETE `src/lib/wheel-gesture.ts`, `src/lib/__tests__/wheel-gesture.test.ts`, `src/components/dag-wheel-nav.tsx`, `src/components/__tests__/dag-wheel-nav.test.tsx`. Rewrite the `mindmap-canvas.tsx` wheel handler (always-zoom). Point the two interactive DAG mounts (`tasks/dag-view.tsx`, `proposals/[proposalUuid]/proposal-editor.tsx`) at inline `zoomOnScroll/panOnDrag/zoomOnPinch` (drop `<DagWheelNav/>` + the shared constant). Remove the now-unused `DAG_INTERACTIVE_PAN_ZOOM_PROPS` from `task-dag.tsx`.
+- Tests: rewrite `mindmap-canvas-wheel.test.tsx` (every wheel zooms) and `task-dag-pan-zoom.test.tsx` (interactive mounts use zoomOnScroll:true, no DagWheelNav; readonly preview unchanged).
+- No API/DB/dependency changes. Behavior-only, front-end only.
+- `docs/design.pen`: graph interaction notes updated to the always-zoom model.

--- a/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/specs/project-resource-graph/spec.md
+++ b/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/specs/project-resource-graph/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Trackpad two-finger pan and pinch-zoom on the canvas
+
+The canvas mind-map SHALL use a deterministic wheel model in which a wheel event over the canvas ALWAYS zooms the tree around the cursor, at any scroll speed and with no modifier key required, and SHALL NOT infer the pointing device or pan in response to a wheel. Because a browser reports a trackpad pinch as a wheel event, a trackpad pinch SHALL therefore also zoom. Zooming SHALL reuse the existing view transform and SHALL clamp the resulting scale to the same minimum and maximum bounds the touch path uses. Panning SHALL be available through dragging (the existing single-pointer drag-to-pan), not through the wheel. While the pointer is over the canvas, the graph SHALL prevent the browser's default page scroll so the page does not move while zooming. These wheel changes SHALL NOT alter the existing touch gestures (two-finger pinch, double-tap, single-finger drag) or the single-pointer drag-to-pan behavior.
+
+#### Scenario: Plain mouse wheel zooms the tree at any speed
+
+- **WHEN** a user scrolls a plain mouse wheel (no modifier) over the canvas, whether slowly or quickly
+- **THEN** the tree zooms around the cursor (scrolling up zooms in, down zooms out), the browser page does not scroll, and the tree does not pan
+
+#### Scenario: Trackpad pinch zooms around the cursor
+
+- **WHEN** a user performs a pinch gesture on a trackpad over the canvas (reported by the browser as a wheel event)
+- **THEN** the tree zooms in or out around the cursor position, clamped to the same minimum and maximum zoom bounds as the other zoom paths
+
+#### Scenario: Panning is via drag, not the wheel
+
+- **WHEN** a user wants to pan the tree
+- **THEN** they drag with a single pointer (the wheel never pans), and the drag-to-pan behaves exactly as before
+
+#### Scenario: Existing touch and drag behavior unchanged
+
+- **WHEN** a user uses a two-finger touch pinch, a double-tap, a single-finger touch drag, or a single-pointer mouse drag on the canvas
+- **THEN** those gestures behave exactly as they did before the wheel model changed

--- a/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/specs/task-dag-navigation/spec.md
+++ b/openspec/changes/archive/2026-07-09-graph-wheel-always-zooms/specs/task-dag-navigation/spec.md
@@ -1,8 +1,5 @@
-# task-dag-navigation Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change add-graph-trackpad-gestures. Update Purpose after archive.
-## Requirements
 ### Requirement: Trackpad-first pan and zoom on the interactive task-dependency DAG
 
 The interactive, full-canvas task-dependency DAG — the ReactFlow graph rendered on the tasks view and in the proposal editor — SHALL use ReactFlow's default wheel-zoom model: a wheel event zooms the graph around the cursor, a trackpad pinch zooms, and panning is by dragging. It SHALL NOT infer the pointing device, SHALL NOT pan on wheel, and SHALL NOT require a modifier key to zoom. This is the same wheel/drag configuration the readonly dashboard-preview DAG uses, so all three DAG mounts converge on the same behavior. Zooming SHALL also remain available through the on-screen zoom controls the interactive mounts display, and the resulting scale SHALL clamp to the DAG's existing minimum and maximum zoom bounds. Node dragging, selection, and connection behavior SHALL be unchanged. The compact, readonly DAG preview embedded in the dashboard proposal panel SHALL retain its existing wheel-zoom / drag-pan behavior (now shared by all mounts).
@@ -31,4 +28,3 @@ The interactive, full-canvas task-dependency DAG — the ReactFlow graph rendere
 
 - **WHEN** a user drags a node, selects a node, or (in an editable DAG) creates a connection
 - **THEN** those interactions behave exactly as they did before the navigation model changed
-

--- a/openspec/specs/project-resource-graph/spec.md
+++ b/openspec/specs/project-resource-graph/spec.md
@@ -383,32 +383,27 @@ When a search ends, the graph SHALL keep every currently expanded node expanded 
 
 ### Requirement: Trackpad two-finger pan and pinch-zoom on the canvas
 
-The canvas mind-map SHALL support a trackpad (touchpad) two-finger swipe to pan the tree and a trackpad pinch to zoom it, following the Figma/Miro interaction model, while preserving the existing mouse-wheel-to-zoom behavior. Wheel events over the canvas SHALL be classified as follows: a wheel event carrying `ctrlKey` (how a browser reports a trackpad pinch, and also the explicit Ctrl/⌘+wheel zoom shortcut) SHALL zoom the tree around the cursor; a plain wheel event that carries a horizontal component or reads as a fine-grained trackpad scroll SHALL pan the tree by the event's horizontal and vertical deltas; and a plain, coarse, vertical-only wheel event (a mouse-wheel notch) SHALL zoom the tree around the cursor exactly as it did before this change. Panning and zooming SHALL reuse the existing view transform and SHALL clamp the resulting scale to the same minimum and maximum bounds the touch and prior wheel paths use. While the pointer is over the canvas and a gesture is classified, the graph SHALL prevent the browser's default page scroll so the page does not move during a pan or zoom. These wheel-gesture changes SHALL NOT alter the existing touch gestures (two-finger pinch, double-tap, single-finger drag) or the single-pointer drag-to-pan behavior.
+The canvas mind-map SHALL use a deterministic wheel model in which a wheel event over the canvas ALWAYS zooms the tree around the cursor, at any scroll speed and with no modifier key required, and SHALL NOT infer the pointing device or pan in response to a wheel. Because a browser reports a trackpad pinch as a wheel event, a trackpad pinch SHALL therefore also zoom. Zooming SHALL reuse the existing view transform and SHALL clamp the resulting scale to the same minimum and maximum bounds the touch path uses. Panning SHALL be available through dragging (the existing single-pointer drag-to-pan), not through the wheel. While the pointer is over the canvas, the graph SHALL prevent the browser's default page scroll so the page does not move while zooming. These wheel changes SHALL NOT alter the existing touch gestures (two-finger pinch, double-tap, single-finger drag) or the single-pointer drag-to-pan behavior.
 
-#### Scenario: Two-finger trackpad swipe pans the tree
+#### Scenario: Plain mouse wheel zooms the tree at any speed
 
-- **WHEN** a user performs a two-finger swipe on a trackpad while the pointer is over the canvas
-- **THEN** the tree pans in the direction of the swipe (both horizontally and vertically) and the browser page does not scroll
+- **WHEN** a user scrolls a plain mouse wheel (no modifier) over the canvas, whether slowly or quickly
+- **THEN** the tree zooms around the cursor (scrolling up zooms in, down zooms out), the browser page does not scroll, and the tree does not pan
 
 #### Scenario: Trackpad pinch zooms around the cursor
 
-- **WHEN** a user performs a pinch gesture on a trackpad over the canvas (reported by the browser as a wheel event with the control modifier)
+- **WHEN** a user performs a pinch gesture on a trackpad over the canvas (reported by the browser as a wheel event)
 - **THEN** the tree zooms in or out around the cursor position, clamped to the same minimum and maximum zoom bounds as the other zoom paths
 
-#### Scenario: Ctrl or Command plus wheel zooms
+#### Scenario: Panning is via drag, not the wheel
 
-- **WHEN** a user holds Ctrl or Command and scrolls the wheel over the canvas
-- **THEN** the tree zooms around the cursor rather than panning
-
-#### Scenario: Mouse wheel still zooms
-
-- **WHEN** a user scrolls a plain mouse wheel (a coarse, vertical-only notch with no modifier) over the canvas
-- **THEN** the tree zooms around the cursor exactly as it did before this change
+- **WHEN** a user wants to pan the tree
+- **THEN** they drag with a single pointer (the wheel never pans), and the drag-to-pan behaves exactly as before
 
 #### Scenario: Existing touch and drag behavior unchanged
 
 - **WHEN** a user uses a two-finger touch pinch, a double-tap, a single-finger touch drag, or a single-pointer mouse drag on the canvas
-- **THEN** those gestures behave exactly as they did before the trackpad wheel gestures were added
+- **THEN** those gestures behave exactly as they did before the wheel model changed
 
 ### Requirement: On-screen zoom and fit controls on the graph canvas
 

--- a/src/app/(dashboard)/projects/[uuid]/graph/__tests__/mindmap-canvas-wheel.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/__tests__/mindmap-canvas-wheel.test.tsx
@@ -1,17 +1,14 @@
 // @vitest-environment jsdom
 //
-// Trackpad wheel-gesture coverage for MindMapCanvas (Task: "Canvas: trackpad
-// wheel classifier + non-passive listener", Spec Delta "Trackpad two-finger pan
-// and pinch-zoom on the canvas"). Two layers, mirroring mindmap-canvas-touch:
-//
-//   1. Pure math — `classifyWheel` is an exported pure helper, so the
-//      pan/pinch/mouse-zoom heuristic is asserted directly without a canvas:
-//      ctrl+wheel → zoom, horizontal wheel → pan, fine pixel vertical → pan,
-//      coarse/line vertical → zoom, and the zoom scaleFactor sign.
-//
-//   2. Behavior — a mounted canvas is driven with a native (non-passive) wheel
-//      event to prove (a) the listener calls preventDefault so the page does not
-//      scroll, and (b) a ctrl+wheel zoom mutates the view transform scale.
+// Wheel-zoom coverage for MindMapCanvas (Spec Delta "Trackpad two-finger pan and
+// pinch-zoom on the canvas", idea 9d326265 elaboration round 3 — "protect
+// mouse-wheel zoom"). The canvas ALWAYS zooms on wheel — no device inference, no
+// pan-on-wheel; panning is via drag. This file drives a native (non-passive)
+// wheel event and asserts:
+//   (a) a plain vertical mouse wheel ZOOMS (view scale changes) + preventDefaults,
+//   (b) a ctrl+wheel (pinch / Ctrl-⌘) also zooms,
+//   (c) scroll up zooms in / scroll down zooms out,
+//   (d) a plain wheel does NOT pan (no translate-only change).
 //
 // Canvas 2D is mocked the same way as mindmap-canvas-touch.test.tsx.
 
@@ -121,53 +118,37 @@ afterEach(() => {
 
 import {
   MindMapCanvas,
-  classifyWheel,
   type ForceNode,
 } from "../mindmap-canvas";
-
-describe("classifyWheel (pure) — Q2=a / Q3=a pan vs zoom heuristic", () => {
-  it("ctrl+wheel (trackpad pinch OR Ctrl/⌘+wheel) → zoom", () => {
-    const g = classifyWheel({ ctrlKey: true, deltaX: 0, deltaY: -10, deltaMode: 0 });
-    expect(g.kind).toBe("zoom");
-    if (g.kind === "zoom") expect(g.scaleFactor).toBeGreaterThan(1); // scroll up = zoom in
-  });
-
-  it("a wheel event with a horizontal component → pan", () => {
-    const g = classifyWheel({ ctrlKey: false, deltaX: 40, deltaY: 5, deltaMode: 0 });
-    expect(g).toEqual({ kind: "pan", dx: 40, dy: 5 });
-  });
-
-  it("a fine pixel-mode vertical wheel (below the mouse-notch threshold) → pan", () => {
-    const g = classifyWheel({ ctrlKey: false, deltaX: 0, deltaY: 12, deltaMode: 0 });
-    expect(g).toEqual({ kind: "pan", dx: 0, dy: 12 });
-  });
-
-  it("a coarse pixel-mode vertical wheel (at/above the threshold) → zoom (mouse notch)", () => {
-    const g = classifyWheel({ ctrlKey: false, deltaX: 0, deltaY: 120, deltaMode: 0 });
-    expect(g.kind).toBe("zoom");
-    if (g.kind === "zoom") expect(g.scaleFactor).toBeLessThan(1); // scroll down = zoom out
-  });
-
-  it("a line-mode vertical wheel → zoom (classic mouse wheel)", () => {
-    const g = classifyWheel({ ctrlKey: false, deltaX: 0, deltaY: -3, deltaMode: 1 });
-    expect(g.kind).toBe("zoom");
-    if (g.kind === "zoom") expect(g.scaleFactor).toBeGreaterThan(1);
-  });
-
-  it("zoom scaleFactor sign matches scroll direction", () => {
-    const inGesture = classifyWheel({ ctrlKey: true, deltaX: 0, deltaY: -20, deltaMode: 0 });
-    const outGesture = classifyWheel({ ctrlKey: true, deltaX: 0, deltaY: 20, deltaMode: 0 });
-    if (inGesture.kind === "zoom") expect(inGesture.scaleFactor).toBeGreaterThan(1);
-    if (outGesture.kind === "zoom") expect(outGesture.scaleFactor).toBeLessThan(1);
-  });
-});
 
 function buildNodes(): ForceNode[] {
   return [{ id: "idea-1", type: "idea", title: "Idea one", status: "building" }];
 }
 
-describe("MindMapCanvas — native non-passive wheel listener", () => {
-  it("calls preventDefault so the page does not scroll during a gesture", () => {
+function dispatchWheel(
+  canvas: HTMLCanvasElement,
+  init: Partial<WheelEventInit>,
+): WheelEvent {
+  const ev = new WheelEvent("wheel", {
+    deltaX: 0,
+    deltaY: 0,
+    deltaMode: 0,
+    ctrlKey: false,
+    clientX: 400,
+    clientY: 300,
+    cancelable: true,
+    bubbles: true,
+    ...init,
+  });
+  act(() => {
+    canvas.dispatchEvent(ev);
+    vi.advanceTimersByTime(50); // let the repaint run
+  });
+  return ev;
+}
+
+describe("MindMapCanvas — wheel always zooms (protect mouse-wheel zoom)", () => {
+  it("a plain vertical mouse wheel zooms (scale changes) and preventDefaults", () => {
     const { container } = render(
       <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
     );
@@ -175,20 +156,16 @@ describe("MindMapCanvas — native non-passive wheel listener", () => {
     act(() => {
       vi.advanceTimersByTime(50); // settle the one-time fit
     });
-    const ev = new WheelEvent("wheel", {
-      deltaX: 30,
-      deltaY: 0,
-      ctrlKey: false,
-      cancelable: true,
-      bubbles: true,
-    });
-    act(() => {
-      canvas.dispatchEvent(ev);
-    });
+    const scaleBefore = setTransformScales.at(-1)!;
+    const ev = dispatchWheel(canvas, { deltaY: -100 }); // scroll up → zoom in
     expect(ev.defaultPrevented).toBe(true);
+    expect(setTransformScales.at(-1)!).toBeGreaterThan(scaleBefore); // zoomed, not panned
   });
 
-  it("a ctrl+wheel zoom mutates the view transform scale", () => {
+  it("a small, fractional vertical wheel still zooms (never pans)", () => {
+    // A hi-res/smooth-scroll mouse reports small, fractional vertical deltas.
+    // Under the always-zoom model that is unambiguously a zoom — the view SCALE
+    // changes rather than translating.
     const { container } = render(
       <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
     );
@@ -197,23 +174,40 @@ describe("MindMapCanvas — native non-passive wheel listener", () => {
       vi.advanceTimersByTime(50);
     });
     const scaleBefore = setTransformScales.at(-1)!;
-    expect(Number.isFinite(scaleBefore)).toBe(true);
+    const ev = dispatchWheel(canvas, { deltaY: -6.7 }); // small + fractional
+    expect(ev.defaultPrevented).toBe(true);
+    expect(setTransformScales.at(-1)!).toBeGreaterThan(scaleBefore);
+  });
+
+  it("a ctrl+wheel (pinch / Ctrl-⌘) also zooms", () => {
+    const { container } = render(
+      <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    const canvas = container.querySelector("canvas")!;
     act(() => {
-      canvas.dispatchEvent(
-        new WheelEvent("wheel", {
-          deltaX: 0,
-          deltaY: -100, // scroll up with ctrl → zoom in
-          ctrlKey: true,
-          clientX: 400,
-          clientY: 300,
-          cancelable: true,
-          bubbles: true,
-        }),
-      );
-      vi.advanceTimersByTime(50); // let the repaint run
+      vi.advanceTimersByTime(50);
     });
-    const scaleAfter = setTransformScales.at(-1)!;
-    expect(scaleAfter).toBeGreaterThan(scaleBefore);
+    const scaleBefore = setTransformScales.at(-1)!;
+    const ev = dispatchWheel(canvas, { deltaY: -100, ctrlKey: true });
+    expect(ev.defaultPrevented).toBe(true);
+    expect(setTransformScales.at(-1)!).toBeGreaterThan(scaleBefore);
+  });
+
+  it("scroll up zooms in and scroll down zooms out", () => {
+    const { container } = render(
+      <MindMapCanvas nodes={buildNodes()} links={[]} selectedId={null} onNodeClick={vi.fn()} />,
+    );
+    const canvas = container.querySelector("canvas")!;
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    const scaleFit = setTransformScales.at(-1)!;
+    dispatchWheel(canvas, { deltaY: -120 }); // up → in
+    const scaleIn = setTransformScales.at(-1)!;
+    expect(scaleIn).toBeGreaterThan(scaleFit);
+    dispatchWheel(canvas, { deltaY: 120 }); // down → out
+    const scaleOut = setTransformScales.at(-1)!;
+    expect(scaleOut).toBeLessThan(scaleIn);
   });
 });
 

--- a/src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx
@@ -222,67 +222,19 @@ export function centerTransformFor(
 const SCALE_MIN = 0.2;
 const SCALE_MAX = 2.5;
 
-// --- Trackpad wheel-gesture tuning (Tech Design D1) -------------------------
+// --- Wheel zoom tuning ------------------------------------------------------
 //
-// The `/graph` canvas classifies raw `wheel` events into a Figma/Miro-style
-// model: a trackpad pinch (reported by browsers as ctrl+wheel) or Ctrl/⌘+wheel
-// zooms; a plain two-finger trackpad swipe pans; a classic mouse-wheel notch
-// still zooms (elaboration Q2=a / Q3=a). See `classifyWheel`.
-//
-// Heuristic honesty: no web API cleanly separates "mouse wheel" from "trackpad
-// two-finger scroll" — both are `WheelEvent`s. We treat a plain wheel as a PAN
-// when it carries a horizontal component (`deltaX`) OR reads as a fine-grained
-// pixel-mode vertical scroll (below MOUSE_NOTCH_MIN px); otherwise (coarse,
-// vertical-only, often line-mode) it is a mouse notch → ZOOM. This is the same
-// signal Figma / tldraw / Excalidraw use. The one accepted ambiguity: a plain
-// vertical two-finger trackpad swipe with pixel deltas at/above MOUSE_NOTCH_MIN
-// is indistinguishable from a mouse notch and will zoom — covered by the pinch
-// path, the on-screen controls, and Ctrl+wheel as unambiguous fallbacks.
-const ZOOM_WHEEL_SENSITIVITY = 0.0015; // mouse-notch zoom feel (unchanged from the old handler)
+// The `/graph` canvas ALWAYS zooms on wheel (idea 9d326265, elaboration round 3
+// — "protect mouse-wheel zoom"): a plain mouse wheel zooms at any speed, a
+// trackpad pinch (delivered by the browser as a ctrl+wheel with fine pixel
+// deltas) zooms, and panning is via drag — the wheel never pans. No device
+// inference. A ctrlKey wheel (pinch / Ctrl-⌘) uses the finer pinch sensitivity;
+// a plain notch uses the mouse-notch feel.
+const ZOOM_WHEEL_SENSITIVITY = 0.0015; // mouse-notch zoom feel
 const ZOOM_PINCH_SENSITIVITY = 0.01; // pinch/ctrl+wheel deltas are fine pixels — a larger factor keeps them responsive without over-zooming
-const MOUSE_NOTCH_MIN = 30; // px: a pixel-mode vertical wheel below this reads as a fine trackpad scroll (pan), not a mouse notch
 
 // The fixed multiplier the on-screen +/- zoom buttons step by (Tech Design D2).
 const ZOOM_BUTTON_STEP = 1.3;
-
-/** The classified intent of a wheel event over the canvas (Tech Design D1). */
-export type WheelGesture =
-  | { kind: "zoom"; scaleFactor: number }
-  | { kind: "pan"; dx: number; dy: number };
-
-/**
- * Classify a raw wheel event into a pan or a zoom (pure + exported so the
- * heuristic is unit-testable without a canvas — mirrors pinchTransform). See
- * the tuning-constant block above for the heuristic rationale.
- *
- *   1. ctrlKey → zoom. Browsers report a trackpad PINCH as a synthetic
- *      ctrl+wheel, and Ctrl/⌘+wheel is the explicit zoom shortcut. Uses the
- *      finer ZOOM_PINCH_SENSITIVITY.
- *   2. else a horizontal component OR a fine pixel-mode vertical scroll → pan
- *      (a two-finger trackpad swipe). dx/dy are the raw deltas.
- *   3. else → zoom (a classic mouse-wheel notch), preserving the old feel via
- *      ZOOM_WHEEL_SENSITIVITY.
- *
- * `scaleFactor` is a multiplier on the current scale; scrolling up (negative
- * deltaY) yields a factor > 1 (zoom in), matching the prior handler.
- */
-export function classifyWheel(ev: {
-  ctrlKey: boolean;
-  deltaX: number;
-  deltaY: number;
-  deltaMode: number; // 0 = pixel, 1 = line, 2 = page
-}): WheelGesture {
-  if (ev.ctrlKey) {
-    return { kind: "zoom", scaleFactor: Math.exp(-ev.deltaY * ZOOM_PINCH_SENSITIVITY) };
-  }
-  const isPixelMode = ev.deltaMode === 0;
-  const looksLikeTrackpadSwipe =
-    ev.deltaX !== 0 || (isPixelMode && Math.abs(ev.deltaY) < MOUSE_NOTCH_MIN);
-  if (looksLikeTrackpadSwipe) {
-    return { kind: "pan", dx: ev.deltaX, dy: ev.deltaY };
-  }
-  return { kind: "zoom", scaleFactor: Math.exp(-ev.deltaY * ZOOM_WHEEL_SENSITIVITY) };
-}
 
 // Double-tap disambiguation window (Tech Design D2). A second tap within this
 // time AND distance of the first is a double-tap (zoom), not a node click.
@@ -1135,12 +1087,18 @@ export function MindMapCanvas({
   const zoomAroundRef = useRef(zoomAround);
   zoomAroundRef.current = zoomAround;
 
-  // Native, NON-PASSIVE wheel listener (Tech Design D1). React's onWheel is
-  // passive in some browsers, so preventDefault() there is ignored (and warns).
-  // Attaching manually with { passive: false } lets us stop the page from
-  // scrolling while the cursor is over the canvas and a gesture is classified.
-  // classifyWheel splits the raw event into a two-finger PAN (trackpad swipe)
-  // or a ZOOM (pinch / ctrl+wheel / mouse notch); see classifyWheel above.
+  // Native, NON-PASSIVE wheel listener. React's onWheel is passive in some
+  // browsers, so preventDefault() there is ignored (and warns). Attaching
+  // manually with { passive: false } lets us stop the page from scrolling while
+  // the cursor is over the canvas.
+  //
+  // Wheel model (idea 9d326265, elaboration round 3 — "protect mouse-wheel
+  // zoom"): a wheel over the canvas ALWAYS zooms around the cursor, at any
+  // speed, with no modifier required. No device inference, no pan-on-wheel —
+  // panning is via drag (see handlePointerMove). A trackpad pinch arrives as a
+  // synthetic ctrlKey wheel with fine pixel deltas, so it uses the finer
+  // ZOOM_PINCH_SENSITIVITY; a plain mouse notch uses ZOOM_WHEEL_SENSITIVITY.
+  // Scrolling up (negative deltaY) yields a factor > 1 (zoom in).
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -1148,20 +1106,12 @@ export function MindMapCanvas({
       const rect = canvas.getBoundingClientRect();
       const sx = ev.clientX - rect.left;
       const sy = ev.clientY - rect.top;
-      const gesture = classifyWheel(ev);
-      // Stop the page from scrolling under any classified graph gesture.
+      // Stop the page from scrolling under the canvas.
       ev.preventDefault();
-      if (gesture.kind === "pan") {
-        // Content follows the fingers: swiping down/right moves the view up/left.
-        viewRef.current = {
-          ...viewRef.current,
-          tx: viewRef.current.tx - gesture.dx,
-          ty: viewRef.current.ty - gesture.dy,
-        };
-        scheduleRender();
-      } else {
-        zoomAroundRef.current(gesture.scaleFactor, sx, sy);
-      }
+      const sensitivity = ev.ctrlKey
+        ? ZOOM_PINCH_SENSITIVITY
+        : ZOOM_WHEEL_SENSITIVITY;
+      zoomAroundRef.current(Math.exp(-ev.deltaY * sensitivity), sx, sy);
     };
     canvas.addEventListener("wheel", onWheel, { passive: false });
     return () => canvas.removeEventListener("wheel", onWheel);

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx
@@ -23,7 +23,6 @@ import { usePresence, injectPresence } from "@/hooks/use-presence";
 import { PresenceIndicator } from "@/components/ui/presence-indicator";
 import { useRealtimeEntityEvent } from "@/contexts/realtime-context";
 import { findNew, findDeleted, shouldRefresh } from "./draft-diff";
-import { DAG_PAN_ZOOM_PROPS } from "@/components/task-dag";
 import { ExportDropdown } from "@/components/export-dropdown";
 import { getProposalDraftsAction } from "./actions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -751,7 +750,9 @@ export function ProposalEditor({
                   minZoom={0.3}
                   maxZoom={1.5}
                   proOptions={{ hideAttribution: true }}
-                  {...DAG_PAN_ZOOM_PROPS}
+                  zoomOnScroll={true}
+                  zoomOnPinch={true}
+                  panOnDrag={true}
                 >
                   <Background color="#E5E0D8" gap={20} />
                   <Controls

--- a/src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx
@@ -20,7 +20,6 @@ import {
   nodeTypes,
   defaultEdgeStyle,
   getLayoutedElements,
-  DAG_PAN_ZOOM_PROPS,
   type TaskNodeData,
 } from "@/components/task-dag";
 import { getProjectDependenciesAction } from "./actions";
@@ -157,7 +156,9 @@ export function DagView({ projectUuid, onTaskSelect, refreshKey }: DagViewProps)
         minZoom={0.3}
         maxZoom={1.5}
         proOptions={{ hideAttribution: true }}
-        {...DAG_PAN_ZOOM_PROPS}
+        zoomOnScroll={true}
+        zoomOnPinch={true}
+        panOnDrag={true}
       >
         <Background color="#E5E0D8" gap={20} />
         <Controls

--- a/src/components/__tests__/task-dag-pan-zoom.test.tsx
+++ b/src/components/__tests__/task-dag-pan-zoom.test.tsx
@@ -1,19 +1,19 @@
 // @vitest-environment jsdom
 //
-// Regression guard for the shared trackpad pan/zoom config on the ReactFlow
-// task-dependency DAG (Task: "ReactFlow DAG: shared trackpad pan-on-scroll
-// config on the two full-canvas mounts", Spec Delta "task-dag-navigation").
+// Regression guard for the interactive ReactFlow task-dependency DAG's wheel
+// behavior (Spec Delta "task-dag-navigation", idea 9d326265 elaboration round 3
+// — "protect mouse-wheel zoom"). All three DAG mounts now use ReactFlow's
+// default wheel-zoom: a plain wheel zooms around the cursor, a pinch zooms, and
+// drag pans. There is no device inference, no pan-on-scroll, and no custom wheel
+// listener — the classifier layer (dag-wheel-nav.tsx / wheel-gesture.ts) was
+// removed.
 //
-// Three checks, matching the tech design's "no behavioral ReactFlow simulation
-// — assert the shared props are applied" strategy (Decision 4 / D3.0):
-//   1. DAG_PAN_ZOOM_PROPS has the exact intended shape (Figma model).
-//   2. The readonly dashboard-preview <ReactFlow> in TaskDag does NOT receive
-//      the pan-on-scroll props — it keeps its own inline zoomOnScroll (the
-//      BLOCKER-fix regression guard: applying zoomOnScroll=false to a mount
-//      that hides <Controls> would strip its only zoom path).
-//   3. The two in-scope mounts (dag-view.tsx, proposal-editor.tsx) spread
-//      {...DAG_PAN_ZOOM_PROPS} into their <ReactFlow> (guards a future edit
-//      dropping the shared spread).
+// Checks:
+//   1. The readonly dashboard-preview <ReactFlow> in TaskDag uses zoomOnScroll
+//      (its long-standing config, now shared by all mounts).
+//   2. The two interactive mounts (dag-view.tsx, proposal-editor.tsx) pass inline
+//      zoomOnScroll:true + panOnDrag:true, and render neither <DagWheelNav/> nor
+//      any panOnScroll / DAG_INTERACTIVE_PAN_ZOOM_PROPS.
 
 import React from "react";
 import fs from "node:fs";
@@ -21,13 +21,11 @@ import path from "node:path";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 
-// Capture the props handed to <ReactFlow> so we can assert what the readonly
-// TaskDag preview passes (and does not pass).
+// Capture the props handed to <ReactFlow> so we can assert the readonly
+// TaskDag preview's wheel/drag config.
 const reactFlowProps: Array<Record<string, unknown>> = [];
 
 vi.mock("@xyflow/react", () => ({
-  // ReactFlow records its props and renders its children so <Controls> gating
-  // stays observable if needed.
   ReactFlow: (props: Record<string, unknown>) => {
     reactFlowProps.push(props);
     return React.createElement("div", { "data-testid": "reactflow" }, props.children as React.ReactNode);
@@ -36,7 +34,6 @@ vi.mock("@xyflow/react", () => ({
   Controls: () => React.createElement("div", { "data-testid": "controls" }),
   Handle: () => null,
   Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
-  PanOnScrollMode: { Free: "free", Vertical: "vertical", Horizontal: "horizontal" },
 }));
 
 vi.mock("next-intl", () => ({
@@ -51,23 +48,10 @@ afterEach(() => {
   cleanup();
 });
 
-import { TaskDag, DAG_PAN_ZOOM_PROPS } from "../task-dag";
+import { TaskDag } from "../task-dag";
 
-describe("DAG_PAN_ZOOM_PROPS — shared Figma-model config", () => {
-  it("has the exact intended shape", () => {
-    expect(DAG_PAN_ZOOM_PROPS).toEqual({
-      panOnScroll: true,
-      panOnScrollMode: "free",
-      zoomOnScroll: false,
-      zoomOnPinch: true,
-      zoomActivationKeyCode: ["Meta", "Control"],
-      panOnDrag: true,
-    });
-  });
-});
-
-describe("TaskDag readonly dashboard preview — excluded from pan-on-scroll", () => {
-  it("does NOT receive panOnScroll and keeps its own inline zoomOnScroll=true", () => {
+describe("TaskDag readonly dashboard preview — default wheel-zoom", () => {
+  it("uses zoomOnScroll and does not adopt pan-on-scroll", () => {
     render(
       <TaskDag
         readonly
@@ -77,34 +61,25 @@ describe("TaskDag readonly dashboard preview — excluded from pan-on-scroll", (
     );
     expect(reactFlowProps).toHaveLength(1);
     const props = reactFlowProps[0];
-    // The BLOCKER-fix invariant: the readonly preview must NOT be switched to
-    // pan-on-scroll (it hides <Controls>, so it would lose its only zoom path).
+    expect(props.zoomOnScroll).toBe(true);
     expect(props.panOnScroll).toBeUndefined();
-    expect(props.zoomOnScroll).toBe(true); // its own inline value, unchanged
   });
 });
 
-describe("the two in-scope mounts spread {...DAG_PAN_ZOOM_PROPS}", () => {
+describe("the two interactive mounts use ReactFlow default wheel-zoom", () => {
   const mounts = [
     "app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx",
     "app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx",
   ];
   for (const rel of mounts) {
-    it(`${rel} imports and spreads the shared config`, () => {
+    it(`${rel} passes zoomOnScroll+panOnDrag and no custom wheel nav`, () => {
       const src = fs.readFileSync(path.join(process.cwd(), "src", rel), "utf8");
-      expect(src).toContain("DAG_PAN_ZOOM_PROPS");
-      expect(src).toContain("{...DAG_PAN_ZOOM_PROPS}");
+      expect(src).toContain("zoomOnScroll={true}");
+      expect(src).toContain("panOnDrag={true}");
+      // The classifier layer + the pan-on-scroll config are gone.
+      expect(src).not.toContain("DagWheelNav");
+      expect(src).not.toContain("DAG_INTERACTIVE_PAN_ZOOM_PROPS");
+      expect(src).not.toContain("panOnScroll");
     });
   }
-
-  it("task-dag.tsx does NOT spread the config into its own preview ReactFlow", () => {
-    const src = fs.readFileSync(
-      path.join(process.cwd(), "src", "components", "task-dag.tsx"),
-      "utf8",
-    );
-    // It exports the const…
-    expect(src).toContain("export const DAG_PAN_ZOOM_PROPS");
-    // …but never spreads it (the readonly preview keeps its own inline props).
-    expect(src).not.toContain("{...DAG_PAN_ZOOM_PROPS}");
-  });
 });

--- a/src/components/task-dag.tsx
+++ b/src/components/task-dag.tsx
@@ -5,7 +5,6 @@ import {
   ReactFlow,
   Background,
   Controls,
-  PanOnScrollMode,
   type Node,
   type Edge,
   type NodeProps,
@@ -127,27 +126,12 @@ const compactEdgeStyle = {
   markerEnd: { type: "arrowclosed" as const, color: "#C67A52" },
 };
 
-// Shared Figma/Miro-style trackpad pan/zoom config for the interactive,
-// full-canvas DAG mounts (tasks view + proposal editor). A two-finger scroll
-// pans freely (both axes); zoom stays available via pinch, Ctrl/⌘+scroll, and
-// the <Controls> buttons those mounts render unconditionally.
-//
-// NOTE (Tech Design D3.0): this is intentionally NOT applied to the readonly
-// dashboard-preview <ReactFlow> below — that mount hides <Controls> (gated
-// behind !readonly) and lives inside a scrollable dashboard, so flipping
-// zoomOnScroll off there would strip its only zoom affordance and its wheel
-// would hijack page scroll. It keeps its own inline zoomOnScroll/panOnDrag.
-// This module owns the constant; the two in-scope mounts import and spread it.
-export const DAG_PAN_ZOOM_PROPS = {
-  panOnScroll: true,
-  panOnScrollMode: PanOnScrollMode.Free,
-  zoomOnScroll: false,
-  zoomOnPinch: true,
-  // Mutable string[] (not `as const`) so it matches ReactFlow's KeyCode type,
-  // which rejects a readonly tuple. ⌘ (macOS) + Ctrl (Windows/Linux)+wheel zoom.
-  zoomActivationKeyCode: ["Meta", "Control"] as string[],
-  panOnDrag: true,
-};
+// Wheel model (idea 9d326265, elaboration round 3 — "protect mouse-wheel zoom"):
+// all DAG mounts use ReactFlow's default wheel-zoom — a plain wheel zooms around
+// the cursor, a pinch zooms, and drag pans. The interactive mounts (tasks view +
+// proposal editor) set the same inline zoomOnScroll/panOnDrag this readonly
+// preview <ReactFlow> uses, so all three converge on the default behavior and no
+// custom wheel listener is needed.
 
 function getLayoutedElements(
   nodes: Node<TaskNodeData>[],


### PR DESCRIPTION
## Summary
Fixes the graph wheel-zoom regression from #408 where a slow / high-resolution mouse wheel intermittently panned instead of zooming. A device-inference classifier (mouse vs trackpad) was attempted but a smooth-scroll mouse is indistinguishable from a trackpad on the wheel event stream — both magnitude- and continuity-based heuristics misfired. This settles on a **deterministic model** (idea `9d326265`, elaboration round 3 — "protect mouse-wheel zoom"): a plain wheel **always zooms** at any speed, a trackpad pinch zooms, and drag pans. Returns the canvas to its pre-#408 wheel behavior and removes the classifier entirely.

## Changed files
| File | Change |
|------|--------|
| `src/app/(dashboard)/projects/[uuid]/graph/mindmap-canvas.tsx` | Wheel handler unconditionally zooms (ctrl/pinch → finer sensitivity, else notch); no pan branch / no stream state; drag + touch paths unchanged |
| `src/app/(dashboard)/projects/[uuid]/tasks/dag-view.tsx` | Interactive DAG → ReactFlow default `zoomOnScroll`/`zoomOnPinch`/`panOnDrag`; custom wheel listener removed |
| `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-editor.tsx` | Same DAG default config |
| `src/components/task-dag.tsx` | Removed the shared pan-zoom-props export + `PanOnScrollMode` import; readonly preview unchanged |
| `src/lib/wheel-gesture.ts`, `src/components/dag-wheel-nav.tsx` | **Deleted** (+ their tests) — the classifier layer |
| `mindmap-canvas-wheel.test.tsx`, `task-dag-pan-zoom.test.tsx` | Rewritten to the always-zoom model |
| `openspec/specs/{project-resource-graph,task-dag-navigation}/spec.md` | Capability specs updated; 2 changes archived |

## Notes
- The intermediate device-classifier change was **deployed to live but never merged to develop**, so relative to `develop` this is a clean return to always-zoom (no add-then-delete churn). The always-zoom build is already deployed to the live env.
- Both archived OpenSpec changes are included per repo convention (spec history stays complete).

## Test plan
- [x] `pnpm test` — 4032 passed / 2 skipped (pre-existing DB integration)
- [x] `npx tsc --noEmit` — exit 0
- [x] `pnpm eslint` on changed source — 0 errors
- [x] Full `pnpm build` (earlier) — 53 routes compiled; deployed to live, prod /login 200
- [ ] Manual browser hardware pass (headless couldn't do it): mouse wheel zooms slow+fast, pinch zooms, drag pans, readonly preview unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)