### PR TITLE
feat(daemon): add --agent kiro headless backend (wake / resume / interrupt / transcript)

### DIFF
--- a/cli/__tests__/daemon-agent.test.mjs
+++ b/cli/__tests__/daemon-agent.test.mjs
@@ -1,9 +1,10 @@
 // cli/__tests__/daemon-agent.test.mjs
-// Covers daemon-agent-selection spec (MODIFIED for add-daemon-codex-backend):
-// resolveAgentType now accepts BOTH claude-code and codex; unknown values are
-// still rejected non-zero with no silent fallback; default stays claude-code.
+// Covers daemon-agent-selection spec (MODIFIED for add-daemon-codex-backend, then
+// add-daemon-kiro-backend): resolveAgentType now accepts claude-code, codex, AND
+// kiro; unknown values are still rejected non-zero with no silent fallback;
+// default stays claude-code.
 import { describe, it, expect } from "vitest";
-import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT, backendClientType } from "../daemon-agent.mjs";
+import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT, backendClientType, backendCli } from "../daemon-agent.mjs";
 
 describe("resolveAgentType — known backends", () => {
   it("defaults to claude-code with no flag and no env", () => {
@@ -30,9 +31,18 @@ describe("resolveAgentType — known backends", () => {
     });
   });
 
-  it("lists both backends in KNOWN_AGENTS and keeps claude-code default", () => {
+  it("accepts kiro via --agent flag", () => {
+    expect(resolveAgentType({ agent: "kiro" }, {})).toEqual({ ok: true, agent: "kiro" });
+  });
+
+  it("accepts kiro via CHORUS_AGENT env", () => {
+    expect(resolveAgentType({}, { CHORUS_AGENT: "kiro" })).toEqual({ ok: true, agent: "kiro" });
+  });
+
+  it("lists all backends in KNOWN_AGENTS and keeps claude-code default", () => {
     expect(KNOWN_AGENTS).toContain("claude-code");
     expect(KNOWN_AGENTS).toContain("codex");
+    expect(KNOWN_AGENTS).toContain("kiro");
     expect(DEFAULT_AGENT).toBe("claude-code");
   });
 });
@@ -43,6 +53,7 @@ describe("resolveAgentType — unknown rejected (no silent fallback)", () => {
     expect(r.ok).toBe(false);
     expect(r.value).toBe("gemini");
     expect(r.error).toContain("codex");
+    expect(r.error).toContain("kiro");
     expect(r.error).toContain("claude-code");
   });
 
@@ -57,11 +68,27 @@ describe("backendClientType — agentType → self-reported clientType", () => {
   it("maps codex → codex", () => {
     expect(backendClientType("codex")).toBe("codex");
   });
+  it("maps kiro → kiro", () => {
+    expect(backendClientType("kiro")).toBe("kiro");
+  });
   it("maps claude-code → claude_code", () => {
     expect(backendClientType("claude-code")).toBe("claude_code");
   });
   it("falls back to claude_code for unknown/undefined", () => {
     expect(backendClientType(undefined)).toBe("claude_code");
     expect(backendClientType("whatever")).toBe("claude_code");
+  });
+});
+
+describe("backendCli — agentType → executable descriptor", () => {
+  it("maps codex → codex / CHORUS_CODEX_PATH", () => {
+    expect(backendCli("codex")).toEqual({ name: "codex", envVar: "CHORUS_CODEX_PATH" });
+  });
+  it("maps kiro → kiro-cli / CHORUS_KIRO_PATH", () => {
+    expect(backendCli("kiro")).toEqual({ name: "kiro-cli", envVar: "CHORUS_KIRO_PATH" });
+  });
+  it("falls back to claude / CHORUS_CLAUDE_PATH for default/unknown", () => {
+    expect(backendCli("claude-code")).toEqual({ name: "claude", envVar: "CHORUS_CLAUDE_PATH" });
+    expect(backendCli(undefined)).toEqual({ name: "claude", envVar: "CHORUS_CLAUDE_PATH" });
   });
 });

--- a/cli/__tests__/kiro-backend-integration.test.mjs
+++ b/cli/__tests__/kiro-backend-integration.test.mjs
@@ -1,0 +1,152 @@
+// cli/__tests__/kiro-backend-integration.test.mjs
+// Integration checkpoint for add-daemon-kiro-backend (task 5): proves the Kiro
+// backend works through the REAL daemon wiring (tasks 1–4 together) and that the
+// claude-code default + codex backend do not regress.
+//
+//   1. Interrupt parity — the real KiroSpawner spawns a detached process group,
+//      so the EXISTING killProcessTree (no new killer) group-signals its tree.
+//   2. Backend selection unchanged — buildDaemon with no agentType injects a
+//      ClaudeSpawner; agentType:"codex" a CodexSpawner; agentType:"kiro" a KiroSpawner.
+//   3. Kiro backend end-to-end — driving the daemon-selected KiroSpawner's wake()
+//      through a fake spawn yields the expected `kiro-cli chat --no-interactive
+//      --agent chorus` (new) and `+ --resume-id <id>` (known anchor) argv, prompt on
+//      stdin, daemon key in the child env (never argv).
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { buildDaemon } from "../daemon.mjs";
+import { ClaudeSpawner } from "../claude-spawner.mjs";
+import { CodexSpawner } from "../codex-spawner.mjs";
+import { KiroSpawner } from "../kiro-spawner.mjs";
+import { killProcessTree } from "../process-killer.mjs";
+
+const CREDS = { url: "https://chorus.test", apiKey: "cho_daemonkey" };
+const ANCHOR = "11111111-1111-4111-8111-111111111111";
+const SID = "540019be-35ec-4740-8880-a6c83f172646";
+const silent = { info() {}, warn() {}, error() {} };
+
+function makeFakeChild(pid = 9200) {
+  const child = new EventEmitter();
+  const stdin = new EventEmitter();
+  stdin.writes = [];
+  stdin.write = (c) => stdin.writes.push(String(c));
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+  child.stdout = new EventEmitter();
+  child.stdout.setEncoding = () => {};
+  child.stderr = new EventEmitter();
+  child.stderr.setEncoding = () => {};
+  child.pid = pid;
+  return child;
+}
+
+describe("interrupt parity — KiroSpawner detached group is reaped by the existing killProcessTree", () => {
+  it("KiroSpawner spawns detached on POSIX (process-group leader)", async () => {
+    const child = makeFakeChild();
+    let spawnOpts;
+    const spawner = new KiroSpawner({
+      kiroPath: "/usr/bin/kiro-cli",
+      platform: "linux",
+      permissionMode: "yolo",
+      creds: CREDS,
+      logger: silent,
+      getSessionIdFn: () => null,
+      setSessionIdFn: () => {},
+      snapshotSessionsFn: () => new Map(),
+      reconstructTranscript: null,
+      spawnImpl: (_c, _a, opts) => {
+        spawnOpts = opts;
+        return child;
+      },
+    });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 0);
+    await p;
+    expect(spawnOpts.detached).toBe(true);
+  });
+
+  it("killProcessTree group-signals the Kiro child's pid (negative pid) — same killer, no new code", async () => {
+    const child = makeFakeChild(4322);
+    const killImpl = vi.fn();
+    const res = await killProcessTree(child, {
+      platform: "linux",
+      logger: silent,
+      killImpl,
+      sigintTimeoutMs: 20,
+      waitForExit: vi.fn(async () => true),
+    });
+    expect(killImpl).toHaveBeenCalledWith(-4322, "SIGINT");
+    expect(res).toMatchObject({ signaled: true, killed: true });
+  });
+});
+
+describe("buildDaemon spawner selection (end-to-end wiring, all three backends)", () => {
+  it("default (no agentType) injects a ClaudeSpawner — claude-code unchanged", () => {
+    const daemon = buildDaemon(CREDS, { logger: silent, permissionMode: "yolo" });
+    expect(daemon.spawner).toBeInstanceOf(ClaudeSpawner);
+  });
+
+  it("agentType 'codex' injects a CodexSpawner — codex unchanged", () => {
+    const daemon = buildDaemon(CREDS, { logger: silent, permissionMode: "yolo", agentType: "codex" });
+    expect(daemon.spawner).toBeInstanceOf(CodexSpawner);
+  });
+
+  it("agentType 'kiro' injects a KiroSpawner carrying creds + permissionMode", () => {
+    const daemon = buildDaemon(CREDS, { logger: silent, permissionMode: "yolo", agentType: "kiro" });
+    expect(daemon.spawner).toBeInstanceOf(KiroSpawner);
+    expect(daemon.spawner.permissionMode).toBe("yolo");
+    expect(daemon.spawner.creds).toEqual(CREDS);
+  });
+});
+
+describe("kiro backend end-to-end argv (via the daemon-selected spawner)", () => {
+  /** Build a daemon, grab its KiroSpawner, and drive wake() with a fake spawn. */
+  function kiroSpawnerWithFakeSpawn({ getSessionId } = {}) {
+    const daemon = buildDaemon(CREDS, { logger: silent, permissionMode: "yolo", agentType: "kiro" });
+    const spawner = daemon.spawner;
+    // Inject test seams onto the real selected spawner.
+    spawner.kiroPath = "/usr/bin/kiro-cli";
+    spawner.platform = "linux";
+    spawner.getSessionIdFn = getSessionId ?? (() => null);
+    spawner.setSessionIdFn = vi.fn();
+    spawner.snapshotSessionsFn = () => new Map();
+    spawner.reconstructTranscript = null; // isolate from the real ~/.kiro store
+    const calls = {};
+    const child = makeFakeChild();
+    spawner.spawnImpl = (command, argv, opts) => {
+      calls.command = command;
+      calls.argv = argv;
+      calls.opts = opts;
+      return child;
+    };
+    return { spawner, calls, child };
+  }
+
+  it("NEW anchor → `kiro-cli chat --no-interactive --agent chorus …`, prompt on stdin, daemon key in env not argv", async () => {
+    const { spawner, calls, child } = kiroSpawnerWithFakeSpawn({ getSessionId: () => null });
+    const p = spawner.wake({ prompt: "wake up kiro", sessionId: ANCHOR, isNew: true });
+    child.stdout.emit("data", "plain text turn output\n");
+    child.emit("close", 0);
+    await p;
+
+    expect(calls.command).toBe("/usr/bin/kiro-cli");
+    expect(calls.argv.slice(0, 4)).toEqual(["chat", "--no-interactive", "--agent", "chorus"]);
+    expect(calls.argv).toContain("--trust-all-tools");
+    expect(calls.argv).not.toContain("--resume-id");
+    expect(calls.argv).not.toContain("--v3");
+    expect(child.stdin.writes.join("")).toBe("wake up kiro");
+    expect(calls.argv.join(" ")).not.toContain("wake up kiro");
+    expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_daemonkey");
+    expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+    expect(calls.argv.join(" ")).not.toContain("cho_daemonkey");
+  });
+
+  it("KNOWN anchor (map hit) → `kiro-cli chat --no-interactive --resume-id <sessionId> --agent chorus`", async () => {
+    const { spawner, calls, child } = kiroSpawnerWithFakeSpawn({ getSessionId: () => SID });
+    const p = spawner.wake({ prompt: "continue", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 0);
+    await p;
+    expect(calls.argv.slice(0, 3)).toEqual(["chat", "--no-interactive", "--resume-id"]);
+    expect(calls.argv[3]).toBe(SID);
+    expect(calls.argv.slice(4, 6)).toEqual(["--agent", "chorus"]);
+  });
+});

--- a/cli/__tests__/kiro-session-map.test.mjs
+++ b/cli/__tests__/kiro-session-map.test.mjs
@@ -1,0 +1,138 @@
+// cli/__tests__/kiro-session-map.test.mjs
+// Covers daemon-kiro-backend spec "Kiro session anchoring via a persisted
+// idea→session-id map": round-trip across restarts, and best-effort degradation
+// (missing file / corrupt JSON / write failure never throw into the wake path).
+// Mirrors codex-session-map.test.mjs — both wrap the shared session-map factory.
+import { describe, it, expect, vi } from "vitest";
+import {
+  getSessionId,
+  setSessionId,
+  kiroSessionMapPath,
+} from "../kiro-session-map.mjs";
+
+const ANCHOR = "11111111-1111-4111-8111-111111111111";
+const ANCHOR2 = "22222222-2222-4222-8222-222222222222";
+const SID = "540019be-35ec-4740-8880-a6c83f172646";
+
+/** An in-memory fake FS implementing just the inject points the module uses. */
+function makeFakeFs(initial = {}) {
+  const files = { ...initial };
+  return {
+    files,
+    read: (p) => {
+      if (!(p in files)) {
+        const err = new Error(`ENOENT: ${p}`);
+        err.code = "ENOENT";
+        throw err;
+      }
+      return files[p];
+    },
+    write: (p, c) => {
+      files[p] = String(c);
+    },
+    mkdir: () => {},
+    rename: (from, to) => {
+      files[to] = files[from];
+      delete files[from];
+    },
+  };
+}
+
+describe("kiroSessionMapPath", () => {
+  it("lives under the ~/.chorus config dir family", () => {
+    expect(kiroSessionMapPath()).toMatch(/[\\/]\.chorus[\\/]kiro-sessions\.json$/);
+  });
+});
+
+describe("get/set round-trip", () => {
+  it("returns null for an unknown anchor on a missing file", () => {
+    const io = makeFakeFs();
+    expect(getSessionId(ANCHOR, { ...io, path: "/cfg/kiro-sessions.json" })).toBeNull();
+  });
+
+  it("persists an anchor→sessionId and reads it back (separate calls = restart)", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/kiro-sessions.json";
+    setSessionId(ANCHOR, SID, { ...io, path });
+    expect(getSessionId(ANCHOR, { ...io, path })).toBe(SID);
+  });
+
+  it("keeps multiple anchors independent and preserves existing entries on set", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/kiro-sessions.json";
+    setSessionId(ANCHOR, SID, { ...io, path });
+    setSessionId(ANCHOR2, "second-session", { ...io, path });
+    expect(getSessionId(ANCHOR, { ...io, path })).toBe(SID);
+    expect(getSessionId(ANCHOR2, { ...io, path })).toBe("second-session");
+  });
+
+  it("overwrites the sessionId when set again for the same anchor", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/kiro-sessions.json";
+    setSessionId(ANCHOR, SID, { ...io, path });
+    setSessionId(ANCHOR, "new-session", { ...io, path });
+    expect(getSessionId(ANCHOR, { ...io, path })).toBe("new-session");
+  });
+
+  it("writes atomically via a .tmp sibling then rename", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/kiro-sessions.json";
+    const rename = vi.fn(io.rename);
+    setSessionId(ANCHOR, SID, { ...io, path, rename });
+    expect(rename).toHaveBeenCalledWith(`${path}.tmp`, path);
+  });
+
+  it("writes the temp file with mode 0600", () => {
+    const io = makeFakeFs();
+    const path = "/cfg/kiro-sessions.json";
+    const write = vi.fn(io.write);
+    setSessionId(ANCHOR, SID, { ...io, path, write });
+    expect(write).toHaveBeenCalledWith(`${path}.tmp`, expect.any(String), { mode: 0o600 });
+  });
+});
+
+describe("best-effort degradation (never throws into the wake path)", () => {
+  it("getSessionId returns null on corrupt JSON (and logs)", () => {
+    const io = makeFakeFs({ "/cfg/kiro-sessions.json": "{ not json" });
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    expect(() => getSessionId(ANCHOR, { ...io, path: "/cfg/kiro-sessions.json", logger })).not.toThrow();
+    expect(getSessionId(ANCHOR, { ...io, path: "/cfg/kiro-sessions.json", logger })).toBeNull();
+  });
+
+  it("getSessionId returns null when the stored value for the anchor is not a string", () => {
+    const io = makeFakeFs({ "/cfg/kiro-sessions.json": JSON.stringify({ [ANCHOR]: 123 }) });
+    expect(getSessionId(ANCHOR, { ...io, path: "/cfg/kiro-sessions.json" })).toBeNull();
+  });
+
+  it("setSessionId swallows a write failure (logs, does not throw)", () => {
+    const io = makeFakeFs();
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    const write = () => {
+      throw new Error("EACCES");
+    };
+    expect(() =>
+      setSessionId(ANCHOR, SID, { ...io, path: "/cfg/kiro-sessions.json", write, logger })
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("setSessionId swallows a rename failure (logs, does not throw)", () => {
+    const io = makeFakeFs();
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    const rename = () => {
+      throw new Error("EXDEV");
+    };
+    expect(() =>
+      setSessionId(ANCHOR, SID, { ...io, path: "/cfg/kiro-sessions.json", rename, logger })
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("ignores a blank anchor or blank sessionId on set (no write)", () => {
+    const io = makeFakeFs();
+    const write = vi.fn(io.write);
+    setSessionId("", SID, { ...io, path: "/cfg/kiro-sessions.json", write });
+    setSessionId(ANCHOR, "", { ...io, path: "/cfg/kiro-sessions.json", write });
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/cli/__tests__/kiro-spawner.test.mjs
+++ b/cli/__tests__/kiro-spawner.test.mjs
@@ -1,0 +1,324 @@
+// cli/__tests__/kiro-spawner.test.mjs
+// Covers daemon-kiro-backend spec: headless `kiro-cli chat --no-interactive` wake
+// (prompt on stdin), buildArgs for new vs resume + trust flags + --agent chorus,
+// post-run sessionId capture via a store-snapshot diff + persistence, daemon-key-
+// via-env, cross-platform exec resolution, and never-throw-into-the-wake-path.
+//
+// Verified against kiro-cli 2.12.1: `chat --no-interactive` reads the prompt and
+// emits plain text (no id-bearing stream); resume is `--resume-id <SESSION_ID>`;
+// trust is `--trust-all-tools` / `--trust-tools=…`; MCP tools are namespaced
+// `@chorus`.
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import {
+  KiroSpawner,
+  buildKiroArgs,
+  trustFlags,
+  resolveKiroPath,
+  pickNewSessionId,
+} from "../kiro-spawner.mjs";
+
+const ANCHOR = "11111111-1111-4111-8111-111111111111";
+const SID = "540019be-35ec-4740-8880-a6c83f172646";
+const SID2 = "7db3039f-f915-4274-8508-6e17c4af1ccf";
+
+/** A fake child process: stdin captures writes; stdout/stderr are emitters. */
+function makeFakeChild() {
+  const child = new EventEmitter();
+  const stdinChunks = [];
+  const stdin = new EventEmitter();
+  stdin.writes = stdinChunks;
+  stdin.write = (c) => stdinChunks.push(String(c));
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+  child.stdout = new EventEmitter();
+  child.stdout.setEncoding = () => {};
+  child.stderr = new EventEmitter();
+  child.stderr.setEncoding = () => {};
+  child.pid = 4242;
+  return child;
+}
+
+describe("trustFlags — permission mode mapping", () => {
+  it("yolo → --trust-all-tools", () => {
+    expect(trustFlags("yolo")).toEqual(["--trust-all-tools"]);
+  });
+  it("chorus → scoped --trust-tools=fs_read,@chorus (read-only fs + Chorus MCP)", () => {
+    expect(trustFlags("chorus")).toEqual(["--trust-tools=fs_read,@chorus"]);
+  });
+  it("defaults unknown/undefined to the restricted scoped set", () => {
+    expect(trustFlags(undefined)).toEqual(["--trust-tools=fs_read,@chorus"]);
+  });
+});
+
+describe("buildKiroArgs — new vs resume", () => {
+  it("new run: chat --no-interactive --agent chorus + trust, no resume, no prompt in argv, no --v3", () => {
+    const args = buildKiroArgs({ isNew: true, permissionMode: "yolo" });
+    expect(args).toEqual(["chat", "--no-interactive", "--agent", "chorus", "--trust-all-tools"]);
+    expect(args).not.toContain("--resume-id");
+    expect(args).not.toContain("--v3");
+  });
+
+  it("resume run (yolo): + --resume-id <sessionId>", () => {
+    const args = buildKiroArgs({ isNew: false, sessionId: SID, permissionMode: "yolo" });
+    expect(args).toEqual([
+      "chat",
+      "--no-interactive",
+      "--resume-id",
+      SID,
+      "--agent",
+      "chorus",
+      "--trust-all-tools",
+    ]);
+  });
+
+  it("chorus mode carries the scoped trust set on both new and resume", () => {
+    expect(buildKiroArgs({ isNew: true, permissionMode: "chorus" })).toContain("--trust-tools=fs_read,@chorus");
+    expect(buildKiroArgs({ isNew: false, sessionId: SID, permissionMode: "chorus" })).toContain(
+      "--trust-tools=fs_read,@chorus"
+    );
+  });
+
+  it("never contains the prompt (prompt is stdin-only)", () => {
+    const args = buildKiroArgs({ isNew: true, permissionMode: "yolo" });
+    expect(args.join(" ")).not.toContain("PROMPT");
+  });
+});
+
+describe("pickNewSessionId — UNAMBIGUOUS post-run capture (reviewer N1 hardening)", () => {
+  it("returns the id when EXACTLY ONE brand-new id appeared", () => {
+    const before = new Map([[SID, 100]]);
+    const after = new Map([
+      [SID, 100],
+      [SID2, 200],
+    ]);
+    expect(pickNewSessionId(before, after)).toBe(SID2);
+  });
+
+  it("returns null when SEVERAL new ids appear (concurrent same-cwd wake → refuse to guess)", () => {
+    // Two fresh runs raced in the same cwd; we must NOT mis-attribute one to the other.
+    const before = new Map();
+    const after = new Map([
+      [SID, 100],
+      [SID2, 300],
+    ]);
+    expect(pickNewSessionId(before, after)).toBeNull();
+  });
+
+  it("returns null when NO new id appeared (only an existing id's updated_at moved)", () => {
+    // No "updated_at advanced" fallback — a fresh run always creates a new id.
+    const before = new Map([[SID, 100]]);
+    const after = new Map([[SID, 250]]);
+    expect(pickNewSessionId(before, after)).toBeNull();
+  });
+
+  it("returns null when nothing changed", () => {
+    const before = new Map([[SID, 100]]);
+    const after = new Map([[SID, 100]]);
+    expect(pickNewSessionId(before, after)).toBeNull();
+  });
+});
+
+describe("resolveKiroPath", () => {
+  const isFile = (set) => (p) => set.has(p);
+
+  it("honors CHORUS_KIRO_PATH override when it is a file", () => {
+    const env = { CHORUS_KIRO_PATH: "/opt/kiro-cli", PATH: "/usr/bin" };
+    expect(resolveKiroPath({ env, platform: "linux", isFile: isFile(new Set(["/opt/kiro-cli"])) })).toBe(
+      "/opt/kiro-cli"
+    );
+  });
+
+  it("walks PATH for `kiro-cli` on POSIX", () => {
+    const env = { PATH: "/a:/b" };
+    expect(resolveKiroPath({ env, platform: "linux", isFile: isFile(new Set(["/b/kiro-cli"])) })).toBe("/b/kiro-cli");
+  });
+
+  it("prefers kiro-cli.cmd / kiro-cli.exe on Windows", () => {
+    const env = { Path: "C:\\bin" };
+    const got = resolveKiroPath({ env, platform: "win32", isFile: isFile(new Set(["C:\\bin\\kiro-cli.cmd"])) });
+    expect(got).toBe("C:\\bin\\kiro-cli.cmd");
+  });
+
+  it("returns null when nothing resolves", () => {
+    expect(resolveKiroPath({ env: { PATH: "/x" }, platform: "linux", isFile: () => false })).toBeNull();
+  });
+});
+
+describe("KiroSpawner.wake — spawn orchestration", () => {
+  const creds = { url: "https://chorus.test", apiKey: "cho_secret" };
+
+  /** Build a spawner whose spawnImpl returns our fake child + records the call. */
+  function makeSpawner({
+    child,
+    permissionMode = "yolo",
+    getSessionId,
+    setSessionId,
+    snapshots,
+    kiroPath = "/usr/bin/kiro-cli",
+  } = {}) {
+    const calls = {};
+    const spawnImpl = vi.fn((command, argv, opts) => {
+      calls.command = command;
+      calls.argv = argv;
+      calls.opts = opts;
+      return child;
+    });
+    // snapshots: an array of Map results returned in order on each snapshot call
+    // (before-run, after-run). Defaults to empty→empty (no id captured).
+    const snaps = snapshots ?? [new Map(), new Map()];
+    let snapIdx = 0;
+    const snapshotSessionsFn = vi.fn(() => snaps[Math.min(snapIdx++, snaps.length - 1)]);
+    const spawner = new KiroSpawner({
+      kiroPath,
+      spawnImpl,
+      permissionMode,
+      creds,
+      platform: "linux",
+      logger: { info() {}, warn() {}, error() {} },
+      getSessionIdFn: getSessionId ?? (() => null),
+      setSessionIdFn: setSessionId ?? (() => {}),
+      snapshotSessionsFn,
+      // Isolate spawn-orchestration tests from the real ~/.kiro store; the tests
+      // that exercise transcript feeding override this with their own hook.
+      reconstructTranscript: null,
+    });
+    return { spawner, spawnImpl, calls };
+  }
+
+  it("new wake: spawns `kiro-cli chat --no-interactive --agent chorus`, prompt over stdin, key in env (not argv)", async () => {
+    const child = makeFakeChild();
+    const { spawner, calls } = makeSpawner({
+      child,
+      // before: empty; after: one new session id
+      snapshots: [new Map(), new Map([[SID, 200]])],
+    });
+    const onChild = vi.fn();
+    const p = spawner.wake({ prompt: "do the thing", sessionId: ANCHOR, isNew: true, onChild });
+    child.stdout.emit("data", "some plain text output\n");
+    child.emit("close", 0);
+    const result = await p;
+
+    expect(calls.argv.slice(0, 4)).toEqual(["chat", "--no-interactive", "--agent", "chorus"]);
+    expect(calls.argv).not.toContain("--resume-id");
+    // prompt only on stdin, never argv
+    expect(child.stdin.writes.join("")).toBe("do the thing");
+    expect(calls.argv.join(" ")).not.toContain("do the thing");
+    // daemon key exported via env, headless flag set, key absent from argv
+    expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_secret");
+    expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+    expect(calls.argv.join(" ")).not.toContain("cho_secret");
+    // detached process group on POSIX (for interrupt parity)
+    expect(calls.opts.detached).toBe(true);
+    // onChild fired exactly once with the live child
+    expect(onChild).toHaveBeenCalledTimes(1);
+    expect(onChild).toHaveBeenCalledWith(child);
+    // returns the captured session id (from the store diff) as the session id
+    expect(result.exitCode).toBe(0);
+    expect(result.sessionId).toBe(SID);
+  });
+
+  it("captures the new sessionId from the store diff and persists anchor→sessionId on a successful new run", async () => {
+    const child = makeFakeChild();
+    const setSessionId = vi.fn();
+    const { spawner } = makeSpawner({
+      child,
+      setSessionId,
+      snapshots: [new Map(), new Map([[SID, 200]])],
+    });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 0);
+    await p;
+    expect(setSessionId).toHaveBeenCalledWith(ANCHOR, SID);
+  });
+
+  it("does NOT persist on a non-zero exit (failed run)", async () => {
+    const child = makeFakeChild();
+    const setSessionId = vi.fn();
+    const { spawner } = makeSpawner({
+      child,
+      setSessionId,
+      snapshots: [new Map(), new Map([[SID, 200]])],
+    });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 1);
+    await p;
+    expect(setSessionId).not.toHaveBeenCalled();
+  });
+
+  it("resume wake: a known anchor produces `--resume-id <sessionId>` (ignores passed isNew)", async () => {
+    const child = makeFakeChild();
+    const setSessionId = vi.fn();
+    const { spawner, calls } = makeSpawner({ child, getSessionId: () => SID, setSessionId });
+    // pass isNew:true but the map has a session id → spawner must resume
+    const p = spawner.wake({ prompt: "again", sessionId: ANCHOR, isNew: true });
+    child.emit("close", 0);
+    const result = await p;
+    expect(calls.argv).toContain("--resume-id");
+    expect(calls.argv[calls.argv.indexOf("--resume-id") + 1]).toBe(SID);
+    // resume returns the known id; does NOT re-persist (not a new run)
+    expect(result.sessionId).toBe(SID);
+    expect(setSessionId).not.toHaveBeenCalled();
+  });
+
+  it("feeds reconstructed transcript entries to onMessage via the injected hook (post-run)", async () => {
+    const child = makeFakeChild();
+    const onMessage = vi.fn();
+    const { spawner } = makeSpawner({
+      child,
+      snapshots: [new Map(), new Map([[SID, 200]])],
+    });
+    // Inject a transcript reconstructor (task 4's seam): it pushes two entries.
+    spawner.reconstructTranscript = ({ sessionId, onMessage: om }) => {
+      om?.({ type: "user", message: { role: "user", content: [{ type: "text", text: "hi" }] } });
+      om?.({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: sessionId }] } });
+    };
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true, onMessage });
+    child.emit("close", 0);
+    await p;
+    expect(onMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("never throws and returns exitCode:null when the kiro-cli executable is unresolved", async () => {
+    const child = makeFakeChild();
+    const { spawner, spawnImpl } = makeSpawner({ child, kiroPath: null });
+    spawner.resolveKiroPathFn = () => null;
+    const result = await spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("never throws when spawn itself throws (returns exitCode:null)", async () => {
+    const spawner = new KiroSpawner({
+      kiroPath: "/usr/bin/kiro-cli",
+      spawnImpl: () => {
+        throw new Error("EACCES");
+      },
+      permissionMode: "yolo",
+      creds,
+      platform: "linux",
+      logger: { info() {}, warn() {}, error() {} },
+      getSessionIdFn: () => null,
+      setSessionIdFn: () => {},
+      snapshotSessionsFn: () => new Map(),
+    });
+    const result = await spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("tolerates a thrown onChild without escaping the wake path", async () => {
+    const child = makeFakeChild();
+    const { spawner } = makeSpawner({ child });
+    const p = spawner.wake({
+      prompt: "x",
+      sessionId: ANCHOR,
+      isNew: true,
+      onChild: () => {
+        throw new Error("boom");
+      },
+    });
+    child.emit("close", 0);
+    const result = await p;
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/cli/__tests__/kiro-transcript.test.mjs
+++ b/cli/__tests__/kiro-transcript.test.mjs
@@ -1,0 +1,277 @@
+// cli/__tests__/kiro-transcript.test.mjs
+// Covers daemon-kiro-backend spec "Kiro transcript reconstructed from the session
+// store with a plain-text fallback": store→structured entries with role mapping +
+// text-block filtering, child (subagent) session inclusion via parent_session_id,
+// malformed-line skip, and the plain-text stdout fallback when the store is
+// missing/unparseable. Fixtures use injected readdir/read — no real FS.
+//
+// Schema verified live against kiro-cli 2.12.1 (see kiro-transcript.mjs header).
+import { describe, it, expect, vi } from "vitest";
+import {
+  reconstructTranscript,
+  parseSessionJsonl,
+  extractLineText,
+  collectSessionChain,
+  stripAnsi,
+} from "../kiro-transcript.mjs";
+
+const RUN = "540019be-35ec-4740-8880-a6c83f172646";
+const CHILD = "203811b1-3831-4f81-9934-0b083a78d133";
+const DIR = "/fake/.kiro/sessions/cli";
+
+/** Build one store `.jsonl` line object (as Kiro writes it). */
+function line(kind, blocks) {
+  return JSON.stringify({ version: "v1", kind, data: { message_id: "m", content: blocks } });
+}
+const textBlock = (s) => ({ kind: "text", data: s });
+const thinkingBlock = (s) => ({ kind: "thinking", data: { text: s } });
+const toolUseBlock = () => ({ kind: "toolUse", data: { toolUseId: "t", name: "x", input: {} } });
+
+describe("stripAnsi — clean headless stdout for the plain-text fallback", () => {
+  it("removes CSI color codes, the leading '> ' marker, and trims", () => {
+    // Mirrors a real headless kiro stdout: color codes + `> ` + the answer.
+    const raw = "\x1b[38;5;141m> \x1b[0mHELLO-FROM-KIRO\x1b[0m\n\n";
+    expect(stripAnsi(raw)).toBe("HELLO-FROM-KIRO");
+  });
+  it("removes braille spinner frames", () => {
+    expect(stripAnsi("⢀⠀ working⡀⠀ done")).toBe("working done");
+  });
+  it("collapses 3+ blank lines and tolerates non-string", () => {
+    expect(stripAnsi("a\n\n\n\nb")).toBe("a\n\nb");
+    expect(stripAnsi(null)).toBe("");
+    expect(stripAnsi(undefined)).toBe("");
+  });
+  it("passes clean text through unchanged (modulo trim)", () => {
+    expect(stripAnsi("just plain text")).toBe("just plain text");
+  });
+});
+
+describe("extractLineText — keep only `text` content blocks", () => {
+  it("concatenates text blocks, dropping thinking/toolUse", () => {
+    const data = { content: [thinkingBlock("secret plan"), textBlock("hello "), toolUseBlock(), textBlock("world")] };
+    expect(extractLineText(data)).toBe("hello world");
+  });
+  it("returns '' when there is no text block", () => {
+    expect(extractLineText({ content: [thinkingBlock("x"), toolUseBlock()] })).toBe("");
+  });
+  it("tolerates a bare string content and non-object data", () => {
+    expect(extractLineText({ content: "bare" })).toBe("bare");
+    expect(extractLineText(null)).toBe("");
+    expect(extractLineText({})).toBe("");
+  });
+});
+
+describe("parseSessionJsonl — lines → Claude-dialect envelopes", () => {
+  it("maps Prompt→user, AssistantMessage→assistant; drops ToolResults + empty", () => {
+    const raw = [
+      line("Prompt", [textBlock("你好你是谁")]),
+      line("AssistantMessage", [thinkingBlock("plan"), textBlock("I am Kiro.")]),
+      line("ToolResults", [{ kind: "toolResult", data: { status: "ok" } }]),
+      line("AssistantMessage", [toolUseBlock()]), // no text → dropped
+    ].join("\n");
+    const entries = parseSessionJsonl(raw);
+    expect(entries).toEqual([
+      { type: "user", message: { role: "user", content: [{ type: "text", text: "你好你是谁" }] } },
+      { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "I am Kiro." }] } },
+    ]);
+  });
+
+  it("skips blank and malformed lines without throwing (logs)", () => {
+    const logger = { warn: vi.fn(), info() {}, error() {} };
+    const raw = ["", "  ", "{ not json", line("Prompt", [textBlock("ok")])].join("\n");
+    const entries = parseSessionJsonl(raw, logger);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message.content[0].text).toBe("ok");
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});
+
+describe("collectSessionChain — parent first, then children by creation order", () => {
+  const meta = (o) => JSON.stringify(o);
+  function fakeStore(files) {
+    return {
+      dir: DIR,
+      readdir: () => Object.keys(files),
+      read: (p) => {
+        const name = p.slice(DIR.length + 1);
+        if (!(name in files)) {
+          const e = new Error("ENOENT");
+          e.code = "ENOENT";
+          throw e;
+        }
+        return files[name];
+      },
+    };
+  }
+
+  it("includes child sessions matched by parent_session_id, ordered by created_at", () => {
+    const files = {
+      [`${RUN}.json`]: meta({ session_id: RUN, parent_session_id: null, created_at: "2026-07-14T05:00:00Z" }),
+      [`${CHILD}.json`]: meta({ session_id: CHILD, parent_session_id: RUN, created_at: "2026-07-14T05:30:00Z" }),
+      ["aaaa1111-0000-4000-8000-000000000000.json"]: meta({
+        session_id: "aaaa1111-0000-4000-8000-000000000000",
+        parent_session_id: RUN,
+        created_at: "2026-07-14T05:10:00Z",
+      }),
+      // unrelated session (different parent) — must be excluded
+      ["bbbb2222-0000-4000-8000-000000000000.json"]: meta({
+        session_id: "bbbb2222-0000-4000-8000-000000000000",
+        parent_session_id: "someone-else",
+      }),
+    };
+    const chain = collectSessionChain(RUN, fakeStore(files));
+    expect(chain.map((c) => c.sessionId)).toEqual([
+      RUN,
+      "aaaa1111-0000-4000-8000-000000000000", // 05:10 before 05:30
+      CHILD,
+    ]);
+  });
+
+  it("does NOT treat a root session with session_created_reason:subagent as a child (keys on parent_session_id)", () => {
+    // The yolo-root case: reason='subagent' but parent_session_id=null.
+    const files = {
+      [`${RUN}.json`]: meta({ session_id: RUN, parent_session_id: null, session_created_reason: "subagent" }),
+    };
+    const chain = collectSessionChain(RUN, fakeStore(files));
+    expect(chain.map((c) => c.sessionId)).toEqual([RUN]);
+  });
+
+  it("returns just the run session when the store dir is unreadable", () => {
+    const chain = collectSessionChain(RUN, {
+      dir: DIR,
+      readdir: () => {
+        throw new Error("ENOENT");
+      },
+      read: () => "",
+    });
+    expect(chain).toEqual([{ sessionId: RUN, createdAt: 0 }]);
+  });
+});
+
+describe("reconstructTranscript — end-to-end store → onMessage, with fallback", () => {
+  function fakeStore(files) {
+    return {
+      dir: DIR,
+      readdir: () => Object.keys(files),
+      read: (p) => {
+        const name = p.slice(DIR.length + 1);
+        if (!(name in files)) {
+          const e = new Error("ENOENT");
+          e.code = "ENOENT";
+          throw e;
+        }
+        return files[name];
+      },
+    };
+  }
+
+  it("emits parent then child conversation text as Claude-dialect envelopes", () => {
+    const files = {
+      [`${RUN}.json`]: JSON.stringify({ session_id: RUN, parent_session_id: null, created_at: "2026-07-14T05:00:00Z" }),
+      [`${RUN}.jsonl`]: [
+        line("Prompt", [textBlock("run this")]),
+        line("AssistantMessage", [thinkingBlock("hmm"), textBlock("done")]),
+      ].join("\n"),
+      [`${CHILD}.json`]: JSON.stringify({
+        session_id: CHILD,
+        parent_session_id: RUN,
+        created_at: "2026-07-14T05:30:00Z",
+      }),
+      [`${CHILD}.jsonl`]: [line("AssistantMessage", [textBlock("VERDICT: PASS")])].join("\n"),
+    };
+    const onMessage = vi.fn();
+    reconstructTranscript({ sessionId: RUN, onMessage, ...fakeStore(files) });
+    const texts = onMessage.mock.calls.map((c) => c[0].message.content[0].text);
+    expect(texts).toEqual(["run this", "done", "VERDICT: PASS"]);
+    // roles preserved
+    expect(onMessage.mock.calls.map((c) => c[0].type)).toEqual(["user", "assistant", "assistant"]);
+  });
+
+  it("falls back to a plain-text stdout entry when the store jsonl is missing", () => {
+    const files = {
+      // metadata present (so the chain resolves) but NO .jsonl for the run
+      [`${RUN}.json`]: JSON.stringify({ session_id: RUN, parent_session_id: null }),
+    };
+    const onMessage = vi.fn();
+    const logger = { warn: vi.fn(), info() {}, error() {} };
+    reconstructTranscript({ sessionId: RUN, onMessage, stdout: "plain output here", logger, ...fakeStore(files) });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "plain output here" }] },
+    });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("emits nothing (no throw) when the store is missing AND stdout is empty", () => {
+    const onMessage = vi.fn();
+    const logger = { warn: vi.fn(), info() {}, error() {} };
+    reconstructTranscript({
+      sessionId: RUN,
+      onMessage,
+      stdout: "   ",
+      logger,
+      dir: DIR,
+      readdir: () => {
+        throw new Error("ENOENT");
+      },
+      read: () => {
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+    });
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("is a no-op when onMessage is absent", () => {
+    expect(() => reconstructTranscript({ sessionId: RUN, stdout: "x" })).not.toThrow();
+  });
+
+  it("headless case: no session persisted → ANSI-styled stdout falls back to ONE clean entry", () => {
+    // Reproduces the verified-live daemon path: `chat --no-interactive` writes no
+    // store session, so the chain has no jsonl and the ANSI stdout is the transcript.
+    const files = { [`${RUN}.json`]: JSON.stringify({ session_id: RUN, parent_session_id: null }) };
+    const onMessage = vi.fn();
+    reconstructTranscript({
+      sessionId: RUN,
+      onMessage,
+      stdout: "\x1b[38;5;141m> \x1b[0mHELLO-FROM-KIRO\x1b[0m\n\n",
+      ...fakeStore(files),
+    });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0].message.content[0].text).toBe("HELLO-FROM-KIRO");
+  });
+
+  it("fires the fallback even when sessionId is empty (no id captured on a headless run)", () => {
+    const onMessage = vi.fn();
+    reconstructTranscript({
+      sessionId: "",
+      onMessage,
+      stdout: "plain answer",
+      dir: DIR,
+      readdir: () => {
+        throw new Error("ENOENT");
+      },
+      read: () => {
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+    });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0].message.content[0].text).toBe("plain answer");
+  });
+
+  it("falls back to plain text when the store has only non-text (tool) content", () => {
+    const files = {
+      [`${RUN}.json`]: JSON.stringify({ session_id: RUN, parent_session_id: null }),
+      [`${RUN}.jsonl`]: [line("AssistantMessage", [toolUseBlock()]), line("ToolResults", [])].join("\n"),
+    };
+    const onMessage = vi.fn();
+    reconstructTranscript({ sessionId: RUN, onMessage, stdout: "fallback text", ...fakeStore(files) });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0].message.content[0].text).toBe("fallback text");
+  });
+});

--- a/cli/__tests__/spawner-select.test.mjs
+++ b/cli/__tests__/spawner-select.test.mjs
@@ -1,11 +1,13 @@
 // cli/__tests__/spawner-select.test.mjs
 // Covers daemon-spawner-interface spec: the daemon selects which spawner backend
 // to inject from the resolved agent type. claude-code → ClaudeSpawner (unchanged
-// construction); codex → CodexSpawner. Both satisfy the same wake(...) contract.
+// construction); codex → CodexSpawner; kiro → KiroSpawner. All satisfy the same
+// wake(...) contract.
 import { describe, it, expect } from "vitest";
 import { selectSpawner } from "../spawner-select.mjs";
 import { ClaudeSpawner } from "../claude-spawner.mjs";
 import { CodexSpawner } from "../codex-spawner.mjs";
+import { KiroSpawner } from "../kiro-spawner.mjs";
 
 const logger = { info() {}, warn() {}, error() {} };
 const creds = { url: "https://example.test", apiKey: "cho_test" };
@@ -21,9 +23,20 @@ describe("selectSpawner", () => {
     expect(s).toBeInstanceOf(CodexSpawner);
   });
 
+  it("returns a KiroSpawner for kiro", () => {
+    const s = selectSpawner("kiro", { logger, permissionMode: "yolo", creds });
+    expect(s).toBeInstanceOf(KiroSpawner);
+  });
+
   it("threads permissionMode into the selected spawner", () => {
     expect(selectSpawner("claude-code", { logger, permissionMode: "chorus", creds }).permissionMode).toBe("chorus");
     expect(selectSpawner("codex", { logger, permissionMode: "yolo", creds }).permissionMode).toBe("yolo");
+    expect(selectSpawner("kiro", { logger, permissionMode: "chorus", creds }).permissionMode).toBe("chorus");
+  });
+
+  it("threads creds into the KiroSpawner (Codex-style: MCP from plugin config + daemon key via env)", () => {
+    const s = selectSpawner("kiro", { logger, permissionMode: "yolo", creds });
+    expect(s.creds).toEqual(creds);
   });
 
   it("defaults to claude-code when the agent type is unrecognized (no throw — selection is post-validation)", () => {
@@ -33,10 +46,12 @@ describe("selectSpawner", () => {
     expect(s).toBeInstanceOf(ClaudeSpawner);
   });
 
-  it("both backends expose a wake() method (shared contract)", () => {
+  it("all backends expose a wake() method (shared contract)", () => {
     const c = selectSpawner("claude-code", { logger, permissionMode: "yolo", creds });
     const x = selectSpawner("codex", { logger, permissionMode: "yolo", creds });
+    const k = selectSpawner("kiro", { logger, permissionMode: "yolo", creds });
     expect(typeof c.wake).toBe("function");
     expect(typeof x.wake).toBe("function");
+    expect(typeof k.wake).toBe("function");
   });
 });

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -13,10 +13,11 @@
  */
 export const DAEMON_ACTIONS = new Set(["stop", "status", "restart", "logs", "install", "uninstall"]);
 
-/** Known agent backends. Only `claude-code` is implemented; the rest reserve
- * the extension point (see daemon-agent-selection). Exported for the resolver
- * the --agent task wires in; parsing here does not validate the value. */
-export const KNOWN_AGENTS = new Set(["claude-code"]);
+/** Known agent backends, kept in sync with the authoritative list in
+ * daemon-agent.mjs (`claude-code`, `codex`, `kiro` — all implemented). This copy
+ * is informational only: parsing here does not validate the value (the resolver
+ * in daemon-agent.mjs is the single source of truth for validation). */
+export const KNOWN_AGENTS = new Set(["claude-code", "codex", "kiro"]);
 
 /**
  * Parse the client-subcommand flags out of an arg list. Recognizes the
@@ -117,7 +118,7 @@ OPTIONS
   --url <url>              Remote Chorus server URL            (env: CHORUS_URL)
   --api-key <cho_...>      Agent API key                       (env: CHORUS_API_KEY)
   --agent <type>           Local agent backend to wake         (env: CHORUS_AGENT)
-                           (claude-code | codex; default: claude-code)
+                           (claude-code | codex | kiro; default: claude-code)
   --yolo                   Full autonomy for the woken agent   (env: CHORUS_YOLO=1)
                            (--dangerously-skip-permissions: Bash, file writes, any
                            command). This is the DEFAULT permission mode.

--- a/cli/codex-session-map.mjs
+++ b/cli/codex-session-map.mjs
@@ -5,60 +5,18 @@
 // keyed by the Chorus session anchor (direct idea uuid, or the entity uuid for an
 // ad-hoc session) and `codex exec resume <thread_id>` on the next wake.
 //
-// The store is a single JSON object `{ "<anchor>": "<thread_id>" }` at
-// ~/.chorus/codex-sessions.json (same dir family as daemon.json). The anchor is a
-// globally-unique Chorus uuid, so one flat file is safe across the daemon's
-// multiple path-connections.
-//
-// CONTRACT: this is best-effort and MUST NEVER throw into the wake path. Any
-// read/parse/write/rename failure degrades to "no mapping → next wake starts
-// fresh" with a visible log (no-silent-errors). IO is injectable for tests.
+// Thin wrapper over the generic `createSessionMap` factory (shared with the Kiro
+// backend); the store is ~/.chorus/codex-sessions.json. The public API
+// (getThreadId / setThreadId / codexSessionMapPath) and its injectable-IO deps are
+// unchanged — see session-map.mjs for the best-effort / never-throw contract.
 
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { createSessionMap } from "./session-map.mjs";
 
-const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+const map = createSessionMap({ filename: "codex-sessions.json", logPrefix: "codex-session-map" });
 
 /** Absolute path to the Codex session-id map, alongside ~/.chorus/daemon.json. */
 export function codexSessionMapPath() {
-  return join(homedir(), ".chorus", "codex-sessions.json");
-}
-
-/** A non-empty trimmed string, or null. */
-function nonEmpty(value) {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
-}
-
-/**
- * Read the whole map as a plain object. Missing / unreadable / malformed file →
- * `{}` (never throws). A non-object JSON value (array / scalar) is also treated
- * as empty.
- * @param {string} path
- * @param {(p: string) => string} read
- * @param {{warn(m:string):void}} logger
- * @returns {Record<string, unknown>}
- */
-function readMap(path, read, logger) {
-  let raw;
-  try {
-    raw = read(path);
-  } catch (err) {
-    // ENOENT is the normal "no map yet" case — silent. Other read errors warn.
-    if (!(err && err.code === "ENOENT")) {
-      logger.warn(`[Chorus] codex-session-map: read failed (${err}) — treating as empty`);
-    }
-    return {};
-  }
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
-    logger.warn("[Chorus] codex-session-map: file is not a JSON object — treating as empty");
-    return {};
-  } catch (err) {
-    logger.warn(`[Chorus] codex-session-map: corrupt JSON (${err}) — treating as empty`);
-    return {};
-  }
+  return map.mapPath();
 }
 
 /**
@@ -69,13 +27,7 @@ function readMap(path, read, logger) {
  * @returns {string | null}
  */
 export function getThreadId(anchor, deps = {}) {
-  const a = nonEmpty(anchor);
-  if (!a) return null;
-  const path = deps.path ?? codexSessionMapPath();
-  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
-  const logger = deps.logger ?? NOOP_LOGGER;
-  const map = readMap(path, read, logger);
-  return nonEmpty(map[a]);
+  return map.get(anchor, deps);
 }
 
 /**
@@ -91,27 +43,5 @@ export function getThreadId(anchor, deps = {}) {
  * @returns {void}
  */
 export function setThreadId(anchor, threadId, deps = {}) {
-  const a = nonEmpty(anchor);
-  const t = nonEmpty(threadId);
-  if (!a || !t) return; // nothing meaningful to persist
-  const path = deps.path ?? codexSessionMapPath();
-  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
-  const write = deps.write ?? writeFileSync;
-  const mkdir = deps.mkdir ?? mkdirSync;
-  const rename = deps.rename ?? renameSync;
-  const logger = deps.logger ?? NOOP_LOGGER;
-
-  try {
-    const map = readMap(path, read, logger);
-    map[a] = t;
-    mkdir(dirname(path), { recursive: true });
-    // Atomic write: temp file (0600) in the same dir, then rename over target,
-    // so a crash mid-write never truncates the live map.
-    const tmp = `${path}.tmp`;
-    write(tmp, JSON.stringify(map, null, 2) + "\n", { mode: 0o600 });
-    rename(tmp, path);
-  } catch (err) {
-    // Best-effort: a failed persist just means the next wake starts fresh.
-    logger.warn(`[Chorus] codex-session-map: failed to persist ${a}→${t} (${err}) — wake will start fresh next time`);
-  }
+  map.set(anchor, threadId, deps);
 }

--- a/cli/daemon-agent.mjs
+++ b/cli/daemon-agent.mjs
@@ -1,12 +1,14 @@
 // cli/daemon-agent.mjs
 // Pure resolution + validation of the daemon's `--agent <type>` selection.
-// `claude-code` (the default) and `codex` are both implemented backends
-// (add-daemon-codex-backend cashed in the reserved `codex` slot). Resolving an
-// unknown value is a hard error (no silent fallback). Zero dependencies.
+// `claude-code` (the default), `codex`, and `kiro` are all implemented backends
+// (add-daemon-codex-backend cashed in the reserved `codex` slot;
+// add-daemon-kiro-backend adds `kiro`). Resolving an unknown value is a hard
+// error (no silent fallback). Zero dependencies.
 
-/** The agent backends the daemon recognizes. Both are implemented (claude-code
- * via ClaudeSpawner, codex via CodexSpawner — see spawner-select.mjs). */
-export const KNOWN_AGENTS = ["claude-code", "codex"];
+/** The agent backends the daemon recognizes. All are implemented (claude-code
+ * via ClaudeSpawner, codex via CodexSpawner, kiro via KiroSpawner — see
+ * spawner-select.mjs). */
+export const KNOWN_AGENTS = ["claude-code", "codex", "kiro"];
 
 /** The default agent backend when neither --agent nor CHORUS_AGENT is set. */
 export const DEFAULT_AGENT = "claude-code";
@@ -21,6 +23,7 @@ export const DEFAULT_AGENT = "claude-code";
  */
 export function backendCli(agentType) {
   if (agentType === "codex") return { name: "codex", envVar: "CHORUS_CODEX_PATH" };
+  if (agentType === "kiro") return { name: "kiro-cli", envVar: "CHORUS_KIRO_PATH" };
   return { name: "claude", envVar: "CHORUS_CLAUDE_PATH" };
 }
 
@@ -33,7 +36,9 @@ export function backendCli(agentType) {
  * @returns {string}
  */
 export function backendClientType(agentType) {
-  return agentType === "codex" ? "codex" : "claude_code";
+  if (agentType === "codex") return "codex";
+  if (agentType === "kiro") return "kiro";
+  return "claude_code";
 }
 
 /**

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -29,6 +29,7 @@ import { Waker } from "./waker.mjs";
 import { LineageResolver } from "./lineage.mjs";
 import { resolveClaudePath } from "./claude-spawner.mjs";
 import { resolveCodexPath } from "./codex-spawner.mjs";
+import { resolveKiroPath } from "./kiro-spawner.mjs";
 import { selectSpawner } from "./spawner-select.mjs";
 import {
   createExecutionUploadHooks,
@@ -484,6 +485,7 @@ export async function runDaemon(flags = {}, deps = {}) {
   // banner shows the right binary instead of always probing for `claude`.
   const findClaude = deps.resolveClaudePath ?? resolveClaudePath;
   const findCodex = deps.resolveCodexPath ?? resolveCodexPath;
+  const findKiro = deps.resolveKiroPath ?? resolveKiroPath;
   const verbose = flags.verbose === true || env.CHORUS_VERBOSE === "1";
 
   // Resolve the agent backend (default claude-code). An unknown --agent /
@@ -557,10 +559,12 @@ export async function runDaemon(flags = {}, deps = {}) {
 
   // Detect the SELECTED backend's executable (non-fatal): the daemon still
   // subscribes when it's missing; a wake surfaces the error visibly when one
-  // arrives. The resolved path (or absence) is shown in the banner below. codex
-  // → resolveCodexPath, otherwise resolveClaudePath — so a `--agent codex` run
-  // probes (and the banner reports) `codex`, not `claude`.
-  const cliPath = agentType === "codex" ? findCodex() : findClaude();
+  // arrives. The resolved path (or absence) is shown in the banner below. Each
+  // backend probes its own binary — codex → resolveCodexPath, kiro →
+  // resolveKiroPath, otherwise resolveClaudePath — so a `--agent kiro` run probes
+  // (and the banner reports) `kiro-cli`, not `claude`.
+  const cliPath =
+    agentType === "codex" ? findCodex() : agentType === "kiro" ? findKiro() : findClaude();
 
   // The daemon.json the layered config readers (credentials, sigint timeout, cwds)
   // consult. Surfacing its absolute path + presence in the banner makes it obvious

--- a/cli/kiro-session-map.mjs
+++ b/cli/kiro-session-map.mjs
@@ -1,0 +1,49 @@
+// cli/kiro-session-map.mjs
+// Daemon-local persistence of the Kiro `anchor → sessionId` map. Kiro GENERATES
+// its own per-cwd conversation sessionId (unlike Claude, which accepts a
+// client-supplied --session-id), and the daemon works one repo cwd shared by many
+// ideas — so Kiro's native "resume most recent conversation from this directory"
+// would cross-contaminate ideas. Instead we record the generated sessionId keyed
+// by the Chorus session anchor (direct idea uuid, or the entity uuid for an ad-hoc
+// session) and `kiro-cli chat --no-interactive --resume-id <sessionId>` on the
+// next wake for that anchor.
+//
+// Thin wrapper over the generic `createSessionMap` factory (shared with the Codex
+// backend); the store is ~/.chorus/kiro-sessions.json. See session-map.mjs for the
+// best-effort / never-throw contract and the injectable-IO deps.
+
+import { createSessionMap } from "./session-map.mjs";
+
+const map = createSessionMap({ filename: "kiro-sessions.json", logPrefix: "kiro-session-map" });
+
+/** Absolute path to the Kiro session-id map, alongside ~/.chorus/daemon.json. */
+export function kiroSessionMapPath() {
+  return map.mapPath();
+}
+
+/**
+ * Look up the Kiro sessionId recorded for `anchor`, or null when there is none
+ * (no file, no entry, or a non-string entry). Never throws.
+ * @param {string} anchor
+ * @param {{ path?: string, read?: (p: string) => string, logger?: any }} [deps]
+ * @returns {string | null}
+ */
+export function getSessionId(anchor, deps = {}) {
+  return map.get(anchor, deps);
+}
+
+/**
+ * Record `anchor → sessionId`, preserving every other entry. Atomic (temp file +
+ * rename). Best-effort: a blank anchor/sessionId is ignored (no write), and any
+ * IO failure is logged and swallowed — it never throws into the wake path.
+ * @param {string} anchor
+ * @param {string} sessionId
+ * @param {{ path?: string, read?: (p: string) => string,
+ *           write?: (p: string, c: string, o?: object) => void,
+ *           mkdir?: (p: string, o?: object) => void,
+ *           rename?: (from: string, to: string) => void, logger?: any }} [deps]
+ * @returns {void}
+ */
+export function setSessionId(anchor, sessionId, deps = {}) {
+  map.set(anchor, sessionId, deps);
+}

--- a/cli/kiro-spawner.mjs
+++ b/cli/kiro-spawner.mjs
@@ -1,0 +1,409 @@
+// cli/kiro-spawner.mjs
+// Cross-platform headless Amazon Kiro CLI spawner — the `kiro` counterpart to
+// ClaudeSpawner / CodexSpawner, satisfying the SAME backend-agnostic
+// Spawner.wake(...) contract so the daemon's wake pipeline (queue, waker,
+// directed delivery, headless guard, reporters) stays backend-neutral.
+//
+// Kiro diverges from BOTH Claude and Codex (verified against kiro-cli 2.12.1 +
+// the live CLI/store on this host):
+//   • `kiro-cli chat --no-interactive` runs a headless turn; the prompt is read
+//     from STDIN (never argv). It runs under the `chorus` agent profile
+//     (`--agent chorus`) so the woken session loads the Kiro plugin's Chorus MCP
+//     server + AI-DLC skills + steering (parity with an interactive plugin user).
+//   • Kiro GENERATES its own per-cwd `sessionId` (like Codex's thread_id, unlike
+//     Claude's client-supplied --session-id) — BUT there is NO id-bearing stream
+//     event (Kiro emits plain text/markdown on stdout; `--format json` is
+//     list-commands-only). So we capture the id POST-RUN by diffing the session
+//     store, and persist anchor→sessionId (kiro-session-map.mjs) so a later wake
+//     can `--resume-id <sessionId>`.
+//   • No `--mcp-config`: MCP comes from the plugin's .kiro/settings/mcp.json
+//     (loaded via --agent chorus), which references ${env:CHORUS_API_KEY}; the
+//     daemon key reaches it via that env var — never argv.
+//   • Permission is a TOOL-TRUST posture (--trust-all-tools / --trust-tools=…),
+//     not a sandbox mode and not a per-tool allowlist.
+//
+// Transcript capture (task 4) is layered on top: this spawner reads the session
+// store for the run's sessionId post-run and, if a `reconstructTranscript` hook is
+// injected, feeds the reconstructed entries to `onMessage`; otherwise it is a
+// no-op here (this task owns spawn/resume/trust/interrupt + sessionId capture).
+
+import { spawn } from "node:child_process";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { win32 as pathWin32, posix as pathPosix, join } from "node:path";
+import { getSessionId as defaultGetSessionId, setSessionId as defaultSetSessionId } from "./kiro-session-map.mjs";
+import { reconstructTranscript as defaultReconstructTranscript } from "./kiro-transcript.mjs";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/** Directory Kiro persists its CLI session store under (per-cwd conversations). */
+export function kiroSessionsDir() {
+  return join(homedir(), ".kiro", "sessions", "cli");
+}
+
+/**
+ * Map the daemon's backend-agnostic permission mode to a Kiro tool-trust posture.
+ * A headless turn can never answer an approval prompt, so trust must be granted
+ * upfront:
+ *   yolo   → --trust-all-tools               (full autonomy for code-writing work)
+ *   chorus → --trust-tools=fs_read,@chorus   (read-only filesystem + the Chorus
+ *            MCP server's tools; no shell exec / file writes). MCP tools are
+ *            namespaced by server in Kiro, so `@chorus` trusts the whole Chorus
+ *            server (verified against the plugin's agent def — matcher `@chorus`).
+ * Anything other than yolo falls back to the restricted posture.
+ * @param {"yolo"|"chorus"|undefined} permissionMode
+ * @returns {string[]}
+ */
+export function trustFlags(permissionMode) {
+  if (permissionMode === "yolo") return ["--trust-all-tools"];
+  return ["--trust-tools=fs_read,@chorus"];
+}
+
+/**
+ * Build the argv for a headless kiro-cli run. Prompt is NEVER here — it goes over
+ * stdin. Runs under the `chorus` agent profile on the default v2 engine (no
+ * `--v3`). A resume passes the recorded sessionId via `--resume-id`.
+ * @param {{ isNew: boolean, sessionId?: string|null, permissionMode?: "yolo"|"chorus" }} o
+ * @returns {string[]}
+ */
+export function buildKiroArgs({ isNew, sessionId, permissionMode }) {
+  const trust = trustFlags(permissionMode);
+  const base = ["chat", "--no-interactive", "--agent", "chorus", ...trust];
+  if (!isNew && sessionId) {
+    return ["chat", "--no-interactive", "--resume-id", sessionId, "--agent", "chorus", ...trust];
+  }
+  return base;
+}
+
+/**
+ * Resolve the real `kiro-cli` executable WITHOUT a shell — same approach as
+ * resolveCodexPath. On Windows the bin may be `kiro-cli.cmd` (npm shim), which
+ * `spawn` can't exec directly without shell:true; we walk PATH for the platform
+ * candidates. `CHORUS_KIRO_PATH` overrides.
+ * @param {{ env?: NodeJS.ProcessEnv, platform?: NodeJS.Platform, isFile?: (p: string) => boolean }} [deps]
+ * @returns {string | null}
+ */
+export function resolveKiroPath(deps = {}) {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const isFile =
+    deps.isFile ??
+    ((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+  if (env.CHORUS_KIRO_PATH && isFile(env.CHORUS_KIRO_PATH)) {
+    return env.CHORUS_KIRO_PATH;
+  }
+
+  const isWin = platform === "win32";
+  const p = isWin ? pathWin32 : pathPosix;
+  const names = isWin ? ["kiro-cli.cmd", "kiro-cli.exe", "kiro-cli"] : ["kiro-cli"];
+  const pathVar = env.PATH || env.Path || "";
+  const dirs = pathVar.split(p.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = p.join(dir, name);
+      if (isFile(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the actual command + argv to spawn. On Windows a `.cmd`/`.bat` shim is
+ * not a PE executable, so it must run via `cmd.exe /d /s /c <path> ...args`; we
+ * keep shell:false and pass argv as an array (no shell word-splitting/injection).
+ * @param {string} kiroPath @param {string[]} args
+ * @param {NodeJS.Platform} [platform] @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ command: string, argv: string[] }}
+ */
+export function resolveSpawnCommand(kiroPath, args, platform = process.platform, env = process.env) {
+  const isWin = platform === "win32";
+  const lower = kiroPath.toLowerCase();
+  if (isWin && (lower.endsWith(".cmd") || lower.endsWith(".bat"))) {
+    const comspec = env.ComSpec || env.COMSPEC || "cmd.exe";
+    return { command: comspec, argv: ["/d", "/s", "/c", kiroPath, ...args] };
+  }
+  return { command: kiroPath, argv: args };
+}
+
+/**
+ * Snapshot the session store as a map of `sessionId → updatedAtMillis` for the
+ * given cwd. Kiro writes `<sessionsDir>/<sessionId>.json` metadata files carrying
+ * `{ session_id, cwd, updated_at, ... }`. Best-effort: any IO/parse failure yields
+ * an empty map (never throws) — a missed capture just means the run isn't
+ * resumable, logged by the caller.
+ * @param {string} cwd
+ * @param {{ dir?: string, readdir?: (d: string) => string[], read?: (p: string) => string, logger?: any }} [deps]
+ * @returns {Map<string, number>}
+ */
+export function snapshotSessions(cwd, deps = {}) {
+  const dir = deps.dir ?? kiroSessionsDir();
+  const readdir = deps.readdir ?? ((d) => readdirSync(d));
+  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
+  const logger = deps.logger ?? NOOP_LOGGER;
+  const out = new Map();
+  let files;
+  try {
+    files = readdir(dir);
+  } catch (err) {
+    if (!(err && err.code === "ENOENT")) {
+      logger.warn(`[Chorus] kiro session snapshot: readdir failed (${err}) — treating as empty`);
+    }
+    return out;
+  }
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue; // .jsonl / .history are not the metadata file
+    let meta;
+    try {
+      meta = JSON.parse(read(join(dir, f)));
+    } catch {
+      continue; // skip an unreadable/partial metadata file
+    }
+    if (!meta || typeof meta !== "object") continue;
+    const sid = typeof meta.session_id === "string" ? meta.session_id : f.replace(/\.json$/, "");
+    // Scope to this daemon's cwd so a concurrent run in a different cwd can't be
+    // mis-attributed. When cwd is unknown, accept all (single-path daemon).
+    if (cwd && typeof meta.cwd === "string" && meta.cwd !== cwd) continue;
+    const updated = Date.parse(meta.updated_at ?? meta.updatedAt ?? "") || 0;
+    out.set(sid, updated);
+  }
+  return out;
+}
+
+/**
+ * Decide the run's sessionId by diffing a before/after store snapshot, UNAMBIGUOUSLY.
+ *
+ * Concurrency (reviewer N1): the WakeQueue serializes wakes per idea-key but runs
+ * DIFFERENT keys concurrently (default maxConcurrency 4), and all keys share the
+ * daemon's single repo cwd — so two fresh Kiro runs can be in flight in the same
+ * cwd at once. A "newest new id wins" heuristic would then mis-attribute one run's
+ * sessionId to the other's anchor. To stay correct we require the id to be
+ * UNAMBIGUOUS: return the new id ONLY when EXACTLY ONE brand-new id appeared in the
+ * window (present in `after`, absent in `before`). If zero or several new ids
+ * appeared, return null — the caller degrades to "not resumable this time" (a
+ * missed resume is a minor efficiency loss; a wrong resume would cross-wire two
+ * ideas' conversations, which is a correctness bug). No "updated_at advanced"
+ * fallback: on a fresh run the id is always new-to-the-store; on a resume the
+ * caller already knows the id and never calls this.
+ * @param {Map<string, number>} before @param {Map<string, number>} after
+ * @returns {string|null}
+ */
+export function pickNewSessionId(before, after) {
+  const fresh = [];
+  for (const sid of after.keys()) {
+    if (!before.has(sid)) fresh.push(sid);
+  }
+  // Exactly one new session created in this run's window → unambiguous.
+  return fresh.length === 1 ? fresh[0] : null;
+}
+
+/**
+ * @typedef {Object} KiroSpawnerOptions
+ * @property {string} [kiroPath]   Resolved kiro-cli path (resolved lazily if omitted).
+ * @property {(o: object) => any} [spawnImpl]   Injectable spawn (tests).
+ * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
+ * @property {"chorus"|"yolo"} [permissionMode]  Maps to a Kiro tool-trust posture.
+ * @property {{ url: string, apiKey: string }} [creds]  Daemon creds — apiKey is exported
+ *   into the child env as CHORUS_API_KEY (the var the plugin's .kiro/settings/mcp.json references).
+ * @property {NodeJS.Platform} [platform]  Injectable for tests; gates POSIX `detached`.
+ * @property {(anchor: string) => string|null} [getSessionIdFn]  Injectable session-map read.
+ * @property {(anchor: string, id: string) => void} [setSessionIdFn]  Injectable session-map write.
+ * @property {(cwd: string) => Map<string, number>} [snapshotSessionsFn]  Injectable store snapshot.
+ * @property {(o: {sessionId: string, cwd: string, onMessage?: Function, stdout: string, logger: any}) => void} [reconstructTranscript]
+ *   Injectable transcript reconstruction (task 4) — invoked post-run; a no-op if absent.
+ */
+
+export class KiroSpawner {
+  /** @param {KiroSpawnerOptions} [opts] */
+  constructor(opts = {}) {
+    this.kiroPath = opts.kiroPath ?? null;
+    this.spawnImpl = opts.spawnImpl ?? spawn;
+    this.logger = opts.logger ?? NOOP_LOGGER;
+    this.permissionMode = opts.permissionMode ?? "chorus";
+    this.creds = opts.creds ?? null;
+    this.platform = opts.platform ?? process.platform;
+    this.getSessionIdFn = opts.getSessionIdFn ?? defaultGetSessionId;
+    this.setSessionIdFn = opts.setSessionIdFn ?? defaultSetSessionId;
+    this.resolveKiroPathFn = opts.resolveKiroPathFn ?? resolveKiroPath;
+    this.snapshotSessionsFn = opts.snapshotSessionsFn ?? snapshotSessions;
+    // Post-run transcript reconstruction from Kiro's on-disk session store (task 4).
+    // Defaults to the real reader; injectable/nullable for tests.
+    this.reconstructTranscript =
+      opts.reconstructTranscript === undefined ? defaultReconstructTranscript : opts.reconstructTranscript;
+  }
+
+  /**
+   * Spawn a headless Kiro run. Resolves when the subprocess exits. The prompt is
+   * written to stdin (never argv). `sessionId` is the Chorus anchor (direct idea
+   * uuid, or entity uuid). Kiro owns its session id, so we IGNORE the passed
+   * `isNew`/`mcpConfigPath` and decide new-vs-resume from the persisted
+   * anchor→sessionId map: a recorded id → `--resume-id`, otherwise a fresh run.
+   *
+   * @param {{ prompt: string, sessionId: string|null, isNew?: boolean, mcpConfigPath?: string,
+   *           cwd?: string, onMessage?: (obj: any) => void,
+   *           onChild?: (child: import("node:child_process").ChildProcess) => void }} params
+   * @returns {Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }>}
+   */
+  async wake({ prompt, sessionId, cwd, onMessage, onChild }) {
+    const anchor = typeof sessionId === "string" ? sessionId : "";
+    const runCwd = cwd ?? process.cwd();
+
+    // new-vs-resume is OWNED by this backend (Kiro session model), not the waker's
+    // Claude transcript probe: a recorded sessionId means resume via --resume-id.
+    const knownSessionId = anchor ? this.getSessionIdFn(anchor) : null;
+    const isNew = !knownSessionId;
+
+    const kiroPath = this.kiroPath ?? this.resolveKiroPathFn();
+    if (!kiroPath) {
+      // No crash — surface visibly and resolve with a failure result.
+      this.logger.error("[Chorus] cannot locate the `kiro-cli` executable on PATH; skipping wake");
+      return { sessionId: anchor, exitCode: null, isNew };
+    }
+
+    const args = buildKiroArgs({ isNew, sessionId: knownSessionId, permissionMode: this.permissionMode });
+    const { command, argv } = resolveSpawnCommand(kiroPath, args, this.platform);
+
+    // POSIX: detached process group so the interrupt path can group-kill the tree
+    // (kiro-cli forks child shells for tools). Windows uses taskkill /T. stdio
+    // stays piped — prompt over stdin + stdout capture are unaffected.
+    const detached = this.platform !== "win32";
+
+    // Daemon key via ENV as CHORUS_API_KEY — the var the plugin's
+    // [mcpServers.chorus] header references (${env:CHORUS_API_KEY}). NEVER argv.
+    // Merged over the inherited env so PATH / model auth / KIRO_* survive.
+    const childEnv = { ...process.env, CHORUS_DAEMON_HEADLESS: "1" };
+    if (this.creds && this.creds.apiKey) childEnv.CHORUS_API_KEY = this.creds.apiKey;
+
+    // Snapshot the session store BEFORE the run so we can identify the sessionId
+    // this run creates (Kiro has no id-bearing stream event). On resume we already
+    // know the id, so the snapshot is only needed for a fresh run.
+    const before = isNew ? this.#safeSnapshot(runCwd) : new Map();
+
+    return new Promise((resolve) => {
+      let child;
+      try {
+        child = this.spawnImpl(command, argv, {
+          cwd: runCwd,
+          stdio: ["pipe", "pipe", "pipe"],
+          env: childEnv,
+          shell: false,
+          detached,
+          windowsHide: true,
+        });
+      } catch (err) {
+        this.logger.error(`[Chorus] failed to spawn kiro-cli: ${err}`);
+        resolve({ sessionId: anchor, exitCode: null, isNew });
+        return;
+      }
+
+      // Hand the live child to the caller (interrupt registry) before resolving.
+      // Never let a throwing callback escape into the spawn path.
+      if (onChild) {
+        try {
+          onChild(child);
+        } catch (err) {
+          this.logger.warn(`[Chorus] onChild handler threw: ${err}`);
+        }
+      }
+
+      let stdoutBuf = "";
+
+      child.stdout?.setEncoding?.("utf8");
+      child.stdout?.on("data", (chunk) => {
+        stdoutBuf += String(chunk);
+      });
+
+      child.stderr?.setEncoding?.("utf8");
+      child.stderr?.on("data", (chunk) => {
+        const text = String(chunk).trim();
+        if (text) this.logger.warn(`[Chorus] kiro-cli stderr: ${text}`);
+      });
+
+      child.on("error", (err) => {
+        this.logger.error(`[Chorus] kiro-cli process error: ${err}`);
+        resolve({ sessionId: knownSessionId || anchor, exitCode: null, isNew });
+      });
+
+      child.on("close", (code) => {
+        if (code !== 0) {
+          this.logger.warn(`[Chorus] kiro-cli exited with code ${code}`);
+        }
+
+        // Resolve the run's sessionId. On resume it's the id we passed; on a fresh
+        // run, diff the store snapshot to find the newly-created conversation.
+        let observedSessionId = knownSessionId || null;
+        if (isNew && code === 0) {
+          const after = this.#safeSnapshot(runCwd);
+          const found = pickNewSessionId(before, after);
+          if (found) {
+            observedSessionId = found;
+            if (anchor) this.setSessionIdFn(anchor, found);
+          } else {
+            // Zero or MULTIPLE new sessions in the window (e.g. a concurrent wake
+            // in the same cwd — reviewer N1). We refuse to guess: not persisting
+            // means a missed resume next time (minor), whereas guessing could
+            // cross-wire two ideas' conversations (a correctness bug).
+            this.logger.warn(
+              "[Chorus] kiro wake: run sessionId ambiguous or absent in the store " +
+                "(0 or >1 new sessions this window) — not persisting; next wake starts fresh"
+            );
+          }
+        }
+
+        // Transcript reconstruction (task 4) — post-run, best-effort. Runs even
+        // when no sessionId was captured: `kiro-cli chat --no-interactive` does NOT
+        // persist a session to the cli store (verified live on 2.12.1 — only
+        // interactive/TUI runs do), so the store path finds nothing and the
+        // reconstructor falls back to the raw `stdout` blob (the authorized option-1
+        // fallback). Gating this on `observedSessionId` would suppress that fallback
+        // and leave headless turns with an empty transcript. Never throws into the
+        // wake path (the reconstructor is also internally wrapped).
+        if (this.reconstructTranscript) {
+          try {
+            this.reconstructTranscript({
+              sessionId: observedSessionId ?? "",
+              cwd: runCwd,
+              onMessage,
+              stdout: stdoutBuf,
+              logger: this.logger,
+            });
+          } catch (err) {
+            this.logger.warn(`[Chorus] kiro transcript reconstruction threw (ignored): ${err}`);
+          }
+        }
+
+        resolve({ sessionId: observedSessionId || anchor, exitCode: code, isNew });
+      });
+
+      // Guard against an ASYNC stdin error (EPIPE) so it never becomes an
+      // uncaughtException that kills the daemon.
+      child.stdin?.on?.("error", (err) => {
+        this.logger.warn(`[Chorus] kiro-cli stdin error (ignored): ${err}`);
+      });
+
+      // Feed the prompt over stdin, then close it so the model runs.
+      try {
+        child.stdin?.write(prompt);
+        child.stdin?.end();
+      } catch (err) {
+        this.logger.warn(`[Chorus] failed writing prompt to kiro-cli stdin: ${err}`);
+      }
+    });
+  }
+
+  /** Snapshot the store, swallowing any failure (best-effort id capture). */
+  #safeSnapshot(cwd) {
+    try {
+      return this.snapshotSessionsFn(cwd, { logger: this.logger });
+    } catch (err) {
+      this.logger.warn(`[Chorus] kiro session snapshot failed (${err}) — id capture degraded`);
+      return new Map();
+    }
+  }
+}

--- a/cli/kiro-transcript.mjs
+++ b/cli/kiro-transcript.mjs
@@ -1,0 +1,262 @@
+// cli/kiro-transcript.mjs
+// Transcript reconstruction for the Kiro backend. `kiro-cli chat --no-interactive`
+// emits no structured per-message stream (its `--format json` is list-commands-
+// only), so unlike Claude/Codex there is nothing to parse live off stdout. Instead
+// we reconstruct the transcript POST-RUN from Kiro's on-disk session store, and
+// fall back to a single plain-text stdout blob if the store can't be read. This
+// encodes the human's transcript decision: prefer store reconstruction, fall back
+// to plain text.
+//
+// ⚠️ VERIFIED LIVE (kiro-cli 2.12.1, integration checkpoint): a `chat
+// --no-interactive` run does NOT persist a session to the cli store — only
+// interactive/TUI runs write `~/.kiro/sessions/cli/<id>.{jsonl,json}`. So on the
+// DAEMON's headless path the store lookup normally finds nothing and the
+// PLAIN-TEXT FALLBACK is the effective path. The store-reconstruction path is kept
+// (it is correct and richer) for two reasons: it works if a future Kiro version
+// persists headless sessions, and it captures reviewer-subagent child sessions
+// when they ARE written. The fallback is not a rare degrade here — it is the
+// common case — so it must produce clean text (see stripAnsi below): headless
+// stdout is ANSI-styled with spinner frames, which must be stripped before storing.
+//
+// Store schema (verified live against kiro-cli 2.12.1):
+//   ~/.kiro/sessions/cli/<sessionId>.jsonl  — one JSON object per line:
+//     { version, kind, data: { message_id, content: [ { kind, data }, ... ] } }
+//     kind ∈ { Prompt, AssistantMessage, ToolResults, ... }
+//     A content block's kind ∈ { text, thinking, toolUse, toolResult, ... };
+//     ONLY `text` blocks are conversation text (data is the string) — thinking /
+//     toolUse / toolResult are dropped (parallels the Claude extractor keeping
+//     only `text` content blocks).
+//   ~/.kiro/sessions/cli/<sessionId>.json   — metadata:
+//     { session_id, cwd, updated_at, created_at, parent_session_id,
+//       session_created_reason, ... }
+//     Reviewer subagents get their OWN session with parent_session_id === the
+//     run's sessionId. NOTE: session_created_reason can be "subagent" even on a
+//     root session, so child detection keys on parent_session_id, NOT on the
+//     reason field.
+//
+// Entries are emitted in the CLAUDE stream-json envelope shape
+//   { type: "user"|"assistant", message: { role, content: [ { type:"text", text } ] } }
+// so the existing upload-hooks `extractTranscriptText` consumes them with NO
+// dialect change (it already recognizes that shape).
+//
+// CONTRACT: best-effort, MUST NEVER throw into the wake path (the caller also
+// wraps it in try/catch). Any IO/parse failure degrades — worst case, nothing (or
+// the plain-text fallback) is emitted, with a visible log.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { kiroSessionsDir } from "./kiro-spawner.mjs";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+// `kiro-cli chat --no-interactive` writes ANSI-styled text + braille spinner
+// frames to stdout (it renders for a terminal even headless). Strip them so the
+// plain-text fallback stores clean conversation text, not escape soup.
+//   - CSI sequences: ESC [ … <final byte>
+//   - OSC sequences: ESC ] … (BEL | ESC \)
+//   - braille spinner glyphs U+2800–U+28FF
+//   - a leading "> " prompt marker Kiro prints before the answer
+const ANSI_CSI = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const ANSI_OSC = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+const SPINNER = /[⠀-⣿]/g;
+
+/**
+ * Strip ANSI escapes + spinner frames from a headless-CLI stdout blob and tidy
+ * whitespace. Exported for testing.
+ * @param {string} s
+ * @returns {string}
+ */
+export function stripAnsi(s) {
+  if (typeof s !== "string") return "";
+  let out = s.replace(ANSI_OSC, "").replace(ANSI_CSI, "").replace(SPINNER, "");
+  // Drop a leading "> " answer marker and collapse runs of blank lines.
+  out = out.replace(/^[ \t]*>[ \t]?/gm, "");
+  out = out.replace(/\n{3,}/g, "\n\n");
+  return out.trim();
+}
+
+/** Map a store line's `kind` to a transcript role, or null to skip the line. */
+function roleForKind(kind) {
+  if (kind === "Prompt") return "user";
+  if (kind === "AssistantMessage") return "assistant";
+  return null; // ToolResults / lifecycle / unknown → not conversation text
+}
+
+/**
+ * Concatenate the `text` content blocks of one store line's `data.content[]`,
+ * dropping thinking / toolUse / toolResult / non-text blocks. Returns "" when the
+ * line carries no conversation text.
+ * @param {any} data  the line's `data` object
+ * @returns {string}
+ */
+export function extractLineText(data) {
+  if (!data || typeof data !== "object") return "";
+  const content = data.content;
+  if (typeof content === "string") return content; // defensive: bare string
+  if (!Array.isArray(content)) return "";
+  const parts = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && block.kind === "text" && typeof block.data === "string") {
+      parts.push(block.data);
+    }
+  }
+  return parts.join("");
+}
+
+/**
+ * Parse one session `.jsonl` into ordered transcript entries (Claude-dialect
+ * envelopes). Skips blank / malformed lines and non-conversation kinds. Never
+ * throws — a malformed line is warned-and-skipped.
+ * @param {string} raw  full file contents
+ * @param {{warn(m:string):void}} logger
+ * @returns {Array<{ type: "user"|"assistant", message: { role: string, content: Array<{type:"text",text:string}> } }>}
+ */
+export function parseSessionJsonl(raw, logger = NOOP_LOGGER) {
+  const out = [];
+  const lines = raw.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      logger.warn("[Chorus] kiro-transcript: skipping a malformed store line");
+      continue;
+    }
+    if (!obj || typeof obj !== "object") continue;
+    const role = roleForKind(obj.kind);
+    if (!role) continue;
+    const text = extractLineText(obj.data);
+    if (!text.trim()) continue; // a message with no conversation text → nothing to store
+    out.push({ type: role, message: { role, content: [{ type: "text", text }] } });
+  }
+  return out;
+}
+
+/**
+ * List the run's session plus any CHILD sessions (reviewer subagents), ordered so
+ * the parent precedes its children and children are in creation order. Each entry
+ * is `{ sessionId, createdAt }`. Best-effort: unreadable metadata is skipped.
+ * @param {string} sessionId  the run's (parent) sessionId
+ * @param {{ dir?: string, readdir?: (d:string)=>string[], read?: (p:string)=>string, logger?: any }} [deps]
+ * @returns {Array<{ sessionId: string, createdAt: number }>}
+ */
+export function collectSessionChain(sessionId, deps = {}) {
+  const dir = deps.dir ?? kiroSessionsDir();
+  const readdir = deps.readdir ?? ((d) => readdirSync(d));
+  const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
+  // (no logging here — collectSessionChain silently skips unreadable metadata.)
+
+  const children = [];
+  let files = [];
+  try {
+    files = readdir(dir);
+  } catch {
+    // No store dir → just the run's own session (its jsonl may still exist elsewhere).
+    return [{ sessionId, createdAt: 0 }];
+  }
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    let meta;
+    try {
+      meta = JSON.parse(read(join(dir, f)));
+    } catch {
+      continue;
+    }
+    if (!meta || typeof meta !== "object") continue;
+    // Child detection keys on parent_session_id (NOT session_created_reason, which
+    // can be "subagent" on a root session too).
+    if (meta.parent_session_id === sessionId) {
+      const sid = typeof meta.session_id === "string" ? meta.session_id : f.replace(/\.json$/, "");
+      children.push({ sessionId: sid, createdAt: Date.parse(meta.created_at ?? meta.updated_at ?? "") || 0 });
+    }
+  }
+  children.sort((a, b) => a.createdAt - b.createdAt);
+  // Parent first, then children in creation order.
+  return [{ sessionId, createdAt: 0 }, ...children];
+}
+
+/**
+ * Reconstruct the transcript for a completed Kiro run and feed each entry to
+ * `onMessage`. This is the hook KiroSpawner invokes post-run. Reads the run's
+ * session `.jsonl` (and any child subagent sessions) from the store; if that
+ * yields nothing usable, falls back to a single plain-text `stdout` entry. Emits
+ * Claude-dialect envelopes so the existing upload-hooks extractor consumes them
+ * unchanged. Never throws.
+ *
+ * @param {{
+ *   sessionId: string,
+ *   cwd?: string,
+ *   onMessage?: (obj: any) => void,
+ *   stdout?: string,
+ *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+ *   dir?: string,
+ *   readdir?: (d: string) => string[],
+ *   read?: (p: string) => string,
+ * }} params
+ * @returns {void}
+ */
+export function reconstructTranscript(params) {
+  const { sessionId, onMessage, stdout } = params;
+  const logger = params.logger ?? NOOP_LOGGER;
+  if (!onMessage) return; // nothing to feed
+  if (typeof sessionId !== "string" || !sessionId) {
+    emitFallback(stdout, onMessage, logger, "no sessionId");
+    return;
+  }
+
+  const dir = params.dir ?? kiroSessionsDir();
+  const read = params.read ?? ((p) => readFileSync(p, "utf8"));
+
+  let emitted = 0;
+  let anyStoreRead = false;
+  try {
+    const chain = collectSessionChain(sessionId, { dir, readdir: params.readdir, read, logger });
+    for (const { sessionId: sid } of chain) {
+      let raw;
+      try {
+        raw = read(join(dir, `${sid}.jsonl`));
+      } catch {
+        continue; // this session has no readable jsonl — skip it
+      }
+      anyStoreRead = true;
+      const entries = parseSessionJsonl(raw, logger);
+      for (const entry of entries) {
+        try {
+          onMessage(entry);
+          emitted++;
+        } catch (err) {
+          logger.warn(`[Chorus] kiro-transcript: onMessage threw (ignored): ${err}`);
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn(`[Chorus] kiro-transcript: store reconstruction failed (${err}) — trying plain-text fallback`);
+  }
+
+  // Fallback (option 1): the store was missing / unreadable / empty of
+  // conversation text — emit the raw stdout as a single plain-text entry so the
+  // turn is not left with an empty transcript.
+  if (emitted === 0) {
+    emitFallback(stdout, onMessage, logger, anyStoreRead ? "store had no conversation text" : "store unreadable");
+  }
+}
+
+/**
+ * Emit the run's raw stdout as one plain-text assistant transcript entry. No-op
+ * when there is no stdout. Logs the degrade. Never throws.
+ */
+function emitFallback(stdout, onMessage, logger, reason) {
+  const text = stripAnsi(stdout);
+  if (!text) {
+    logger.warn(`[Chorus] kiro-transcript: ${reason} and no stdout — transcript left empty for this turn`);
+    return;
+  }
+  logger.warn(`[Chorus] kiro-transcript: ${reason} — falling back to a plain-text stdout entry`);
+  try {
+    onMessage({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text }] } });
+  } catch (err) {
+    logger.warn(`[Chorus] kiro-transcript: fallback onMessage threw (ignored): ${err}`);
+  }
+}

--- a/cli/session-map.mjs
+++ b/cli/session-map.mjs
@@ -1,0 +1,126 @@
+// cli/session-map.mjs
+// Generic daemon-local persistence of an `anchor → session-handle` map, shared by
+// the backends whose CLI GENERATES its own conversation id (Codex thread_id, Kiro
+// sessionId) rather than accepting a client-supplied one. To make such a wake
+// resumable across daemon restarts we record the generated handle keyed by the
+// Chorus session anchor (direct idea uuid, or the entity uuid for an ad-hoc
+// session) and pass it back to the CLI's resume flag on the next wake.
+//
+// The store is a single JSON object `{ "<anchor>": "<handle>" }` at
+// ~/.chorus/<filename> (same dir family as daemon.json). The anchor is a
+// globally-unique Chorus uuid, so one flat file is safe across the daemon's
+// multiple path-connections.
+//
+// CONTRACT: this is best-effort and MUST NEVER throw into the wake path. Any
+// read/parse/write/rename failure degrades to "no mapping → next wake starts
+// fresh" with a visible log (no-silent-errors). IO is injectable for tests.
+//
+// Backends wrap this factory with their own filename + semantic export names:
+//   codex-session-map.mjs → codex-sessions.json, getThreadId/setThreadId
+//   kiro-session-map.mjs  → kiro-sessions.json,  getSessionId/setSessionId
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/** A non-empty trimmed string, or null. */
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Read the whole map as a plain object. Missing / unreadable / malformed file →
+ * `{}` (never throws). A non-object JSON value (array / scalar) is also treated
+ * as empty.
+ * @param {string} path @param {(p: string) => string} read
+ * @param {{warn(m:string):void}} logger @param {string} logPrefix
+ * @returns {Record<string, unknown>}
+ */
+function readMap(path, read, logger, logPrefix) {
+  let raw;
+  try {
+    raw = read(path);
+  } catch (err) {
+    // ENOENT is the normal "no map yet" case — silent. Other read errors warn.
+    if (!(err && err.code === "ENOENT")) {
+      logger.warn(`[Chorus] ${logPrefix}: read failed (${err}) — treating as empty`);
+    }
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+    logger.warn(`[Chorus] ${logPrefix}: file is not a JSON object — treating as empty`);
+    return {};
+  } catch (err) {
+    logger.warn(`[Chorus] ${logPrefix}: corrupt JSON (${err}) — treating as empty`);
+    return {};
+  }
+}
+
+/**
+ * Build a backend-specific session map bound to a `~/.chorus/<filename>` store and
+ * a `logPrefix` for its warnings. Returns `{ mapPath, get, set }` — the get/set
+ * signatures and their injectable-IO deps are identical to the original
+ * codex-session-map so its tests pass unchanged.
+ *
+ * @param {{ filename: string, logPrefix: string }} config
+ * @returns {{
+ *   mapPath: () => string,
+ *   get: (anchor: string, deps?: object) => string | null,
+ *   set: (anchor: string, handle: string, deps?: object) => void,
+ * }}
+ */
+export function createSessionMap({ filename, logPrefix }) {
+  /** Absolute path to this backend's session-id map, alongside ~/.chorus/daemon.json. */
+  const mapPath = () => join(homedir(), ".chorus", filename);
+
+  /**
+   * Look up the handle recorded for `anchor`, or null when there is none (no file,
+   * no entry, or a non-string entry). Never throws.
+   */
+  const get = (anchor, deps = {}) => {
+    const a = nonEmpty(anchor);
+    if (!a) return null;
+    const path = deps.path ?? mapPath();
+    const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
+    const logger = deps.logger ?? NOOP_LOGGER;
+    const map = readMap(path, read, logger, logPrefix);
+    return nonEmpty(map[a]);
+  };
+
+  /**
+   * Record `anchor → handle`, preserving every other entry. Atomic (temp file +
+   * rename). Best-effort: a blank anchor/handle is ignored (no write), and any IO
+   * failure is logged and swallowed — it never throws into the wake path.
+   */
+  const set = (anchor, handle, deps = {}) => {
+    const a = nonEmpty(anchor);
+    const h = nonEmpty(handle);
+    if (!a || !h) return; // nothing meaningful to persist
+    const path = deps.path ?? mapPath();
+    const read = deps.read ?? ((p) => readFileSync(p, "utf8"));
+    const write = deps.write ?? writeFileSync;
+    const mkdir = deps.mkdir ?? mkdirSync;
+    const rename = deps.rename ?? renameSync;
+    const logger = deps.logger ?? NOOP_LOGGER;
+
+    try {
+      const map = readMap(path, read, logger, logPrefix);
+      map[a] = h;
+      mkdir(dirname(path), { recursive: true });
+      // Atomic write: temp file (0600) in the same dir, then rename over target,
+      // so a crash mid-write never truncates the live map.
+      const tmp = `${path}.tmp`;
+      write(tmp, JSON.stringify(map, null, 2) + "\n", { mode: 0o600 });
+      rename(tmp, path);
+    } catch (err) {
+      // Best-effort: a failed persist just means the next wake starts fresh.
+      logger.warn(`[Chorus] ${logPrefix}: failed to persist ${a}→${h} (${err}) — wake will start fresh next time`);
+    }
+  };
+
+  return { mapPath, get, set };
+}

--- a/cli/spawner-select.mjs
+++ b/cli/spawner-select.mjs
@@ -11,10 +11,11 @@
 
 import { ClaudeSpawner } from "./claude-spawner.mjs";
 import { CodexSpawner } from "./codex-spawner.mjs";
+import { KiroSpawner } from "./kiro-spawner.mjs";
 
 /**
  * Construct the spawner backend for `agentType`.
- * @param {string} agentType  "claude-code" | "codex" (already validated upstream).
+ * @param {string} agentType  "claude-code" | "codex" | "kiro" (already validated upstream).
  * @param {{ logger?: any, permissionMode?: "chorus"|"yolo", creds?: { url: string, apiKey: string } }} [opts]
  * @returns {import("./codex-spawner.mjs").Spawner}
  */
@@ -22,6 +23,11 @@ export function selectSpawner(agentType, opts = {}) {
   const { logger, permissionMode, creds } = opts;
   if (agentType === "codex") {
     return new CodexSpawner({ logger, permissionMode, creds });
+  }
+  if (agentType === "kiro") {
+    // Kiro follows the Codex model — MCP from the user's plugin config, daemon key
+    // via env — so it takes the same { logger, permissionMode, creds } shape.
+    return new KiroSpawner({ logger, permissionMode, creds });
   }
   // Default / "claude-code": construction byte-identical to the prior daemon
   // (ClaudeSpawner takes only { logger, permissionMode } — creds are not used by

--- a/messages/en.json
+++ b/messages/en.json
@@ -1462,6 +1462,7 @@
     "clientClaudeCode": "Claude Code",
     "clientOpenclaw": "OpenClaw",
     "clientCodex": "Codex",
+    "clientKiro": "Kiro",
     "clientUnknown": "Unknown client",
     "uptimeMonoDays": "{days}d {time}",
     "mobileBack": "Connections",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1462,6 +1462,7 @@
     "clientClaudeCode": "Claude Code",
     "clientOpenclaw": "OpenClaw",
     "clientCodex": "Codex",
+    "clientKiro": "Kiro",
     "clientUnknown": "不明なクライアント",
     "uptimeMonoDays": "{days}日 {time}",
     "mobileBack": "接続",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1462,6 +1462,7 @@
     "clientClaudeCode": "Claude Code",
     "clientOpenclaw": "OpenClaw",
     "clientCodex": "Codex",
+    "clientKiro": "Kiro",
     "clientUnknown": "알 수 없는 클라이언트",
     "uptimeMonoDays": "{days}일 {time}",
     "mobileBack": "연결",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1462,6 +1462,7 @@
     "clientClaudeCode": "Claude Code",
     "clientOpenclaw": "OpenClaw",
     "clientCodex": "Codex",
+    "clientKiro": "Kiro",
     "clientUnknown": "未知客户端",
     "uptimeMonoDays": "{days}天 {time}",
     "mobileBack": "返回连接列表",

--- a/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/README.md
+++ b/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/README.md
@@ -1,0 +1,3 @@
+# add-daemon-kiro-backend
+
+Add a --agent kiro headless daemon backend (wake / yolo / resume / interrupt), parallel to --agent codex

--- a/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/design.md
+++ b/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/design.md
@@ -1,0 +1,105 @@
+# Technical Design: daemon Kiro backend
+
+## Overview
+
+Add a third spawner backend behind the daemon's existing `--agent` selection. The wake pipeline (SSE → EventRouter → WakeQueue → Waker → spawner) stays backend-agnostic; only the leaf that turns a wake into a subprocess changes. `KiroSpawner` satisfies the same `Spawner.wake(...)` contract that `ClaudeSpawner` and `CodexSpawner` already implement, and `selectSpawner(agentType, opts)` dispatches to it.
+
+The design follows five verified facts about Kiro CLI 2.12.1 vs Codex/Claude (see proposal §Why): (1) `chat --no-interactive` with stdin prompt + trust flags; (2) native `--resume-id` where **Kiro owns the id** (Codex-like); (3) **no** structured chat-turn stream; (4) but a structured on-disk **session store**; (5) a v2/v3 engine fork we pin to v2. Where Kiro matches Codex (own-id resume, MCP-from-user-config, env key, detached kill) the Codex modules are the template; where it diverges (transcript reconstruction, `--resume-id` vs `exec resume`, `--agent chorus` profile) the design calls it out.
+
+## Architecture
+
+```
+resolveAgentType(flags, env)  →  "claude-code" | "codex" | "kiro"
+                                        │
+                     spawner-select.mjs  selectSpawner(agentType, {logger, permissionMode, creds})
+                                        │
+        ┌───────────────────────────────┼───────────────────────────────┐
+  ClaudeSpawner                    CodexSpawner                      KiroSpawner
+ (claude -p,                 (codex exec --json,              (kiro-cli chat --no-interactive
+  transcript-file probe,      id-map = new/resume,             --agent chorus,
+  --mcp-config,               --sandbox flags,                 id-map = new/--resume-id,
+  --allowedTools)             MCP from ~/.codex config)         --trust-* flags,
+        │                            │                          MCP from .kiro/settings,
+        │                            │                          transcript from session store)
+        └──────── all implement Spawner.wake(params) → { sessionId, exitCode, isNew } ────────┘
+```
+
+The Waker is unchanged. As with Codex, the waker's `isNew` (a Claude transcript probe) and `mcpConfigPath` (a Claude `--mcp-config` file) are Claude-shaped; `KiroSpawner` **ignores** them and derives its own new-vs-resume (from the id map) and MCP wiring (from the plugin config + env key). This is the same "each backend owns its session model" move the Codex backend already established.
+
+## Module Contracts
+
+### Spawner interface (unchanged seam)
+
+`KiroSpawner` implements the existing contract verbatim — no interface change:
+
+```
+wake({
+  prompt: string,          // fed over stdin, NEVER argv
+  sessionId: string|null,  // Chorus anchor (direct idea uuid | entity uuid)
+  isNew: boolean,          // Claude: authoritative; Kiro: advisory (spawner re-derives from id map)
+  mcpConfigPath?: string,  // Claude: --mcp-config; Kiro: ignored (uses .kiro/settings/mcp.json)
+  cwd?: string,            // spawn cwd
+  onMessage?: (obj) => void,  // per reconstructed transcript entry (see below)
+  onChild?: (child) => void,  // live ChildProcess, sync, only on successful spawn
+}) → Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }>
+```
+
+Invariants carried over from the other spawners (all must hold for Kiro):
+- **Never throw into the wake path.** Failed executable resolution / spawn / stdin EPIPE / session-store read resolves with `exitCode: null` (or a completed exit) and a visible log — never an uncaught exception.
+- **`onChild` fires exactly once, synchronously, only on a successful spawn.**
+- **POSIX `detached: true`** (process-group leader) so `killProcessTree` group-kills descendants; Windows `taskkill /T /F`. stdio `["pipe","pipe","pipe"]`.
+- **Returned `sessionId`** is the id the daemon anchors on going forward — Kiro returns its **generated** `sessionId` (read from the store / metadata after the run), reconciled by the waker's `observedSessionId` tracking.
+
+### `KiroSpawner` specifics
+
+- **buildArgs (new):** `["chat", "--no-interactive", "--agent", "chorus", ...trustFlags]`, prompt via stdin. Engine left at v2 default (no `--v3`).
+- **buildArgs (resume):** `["chat", "--no-interactive", "--resume-id", "<sessionId>", "--agent", "chorus", ...trustFlags]`, prompt via stdin.
+- **Trust flags from permission mode:** `yolo → ["--trust-all-tools"]`; `chorus → ["--trust-tools=fs_read,<chorus-mcp-tool-names>"]` (the exact trustable Chorus MCP tool identifiers verified at impl time against `kiro-cli` — MCP tool trust names are namespaced, e.g. `@chorus/<tool>`). Mirrors `CodexSpawner`'s `permissionMode` constructor option.
+- **sessionId capture:** `chat --no-interactive` has no id-bearing stream event, so capture is **post-run**: after the child exits, resolve the run's `sessionId` by reading Kiro's session store for this cwd — either the most-recent session created during the run (compare `--list-sessions` / store `updated_at` before vs after), or (on resume) the `--resume-id` we passed. Persist `anchor → sessionId` on a successful new run.
+- **new-vs-resume:** look up `sessionId` (the Chorus anchor) in the id map. Hit → `--resume-id <stored>`. Miss → new run. Replaces the waker's Claude transcript probe.
+
+### Transcript reconstruction (transcript decision: store-first, plain-text fallback)
+
+Kiro emits no per-message stream, so `onMessage` is fed **post-run** from Kiro's on-disk store rather than live from stdout:
+
+- **Primary (option 2):** after the child exits, read `~/.kiro/sessions/cli/<sessionId>.jsonl` for the run's session. Each line is `{version, kind, data}` with `kind ∈ {Prompt, AssistantMessage, ...}` and the body in `data.content[]` (only `text` content blocks are kept; thinking/toolUse/toolResult dropped). Map `Prompt → user`, `AssistantMessage → assistant`, forward each via `onMessage`. **Child sessions:** reviewer subagents create separate sessions with `parent_session_id` pointing at ours — walk children so subagent turns are captured. (Child detection keys on `parent_session_id`, NOT `session_created_reason`, which is `"subagent"` even on root sessions.)
+- **Fallback (option 1):** capture the run's stdout as **one plain-text transcript entry**, ANSI-stripped (headless stdout is color-styled with spinner frames + a `> ` answer marker — `stripAnsi` cleans it).
+- **⚠️ Verified live at the integration checkpoint (kiro-cli 2.12.1):** `chat --no-interactive` does **NOT** persist a session to the cli store — only interactive/TUI runs write it. So on the daemon's headless path the store lookup normally finds nothing and **the plain-text fallback is the effective (common) path, not a rare degrade.** The store-reconstruction code is kept because it is correct + richer (and would light up if a future Kiro persists headless sessions or when subagent sessions are written), but the fallback must produce clean text — hence `stripAnsi`. Two consequences follow the same root cause: (a) `--resume-id` resume is best-effort — a headless run leaves no session to resume, so a re-wake simply starts fresh (honest degrade, no crash); (b) the transcript reconstruction runs **regardless of whether a sessionId was captured**, so the fallback always fires.
+- The reconstruction reader lives in a small helper (e.g. `cli/kiro-transcript.mjs`) so it is unit-testable against a fixture store and the fallback is a clean branch. A dialect extension in `upload-hooks.mjs` is only needed if the reconstructed entries don't fit the existing user/assistant envelope.
+
+### `kiro-session-map` (daemon-local persistence)
+
+- Single JSON file `~/.chorus/kiro-sessions.json`, shape `{ "<anchor-uuid>": "<kiro-session-id>" }`, keyed by the globally-unique Chorus anchor (safe across the daemon's multiple path-connections).
+- `getSessionId(anchor) → string|null`, `setSessionId(anchor, id)`; atomic write (temp + rename, mode 0600), never throws into the wake path (a write failure logs and degrades to "next wake starts fresh"). Same contract as `codex-session-map.mjs` — factor a shared helper if the two are byte-identical apart from the filename.
+
+### MCP authentication wiring (fallback decision = a: rely on plugin config)
+
+The daemon does not write a Kiro MCP config. It relies on the Kiro plugin's `.kiro/settings/mcp.json`, whose `chorus` server carries a static Bearer header `Authorization: Bearer ${env:CHORUS_API_KEY}`. Before spawning, `KiroSpawner` sets the child env: `{ ...process.env, CHORUS_API_KEY: creds.apiKey, CHORUS_DAEMON_HEADLESS: "1" }` — key via env, **never argv** — so the woken Kiro authenticates its Chorus MCP calls as the daemon's agent. If the plugin/MCP config is absent, the woken Kiro simply lacks Chorus tools — logged, not fatal. The `--agent chorus` profile is what pulls in that MCP config plus the AI-DLC skills and steering.
+
+## Risks & Mitigations
+
+- **Kiro CLI drift.** Flags, engine names, session-store path/schema, and MCP tool trust names can change between releases. *Mitigation:* the implementation tasks MUST re-verify against installed `kiro-cli chat --help` + the live store; tests assert on our `buildArgs`, not Kiro's runtime; unknown store lines are skipped, not fatal.
+- **Session-store schema is undocumented (transcript primary path).** The `.jsonl` `{kind, data.content[]}` shape is reverse-engineered, not a public contract. *Mitigation:* the plain-text-blob fallback is explicitly authorized (transcript decision) — reconstruction is best-effort and never blocks the wake; a parse failure degrades cleanly.
+- **sessionId capture is post-run, not from a stream.** Unlike Codex's `thread.started` event, Kiro gives no in-stream id, so we infer the run's `sessionId` from the store. *Mitigation:* on resume the id is known (we passed `--resume-id`); on a new run, snapshot the store before/after and take the newly-created session.
+  - **Concurrency (reviewer N1) — RESOLVED by unambiguous-only capture.** Confirmed at integration time: the WakeQueue serializes wakes **per idea-key** but runs **different keys concurrently** (default `maxConcurrency` 4), and all keys share the daemon's single repo cwd — so two fresh Kiro runs CAN be in flight in the same cwd at once. The capture is therefore hardened to be **unambiguous rather than "newest wins"**: `pickNewSessionId(before, after)` returns the new id **only when exactly one** brand-new session id appeared in the window; if **zero or several** new ids appeared (a concurrent same-cwd run), it returns null and the spawner **does not persist** — degrading to "not resumable this time" (a missed resume is a minor efficiency loss) rather than risk cross-wiring two ideas' conversations (a correctness bug). There is no "updated_at advanced" fallback: a fresh run always creates a new id, and a resume already knows its id.
+- **Headless MCP not loading (the #5958 concern).** *Mitigation:* root cause was a missing node-22 in the workspace, not a Kiro bug; this host has node 22 + kiro 2.12.1. The first integration task validates headless MCP end-to-end **live**; the `chorus-api.sh` REST fallback (already in the plugin) is the contingency if it fails. node-22 documented as a prereq.
+- **Plugin dependency.** `--agent chorus` requires the Kiro plugin installed (like Codex needs `~/.codex/config.toml`). *Mitigation:* documented prereq; absence is logged (no Chorus tools) rather than crashing.
+- **Interrupt reaching Kiro's child shells.** *Mitigation:* `detached` process-group + group-kill is the mechanism the other two spawners already proved; reused unchanged (spawn `detached`, hand the child to `onChild`).
+- **claude-code / codex regression.** *Mitigation:* those spawners are untouched; a test asserts the default agent still selects `ClaudeSpawner` and `--agent codex` still selects `CodexSpawner` with unchanged argv.
+
+## Implementation Plan
+
+1. Register `kiro` as a backend: `daemon-agent.mjs` (`KNOWN_AGENTS`, `backendCli`, `backendClientType`), `spawner-select.mjs` branch, server `DAEMON_CLIENT_TYPES` + presence label; reconcile the stale `client-args.mjs` list. Tests: resolution accepts kiro / rejects unknown; selection picks `KiroSpawner`; claude/codex argv unchanged.
+2. `kiro-session-map.mjs` — persistence (round-trip / missing / corrupt / write-failure tests), sharing with `codex-session-map` where identical.
+3. `KiroSpawner` — executable resolution, buildArgs (new/`--resume-id`, `--agent chorus`, trust per mode, prompt on stdin), spawn (detached, env key + `CHORUS_DAEMON_HEADLESS`), sessionId capture, id-map write. Unit tests on argv + capture.
+4. Transcript reconstruction (`kiro-transcript.mjs`) from a fixture session store incl. a child subagent session, plus the plain-text fallback branch. Wire into the transcript-upload hook.
+5. Live integration + validation on this host: confirm headless MCP loads under `--agent chorus` (build the REST fallback only if it fails); confirm a real wake → `kiro-cli chat --no-interactive` argv (new + resume), interrupt via process-group kill, and transcript capture end-to-end. Re-verify all flags/paths against installed `kiro-cli`.
+
+## Verification notes for implementers (anti-hallucination)
+
+Before coding, run and read:
+- `kiro-cli chat --help` (confirm `--no-interactive`, `--resume-id`, `-r/--resume`, `--list-sessions`, `--trust-all-tools`, `--trust-tools`, `--agent`, `--agent-engine`, `--require-mcp-startup`, `--format`).
+- `kiro-cli chat --list-sessions --format json` and the on-disk `~/.kiro/sessions/cli/<id>.jsonl` + `<id>.json` for the exact store schema and the `parent_session_id` / `session_created_reason` fields.
+- The Kiro plugin's `.kiro/settings/mcp.json` (`public/kiro-plugin/`) as the MCP config the daemon relies on, and its agent name (`chorus`).
+- The trustable Chorus MCP tool identifiers as Kiro names them (namespaced, verify exact form) for the restricted `--trust-tools=` set.
+- `node --version` (headless MCP needs node ≥ 22 per the #5958 root cause).

--- a/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/proposal.md
+++ b/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/proposal.md
@@ -1,0 +1,79 @@
+# Proposal: daemon Kiro backend — `--agent kiro` wakes a local headless Amazon Kiro CLI
+
+## Why
+
+The daemon's remote-wake path can spawn Claude Code (`--agent claude-code`, default) and Codex (`--agent codex`). This change adds a **third** backend: `--agent kiro` (or `CHORUS_AGENT=kiro`) wakes a local **headless Amazon Kiro CLI** subprocess (`kiro-cli chat --no-interactive`), routed into the same Chorus AI-DLC skill workflow as the other backends. It is the "daemon 唤醒" deliverable of the Kiro-integration theme (`a1e25b50`), sibling to the already-merged Kiro plugin.
+
+The wake pipeline (SSE → EventRouter → WakeQueue → Waker) is already backend-agnostic — the `daemon-spawner-interface` capability defines the `wake(...)` contract, and `selectSpawner(agentType, opts)` is the single dispatch seam. Adding Kiro means adding a `KiroSpawner` that satisfies that contract, plus registering `kiro` as a known backend and daemon client type. No waker rewrite.
+
+**The framed "primary risk" is largely dissolved.** The idea flagged Kiro#5958 (MCP tools not loading under `--no-interactive`) as a blocker requiring a REST/agent-key fallback. Live verification (2026-07-14, `gh issue view 5958`): the issue is **closed COMPLETED**, and the reporter's own root cause was *"NodeJS22 missing in the workspace, due to which Kiro was not able to pull the MCP server tools correctly"* — an **environment prerequisite, not a Kiro bug** (the failure was on Amazon Linux 2 without node; it worked on macOS; a duplicate-detector bot mislabeled it before the reporter self-closed). This daemon host already runs **node v22.22.0 + kiro-cli 2.12.1** and carries the shipped Kiro plugin's `.kiro/settings/mcp.json`. So headless MCP should load; the fallback becomes "validate live, then build only if it actually fails," not a v1 blocker.
+
+Verified on this host (Kiro CLI **2.12.1** — newer than the pinned 1.26.2 docs at kiro.dev/docs/cli/headless, which are stale on several points):
+
+1. **Non-interactive interface exists and is sufficient.** `kiro-cli chat --no-interactive "<prompt>"` runs a single headless turn. `--trust-all-tools` / `--trust-tools=<names>` (e.g. `fs_read,fs_write`) / `--trust-tools=` (trust nothing) set the tool-approval posture so a headless turn never blocks on a prompt. `--require-mcp-startup` exits with code 3 if any MCP server fails to start. `--agent <name>` selects a context profile. Auth is inherited from the environment (the interactive login / `KIRO_API_KEY`), like Codex's model auth.
+2. **Native per-cwd resume exists — Kiro owns the id (like Codex).** `kiro-cli chat --resume-id <SESSION_ID>` resumes a specific conversation; `-r/--resume` resumes the most-recent-per-cwd; `--list-sessions [--format json]` enumerates them. Kiro **generates** its own UUID `sessionId` per conversation. Because the daemon works one repo cwd, many ideas share that cwd, so "resume most recent" would cross-contaminate — the daemon needs a persisted **`idea uuid → kiro sessionId`** map and `--resume-id`, exactly the model the Codex backend uses.
+3. **No structured chat-turn stream.** `--format json` is **list-commands-only** (`--list-models` / `--list-sessions`); `chat --no-interactive` emits plain text/markdown on stdout — there is no `exec --json`-style NDJSON event stream to parse per message. Transcript capture therefore cannot reuse the Codex/Claude `parseNdjsonChunk` path.
+4. **But Kiro persists a structured session store on disk.** `~/.kiro/sessions/cli/<sessionId>.jsonl` is per-message JSONL (`{version, kind: "Prompt" | "AssistantMessage" | …, data.content[], data.message_id}`), with a `<sessionId>.json` metadata sibling (`{session_id, cwd, created_at, updated_at, title, parent_session_id, session_created_reason, session_state}`). This store is the source behind `--list-sessions messageCount` and is convertible to structured transcript entries.
+5. **Engine fork.** `kiro-cli chat` exposes `--agent-engine v2|v3` (v2 default) and `--v3` (+ `--mode default|spec`). V3 is breaking and early-release; a separate sibling idea (`d4a59bab`) owns the full V3 adaptation. This backend targets **v2**.
+
+> Provenance: idea `dc53a459-5f61-4c32-a02e-359babb41d76` (project chorus 0.14.1, child of theme `a1e25b50`), elaborated and **human-verified** (Round 1, 6 questions, resolved). The decisions below encode those answers verbatim. The elaboration dogfooded the headless flow — it ran from a daemon-woken headless Claude session that routed its questions to the Chorus elaboration panel.
+
+## What Changes
+
+The verified elaboration answers set a scoped v1 that mirrors the Codex backend's shape wherever Kiro behaves like Codex, and diverges only where Kiro's surface differs (transcript, resume flag, agent profile).
+
+- **`kiro` becomes a known backend (fallback = a).** `cli/daemon-agent.mjs` adds `kiro` to `KNOWN_AGENTS`, a `backendCli` branch (`{ name: "kiro", envVar: "CHORUS_KIRO_PATH" }`), and a `backendClientType` branch (`"kiro"`). Server-side, `DAEMON_CLIENT_TYPES` gains `"kiro"` (else the Kiro daemon's connection self-report is refused) and the presence-UI label map gets a `kiro` case. Selecting `claude-code`/`codex` behaves exactly as today.
+
+- **`KiroSpawner` — new wake (all decisions).** New `cli/kiro-spawner.mjs` implementing the shared `wake({ prompt, sessionId, isNew, cwd, onMessage, onChild }) → { sessionId, exitCode, isNew }` contract. Spawns `kiro-cli chat --no-interactive` with the prompt over **stdin** (never argv), `detached: true` on POSIX so the existing `killProcessTree` reaches Kiro's child shells. Cross-platform executable resolution mirrors `resolveCodexPath`/`resolveClaudePath` (PATH walk + `.cmd`/`.bat` via `cmd.exe` on Windows + a `CHORUS_KIRO_PATH` override).
+
+- **Agent profile: `--agent chorus` (profile = a).** The woken session runs `kiro-cli chat --agent chorus` so it loads the Kiro plugin's Chorus agent (Chorus MCP server + AI-DLC skills + steering) — parity with an interactive plugin user. This makes the Kiro backend **depend on the Kiro plugin being installed**, exactly as the Codex backend depends on `~/.codex/config.toml`. Documented as a prereq.
+
+- **Engine: v2 (engine = a).** Spawn on the default v2 engine (do not pass `--v3`); the V3 adaptation stays with its dedicated sibling idea.
+
+- **Tool trust mirrors Codex (trust = a).** The daemon's backend-agnostic permission mode maps to Kiro trust flags: `yolo → --trust-all-tools` (full autonomy for code-writing AI-DLC work; the daemon default is already `yolo`), and the restricted `chorus` posture → a scoped `--trust-tools=` read-ish subset (`fs_read` + the Chorus MCP tool names) so MCP calls still work while shell/file-writes are withheld.
+
+- **Session anchoring via a persisted id map (resume = a).** Because Kiro owns the id, `KiroSpawner` captures the generated `sessionId` after a run and persists `idea uuid → kiro sessionId` under the daemon config dir (`~/.chorus/kiro-sessions.json`), reusing the `codex-session-map.mjs` shape (atomic write, never throws into the wake path). A subsequent wake for the same anchor runs `kiro-cli chat --resume-id <sessionId>`; with no mapping it starts fresh. new-vs-resume is decided inside the spawner from this map — the on-disk transcript probe the waker does for Claude does not apply.
+
+- **MCP wiring: rely on the user's config, do not inject (fallback = a).** Like Codex, the daemon does **not** synthesize a Kiro MCP config. It relies on the Kiro plugin's `.kiro/settings/mcp.json` (which references `${env:CHORUS_API_KEY}` as a static Bearer header) and exports the daemon's resolved key into the child env as `CHORUS_API_KEY` (via env, never argv), plus `CHORUS_DAEMON_HEADLESS=1`. The first integration task **validates headless MCP loading live on this host**; the `chorus-api.sh` REST fallback (already shipped in the Kiro plugin) is built **only if** live MCP proves unreliable — it is not a v1 deliverable by default.
+
+- **Transcript: reconstruct from the session store, fall back to plain-text (transcript = human steer "优先选择2，回退到1").** Since Kiro has no per-message stream, after each turn `KiroSpawner` reads Kiro's on-disk v2 session store for the run's `sessionId` (`~/.kiro/sessions/cli/<sessionId>.jsonl` + metadata sibling), converts each `{kind, data.content[]}` line to a structured transcript entry, and feeds them to the existing transcript-upload hook. Reviewer subagents spawn **child** sessions (`session_created_reason:"subagent"` + `parent_session_id`), so reconstruction walks child sessions too. **If** the (undocumented) store schema proves unstable at implementation time, the backend falls back to capturing raw stdout as one **plain-text blob per turn** — the fallback is explicitly authorized so a schema surprise never blocks the wake.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-kiro-backend`: the contract for the Kiro spawn path — `kiro-cli chat --no-interactive` headless wake with the prompt over stdin, `--agent chorus` profile coupling, the v2 engine target, cross-platform `kiro-cli` executable resolution with a `CHORUS_KIRO_PATH` override, the persisted `idea uuid → kiro sessionId` map driving new-vs-`--resume-id`, the permission-mode → trust-flag mapping (`yolo → --trust-all-tools`; `chorus → scoped --trust-tools=`), the MCP-from-plugin-config posture with the daemon key exported via env, transcript reconstruction from Kiro's on-disk session store (with a plain-text-blob fallback), and detached-process-group interrupt parity.
+
+### Modified Capabilities
+
+- `daemon-agent-selection`: the current requirement enumerates `claude-code` and `codex` as the known backends. This change implements `kiro`, so the requirement is updated: `kiro` is now a known, accepted backend that wakes a local headless Kiro CLI; unknown values are still rejected non-zero; `claude-code` remains the default and behaves exactly as before.
+
+> The `daemon-spawner-interface` capability is **not** changed — `KiroSpawner` satisfies the existing `wake(...)` contract as-is; adding a third implementer requires no interface change.
+
+## Impact
+
+- **Schema**: none. No migration, no Prisma model, no enum. The `idea → sessionId` map is a daemon-local JSON file, not a DB entity.
+- **Server code** (`src/`):
+  - `src/services/daemon-connection.service.ts` — add `"kiro"` to `DAEMON_CLIENT_TYPES` (else `isValidClientType` refuses the Kiro daemon's registration).
+  - `src/components/agent-presence/hooks.ts` — add a `case "kiro"` to the `useClientTypeLabel` switch (else the presence UI mislabels a Kiro daemon).
+- **Daemon client code** (in-repo, `cli/`, shipped verbatim in the npm package):
+  - `cli/daemon-agent.mjs` — add `kiro` to `KNOWN_AGENTS`; `backendCli` (`CHORUS_KIRO_PATH`) and `backendClientType` (`"kiro"`) branches. Reconcile the stale `client-args.mjs` `KNOWN_AGENTS` (currently only `claude-code`, unused for validation) while here.
+  - `cli/kiro-spawner.mjs` *(new)* — `KiroSpawner` implementing the shared `wake(...)`: executable resolution, `buildArgs` (`chat --no-interactive` / `--resume-id <id>` + `--agent chorus` + trust flags), spawn (detached, stdin prompt), sessionId capture, transcript reconstruction from the session store.
+  - `cli/kiro-session-map.mjs` *(new)* — persist/read the `idea uuid → kiro sessionId` map (same atomic-write, never-throw shape as `codex-session-map.mjs`; may share a generic helper).
+  - `cli/spawner-select.mjs` — add `if (agentType === "kiro") return new KiroSpawner({ logger, permissionMode, creds })`.
+  - `cli/claude-spawner.mjs` / `cli/codex-spawner.mjs` — no behavior change (claude-code and codex must not regress).
+  - `cli/__tests__/` — unit tests for: agent resolution accepting `kiro` / rejecting unknown; `KiroSpawner` argv (new vs resume, `--agent chorus`, trust flag per mode, prompt never in argv); sessionId capture + map round-trip; executable resolution incl. Windows `.cmd` and `CHORUS_KIRO_PATH`; transcript reconstruction from a fixture session store incl. a child (subagent) session; spawner selection.
+- **Kiro is an external dependency**: all `kiro-cli chat` flags (`--no-interactive`, `--resume-id`, `--trust-tools`, `--agent`, `--agent-engine`), the session-store path/schema (`~/.kiro/sessions/cli/<id>.jsonl`), and the plugin agent name (`chorus`) MUST be verified against the installed `kiro-cli chat --help` and the on-disk store at implementation time, not assumed from this proposal (versions drift — verified here against 2.12.1). The store schema is undocumented — the transcript task treats reconstruction as best-effort with a plain-text fallback.
+- **MCP tools / `docs/MCP_TOOLS.md`**: unchanged — no new Chorus tool.
+- **Skill / onboarding docs**: the daemon onboarding surface (`--agent kiro` command, connection identity) is the sibling **onboarding-UI** child idea (`4181e7b1`), not this backend. This change only updates the daemon's own agent-type docs/banner wording as needed.
+- **`docs/design.pen`**: not applicable — daemon CLI behavior change, no user-facing screen (the connection UI is the sibling idea).
+- **Cross-platform / deps**: no new npm dependency (pitfall #9); spawn stays `shell:false` with argv arrays; Windows `.cmd` handled via `cmd.exe` like the Claude/Codex path; node-22 documented as a prereq for headless MCP (per the #5958 root cause).
+
+## Out of Scope
+
+- **The REST/agent-key fallback as a default deliverable.** Per `fallback = a`, native MCP is the path; the `chorus-api.sh` fallback is built only if the live-validation task shows headless MCP is unreliable on the daemon host. If validation passes, no fallback ships in v1.
+- **Kiro V3 engine.** `--v3` / `--agent-engine v3` / `--mode spec` are owned by the dedicated V3-adaptation sibling idea (`d4a59bab`). This backend targets v2.
+- **Kiro model / login authentication.** `kiro-cli` login / `KIRO_API_KEY` setup is the user's responsibility (like Codex model auth); the daemon does not manage Kiro's model credentials.
+- **Daemon-side synthesis of a Kiro MCP config.** Not done in v1 — the backend relies on the plugin's `.kiro/settings/mcp.json`.
+- **Onboarding / connection UI.** The `npx … daemon --agent kiro` onboarding command, `clientType=kiro` connection identity presentation, and connect/login docs are the sibling onboarding-UI child idea — this change only adds the minimum server-side `clientType` registration + label so a Kiro daemon can connect at all.
+- **A fourth backend.** The interface is general, but only `claude-code`, `codex`, and `kiro` are implemented.

--- a/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/specs/daemon-agent-selection/spec.md
+++ b/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/specs/daemon-agent-selection/spec.md
@@ -1,8 +1,5 @@
-# daemon-agent-selection Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change improve-daemon-cli-ux. Update Purpose after archive.
-## Requirements
 ### Requirement: `--agent` selection with claude-code and codex backends
 
 The daemon SHALL accept an `--agent <type>` flag and a `CHORUS_AGENT` environment variable selecting which local agent backend to wake, defaulting to `claude-code`. The daemon SHALL validate the resolved value against the set of known agent types — which SHALL include `claude-code`, `codex`, and `kiro` — and SHALL reject an unknown value with a clear, non-zero error naming the accepted values (it SHALL NOT silently fall back). The resolved agent type SHALL be displayed in the startup banner. The daemon SHALL select which spawner backend to inject based on the resolved agent type. Selecting `claude-code` (explicitly or by default) SHALL behave exactly as the current daemon spawn. Selecting `codex` SHALL wake a local headless Codex subprocess (see the `daemon-codex-backend` capability). Selecting `kiro` SHALL wake a local headless Kiro CLI subprocess (see the `daemon-kiro-backend` capability).
@@ -31,4 +28,3 @@ The daemon SHALL accept an `--agent <type>` flag and a `CHORUS_AGENT` environmen
 
 - **WHEN** the user passes `--agent <unknown>` (or sets `CHORUS_AGENT` to an unknown value)
 - **THEN** the daemon exits non-zero with a clear error naming the accepted agent types and does not start, rather than silently falling back to a default
-

--- a/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/specs/daemon-kiro-backend/spec.md
+++ b/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/specs/daemon-kiro-backend/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Headless Kiro wake over `kiro-cli chat --no-interactive`
+
+When the resolved backend is `kiro`, the daemon SHALL wake the local Kiro CLI by spawning `kiro-cli chat --no-interactive` as a headless subprocess, feeding the wake prompt over **stdin** (never as a command-line argument), and running under the `chorus` agent profile (`--agent chorus`) so the woken session loads the Kiro plugin's Chorus MCP server, AI-DLC skills, and steering. The spawned child SHALL carry `CHORUS_DAEMON_HEADLESS=1` in its environment, matching the other backends' headless signal, and SHALL target the default v2 engine (it SHALL NOT pass `--v3`). The spawner SHALL resolve the `kiro-cli` executable without a shell (PATH walk for the platform's candidate names, a `.cmd`/`.bat` shim run via `cmd.exe` on Windows), honoring a `CHORUS_KIRO_PATH` override when set, and SHALL refuse to spawn with a visible log if it cannot locate the executable.
+
+#### Scenario: New wake spawns kiro-cli chat with the prompt on stdin
+
+- **WHEN** the daemon wakes the kiro backend for an anchor that has no recorded Kiro session id
+- **THEN** it spawns `kiro-cli chat --no-interactive --agent chorus` (plus the resolved trust flags) with the prompt written to stdin, and no part of the prompt appears in the process arguments
+
+#### Scenario: Missing kiro-cli executable fails visibly without crashing
+
+- **WHEN** no `kiro-cli` executable can be resolved on PATH and `CHORUS_KIRO_PATH` is unset or invalid
+- **THEN** the wake resolves without spawning, emits a visible error log, and the daemon keeps running
+
+### Requirement: Kiro session anchoring via a persisted idea→session-id map
+
+Because Kiro generates its own conversation `sessionId` per cwd rather than accepting a client-supplied session id, the daemon SHALL capture the generated `sessionId` for a run and SHALL persist a mapping from the Chorus session anchor (the direct idea uuid, or the entity uuid for an ad-hoc session) to that `sessionId` in a daemon-local store. On a subsequent wake for the same anchor, the daemon SHALL resume the existing Kiro conversation via `kiro-cli chat --no-interactive --resume-id <sessionId>`; when no mapping exists for the anchor, it SHALL start a fresh run. The new-vs-resume decision for the Kiro backend SHALL be made from this map, not from Kiro's most-recent-per-cwd `--resume` (which would cross-contaminate ideas sharing the daemon's single repo cwd) and not from the Claude on-disk transcript probe. The persistence SHALL be best-effort: a read/write failure SHALL degrade to starting a fresh session with a visible log, never throwing into the wake path.
+
+#### Scenario: Same anchor resumes the same Kiro session
+
+- **WHEN** a wake fires for an anchor whose `sessionId` was recorded by a prior successful Kiro run
+- **THEN** the daemon runs `kiro-cli chat --no-interactive --resume-id <sessionId>` so the conversation continues, rather than starting a new session
+
+#### Scenario: First wake for an anchor starts fresh and records the session id
+
+- **WHEN** a wake fires for an anchor with no recorded `sessionId`
+- **THEN** the daemon starts a fresh Kiro run, captures the generated `sessionId` after the run, and persists the anchor→session-id mapping for future resumes
+
+### Requirement: Permission mode maps to a Kiro tool-trust posture, defaulting to YOLO
+
+The daemon's backend-agnostic permission mode SHALL map to a Kiro tool-trust posture so a headless turn never blocks on an approval prompt: `yolo` SHALL run with `--trust-all-tools` (full autonomy for code-writing work), and the restricted `chorus` posture SHALL run with a scoped `--trust-tools=` set granting read-only filesystem access plus the Chorus MCP tools (no shell execution or file writes). Consistent with the daemon's existing default, an unconfigured daemon SHALL wake Kiro in `yolo`.
+
+#### Scenario: Default kiro wake trusts all tools
+
+- **WHEN** the daemon wakes the kiro backend with no permission flags overriding the default
+- **THEN** the `kiro-cli chat` invocation includes `--trust-all-tools`
+
+#### Scenario: Restricted posture trusts only a read-ish scoped set
+
+- **WHEN** the daemon is run in the restricted `chorus` posture and wakes the kiro backend
+- **THEN** the `kiro-cli chat` invocation includes a scoped `--trust-tools=` set (read-only filesystem plus the Chorus MCP tools) so the woken Kiro can call Chorus tools but cannot run shell commands or write files
+
+### Requirement: Kiro MCP comes from the plugin config with the daemon key via env
+
+The daemon SHALL NOT synthesize a Kiro MCP configuration. It SHALL rely on the Kiro plugin's `.kiro/settings/mcp.json` (loaded via `--agent chorus`) to declare the Chorus MCP server. To make the woken Kiro authenticate as the daemon's own agent, the spawner SHALL export the daemon's resolved API key into the child process environment as `CHORUS_API_KEY` (the variable the plugin's MCP config references via `${env:CHORUS_API_KEY}`); the key SHALL be passed through the environment and SHALL NOT appear in the process arguments. When no Chorus MCP server is configured, the woken Kiro SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail. Because headless MCP loading requires a Node.js runtime present in the workspace, the daemon SHALL document node ≥ 22 as a prerequisite for the kiro backend.
+
+#### Scenario: Daemon key reaches the plugin-configured Chorus MCP server via env
+
+- **WHEN** the Kiro plugin's `.kiro/settings/mcp.json` declares the `chorus` server with an `Authorization: Bearer ${env:CHORUS_API_KEY}` header and the daemon wakes the kiro backend
+- **THEN** the spawned Kiro receives the daemon's resolved API key in its `CHORUS_API_KEY` environment variable (never in argv), so its Chorus MCP calls authenticate as the daemon's agent
+
+#### Scenario: No Chorus MCP configured still runs
+
+- **WHEN** no Chorus MCP server is configured for the woken Kiro
+- **THEN** the wake still spawns and completes, the woken Kiro simply lacks Chorus tools, and the daemon logs the absence instead of crashing
+
+### Requirement: Kiro transcript reconstructed from the session store with a plain-text fallback
+
+Because `kiro-cli chat --no-interactive` emits no structured per-message stream (its `--format json` applies only to list commands), the daemon SHALL capture the transcript by reading Kiro's on-disk session store for the run's `sessionId` after the turn completes: it SHALL convert each stored message entry (per-message JSONL keyed by a message kind such as prompt / assistant message, with the body under a content field) into a structured transcript entry and feed it to the existing transcript-upload path. When a woken Kiro session spawns child sessions (e.g. reviewer subagents, identified by a parent-session reference in the store), the reconstruction SHALL include those child sessions' messages. If the session store cannot be parsed reliably, the daemon SHALL fall back to capturing the run's raw stdout as a single plain-text transcript entry per turn. Transcript capture SHALL be best-effort and SHALL NOT block or fail the wake.
+
+#### Scenario: Structured entries reconstructed from the session store
+
+- **WHEN** a Kiro wake completes and its session store file for the run's `sessionId` is present and parseable
+- **THEN** the daemon converts the stored per-message entries into structured transcript entries (including any child subagent sessions) and uploads them
+
+#### Scenario: Unparseable store degrades to a plain-text blob
+
+- **WHEN** the session store for the run cannot be located or parsed
+- **THEN** the daemon uploads the run's raw stdout as a single plain-text transcript entry and logs the degrade, without failing the wake
+
+### Requirement: Kiro interrupt via detached process-group kill
+
+The Kiro backend SHALL spawn its subprocess in a detached POSIX process group (so it leads its own group and a group-directed signal reaches any child shells Kiro forks for tool calls), and the daemon's existing two-stage process-tree killer (graceful SIGINT, then forceful SIGKILL of the group after a timeout; `taskkill /T /F` on Windows) SHALL be reused unchanged to interrupt a running Kiro wake. After an interrupt, a subsequent wake for the same anchor SHALL resume the recorded Kiro `sessionId` when one was captured before the interrupt.
+
+#### Scenario: Interrupting a running Kiro wake stops its process tree
+
+- **WHEN** an authorized interrupt is verified for a running Kiro wake
+- **THEN** the daemon group-signals the detached Kiro process so the Kiro process and the child shells it spawned are stopped, escalating to a forceful kill if it does not exit within the timeout
+
+#### Scenario: Re-wake after interrupt resumes when a session id was captured
+
+- **WHEN** a Kiro wake was interrupted after its `sessionId` had been captured and persisted, and a new wake fires for the same anchor
+- **THEN** the daemon resumes that `sessionId` via `kiro-cli chat --no-interactive --resume-id` rather than starting a fresh session

--- a/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/tasks.md
+++ b/openspec/changes/archive/2026-07-14-add-daemon-kiro-backend/tasks.md
@@ -1,0 +1,32 @@
+# Tasks
+
+## 1. Register kiro as a backend (agent selection + client type + dispatch)
+- [ ] Add `kiro` to `KNOWN_AGENTS` in `cli/daemon-agent.mjs`; add `backendCli` (`{name:"kiro", envVar:"CHORUS_KIRO_PATH"}`) and `backendClientType` (`"kiro"`) branches
+- [ ] `cli/spawner-select.mjs`: add `if (agentType === "kiro") return new KiroSpawner({logger, permissionMode, creds})`
+- [ ] Server: add `"kiro"` to `DAEMON_CLIENT_TYPES` (`src/services/daemon-connection.service.ts`); add `case "kiro"` to `useClientTypeLabel` (`src/components/agent-presence/hooks.ts`)
+- [ ] Reconcile the stale `KNOWN_AGENTS` in `cli/client-args.mjs` (currently only `claude-code`)
+- [ ] Tests: agent resolution accepts kiro / rejects unknown; default+codex+kiro select the right spawner; claude/codex argv unchanged; `isValidClientType("kiro")` true
+
+## 2. Kiro session-id map (persistence)
+- [ ] `cli/kiro-session-map.mjs`: get/set `anchor → sessionId`, atomic write, never throws (share a generic helper with `codex-session-map.mjs` if byte-identical apart from filename/path `~/.chorus/kiro-sessions.json`)
+- [ ] Tests: round-trip, missing-file, corrupt-file, write-failure degradation
+
+## 3. KiroSpawner
+- [ ] Executable resolution (PATH walk, Windows `.cmd` via cmd.exe, `CHORUS_KIRO_PATH` override)
+- [ ] buildArgs: new (`chat --no-interactive --agent chorus` + trust flags) and resume (`+ --resume-id <id>`); prompt over stdin; v2 engine (no `--v3`)
+- [ ] Permission mode → trust flags (`yolo → --trust-all-tools`; `chorus → --trust-tools=fs_read,<chorus-mcp-tool-names>`) — verify exact Chorus MCP trust names against installed kiro-cli
+- [ ] Spawn detached, `onChild`, daemon key exported as `CHORUS_API_KEY` in child env (never argv) + `CHORUS_DAEMON_HEADLESS=1`
+- [ ] sessionId capture post-run (resume: known; new: session whose store `updated_at` advanced during the run) + map write on new-run success
+- [ ] Tests: argv (new/resume, `--agent chorus`, trust per mode, prompt-not-in-argv), env key export, exec resolution incl. Windows + override, no-throw on spawn failure, sessionId capture
+
+## 4. Transcript reconstruction (store-first, plain-text fallback)
+- [ ] `cli/kiro-transcript.mjs`: read `~/.kiro/sessions/cli/<sessionId>.jsonl` + `<id>.json`, map `{kind, data.content[]}` → structured transcript entries; walk child sessions (`session_created_reason:"subagent"` + `parent_session_id`)
+- [ ] Fallback branch: unparseable store → single plain-text stdout blob per turn (logged degrade, never fails wake)
+- [ ] Wire into the transcript-upload hook (`cli/upload-hooks.mjs`); extend the dialect extractor only if reconstructed entries don't fit the existing user/assistant envelope
+- [ ] Tests: reconstruction from a fixture store incl. a child subagent session; fallback path on a corrupt/missing store
+
+## 5. Live integration + validation (integration checkpoint)
+- [ ] Validate headless MCP loads live under `kiro-cli chat --no-interactive --agent chorus` on this host (node ≥ 22); document node-22 prereq. Build the `chorus-api.sh` REST fallback ONLY if this fails
+- [ ] Integration: default daemon spawns Claude with identical argv; `--agent codex` unchanged; `--agent kiro` produces expected `kiro-cli chat --no-interactive` argv for new and resume with prompt on stdin
+- [ ] End-to-end on this host: real wake → turn runs → interrupt via process-group kill stops the tree → re-wake resumes `--resume-id` → transcript reconstructed and uploaded
+- [ ] Re-verify all `kiro-cli chat` flags / session-store path+schema / plugin agent name (`chorus`) against installed kiro-cli 2.12.1 and the live store

--- a/openspec/specs/daemon-kiro-backend/spec.md
+++ b/openspec/specs/daemon-kiro-backend/spec.md
@@ -1,0 +1,89 @@
+# daemon-kiro-backend Specification
+
+## Purpose
+TBD - created by archiving change add-daemon-kiro-backend. Update Purpose after archive.
+## Requirements
+### Requirement: Headless Kiro wake over `kiro-cli chat --no-interactive`
+
+When the resolved backend is `kiro`, the daemon SHALL wake the local Kiro CLI by spawning `kiro-cli chat --no-interactive` as a headless subprocess, feeding the wake prompt over **stdin** (never as a command-line argument), and running under the `chorus` agent profile (`--agent chorus`) so the woken session loads the Kiro plugin's Chorus MCP server, AI-DLC skills, and steering. The spawned child SHALL carry `CHORUS_DAEMON_HEADLESS=1` in its environment, matching the other backends' headless signal, and SHALL target the default v2 engine (it SHALL NOT pass `--v3`). The spawner SHALL resolve the `kiro-cli` executable without a shell (PATH walk for the platform's candidate names, a `.cmd`/`.bat` shim run via `cmd.exe` on Windows), honoring a `CHORUS_KIRO_PATH` override when set, and SHALL refuse to spawn with a visible log if it cannot locate the executable.
+
+#### Scenario: New wake spawns kiro-cli chat with the prompt on stdin
+
+- **WHEN** the daemon wakes the kiro backend for an anchor that has no recorded Kiro session id
+- **THEN** it spawns `kiro-cli chat --no-interactive --agent chorus` (plus the resolved trust flags) with the prompt written to stdin, and no part of the prompt appears in the process arguments
+
+#### Scenario: Missing kiro-cli executable fails visibly without crashing
+
+- **WHEN** no `kiro-cli` executable can be resolved on PATH and `CHORUS_KIRO_PATH` is unset or invalid
+- **THEN** the wake resolves without spawning, emits a visible error log, and the daemon keeps running
+
+### Requirement: Kiro session anchoring via a persisted idea→session-id map
+
+Because Kiro generates its own conversation `sessionId` per cwd rather than accepting a client-supplied session id, the daemon SHALL capture the generated `sessionId` for a run and SHALL persist a mapping from the Chorus session anchor (the direct idea uuid, or the entity uuid for an ad-hoc session) to that `sessionId` in a daemon-local store. On a subsequent wake for the same anchor, the daemon SHALL resume the existing Kiro conversation via `kiro-cli chat --no-interactive --resume-id <sessionId>`; when no mapping exists for the anchor, it SHALL start a fresh run. The new-vs-resume decision for the Kiro backend SHALL be made from this map, not from Kiro's most-recent-per-cwd `--resume` (which would cross-contaminate ideas sharing the daemon's single repo cwd) and not from the Claude on-disk transcript probe. The persistence SHALL be best-effort: a read/write failure SHALL degrade to starting a fresh session with a visible log, never throwing into the wake path.
+
+#### Scenario: Same anchor resumes the same Kiro session
+
+- **WHEN** a wake fires for an anchor whose `sessionId` was recorded by a prior successful Kiro run
+- **THEN** the daemon runs `kiro-cli chat --no-interactive --resume-id <sessionId>` so the conversation continues, rather than starting a new session
+
+#### Scenario: First wake for an anchor starts fresh and records the session id
+
+- **WHEN** a wake fires for an anchor with no recorded `sessionId`
+- **THEN** the daemon starts a fresh Kiro run, captures the generated `sessionId` after the run, and persists the anchor→session-id mapping for future resumes
+
+### Requirement: Permission mode maps to a Kiro tool-trust posture, defaulting to YOLO
+
+The daemon's backend-agnostic permission mode SHALL map to a Kiro tool-trust posture so a headless turn never blocks on an approval prompt: `yolo` SHALL run with `--trust-all-tools` (full autonomy for code-writing work), and the restricted `chorus` posture SHALL run with a scoped `--trust-tools=` set granting read-only filesystem access plus the Chorus MCP tools (no shell execution or file writes). Consistent with the daemon's existing default, an unconfigured daemon SHALL wake Kiro in `yolo`.
+
+#### Scenario: Default kiro wake trusts all tools
+
+- **WHEN** the daemon wakes the kiro backend with no permission flags overriding the default
+- **THEN** the `kiro-cli chat` invocation includes `--trust-all-tools`
+
+#### Scenario: Restricted posture trusts only a read-ish scoped set
+
+- **WHEN** the daemon is run in the restricted `chorus` posture and wakes the kiro backend
+- **THEN** the `kiro-cli chat` invocation includes a scoped `--trust-tools=` set (read-only filesystem plus the Chorus MCP tools) so the woken Kiro can call Chorus tools but cannot run shell commands or write files
+
+### Requirement: Kiro MCP comes from the plugin config with the daemon key via env
+
+The daemon SHALL NOT synthesize a Kiro MCP configuration. It SHALL rely on the Kiro plugin's `.kiro/settings/mcp.json` (loaded via `--agent chorus`) to declare the Chorus MCP server. To make the woken Kiro authenticate as the daemon's own agent, the spawner SHALL export the daemon's resolved API key into the child process environment as `CHORUS_API_KEY` (the variable the plugin's MCP config references via `${env:CHORUS_API_KEY}`); the key SHALL be passed through the environment and SHALL NOT appear in the process arguments. When no Chorus MCP server is configured, the woken Kiro SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail. Because headless MCP loading requires a Node.js runtime present in the workspace, the daemon SHALL document node ≥ 22 as a prerequisite for the kiro backend.
+
+#### Scenario: Daemon key reaches the plugin-configured Chorus MCP server via env
+
+- **WHEN** the Kiro plugin's `.kiro/settings/mcp.json` declares the `chorus` server with an `Authorization: Bearer ${env:CHORUS_API_KEY}` header and the daemon wakes the kiro backend
+- **THEN** the spawned Kiro receives the daemon's resolved API key in its `CHORUS_API_KEY` environment variable (never in argv), so its Chorus MCP calls authenticate as the daemon's agent
+
+#### Scenario: No Chorus MCP configured still runs
+
+- **WHEN** no Chorus MCP server is configured for the woken Kiro
+- **THEN** the wake still spawns and completes, the woken Kiro simply lacks Chorus tools, and the daemon logs the absence instead of crashing
+
+### Requirement: Kiro transcript reconstructed from the session store with a plain-text fallback
+
+Because `kiro-cli chat --no-interactive` emits no structured per-message stream (its `--format json` applies only to list commands), the daemon SHALL capture the transcript by reading Kiro's on-disk session store for the run's `sessionId` after the turn completes: it SHALL convert each stored message entry (per-message JSONL keyed by a message kind such as prompt / assistant message, with the body under a content field) into a structured transcript entry and feed it to the existing transcript-upload path. When a woken Kiro session spawns child sessions (e.g. reviewer subagents, identified by a parent-session reference in the store), the reconstruction SHALL include those child sessions' messages. If the session store cannot be parsed reliably, the daemon SHALL fall back to capturing the run's raw stdout as a single plain-text transcript entry per turn. Transcript capture SHALL be best-effort and SHALL NOT block or fail the wake.
+
+#### Scenario: Structured entries reconstructed from the session store
+
+- **WHEN** a Kiro wake completes and its session store file for the run's `sessionId` is present and parseable
+- **THEN** the daemon converts the stored per-message entries into structured transcript entries (including any child subagent sessions) and uploads them
+
+#### Scenario: Unparseable store degrades to a plain-text blob
+
+- **WHEN** the session store for the run cannot be located or parsed
+- **THEN** the daemon uploads the run's raw stdout as a single plain-text transcript entry and logs the degrade, without failing the wake
+
+### Requirement: Kiro interrupt via detached process-group kill
+
+The Kiro backend SHALL spawn its subprocess in a detached POSIX process group (so it leads its own group and a group-directed signal reaches any child shells Kiro forks for tool calls), and the daemon's existing two-stage process-tree killer (graceful SIGINT, then forceful SIGKILL of the group after a timeout; `taskkill /T /F` on Windows) SHALL be reused unchanged to interrupt a running Kiro wake. After an interrupt, a subsequent wake for the same anchor SHALL resume the recorded Kiro `sessionId` when one was captured before the interrupt.
+
+#### Scenario: Interrupting a running Kiro wake stops its process tree
+
+- **WHEN** an authorized interrupt is verified for a running Kiro wake
+- **THEN** the daemon group-signals the detached Kiro process so the Kiro process and the child shells it spawned are stopped, escalating to a forceful kill if it does not exit within the timeout
+
+#### Scenario: Re-wake after interrupt resumes when a session id was captured
+
+- **WHEN** a Kiro wake was interrupted after its `sessionId` had been captured and persisted, and a new wake fires for the same anchor
+- **THEN** the daemon resumes that `sessionId` via `kiro-cli chat --no-interactive --resume-id` rather than starting a fresh session
+

--- a/src/components/agent-presence/hooks.ts
+++ b/src/components/agent-presence/hooks.ts
@@ -94,6 +94,8 @@ export function useClientTypeLabel() {
           return t("clientOpenclaw");
         case "codex":
           return t("clientCodex");
+        case "kiro":
+          return t("clientKiro");
         default:
           return t("clientUnknown");
       }

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -112,8 +112,8 @@ beforeEach(() => {
 
 // ===== Constants =====
 describe("constants", () => {
-  it("DAEMON_CLIENT_TYPES are claude_code + openclaw + codex", () => {
-    expect(DAEMON_CLIENT_TYPES).toEqual(["claude_code", "openclaw", "codex"]);
+  it("DAEMON_CLIENT_TYPES are claude_code + openclaw + codex + kiro", () => {
+    expect(DAEMON_CLIENT_TYPES).toEqual(["claude_code", "openclaw", "codex", "kiro"]);
   });
 
   it("STALE_THRESHOLD_MS is 90s (3x the 30s heartbeat)", () => {

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -21,7 +21,7 @@ import logger from "@/lib/logger";
 // The `clientType` column also reserves "browser" / "other" (see schema) so
 // browser registration can be added later without a migration, but only these
 // machine daemon types are registered now.
-export const DAEMON_CLIENT_TYPES = ["claude_code", "openclaw", "codex"] as const;
+export const DAEMON_CLIENT_TYPES = ["claude_code", "openclaw", "codex", "kiro"] as const;
 export type DaemonClientType = (typeof DAEMON_CLIENT_TYPES)[number];
 
 // Staleness threshold for the liveness rule a downstream reader MUST apply:


### PR DESCRIPTION
## Summary
Adds a third Chorus daemon spawner backend — `--agent kiro` — parallel to `--agent codex`. It wakes a local headless `kiro-cli chat --no-interactive --agent chorus` with tool-trust scoping, per-idea `--resume-id` resume, detached-process-group interrupt (reusing the existing killer), and post-run transcript capture. Implements idea `dc53a459` (child of the Kiro-integration theme); OpenSpec change `add-daemon-kiro-backend` is archived in this PR.

## Design decisions (from human-verified elaboration)
- **Headless MCP risk (Kiro#5958) dissolved** — validated live: `--agent chorus` loads the Chorus MCP server and calls tools headlessly. #5958 was a node-22 env prereq, not a Kiro bug; node ≥ 22 documented. No REST fallback built.
- **Resume** via a per-idea `sessionId` map, mirroring `codex-session-map.mjs` (factored a shared `session-map.mjs` factory; codex refactored onto it, behavior-preserving).
- **Transcript**: reconstruct from Kiro's on-disk session store, ANSI-stripped plain-text stdout fallback. Live finding: `chat --no-interactive` does **not** persist a store session (only interactive runs do), so the fallback is the effective path and resume is best-effort.
- **sessionId capture is unambiguous-only** — the WakeQueue runs different ideas concurrently in the shared cwd, so capture persists only when exactly one new session appeared (else declines, to avoid cross-wiring two ideas).
- **v2 engine**; trust mirrors Codex (`yolo → --trust-all-tools`, `chorus → --trust-tools=fs_read,@chorus`).

## Changed files
| File | Change |
|------|--------|
| `cli/kiro-spawner.mjs` | new — KiroSpawner (spawn / resume / trust / interrupt / sessionId capture) |
| `cli/kiro-session-map.mjs`, `cli/session-map.mjs` | new — shared anchor→handle store; codex refactored onto it |
| `cli/kiro-transcript.mjs` | new — store reconstruction + ANSI-stripped plain-text fallback |
| `cli/daemon-agent.mjs`, `cli/spawner-select.mjs`, `cli/daemon.mjs`, `cli/client-args.mjs` | register `kiro` (KNOWN_AGENTS, backendCli/ClientType, dispatch, banner probe) |
| `src/services/daemon-connection.service.ts` | `DAEMON_CLIENT_TYPES += "kiro"` |
| `src/components/agent-presence/hooks.ts` + `messages/{en,zh,ko,ja}.json` | `clientKiro` presence label (4 locales) |
| `cli/__tests__/kiro-*.test.mjs` (+ updated daemon-agent/spawner-select) | unit + integration tests |
| `openspec/…/add-daemon-kiro-backend`, `openspec/specs/daemon-{agent-selection,kiro-backend}` | archived change + updated specs |

## Test plan
- [x] Full suite green: cli 712, server/src 3481 (4193 total), tsc clean, eslint 0 errors
- [x] **Live e2e**: real `--agent kiro` daemon registers as `clientType=kiro`; a `human_instruction` wake spawns `kiro-cli chat --no-interactive --agent chorus`, runs the turn (exit 0), uploads the transcript
- [x] Live: headless MCP load + `chorus_checkin`; `killProcessTree` interrupt of a live kiro turn; ANSI-stripped transcript fallback
- [ ] Browser render of the transcript in the daemon-session UI (backend upload confirmed; visual render deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)