### PR TITLE
feat(projects): persist group expand/collapse state across visits

### DIFF
--- a/openspec/changes/archive/2026-07-13-persist-project-group-expansion/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-persist-project-group-expansion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-persist-project-group-expansion/README.md
+++ b/openspec/changes/archive/2026-07-13-persist-project-group-expansion/README.md
@@ -1,0 +1,3 @@
+# persist-project-group-expansion
+
+Persist project-list group expand/collapse state in localStorage

--- a/openspec/changes/archive/2026-07-13-persist-project-group-expansion/design.md
+++ b/openspec/changes/archive/2026-07-13-persist-project-group-expansion/design.md
@@ -1,0 +1,171 @@
+# Design: Persist project-list group expand/collapse state
+
+## Context
+
+`ProjectsPage` (`src/app/(dashboard)/projects/page.tsx`, a `"use client"`
+component) renders the grouped project list. Two sub-components own the
+expand/collapse UI:
+
+- `GroupSection` — one real ProjectGroup, keyed by `group.uuid`. It renders a
+  Radix `Collapsible` wired to `const [isOpen, setIsOpen] = useState(defaultOpen)`
+  (line ~307). The page passes `defaultOpen={index === 0}` (line ~944), so only
+  the first group opens on mount.
+- `UngroupedSection` — the projects with no group (a pseudo-group, not a real
+  `ProjectGroup`). Its droppable id is the module constant
+  `UNGROUPED_DROPPABLE_ID = "__ungrouped__"` (line ~289). It seeds
+  `useState(false)` (line ~452) — always collapsed on mount.
+
+Because `defaultOpen` only feeds the `useState` **initializer**, it is read once
+at mount and any subsequent toggle is purely local and never persisted. There is
+no shared store of "which groups are open."
+
+The same file already persists the list/grid view mode to `localStorage` under
+key `chorus_projects_view_mode` (lines ~587–596), reading it in a `useState`
+initializer guarded by `typeof window !== "undefined"` and writing it back in a
+`useEffect`. That is the established local pattern; a more defensive,
+unit-tested variant lives at
+`src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-view-preference.ts`
+(`readStoredView` / `storeView`, SSR-guarded, try/catch-degrading). This design
+follows the *latter* (extract a tiny tested helper) because the expansion state
+is a set, not a scalar, and benefits from a parse/serialize seam we can test.
+
+## Elaboration contract (binding)
+
+One resolved round on idea `db1d007f`:
+
+- **Q1 = a** — store client-side in browser `localStorage`, per browser. No
+  server-side per-user preference, no new API.
+- **Q2 = b** — a group the user has never toggled (first-ever visit, or a
+  newly-created group not in the saved state) defaults to **collapsed**. This
+  changes today's "first group auto-expands" behavior.
+- **Q3 = a** — the "Ungrouped" section is remembered too, like any real group.
+
+## Goal
+
+The project list reopens exactly as the user left it. The only "no saved state"
+fallback is all-collapsed.
+
+## Decisions
+
+### D1 — Model expansion as a Set of expanded keys (collapsed = absent)
+
+Persist the **set of keys that are currently expanded**, not a per-group boolean
+map. This directly encodes Q2: a key that is not in the set is collapsed, which
+means (a) a brand-new user with no saved state has an empty set → everything
+collapsed, and (b) a newly-created group is absent from the set → collapsed,
+with no special "seen this group before?" bookkeeping. Toggling a group open
+adds its key; collapsing removes it. Stale keys for deleted groups sit
+harmlessly in storage (never matched against a rendered group) — they are simply
+ignored on read, so no active pruning is required.
+
+**Key scheme:** real groups use `group.uuid`; the Ungrouped section uses the
+existing sentinel `"__ungrouped__"` (reuse `UNGROUPED_DROPPABLE_ID`, do not
+invent a second constant). UUIDs never collide with the sentinel.
+
+### D2 — Extract an SSR-safe, tested helper module
+
+New file `src/app/(dashboard)/projects/group-expansion-preference.ts`, modeled on
+`dashboard-view-preference.ts`:
+
+```ts
+const STORAGE_KEY = "chorus_projects_expanded_groups";
+
+/** Read the set of expanded group keys. Empty set when unset / SSR / malformed. */
+export function readExpandedGroups(): Set<string> { … }
+
+/** Persist the set of expanded group keys. No-op server-side; best-effort. */
+export function writeExpandedGroups(keys: Set<string>): void { … }
+```
+
+- Serialize as a JSON string array (`JSON.stringify([...keys])`); parse with a
+  guard that returns an empty set on non-array / parse error / non-string
+  members. Never throws.
+- `readExpandedGroups()` returns `new Set()` when `typeof window === "undefined"`,
+  when the key is absent, or when the value is malformed (older/other build).
+- `writeExpandedGroups()` is a no-op server-side and swallows quota/security
+  exceptions (privacy mode), matching `storeView`.
+
+Storage-key name follows the same-file `chorus_projects_*` convention
+(`chorus_projects_expanded_groups`), not the `chorus:...:scope` form — this state
+is global to the project list, not scoped to one entity.
+
+### D3 — Lift open-state into the page; make the sections controlled
+
+`ProjectsPage` owns a single `expandedGroups: Set<string>` state:
+
+- **Seed to empty on the server / first render, hydrate from storage in a
+  post-mount `useEffect`.** Do NOT read `localStorage` in the `useState`
+  initializer here. Rationale: unlike the `viewMode` scalar (which the existing
+  code reads inline), seeding from storage inline is only safe because the page
+  gates all group rendering behind `loading` and renders nothing group-related in
+  server HTML. To be defensive and consistent with the tested
+  `idea-tracker.tsx` approach — and because the data is fetched client-side after
+  mount anyway (groups don't exist until `fetchData` resolves) — we seed empty
+  and apply stored state in an effect. There is no flash: the group cards only
+  appear after the client-side fetch completes, well after hydration.
+
+- A `toggleGroup(key: string, open: boolean)` callback updates the set
+  immutably and writes it through `writeExpandedGroups`. Wire persistence either
+  inside the callback or via a `useEffect([expandedGroups])` that skips the
+  initial empty render — either is acceptable; the callback approach avoids
+  persisting the transient empty seed.
+
+- `GroupSection` and `UngroupedSection` become **controlled**: replace their
+  internal `useState` with props `open: boolean` and
+  `onOpenChange: (open: boolean) => void`, passed from the page. The page
+  computes `open={expandedGroups.has(group.uuid)}` (and
+  `expandedGroups.has(UNGROUPED_DROPPABLE_ID)` for Ungrouped) and passes
+  `onOpenChange={(o) => toggleGroup(key, o)}`. Radix `Collapsible` already takes
+  `open` + `onOpenChange`, so the `Collapsible` wiring is unchanged; only the
+  source of the boolean moves up.
+
+- **Remove `defaultOpen` / `index === 0`.** The `index` argument of
+  `groups.map` is no longer needed for expansion (keep it only if still used for
+  keys — it is not; `key={group.uuid}`).
+
+### D4 — Why not keep per-component state + a persistence effect each
+
+Keeping `useState` inside each section and syncing to storage per-instance would
+re-introduce the mount-time seeding problem (each instance reads storage
+independently) and scatter the storage key across two components. Lifting to the
+page centralizes the read/write to one place and one effect, and makes the
+sections dumb/controlled — easier to reason about and test.
+
+## Alternatives considered
+
+- **Server-side per-user preference** (Q1 option b) — rejected by the owner;
+  would need a new preference API + storage and cross-device sync semantics for a
+  minor UI convenience.
+- **Persist a full `{key: boolean}` map** — rejected: it forces us to distinguish
+  "explicitly collapsed" from "never seen," which Q2=b makes unnecessary (both
+  are just "collapsed"). A set of expanded keys is the minimal encoding.
+
+## Risks
+
+- **Behavior change on first visit.** Existing users who relied on the first
+  group being open will now see everything collapsed until they expand once (then
+  it sticks). This is the explicit Q2=b decision; called out in the PRD so it is
+  not a surprise at review.
+- **Stale keys accumulate** for deleted groups. Harmless (ignored on read); not
+  worth active pruning. Noted so a reviewer doesn't flag it as a leak.
+- **localStorage disabled / privacy mode.** Helper degrades to empty-set reads
+  and no-op writes; the page still works, just without persistence — same
+  posture as the existing view-mode and dashboard-view helpers.
+
+## Testing
+
+- **Unit-test the helper** (`group-expansion-preference.test.ts`): round-trip a
+  set; empty set when key absent; empty set on malformed JSON / non-array /
+  non-string members; no-op / empty under a stubbed missing `window` or a
+  throwing `localStorage`. This is the pure, deterministic core.
+- **Manual e2e (both themes):** on `/projects`, expand a non-first group and
+  collapse the first, reload → the same groups are open; expand Ungrouped, reload
+  → Ungrouped stays open; clear the key, reload → all collapsed. Verified in
+  light and dark (no color/layout-class change, so this is a structural check).
+
+## Design.pen
+
+This is a behavior-only refinement to an existing control (which groups start
+open) — no new screen or component, no layout/visual change to the group cards.
+The project-list screen is already represented in `docs/design.pen`; this change
+does not add or restructure frames. No `.pen` edit is required.

--- a/openspec/changes/archive/2026-07-13-persist-project-group-expansion/proposal.md
+++ b/openspec/changes/archive/2026-07-13-persist-project-group-expansion/proposal.md
@@ -1,0 +1,55 @@
+# Persist project-list group expand/collapse state across visits
+
+## Why
+
+On the project list page (`/projects`), projects are shown grouped by
+ProjectGroup, and each group card can be expanded or collapsed. Today the
+expand state is hardcoded: the page passes `defaultOpen={index === 0}` to each
+group, so **only the first group is expanded on every load** and the "Ungrouped"
+section always starts collapsed. Each group's open/collapsed boolean lives in
+its own `useState` initialized once at mount — nothing is persisted. If a user
+expands other groups (or collapses the first), that choice is lost the next time
+they open the page; the list always resets to "first group only."
+
+This is a small but recurring papercut for anyone who works out of a group other
+than the top one: every visit re-hides the group they care about.
+
+## What Changes
+
+- The project-list page **remembers which groups the user has expanded** and
+  restores that state on the next visit, so the page comes back the way the user
+  left it instead of resetting to "first group only."
+- State is persisted **client-side in `localStorage`** (per browser), matching
+  the existing `chorus_projects_view_mode` toggle already on this page
+  (elaboration Q1 = a). No server, API, or data-model change.
+- The empty-state default — for a user who has never toggled anything, or for a
+  newly-created group that isn't in the saved state — is **collapsed**
+  (elaboration Q2 = b). This replaces today's "first group auto-expands"
+  behavior: on a first visit (or after clearing storage) every group starts
+  collapsed until the user opens one.
+- The **"Ungrouped" section is remembered too**, like any real group
+  (elaboration Q3 = a), keyed by a stable sentinel.
+- The `defaultOpen`/`index === 0` special-casing of the first group is removed —
+  open state is driven entirely by the persisted set.
+
+## Capabilities
+
+### Added Capabilities
+
+- `project-list-group-expansion`: the project-list page SHALL persist each
+  group's (and the Ungrouped section's) expand/collapse state in `localStorage`
+  and restore it on the next visit, defaulting untracked groups to collapsed, so
+  the page reopens the way the user left it.
+
+## Impact
+
+- **UI (client only)** — `src/app/(dashboard)/projects/page.tsx`
+  (`ProjectsPage`, `GroupSection`, `UngroupedSection`): lift open-state into the
+  page, drive it from a persisted set of expanded keys, drop `defaultOpen`.
+- **New helper** — `src/app/(dashboard)/projects/group-expansion-preference.ts`:
+  small SSR-safe `readExpandedGroups()` / `writeExpandedGroups()` localStorage
+  helpers (mirrors the existing `dashboard-view-preference.ts` pattern), plus its
+  unit test.
+- No i18n string changes, no shadcn component additions, no schema/API/service
+  change. Both light and dark themes are structurally unaffected (no color or
+  layout-class change to the group cards themselves).

--- a/openspec/changes/archive/2026-07-13-persist-project-group-expansion/specs/project-list-group-expansion/spec.md
+++ b/openspec/changes/archive/2026-07-13-persist-project-group-expansion/specs/project-list-group-expansion/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Project-list group expand/collapse state persists across visits
+
+The project-list page SHALL remember which project groups (and the Ungrouped
+section) the user has expanded, and SHALL restore that state on the next visit,
+so the page reopens the way the user left it rather than resetting to a fixed
+default. The state SHALL be persisted client-side in the browser's
+`localStorage` (per browser; no server-side sync). A group whose expansion state
+has never been recorded — including a user's first-ever visit and any
+newly-created group not present in the saved state — SHALL default to collapsed.
+The Ungrouped section SHALL be persisted and restored on the same terms as a
+real group, keyed by a stable sentinel. When `localStorage` is unavailable
+(disabled or throwing), the page SHALL still render with all groups collapsed and
+SHALL NOT error.
+
+#### Scenario: Expanded groups are restored on the next visit
+
+- **WHEN** a user expands one or more project groups (and/or collapses others) and later reloads the project-list page in the same browser
+- **THEN** exactly the groups that were expanded are shown expanded, and the others collapsed, matching the state the user left
+
+#### Scenario: First visit / never-toggled groups default to collapsed
+
+- **WHEN** the project-list page is opened with no saved expansion state (first-ever visit, or after the stored value is cleared)
+- **THEN** every group is rendered collapsed, and no group is auto-expanded by position
+
+#### Scenario: A newly-created group defaults to collapsed
+
+- **WHEN** a group that is not present in the saved expansion state is rendered
+- **THEN** it is shown collapsed until the user expands it, after which its expanded state is remembered on the next visit
+
+#### Scenario: The Ungrouped section is remembered
+
+- **WHEN** the user expands the Ungrouped section and reloads the page
+- **THEN** the Ungrouped section is shown expanded on return, persisted under its own stable key like any real group
+
+#### Scenario: localStorage unavailable degrades gracefully
+
+- **WHEN** `localStorage` cannot be read or written (server-side render, privacy mode, or a throwing storage)
+- **THEN** the page renders with all groups collapsed and continues to function without error, simply not persisting the expansion state

--- a/openspec/specs/project-list-group-expansion/spec.md
+++ b/openspec/specs/project-list-group-expansion/spec.md
@@ -1,0 +1,44 @@
+# project-list-group-expansion Specification
+
+## Purpose
+TBD - created by archiving change persist-project-group-expansion. Update Purpose after archive.
+## Requirements
+### Requirement: Project-list group expand/collapse state persists across visits
+
+The project-list page SHALL remember which project groups (and the Ungrouped
+section) the user has expanded, and SHALL restore that state on the next visit,
+so the page reopens the way the user left it rather than resetting to a fixed
+default. The state SHALL be persisted client-side in the browser's
+`localStorage` (per browser; no server-side sync). A group whose expansion state
+has never been recorded — including a user's first-ever visit and any
+newly-created group not present in the saved state — SHALL default to collapsed.
+The Ungrouped section SHALL be persisted and restored on the same terms as a
+real group, keyed by a stable sentinel. When `localStorage` is unavailable
+(disabled or throwing), the page SHALL still render with all groups collapsed and
+SHALL NOT error.
+
+#### Scenario: Expanded groups are restored on the next visit
+
+- **WHEN** a user expands one or more project groups (and/or collapses others) and later reloads the project-list page in the same browser
+- **THEN** exactly the groups that were expanded are shown expanded, and the others collapsed, matching the state the user left
+
+#### Scenario: First visit / never-toggled groups default to collapsed
+
+- **WHEN** the project-list page is opened with no saved expansion state (first-ever visit, or after the stored value is cleared)
+- **THEN** every group is rendered collapsed, and no group is auto-expanded by position
+
+#### Scenario: A newly-created group defaults to collapsed
+
+- **WHEN** a group that is not present in the saved expansion state is rendered
+- **THEN** it is shown collapsed until the user expands it, after which its expanded state is remembered on the next visit
+
+#### Scenario: The Ungrouped section is remembered
+
+- **WHEN** the user expands the Ungrouped section and reloads the page
+- **THEN** the Ungrouped section is shown expanded on return, persisted under its own stable key like any real group
+
+#### Scenario: localStorage unavailable degrades gracefully
+
+- **WHEN** `localStorage` cannot be read or written (server-side render, privacy mode, or a throwing storage)
+- **THEN** the page renders with all groups collapsed and continues to function without error, simply not persisting the expansion state
+

--- a/src/app/(dashboard)/projects/__tests__/group-expansion-preference.test.ts
+++ b/src/app/(dashboard)/projects/__tests__/group-expansion-preference.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+//
+// Unit tests for the project-list group-expansion preference helper:
+// round-trip, absent key, malformed-value fallback, and graceful degradation
+// when localStorage is unavailable or throws.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readExpandedGroups, writeExpandedGroups } from "../group-expansion-preference";
+
+const STORAGE_KEY = "chorus_projects_expanded_groups";
+
+describe("readExpandedGroups / writeExpandedGroups", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns an empty set when nothing is stored", () => {
+    expect(readExpandedGroups()).toEqual(new Set());
+  });
+
+  it("round-trips a set of keys", () => {
+    writeExpandedGroups(new Set(["group-a", "group-b", "__ungrouped__"]));
+    expect(readExpandedGroups()).toEqual(new Set(["group-a", "group-b", "__ungrouped__"]));
+  });
+
+  it("round-trips an empty set (all collapsed)", () => {
+    writeExpandedGroups(new Set());
+    expect(readExpandedGroups()).toEqual(new Set());
+  });
+
+  it("serializes as a JSON string array", () => {
+    writeExpandedGroups(new Set(["x", "y"]));
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual(["x", "y"]);
+  });
+
+  it("returns an empty set for malformed JSON", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(readExpandedGroups()).toEqual(new Set());
+  });
+
+  it("returns an empty set for a non-array JSON value", () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ "group-a": true }));
+    expect(readExpandedGroups()).toEqual(new Set());
+  });
+
+  it("returns an empty set when the array has non-string members", () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(["group-a", 42, null]));
+    expect(readExpandedGroups()).toEqual(new Set());
+  });
+});
+
+describe("graceful degradation when localStorage is unavailable / throws", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("read returns an empty set when getItem throws (privacy mode)", () => {
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    expect(readExpandedGroups()).toEqual(new Set());
+  });
+
+  it("write is a no-op (does not throw) when setItem throws (quota / privacy mode)", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => writeExpandedGroups(new Set(["group-a"]))).not.toThrow();
+  });
+});

--- a/src/app/(dashboard)/projects/group-expansion-preference.ts
+++ b/src/app/(dashboard)/projects/group-expansion-preference.ts
@@ -1,0 +1,60 @@
+// Expand/collapse memory for the project-list group cards.
+//
+// The project list (see page.tsx) shows projects grouped by ProjectGroup, plus
+// an "Ungrouped" bucket. This module owns how the open/collapsed choice is
+// *remembered* across visits: it persists the SET OF EXPANDED group keys in
+// localStorage (per browser).
+//
+// Modeling the state as a set of *expanded* keys — rather than a per-group
+// boolean map — is deliberate. A key that is absent from the set is collapsed,
+// which means both a first-ever visit (empty set) and a newly-created group
+// (not yet in the set) default to collapsed with no "have I seen this group
+// before?" bookkeeping. Real groups key on their `group.uuid`; the Ungrouped
+// section keys on the existing `UNGROUPED_DROPPABLE_ID` ("__ungrouped__")
+// sentinel. Stale keys for deleted groups are harmless — they are never matched
+// against a rendered group, so they are simply ignored on read.
+//
+// Mirrors the SSR-guarded, try/catch-degrading shape of
+// dashboard-view-preference.ts (readStoredView / storeView).
+
+/** localStorage key — global to the project list (not scoped to an entity). */
+const STORAGE_KEY = "chorus_projects_expanded_groups";
+
+/**
+ * Read the set of currently-expanded group keys.
+ *
+ * Returns an empty Set when running server-side (no `window`), when nothing has
+ * been stored yet, or when the stored value is malformed (not valid JSON, not an
+ * array, or an array with non-string members — e.g. written by an older build).
+ * Never throws — a bad read degrades to "everything collapsed".
+ */
+export function readExpandedGroups(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    if (!parsed.every((k) => typeof k === "string")) return new Set();
+    return new Set(parsed as string[]);
+  } catch {
+    // Malformed JSON, or localStorage throwing (privacy mode / disabled) —
+    // degrade to an empty set.
+    return new Set();
+  }
+}
+
+/**
+ * Persist the set of expanded group keys as a JSON string array.
+ *
+ * No-op server-side. Best-effort: a failed write (quota, privacy mode) just
+ * means the choice isn't remembered — it never throws.
+ */
+export function writeExpandedGroups(keys: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...keys]));
+  } catch {
+    // Best-effort: swallow storage exceptions.
+  }
+}

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -41,6 +41,7 @@ import { MoveProjectConfirmDialog } from "@/components/move-project-confirm-dial
 import { CreateProjectGroupDialog } from "@/components/create-project-group-dialog";
 import { CreateProjectDialog } from "@/components/create-project-dialog";
 import { getProjectInitials, getProjectIconColor, projectIconStyle } from "@/lib/project-colors";
+import { readExpandedGroups, writeExpandedGroups } from "./group-expansion-preference";
 
 // Types
 interface ProjectData {
@@ -293,18 +294,19 @@ function GroupSection({
   projects,
   stats,
   onNewProject,
-  defaultOpen = false,
+  open,
+  onOpenChange,
   viewMode,
 }: {
   group: ProjectGroupData;
   projects: ProjectData[];
   stats: { totalTasks: number; completedTasks: number; openIdeas: number };
   onNewProject: () => void;
-  defaultOpen?: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   viewMode: ViewMode;
 }) {
   const t = useTranslations();
-  const [isOpen, setIsOpen] = useState(defaultOpen);
   const completionRate =
     stats.totalTasks > 0
       ? Math.round((stats.completedTasks / stats.totalTasks) * 100)
@@ -314,7 +316,7 @@ function GroupSection({
     <Droppable droppableId={group.uuid}>
       {(provided, snapshot) => (
         <div ref={provided.innerRef} {...provided.droppableProps}>
-          <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+          <Collapsible open={open} onOpenChange={onOpenChange}>
             <Card
               className={`overflow-hidden rounded-2xl border-[#E5E2DC] dark:border-[#2a2a2e] gap-0 py-0 shadow-none transition-colors hover:border-primary/40 ${
                 snapshot.isDraggingOver
@@ -350,7 +352,7 @@ function GroupSection({
                       </span>
                     </div>
                   </div>
-                  {isOpen ? (
+                  {open ? (
                     <ChevronDown className="ml-auto h-3.5 w-3.5 shrink-0 text-[#9A9A9A] md:h-4 md:w-4" />
                   ) : (
                     <ChevronRight className="ml-auto h-3.5 w-3.5 shrink-0 text-[#9A9A9A] md:h-4 md:w-4" />
@@ -447,9 +449,8 @@ function GroupSection({
   );
 }
 
-function UngroupedSection({ projects, onNewProject, viewMode }: { projects: ProjectData[]; onNewProject: () => void; viewMode: ViewMode }) {
+function UngroupedSection({ projects, onNewProject, viewMode, open, onOpenChange }: { projects: ProjectData[]; onNewProject: () => void; viewMode: ViewMode; open: boolean; onOpenChange: (open: boolean) => void }) {
   const t = useTranslations();
-  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <Droppable droppableId={UNGROUPED_DROPPABLE_ID}>
@@ -464,7 +465,7 @@ function UngroupedSection({ projects, onNewProject, viewMode }: { projects: Proj
 
         return (
           <div ref={provided.innerRef} {...provided.droppableProps}>
-            <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+            <Collapsible open={open} onOpenChange={onOpenChange}>
               <Card
                 className={`overflow-hidden rounded-2xl border-[#E5E2DC] dark:border-[#2a2a2e] gap-0 py-0 shadow-none transition-colors hover:border-primary/40 ${
                   snapshot.isDraggingOver
@@ -489,7 +490,7 @@ function UngroupedSection({ projects, onNewProject, viewMode }: { projects: Proj
                         {projects.length}
                       </Badge>
                     </div>
-                    {isOpen ? (
+                    {open ? (
                       <ChevronDown className="ml-auto h-3.5 w-3.5 shrink-0 text-[#9A9A9A] md:h-4 md:w-4" />
                     ) : (
                       <ChevronRight className="ml-auto h-3.5 w-3.5 shrink-0 text-[#9A9A9A] md:h-4 md:w-4" />
@@ -594,6 +595,28 @@ export default function ProjectsPage() {
   useEffect(() => {
     localStorage.setItem("chorus_projects_view_mode", viewMode);
   }, [viewMode]);
+
+  // Which group cards are expanded, remembered across visits. Seed empty (so
+  // server and first client render agree) and hydrate from localStorage after
+  // mount — no flash, since the group cards only render once fetchData resolves.
+  // A key absent from the set is collapsed, so first visits / new groups start
+  // collapsed (elaboration Q2). Real groups key on group.uuid; the Ungrouped
+  // section keys on UNGROUPED_DROPPABLE_ID.
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    setExpandedGroups(readExpandedGroups());
+  }, []);
+  const toggleGroup = useCallback((key: string, open: boolean) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (open) next.add(key);
+      else next.delete(key);
+      // Persist inside the callback (not a blanket effect) so the transient
+      // empty seed never overwrites real saved state.
+      writeExpandedGroups(next);
+      return next;
+    });
+  }, []);
 
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [createProjectTarget, setCreateProjectTarget] = useState<{ groupUuid: string | null; groupName: string } | null>(null);
@@ -932,7 +955,7 @@ export default function ProjectsPage() {
           ) : (
             <div className="space-y-4">
               {/* Groups */}
-              {groups.map((group, index) => {
+              {groups.map((group) => {
                 const groupProjects = projectsByGroup.get(group.uuid) || [];
                 const stats = getGroupStats(groupProjects);
                 return (
@@ -941,7 +964,8 @@ export default function ProjectsPage() {
                     group={group}
                     projects={groupProjects}
                     stats={stats}
-                    defaultOpen={index === 0}
+                    open={expandedGroups.has(group.uuid)}
+                    onOpenChange={(o) => toggleGroup(group.uuid, o)}
                     viewMode={viewMode}
                     onNewProject={() => setCreateProjectTarget({ groupUuid: group.uuid, groupName: group.name })}
                   />
@@ -952,6 +976,8 @@ export default function ProjectsPage() {
               <UngroupedSection
                 projects={ungroupedProjects}
                 viewMode={viewMode}
+                open={expandedGroups.has(UNGROUPED_DROPPABLE_ID)}
+                onOpenChange={(o) => toggleGroup(UNGROUPED_DROPPABLE_ID, o)}
                 onNewProject={() => setCreateProjectTarget({ groupUuid: null, groupName: t("projectGroups.ungrouped") })}
               />
 


### PR DESCRIPTION
## Summary
The project-list page (`/projects`) hardcoded `defaultOpen={index === 0}`, so only the first group ever opened on load and any expand/collapse the user made was lost on reload. This remembers which groups (and the Ungrouped section) the user has expanded, per-browser in `localStorage`, and restores that state on the next visit.

Behavior per the idea's elaboration (idea `db1d007f`):
- **Storage:** browser `localStorage`, per-browser (no server sync) — mirrors the existing `chorus_projects_view_mode` toggle on the same page.
- **Default:** groups the user has never toggled — first-ever visit, cleared storage, or a newly-created group — start **collapsed**. ⚠️ This intentionally replaces the old "first group auto-opens" behavior.
- **Ungrouped:** the Ungrouped section is remembered too, keyed by the existing `__ungrouped__` sentinel.

## Changed files
| File | Change |
|------|--------|
| `src/app/(dashboard)/projects/group-expansion-preference.ts` | **New** SSR-safe helper: `readExpandedGroups` / `writeExpandedGroups`, key `chorus_projects_expanded_groups`, set-of-expanded-keys model (collapsed == absent). Degrades to empty-set / no-op when `localStorage` is unavailable. |
| `src/app/(dashboard)/projects/__tests__/group-expansion-preference.test.ts` | **New** 9-case unit test (round-trip, absent key, malformed value, throwing storage). |
| `src/app/(dashboard)/projects/page.tsx` | Lift group open-state into `ProjectsPage` (empty seed + post-mount hydrate effect + persist-on-toggle); make `GroupSection`/`UngroupedSection` controlled (`open` + `onOpenChange`); remove `defaultOpen`/`index===0`. |
| `openspec/specs/project-list-group-expansion/spec.md`, `openspec/changes/archive/2026-07-13-persist-project-group-expansion/**` | OpenSpec cumulative spec + archived change. |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on changed source files clean
- [x] `pnpm test` full suite green (4124 passed)
- [x] Live browser e2e (Playwright) in **both light and dark themes**: fresh state = all collapsed (incl. first group); expanding a non-first group + Ungrouped persists and restores on reload; clearing the key returns to all-collapsed
- [x] No regression to view-mode persistence, drag-and-drop, stats, or SSE refresh

Generated with [Claude Code](https://claude.com/claude-code)