### PR TITLE
feat(i18n): complete Korean (ko) locale coverage + parity guard

### DIFF
--- a/messages/ko.json
+++ b/messages/ko.json
@@ -55,6 +55,12 @@
     "system": "시스템",
     "confirmDelete": "정말 삭제하시겠습니까?"
   },
+  "theme": {
+    "toggleLabel": "테마",
+    "light": "라이트",
+    "dark": "다크",
+    "system": "시스템"
+  },
   "activity": {
     "taskCreated": "{actor}님이 이 작업을 생성했습니다",
     "taskAssigned": "{actor}님이 이 작업에 배정되었습니다",
@@ -678,6 +684,33 @@
     "deleteFailed": "문서를 삭제하지 못했습니다.",
     "deleteFailedNotFound": "이 문서는 더 이상 존재하지 않습니다."
   },
+  "references": {
+    "title": "참고 자료",
+    "empty": "공식 문서, 참고 구현체 또는 이슈 스레드를 연결해 근거를 마련하세요.",
+    "loading": "참고 자료를 불러오는 중...",
+    "add": "추가",
+    "addReference": "참고 자료 추가",
+    "editReference": "참고 자료 편집",
+    "deleteReference": "참고 자료 삭제",
+    "deleteConfirm": "참고 자료 \"{title}\"이(가) 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+    "typeLabel": "유형",
+    "typeDocs": "문서",
+    "typeRepo": "저장소",
+    "typeIssuePr": "이슈 / PR",
+    "typePaperBlog": "논문 / 블로그",
+    "urlLabel": "URL",
+    "urlPlaceholder": "https://example.com/...",
+    "urlRequired": "URL을 입력하세요",
+    "titleLabel": "제목",
+    "titlePlaceholder": "짧은 제목을 입력하세요",
+    "titleRequired": "제목을 입력하세요",
+    "notesLabel": "메모",
+    "notesPlaceholder": "선택 사항: 요약 또는 관련성 설명",
+    "addFailed": "참고 자료 추가에 실패했습니다",
+    "updateFailed": "참고 자료 업데이트에 실패했습니다",
+    "deleteFailed": "참고 자료 삭제에 실패했습니다",
+    "countLabel": "참고 자료 {count}개"
+  },
   "export": {
     "exportDocument": "내보내기",
     "exportAs": "{format}(으)로 내보내기",
@@ -1213,7 +1246,15 @@
       "pickerTruncated": "처음 200개의 아이디어만 표시됩니다. 원하는 상위 항목이 보이지 않으면 제목으로 검색해 좁혀보세요.",
       "save": "상위 항목으로 설정",
       "saveFailed": "상위 항목 설정에 실패했습니다",
-      "deriveFailed": "아이디어 파생에 실패했습니다"
+      "deriveFailed": "아이디어 파생에 실패했습니다",
+      "container": "테마",
+      "containerDescription": "테마는 관련된 하위 아이디어를 묶어 공통 방향을 정합니다. 구체화는 가능하지만 실제 작업은 테마에서 파생한 아이디어에서 이루어지며, 테마 자체는 제안을 작성하지 않습니다.",
+      "containerBadge": "테마",
+      "typeIdea": "아이디어",
+      "typeTheme": "테마",
+      "makeContainer": "테마로 설정",
+      "containerHint": "테마는 하위 아이디어를 파생하며 진행됩니다.",
+      "childrenDone": "{done}/{total} 완료"
     },
     "actions": {
       "newIdea": "새 아이디어",
@@ -1237,7 +1278,9 @@
       "descriptionPlaceholder": "아이디어를 명확히 하는 데 도움이 되는 배경, 목표, 세부 정보를 추가하세요...",
       "modeForm": "양식 작성",
       "modeConversation": "에이전트에게 설명",
-      "modeConversationOfflineHint": "에이전트에게 설명하려면 온라인 상태인 데몬이 필요합니다."
+      "modeConversationOfflineHint": "에이전트에게 설명하려면 온라인 상태인 데몬이 필요합니다.",
+      "decompose": "하위 아이디어로 나누도록 도와주세요",
+      "decomposeHint": "테마를 생성하고, 에이전트가 확인용 하위 아이디어 후보를 제안하도록 합니다."
     },
     "error": {
       "loadFailed": "아이디어를 불러오지 못했습니다",
@@ -1652,6 +1695,11 @@
     },
     "tooltip": {
       "loading": "로딩 중…"
+    },
+    "zoom": {
+      "in": "확대",
+      "out": "축소",
+      "fit": "화면에 맞추기"
     },
     "status": {
       "unknown": "알 수 없음"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -406,7 +406,6 @@
     "submit": "提交",
     "editIdea": "编辑想法",
     "saveChanges": "保存更改",
-    "completed": "已完成",
     "titleRequired": "标题不能为空",
     "updateFailed": "更新想法失败",
     "deleteIdea": "删除想法",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
+    "@formatjs/icu-messageformat-parser": "^3.5.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.3
         version: 3.3.3
+      '@formatjs/icu-messageformat-parser':
+        specifier: ^3.5.1
+        version: 3.5.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.18

--- a/src/i18n/__tests__/locale-parity.test.ts
+++ b/src/i18n/__tests__/locale-parity.test.ts
@@ -1,0 +1,172 @@
+// Locale-key parity guard.
+//
+// CLAUDE.md's i18n rule is absolute: every user-facing string must exist in
+// EVERY locale. There are no legitimate single-locale keys — so the locale
+// files must expose an identical key set, with matching ICU arguments, and no
+// empty values. This test pins that invariant so a future feature that adds a
+// key to en/ (or zh) but forgets ko can't merge silently. It generalizes the
+// older, narrow report-locale-keys.test.ts (which only pinned 3 keys) to the
+// whole corpus, driven by the `locales` array so a 4th locale is covered for
+// free the moment it's registered.
+//
+// Why the ICU argument check parses the AST instead of a brace regex:
+// a message like en `proposalValidation.errorCount` =
+//   "{count} {count, plural, one {error} other {errors}}"
+// has exactly ONE argument (`count`), but its plural sub-messages contain the
+// literal words "error"/"errors". A brace regex (`/\{(\w+)\}/g` or
+// `/\{\s*(\w+)\s*[,}]/g`) can't tell an argument name from sub-message text —
+// it over- or under-extracts, and would falsely fail parity against a locale
+// that correctly flattens the plural (Korean/Chinese have no grammatical
+// plural, so `references.countLabel` becomes a single "{count}" phrase). Only
+// parsing the ICU AST and collecting element argument names is correct; it
+// yields the same argument set for the en plural block and the flattened
+// locale value. @formatjs/icu-messageformat-parser is next-intl's own parser.
+
+import { describe, expect, it } from "vitest";
+import { parse, TYPE, type MessageFormatElement } from "@formatjs/icu-messageformat-parser";
+import { locales, defaultLocale, type Locale } from "../config";
+
+import en from "../../../messages/en.json";
+import zh from "../../../messages/zh.json";
+import ko from "../../../messages/ko.json";
+
+type MessageNode = string | { [key: string]: MessageNode };
+type Messages = Record<string, MessageNode>;
+
+// Locale JSON is loaded here and keyed by locale code. If a new locale is added
+// to `locales` in config.ts without a matching import + entry, the guard below
+// fails loudly rather than silently skipping the new locale.
+const MESSAGES: Record<string, Messages> = {
+  en: en as Messages,
+  zh: zh as Messages,
+  ko: ko as Messages,
+};
+
+const REFERENCE: Locale = defaultLocale; // en
+
+/** Flatten a nested message object to a dotted-key -> string map. */
+function flatten(node: MessageNode, prefix = "", out: Record<string, string> = {}): Record<string, string> {
+  if (node !== null && typeof node === "object") {
+    for (const key of Object.keys(node)) {
+      flatten(node[key], prefix ? `${prefix}.${key}` : key, out);
+    }
+  } else {
+    out[prefix] = node as string;
+  }
+  return out;
+}
+
+/**
+ * Collect the set of named ICU arguments in a message by walking its AST.
+ * Includes simple placeholders, number/date/time args, and plural/select
+ * argument names; recurses into plural/select option sub-messages and tag
+ * children. Excludes ICU keywords, category selectors, the `#` pound marker,
+ * and all literal sub-message text.
+ */
+function namedArgs(message: string): Set<string> {
+  const out = new Set<string>();
+  const walk = (nodes: MessageFormatElement[]): void => {
+    for (const node of nodes) {
+      switch (node.type) {
+        case TYPE.argument:
+        case TYPE.number:
+        case TYPE.date:
+        case TYPE.time:
+          out.add(node.value);
+          break;
+        case TYPE.plural:
+        case TYPE.select:
+          out.add(node.value);
+          for (const opt of Object.values(node.options)) walk(opt.value);
+          break;
+        case TYPE.tag:
+          walk(node.children);
+          break;
+        // literal, pound (#) -> no argument
+        default:
+          break;
+      }
+    }
+  };
+  walk(parse(message));
+  return out;
+}
+
+const flat: Record<string, Record<string, string>> = {};
+for (const loc of locales) {
+  const messages = MESSAGES[loc];
+  if (!messages) {
+    throw new Error(
+      `locale "${loc}" is registered in src/i18n/config.ts but has no messages import in locale-parity.test.ts — add it.`,
+    );
+  }
+  flat[loc] = flatten(messages);
+}
+
+const refKeys = Object.keys(flat[REFERENCE]).sort();
+const nonReferenceLocales = locales.filter((l) => l !== REFERENCE);
+
+describe("locale key parity", () => {
+  it(`every registered locale is importable (${locales.join(", ")})`, () => {
+    for (const loc of locales) expect(flat[loc], `messages for ${loc}`).toBeDefined();
+  });
+
+  describe.each(nonReferenceLocales)("%s.json vs en.json", (loc) => {
+    const locKeys = new Set(Object.keys(flat[loc]));
+    const refKeySet = new Set(refKeys);
+
+    it("has no keys missing relative to en", () => {
+      const missing = refKeys.filter((k) => !locKeys.has(k));
+      expect(missing, `${loc}.json is missing keys present in en.json:\n${missing.join("\n")}`).toEqual([]);
+    });
+
+    it("has no orphan keys absent from en", () => {
+      const extra = [...locKeys].filter((k) => !refKeySet.has(k)).sort();
+      expect(extra, `${loc}.json has keys not present in en.json:\n${extra.join("\n")}`).toEqual([]);
+    });
+  });
+
+  describe.each(locales)("%s.json values", (loc) => {
+    it("are all non-empty strings", () => {
+      const bad = Object.entries(flat[loc])
+        .filter(([, v]) => typeof v !== "string" || v.trim().length === 0)
+        .map(([k]) => k);
+      expect(bad, `${loc}.json has empty/non-string values at:\n${bad.join("\n")}`).toEqual([]);
+    });
+  });
+
+  describe.each(nonReferenceLocales)("%s.json ICU arguments", (loc) => {
+    it("match en's named-argument set per key", () => {
+      const mismatches: string[] = [];
+      for (const key of refKeys) {
+        const refVal = flat[REFERENCE][key];
+        const locVal = flat[loc][key];
+        if (typeof refVal !== "string" || typeof locVal !== "string") continue; // key-set test covers this
+        const refArgs = [...namedArgs(refVal)].sort();
+        const locArgs = [...namedArgs(locVal)].sort();
+        if (refArgs.join(",") !== locArgs.join(",")) {
+          mismatches.push(`${key}: en={${refArgs.join(",")}} ${loc}={${locArgs.join(",")}}`);
+        }
+      }
+      expect(mismatches, `ICU argument drift in ${loc}.json:\n${mismatches.join("\n")}`).toEqual([]);
+    });
+  });
+
+  it("every locale value is a parseable ICU message", () => {
+    // A malformed ICU string (e.g. an unbalanced brace introduced by a bad
+    // translation) is a real runtime bug — next-intl would throw at format
+    // time. Surface it here instead.
+    const errors: string[] = [];
+    for (const loc of locales) {
+      for (const [key, value] of Object.entries(flat[loc])) {
+        if (typeof value !== "string") continue;
+        try {
+          parse(value);
+        } catch (e) {
+          errors.push(`${loc}.${key}: ${(e as Error).message.split("\n")[0]}`);
+        }
+      }
+    }
+    expect(errors, `unparseable ICU messages:\n${errors.join("\n")}`).toEqual([]);
+  });
+});

--- a/src/i18n/__tests__/report-locale-keys.test.ts
+++ b/src/i18n/__tests__/report-locale-keys.test.ts
@@ -1,19 +1,14 @@
-// Locale-key contract for the idea-completion-report feature.
+// Value-specific i18n contracts for the idea-completion-report surface.
 //
-// The Reports surface relies on three i18n keys that MUST exist with non-empty
-// values in BOTH `en` and `zh` — losing any of them would render the
-// reports-list with raw key strings as fallback (verified visually + via the
-// reports-list render tests). This test pins the contract so a translation
-// drift can't ship silently.
-//
-// Note: the original task description referenced `proposals.reports`, but the
-// actual surface (T2) lives on the Idea overview tab and uses `idea.reportsList`
-// + `idea.reportsAcrossProposals` instead. We assert against the keys that
-// were actually shipped, not the placeholder names from the task spec.
+// Key EXISTENCE + non-empty + ICU-argument parity across all locales is now
+// enforced generally by locale-parity.test.ts — this file no longer duplicates
+// that. What remains here are the VALUE-specific assertions that the parity
+// guard can't express: specific en label strings the reports-list render tests
+// depend on. Losing these would break the UI tests, so they stay pinned at the
+// locale layer.
 
 import { describe, expect, it } from "vitest";
 import enMessages from "../../../messages/en.json";
-import zhMessages from "../../../messages/zh.json";
 
 type MessageNode = string | { [key: string]: MessageNode };
 
@@ -33,52 +28,13 @@ function resolveDeep(messages: Record<string, MessageNode>, path: string): unkno
   return node;
 }
 
-const REQUIRED_KEYS = [
-  "documents.typeReport",
-  "idea.reportsList",
-  "idea.reportsAcrossProposals",
-] as const;
-
-const LOCALES = [
-  ["en", enMessages as Record<string, MessageNode>],
-  ["zh", zhMessages as Record<string, MessageNode>],
-] as const;
-
-describe("idea-completion-report locale keys", () => {
-  for (const [localeName, messages] of LOCALES) {
-    describe(`${localeName}.json`, () => {
-      for (const key of REQUIRED_KEYS) {
-        it(`has a non-empty string at "${key}"`, () => {
-          const value = resolveDeep(messages, key);
-          expect(value, `missing key ${key} in ${localeName}.json`).toBeDefined();
-          expect(
-            typeof value,
-            `key ${key} in ${localeName}.json must be a string`,
-          ).toBe("string");
-          // Non-empty AND not just whitespace — an empty translation in either
-          // locale is functionally a missing key for the UI.
-          expect(
-            (value as string).trim().length,
-            `key ${key} in ${localeName}.json must be non-empty`,
-          ).toBeGreaterThan(0);
-        });
-      }
-    });
-  }
-
-  it("documents.typeReport renders the same Document type across locales", () => {
-    // Both locales must define typeReport (we assert the value is a string
-    // above) — here we just confirm the en and zh entries are independent
-    // strings, not accidentally cross-pointed at the same fallback constant.
+describe("idea-completion-report locale values", () => {
+  it("documents.typeReport is the English label 'Report'", () => {
     const en = resolveDeep(enMessages as Record<string, MessageNode>, "documents.typeReport");
-    const zh = resolveDeep(zhMessages as Record<string, MessageNode>, "documents.typeReport");
-    expect(typeof en).toBe("string");
-    expect(typeof zh).toBe("string");
-    // Sanity: en should be the English label "Report".
     expect(en).toBe("Report");
   });
 
-  it("idea.reportsList is a SCREAMING-CASE label in en (matches reports-list header expectation)", () => {
+  it("idea.reportsList is the SCREAMING-CASE header 'REPORTS'", () => {
     // The reports-list render test asserts the header text is "REPORTS" — this
     // pins that contract at the locale layer so a future translation edit
     // can't quietly break the UI test by lowercasing the label.


### PR DESCRIPTION
## Summary

Completes Korean (`ko`) locale coverage after #411 and adds an automated guard so the locales can't silently drift again.

- **Backfill 42 missing `ko` keys** — `theme.*` (dark-mode toggle), `references.*` (reference artifacts #418), `ideaTracker.lineage.*`/`ideaTracker.newIdea.*` (theme/decompose idea), `graph.zoom.*`. `messages/ko.json` now has exact key parity with `en.json` (1482/1482). Insertion-only; no existing Korean values changed. Every ICU argument preserved; `references.countLabel` flattened to a single `{count}` phrasing per the `zh.json` precedent (Korean has no grammatical plural). Focused quality pass on the new entries + high-frequency UI (nav/buttons/status/settings/errors); "Theme" (container idea) = 테마 consistently.
- **Automated locale-key-parity guard** — new `src/i18n/__tests__/locale-parity.test.ts` asserts, across every locale in `src/i18n/config.ts` `locales` (en/zh/ko): identical leaf-key sets, non-empty string values, matching named-ICU-argument sets per key, and that every value is a parseable ICU message.
- **Removed the orphan `zh.ideas.completed`** (grep-verified unused — code `"completed"` refs are `normalizeIdeaStatus` status values, not `t()` keys) to bring all three locales to exact parity.

### Why the guard parses the ICU AST instead of a regex

A brace regex cannot tell an ICU argument name from literal text inside plural/select sub-messages. `en` `proposalValidation.errorCount` = `"{count} {count, plural, one {error} other {errors}}"` has exactly one argument (`count`), but a regex also captures `error`/`errors`; a correctly-flattened `ko` value yields only `count`, so set-equality would falsely fail CI on already-shipped-correct translations (4 such keys exist today). The guard uses `@formatjs/icu-messageformat-parser` (next-intl's own parser, added as an explicit pure-JS devDependency) and walks the AST — 0 false mismatches across all 1482 keys.

## Changed files

| File | Change |
|------|--------|
| `messages/ko.json` | +42 keys → full parity with en (insertion-only) |
| `messages/zh.json` | remove orphan `ideas.completed` |
| `src/i18n/__tests__/locale-parity.test.ts` | new full-coverage parity guard (AST-based) |
| `src/i18n/__tests__/report-locale-keys.test.ts` | fold existence loop into the guard; keep `Report`/`REPORTS` value assertions |
| `package.json` / `pnpm-lock.yaml` | add `@formatjs/icu-messageformat-parser` devDependency |

## Out of scope (per elaboration)

- Automatic system-language detection / follow-system "System" locale tri-state — dropped this round; may become its own idea.
- The marketing landing page `packages/landing`.
- Language switcher needed **no code change** — both the Settings picker and sidebar quick-settings already iterate `locales`; browser-verified 한국어 selectable at both, persisting across reload, in light and dark themes.

## Test plan

- [x] `pnpm test` — 4109 passed / 14 skipped / 0 failed
- [x] `npx tsc --noEmit` — clean
- [x] Parity guard negative controls: deleting a key, dropping an ICU arg, and emptying a value each fail the guard with an actionable message
- [x] Browser-verified the switcher end-to-end (both entry points, both themes) on the running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)