### PR TITLE
feat(idea-panel): move offline hint on stage-advance buttons into a tooltip

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -963,7 +963,7 @@
     "button": "Start Development",
     "starting": "Starting...",
     "startedHint": "Development started — the agent is executing the remaining tasks",
-    "offlineHint": "The assigned agent is offline — the button enables when it reconnects",
+    "offlineHint": "Agent offline — enables on reconnect",
     "errorAgentOffline": "The assigned agent is offline. Start development after it reconnects.",
     "errorNoApprovedProposal": "This idea has no approved proposal yet",
     "errorNoUnfinishedTasks": "All tasks are already finished",
@@ -978,7 +978,7 @@
     "confirmCta": "Run Yolo",
     "starting": "Starting...",
     "startedHint": "Yolo started — the agent is driving this idea to done",
-    "offlineHint": "The assigned agent is offline — the button enables when it reconnects",
+    "offlineHint": "Agent offline — enables on reconnect",
     "errorAgentOffline": "The assigned agent is offline. Run Yolo after it reconnects.",
     "errorAssigneeNotAgent": "The idea's assignee is not an agent",
     "errorGeneric": "Failed to start Yolo"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -963,7 +963,7 @@
     "button": "開発を開始",
     "starting": "開始中...",
     "startedHint": "開発を開始しました — エージェントが残りの課題を実行しています",
-    "offlineHint": "割り当てられたエージェントはオフラインです — 再接続するとボタンが有効になります",
+    "offlineHint": "エージェントオフライン — 再接続で有効化",
     "errorAgentOffline": "割り当てられたエージェントはオフラインです。再接続後に開発を開始してください。",
     "errorNoApprovedProposal": "この着想にはまだ承認済みの提案がありません",
     "errorNoUnfinishedTasks": "すべての課題はすでに完了しています",
@@ -978,7 +978,7 @@
     "confirmCta": "Yolo を実行",
     "starting": "開始中...",
     "startedHint": "Yolo を開始しました — エージェントがこの着想を完了まで進めています",
-    "offlineHint": "割り当てられたエージェントはオフラインです — 再接続するとボタンが有効になります",
+    "offlineHint": "エージェントオフライン — 再接続で有効化",
     "errorAgentOffline": "割り当てられたエージェントはオフラインです。再接続後に Yolo を実行してください。",
     "errorAssigneeNotAgent": "この着想の担当者はエージェントではありません",
     "errorGeneric": "Yolo の開始に失敗しました"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -963,7 +963,7 @@
     "button": "개발 시작",
     "starting": "시작 중...",
     "startedHint": "개발이 시작되었습니다 — 에이전트가 남은 작업을 실행하고 있습니다",
-    "offlineHint": "배정된 에이전트가 오프라인입니다 — 다시 연결되면 버튼이 활성화됩니다",
+    "offlineHint": "에이전트 오프라인 — 재연결 시 사용 가능",
     "errorAgentOffline": "배정된 에이전트가 오프라인입니다. 다시 연결된 후 개발을 시작하세요.",
     "errorNoApprovedProposal": "이 아이디어에는 승인된 제안이 아직 없습니다",
     "errorNoUnfinishedTasks": "모든 작업이 이미 완료되었습니다",
@@ -978,7 +978,7 @@
     "confirmCta": "Yolo 실행",
     "starting": "시작 중...",
     "startedHint": "Yolo가 시작되었습니다 — 에이전트가 이 아이디어를 완료까지 진행시키고 있습니다",
-    "offlineHint": "배정된 에이전트가 오프라인입니다 — 다시 연결되면 버튼이 활성화됩니다",
+    "offlineHint": "에이전트 오프라인 — 재연결 시 사용 가능",
     "errorAgentOffline": "배정된 에이전트가 오프라인입니다. 다시 연결된 후 Yolo를 실행하세요.",
     "errorAssigneeNotAgent": "이 아이디어의 담당자는 에이전트가 아닙니다",
     "errorGeneric": "Yolo를 시작하지 못했습니다"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -963,7 +963,7 @@
     "button": "开始开发",
     "starting": "启动中...",
     "startedHint": "开发已启动 —— agent 正在执行剩余任务",
-    "offlineHint": "该 agent 当前离线，重新连接后按钮将可用",
+    "offlineHint": "Agent 离线，重连后可用",
     "errorAgentOffline": "该 agent 当前离线，请等它重新连接后再开始开发。",
     "errorNoApprovedProposal": "该 idea 还没有已批准的 proposal",
     "errorNoUnfinishedTasks": "所有任务都已完成",
@@ -978,7 +978,7 @@
     "confirmCta": "执行 Yolo",
     "starting": "启动中...",
     "startedHint": "Yolo 已启动 —— agent 正在推进这个 idea 到完成",
-    "offlineHint": "该 agent 当前离线，重新连接后按钮将可用",
+    "offlineHint": "Agent 离线，重连后可用",
     "errorAgentOffline": "该 agent 当前离线，请等它重新连接后再执行 Yolo。",
     "errorAssigneeNotAgent": "该 idea 的负责人不是 agent",
     "errorGeneric": "启动 Yolo 失败"

--- a/openspec/changes/stage-advance-offline-hint-tooltip/.openspec.yaml
+++ b/openspec/changes/stage-advance-offline-hint-tooltip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/stage-advance-offline-hint-tooltip/README.md
+++ b/openspec/changes/stage-advance-offline-hint-tooltip/README.md
@@ -1,0 +1,3 @@
+# stage-advance-offline-hint-tooltip
+
+Move the offline explanatory hint next to Start Development / Yolo into a hover/focus tooltip

--- a/openspec/changes/stage-advance-offline-hint-tooltip/design.md
+++ b/openspec/changes/stage-advance-offline-hint-tooltip/design.md
@@ -1,0 +1,117 @@
+# Design: offline-hint tooltip for stage-advance buttons
+
+## Context
+
+`StartDevelopmentButton` and `YoloButton` (in `src/components/`) are shared
+components rendered by both idea-detail panels (the `/ideas` route panel and the
+dashboard idea-tracker panel). Each computes `agentOnline` from the client-side
+agent-presence context and, when the assignee agent is offline, renders:
+
+- the button in a `disabled` state, **and**
+- a persistent inline `<span className="text-[11px] text-muted-foreground">`
+  holding `t("offlineHint")`.
+
+This change replaces that inline `<span>` with an on-demand tooltip.
+
+## The disabled-trigger problem
+
+A native disabled `<button>` receives no pointer events, so Radix's
+`TooltipTrigger asChild` wrapping a disabled button never fires on hover. The
+established fix (and the one the elaboration Q2=a answer selected) is to wrap the
+button in a focusable, hover-receiving element and hang the tooltip trigger on
+that wrapper instead of the button.
+
+### Decision
+
+When the agent is offline, wrap the (disabled) button in a `<span>` that:
+
+- is the `TooltipTrigger asChild` target,
+- carries `tabIndex={0}` so keyboard users can focus it and read the tooltip,
+- uses `inline-flex` so it does not disturb the existing flex action-row layout.
+
+When the agent is online there is no offline hint to show, so the button renders
+without the tooltip wrapper (no behavior change to the enabled path).
+
+The tooltip content is the shortened offline copy. `TooltipProvider` wraps the
+tooltip locally in each component (mirroring the existing
+`TooltipProvider delayDuration={300}` usage already present in the ideas
+idea-detail panel), so the components remain self-contained and don't rely on an
+ambient provider.
+
+### Yolo button: nested `asChild` triggers
+
+`StartDevelopmentButton` renders a bare `<Button>`, so wrapping it is
+straightforward. `YoloButton` is different: its `<Button>` is already the child of
+`AlertDialogTrigger asChild` (the confirm-dialog trigger). Stacking a
+`TooltipTrigger asChild` directly onto the same button would make two Radix
+primitives fight over the single child slot.
+
+Because the offline state is *mutually exclusive* with the interactive state — an
+offline Yolo button is disabled and clicking it never opens the dialog — the two
+triggers never need to be active at once. The clean structure is:
+
+- When **offline**: render the disabled button wrapped in the focusable
+  `TooltipTrigger` span, and do NOT mount it as the `AlertDialogTrigger` (a
+  disabled trigger opens nothing anyway). The tooltip surfaces the offline reason.
+- When **online**: render exactly as today — the button as `AlertDialogTrigger
+  asChild`, no tooltip wrapper.
+
+This keeps each Radix primitive owning a single child and avoids nested-`asChild`
+ambiguity, while preserving the existing confirm-dialog behavior on the online
+path unchanged.
+
+## Copy
+
+`offlineHint` is shortened to a concise, tooltip-sized phrase in **all four**
+registered locales. The repo registers `en`, `zh`, `ko`, `ja` in
+`src/i18n/config.ts` and enforces key parity across them via
+`src/i18n/__tests__/locale-parity.test.ts`; `offlineHint` currently exists in all
+four (under both the `startDevelopment` and `yolo` namespaces) as the long
+sentence. All four are shortened together — shortening a subset would leave the
+rest with the long sentence squeezed into a tooltip (the clutter we are removing)
+and, while key-parity would still pass (the key is present), it would defeat the
+change's intent for those languages. The short forms:
+
+- en: `Agent offline — enables on reconnect`
+- zh: `Agent 离线，重连后可用`
+- ko: `에이전트 오프라인 — 재연결 시 사용 가능`
+- ja: `エージェントオフライン — 再接続で有効化`
+
+The key name `offlineHint` is preserved (no key add/remove, so locale-parity is
+unaffected); only the values change.
+
+`errorAgentOffline` (the click-time server-rejection toast) is a different string
+and is left unchanged — it is a full-sentence toast, not a tooltip.
+
+## Scope guard
+
+- Only `offlineHint` moves. `startedHint` and any other inline text are untouched
+  (elaboration Q1=a).
+- Button visible-but-disabled behavior is preserved (elaboration Q2=a); no info
+  icon is added.
+- No change to `canStartDevelopment` / `canRequestYolo` predicates, the presence
+  computation, or the server actions.
+
+## Testing
+
+Both component test suites already assert the offline path via
+`screen.getByText(/assigned agent is offline/i)`. Those assertions are updated to
+match the tooltip mechanism:
+
+- The persistent inline text is gone; instead the button is wrapped by a
+  focusable tooltip trigger when offline.
+- Radix renders `TooltipContent` into a portal only once the trigger is
+  hovered/focused; in jsdom we assert the tooltip trigger wrapper exists and (on
+  focus/hover) the shortened copy is reachable, rather than asserting a
+  persistent inline node.
+- The button's `disabled` state on the offline path is retained and still
+  asserted.
+- The online-path, click-behavior, and error-code-mapping tests are unaffected.
+
+## Design.pen
+
+This is a small refinement to an existing action-row control (hint text →
+tooltip), not a new screen or component. The idea-detail panel action row is
+already represented in `docs/design.pen`; this change does not add or restructure
+screens. If a reviewer requires the `.pen` action-row annotation refreshed, that
+is done via the Pencil MCP tools against the existing idea-detail-panel frame.

--- a/openspec/changes/stage-advance-offline-hint-tooltip/proposal.md
+++ b/openspec/changes/stage-advance-offline-hint-tooltip/proposal.md
@@ -1,0 +1,50 @@
+# Move the offline hint next to Start Development / Yolo into a tooltip
+
+## Why
+
+On an idea-detail panel, the **Start Development** and **Yolo** stage-advance
+buttons render a persistent inline line of explanatory text next to them
+whenever the assigned agent (daemon) is offline — e.g. "The assigned agent is
+offline — the button enables when it reconnects". This line always takes a full
+row of horizontal space in the footer action row, wraps awkwardly on narrow
+panels, and reads as visual clutter for what is a secondary, why-is-this-disabled
+explanation.
+
+The disabled button already communicates the primary signal ("you can't click
+this right now"). The *reason* only needs to surface on demand. Moving it into a
+hover / focus tooltip declutters the action row while keeping the explanation one
+interaction away.
+
+## What Changes
+
+- The offline explanatory text (`offlineHint`) for both `StartDevelopmentButton`
+  and `YoloButton` is no longer rendered as a persistent inline `<span>`. It
+  moves into a shadcn/Radix tooltip that surfaces on hover or keyboard focus of
+  the disabled button.
+- Because a disabled `<button>` does not emit pointer events (so it cannot
+  trigger a hover tooltip on its own), the button is wrapped in a focusable
+  element that owns the tooltip trigger when the agent is offline.
+- The offline copy is shortened to a single concise phrase, suitable for a
+  tooltip, in **all** registered locales — `en`, `zh`, `ko`, `ja` (the repo
+  registers four locales in `src/i18n/config.ts` and enforces key parity via
+  `src/i18n/__tests__/locale-parity.test.ts`). Shortening only a subset would
+  leave the other locales with the long sentence crammed into a tooltip (the
+  very clutter this change removes) and break the parity guard.
+- Scope is limited to the offline hint. The `startedHint` ("Development
+  started…" / "Yolo started…") and other inline text stay exactly as they are.
+
+## Capabilities
+
+- `idea-panel-action-row` — ADDED requirement: the offline hint on the stage-advance
+  buttons is presented as a tooltip, not persistent inline text.
+
+## Impact
+
+- Affected code: `src/components/start-development-button.tsx`,
+  `src/components/yolo-button.tsx`, all four locale files (`messages/en.json`,
+  `messages/zh.json`, `messages/ko.json`, `messages/ja.json`), and the two
+  component test files.
+- No server, service, API, or data-model change. Purely a client-side
+  presentation refinement of an existing disabled-state hint.
+- No change to the underlying stage-advance gating, offline policy, or the
+  server-side error surfacing (`errorAgentOffline` toast is untouched).

--- a/openspec/changes/stage-advance-offline-hint-tooltip/specs/idea-panel-action-row/spec.md
+++ b/openspec/changes/stage-advance-offline-hint-tooltip/specs/idea-panel-action-row/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Offline hint on stage-advance buttons is a tooltip
+
+The Start Development and Yolo stage-advance buttons SHALL present their
+agent-offline explanation as an on-demand tooltip rather than as persistent
+inline text next to the button. When the assigned agent is offline the button
+SHALL remain visible but disabled, and its offline explanation SHALL surface only
+on hover or keyboard focus. Because a disabled button emits no pointer events, the
+disabled button SHALL be wrapped in a focusable element (`tabIndex = 0`) that owns
+the tooltip trigger so the explanation is reachable by both pointer and keyboard
+users. The offline explanation copy SHALL be a short, tooltip-sized phrase,
+localized in every registered locale (`en`, `zh`, `ko`, `ja`).
+
+The scope of this requirement is the offline hint only. The "started" hint
+(shown after a successful click) and any other inline text next to the buttons
+SHALL be left unchanged. This behavior applies wherever the shared Start
+Development and Yolo buttons are rendered (both the `/ideas` route panel and the
+dashboard idea-tracker panel), and it does not change the buttons' gating
+predicates, offline policy, or the click-time server-rejection error message.
+
+#### Scenario: Offline hint is not rendered as persistent inline text
+
+- **WHEN** an idea-detail panel shows the Start Development or Yolo button and the assigned agent is offline
+- **THEN** the button is visible but disabled
+- **AND** no persistent inline hint text is rendered beside the button
+- **AND** the offline explanation is available through a tooltip on the button
+
+#### Scenario: Tooltip is reachable on a disabled button via a focusable wrapper
+
+- **WHEN** the offline (disabled) button is hovered or focused with the keyboard
+- **THEN** the shortened offline explanation is shown in a tooltip
+- **AND** the wrapper element that carries the tooltip trigger is focusable (`tabIndex = 0`) so keyboard users can reveal it
+
+#### Scenario: Only the offline hint changes
+
+- **WHEN** the button transitions to its "started" state after a successful click
+- **THEN** the existing "started" hint is shown unchanged
+- **AND** the click-time agent-offline server-rejection message is shown unchanged when the server rejects a click
+
+#### Scenario: Offline copy is short and localized
+
+- **WHEN** the offline tooltip is shown
+- **THEN** its text is a concise tooltip-sized phrase
+- **AND** the phrase is defined in all four registered locale files (`en`, `zh`, `ko`, `ja`), preserving the existing `offlineHint` key name so locale key-parity is unaffected

--- a/openspec/changes/stage-advance-offline-hint-tooltip/tasks.md
+++ b/openspec/changes/stage-advance-offline-hint-tooltip/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+## 1. Move offline hint into a tooltip on both stage-advance buttons
+
+- [ ] 1.1 Shorten `offlineHint` copy in all four locale files (`messages/en.json`, `messages/zh.json`, `messages/ko.json`, `messages/ja.json`), preserving the key name
+- [ ] 1.2 In `StartDevelopmentButton`, replace the inline offline `<span>` with a Tooltip whose trigger is a focusable wrapper around the disabled button
+- [ ] 1.3 In `YoloButton`, do the same — but handle the nested `asChild`: on the offline path render the disabled button inside the focusable TooltipTrigger (not as the AlertDialogTrigger); on the online path keep the button as AlertDialogTrigger with no tooltip wrapper
+- [ ] 1.4 Update `start-development-button.test.tsx` and `yolo-button.test.tsx` to assert the tooltip mechanism (focusable wrapper, no persistent inline text) while keeping the disabled-state and online/click/error-code assertions
+- [ ] 1.5 Verify: `pnpm test` for both suites green, `npx tsc --noEmit` clean, `pnpm lint` clean; confirm both light/dark themes visually

--- a/src/components/__tests__/start-development-button.test.tsx
+++ b/src/components/__tests__/start-development-button.test.tsx
@@ -10,8 +10,25 @@
 
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+// The offline hint now rides a Radix Tooltip, whose Popper-based primitives use
+// ResizeObserver + pointer-capture — absent from jsdom. Stub them so focusing
+// the trigger to open the tooltip doesn't throw.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+if (typeof Element !== "undefined" && !Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+}
 
 const { startDevelopmentActionMock, toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
   startDevelopmentActionMock: vi.fn(),
@@ -114,13 +131,29 @@ describe("StartDevelopmentButton — render gating", () => {
 });
 
 describe("StartDevelopmentButton — presence gating", () => {
-  it("disables with the offline hint when the agent has no online connection", () => {
+  it("disables the button and moves the offline hint into a focusable tooltip trigger (no persistent inline text)", async () => {
     presenceValue.current = {
       connections: [{ agentUuid: "agent-1", effectiveStatus: "offline" }],
     };
     render(<StartDevelopmentButton {...HAPPY_PROPS} />);
-    expect(screen.getByRole<HTMLButtonElement>("button", { name: "Start Development" }).disabled).toBe(true);
-    expect(screen.getByText(/assigned agent is offline/i)).toBeTruthy();
+
+    const btn = screen.getByRole<HTMLButtonElement>("button", { name: "Start Development" });
+    expect(btn.disabled).toBe(true);
+
+    // No persistent inline hint text is rendered up front — it only exists in
+    // the tooltip, which is closed until the trigger is hovered/focused.
+    expect(screen.queryByText(/enables on reconnect/i)).toBeNull();
+
+    // The disabled button is wrapped by a focusable (tabIndex=0) span that owns
+    // the tooltip trigger, so keyboard users can reveal the hint.
+    const trigger = btn.closest<HTMLElement>('[tabindex="0"]');
+    expect(trigger).toBeTruthy();
+
+    // Focusing the trigger opens the tooltip; the shortened offline copy shows.
+    fireEvent.focus(trigger!);
+    await waitFor(() => {
+      expect(screen.getAllByText(/enables on reconnect/i).length).toBeGreaterThan(0);
+    });
   });
 
   it("treats a missing presence provider as offline, never online", () => {

--- a/src/components/__tests__/yolo-button.test.tsx
+++ b/src/components/__tests__/yolo-button.test.tsx
@@ -14,7 +14,7 @@
 
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // The Yolo confirm step uses a shadcn (Radix) AlertDialog, whose Popper-based
@@ -149,13 +149,30 @@ describe("YoloButton — render gating", () => {
 });
 
 describe("YoloButton — presence gating", () => {
-  it("disables with the offline hint when the agent has no online connection", () => {
+  it("disables the button and moves the offline hint into a focusable tooltip trigger (no persistent inline text, no dialog trigger)", async () => {
     presenceValue.current = {
       connections: [{ agentUuid: "agent-1", effectiveStatus: "offline" }],
     };
     render(<YoloButton {...HAPPY_PROPS} />);
-    expect(screen.getByRole<HTMLButtonElement>("button", { name: "Yolo" }).disabled).toBe(true);
-    expect(screen.getByText(/assigned agent is offline/i)).toBeTruthy();
+
+    const btn = screen.getByRole<HTMLButtonElement>("button", { name: "Yolo" });
+    expect(btn.disabled).toBe(true);
+
+    // No persistent inline hint text — it lives only in the (closed) tooltip.
+    expect(screen.queryByText(/enables on reconnect/i)).toBeNull();
+
+    // The disabled button is wrapped by a focusable tooltip-trigger span, and on
+    // the offline path it is NOT an AlertDialogTrigger (so the two asChild
+    // triggers never conflict).
+    const trigger = btn.closest<HTMLElement>('[tabindex="0"]');
+    expect(trigger).toBeTruthy();
+    expect(btn.getAttribute("aria-haspopup")).not.toBe("dialog");
+
+    // Focusing the trigger opens the tooltip; the shortened offline copy shows.
+    fireEvent.focus(trigger!);
+    await waitFor(() => {
+      expect(screen.getAllByText(/enables on reconnect/i).length).toBeGreaterThan(0);
+    });
   });
 
   it("treats a missing presence provider as offline, never online", () => {

--- a/src/components/start-development-button.tsx
+++ b/src/components/start-development-button.tsx
@@ -12,6 +12,12 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Loader2, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
 import {
   canStartDevelopment,
@@ -112,28 +118,44 @@ export function StartDevelopmentButton({
     }
   };
 
-  return (
-    <>
-      <Button
-        className="bg-primary hover:bg-[#B56A42] text-white"
-        onClick={handleClick}
-        disabled={!enabled || isStarting}
-      >
-        {isStarting ? (
-          <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            {t("starting")}
-          </>
-        ) : (
-          <>
-            <Play className="mr-2 h-4 w-4" />
-            {t("button")}
-          </>
-        )}
-      </Button>
-      {!agentOnline && (
-        <span className="text-[11px] text-muted-foreground">{t("offlineHint")}</span>
+  const button = (
+    <Button
+      className="bg-primary hover:bg-[#B56A42] text-white"
+      onClick={handleClick}
+      disabled={!enabled || isStarting}
+    >
+      {isStarting ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {t("starting")}
+        </>
+      ) : (
+        <>
+          <Play className="mr-2 h-4 w-4" />
+          {t("button")}
+        </>
       )}
-    </>
+    </Button>
   );
+
+  // Offline: the button is disabled and a disabled <button> emits no pointer
+  // events, so the offline explanation rides a tooltip whose trigger is a
+  // focusable wrapper span (tabIndex=0) around the button — reachable by both
+  // hover and keyboard focus. Online: render the button as-is, no wrapper.
+  if (!agentOnline) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0} className="inline-flex">
+              {button}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{t("offlineHint")}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return button;
 }

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -26,6 +26,12 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
 import {
   canRequestYolo,
@@ -57,6 +63,11 @@ const ERROR_CODE_I18N_KEY: Record<YoloRequestedErrorCode, string> = {
   agent_offline: "errorAgentOffline",
   unknown: "errorGeneric",
 };
+
+// Shared purple styling for the Yolo button — used by the offline (disabled),
+// online (dialog trigger), and confirm-dialog copies so the three never drift.
+const YOLO_BUTTON_CLASS =
+  "bg-[#7F5AF0] hover:bg-[#6D48DE] dark:bg-[#6E56C8] dark:hover:bg-[#7C63D8] text-white";
 
 export function YoloButton({
   ideaUuid,
@@ -122,6 +133,35 @@ export function YoloButton({
     }
   };
 
+  // Offline: the button is disabled and a disabled <button> emits no pointer
+  // events, so the offline explanation rides a tooltip whose trigger is a
+  // focusable wrapper span (tabIndex=0) around the button. We deliberately do
+  // NOT mount the button as an AlertDialogTrigger here — a disabled trigger
+  // opens nothing, and stacking TooltipTrigger asChild onto an already-asChild
+  // AlertDialogTrigger would make two Radix primitives fight over one child.
+  // Offline and interactive states are mutually exclusive, so each path owns a
+  // single trigger.
+  if (!agentOnline) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0} className="inline-flex">
+              <Button
+                className={YOLO_BUTTON_CLASS}
+                disabled
+              >
+                <Rocket className="mr-2 h-4 w-4" />
+                {t("button")}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{t("offlineHint")}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
   return (
     <>
       <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -130,7 +170,7 @@ export function YoloButton({
             like Start Development rather than an icon-only shortcut. */}
         <AlertDialogTrigger asChild>
           <Button
-            className="bg-[#7F5AF0] hover:bg-[#6D48DE] dark:bg-[#6E56C8] dark:hover:bg-[#7C63D8] text-white"
+            className={YOLO_BUTTON_CLASS}
             disabled={!enabled}
           >
             <Rocket className="mr-2 h-4 w-4" />
@@ -150,7 +190,7 @@ export function YoloButton({
                 call and close it ourselves in handleConfirm, so the spinner is
                 visible and a failure toast surfaces without a flash-close. */}
             <Button
-              className="bg-[#7F5AF0] hover:bg-[#6D48DE] dark:bg-[#6E56C8] dark:hover:bg-[#7C63D8] text-white"
+              className={YOLO_BUTTON_CLASS}
               onClick={handleConfirm}
               disabled={isStarting}
             >
@@ -166,9 +206,6 @@ export function YoloButton({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      {!agentOnline && (
-        <span className="text-[11px] text-muted-foreground">{t("offlineHint")}</span>
-      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- When the assigned agent is offline, the **Start Development** and **Yolo** buttons no longer render a persistent inline hint line next to them. The button stays visible-but-disabled and the offline explanation surfaces only on hover / keyboard-focus via a Radix tooltip.
- A disabled `<button>` emits no pointer events, so it's wrapped in a focusable `<span tabIndex={0}>` that owns the `TooltipTrigger` — reachable by both hover and keyboard.
- **Yolo** already uses `AlertDialogTrigger asChild`; offline and interactive states are mutually exclusive, so the offline path renders the disabled button inside the tooltip trigger (not the dialog trigger) to avoid stacking two Radix `asChild` primitives. The online confirm-dialog flow is unchanged.
- `offlineHint` copy shortened across all four locales (en/zh/ko/ja), key name preserved so the locale-parity guard stays green.

Authored spec-driven via OpenSpec (slug `stage-advance-offline-hint-tooltip`, capability `idea-panel-action-row`).

## Changed files
| File | Change |
|------|--------|
| `src/components/start-development-button.tsx` | Offline path returns the disabled button wrapped in a tooltip; no persistent inline span |
| `src/components/yolo-button.tsx` | Offline early-return renders disabled button inside tooltip trigger (not dialog trigger); extracted shared `YOLO_BUTTON_CLASS` |
| `messages/{en,zh,ko,ja}.json` | Shortened `offlineHint` under `startDevelopment` + `yolo` namespaces (key preserved) |
| `src/components/__tests__/{start-development,yolo}-button.test.tsx` | Assert the tooltip mechanism (focusable wrapper, no persistent inline text); Radix jsdom stubs |
| `openspec/changes/stage-advance-offline-hint-tooltip/**` | OpenSpec proposal / design / spec / tasks |

## Test plan
- [x] `pnpm test` — both component suites + `locale-parity`: 36/36 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on both components — clean
- [ ] Manual browser check of the offline tooltip in light + dark themes (offline UI state can't be staged headless; verified by-construction with semantic tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)