### PR TITLE
feat(skills): external-reference attachment reflex + bump plugins to 0.14.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -228,6 +228,9 @@ describe("HEADLESS_PREAMBLE (daemon headless interaction guard)", () => {
     // (3) general route-through-Chorus rule
     expect(HEADLESS_PREAMBLE).toContain("chorus_add_comment");
     expect(HEADLESS_PREAMBLE.toLowerCase()).toContain("elaboration");
+    // (4) reference-attachment reflex (strengthen-reference-association)
+    expect(HEADLESS_PREAMBLE).toContain("references[]");
+    expect(HEADLESS_PREAMBLE).toContain("chorus_add_reference");
     // (5) async hand-off — post then end the turn, don't block
     expect(HEADLESS_PREAMBLE.toLowerCase()).toContain("end the turn");
     expect(HEADLESS_PREAMBLE.toLowerCase()).toContain("pending");

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -53,6 +53,8 @@ function mentionGuidance(n, entityType) {
  * `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` tool names, because
  * this preamble rides EVERY wake including `elaboration_verified` (write-the-proposal),
  * whose contract is that it never mentions the answer-questions tools. Keep it that way.
+ * The reference-attachment nudge (strengthen-reference-association) names `references[]` /
+ * `chorus_add_reference` only — never the elaboration tools — so it is safe on every wake.
  *
  * Kept compact: it is paid on every wake, so each line costs tokens per wake.
  */
@@ -71,6 +73,11 @@ export const HEADLESS_PREAMBLE = [
   "answer in the UI; when a skill says to ask permission before skipping a step, do not skip",
   "silently — record the reason in a Chorus comment; when a skill offers to write a report,",
   "create it directly or skip it, never prompt for it.",
+  "",
+  "When working an idea/proposal/task, if you come across an external link that is evidence",
+  "(a precedent issue/PR, a reference implementation, official docs, a paper/blog), attach it",
+  "via references — prefer the inline references[] param at creation time over a post-hoc",
+  "chorus_add_reference. Make it a reflex, not an afterthought.",
   "",
   "After you post something that needs a human decision, END THE TURN and leave the work",
   "pending — do not poll or wait for a synchronous reply. The human's later comment or",

--- a/openspec/changes/archive/2026-07-13-strengthen-reference-association/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-strengthen-reference-association/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-strengthen-reference-association/README.md
+++ b/openspec/changes/archive/2026-07-13-strengthen-reference-association/README.md
@@ -1,0 +1,3 @@
+# strengthen-reference-association
+
+Make attaching external reference artifacts a default agent reflex via idea+chorus skill docs and both daemon wake prompts; fix long-URL overflow in the reference display

--- a/openspec/changes/archive/2026-07-13-strengthen-reference-association/design.md
+++ b/openspec/changes/archive/2026-07-13-strengthen-reference-association/design.md
@@ -1,0 +1,102 @@
+# Design: Strengthen reference-artifact association
+
+## Context
+
+This is a documentation + prompt + one-CSS-fix change. No schema, API, or runtime-logic change. The scope was fixed by a one-round elaboration (idea `623af7aa`), whose answers are the binding contract:
+
+- **Q1 = a** — surfaces are skill docs + wake prompts only. NOT MCP tool descriptions, NOT an empty-references soft-hint UI feature.
+- **Q2 = "a + chorus skill"** + a UI overflow bug fix — reference guidance goes into the idea skill and the chorus overview skill; plus fix the long-URL-not-truncated display bug.
+- **Q3 = a** — one-line reflex nudge in both wake prompts (they are already long; keep it compact).
+- **Q4 = a** — teach the four-type selection criteria + a full inline example.
+- **Q5 = a** — include one generic example (docs are public + English, so the example is a generic locale/official-docs scenario, not bound to an internal idea).
+
+## Goal
+
+Make "attach external references" a default agent reflex: the moment an agent sees an external link (precedent issue/PR, reference implementation, official docs, paper/blog), it attaches it via references — preferring the inline `references[]` param **at creation time** over a post-hoc `chorus_add_reference`.
+
+## Decisions
+
+### D1 — Skill roots are NOT byte-identical; adapt per root
+
+The four idea SKILLs differ by design (frontmatter `name:`, cross-link style `/chorus` vs `` `chorus` skill ``, host prompt mechanism, and the OpenClaw `chorus__` tool-namespace note). The same is true for the four chorus SKILLs. So this change inserts the **same guidance content**, adapted to each root's existing conventions — never a blind copy of one file over another. The parity to preserve is *semantic* (every root teaches the same reference reflex), not textual.
+
+Root-specific adaptation rules:
+- **standalone** (`public/skill/idea-chorus`, `public/skill/chorus`): cross-links use `` `chorus` skill (`<BASE_URL>/skill/chorus/SKILL.md`) `` form; no slash-command syntax.
+- **CC plugin** (`public/chorus-plugin/skills/*`) and **Codex plugin** (`plugins/chorus/skills/*`): cross-links use `/chorus` slash form.
+- **OpenClaw** (`packages/openclaw-plugin/skills/*`): tool names get the `chorus__` prefix per that root's namespace note; keep bare names in prose with the prefix reminder already present.
+
+### D2 — Guidance content (idea skill)
+
+A compact "External references" subsection placed in the idea workflow (in or right after Step 4 "Gather Context", where the agent is already reading the idea and related material — the natural moment to notice external links). Content:
+
+1. **The reflex.** When you encounter an external link that is evidence for the idea — a precedent issue/PR, a reference implementation, official docs, a paper/blog — attach it as a reference. Prefer attaching **at creation time** via the inline `references[]` param on `chorus_pm_create_idea` (and `chorus_pm_create_proposal` / `chorus_create_tasks`) rather than a post-hoc `chorus_add_reference`.
+2. **Four-type selection criteria** (Q4=a):
+   - `docs` — official documentation (framework/API/library reference).
+   - `repo` — a reference implementation or source repository.
+   - `issue_pr` — an issue or pull-request thread (precedent, prior art, the delivering PR).
+   - `paper_blog` — a paper or blog post (background, design rationale).
+3. **One generic inline example** (Q5=a), public-safe:
+
+   ```
+   chorus_pm_create_idea({
+     projectUuid: "...",
+     title: "Add Portuguese (pt) locale",
+     content: "...",
+     references: [
+       { type: "issue_pr", url: "https://github.com/org/repo/pull/411",
+         title: "PR #411 — prior ko locale work (precedent to mirror)" },
+       { type: "docs", url: "https://next-intl.dev/docs/routing",
+         title: "next-intl routing docs (locale registration)" }
+     ]
+   })
+   ```
+
+### D3 — Guidance content (chorus overview skill)
+
+The chorus skill already lists `chorus_add_reference` / `chorus_update_reference` / `chorus_remove_reference` in a tool table. Add a short behavior note near that table (or the shared-tools/@mention area) that states the reflex in one or two sentences and points to the idea skill for the full type criteria + example — so the overview reinforces the reflex without duplicating the whole block.
+
+### D4 — Wake-prompt nudge (one line each, Q3=a)
+
+Two surfaces, and only two — grep-confirmed:
+
+1. `cli/prompts.mjs` → `HEADLESS_PREAMBLE`. This block is prepended to **every** wake, so a single line here covers all idea/proposal/task wakes at once. Constraint from the file's own header comment: the preamble must NOT embed the literal `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` tool names (it rides `elaboration_verified` too). A references nudge is safe — it names `chorus_add_reference` / `references[]`, not the elaboration tools. Add one compact line, keeping the block's terse style.
+
+2. `src/services/daemon-instruction.service.ts` → `composeConversationalIdeaInstruction`. The conversational-idea entry. Add one line to the shared lead-in so both `elaborate` and `decompose` modes carry it, without disturbing the numbered step contract that its unit test asserts.
+
+**Out:** the OpenClaw event-router (`packages/openclaw-plugin/src/event-router.ts`) deliberately has no headless preamble — the CLI↔OpenClaw parity guard (`cli/__tests__/openclaw-plugin-wake-parity.test.mjs`) checks *action coverage only, never prompt text*, and each host keeps its own voice. So OpenClaw is correctly untouched; adding a preamble there would contradict that design decision.
+
+Both prompt bodies are under wording tests (`cli/__tests__/wake-orchestration.test.mjs` asserts specific `HEADLESS_PREAMBLE` substrings; `daemon-instruction.conversational.test.ts` asserts the conversational template). Update the tests to assert the new nudge substring so the wording stays a review-visible, enforced diff.
+
+### D5 — UI overflow fix (root cause + fix)
+
+**Root cause.** In both `references-section.tsx` (~L226) and `idea-references-panel.tsx` (~L63) the reference link is:
+
+```
+<a className="inline-flex items-center gap-1 ...">
+  <span className="truncate">{ref.title}</span>
+  <ExternalLink className="... shrink-0" />
+</a>
+```
+
+`inline-flex` makes the anchor shrink-wrap to its content width, so it ignores the `min-w-0 flex-1` parent. `truncate` on the inner span needs a bounded width to engage; because the anchor is unbounded, the span grows and a long title/URL overflows the card.
+
+**Fix.** Make the anchor a block-level, width-constrained flex container so the inner span truncates against the card width:
+
+```
+<a className="flex min-w-0 items-center gap-1 ...">
+  <span className="truncate">{ref.title}</span>
+  <ExternalLink className="... shrink-0" />
+</a>
+```
+
+- `flex` (not `inline-flex`) + `min-w-0` lets the anchor take the parent's width and lets the truncating child shrink below its content size.
+- The `ExternalLink` icon keeps `shrink-0` so only the title truncates, icon stays visible.
+- The native `title`/hover already exposes the full title; the URL remains reachable via the link. No new i18n strings.
+
+**Verification.** Semantic tokens only — no color change, so both themes are structurally covered; still verify visually in light + dark with a pathologically long title/URL (e.g. a 300-char URL used as the title) that the ellipsis appears and the card does not widen.
+
+## Risks
+
+- **Doc drift across 8 files.** Mitigated by treating the two capabilities as separate tasks and a final code-review gateway over the aggregate diff. The plugin-maintenance skill's guidance on the 4-root sync applies.
+- **Wake-prompt token cost.** One line each; the preamble line is the only per-wake cost and is intentionally single-sentence.
+- **Test wording lock.** Both prompt tests assert substrings; updating them in the same task as the prompt edit keeps them green and makes the wording change reviewable.

--- a/openspec/changes/archive/2026-07-13-strengthen-reference-association/proposal.md
+++ b/openspec/changes/archive/2026-07-13-strengthen-reference-association/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Reference artifacts (`chorus_add_reference` + the inline `references[]` param on create, types `docs` / `repo` / `issue_pr` / `paper_blog`, shipped in #418) are the first-class field for hanging **external evidence** — a precedent issue, a reference implementation, official docs, a related PR — onto an idea / proposal / task. But in practice agents almost never reach for it. A real case: the 0.14.0 "complete Korean locale" idea was plainly related to its delivery PR #419 and the prior `ko` work in #411, yet went the whole lifecycle with **zero** references attached until a human pointed it out.
+
+The root cause is that the agent-facing surfaces never tell the agent to do it (grep-confirmed, not a guess):
+
+- The **idea skill** mentions references **0 times** across all four skill roots — and idea → proposal → execute is exactly the stage where hanging precedent/evidence at the source matters most.
+- The **chorus overview skill** names the reference tools in passing (a tool table row) but carries no "see an external link → attach it now" behavioral guidance.
+- **Both daemon wake prompts** mention references **0 times**: the headless preamble in `cli/prompts.mjs` that rides every wake, and the conversational-idea entry template in `src/services/daemon-instruction.service.ts`. A headless agent woken to work an idea/proposal/task gets no nudge to associate external references.
+
+Separately, the reference **display** has a pre-existing UI bug: a long URL or title overflows its card because the link anchor is `inline-flex` (it shrink-wraps to its content and ignores the parent's width), so the inner `truncate` span never engages.
+
+## What Changes
+
+- **Idea skill (all 4 roots): add reference guidance from scratch.** A short "External references" subsection in the Gather-Context / elaboration flow: when you encounter an external link (precedent issue/PR, reference implementation, official docs, paper/blog), attach it **at creation time** via the inline `references[]` param (preferred over a post-hoc `chorus_add_reference`), and how to pick among the four types. One generic inline example (locale-PR / official-docs scenario — not bound to any internal idea, since these docs ship publicly in English).
+- **Chorus overview skill (all 4 roots): strengthen the existing mention into a reflex.** Turn the passing tool-table reference into an explicit "attach external evidence on sight, inline at create" behavior note, cross-linked from the shared-tools area.
+- **Both daemon wake prompts: one-line reflex nudge each.** Add a single compact sentence to the `HEADLESS_PREAMBLE` in `cli/prompts.mjs` (rides every wake) and to `composeConversationalIdeaInstruction` in `src/services/daemon-instruction.service.ts`: when working an idea/proposal/task, if you hit an external link, attach it via references, preferring inline `references[]` at create. Kept to one line — the preamble is paid on every wake.
+- **Fix the long-URL/title overflow** in the reference display: constrain the link anchor so its inner `truncate` span actually engages. Both render sites — `src/components/references-section.tsx` and `src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx` — verified in light and dark themes.
+
+Out of scope (confirmed in elaboration): MCP tool-description changes (Q1=a); an empty-references soft-hint UI feature (Q1=a rejected it — the UI work here is only the overflow bug); the proposal / develop / quick-dev / review skills (Q2 narrowed skill scope to idea + chorus); the OpenClaw wake router, which deliberately carries no headless preamble (the CLI↔OpenClaw parity guard checks action coverage only, not prompt text).
+
+## Capabilities
+
+### Added Capabilities
+- `reference-association-guidance`: the agent-facing surfaces (idea skill, chorus overview skill, and both daemon wake prompts) SHALL instruct agents to attach external references as evidence, preferring inline `references[]` at creation, so that hanging external evidence becomes a default reflex rather than a forgotten step.
+- `reference-display`: the reference list UI SHALL keep an over-long reference URL or title within its card via truncation, so a pasted long link never breaks the card layout in either theme.
+
+## Impact
+
+- **Skill docs (idea, 4 roots)** — `public/skill/idea-chorus/SKILL.md`, `public/chorus-plugin/skills/idea/SKILL.md`, `plugins/chorus/skills/idea/SKILL.md`, `packages/openclaw-plugin/skills/idea/SKILL.md`.
+- **Skill docs (chorus overview, 4 roots)** — `public/skill/chorus/SKILL.md`, `public/chorus-plugin/skills/chorus/SKILL.md`, `plugins/chorus/skills/chorus/SKILL.md`, `packages/openclaw-plugin/skills/chorus/SKILL.md`.
+- **Wake prompts** — `cli/prompts.mjs` (`HEADLESS_PREAMBLE`) and `src/services/daemon-instruction.service.ts` (`composeConversationalIdeaInstruction`, both `elaborate` and `decompose` share the same preamble line). Their wording tests: `cli/__tests__/wake-orchestration.test.mjs` and `src/services/__tests__/daemon-instruction.conversational.test.ts`.
+- **UI** — `src/components/references-section.tsx`, `src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx`. No i18n string changes (behavior-only CSS fix). No runtime/schema/API changes.

--- a/openspec/changes/archive/2026-07-13-strengthen-reference-association/specs/reference-association-guidance/spec.md
+++ b/openspec/changes/archive/2026-07-13-strengthen-reference-association/specs/reference-association-guidance/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Idea skill teaches the reference-attachment reflex
+The idea skill SHALL, in all four skill roots (`public/skill/idea-chorus`, `public/chorus-plugin/skills/idea`, `plugins/chorus/skills/idea`, `packages/openclaw-plugin/skills/idea`), instruct the agent to attach external references as evidence when working an idea, preferring the inline `references[]` param at creation time over a post-hoc `chorus_add_reference`, and SHALL document how to choose among the four reference types (`docs`, `repo`, `issue_pr`, `paper_blog`) with one concrete inline example.
+
+#### Scenario: Idea skill contains reference guidance in every root
+- **WHEN** any of the four idea `SKILL.md` files is read
+- **THEN** it contains a reference-attachment guidance section that names the inline `references[]` param, states the preference for attaching at creation time, and lists the four types with a selection criterion for each
+
+#### Scenario: Guidance includes a public-safe example
+- **WHEN** the idea skill's reference guidance is read
+- **THEN** it shows one inline `references[]` usage example built from a generic scenario (e.g. a locale PR / official docs), not bound to any internal idea, and the docs remain in English
+
+#### Scenario: Root-specific conventions are preserved
+- **WHEN** the guidance is added to the OpenClaw idea skill root
+- **THEN** tool names follow that root's `chorus__`-prefix convention and cross-links follow each root's existing link style, rather than a verbatim copy of another root
+
+### Requirement: Chorus overview skill states the reference reflex
+The chorus overview skill SHALL, in all four roots (`public/skill/chorus`, `public/chorus-plugin/skills/chorus`, `plugins/chorus/skills/chorus`, `packages/openclaw-plugin/skills/chorus`), carry an explicit behavioral note that agents attach external evidence on sight — inline at create — beyond the passing mention of the reference tools already present in its tool table.
+
+#### Scenario: Overview skill reinforces the reflex
+- **WHEN** any of the four chorus `SKILL.md` files is read
+- **THEN** it contains a short behavior note directing the agent to attach external references as evidence (inline at create), in addition to the existing `chorus_add_reference` tool-table row
+
+### Requirement: Daemon wake prompts nudge reference attachment
+Both daemon wake-prompt surfaces SHALL carry a one-line reflex nudge to attach external references when working an idea/proposal/task, preferring inline `references[]` at create. The `HEADLESS_PREAMBLE` in `cli/prompts.mjs` and the `composeConversationalIdeaInstruction` template in `src/services/daemon-instruction.service.ts` SHALL each include such a line, and their wording tests SHALL assert the new nudge substring. The nudge SHALL NOT introduce the literal `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` tool names into the shared preamble.
+
+#### Scenario: Headless preamble carries the nudge
+- **WHEN** a wake prompt is built via the daemon prompt builder
+- **THEN** the prepended headless preamble includes a single sentence instructing the agent to attach external references (naming `references[]` and/or `chorus_add_reference`), and does not contain the elaboration-start/validate tool names
+
+#### Scenario: Conversational idea entry carries the nudge
+- **WHEN** the conversational-idea wake instruction is composed in either `elaborate` or `decompose` mode
+- **THEN** the composed text includes the one-line reference-attachment nudge
+
+#### Scenario: Wake-prompt wording tests are updated
+- **WHEN** the wake-orchestration and conversational-instruction test suites run
+- **THEN** they assert the presence of the new reference-nudge substring in the respective prompt, keeping the wording an enforced, review-visible diff
+
+#### Scenario: OpenClaw router is intentionally excluded
+- **WHEN** the CLI↔OpenClaw wake-parity guard runs
+- **THEN** it continues to pass on action-coverage only, and the OpenClaw event-router remains without a headless preamble (no reference nudge is added there)

--- a/openspec/changes/archive/2026-07-13-strengthen-reference-association/specs/reference-display/spec.md
+++ b/openspec/changes/archive/2026-07-13-strengthen-reference-association/specs/reference-display/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Reference links truncate instead of overflowing
+The reference-list UI SHALL keep an over-long reference URL or title within the bounds of its card by truncating the visible link text, in both the editable references section and the read-only idea-tracker references panel, and in both light and dark themes. The link anchor SHALL be width-constrained (a block-level, `min-w-0` flex container) so the inner truncating span engages against the card width, while the external-link icon remains visible.
+
+#### Scenario: Long title truncates in the references section
+- **WHEN** a reference whose title (or a title that is a pasted long URL) exceeds the card width is rendered in `references-section.tsx`
+- **THEN** the title is truncated with an ellipsis and the card width is unchanged (no horizontal overflow), and the external-link icon stays visible
+
+#### Scenario: Long title truncates in the idea references panel
+- **WHEN** such a reference is rendered in the read-only `idea-references-panel.tsx`
+- **THEN** the title is truncated with an ellipsis and the card does not widen or overflow
+
+#### Scenario: Both themes render correctly
+- **WHEN** the truncation fix is viewed in light and in dark theme
+- **THEN** the layout is correct in both, with no color regression (the fix changes layout classes only, using existing semantic tokens)

--- a/openspec/changes/archive/2026-07-13-strengthen-reference-association/tasks.md
+++ b/openspec/changes/archive/2026-07-13-strengthen-reference-association/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## 1. Skill docs — reference guidance (idea + chorus, 4 roots each)
+- [ ] 1.1 Add "External references" guidance to the idea skill in all 4 roots (reflex + inline `references[]` at create + 4-type criteria + one generic example), adapted per root convention
+- [ ] 1.2 Add the reference-reflex behavior note to the chorus overview skill in all 4 roots
+- [ ] 1.3 Verify semantic parity across roots (same guidance, root-appropriate wording)
+
+## 2. Daemon wake prompts — one-line nudge
+- [ ] 2.1 Add the reflex line to `HEADLESS_PREAMBLE` in `cli/prompts.mjs` (no elaboration tool names)
+- [ ] 2.2 Add the nudge line to `composeConversationalIdeaInstruction` in `daemon-instruction.service.ts` (covers elaborate + decompose)
+- [ ] 2.3 Update wording tests: `wake-orchestration.test.mjs` + `daemon-instruction.conversational.test.ts`
+- [ ] 2.4 Confirm the OpenClaw wake-parity guard still passes (no OpenClaw preamble added)
+
+## 3. UI — long-URL/title overflow fix
+- [ ] 3.1 Constrain the link anchor (`flex min-w-0`) in `references-section.tsx`
+- [ ] 3.2 Same fix in `idea-references-panel.tsx`
+- [ ] 3.3 Verify truncation + no overflow in light and dark themes with a pathologically long title

--- a/openspec/specs/reference-association-guidance/spec.md
+++ b/openspec/specs/reference-association-guidance/spec.md
@@ -1,0 +1,46 @@
+# reference-association-guidance Specification
+
+## Purpose
+TBD - created by archiving change strengthen-reference-association. Update Purpose after archive.
+## Requirements
+### Requirement: Idea skill teaches the reference-attachment reflex
+The idea skill SHALL, in all four skill roots (`public/skill/idea-chorus`, `public/chorus-plugin/skills/idea`, `plugins/chorus/skills/idea`, `packages/openclaw-plugin/skills/idea`), instruct the agent to attach external references as evidence when working an idea, preferring the inline `references[]` param at creation time over a post-hoc `chorus_add_reference`, and SHALL document how to choose among the four reference types (`docs`, `repo`, `issue_pr`, `paper_blog`) with one concrete inline example.
+
+#### Scenario: Idea skill contains reference guidance in every root
+- **WHEN** any of the four idea `SKILL.md` files is read
+- **THEN** it contains a reference-attachment guidance section that names the inline `references[]` param, states the preference for attaching at creation time, and lists the four types with a selection criterion for each
+
+#### Scenario: Guidance includes a public-safe example
+- **WHEN** the idea skill's reference guidance is read
+- **THEN** it shows one inline `references[]` usage example built from a generic scenario (e.g. a locale PR / official docs), not bound to any internal idea, and the docs remain in English
+
+#### Scenario: Root-specific conventions are preserved
+- **WHEN** the guidance is added to the OpenClaw idea skill root
+- **THEN** tool names follow that root's `chorus__`-prefix convention and cross-links follow each root's existing link style, rather than a verbatim copy of another root
+
+### Requirement: Chorus overview skill states the reference reflex
+The chorus overview skill SHALL, in all four roots (`public/skill/chorus`, `public/chorus-plugin/skills/chorus`, `plugins/chorus/skills/chorus`, `packages/openclaw-plugin/skills/chorus`), carry an explicit behavioral note that agents attach external evidence on sight — inline at create — beyond the passing mention of the reference tools already present in its tool table.
+
+#### Scenario: Overview skill reinforces the reflex
+- **WHEN** any of the four chorus `SKILL.md` files is read
+- **THEN** it contains a short behavior note directing the agent to attach external references as evidence (inline at create), in addition to the existing `chorus_add_reference` tool-table row
+
+### Requirement: Daemon wake prompts nudge reference attachment
+Both daemon wake-prompt surfaces SHALL carry a one-line reflex nudge to attach external references when working an idea/proposal/task, preferring inline `references[]` at create. The `HEADLESS_PREAMBLE` in `cli/prompts.mjs` and the `composeConversationalIdeaInstruction` template in `src/services/daemon-instruction.service.ts` SHALL each include such a line, and their wording tests SHALL assert the new nudge substring. The nudge SHALL NOT introduce the literal `chorus_pm_start_elaboration` / `chorus_pm_validate_elaboration` tool names into the shared preamble.
+
+#### Scenario: Headless preamble carries the nudge
+- **WHEN** a wake prompt is built via the daemon prompt builder
+- **THEN** the prepended headless preamble includes a single sentence instructing the agent to attach external references (naming `references[]` and/or `chorus_add_reference`), and does not contain the elaboration-start/validate tool names
+
+#### Scenario: Conversational idea entry carries the nudge
+- **WHEN** the conversational-idea wake instruction is composed in either `elaborate` or `decompose` mode
+- **THEN** the composed text includes the one-line reference-attachment nudge
+
+#### Scenario: Wake-prompt wording tests are updated
+- **WHEN** the wake-orchestration and conversational-instruction test suites run
+- **THEN** they assert the presence of the new reference-nudge substring in the respective prompt, keeping the wording an enforced, review-visible diff
+
+#### Scenario: OpenClaw router is intentionally excluded
+- **WHEN** the CLI↔OpenClaw wake-parity guard runs
+- **THEN** it continues to pass on action-coverage only, and the OpenClaw event-router remains without a headless preamble (no reference nudge is added there)
+

--- a/openspec/specs/reference-display/spec.md
+++ b/openspec/specs/reference-display/spec.md
@@ -1,0 +1,20 @@
+# reference-display Specification
+
+## Purpose
+TBD - created by archiving change strengthen-reference-association. Update Purpose after archive.
+## Requirements
+### Requirement: Reference links truncate instead of overflowing
+The reference-list UI SHALL keep an over-long reference URL or title within the bounds of its card by truncating the visible link text, in both the editable references section and the read-only idea-tracker references panel, and in both light and dark themes. The link anchor SHALL be width-constrained (a block-level, `min-w-0` flex container) so the inner truncating span engages against the card width, while the external-link icon remains visible.
+
+#### Scenario: Long title truncates in the references section
+- **WHEN** a reference whose title (or a title that is a pasted long URL) exceeds the card width is rendered in `references-section.tsx`
+- **THEN** the title is truncated with an ellipsis and the card width is unchanged (no horizontal overflow), and the external-link icon stays visible
+
+#### Scenario: Long title truncates in the idea references panel
+- **WHEN** such a reference is rendered in the read-only `idea-references-panel.tsx`
+- **THEN** the title is truncated with an ellipsis and the card does not widen or overflow
+
+#### Scenario: Both themes render correctly
+- **WHEN** the truncation fix is viewed in light and in dark theme
+- **THEN** the layout is correct in both, with no color regression (the fix changes layout classes only, using existing semantic tokens)
+

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus-openclaw-plugin",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "OpenClaw plugin for Chorus AI-DLC collaboration platform — native MCP + SSE real-time events",
   "license": "MIT",
   "type": "module",

--- a/packages/openclaw-plugin/skills/brainstorm/SKILL.md
+++ b/packages/openclaw-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -131,6 +131,12 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 ### Reports
 
 A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `/yolo` writes one mandatorily; `/develop` offers it advisorily on last-task verify.
+
+### References
+
+A **reference** is a first-class external-evidence link (`docs` / `repo` / `issue_pr` / `paper_blog`) attached to an idea / proposal / task via `chorus_add_reference`, or inline at creation via the `references[]` param on `chorus_pm_create_idea` / `chorus_pm_create_proposal` / `chorus_create_tasks`. References read back inline through the `chorus_get_*` tools. (Bare tool names per the namespace note above — prepend `chorus__` when invoking.)
+
+**Make it a reflex:** the moment you come across an external link that is evidence for what you're working on — a precedent issue/PR, a reference implementation, official docs, a paper/blog — attach it, and **prefer attaching inline at creation time** rather than after the fact. See `/idea` (Step 4.4) for the type-selection criteria and a worked example.
 
 ### Proposals
 

--- a/packages/openclaw-plugin/skills/code-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/code-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Final ship-time review of an Idea's aggregate code change — the w
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/develop/SKILL.md
+++ b/packages/openclaw-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/idea/SKILL.md
+++ b/packages/openclaw-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -116,6 +116,37 @@ Before elaborating, understand the full picture:
    ```
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
+
+### Step 4.4: Attach External References
+
+**Make attaching external references a reflex, not an afterthought.** While gathering context you will often surface external links that are *evidence* for this Idea — a precedent issue or PR, a reference implementation, official documentation, a paper or blog post. The moment you see one, attach it as a reference artifact. References are read back inline by `chorus_get_idea` / `chorus_get_proposal` / `chorus_get_task`, so they carry the "why" forward to whoever picks up the proposal or task next. (Tool names are bare here per the namespace note above — prepend `chorus__` when invoking on OpenClaw.)
+
+**Prefer attaching at creation time** via the inline `references[]` param on `chorus_pm_create_idea` (and later `chorus_pm_create_proposal` / `chorus_create_tasks`) rather than a post-hoc `chorus_add_reference`. Attaching at create means the evidence is present from the first read; use `chorus_add_reference` only when the link surfaces after the entity already exists.
+
+**Pick the `type` that fits the link:**
+
+| `type` | Use for |
+|--------|---------|
+| `docs` | Official documentation — framework / API / library reference |
+| `repo` | A reference implementation or source repository |
+| `issue_pr` | An issue or pull-request thread — precedent, prior art, the delivering PR |
+| `paper_blog` | A paper or blog post — background or design rationale |
+
+**Example** — a new localization Idea, attaching the precedent PR and the framework docs inline at creation:
+
+```
+chorus_pm_create_idea({
+  projectUuid: "<project-uuid>",
+  title: "Add Portuguese (pt) locale",
+  content: "...",
+  references: [
+    { type: "issue_pr", url: "https://github.com/org/repo/pull/411",
+      title: "PR #411 — prior locale work (precedent to mirror)" },
+    { type: "docs", url: "https://next-intl.dev/docs/routing",
+      title: "next-intl routing docs (locale registration)" }
+  ]
+})
+```
 
 ### Step 4.5: Brainstorm Mode (Optional Prelude)
 

--- a/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
+++ b/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows on OpenClaw.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial read-only review of a submitted Chorus proposal — doc
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/quick-dev/SKILL.md
+++ b/packages/openclaw-plugin/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/review/SKILL.md
+++ b/packages/openclaw-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial verification of a submitted Chorus task against its AC 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/yolo/SKILL.md
+++ b/packages/openclaw-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -54,7 +54,7 @@ ACCEPT="Accept: application/json, text/event-stream"
 CT="Content-Type: application/json"
 
 INIT=$(cat <<JSON
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.14.0"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.14.1"}}}
 JSON
 )
 

--- a/plugins/chorus/skills/brainstorm/SKILL.md
+++ b/plugins/chorus/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/chorus-code-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-code-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus code-review gateway — the final ship-time revie
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus code-review gateway

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, au
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus proposal reviewer

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus task reviewer

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -143,6 +143,12 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 ### Reports
 
 A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `$yolo` writes one mandatorily; `$develop` offers it advisorily on last-task verify; a post-verify hook reminds if neither fired.
+
+### References
+
+A **reference** is a first-class external-evidence link (`docs` / `repo` / `issue_pr` / `paper_blog`) attached to an idea / proposal / task via `chorus_add_reference`, or inline at creation via the `references[]` param on `chorus_pm_create_idea` / `chorus_pm_create_proposal` / `chorus_create_tasks`. References read back inline through the `chorus_get_*` tools.
+
+**Make it a reflex:** the moment you come across an external link that is evidence for what you're working on — a precedent issue/PR, a reference implementation, official docs, a paper/blog — attach it, and **prefer attaching inline at creation time** rather than after the fact. See `/idea` (Step 4.4) for the type-selection criteria and a worked example.
 
 ### Proposals
 

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, and spawn
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -114,6 +114,37 @@ Before elaborating, understand the full picture:
    ```
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
+
+### Step 4.4: Attach External References
+
+**Make attaching external references a reflex, not an afterthought.** While gathering context you will often surface external links that are *evidence* for this Idea — a precedent issue or PR, a reference implementation, official documentation, a paper or blog post. The moment you see one, attach it as a reference artifact. References are read back inline by `chorus_get_idea` / `chorus_get_proposal` / `chorus_get_task`, so they carry the "why" forward to whoever picks up the proposal or task next.
+
+**Prefer attaching at creation time** via the inline `references[]` param on `chorus_pm_create_idea` (and later `chorus_pm_create_proposal` / `chorus_create_tasks`) rather than a post-hoc `chorus_add_reference`. Attaching at create means the evidence is present from the first read; use `chorus_add_reference` only when the link surfaces after the entity already exists.
+
+**Pick the `type` that fits the link:**
+
+| `type` | Use for |
+|--------|---------|
+| `docs` | Official documentation — framework / API / library reference |
+| `repo` | A reference implementation or source repository |
+| `issue_pr` | An issue or pull-request thread — precedent, prior art, the delivering PR |
+| `paper_blog` | A paper or blog post — background or design rationale |
+
+**Example** — a new localization Idea, attaching the precedent PR and the framework docs inline at creation:
+
+```
+chorus_pm_create_idea({
+  projectUuid: "<project-uuid>",
+  title: "Add Portuguese (pt) locale",
+  content: "...",
+  references: [
+    { type: "issue_pr", url: "https://github.com/org/repo/pull/411",
+      title: "PR #411 — prior locale work (precedent to mirror)" },
+    { type: "docs", url: "https://next-intl.dev/docs/routing",
+      title: "next-intl routing docs (locale registration)" }
+  ]
+})
+```
 
 ### Step 4.5: Brainstorm Mode (Optional Prelude)
 

--- a/plugins/chorus/skills/openspec-aware/SKILL.md
+++ b/plugins/chorus/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Codex. De
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/skills/brainstorm/SKILL.md
+++ b/public/chorus-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -150,6 +150,12 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 ### Reports
 
 A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `/yolo` writes one mandatorily; `/develop` offers it advisorily on last-task verify; a PostToolUse hook reminds if neither fired.
+
+### References
+
+A **reference** is a first-class external-evidence link (`docs` / `repo` / `issue_pr` / `paper_blog`) attached to an idea / proposal / task via `chorus_add_reference`, or inline at creation via the `references[]` param on `chorus_pm_create_idea` / `chorus_pm_create_proposal` / `chorus_create_tasks`. References read back inline through the `chorus_get_*` tools.
+
+**Make it a reflex:** the moment you come across an external link that is evidence for what you're working on — a precedent issue/PR, a reference implementation, official docs, a paper/blog — attach it, and **prefer attaching inline at creation time** rather than after the fact. See `/idea` (Step 4.4) for the type-selection criteria and a worked example.
 
 ### Proposals
 

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -114,6 +114,37 @@ Before elaborating, understand the full picture:
    ```
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
+
+### Step 4.4: Attach External References
+
+**Make attaching external references a reflex, not an afterthought.** While gathering context you will often surface external links that are *evidence* for this Idea — a precedent issue or PR, a reference implementation, official documentation, a paper or blog post. The moment you see one, attach it as a reference artifact. References are read back inline by `chorus_get_idea` / `chorus_get_proposal` / `chorus_get_task`, so they carry the "why" forward to whoever picks up the proposal or task next.
+
+**Prefer attaching at creation time** via the inline `references[]` param on `chorus_pm_create_idea` (and later `chorus_pm_create_proposal` / `chorus_create_tasks`) rather than a post-hoc `chorus_add_reference`. Attaching at create means the evidence is present from the first read; use `chorus_add_reference` only when the link surfaces after the entity already exists.
+
+**Pick the `type` that fits the link:**
+
+| `type` | Use for |
+|--------|---------|
+| `docs` | Official documentation — framework / API / library reference |
+| `repo` | A reference implementation or source repository |
+| `issue_pr` | An issue or pull-request thread — precedent, prior art, the delivering PR |
+| `paper_blog` | A paper or blog post — background or design rationale |
+
+**Example** — a new localization Idea, attaching the precedent PR and the framework docs inline at creation:
+
+```
+chorus_pm_create_idea({
+  projectUuid: "<project-uuid>",
+  title: "Add Portuguese (pt) locale",
+  content: "...",
+  references: [
+    { type: "issue_pr", url: "https://github.com/org/repo/pull/411",
+      title: "PR #411 — prior locale work (precedent to mirror)" },
+    { type: "docs", url: "https://next-intl.dev/docs/routing",
+      title: "next-intl routing docs (locale registration)" }
+  ]
+})
+```
 
 ### Step 4.5: Brainstorm Mode (Optional Prelude)
 

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Co
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/brainstorm-chorus/SKILL.md
+++ b/public/skill/brainstorm-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -197,6 +197,12 @@ Results can be filtered by project(s) using optional HTTP headers in your MCP co
 ### Reports
 
 A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. The `yolo` skill writes one mandatorily; the `develop` skill offers it advisorily on last-task verify.
+
+### References
+
+A **reference** is a first-class external-evidence link (`docs` / `repo` / `issue_pr` / `paper_blog`) attached to an idea / proposal / task via `chorus_add_reference`, or inline at creation via the `references[]` param on `chorus_pm_create_idea` / `chorus_pm_create_proposal` / `chorus_create_tasks`. References read back inline through the `chorus_get_*` tools.
+
+**Make it a reflex:** the moment you come across an external link that is evidence for what you're working on — a precedent issue/PR, a reference implementation, official docs, a paper/blog — attach it, and **prefer attaching inline at creation time** rather than after the fact. See the `idea-chorus` skill (`<BASE_URL>/skill/idea-chorus/SKILL.md`), Step 4.4, for the type-selection criteria and a worked example.
 
 ### Proposals
 

--- a/public/skill/code-reviewer-chorus/SKILL.md
+++ b/public/skill/code-reviewer-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Read-only adversarial Chorus code-review gateway — independently 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/develop-chorus/SKILL.md
+++ b/public/skill/develop-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, self-chec
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/idea-chorus/SKILL.md
+++ b/public/skill/idea-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---
@@ -114,6 +114,37 @@ Before elaborating, understand the full picture:
    ```
    chorus_get_comments({ targetType: "idea", targetUuid: "<idea-uuid>" })
    ```
+
+### Step 4.4: Attach External References
+
+**Make attaching external references a reflex, not an afterthought.** While gathering context you will often surface external links that are *evidence* for this Idea — a precedent issue or PR, a reference implementation, official documentation, a paper or blog post. The moment you see one, attach it as a reference artifact. References are read back inline by `chorus_get_idea` / `chorus_get_proposal` / `chorus_get_task`, so they carry the "why" forward to whoever picks up the proposal or task next.
+
+**Prefer attaching at creation time** via the inline `references[]` param on `chorus_pm_create_idea` (and later `chorus_pm_create_proposal` / `chorus_create_tasks`) rather than a post-hoc `chorus_add_reference`. Attaching at create means the evidence is present from the first read; use `chorus_add_reference` only when the link surfaces after the entity already exists.
+
+**Pick the `type` that fits the link:**
+
+| `type` | Use for |
+|--------|---------|
+| `docs` | Official documentation — framework / API / library reference |
+| `repo` | A reference implementation or source repository |
+| `issue_pr` | An issue or pull-request thread — precedent, prior art, the delivering PR |
+| `paper_blog` | A paper or blog post — background or design rationale |
+
+**Example** — a new localization Idea, attaching the precedent PR and the framework docs inline at creation:
+
+```
+chorus_pm_create_idea({
+  projectUuid: "<project-uuid>",
+  title: "Add Portuguese (pt) locale",
+  content: "...",
+  references: [
+    { type: "issue_pr", url: "https://github.com/org/repo/pull/411",
+      title: "PR #411 — prior locale work (precedent to mirror)" },
+    { type: "docs", url: "https://next-intl.dev/docs/routing",
+      title: "next-intl routing docs (locale registration)" }
+  ]
+})
+```
 
 ### Step 4.5: Brainstorm Mode (Optional Prelude)
 

--- a/public/skill/package.json
+++ b/public/skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus-skill",
-  "version": "0.11.0",
+  "version": "0.14.1",
   "description": "Chorus AI Agent collaboration platform skill. Supports PM, Developer, and Admin roles via MCP tools for the Idea-Proposal-Task workflow.",
   "author": "chorus",
   "license": "AGPL-3.0",

--- a/public/skill/proposal-chorus/SKILL.md
+++ b/public/skill/proposal-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/proposal-reviewer-chorus/SKILL.md
+++ b/public/skill/proposal-reviewer-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Read-only adversarial Chorus proposal reviewer — audits PRD/task 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/quick-dev-chorus/SKILL.md
+++ b/public/skill/quick-dev-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/review-chorus/SKILL.md
+++ b/public/skill/review-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/task-reviewer-chorus/SKILL.md
+++ b/public/skill/task-reviewer-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Read-only adversarial Chorus task reviewer — independently verifi
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/yolo-chorus/SKILL.md
+++ b/public/skill/yolo-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — drive a single prompt from Idea throu
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.0"
+  version: "0.14.1"
   category: project-management
   mcp_server: chorus
 ---

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx
@@ -64,7 +64,8 @@ export function IdeaReferencesContent({
                 href={ref.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                title={ref.title}
+                className="flex min-w-0 items-center gap-1 text-sm font-medium text-primary hover:underline"
               >
                 <span className="truncate">{ref.title}</span>
                 <ExternalLink className="h-3 w-3 shrink-0" />

--- a/src/components/references-section.tsx
+++ b/src/components/references-section.tsx
@@ -227,7 +227,8 @@ export function ReferencesSection({
                       href={ref.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                      title={ref.title}
+                      className="flex min-w-0 items-center gap-1 text-sm font-medium text-primary hover:underline"
                     >
                       <span className="truncate">{ref.title}</span>
                       <ExternalLink className="h-3 w-3 shrink-0" />

--- a/src/services/__tests__/daemon-instruction.conversational.test.ts
+++ b/src/services/__tests__/daemon-instruction.conversational.test.ts
@@ -199,6 +199,12 @@ describe("composeConversationalIdeaInstruction", () => {
     expect(text).toContain("End the turn");
   });
 
+  it("carries the reference-attachment reflex nudge (strengthen-reference-association)", () => {
+    const text = composeConversationalIdeaInstruction(base);
+    expect(text).toContain("references[]");
+    expect(text).toContain("chorus_add_reference");
+  });
+
   it("contains NO create-idea or claim directives (the idea pre-exists, assigned)", () => {
     const text = composeConversationalIdeaInstruction(base);
     expect(text).not.toContain("chorus_pm_create_idea");
@@ -237,6 +243,12 @@ describe("composeConversationalIdeaInstruction", () => {
       expect(text).toContain("isContainer");
       expect(text).toContain("chorus_pm_start_elaboration");
       expect(text).toContain("End the turn");
+    });
+
+    it("also carries the reference-attachment reflex nudge (both modes)", () => {
+      const text = decomposeText();
+      expect(text).toContain("references[]");
+      expect(text).toContain("chorus_add_reference");
     });
 
     it("proposes children as a one-question-per-child elaboration round (single-select, ≤15, no multi-select)", () => {

--- a/src/services/daemon-instruction.service.ts
+++ b/src/services/daemon-instruction.service.ts
@@ -611,6 +611,8 @@ export function composeConversationalIdeaInstruction(params: {
       `5. End the turn. The user's answers in the idea's elaboration panel will wake this same conversation (the existing elaboration-answered wake).`,
       `6. On that re-wake, create each ACCEPTED child via chorus_pm_create_idea with parentUuid=${params.ideaUuid}. Each child starts in the "open" state — do NOT auto-elaborate them. The container's OWN status stays "elaborated"; creating children does not advance or alter it.`,
       ``,
+      `Reference reflex: whenever an external link is evidence for this work (a precedent issue/PR, a reference implementation, official docs, a paper/blog), attach it via references — prefer the inline references[] param at creation time over a post-hoc chorus_add_reference.`,
+      ``,
       `--- User's idea description ---`,
       params.descriptionText,
     ].join("\n");
@@ -624,6 +626,8 @@ export function composeConversationalIdeaInstruction(params: {
     `1. Edit the idea via chorus_edit_idea: derive a concise title from the description and polish the content (keep the user's meaning; you may restructure). The current title is a placeholder.`,
     `2. Immediately start elaboration on the idea (chorus_pm_start_elaboration), following the idea skill — do NOT wait for another wake. Post a short summary of your questions in this conversation and direct the user to answer in the idea's elaboration panel.`,
     `3. End the turn. The user's panel answers will wake this same conversation.`,
+    ``,
+    `Reference reflex: whenever an external link is evidence for this idea (a precedent issue/PR, a reference implementation, official docs, a paper/blog), attach it via references — prefer the inline references[] param at creation time over a post-hoc chorus_add_reference.`,
     ``,
     `--- User's idea description ---`,
     params.descriptionText,


### PR DESCRIPTION
## Summary
Reference artifacts (#418) are the first-class way to hang external evidence (precedent PR, reference impl, docs, paper/blog) on an idea/proposal/task, but agents almost never use them — a real case: the ko-locale idea related to PRs #419/#411 attached zero references until a human pointed it out. This adds the missing behavioral guidance at the source, nudges it from the daemon wake prompts, fixes a long-URL display bug, and bumps all plugin surfaces to 0.14.1.

Idea: `623af7aa` (chorus 0.14.1). Full-auto AI-DLC pass — proposal-, task-, and code-review gateways all PASS.

## Changes
| Area | Change |
|------|--------|
| `idea` skill (4 roots) | New **Step 4.4: Attach External References** — reflex, inline `references[]` at create over post-hoc `chorus_add_reference`, 4-type selection table, generic public-safe example (was 0 mentions) |
| `chorus` overview skill (4 roots) | New **### References** reflex note cross-linking Step 4.4 |
| Daemon wake prompts | One-line reference nudge in `HEADLESS_PREAMBLE` (`cli/prompts.mjs`) + `composeConversationalIdeaInstruction` (both modes); wording tests updated. Names only `references[]`/`chorus_add_reference`, never the elaboration tools (preserves the `elaboration_verified` contract). OpenClaw router intentionally untouched (parity guard is action-coverage-only) |
| UI fix | Reference link anchor `inline-flex` → `flex min-w-0` (+ `title` attr) in `references-section.tsx` and `idea-references-panel.tsx` — a long URL/title now truncates instead of overflowing its card |
| Version | All plugin + skill surfaces `0.14.0` → `0.14.1` (Claude Code, Codex, OpenClaw, standalone), incl. codex `clientInfo` and the standalone served `public/skill/package.json` manifest (was lagging at `0.11.0`) |
| OpenSpec | Change `strengthen-reference-association` archived; cumulative specs added |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `vitest run` on wake-orchestration (47) + openclaw-plugin-wake-parity (3) + daemon-instruction.conversational (31) = 81 passed
- [x] UI overflow fix browser-verified in light + dark with a 339-char URL (truncation engaged, no card overflow) via getBoundingClientRect
- [x] Scope honored vs elaboration answers (docs+prompts only, no MCP tool-desc change, no references soft-hint feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)