### PR TITLE
fix(checkin): roll up container idea status from children in idea tracker

### DIFF
--- a/src/services/__tests__/idea-tracker.container.integration.test.ts
+++ b/src/services/__tests__/idea-tracker.container.integration.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Integration test for the container-idea rollup in the checkin/assignments
+// idea tracker. Unlike idea-tracker.service.test.ts (which mocks the rollup
+// source to test the seam in isolation), this mocks ONLY prisma and drives the
+// REAL buildIdeaTracker + getIdeasWithDerivedStatus together — proving the two
+// halves actually compose: a container whose children are all done is dropped.
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    idea: { findMany: vi.fn(), groupBy: vi.fn() },
+    proposal: { findMany: vi.fn() },
+    task: { findMany: vi.fn() },
+    project: { findMany: vi.fn() },
+    agentInstance: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+import { buildIdeaTracker } from "@/services/idea-tracker.service";
+import type { AuthContext } from "@/types/auth";
+
+const COMPANY = "company-1111-1111-1111-111111111111";
+const AGENT = "agent-2222-2222-2222-222222222222";
+const PROJECT = "project-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const CONTAINER = "idea-container-cccc-cccc-cccccccccccc";
+const now = new Date("2026-05-01T10:00:00Z");
+
+const agentAuth: AuthContext = {
+  type: "agent",
+  companyUuid: COMPANY,
+  actorUuid: AGENT,
+  roles: ["developer_agent"],
+};
+
+/**
+ * Seed prisma so that:
+ *   - the agent is assigned exactly the container idea (tracker Q1),
+ *   - the project holds the container + N children with the given child derived
+ *     statuses (board Q1), each child's status driven by its own proposal/tasks.
+ *
+ * `childDone` children get an approved proposal with all tasks done → derived
+ * "done"; the rest are left "open" → derived "todo".
+ */
+function seed(childCount: number, childDone: number) {
+  const children = Array.from({ length: childCount }, (_, i) => ({
+    uuid: `child-${i}`,
+    title: `Child ${i}`,
+    status: i < childDone ? "elaborated" : "open",
+    elaborationStatus: i < childDone ? "resolved" : null,
+    parentUuid: CONTAINER,
+    isContainer: false,
+    projectUuid: PROJECT,
+    createdAt: now,
+    updatedAt: now,
+  }));
+
+  const container = {
+    uuid: CONTAINER,
+    title: "Theme",
+    status: "elaborated",
+    elaborationStatus: "resolved",
+    parentUuid: null,
+    isContainer: true,
+    projectUuid: PROJECT,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  // idea.findMany is called by BOTH functions. Tracker Q1 carries where.OR
+  // (assignee match) and returns only the agent's plate (the container). The
+  // board query has no OR and returns every idea in the project.
+  mockPrisma.idea.findMany.mockImplementation(async (args: { where?: { OR?: unknown } }) => {
+    if (args?.where?.OR) return [container];
+    return [container, ...children];
+  });
+
+  mockPrisma.idea.groupBy.mockResolvedValue([
+    { parentUuid: CONTAINER, _count: { _all: childCount } },
+  ]);
+
+  // One approved proposal per done child. proposal.findMany is called by both;
+  // the same rows satisfy each (board filters in-memory by inputUuids overlap).
+  const proposals = Array.from({ length: childDone }, (_, i) => ({
+    uuid: `p-${i}`,
+    projectUuid: PROJECT,
+    status: "approved",
+    inputType: "idea",
+    inputUuids: [`child-${i}`],
+    createdAt: now,
+  }));
+  mockPrisma.proposal.findMany.mockResolvedValue(proposals);
+
+  // Every task on those proposals is done.
+  const tasks = proposals.map((p) => ({ proposalUuid: p.uuid, status: "done" }));
+  mockPrisma.task.findMany.mockResolvedValue(tasks);
+
+  mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT, name: "A" }]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.agentInstance.findMany.mockResolvedValue([]);
+});
+
+describe("buildIdeaTracker container rollup (real getIdeasWithDerivedStatus)", () => {
+  it("drops a container whose children are ALL done", async () => {
+    seed(3, 3);
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker).toEqual({});
+  });
+
+  it("keeps a container with a mix of done and not-done children, marked in_progress", async () => {
+    seed(3, 1);
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT].ideas.map((i) => i.uuid)).toEqual([CONTAINER]);
+    expect(tracker[PROJECT].ideas[0].status).toBe("in_progress");
+  });
+
+  it("keeps a container whose children are ALL todo, marked todo", async () => {
+    seed(3, 0);
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT].ideas.map((i) => i.uuid)).toEqual([CONTAINER]);
+    expect(tracker[PROJECT].ideas[0].status).toBe("todo");
+  });
+
+  it("keeps a childless container (no rollup to override its own status)", async () => {
+    seed(0, 0);
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT].ideas.map((i) => i.uuid)).toEqual([CONTAINER]);
+  });
+});

--- a/src/services/__tests__/idea-tracker.service.test.ts
+++ b/src/services/__tests__/idea-tracker.service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ===== Prisma mock (hoisted) =====
-const { mockPrisma } = vi.hoisted(() => ({
+const { mockPrisma, mockGetIdeasWithDerivedStatus } = vi.hoisted(() => ({
   mockPrisma: {
     idea: { findMany: vi.fn() },
     proposal: { findMany: vi.fn() },
@@ -9,9 +9,18 @@ const { mockPrisma } = vi.hoisted(() => ({
     project: { findMany: vi.fn() },
     agentInstance: { findMany: vi.fn() },
   },
+  mockGetIdeasWithDerivedStatus: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// Container (theme) ideas roll their status up from their children via the
+// project-wide board builder. Mock only that function; keep computeDerivedStatus
+// (used for every non-container idea) real via importActual.
+vi.mock("@/services/idea.service", async (importActual) => {
+  const actual = await importActual<typeof import("@/services/idea.service")>();
+  return { ...actual, getIdeasWithDerivedStatus: mockGetIdeasWithDerivedStatus };
+});
 
 import { buildIdeaTracker, buildTaskTracker } from "@/services/idea-tracker.service";
 import type { AuthContext } from "@/types/auth";
@@ -51,6 +60,7 @@ function makeIdea(
     status,
     elaborationStatus: null,
     parentUuid: null,
+    isContainer: false,
     projectUuid,
     createdAt: now,
     updatedAt: now,
@@ -85,6 +95,9 @@ beforeEach(() => {
   // By default the agent owns no instances → buildAssigneeMatch omits the
   // agent_instance arm, so the existing OR-shape assertions stay unchanged.
   mockPrisma.agentInstance.findMany.mockResolvedValue([]);
+  // Container rollup source: default to no ideas. Only container-idea tests
+  // populate it; the guard means it isn't called unless a container is present.
+  mockGetIdeasWithDerivedStatus.mockResolvedValue([]);
 });
 
 // ============================================================
@@ -217,6 +230,50 @@ describe("buildIdeaTracker — filters", () => {
     const tracker = await buildIdeaTracker(agentAuth);
     expect(tracker).toEqual({});
     expect(mockPrisma.proposal.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildIdeaTracker — container (theme) rollup", () => {
+  const CONTAINER = "idea-container-cccc-cccc-cccccccccccc";
+
+  it("filters out a container idea whose children are all done", async () => {
+    // A container has no proposal/task chain of its own, so computeDerivedStatus
+    // on its "elaborated" status yields "in_progress" — it must be rolled up from
+    // its children instead. All children done => the container is done => dropped.
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea(CONTAINER, PROJECT_A, "elaborated", { isContainer: true }),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+    mockGetIdeasWithDerivedStatus.mockResolvedValue([
+      { uuid: CONTAINER, isContainer: true, derivedStatus: "done" },
+    ]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker).toEqual({});
+  });
+
+  it("keeps a container idea whose children are still in progress", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea(CONTAINER, PROJECT_A, "elaborated", { isContainer: true }),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+    mockGetIdeasWithDerivedStatus.mockResolvedValue([
+      { uuid: CONTAINER, isContainer: true, derivedStatus: "in_progress" },
+    ]);
+
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker[PROJECT_A].ideas.map((i) => i.uuid)).toEqual([CONTAINER]);
+    expect(tracker[PROJECT_A].ideas[0].status).toBe("in_progress");
+  });
+
+  it("does not consult the rollup source when no container ideas are present", async () => {
+    mockPrisma.idea.findMany.mockResolvedValue([
+      makeIdea("i_plain", PROJECT_A, "open"),
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT_A, name: "A" }]);
+
+    await buildIdeaTracker(agentAuth);
+    expect(mockGetIdeasWithDerivedStatus).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/idea-tracker.service.ts
+++ b/src/services/idea-tracker.service.ts
@@ -9,7 +9,11 @@
 import { prisma } from "@/lib/prisma";
 import type { AuthContext } from "@/types/auth";
 import { buildAssigneeMatch } from "@/lib/uuid-resolver";
-import { computeDerivedStatus, type DerivedIdeaStatus } from "@/services/idea.service";
+import {
+  computeDerivedStatus,
+  getIdeasWithDerivedStatus,
+  type DerivedIdeaStatus,
+} from "@/services/idea.service";
 
 // ===== Idea tracker types =====
 
@@ -66,12 +70,20 @@ export interface BuildTaskTrackerOptions {
  * each carrying derivedStatus + proposal/task counts.
  *
  * Filters: excludes status="closed" (terminal) and derivedStatus="done"
- * (rolled-up completion of the proposal/task chain).
+ * (rolled-up completion of the proposal/task chain). A container (theme) idea's
+ * derivedStatus is rolled up from its children — so a theme whose children are
+ * all done is dropped like any other completed idea, rather than lingering
+ * forever (containers have no proposal/task chain of their own).
  *
  * Ordering: ideas are visited in `updatedAt desc` so the cap, when applied,
  * keeps the most-recently-touched work.
  *
- * Query budget: 4 prisma calls (ideas → proposals → tasks → projects).
+ * Query budget: 4 prisma calls (ideas → proposals → tasks → projects), plus —
+ * ONLY when the agent has a container idea on their plate — one
+ * getIdeasWithDerivedStatus (itself ~3-4 queries over the whole project) per
+ * distinct project that holds a container. This container rollup runs before the
+ * maxIdeas cap, so it is bounded by the agent's container-bearing projects, not
+ * by the cap. Skipped entirely when there are no containers.
  */
 export async function buildIdeaTracker(
   auth: AuthContext,
@@ -103,6 +115,7 @@ export async function buildIdeaTracker(
       status: true,
       elaborationStatus: true,
       parentUuid: true,
+      isContainer: true,
       projectUuid: true,
       createdAt: true,
       updatedAt: true,
@@ -187,6 +200,28 @@ export async function buildIdeaTracker(
   });
   const projectNames = new Map(projects.map((p) => [p.uuid, p.name]));
 
+  // Q5 (containers only): a theme (container) idea has no proposal/task chain of
+  // its own, so computeDerivedStatus would stall it at "in_progress" forever —
+  // even when every child is done. Its real status must roll up from its
+  // children, which may be assigned to other actors and thus absent from the
+  // assignee-matched set above. Resolve the rolled-up status from the same
+  // project-wide board builder the UI uses, so this surface can't drift from it.
+  // Only fires when the agent actually has a container on their plate.
+  const containerProjectUuids = [
+    ...new Set(rawIdeas.filter((i) => i.isContainer).map((i) => i.projectUuid)),
+  ];
+  const containerDerivedStatus = new Map<string, DerivedIdeaStatus>();
+  if (containerProjectUuids.length > 0) {
+    const rolled = await Promise.all(
+      containerProjectUuids.map((projectUuid) =>
+        getIdeasWithDerivedStatus(auth.companyUuid, projectUuid),
+      ),
+    );
+    for (const item of rolled.flat()) {
+      if (item.isContainer) containerDerivedStatus.set(item.uuid, item.derivedStatus);
+    }
+  }
+
   const tracker: Record<string, IdeaTrackerProject> = {};
   let count = 0;
 
@@ -198,13 +233,24 @@ export async function buildIdeaTracker(
       ? proposalToTaskStatuses.get(latestApproved.uuid) ?? []
       : [];
 
-    const { derivedStatus } = computeDerivedStatus({
+    const own = computeDerivedStatus({
       ideaStatus: idea.status,
       elaborationStatus: idea.elaborationStatus,
       hasPendingProposal: ideaHasPending.has(idea.uuid),
       hasApprovedProposal: !!latestApproved,
       taskStatuses,
     });
+
+    // A container idea takes its children's rolled-up status; everything else
+    // uses the status derived from its own proposal/task chain. The board query
+    // is company+project scoped with no status/assignee filter, so any container
+    // in rawIdeas is guaranteed to reappear in its project's board result (a
+    // childless theme included — it just carries its own base status there).
+    // The `?? own` fallback is therefore belt-and-suspenders for the impossible
+    // case where the two queries disagree on company/project.
+    const derivedStatus = idea.isContainer
+      ? containerDerivedStatus.get(idea.uuid) ?? own.derivedStatus
+      : own.derivedStatus;
 
     if (derivedStatus === "done") continue;
 


### PR DESCRIPTION
## Summary

A **container (theme) idea** whose child ideas are all done was still being injected into the plugin's SessionStart checkin as unfinished work.

**Root cause:** `buildIdeaTracker` (the shared source for both `chorus_checkin` and `chorus_get_my_assignments`) computed each idea's derived status from *that idea's own* proposal/task chain via `computeDerivedStatus`, then dropped anything with `derivedStatus === "done"`. But a container idea has **no proposal/task chain of its own** (it can't create a proposal), so `computeDerivedStatus` on an `elaborated` container always returned `in_progress` — it could never reach the `"done"` drop and lingered forever.

The board view (`getIdeasWithDerivedStatus`) already rolls a container's status up from its children via `rollupThemeDerivedStatus`, but the tracker never applied that rollup — the two surfaces had drifted.

**Fix:** in `buildIdeaTracker`, when the agent's plate contains a container idea, resolve its rolled-up status from the **same** `getIdeasWithDerivedStatus` the board uses (reusing it rather than re-implementing the rollup, so the surfaces can't drift again). Non-container ideas are unchanged. The extra fetch only runs when a container is present, once per container-bearing project — a project-wide rollup is required because a container's children may be assigned to other actors and thus absent from the assignee-matched tracker set.

## Changed files

| File | Change |
|------|--------|
| `src/services/idea-tracker.service.ts` | Select `isContainer`; resolve container status via `getIdeasWithDerivedStatus` before the `done` drop |
| `src/services/__tests__/idea-tracker.service.test.ts` | Unit tests: container done/in-progress/childless + guard that rollup source isn't consulted without containers |
| `src/services/__tests__/idea-tracker.container.integration.test.ts` | New: mocks only prisma, drives both real functions together (all-done → dropped, mixed → in_progress, all-todo → todo, childless → kept) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test src/services/__tests__/idea-tracker` — 50 pass
- [x] Full service suite — 1629 pass (14 pre-existing live-DB skips)
- [x] Failing-test-first (TDD): all-children-done drop test failed before the fix, passes after
- [x] Independent adversarial code review — no ship-blockers, no correctness regression

## Follow-ups (pre-existing board bugs, out of scope)
The fix faithfully inherits two pre-existing limitations of the board's `rollupThemeDerivedStatus` (Pass 2 in `idea.service.ts`), which would change board behavior to fix:
- **Nested containers** don't roll up (a container-of-containers reads its child container's own status, not its rolled-up status).
- **All-`closed` children**: `closed` normalizes to `elaborated`→`in_progress` in the board, so a theme whose remaining children were all abandoned lingers.

Generated with [Claude Code](https://claude.com/claude-code)