### PR TITLE
fix(daemon): anchor child-idea wake to the child conversation + deliver approve note inline

### DIFF
--- a/cli/__tests__/upload-hooks.test.mjs
+++ b/cli/__tests__/upload-hooks.test.mjs
@@ -211,7 +211,7 @@ describe("Waker.buildExecutionSnapshot from lifecycle transitions", () => {
     // Enqueue: marks the task queued and emits a snapshot.
     waker.markQueued(TASK_NOTIF, `idea:${DIRECT_IDEA}`, attrib("root-1"));
     expect(waker.buildExecutionSnapshot()).toEqual([
-      { entityType: "task", entityUuid: "task-1", rootIdeaUuid: "root-1", status: "queued", startedAt: null },
+      { entityType: "task", entityUuid: "task-1", rootIdeaUuid: "root-1", directIdeaUuid: DIRECT_IDEA, status: "queued", startedAt: null },
     ]);
     expect(changes).toHaveLength(1);
 
@@ -229,7 +229,7 @@ describe("Waker.buildExecutionSnapshot from lifecycle transitions", () => {
     await waker2.wake(TASK_NOTIF, `idea:${DIRECT_IDEA}`, attrib("root-1"));
 
     expect(snapshotDuringRun).toHaveLength(1);
-    expect(snapshotDuringRun[0]).toMatchObject({ entityType: "task", entityUuid: "task-1", rootIdeaUuid: "root-1", status: "running" });
+    expect(snapshotDuringRun[0]).toMatchObject({ entityType: "task", entityUuid: "task-1", rootIdeaUuid: "root-1", directIdeaUuid: DIRECT_IDEA, status: "running" });
     expect(snapshotDuringRun[0].startedAt).toBeTruthy();
     expect(Number.isNaN(Date.parse(snapshotDuringRun[0].startedAt))).toBe(false);
 
@@ -274,7 +274,8 @@ describe("Waker.buildExecutionSnapshot from lifecycle transitions", () => {
     // Idea wake: direct == root == idea-7 (a top-level idea); attribution carries the root.
     waker.markQueued(ideaNotif, "idea:idea-7", { key: "idea:idea-7", rootIdeaUuid: "idea-7", directIdeaUuid: "idea-7" });
     expect(waker.buildExecutionSnapshot()).toEqual([
-      { entityType: "idea", entityUuid: "idea-7", rootIdeaUuid: "idea-7", status: "queued", startedAt: null },
+      // Top-level idea: direct == root == idea-7.
+      { entityType: "idea", entityUuid: "idea-7", rootIdeaUuid: "idea-7", directIdeaUuid: "idea-7", status: "queued", startedAt: null },
     ]);
     expect(changes).toEqual(["c"]); // tracked → snapshot emitted
   });
@@ -300,13 +301,34 @@ describe("Waker.buildExecutionSnapshot from lifecycle transitions", () => {
     await expect(waker.wake(TASK_NOTIF, `idea:${DIRECT_IDEA}`, attrib("root-1"))).resolves.toBeUndefined();
   });
 
-  it("per-entity fallback (no idea ancestor) yields a null rootIdeaUuid in the snapshot", () => {
+  it("per-entity fallback (no idea ancestor) yields null rootIdeaUuid AND null directIdeaUuid in the snapshot", () => {
     const hooks = createNoopUploadHooks();
     const { waker } = makeWaker(hooks);
     waker.markQueued(TASK_NOTIF, "entity:task:task-1", { key: "entity:task:task-1", rootIdeaUuid: null, directIdeaUuid: null });
     expect(waker.buildExecutionSnapshot()).toEqual([
-      { entityType: "task", entityUuid: "task-1", rootIdeaUuid: null, status: "queued", startedAt: null },
+      { entityType: "task", entityUuid: "task-1", rootIdeaUuid: null, directIdeaUuid: null, status: "queued", startedAt: null },
     ]);
+  });
+
+  it("a child-idea wake emits directIdeaUuid = child DISTINCT from rootIdeaUuid = parent", () => {
+    // The core fix: for a derived (child) idea, the task/proposal wake resolves
+    // directIdeaUuid = child (the session anchor) and rootIdeaUuid = the topmost
+    // parent. Both must reach the snapshot, distinctly, so the UI can anchor the
+    // running/interruptible indicator to the CHILD conversation, not the parent.
+    const hooks = createNoopUploadHooks();
+    const { waker } = makeWaker(hooks);
+    const child = "child-idea-2222-4222-8222-222222222222";
+    const parent = "parent-idea-3333-4333-8333-333333333333";
+    waker.markQueued(TASK_NOTIF, `idea:${child}`, {
+      key: `idea:${child}`,
+      rootIdeaUuid: parent,
+      directIdeaUuid: child,
+    });
+    const snap = waker.buildExecutionSnapshot();
+    expect(snap).toEqual([
+      { entityType: "task", entityUuid: "task-1", rootIdeaUuid: parent, directIdeaUuid: child, status: "queued", startedAt: null },
+    ]);
+    expect(snap[0].directIdeaUuid).not.toBe(snap[0].rootIdeaUuid);
   });
 });
 

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -63,6 +63,55 @@ describe("buildPrompt", () => {
     }
   });
 
+  it("proposal_approved surfaces the reviewer's note inline when message carries one", () => {
+    const p = buildPrompt({
+      ...TASK_NOTIF,
+      action: "proposal_approved",
+      entityType: "proposal",
+      entityUuid: "prop-1",
+      entityTitle: "My Proposal",
+      message: 'Proposal "My Proposal" has been approved. Note: ship it but rename the flag',
+    });
+    expect(p).not.toBeNull();
+    expect(p).toContain("APPROVED");
+    // The reviewer's opinion is inline so the daemon needs no follow-up fetch.
+    expect(p).toContain("Review note:");
+    expect(p).toContain("ship it but rename the flag");
+    // Still points at the unblocked-tasks tool.
+    expect(p).toContain("chorus_get_unblocked_tasks");
+  });
+
+  it("proposal_approved WITHOUT a note reads cleanly (no empty note text)", () => {
+    const p = buildPrompt({
+      ...TASK_NOTIF,
+      action: "proposal_approved",
+      entityType: "proposal",
+      entityUuid: "prop-1",
+      entityTitle: "My Proposal",
+      message: 'Proposal "My Proposal" has been approved',
+    });
+    expect(p).not.toBeNull();
+    expect(p).toContain("APPROVED");
+    // No "Note: " marker in the message → no review-note fragment, no empty placeholder.
+    expect(p).not.toContain("Review note:");
+    expect(p).toContain("chorus_get_unblocked_tasks");
+  });
+
+  it("proposal_rejected still embeds the reviewer's reason (unchanged by the approve-note fix)", () => {
+    const p = buildPrompt({
+      ...TASK_NOTIF,
+      action: "proposal_rejected",
+      entityType: "proposal",
+      entityUuid: "prop-1",
+      entityTitle: "My Proposal",
+      message: "too risky, split it",
+    });
+    expect(p).not.toBeNull();
+    expect(p).toContain("REJECTED");
+    expect(p).toContain('Review note: "too risky, split it"');
+    expect(p).toContain("chorus_pm_submit_proposal");
+  });
+
   it("resource_resumed is an entity-generic wake action with a continue prompt (子3)", () => {
     expect(WAKE_ACTIONS.has("resource_resumed")).toBe(true);
     // Resume is entity-generic and arrives off the control channel as a synthetic
@@ -485,7 +534,7 @@ describe("Waker interrupt / crash reporting (子3)", () => {
     expect(snapshotDuringRun).toHaveLength(1);
     expect(snapshotDuringRun[0]).not.toHaveProperty("child");
     expect(Object.keys(snapshotDuringRun[0]).sort()).toEqual(
-      ["entityType", "entityUuid", "rootIdeaUuid", "startedAt", "status"].sort()
+      ["directIdeaUuid", "entityType", "entityUuid", "rootIdeaUuid", "startedAt", "status"].sort()
     );
   });
 

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -188,12 +188,22 @@ function buildPromptBody(n) {
         `fix issues with chorus_pm_update_task_draft / chorus_pm_update_document_draft, then ` +
         `chorus_pm_validate_proposal and chorus_pm_submit_proposal to resubmit.\n${mentionGuidance(n, "proposal")}`
       );
-    case "proposal_approved":
+    case "proposal_approved": {
+      // Surface the approver's note inline, symmetric with proposal_rejected — so the
+      // daemon knows the reviewer's opinion without a follow-up chorus_get_proposal
+      // fetch. The server bakes the note into n.message as "... approved. Note: <note>"
+      // (buildMessage in notification-listener.ts); an approve WITHOUT a note has no
+      // "Note: " marker, so reviewInfo stays empty and the prompt reads cleanly. This
+      // mirrors the OpenClaw plugin's proposal_approved handler (event-router.ts).
+      const reviewInfo = n.message?.includes("Note: ")
+        ? ` Review note: "${n.message.split("Note: ").pop()}".`
+        : "";
       return (
         `[Chorus] Proposal '${n.entityTitle}' was APPROVED (proposalUuid: ${n.entityUuid}, ` +
-        `projectUuid: ${n.projectUuid}). Its documents and tasks have been created. Use ` +
+        `projectUuid: ${n.projectUuid}).${reviewInfo} Its documents and tasks have been created. Use ` +
         `chorus_get_unblocked_tasks (projectUuid: "${n.projectUuid}") to find tasks ready to start.\n${mentionGuidance(n, "proposal")}`
       );
+    }
     case "idea_claimed":
       return (
         `[Chorus] Idea '${n.entityTitle}' was assigned to you (ideaUuid: ${n.entityUuid}, ` +

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -121,7 +121,12 @@ export class Waker {
     // control handler can target it for an interrupt. `child` is null while queued.
     // buildExecutionSnapshot() maps ONLY the serializable fields and NEVER emits
     // `child` — the handle stays daemon-local and never leaks onto the wire.
-    /** @type {Map<string, { entityType: string, entityUuid: string, rootIdeaUuid: string|null, status: "running"|"queued", startedAt: string|null, child: import("node:child_process").ChildProcess|null }>} */
+    // The entry also carries the `directIdeaUuid` the waker ALREADY resolved (the
+    // entity's directly-attached idea — the same value used as the session anchor)
+    // so the UI can match a conversation's execution by the DIRECT idea rather than
+    // the root — surfacing a child idea's wake on the child conversation, not its
+    // parent.
+    /** @type {Map<string, { entityType: string, entityUuid: string, rootIdeaUuid: string|null, directIdeaUuid: string|null, status: "running"|"queued", startedAt: string|null, child: import("node:child_process").ChildProcess|null }>} */
     this.executions = new Map();
   }
 
@@ -231,13 +236,14 @@ export class Waker {
    * resource (running or queued), carrying entityType/entityUuid, the reused
    * rootIdeaUuid, and the daemon-side status/startedAt. Returns a fresh array each
    * call so the caller can't mutate internal state. Never throws.
-   * @returns {Array<{ entityType: string, entityUuid: string, rootIdeaUuid: string|null, status: "running"|"queued", startedAt: string|null }>}
+   * @returns {Array<{ entityType: string, entityUuid: string, rootIdeaUuid: string|null, directIdeaUuid: string|null, status: "running"|"queued", startedAt: string|null }>}
    */
   buildExecutionSnapshot() {
     return [...this.executions.values()].map((e) => ({
       entityType: e.entityType,
       entityUuid: e.entityUuid,
       rootIdeaUuid: e.rootIdeaUuid,
+      directIdeaUuid: e.directIdeaUuid,
       status: e.status,
       startedAt: e.startedAt,
     }));
@@ -253,13 +259,20 @@ export class Waker {
    * task/idea/proposal/document set) is ignored. Never throws.
    * @param {{ entityType?: string, entityUuid?: string }} notification
    * @param {string} key  The serialization key from keyFor (idea:<direct> | entity:…).
-   * @param {{ rootIdeaUuid?: string|null }} [attribution]  Server-resolved root idea.
+   * @param {{ rootIdeaUuid?: string|null, directIdeaUuid?: string|null }} [attribution]
+   *   Server-resolved ids: `rootIdeaUuid` → execution snapshot grouping; `directIdeaUuid`
+   *   → the session anchor the UI matches a conversation's execution by. Both threaded
+   *   from `attribution`, NEVER sliced from `key`.
    */
   markQueued(notification, key, attribution) {
     const entity = this.#entityOf(notification);
     if (!entity) return;
     const execKey = this.#execKey(entity.entityType, entity.entityUuid);
     const rootIdeaUuid = attribution?.rootIdeaUuid ?? null;
+    // The DIRECT idea (session anchor) the UI matches a conversation's execution by
+    // — carried from the SAME server-resolved attribution as rootIdeaUuid, never
+    // sliced from the key.
+    const directIdeaUuid = attribution?.directIdeaUuid ?? null;
     const existing = this.executions.get(execKey);
     // Don't downgrade a running resource to queued if a duplicate dispatch
     // arrives while it's mid-wake; only (re)mark queued when not already running.
@@ -268,6 +281,7 @@ export class Waker {
       entityType: entity.entityType,
       entityUuid: entity.entityUuid,
       rootIdeaUuid,
+      directIdeaUuid,
       status: "queued",
       startedAt: existing?.startedAt ?? null,
       // Queued entries hold no live child yet — only the running entry does (子3).
@@ -346,6 +360,7 @@ export class Waker {
           entityType: entity.entityType,
           entityUuid: entity.entityUuid,
           rootIdeaUuid,
+          directIdeaUuid,
           status: "running",
           startedAt: new Date().toISOString(),
           child: null,

--- a/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/README.md
+++ b/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-child-idea-wake-anchor
+
+Anchor daemon wake in-progress/interruptible UI to the child (direct) idea, not the parent, and deliver the approve note inline

--- a/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/design.md
+++ b/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/design.md
@@ -1,0 +1,75 @@
+# Design — Fix daemon child-idea wake anchoring + approve-note delivery
+
+## Context
+
+The daemon's **two-ID contract** (documented in `cli/waker.mjs` and `cli/lineage.mjs`): every inbound notification is resolved by one server round-trip to `GET /api/entities/{type}/{uuid}/root-idea`, which returns BOTH:
+
+- `directIdeaUuid` — the entity's directly-attached idea (the first idea node on the lineage; for a task → its proposal's `inputUuids[0]` idea). The daemon anchors the Claude `--session-id` here so a human can `claude --resume <directIdeaUuid>` and same-idea wakes continue one session.
+- `rootIdeaUuid` — the topmost ancestor reached by walking `parentUuid`. Reported in the execution snapshot for observability.
+
+For a **top-level** idea `direct == root`. For a **child** idea (`child.parentUuid = parent`), a task/proposal wake resolves `direct = child`, `root = parent`.
+
+The chat UI (`src/components/agent-presence/chat/`) renders one conversation per DIRECT idea (`session.directIdeaUuid`) and shows a per-conversation running/interruptible indicator. `executionMatchesSession` decides which conversation an execution row belongs to.
+
+## The bug (Problem 1)
+
+`executionMatchesSession` (`session-execution.ts:35-42`) matches an idea-anchored conversation to an execution via:
+
+```ts
+(exec.entityType === "idea" && exec.entityUuid === session.directIdeaUuid) ||
+exec.rootIdeaUuid === session.directIdeaUuid   // ← only true when direct == root
+```
+
+The second clause was intended to catch a child-resource wake (a `task:<uuid>` execution whose idea is this conversation). But the daemon reports `exec.rootIdeaUuid`, so for a child idea the row carries `rootIdeaUuid = parent`. The clause then matches the row to the **parent's** conversation (whose `directIdeaUuid = parent`), lighting up the parent and leaving the child — which actually owns the woken `--session-id <child>` session — idle. Proposal `approve`/`reject` wakes hit the same path (both collapse to the `task_assigned` turn trigger, anchored on the proposal's direct idea).
+
+The `directIdeaUuid` that would fix this is **already resolved** by `cli/lineage.mjs` and lives in `attribution` inside `waker.mjs` — it is just never stored on the execution registry entry, so it never reaches the snapshot, the DB, or the UI.
+
+### Fix 1 — thread `directIdeaUuid` end-to-end, match on it
+
+Add `directIdeaUuid` to every hop the snapshot passes through, then change the UI predicate to key on it.
+
+| Hop | File | Change |
+|---|---|---|
+| Registry entry | `cli/waker.mjs` (map type ~124; `markQueued` set ~267; `wake` running set ~345) | carry `directIdeaUuid` (from `attribution.directIdeaUuid`) on each entry |
+| Snapshot serializer | `cli/waker.mjs` `buildExecutionSnapshot` ~236 | add `directIdeaUuid` to the mapped object + JSDoc |
+| OpenClaw mirror | `packages/openclaw-plugin/src/daemon-client.ts` (`ExecutionEntry` ~94; sets ~387,~493; `buildExecutionSnapshot` ~507) + `daemon-rest-client.ts` `DaemonExecutionRow` ~59 | mirror the field (host already resolves `directIdeaUuid` in `WakeRequest`) |
+| Ingest zod | `src/app/api/daemon/execution-state/route.ts` `snapshotEntrySchema` ~46 | `directIdeaUuid: z.string().min(1).nullish()` |
+| Service type | `daemon-execution.service.ts` `SnapshotExecution` ~88, `DaemonExecutionRow` ~147 | add `directIdeaUuid?: string | null` / `directIdeaUuid: string | null` |
+| Persistence | `daemon-execution.service.ts` `reconcileSnapshot` upsert create+update ~435/~445 | write `directIdeaUuid: exec.directIdeaUuid ?? null` |
+| Prisma model | `prisma/schema.prisma` `DaemonExecution` ~533 | `directIdeaUuid String?` (nullable); CLI-generated DDL-only migration |
+| Read projection | `daemon-execution.service.ts` `ExecutionView` ~101 + `toExecutionView` ~182 | add `directIdeaUuid: row.directIdeaUuid` |
+| UI predicate | `src/components/agent-presence/chat/session-execution.ts` ~31-42 | see below |
+
+The UI predicate becomes:
+
+```ts
+if (session.directIdeaUuid) {
+  return (
+    (exec.entityType === "idea" && exec.entityUuid === session.directIdeaUuid) ||
+    exec.directIdeaUuid === session.directIdeaUuid   // ← was exec.rootIdeaUuid
+  );
+}
+return exec.entityType === "daemon_session" && exec.entityUuid === session.sessionId;
+```
+
+The `Pick<ExecutionView, ...>` in the function signature adds `"directIdeaUuid"` (and may drop `"rootIdeaUuid"` if no longer read there).
+
+**Why match on `directIdeaUuid` and keep the first clause:** the first clause handles a direct wake ON the idea (`entityType === "idea"`, e.g. `elaboration_verified`), where the execution's `entityUuid` IS the idea. The second handles a child-resource wake (task/proposal/document), where the execution keys on the resource but its `directIdeaUuid` is the conversation's idea. Together they cover every wake a conversation owns, and — critically — a child idea's row now carries `directIdeaUuid = child`, matching the child conversation, never the parent.
+
+**Backward compatibility / rollout.** The column is nullable and the zod field is `nullish`. An older daemon that does not yet send `directIdeaUuid` produces rows with `directIdeaUuid = null`; the new predicate's second clause is then `null === session.directIdeaUuid` → false, but the first clause (`entityType === "idea"` direct wake) still matches, so a top-level idea's own-idea wakes still show correctly — the only regression window is a child-resource wake from a not-yet-updated daemon, which is exactly today's (already-buggy) behavior. Once the daemon ships the field, child and top-level both resolve correctly. No backfill of historical rows is needed (they are `ended` history, excluded from the active read).
+
+## The bug (Problem 2) + Fix 2
+
+`buildMessage` in `src/services/notification-listener.ts` already bakes the approver's note into the notification `message` for `proposal_approved` (`… approved. Note: <note>`) — symmetric with `proposal_rejected`. The daemon reads `message` as `n.message`. But `cli/prompts.mjs` `proposal_rejected` surfaces `n.message` (`Review note: "${n.message}"`) while `proposal_approved` never references it. So the note is delivered to the daemon and then discarded at the prompt.
+
+**Fix 2 is a single `cli/prompts.mjs` edit:** the `proposal_approved` body includes the decision context from `n.message` inline, mirroring `proposal_rejected`, so the woken daemon knows the reviewer's opinion without a `chorus_get_proposal` round-trip. No server change (the note already rides `message`); applies to every approve wake regardless of lineage.
+
+## Risks / trade-offs
+
+- **Two daemon hosts, one wire contract.** The CLI daemon and the OpenClaw plugin both POST to `/api/daemon/execution-state`. The zod field is `nullish`, so the OpenClaw host that hasn't added the field still validates; but to avoid the OpenClaw-hosted child-idea bug we mirror the field there too, in the same change.
+- **Migration.** A single additive nullable column — safe, DDL-only, generated via the Prisma CLI (no hand-written SQL, no DML backfill).
+- **`rootIdeaUuid` stays.** It is still reported and persisted (used for the session-label `rootIdeaTitle` enrichment and observability grouping). This change adds `directIdeaUuid` beside it; it does not remove `rootIdeaUuid`.
+
+## Migration / rollout order
+
+Ship server (nullable column + zod accept + projection) and daemon (emit field) together in one PR; the nullable column tolerates either arriving first. The UI predicate change is safe once `ExecutionView.directIdeaUuid` exists (null for old rows → falls through to the direct-idea clause).

--- a/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/proposal.md
+++ b/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+When an idea derived from a parent (a **child** idea) receives a daemon wake — a `task_assigned`, or a proposal `approve`/`reject` — the daemon chat UI shows the **parent** idea as "in progress" and interruptible, while the child that actually owns the woken session looks idle. The wrong conversation lights up, and a human trying to interrupt the running work targets the wrong idea.
+
+Root cause is the daemon's **two-ID contract** leaking. Each wake resolves both a `directIdeaUuid` (the entity's directly-attached idea — the child) and a `rootIdeaUuid` (the topmost ancestor — the parent). The daemon correctly anchors the Claude session on `directIdeaUuid`, but the execution snapshot it reports carries only `rootIdeaUuid`. The chat UI's per-conversation match predicate (`session-execution.ts`) therefore matches an execution to a conversation via `exec.rootIdeaUuid === session.directIdeaUuid` — an equality that holds **only for a top-level idea** (where direct == root). For a child, a task/proposal wake resolves `directIdeaUuid = child`, `rootIdeaUuid = parent`, so the execution matches the **parent** conversation and the child shows idle. The `directIdeaUuid` needed to fix this is already computed by the daemon; it is simply dropped before the execution registry.
+
+Separately — and independent of lineage — the daemon's `proposal_approved` wake prompt **drops the approver's note**. The `proposal_rejected` prompt already embeds the reviewer's reason (via the notification `message`), but the approve prompt omits it, so on approval the daemon does not know the reviewer's opinion and must re-fetch the proposal to discover it. The note is already carried on the notification `message`; the approve prompt just fails to surface it.
+
+## What Changes
+
+- **Thread `directIdeaUuid` through the execution snapshot end-to-end.** The daemon already resolves `directIdeaUuid` per wake; carry it on the execution registry entry, emit it in the execution snapshot, validate it at the ingest zod boundary, persist it as a new nullable `DaemonExecution.directIdeaUuid` column, and project it onto `ExecutionView`. Mirror the same field in the OpenClaw plugin's execution-snapshot client so both daemon hosts report the identical wire shape.
+- **Match a conversation's execution by the DIRECT idea, not the root.** The chat UI predicate `executionMatchesSession` changes from matching `exec.rootIdeaUuid === session.directIdeaUuid` to matching `exec.directIdeaUuid === session.directIdeaUuid` (plus the existing direct `entityType==="idea"` case). Result: a child idea's task/proposal wake surfaces the running/interruptible state on the **child** conversation only; the parent shows nothing about the child's run (elaboration Q1 = child-only). This also fixes the identical mis-display for proposal `approve`/`reject` wakes, which anchor on the proposal's direct idea.
+- **Deliver the reviewer's note inline on the approve wake, for every proposal wake.** The `proposal_approved` daemon prompt is updated to surface the approver's note (from the notification `message`, exactly as `proposal_rejected` already does) so the daemon knows the decision context without a follow-up fetch. Applies to all proposal wakes regardless of lineage (elaboration Q2 = inline note for both, Q4 = all proposal wakes). No new payload field — the note already rides `message`.
+
+Out of scope (elaboration Q3 = reported symptoms only): the latent proposal-pin-inheritance direct-vs-root asymmetry (`resolveRootIdeaUuidForPin`) is **not** touched by this change.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `daemon-execution-state`: the execution snapshot / persisted row / read projection currently carry only `rootIdeaUuid` as the lineage anchor. This adds a `directIdeaUuid` field across the wire, the `DaemonExecution` model, and the `ExecutionView` projection, and makes the per-conversation execution match key the **direct** idea — so a child-idea wake surfaces on the child conversation, not its parent.
+- `stage-advance-wake`: extended (via the daemon wake-prompt contract) so the `proposal_approved` wake surfaces the reviewer's note inline, matching `proposal_rejected`, for every proposal wake.
+
+## Impact
+
+- **Daemon (CLI)**: `cli/waker.mjs` (execution registry entry + `buildExecutionSnapshot` + the two set-sites in `markQueued`/`wake` carry `directIdeaUuid`), `cli/prompts.mjs` (`proposal_approved` body surfaces the note). `directIdeaUuid` is already resolved by `cli/lineage.mjs` and threaded in `attribution` — no lineage change.
+- **OpenClaw plugin**: `packages/openclaw-plugin/src/daemon-client.ts` (`ExecutionEntry` + `buildExecutionSnapshot` + set-sites) and `packages/openclaw-plugin/src/daemon-rest-client.ts` (`DaemonExecutionRow` wire type) mirror the field so the second daemon host reports the identical shape.
+- **Server**: `src/app/api/daemon/execution-state/route.ts` (`snapshotEntrySchema` accepts `directIdeaUuid`), `src/services/daemon-execution.service.ts` (`SnapshotExecution`, `DaemonExecutionRow`, `ExecutionView`, `toExecutionView`, `reconcileSnapshot` create+update). SSE delivery (`src/app/api/events/route.ts`) carries the field automatically via the `ExecutionView` spread.
+- **Database**: one Prisma-CLI-generated migration adding a nullable `directIdeaUuid String?` column to `DaemonExecution` (DDL only, no backfill).
+- **Frontend**: `src/components/agent-presence/chat/session-execution.ts` (the match predicate switches to `directIdeaUuid`); the re-exported `ExecutionView` type propagates the new field with no separate frontend type edit.
+- **No new permission bit. No new MCP tool.** The note delivery reuses the existing notification `message` (no new wire field).
+- **Tests**: CLI (`upload-hooks`, `daemon-rest-client`, `wake-orchestration`), OpenClaw (`daemon-client`), server (`daemon-execution.service`, `execution-state` route), and frontend (`session-execution`, `agent-presence-context`) snapshot-shape + match-predicate assertions; a `prompts` assertion that the approve prompt surfaces the note.

--- a/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/specs/daemon-execution-state/spec.md
+++ b/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/specs/daemon-execution-state/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: The execution snapshot and row SHALL carry the direct idea alongside the root idea
+
+The daemon SHALL report a `directIdeaUuid` (the entity's directly-attached idea — the server-resolved `directIdeaUuid` the daemon already uses as its Claude session anchor) on every execution-snapshot entry, in addition to the existing `rootIdeaUuid`. The server SHALL accept `directIdeaUuid` at the `POST /api/daemon/execution-state` ingest boundary as an optional, nullable string, SHALL persist it on the `DaemonExecution` model as a nullable column, and SHALL include it in the `ExecutionView` read projection returned by every execution read (per-connection first paint, aggregate read, and the SSE `execution:{connectionUuid}` event). The `directIdeaUuid` column SHALL be added through a Prisma-CLI-generated migration containing only DDL (no `INSERT`/`UPDATE`/`DELETE` backfill). `rootIdeaUuid` SHALL remain reported, persisted, and projected unchanged.
+
+#### Scenario: A child-idea task wake reports both ids distinctly
+
+- **WHEN** the daemon wakes for a `task_assigned` notification whose task belongs to a child idea (the task's direct idea has a `parentUuid`)
+- **THEN** the execution-snapshot entry it uploads carries `directIdeaUuid` equal to the child idea's uuid and `rootIdeaUuid` equal to the topmost ancestor idea's uuid, and the persisted row and the `ExecutionView` returned to clients carry both values distinctly.
+
+#### Scenario: A top-level idea reports equal ids
+
+- **WHEN** the daemon wakes for a wake whose entity's direct idea has no parent
+- **THEN** the entry's `directIdeaUuid` and `rootIdeaUuid` are the same idea uuid.
+
+#### Scenario: A wake with no idea ancestor reports null ids
+
+- **WHEN** the daemon wakes for an entity that resolves to no idea (e.g. a standalone/quick task)
+- **THEN** the entry's `directIdeaUuid` is null and the row/projection tolerate the null.
+
+#### Scenario: An older daemon that omits the field is accepted
+
+- **WHEN** a daemon that has not been updated uploads a snapshot entry without `directIdeaUuid`
+- **THEN** the ingest endpoint accepts the entry and persists `directIdeaUuid` as null (the field is optional and nullable), without rejecting the snapshot.
+
+### Requirement: A conversation's running/interruptible execution SHALL be matched by the direct idea, not the root idea
+
+The chat UI SHALL determine whether a daemon execution belongs to an idea-anchored conversation by matching the execution's `directIdeaUuid` against the conversation's `directIdeaUuid` (in addition to matching a direct wake ON the idea, where the execution's `entityType` is `idea` and its `entityUuid` equals the conversation's `directIdeaUuid`). It SHALL NOT match a child-resource execution to a conversation by comparing the execution's `rootIdeaUuid` against the conversation's `directIdeaUuid`. Consequently, when a child idea receives a wake, the child idea's conversation SHALL show the running/interruptible state and the parent idea's conversation SHALL NOT.
+
+#### Scenario: Child idea's conversation shows the run, parent's does not
+
+- **WHEN** a child idea (whose parent is another idea) receives a `task_assigned`, `proposal_approved`, or `proposal_rejected` wake and the daemon is executing it
+- **THEN** the child idea's conversation shows the in-progress / interruptible indicator, AND the parent idea's conversation shows no in-progress indicator for that run.
+
+#### Scenario: A direct wake on the idea still matches its own conversation
+
+- **WHEN** a conversation's idea receives a wake whose execution entity is the idea itself (e.g. `elaboration_verified`, reported as `entityType: "idea"`, `entityUuid: <idea>`)
+- **THEN** that conversation shows the in-progress / interruptible indicator via the direct-idea match.
+
+#### Scenario: An interrupt targets the child idea's run
+
+- **WHEN** a human interrupts the in-progress run shown on a child idea's conversation
+- **THEN** the interrupt targets the execution the child idea's conversation owns, not the parent idea's.

--- a/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/specs/stage-advance-wake/spec.md
+++ b/openspec/changes/archive/2026-07-14-fix-daemon-child-idea-wake-anchor/specs/stage-advance-wake/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: The proposal-approved wake SHALL deliver the reviewer's note inline
+
+The daemon wake prompt for a `proposal_approved` notification SHALL surface the reviewer's decision note inline (drawn from the notification `message`, which already carries the approver's note), so the woken daemon knows the reviewer's opinion without a follow-up `chorus_get_proposal` fetch — symmetric with the existing `proposal_rejected` wake, which already embeds the reviewer's reason. This SHALL apply to every proposal-approved wake regardless of whether the proposal's idea is top-level or a derived child. No new notification field is introduced; the note is carried on the existing `message`.
+
+#### Scenario: Approve wake surfaces the note
+
+- **WHEN** a reviewer approves a proposal with a review note and the assigned daemon agent is woken for `proposal_approved`
+- **THEN** the wake prompt includes the reviewer's note text inline, so the daemon can act on the reviewer's opinion without separately fetching the proposal.
+
+#### Scenario: Approve wake without a note is unchanged
+
+- **WHEN** a reviewer approves a proposal without a review note
+- **THEN** the wake prompt renders without a note (no empty/placeholder note text) and still directs the daemon to find the now-unblocked tasks.
+
+#### Scenario: Reject wake note delivery is unchanged
+
+- **WHEN** a reviewer rejects a proposal with a reason
+- **THEN** the `proposal_rejected` wake prompt continues to embed that reason inline exactly as before this change.

--- a/openspec/specs/daemon-execution-state/spec.md
+++ b/openspec/specs/daemon-execution-state/spec.md
@@ -234,3 +234,46 @@ resource deep link.
 - **THEN** they are validated and reconciled exactly as before (the
   `daemon_session` addition is additive and does not alter existing behavior)
 
+### Requirement: The execution snapshot and row SHALL carry the direct idea alongside the root idea
+
+The daemon SHALL report a `directIdeaUuid` (the entity's directly-attached idea — the server-resolved `directIdeaUuid` the daemon already uses as its Claude session anchor) on every execution-snapshot entry, in addition to the existing `rootIdeaUuid`. The server SHALL accept `directIdeaUuid` at the `POST /api/daemon/execution-state` ingest boundary as an optional, nullable string, SHALL persist it on the `DaemonExecution` model as a nullable column, and SHALL include it in the `ExecutionView` read projection returned by every execution read (per-connection first paint, aggregate read, and the SSE `execution:{connectionUuid}` event). The `directIdeaUuid` column SHALL be added through a Prisma-CLI-generated migration containing only DDL (no `INSERT`/`UPDATE`/`DELETE` backfill). `rootIdeaUuid` SHALL remain reported, persisted, and projected unchanged.
+
+#### Scenario: A child-idea task wake reports both ids distinctly
+
+- **WHEN** the daemon wakes for a `task_assigned` notification whose task belongs to a child idea (the task's direct idea has a `parentUuid`)
+- **THEN** the execution-snapshot entry it uploads carries `directIdeaUuid` equal to the child idea's uuid and `rootIdeaUuid` equal to the topmost ancestor idea's uuid, and the persisted row and the `ExecutionView` returned to clients carry both values distinctly.
+
+#### Scenario: A top-level idea reports equal ids
+
+- **WHEN** the daemon wakes for a wake whose entity's direct idea has no parent
+- **THEN** the entry's `directIdeaUuid` and `rootIdeaUuid` are the same idea uuid.
+
+#### Scenario: A wake with no idea ancestor reports null ids
+
+- **WHEN** the daemon wakes for an entity that resolves to no idea (e.g. a standalone/quick task)
+- **THEN** the entry's `directIdeaUuid` is null and the row/projection tolerate the null.
+
+#### Scenario: An older daemon that omits the field is accepted
+
+- **WHEN** a daemon that has not been updated uploads a snapshot entry without `directIdeaUuid`
+- **THEN** the ingest endpoint accepts the entry and persists `directIdeaUuid` as null (the field is optional and nullable), without rejecting the snapshot.
+
+### Requirement: A conversation's running/interruptible execution SHALL be matched by the direct idea, not the root idea
+
+The chat UI SHALL determine whether a daemon execution belongs to an idea-anchored conversation by matching the execution's `directIdeaUuid` against the conversation's `directIdeaUuid` (in addition to matching a direct wake ON the idea, where the execution's `entityType` is `idea` and its `entityUuid` equals the conversation's `directIdeaUuid`). It SHALL NOT match a child-resource execution to a conversation by comparing the execution's `rootIdeaUuid` against the conversation's `directIdeaUuid`. Consequently, when a child idea receives a wake, the child idea's conversation SHALL show the running/interruptible state and the parent idea's conversation SHALL NOT.
+
+#### Scenario: Child idea's conversation shows the run, parent's does not
+
+- **WHEN** a child idea (whose parent is another idea) receives a `task_assigned`, `proposal_approved`, or `proposal_rejected` wake and the daemon is executing it
+- **THEN** the child idea's conversation shows the in-progress / interruptible indicator, AND the parent idea's conversation shows no in-progress indicator for that run.
+
+#### Scenario: A direct wake on the idea still matches its own conversation
+
+- **WHEN** a conversation's idea receives a wake whose execution entity is the idea itself (e.g. `elaboration_verified`, reported as `entityType: "idea"`, `entityUuid: <idea>`)
+- **THEN** that conversation shows the in-progress / interruptible indicator via the direct-idea match.
+
+#### Scenario: An interrupt targets the child idea's run
+
+- **WHEN** a human interrupts the in-progress run shown on a child idea's conversation
+- **THEN** the interrupt targets the execution the child idea's conversation owns, not the parent idea's.
+

--- a/openspec/specs/stage-advance-wake/spec.md
+++ b/openspec/specs/stage-advance-wake/spec.md
@@ -291,3 +291,22 @@ The Idea detail panels SHALL NOT render the teaching-style workflow hint that in
 - **WHEN** the teaching hint is removed
 - **THEN** the agent-offline, development-started, and elaboration-verified queued hints MUST still render under their existing conditions
 
+### Requirement: The proposal-approved wake SHALL deliver the reviewer's note inline
+
+The daemon wake prompt for a `proposal_approved` notification SHALL surface the reviewer's decision note inline (drawn from the notification `message`, which already carries the approver's note), so the woken daemon knows the reviewer's opinion without a follow-up `chorus_get_proposal` fetch — symmetric with the existing `proposal_rejected` wake, which already embeds the reviewer's reason. This SHALL apply to every proposal-approved wake regardless of whether the proposal's idea is top-level or a derived child. No new notification field is introduced; the note is carried on the existing `message`.
+
+#### Scenario: Approve wake surfaces the note
+
+- **WHEN** a reviewer approves a proposal with a review note and the assigned daemon agent is woken for `proposal_approved`
+- **THEN** the wake prompt includes the reviewer's note text inline, so the daemon can act on the reviewer's opinion without separately fetching the proposal.
+
+#### Scenario: Approve wake without a note is unchanged
+
+- **WHEN** a reviewer approves a proposal without a review note
+- **THEN** the wake prompt renders without a note (no empty/placeholder note text) and still directs the daemon to find the now-unblocked tasks.
+
+#### Scenario: Reject wake note delivery is unchanged
+
+- **WHEN** a reviewer rejects a proposal with a reason
+- **THEN** the `proposal_rejected` wake prompt continues to embed that reason inline exactly as before this change.
+

--- a/packages/openclaw-plugin/src/__tests__/daemon-client.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/daemon-client.test.ts
@@ -165,7 +165,7 @@ describe("runWake — lifecycle reporting", () => {
     });
   });
 
-  it("publishes an execution snapshot with rootIdeaUuid + startedAt while running, then empty when ended", async () => {
+  it("publishes an execution snapshot with rootIdeaUuid + directIdeaUuid + startedAt while running, then empty when ended", async () => {
     const rest = makeRestClient();
     let snapshotWhileRunning: unknown;
     const runEmbeddedAgent = vi.fn(async () => {
@@ -190,12 +190,17 @@ describe("runWake — lifecycle reporting", () => {
         expect.objectContaining({
           entityType: "task",
           entityUuid: "task-3",
+          // Child-idea case: rootIdeaUuid (parent) and directIdeaUuid (child) are
+          // distinct and BOTH reach the snapshot — the UI anchors on the direct id.
           rootIdeaUuid: "idea-root",
+          directIdeaUuid: "idea-9",
           status: "running",
           startedAt: expect.any(String),
         }),
       ],
     });
+    const running = (snapshotWhileRunning as { executions: Array<Record<string, unknown>> }).executions[0];
+    expect(running.directIdeaUuid).not.toBe(running.rootIdeaUuid);
     // Last snapshot after the run finishes is empty (absence == ended server-side).
     const last = rest.executionState.mock.calls[rest.executionState.mock.calls.length - 1][0];
     expect(last).toEqual({ executions: [] });

--- a/packages/openclaw-plugin/src/__tests__/daemon-rest-client.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/daemon-rest-client.test.ts
@@ -78,14 +78,15 @@ describe("createDaemonRestClient — payload shapes (single source of truth)", (
     const client = createDaemonRestClient({ ...BASE, getConnectionUuid: () => "conn-1", fetchImpl });
     await client.executionState({
       executions: [
-        { entityType: "task", entityUuid: "task-3", rootIdeaUuid: "idea-root", status: "running", startedAt: "2026-06-20T00:00:00Z" },
+        { entityType: "task", entityUuid: "task-3", rootIdeaUuid: "idea-root", directIdeaUuid: "idea-9", status: "running", startedAt: "2026-06-20T00:00:00Z" },
       ],
     });
     expect(calls[0].url).toBe("https://chorus.example.com/api/daemon/execution-state");
     expect(JSON.parse((calls[0].init as RequestInit).body as string)).toEqual({
       connectionUuid: "conn-1",
       executions: [
-        { entityType: "task", entityUuid: "task-3", rootIdeaUuid: "idea-root", status: "running", startedAt: "2026-06-20T00:00:00Z" },
+        // directIdeaUuid (child) rides the wire distinct from rootIdeaUuid (parent).
+        { entityType: "task", entityUuid: "task-3", rootIdeaUuid: "idea-root", directIdeaUuid: "idea-9", status: "running", startedAt: "2026-06-20T00:00:00Z" },
       ],
     });
   });

--- a/packages/openclaw-plugin/src/daemon-client.ts
+++ b/packages/openclaw-plugin/src/daemon-client.ts
@@ -95,6 +95,10 @@ interface ExecutionEntry {
   entityType: string;
   entityUuid: string;
   rootIdeaUuid: string | null;
+  // The DIRECT idea (session anchor) the UI matches a conversation's execution by,
+  // so a derived child idea's wake surfaces on the child conversation, not its
+  // parent. From the same lineage resolve as rootIdeaUuid (the two-id contract).
+  directIdeaUuid: string | null;
   status: "running" | "queued";
   startedAt: string | null;
 }
@@ -323,6 +327,9 @@ export class OpenClawDaemonClient {
     const entity = entityOf(req);
     const key = entity ? execKey(entity.entityType, entity.entityUuid) : null;
     const rootIdeaUuid = req.rootIdeaUuid ?? null;
+    // DIRECT idea (session anchor) — reported alongside the root so the UI anchors
+    // a conversation's execution to the child idea, not its parent.
+    const directIdeaUuid = req.directIdeaUuid ?? null;
     // Session anchor = the business key: directIdeaUuid when present, else the entity
     // uuid (quick task / standalone doc / ad-hoc daemon_session). This is the `sessionId`
     // used in ALL reports (turn-advance/transcript) — NOT the OpenClaw sessionKey, which
@@ -388,6 +395,7 @@ export class OpenClawDaemonClient {
         entityType: entity.entityType,
         entityUuid: entity.entityUuid,
         rootIdeaUuid,
+        directIdeaUuid,
         status: "running",
         startedAt: new Date().toISOString(),
       });
@@ -494,6 +502,7 @@ export class OpenClawDaemonClient {
       entityType: entity.entityType,
       entityUuid: entity.entityUuid,
       rootIdeaUuid: req.rootIdeaUuid ?? null,
+      directIdeaUuid: req.directIdeaUuid ?? null,
       status: "queued",
       startedAt: existing?.startedAt ?? null,
     });
@@ -509,6 +518,7 @@ export class OpenClawDaemonClient {
       entityType: e.entityType,
       entityUuid: e.entityUuid,
       rootIdeaUuid: e.rootIdeaUuid,
+      directIdeaUuid: e.directIdeaUuid,
       status: e.status,
       startedAt: e.startedAt,
     }));

--- a/packages/openclaw-plugin/src/daemon-rest-client.ts
+++ b/packages/openclaw-plugin/src/daemon-rest-client.ts
@@ -22,7 +22,8 @@
 //                      { sessionId, messages: [{ role, text }] }
 //   executionState   → POST /api/daemon/execution-state
 //                      { connectionUuid, executions: [{ entityType, entityUuid,
-//                                                       rootIdeaUuid|null, status,
+//                                                       rootIdeaUuid|null,
+//                                                       directIdeaUuid|null, status,
 //                                                       startedAt|null }] }
 //   reportInterrupt  → POST /api/daemon/report-interrupt
 //                      { connectionUuid, entityType, entityUuid, reason }
@@ -60,6 +61,9 @@ export interface DaemonExecutionRow {
   entityType: string;
   entityUuid: string;
   rootIdeaUuid: string | null;
+  // The DIRECT idea (session anchor) — the UI matches a conversation's execution
+  // by this, not rootIdeaUuid. Null when the wake has no idea ancestor.
+  directIdeaUuid: string | null;
   status: "running" | "queued";
   startedAt: string | null;
 }

--- a/prisma/migrations/20260714091007_add_daemon_execution_direct_idea/migration.sql
+++ b/prisma/migrations/20260714091007_add_daemon_execution_direct_idea/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DaemonExecution" ADD COLUMN     "directIdeaUuid" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -546,6 +546,14 @@ model DaemonExecution {
   // → Idea.uuid; the root-idea lineage anchor for grouping/labeling. Null when
   //   the wake has no idea ancestor (e.g. a standalone/quick task).
   rootIdeaUuid   String?
+  // → Idea.uuid; the DIRECT idea (the entity's directly-attached idea — the same
+  //   value the daemon anchors its Claude session on). For a top-level idea this
+  //   equals rootIdeaUuid; for a derived (child) idea it is the child while
+  //   rootIdeaUuid is the topmost ancestor. The chat UI matches a conversation's
+  //   running/interruptible execution by this DIRECT idea, so a child idea's wake
+  //   surfaces on the child conversation, not its parent. Null when the wake has
+  //   no idea ancestor. Weak ref, no DB FK.
+  directIdeaUuid String?
 
   // running | queued | ended | interrupted
   //   `interrupted` is a STICKY status: when a wake's subprocess is stopped (by a

--- a/src/app/api/daemon/execution-state/__tests__/route.test.ts
+++ b/src/app/api/daemon/execution-state/__tests__/route.test.ts
@@ -117,6 +117,42 @@ describe("POST /api/daemon/execution-state", () => {
     expect(mockPublishExecutionChange).toHaveBeenCalledWith(companyUuid, connectionUuid);
   });
 
+  it("passes directIdeaUuid through the zod boundary to reconcileSnapshot (child-idea entry)", async () => {
+    const childIdea = "child-idea-0000-0000-0000-0000000c1111";
+    const parentIdea = "parent-idea-0000-0000-0000-000000p22222";
+    const body = {
+      connectionUuid,
+      executions: [
+        {
+          entityType: "task",
+          entityUuid: t1,
+          rootIdeaUuid: parentIdea,
+          directIdeaUuid: childIdea,
+          status: "running",
+          startedAt: "2026-06-15T03:00:00.000Z",
+        },
+      ],
+    };
+
+    const res = await POST(postRequest(body), emptyCtx);
+    expect(res.status).toBe(200);
+
+    // The new field survived zod parsing (not stripped) and reached the service
+    // distinct from rootIdeaUuid.
+    const [, , , execs] = mockReconcileSnapshot.mock.calls[0];
+    expect(execs[0].directIdeaUuid).toBe(childIdea);
+    expect(execs[0].rootIdeaUuid).toBe(parentIdea);
+  });
+
+  it("accepts a snapshot entry that OMITS directIdeaUuid (older daemon) without rejecting", async () => {
+    // validEntry has no directIdeaUuid — the field is optional/nullable.
+    const res = await POST(postRequest(validBody), emptyCtx);
+    expect(res.status).toBe(200);
+    const [, , , execs] = mockReconcileSnapshot.mock.calls[0];
+    // Omitted → undefined at the zod boundary (reconcileSnapshot coerces to null).
+    expect(execs[0].directIdeaUuid ?? null).toBeNull();
+  });
+
   it("foreign connection → 404 not-found, no rows reconciled, no event published", async () => {
     mockConnectionBelongsToAgent.mockResolvedValue(false);
 

--- a/src/app/api/daemon/execution-state/route.ts
+++ b/src/app/api/daemon/execution-state/route.ts
@@ -40,13 +40,20 @@ import {
 // `entityUuid` its uuid. `status` is
 // constrained to the two active values a daemon can report — `ended` is a
 // server-only terminal state set by reconcile, never accepted from the wire.
-// `startedAt`/`rootIdeaUuid` are nullable/optional (a queued resource has no
-// start time; a wake with no idea ancestor has no root idea). `startedAt` is
-// coerced from an ISO-8601 string to a Date.
+// `startedAt`/`rootIdeaUuid`/`directIdeaUuid` are nullable/optional (a queued
+// resource has no start time; a wake with no idea ancestor has neither idea id;
+// an older daemon may omit `directIdeaUuid`). `directIdeaUuid` is the entity's
+// direct idea (the daemon session anchor) the chat UI matches a conversation's
+// execution by. `startedAt` is coerced from an ISO-8601 string to a Date.
 const snapshotEntrySchema = z.object({
   entityType: z.enum([...EXECUTION_ENTITY_TYPES]),
   entityUuid: z.string().min(1),
   rootIdeaUuid: z.string().min(1).nullish(),
+  // The DIRECT idea (the entity's directly-attached idea — the daemon session
+  // anchor). Optional + nullable: a wake with no idea ancestor has none, and an
+  // older daemon that predates this field omits it (persisted as null). The chat
+  // UI matches a conversation's execution by this value, not rootIdeaUuid.
+  directIdeaUuid: z.string().min(1).nullish(),
   status: z.enum([...ACTIVE_EXECUTION_STATUSES]),
   startedAt: z.coerce.date().nullish(),
 });

--- a/src/components/agent-presence/__tests__/instance-group.test.ts
+++ b/src/components/agent-presence/__tests__/instance-group.test.ts
@@ -40,6 +40,7 @@ function exec(overrides: Partial<ExecutionView> & { uuid: string }): ExecutionVi
     entityType: "task",
     entityUuid: "task-" + overrides.uuid,
     rootIdeaUuid: null,
+    directIdeaUuid: null,
     status: "running",
     interruptedReason: null,
     startedAt: NOW,

--- a/src/components/agent-presence/__tests__/session-execution.test.ts
+++ b/src/components/agent-presence/__tests__/session-execution.test.ts
@@ -15,6 +15,7 @@ function exec(over: Partial<ExecutionView> = {}): ExecutionView {
     entityType: "daemon_session",
     entityUuid: "sid-1",
     rootIdeaUuid: null,
+    directIdeaUuid: null,
     status: "running",
     interruptedReason: null,
     startedAt: null,
@@ -45,20 +46,59 @@ describe("executionMatchesSession", () => {
     expect(executionMatchesSession(exec({ entityType: "daemon_session", entityUuid: "idea-9", rootIdeaUuid: null }), ideaSession)).toBe(false);
   });
 
-  it("matches an idea-anchored conversation's AUTONOMOUS child wakes via rootIdeaUuid", () => {
-    // A task_assigned wake on the idea reports as task:<taskUuid> with rootIdeaUuid =
-    // the idea. It IS the conversation's work on that idea, so it must match (the old
-    // entityType==idea-only predicate showed such a conversation idle).
+  it("matches an idea-anchored conversation's AUTONOMOUS child wakes via directIdeaUuid", () => {
+    // A task_assigned wake on the idea reports as task:<taskUuid> with directIdeaUuid =
+    // the idea (its session anchor). It IS the conversation's work on that idea, so it
+    // must match (the old entityType==idea-only predicate showed such a conversation idle).
     expect(
       executionMatchesSession(
-        exec({ entityType: "task", entityUuid: "task-77", rootIdeaUuid: "idea-9" }),
+        exec({ entityType: "task", entityUuid: "task-77", directIdeaUuid: "idea-9" }),
         ideaSession,
       ),
     ).toBe(true);
-    // A task whose root idea is a DIFFERENT idea does not match.
+    // A task whose direct idea is a DIFFERENT idea does not match.
     expect(
       executionMatchesSession(
-        exec({ entityType: "task", entityUuid: "task-88", rootIdeaUuid: "idea-OTHER" }),
+        exec({ entityType: "task", entityUuid: "task-88", directIdeaUuid: "idea-OTHER" }),
+        ideaSession,
+      ),
+    ).toBe(false);
+  });
+
+  it("a DERIVED (child) idea's child-resource wake matches the CHILD session, NOT the parent", () => {
+    // The core fix. A task under a child idea resolves directIdeaUuid = child (session
+    // anchor) and rootIdeaUuid = parent. It must surface on the CHILD conversation only.
+    const childSession = { sessionId: "child-idea", directIdeaUuid: "child-idea" };
+    const parentSession = { sessionId: "parent-idea", directIdeaUuid: "parent-idea" };
+    const childTaskExec = exec({
+      entityType: "task",
+      entityUuid: "task-child",
+      directIdeaUuid: "child-idea",
+      rootIdeaUuid: "parent-idea",
+    });
+    // CHILD conversation lights up...
+    expect(executionMatchesSession(childTaskExec, childSession)).toBe(true);
+    // ...and the PARENT conversation shows nothing about the child's run (the bug).
+    expect(executionMatchesSession(childTaskExec, parentSession)).toBe(false);
+  });
+
+  it("does NOT match a child-resource wake by rootIdeaUuid (the old, buggy behavior is gone)", () => {
+    // An execution whose ROOT idea equals the session's idea but whose DIRECT idea is a
+    // child must NOT match this (parent) session — matching by root was the bug.
+    expect(
+      executionMatchesSession(
+        exec({ entityType: "task", entityUuid: "task-99", directIdeaUuid: "child-idea", rootIdeaUuid: "idea-9" }),
+        ideaSession, // directIdeaUuid: "idea-9" (the parent)
+      ),
+    ).toBe(false);
+  });
+
+  it("an old row with null directIdeaUuid does not match an idea session via root fallback", () => {
+    // Backward-compat: a pre-field daemon reports directIdeaUuid = null. A child-resource
+    // row then cannot match an idea conversation (only a direct entityType==='idea' wake can).
+    expect(
+      executionMatchesSession(
+        exec({ entityType: "task", entityUuid: "task-old", directIdeaUuid: null, rootIdeaUuid: "idea-9" }),
         ideaSession,
       ),
     ).toBe(false);

--- a/src/components/agent-presence/chat/session-execution.ts
+++ b/src/components/agent-presence/chat/session-execution.ts
@@ -24,20 +24,27 @@ export type SessionExecStatus = "running" | "interrupted" | "error" | null;
 //  - Ad-hoc conversation → matches its own `daemon_session:<sessionId>` execution.
 //  - Idea-anchored conversation → matches BOTH (a) a direct wake ON the idea
 //    (`idea:<directIdeaUuid>`), AND (b) an autonomous wake on a child resource of that
-//    idea (e.g. `task_assigned` → `task:<taskUuid>` with `rootIdeaUuid === directIdeaUuid`).
-//    A task wake IS the conversation's work on that idea, so it must surface the
-//    conversation's running/interrupt state — matching by `rootIdeaUuid` catches it
-//    (the prior `entityType === "idea"`-only predicate showed such a conversation idle).
+//    idea (e.g. `task_assigned` → `task:<taskUuid>`), matched by the execution's
+//    `directIdeaUuid` (the entity's directly-attached idea — the daemon's session anchor).
+//    A task/proposal wake IS the conversation's work on that idea, so it must surface the
+//    conversation's running/interrupt state.
+//
+//    We match on `directIdeaUuid`, NOT `rootIdeaUuid`: for a DERIVED (child) idea a
+//    child-resource wake resolves `directIdeaUuid = child` (this conversation) but
+//    `rootIdeaUuid = parent`. Matching by root would light up the PARENT conversation and
+//    leave the child (which actually owns the woken session) idle — the exact bug this
+//    fixes. Matching by the direct idea anchors the run on the child only; the parent
+//    shows nothing about the child's run.
 export function executionMatchesSession(
-  exec: Pick<ExecutionView, "entityType" | "entityUuid" | "rootIdeaUuid">,
+  exec: Pick<ExecutionView, "entityType" | "entityUuid" | "directIdeaUuid">,
   session: { sessionId: string; directIdeaUuid: string | null },
 ): boolean {
   if (session.directIdeaUuid) {
-    // Direct wake on the idea itself, OR any wake whose root idea IS this conversation's
+    // Direct wake on the idea itself, OR any wake whose DIRECT idea IS this conversation's
     // idea (its child task/proposal/document wakes).
     return (
       (exec.entityType === "idea" && exec.entityUuid === session.directIdeaUuid) ||
-      exec.rootIdeaUuid === session.directIdeaUuid
+      exec.directIdeaUuid === session.directIdeaUuid
     );
   }
   return (

--- a/src/contexts/__tests__/agent-presence-context.test.tsx
+++ b/src/contexts/__tests__/agent-presence-context.test.tsx
@@ -96,6 +96,7 @@ function exec(
     entityType: "task",
     entityUuid: `task-${uuid}`,
     rootIdeaUuid: null,
+    directIdeaUuid: null,
     status,
     interruptedReason: null,
     startedAt: null,

--- a/src/services/__tests__/daemon-direct-idea-wire.integration.test.ts
+++ b/src/services/__tests__/daemon-direct-idea-wire.integration.test.ts
@@ -1,0 +1,221 @@
+// Integration checkpoint for the daemon `directIdeaUuid` execution-snapshot contract
+// (fix-daemon-child-idea-wake-anchor, Task 6 — the Round-1 proposal-reviewer BLOCKER).
+//
+// WHY this exists: `directIdeaUuid` is threaded across a cross-process, largely UNTYPED
+// wire — the CLI daemon's JS emitter (cli/waker.mjs), a hand-maintained OpenClaw wire
+// type (packages/openclaw-plugin/src/daemon-rest-client.ts), the server zod schema, the
+// Prisma column, the ExecutionView projection, and the chat-UI match predicate. Every
+// layer has its own single-layer unit test, but a field-name drift at a seam (the CLI
+// emitting `directIdea` instead of `directIdeaUuid`, say) is invisible to `tsc` (the CLI
+// is JS) and would pass every per-layer test while the server silently persists
+// `directIdeaUuid = null` — re-shipping the exact parent-anchors-the-child bug.
+//
+// This test ties the layers together so a seam drift FAILS:
+//   1. It takes the REAL entry the CLI daemon emits (a live `Waker.buildExecutionSnapshot()`),
+//   2. POSTs it through the REAL server route (real zod parse → real
+//      `filterValidExecutionEntities` → real `reconcileSnapshot` → real
+//      `publishExecutionChange` → real `toExecutionView`), only Prisma/auth/eventBus mocked,
+//   3. asserts `directIdeaUuid = child` survived persistence (upsert create + update) AND the
+//      published ExecutionView,
+//   4. feeds that ExecutionView into the REAL `executionMatchesSession` and asserts it matches
+//      the CHILD conversation but NOT the parent — the child-only anchoring regression, and
+//   5. guards CLI ↔ OpenClaw field-set parity so the two daemon hosts cannot drift apart.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// ===== Mocks (only the infra edges; the whole service + route stay REAL) =====
+const mockPrisma = vi.hoisted(() => ({
+  daemonExecution: {
+    upsert: vi.fn(),
+    updateMany: vi.fn(),
+    findMany: vi.fn(),
+  },
+  daemonConnection: {
+    count: vi.fn(),
+    findMany: vi.fn(),
+  },
+  task: { findMany: vi.fn() },
+  idea: { findMany: vi.fn() },
+  proposal: { findMany: vi.fn() },
+  document: { findMany: vi.fn() },
+  daemonSession: { findMany: vi.fn() },
+  daemonSessionTurn: { findMany: vi.fn() },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockLogger = vi.hoisted(() => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }));
+// The route runs through withErrorHandler, which calls createRequestLogger — provide it so
+// the REAL route module loads (this test deliberately keeps the route unmocked).
+vi.mock("@/lib/logger", () => ({
+  default: mockLogger,
+  createRequestLogger: () => mockLogger,
+  getRequestLogger: () => mockLogger,
+}));
+
+const mockEventBus = vi.hoisted(() => ({ emit: vi.fn() }));
+vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
+
+const mockGetAuthContext = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/auth", () => ({ getAuthContext: (...a: unknown[]) => mockGetAuthContext(...a) }));
+
+// The route + service are the REAL modules under test (NOT mocked).
+import { POST } from "@/app/api/daemon/execution-state/route";
+import { executionMatchesSession } from "@/components/agent-presence/chat/session-execution";
+// The real CLI daemon emitter — the actual wire producer, not a fixture.
+import { Waker } from "../../../cli/waker.mjs";
+
+// ===== Fixtures =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const agentUuid = "agent-0000-0000-0000-000000000001";
+const connectionUuid = "conn-0000-0000-0000-000000000001";
+const taskUuid = "task-0000-0000-0000-0000000000aa";
+const childIdea = "idea-child-0000-0000-0000-00000000c1";
+const parentIdea = "idea-parent-0000-0000-0000-0000000p2";
+
+const agentAuth = { type: "agent", companyUuid, actorUuid: agentUuid, permissions: [] };
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest(new URL("http://localhost:3000/api/daemon/execution-state"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// Produce the EXACT snapshot entry the CLI daemon emits for a child-idea wake, from a live
+// Waker — so a rename in cli/waker.mjs's buildExecutionSnapshot is caught here, not masked.
+function cliEmittedChildIdeaEntry() {
+  const waker = new Waker({
+    creds: { url: "https://c", apiKey: "cho_x" },
+    lineage: { resolve: async () => ({ rootIdeaUuid: parentIdea, directIdeaUuid: childIdea }) },
+    spawner: { wake: async () => ({ sessionId: childIdea, exitCode: 0, isNew: true }) },
+  });
+  // Attribution as keyFor would thread it for a task under a derived (child) idea.
+  waker.markQueued(
+    { entityType: "task", entityUuid: taskUuid },
+    `idea:${childIdea}`,
+    { rootIdeaUuid: parentIdea, directIdeaUuid: childIdea },
+  );
+  const snapshot = waker.buildExecutionSnapshot();
+  return snapshot[0];
+}
+
+describe("directIdeaUuid end-to-end wire contract (integration checkpoint)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue(agentAuth);
+
+    // connectionBelongsToAgent → owns it.
+    mockPrisma.daemonConnection.count.mockResolvedValue(1);
+    // filterRowsByLiveConnection → connection online.
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { uuid: connectionUuid, status: "online", lastSeenAt: new Date() },
+    ]);
+    // Entity + idea existence (filterValidExecutionEntities validity + enrichment titles).
+    mockPrisma.task.findMany.mockResolvedValue([
+      { uuid: taskUuid, title: "Child task", projectUuid: "proj-1" },
+    ]);
+    mockPrisma.idea.findMany.mockResolvedValue([
+      { uuid: parentIdea, title: "Parent idea", projectUuid: "proj-1" },
+    ]);
+    // reconcileSnapshot's "end absent" active-row query (has a `select`) → none to end.
+    // getExecutionsForConnection's read query (no `select`) → the just-persisted row,
+    // carrying directIdeaUuid = child, so the REAL toExecutionView projects it.
+    mockPrisma.daemonExecution.findMany.mockImplementation(async (args: { select?: unknown }) => {
+      if (args?.select) return []; // reconcile active-rows sweep
+      return [
+        {
+          id: 1,
+          uuid: "exec-1",
+          agentUuid,
+          connectionUuid,
+          entityType: "task",
+          entityUuid: taskUuid,
+          rootIdeaUuid: parentIdea,
+          directIdeaUuid: childIdea,
+          status: "running",
+          interruptedReason: null,
+          startedAt: new Date("2026-07-14T00:00:00.000Z"),
+          createdAt: new Date("2026-07-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-07-14T00:00:00.000Z"),
+        },
+      ];
+    });
+    mockPrisma.daemonExecution.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.daemonExecution.upsert.mockResolvedValue({});
+  });
+
+  it("carries directIdeaUuid from the real CLI emit → zod → reconcile → toExecutionView → match", async () => {
+    const entry = cliEmittedChildIdeaEntry();
+    // Sanity: the live CLI emitter actually produced the field with the child value
+    // (guards the daemon-side seam — a rename here fails immediately).
+    expect(entry).toHaveProperty("directIdeaUuid", childIdea);
+    expect(entry.rootIdeaUuid).toBe(parentIdea);
+
+    // Drive the REAL route: real zod parse + real filter + real reconcile + real publish.
+    const res = await POST(postRequest({ connectionUuid, executions: [entry] }), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(200);
+
+    // (a) Persistence hop: the upsert on BOTH arms carries directIdeaUuid = child, distinct
+    //     from rootIdeaUuid = parent. If zod stripped the field or the CLI emitted the wrong
+    //     key, this is null here.
+    expect(mockPrisma.daemonExecution.upsert).toHaveBeenCalledTimes(1);
+    const upArg = mockPrisma.daemonExecution.upsert.mock.calls[0][0];
+    expect(upArg.create.directIdeaUuid).toBe(childIdea);
+    expect(upArg.create.rootIdeaUuid).toBe(parentIdea);
+    expect(upArg.update.directIdeaUuid).toBe(childIdea);
+    expect(upArg.update.rootIdeaUuid).toBe(parentIdea);
+
+    // (b) Projection hop: publishExecutionChange emitted an ExecutionView (via the REAL
+    //     toExecutionView) carrying directIdeaUuid = child.
+    expect(mockEventBus.emit).toHaveBeenCalledTimes(1);
+    const event = mockEventBus.emit.mock.calls[0][1] as {
+      executions: Array<{
+        entityType: string;
+        entityUuid: string;
+        directIdeaUuid: string | null;
+        rootIdeaUuid: string | null;
+      }>;
+    };
+    expect(event.executions).toHaveLength(1);
+    const view = event.executions[0];
+    expect(view.directIdeaUuid).toBe(childIdea);
+    expect(view.rootIdeaUuid).toBe(parentIdea);
+
+    // (c) Match hop: the emitted ExecutionView matches the CHILD conversation and NOT the
+    //     parent — the whole point of the fix (child-only anchoring, no parent bleed).
+    expect(executionMatchesSession(view, { sessionId: childIdea, directIdeaUuid: childIdea })).toBe(true);
+    expect(executionMatchesSession(view, { sessionId: parentIdea, directIdeaUuid: parentIdea })).toBe(false);
+  });
+
+  it("cross-host parity: the CLI and OpenClaw snapshot emitters expose the SAME field set (incl. directIdeaUuid)", () => {
+    // CLI keys: from the LIVE emitter (runtime truth).
+    const cliKeys = Object.keys(cliEmittedChildIdeaEntry()).sort();
+
+    // OpenClaw keys: parsed from its buildExecutionSnapshot source (a separately-published
+    // package that cannot be imported here — same rationale as the wake-parity guard). We
+    // extract the `<key>: e.<field>` mappings inside its buildExecutionSnapshot().
+    const HERE = path.dirname(fileURLToPath(import.meta.url));
+    const openclawClient = path.resolve(
+      HERE, "..", "..", "..", "packages", "openclaw-plugin", "src", "daemon-client.ts",
+    );
+    const src = readFileSync(openclawClient, "utf8");
+    const start = src.indexOf("buildExecutionSnapshot()");
+    expect(start, "buildExecutionSnapshot not found in OpenClaw daemon-client.ts").toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf("}", src.indexOf(".map((e) => ({", start)));
+    const openclawKeys = [...body.matchAll(/(\w+):\s*e\.\w+/g)].map((m) => m[1]).sort();
+
+    // Both hosts MUST include directIdeaUuid...
+    expect(cliKeys).toContain("directIdeaUuid");
+    expect(openclawKeys).toContain("directIdeaUuid");
+    // ...and expose the identical field set, so one host adding/renaming a field without the
+    // other fails this guard (the server zod is nullish-tolerant and would not catch it).
+    expect(openclawKeys).toEqual(cliKeys);
+  });
+});

--- a/src/services/__tests__/daemon-execution.service.test.ts
+++ b/src/services/__tests__/daemon-execution.service.test.ts
@@ -217,14 +217,38 @@ describe("reconcileSnapshot", () => {
     expect(queuedUpsert.create.startedAt).toBeNull();
   });
 
-  it("coerces missing rootIdeaUuid/startedAt to null", async () => {
+  it("coerces missing rootIdeaUuid/directIdeaUuid/startedAt to null", async () => {
     await reconcileSnapshot(companyUuid, agentUuid, connectionUuid, [
       { entityType: "task", entityUuid: t1, status: "queued" },
     ]);
     const upArg = mockPrisma.daemonExecution.upsert.mock.calls[0][0];
     expect(upArg.create.rootIdeaUuid).toBeNull();
+    expect(upArg.create.directIdeaUuid).toBeNull();
     expect(upArg.create.startedAt).toBeNull();
     expect(upArg.update.rootIdeaUuid).toBeNull();
+    expect(upArg.update.directIdeaUuid).toBeNull();
+  });
+
+  it("persists directIdeaUuid distinct from rootIdeaUuid for a child-idea wake (create + update)", async () => {
+    // A derived (child) idea: the wake's direct idea is the child; the root idea
+    // is the topmost parent. Both must persist, distinctly, on both upsert arms.
+    const childIdea = "child-idea-0000-0000-0000-0000000c1111";
+    const parentIdea = "parent-idea-0000-0000-0000-000000p22222";
+    await reconcileSnapshot(companyUuid, agentUuid, connectionUuid, [
+      {
+        entityType: "task",
+        entityUuid: t1,
+        rootIdeaUuid: parentIdea,
+        directIdeaUuid: childIdea,
+        status: "running",
+        startedAt: new Date(),
+      },
+    ]);
+    const upArg = mockPrisma.daemonExecution.upsert.mock.calls[0][0];
+    expect(upArg.create.rootIdeaUuid).toBe(parentIdea);
+    expect(upArg.create.directIdeaUuid).toBe(childIdea);
+    expect(upArg.update.rootIdeaUuid).toBe(parentIdea);
+    expect(upArg.update.directIdeaUuid).toBe(childIdea);
   });
 
   it("an empty snapshot ends ALL of the connection's active rows", async () => {
@@ -320,6 +344,7 @@ describe("getVisibleExecutions", () => {
       entityType: "task",
       entityUuid: t1,
       rootIdeaUuid: null,
+      directIdeaUuid: null,
       status: "running",
       interruptedReason: null,
       startedAt: new Date("2026-06-15T03:00:00.000Z"),
@@ -359,6 +384,7 @@ describe("getVisibleExecutions", () => {
       entityType: "task",
       entityUuid: t1,
       rootIdeaUuid: null,
+      directIdeaUuid: null,
       status: "running",
       interruptedReason: null,
       startedAt: "2026-06-15T03:00:00.000Z",

--- a/src/services/daemon-execution.service.ts
+++ b/src/services/daemon-execution.service.ts
@@ -89,6 +89,11 @@ export interface SnapshotExecution {
   entityType: ExecutionEntityType;
   entityUuid: string;
   rootIdeaUuid?: string | null;
+  // The DIRECT idea (the entity's directly-attached idea — the daemon's session
+  // anchor). Equals rootIdeaUuid for a top-level idea; for a derived child it is
+  // the child while rootIdeaUuid is the topmost ancestor. Optional/nullable: a
+  // wake with no idea ancestor has none, and an older daemon may omit it.
+  directIdeaUuid?: string | null;
   status: ActiveExecutionStatus; // "running" | "queued" — never "ended"
   startedAt?: Date | null;
 }
@@ -105,6 +110,11 @@ export interface ExecutionView {
   entityType: string; // task | idea | proposal | document | daemon_session
   entityUuid: string;
   rootIdeaUuid: string | null;
+  // The DIRECT idea (the entity's directly-attached idea — the daemon session
+  // anchor). Null when the wake has no idea ancestor or when reported by an older
+  // daemon that predates this field. The chat UI matches a conversation's
+  // execution by this value, not rootIdeaUuid.
+  directIdeaUuid: string | null;
   status: string; // running | queued | ended | interrupted
   // Discriminator for the `interrupted` status: "user" | "crash" | null. Null for
   // any non-interrupted row. The UI uses it to show a manual "Resume" affordance
@@ -151,6 +161,7 @@ interface DaemonExecutionRow {
   entityType: string;
   entityUuid: string;
   rootIdeaUuid: string | null;
+  directIdeaUuid: string | null;
   status: string;
   interruptedReason: string | null;
   startedAt: Date | null;
@@ -192,6 +203,7 @@ function toExecutionView(
     entityType: row.entityType,
     entityUuid: row.entityUuid,
     rootIdeaUuid: row.rootIdeaUuid,
+    directIdeaUuid: row.directIdeaUuid,
     status: row.status,
     interruptedReason: row.interruptedReason,
     startedAt: row.startedAt ? row.startedAt.toISOString() : null,
@@ -439,6 +451,7 @@ export async function reconcileSnapshot(
         entityType: exec.entityType,
         entityUuid: exec.entityUuid,
         rootIdeaUuid: exec.rootIdeaUuid ?? null,
+        directIdeaUuid: exec.directIdeaUuid ?? null,
         status: exec.status,
         startedAt: exec.startedAt ?? null,
       },
@@ -447,6 +460,7 @@ export async function reconcileSnapshot(
         companyUuid,
         agentUuid,
         rootIdeaUuid: exec.rootIdeaUuid ?? null,
+        directIdeaUuid: exec.directIdeaUuid ?? null,
         status: exec.status,
         startedAt: exec.startedAt ?? null,
         // A reported active status means the daemon is running/queuing this entity


### PR DESCRIPTION
## Summary

Fixes two daemon-wake defects for **derived (child) ideas** (idea f49e919f, OpenSpec change `fix-daemon-child-idea-wake-anchor`, 6 tasks):

1. **Child-idea wake lit up the PARENT conversation.** The daemon anchors a woken session on the child's `directIdeaUuid` but reported the execution snapshot with only `rootIdeaUuid` (the topmost parent); the chat-UI predicate matched `exec.rootIdeaUuid === session.directIdeaUuid`, true only for a top-level idea. So a child's run surfaced the in-progress/interruptible indicator on the **parent** and left the child idle. Fix: thread a new `directIdeaUuid` field end-to-end and switch the UI match to it — the child conversation now owns its run; the parent shows nothing.
2. **Approve wake dropped the reviewer's note.** `proposal_rejected` already embedded the reason; `proposal_approved` omitted the approver's note, forcing a proposal re-fetch. Fix: `cli/prompts.mjs` surfaces the note inline from the notification `message`, symmetric with reject, for every proposal wake.

Backward-compatible: the column is nullable and the zod field is `nullish`, so an older daemon that omits `directIdeaUuid` persists null and still matches its own top-level idea via the direct `entityType === "idea"` clause. `rootIdeaUuid` is unchanged (still reported, persisted, and used for the session-label enrichment).

## Changed files
| File | Change |
|------|--------|
| `prisma/schema.prisma` + `prisma/migrations/20260714091007_*` | nullable `DaemonExecution.directIdeaUuid` column (DDL-only migration) |
| `src/app/api/daemon/execution-state/route.ts` | zod ingest accepts `directIdeaUuid` (optional/nullable) |
| `src/services/daemon-execution.service.ts` | `SnapshotExecution` / `DaemonExecutionRow` / `ExecutionView` + `toExecutionView` + `reconcileSnapshot` (create+update) carry the field |
| `cli/waker.mjs` | registry entry + `markQueued`/`wake` set-sites + `buildExecutionSnapshot` emit `directIdeaUuid` |
| `cli/prompts.mjs` | `proposal_approved` surfaces the reviewer's note inline |
| `packages/openclaw-plugin/src/daemon-client.ts` + `daemon-rest-client.ts` | mirror `directIdeaUuid` in the second daemon host's snapshot client |
| `src/components/agent-presence/chat/session-execution.ts` | predicate matches `exec.directIdeaUuid === session.directIdeaUuid` (was `rootIdeaUuid`) |
| `openspec/**` | change archived; `daemon-execution-state` (+2 reqs) and `stage-advance-wake` (+1) specs updated |
| `src/services/__tests__/daemon-direct-idea-wire.integration.test.ts` (new) | end-to-end wire test (live CLI emit → real route → projection → match) + CLI↔OpenClaw field-parity drift guard |
| various `__tests__` | per-layer snapshot-shape + predicate assertions |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full repo suite `pnpm test` → 4205 passed, 0 failed
- [x] OpenClaw package suite → 142 passed
- [x] Integration checkpoint mutation-verified load-bearing (renaming the CLI emit key fails both integration tests)
- [x] Deployed to the live env and verified (`/login` 200); `prisma migrate deploy` applied the column on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)