### PR TITLE
fix(cli): daemon install persists+validates credentials for the boot service + interactive multi-cwd setup

### DIFF
--- a/chorus.mjs
+++ b/chorus.mjs
@@ -181,6 +181,10 @@ DAEMON / LOGIN (client mode)
   --sigint-timeout <ms>    Grace window after SIGINT before a forceful kill    (env: CHORUS_DAEMON_SIGINT_TIMEOUT)
                            when an interrupt is received (default: 10000).
                            Also configurable via ~/.chorus/daemon.json sigintTimeoutMs.
+  -y, --yes                Non-interactive 'chorus daemon install': skip all install
+                           prompts (credentials are still resolved, persisted, and
+                           validated; install aborts if none resolve). A non-TTY
+                           install behaves as if --yes were passed.
 
   Credential resolution order: flags > CHORUS_URL/CHORUS_API_KEY env >
   ~/.chorus/daemon.json (from 'chorus login') > Claude Code plugin config.

--- a/cli/__tests__/client-args.test.mjs
+++ b/cli/__tests__/client-args.test.mjs
@@ -44,6 +44,11 @@ describe("parseClientFlags — new daemon flags", () => {
     expect(parseClientFlags(["--force"]).force).toBe(true);
   });
 
+  it("parses boolean --yes / -y into yes:true (non-interactive install)", () => {
+    expect(parseClientFlags(["--yes"]).yes).toBe(true);
+    expect(parseClientFlags(["-y"]).yes).toBe(true);
+  });
+
   it("parses --help / -h into help:true", () => {
     expect(parseClientFlags(["--help"]).help).toBe(true);
     expect(parseClientFlags(["-h"]).help).toBe(true);
@@ -57,6 +62,7 @@ describe("parseClientFlags — new daemon flags", () => {
     expect(f.detach).toBeUndefined();
     expect(f.agent).toBeUndefined();
     expect(f.force).toBeUndefined();
+    expect(f.yes).toBeUndefined();
     expect(f.help).toBeUndefined();
   });
 
@@ -112,6 +118,7 @@ describe("daemonHelpText", () => {
       "--agent",
       "--verbose",
       "-d",
+      "--yes",
       "stop",
       "status",
       "restart",

--- a/cli/__tests__/daemon-install-config.test.mjs
+++ b/cli/__tests__/daemon-install-config.test.mjs
@@ -1,0 +1,152 @@
+// cli/__tests__/daemon-install-config.test.mjs
+// Unit tests for the `chorus daemon install` pre-install config phase
+// (fix-daemon-install-config, task 2). Both helpers are pure with injected IO —
+// no real disk / network / TTY. Covers the credential preflight
+// (resolve → persist → validate → abort) and the multi-cwd wizard
+// (configured-detection, blank-terminated loop, normalize+dedup, persist), plus
+// the --yes / non-TTY skip semantics.
+import { describe, it, expect, vi } from "vitest";
+import {
+  resolveInstallCredentials,
+  resolveInstallCwds,
+} from "../daemon-install-config.mjs";
+
+// ---- resolveInstallCredentials ------------------------------------------
+
+describe("resolveInstallCredentials", () => {
+  function deps(over = {}) {
+    return {
+      resolve: vi.fn(() => ({ url: "https://x", apiKey: "cho_k", source: "env" })),
+      validate: vi.fn(async () => ({ uuid: "agent-1", name: "Bot" })),
+      writeConfig: vi.fn(() => "/home/u/.chorus/daemon.json"),
+      prompt: vi.fn(async () => ""),
+      log: vi.fn(),
+      errLog: vi.fn(),
+      ...over,
+    };
+  }
+
+  it("resolved-from-any-source: validates then persists creds + identity, returns ok", async () => {
+    const d = deps();
+    const r = await resolveInstallCredentials({}, {}, { isTTY: true, skip: false, ...d });
+    expect(r.ok).toBe(true);
+    expect(d.validate).toHaveBeenCalledWith({ url: "https://x", apiKey: "cho_k" });
+    // persisted the credential + identity fields via the merge writer
+    expect(d.writeConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://x", apiKey: "cho_k", agentUuid: "agent-1", agentName: "Bot" })
+    );
+    expect(d.prompt).not.toHaveBeenCalled();
+  });
+
+  it("validation failure: aborts (ok:false), writes nothing", async () => {
+    const d = deps({ validate: vi.fn(async () => { throw new Error("invalid key"); }) });
+    const r = await resolveInstallCredentials({}, {}, { isTTY: true, skip: false, ...d });
+    expect(r.ok).toBe(false);
+    expect(d.writeConfig).not.toHaveBeenCalled();
+    expect(d.errLog).toHaveBeenCalled();
+  });
+
+  it("unresolved on a TTY (no skip): prompts login-style (masked), then validates + persists", async () => {
+    const resolve = vi.fn(() => { throw new Error("Could not resolve Chorus credentials (url + cho_ API key)."); });
+    const prompt = vi.fn()
+      .mockResolvedValueOnce("https://typed")   // URL
+      .mockResolvedValueOnce("cho_typed");       // masked key
+    const d = deps({ resolve, prompt });
+    const r = await resolveInstallCredentials({}, {}, { isTTY: true, skip: false, ...d });
+    expect(r.ok).toBe(true);
+    // second prompt (key) must be masked
+    expect(prompt).toHaveBeenNthCalledWith(2, expect.any(String), { mask: true });
+    expect(d.validate).toHaveBeenCalledWith({ url: "https://typed", apiKey: "cho_typed" });
+    expect(d.writeConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://typed", apiKey: "cho_typed" })
+    );
+  });
+
+  it("unresolved + skip: aborts with the multi-source hint, no prompt, no write", async () => {
+    const resolve = vi.fn(() => { throw new Error("Could not resolve Chorus credentials — tried flags, env, login file, plugin."); });
+    const d = deps({ resolve });
+    const r = await resolveInstallCredentials({}, {}, { isTTY: true, skip: true, ...d });
+    expect(r.ok).toBe(false);
+    expect(d.prompt).not.toHaveBeenCalled();
+    expect(d.writeConfig).not.toHaveBeenCalled();
+    expect(d.errLog.mock.calls.join(" ")).toMatch(/Could not resolve Chorus credentials/);
+  });
+
+  it("unresolved + non-TTY: aborts without prompting even when skip is false", async () => {
+    const resolve = vi.fn(() => { throw new Error("Could not resolve Chorus credentials."); });
+    const d = deps({ resolve });
+    const r = await resolveInstallCredentials({}, {}, { isTTY: false, skip: false, ...d });
+    expect(r.ok).toBe(false);
+    expect(d.prompt).not.toHaveBeenCalled();
+    expect(d.writeConfig).not.toHaveBeenCalled();
+  });
+
+  it("skip mode still validates the key (does not bypass server validation)", async () => {
+    const d = deps({ validate: vi.fn(async () => { throw new Error("revoked key"); }) });
+    const r = await resolveInstallCredentials({}, {}, { isTTY: false, skip: true, ...d });
+    expect(r.ok).toBe(false);
+    expect(d.validate).toHaveBeenCalledOnce();
+    expect(d.writeConfig).not.toHaveBeenCalled();
+  });
+});
+
+// ---- resolveInstallCwds -------------------------------------------------
+
+describe("resolveInstallCwds", () => {
+  function deps(over = {}) {
+    return {
+      // readJson stands in for reading ~/.chorus/daemon.json
+      readJson: vi.fn(() => null),
+      writeConfig: vi.fn(() => "/home/u/.chorus/daemon.json"),
+      prompt: vi.fn(async () => ""),
+      home: "/home/u",
+      processCwd: "/home/u/proj",
+      log: vi.fn(),
+      ...over,
+    };
+  }
+
+  it("--cwd flag present: uses it, no prompt, persists normalized+deduped set", async () => {
+    const d = deps();
+    const r = await resolveInstallCwds({ cwd: ["/a", "/a", "~/b"] }, { isTTY: true, skip: false, ...d });
+    expect(d.prompt).not.toHaveBeenCalled();
+    expect(r.cwds).toEqual(["/a", "/home/u/b"]);
+    expect(d.writeConfig).toHaveBeenCalledWith(expect.objectContaining({ cwds: ["/a", "/home/u/b"] }));
+  });
+
+  it("existing daemon.json cwds: uses them, no prompt", async () => {
+    const d = deps({ readJson: vi.fn(() => ({ cwds: ["/x", "/y"] })) });
+    const r = await resolveInstallCwds({}, { isTTY: true, skip: false, ...d });
+    expect(d.prompt).not.toHaveBeenCalled();
+    expect(r.cwds).toEqual(["/x", "/y"]);
+  });
+
+  it("unconfigured + TTY (no skip): wizard pre-seeds cwd, loops until blank, dedups", async () => {
+    // Enter: accept preseed (blank first → takes processCwd), then add /b, /b (dup), ~/c, blank ends.
+    // Simpler: first prompt returns "" meaning "accept preseeded current dir"; then add loop.
+    const prompt = vi.fn()
+      .mockResolvedValueOnce("")          // accept preseeded current dir → /home/u/proj
+      .mockResolvedValueOnce("/b")        // add /b
+      .mockResolvedValueOnce("/b")        // dup, deduped away
+      .mockResolvedValueOnce("~/c")       // add ~/c → /home/u/c
+      .mockResolvedValueOnce("");         // blank → finish
+    const d = deps({ prompt });
+    const r = await resolveInstallCwds({}, { isTTY: true, skip: false, ...d });
+    expect(r.cwds).toEqual(["/home/u/proj", "/b", "/home/u/c"]);
+    expect(d.writeConfig).toHaveBeenCalledWith(expect.objectContaining({ cwds: ["/home/u/proj", "/b", "/home/u/c"] }));
+  });
+
+  it("unconfigured + skip: no prompt, falls back to process cwd, persists it", async () => {
+    const d = deps();
+    const r = await resolveInstallCwds({}, { isTTY: true, skip: true, ...d });
+    expect(d.prompt).not.toHaveBeenCalled();
+    expect(r.cwds).toEqual(["/home/u/proj"]);
+  });
+
+  it("unconfigured + non-TTY: no prompt, falls back to process cwd", async () => {
+    const d = deps();
+    const r = await resolveInstallCwds({}, { isTTY: false, skip: false, ...d });
+    expect(d.prompt).not.toHaveBeenCalled();
+    expect(r.cwds).toEqual(["/home/u/proj"]);
+  });
+});

--- a/cli/__tests__/daemon-install-integration.test.mjs
+++ b/cli/__tests__/daemon-install-integration.test.mjs
@@ -1,0 +1,203 @@
+// cli/__tests__/daemon-install-integration.test.mjs
+// Integration checkpoint for `chorus daemon install` (fix-daemon-install-config,
+// task 3). Drives the REAL install wiring end-to-end through runDaemon →
+// handleLifecycleAction("install") → the REAL resolveInstallCredentials /
+// resolveInstallCwds helpers, persisting to a REAL temp ~/.chorus/daemon.json via
+// the REAL updateDaemonConfig writer. Only two things are stubbed:
+//   - the network (validate) — no live Chorus server in CI,
+//   - the unit writer + systemctl (service.installService / resolveServicePaths) —
+//     we must NEVER `systemctl --user enable --now` the chorus-daemon.service that
+//     may be running the host session.
+// This proves the whole chain: env-only creds → validated → written to daemon.json
+// (so a clean boot env can read them) → unit rendered WITHOUT --cwd → cwds persisted
+// to daemon.json. The bad-key path proves no unit is written and exit is non-zero.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDaemon } from "../daemon.mjs";
+import { updateDaemonConfig } from "../login.mjs";
+import { renderSystemdUnit } from "../daemon-service.mjs";
+
+let dir;
+let loginPath;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "chorus-install-it-"));
+  loginPath = join(dir, "daemon.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Read the temp daemon.json (or null if absent). */
+function readConfig() {
+  if (!existsSync(loginPath)) return null;
+  return JSON.parse(readFileSync(loginPath, "utf8"));
+}
+
+/**
+ * A service seam that captures the spec + renders a REAL unit (so we assert the
+ * real ExecStart), but NEVER touches systemctl or the real filesystem unit path.
+ */
+function captureService() {
+  const calls = { spec: null };
+  return {
+    detectSupervisor: () => ({ kind: "none" }),
+    resolveServicePaths: () => ({ nodePath: "/usr/bin/node", scriptPath: "/opt/chorus/chorus.mjs", path: "/usr/bin:/bin" }),
+    installService: vi.fn((spec) => {
+      calls.spec = spec;
+      // Render the REAL systemd unit from the spec to assert its content, but do
+      // not write it anywhere or run systemctl.
+      const unitText = renderSystemdUnit({ ...spec, home: dir });
+      return { platform: "linux", installed: true, unitPath: join(dir, "unit"), unitText, steps: ["wrote (stub)"] };
+    }),
+    uninstallService: vi.fn(),
+    systemctlUser: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
+    journalctlUser: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
+    __calls: calls,
+  };
+}
+
+const fakeLifecycle = () => ({
+  isRunning: () => ({ running: false, pid: null, stale: false }),
+  startBackground: vi.fn(),
+  stopDaemon: vi.fn(),
+  readLog: vi.fn(),
+});
+
+describe("chorus daemon install — end-to-end config phase (real helpers, temp daemon.json)", () => {
+  it("env-only creds: validates, persists creds+cwds to daemon.json, renders a --cwd-free unit", async () => {
+    const service = captureService();
+    const logs = [];
+    const code = await runDaemon(
+      { action: "install", cwd: ["/srv/one", "/srv/two", "/srv/one"] }, // dup dropped
+      {
+        isTTY: false, // non-TTY → skip prompts, but still resolve+persist+validate
+        env: { CHORUS_URL: "https://chorus.example", CHORUS_API_KEY: "cho_realkey" },
+        // Only the network is stubbed.
+        validate: async ({ url, apiKey }) => {
+          expect(url).toBe("https://chorus.example");
+          expect(apiKey).toBe("cho_realkey");
+          return { uuid: "agent-xyz", name: "Installer Bot" };
+        },
+        // Real 0600 field-merge writer, pointed at the temp file.
+        writeConfig: (partial) => updateDaemonConfig(partial, { path: loginPath }),
+        readJson: () => readConfig(),
+        loginPath,
+        service,
+        lifecycle: fakeLifecycle(),
+        log: (m) => logs.push(m),
+        errLog: (m) => logs.push("E:" + m),
+      }
+    );
+
+    expect(code).toBe(0);
+
+    // daemon.json gained the validated credentials + identity...
+    const cfg = readConfig();
+    expect(cfg).toMatchObject({
+      url: "https://chorus.example",
+      apiKey: "cho_realkey",
+      agentUuid: "agent-xyz",
+      agentName: "Installer Bot",
+    });
+    // ...and the normalized, de-duplicated cwd set (single source of truth).
+    expect(cfg.cwds).toEqual(["/srv/one", "/srv/two"]);
+
+    // The rendered unit authenticates from the file, so it must carry NO --cwd
+    // and NO credential env line.
+    const unit = service.__calls.spec ? service.installService.mock.results[0].value.unitText : "";
+    expect(unit).toMatch(/ExecStart=.*chorus\.mjs daemon$/m);
+    expect(unit).not.toMatch(/--cwd/);
+    expect(unit).not.toMatch(/CHORUS_API_KEY/);
+    expect(unit).not.toMatch(/CHORUS_URL/);
+  });
+
+  it("bad key: aborts non-zero, writes NO unit, and no daemon.json", async () => {
+    const service = captureService();
+    const errs = [];
+    const code = await runDaemon(
+      { action: "install", cwd: ["/srv/one"] },
+      {
+        isTTY: false,
+        env: { CHORUS_URL: "https://chorus.example", CHORUS_API_KEY: "cho_badkey" },
+        validate: async () => { throw new Error("401 Unauthorized — invalid API key"); },
+        writeConfig: (partial) => updateDaemonConfig(partial, { path: loginPath }),
+        readJson: () => readConfig(),
+        loginPath,
+        service,
+        lifecycle: fakeLifecycle(),
+        log: () => {},
+        errLog: (m) => errs.push(m),
+      }
+    );
+
+    expect(code).toBe(1);
+    // No unit was written (installService never called)...
+    expect(service.installService).not.toHaveBeenCalled();
+    // ...and no credentials were persisted.
+    expect(readConfig()).toBeNull();
+    expect(errs.join("")).toMatch(/validation failed|aborted/i);
+  });
+
+  it("no resolvable creds on a non-TTY: aborts with the multi-source hint, writes nothing", async () => {
+    const service = captureService();
+    const errs = [];
+    const code = await runDaemon(
+      { action: "install" },
+      {
+        isTTY: false,
+        env: {}, // nothing exported
+        // resolve default would read the real ~/.chorus/daemon.json + plugin; to keep
+        // the test hermetic, inject a resolve that fails like the real one when empty.
+        resolve: () => { throw new Error("Could not resolve Chorus credentials (url + cho_ API key). Tried, in order: ..."); },
+        validate: async () => { throw new Error("should not be called"); },
+        writeConfig: (partial) => updateDaemonConfig(partial, { path: loginPath }),
+        readJson: () => readConfig(),
+        loginPath,
+        service,
+        lifecycle: fakeLifecycle(),
+        log: () => {},
+        errLog: (m) => errs.push(m),
+      }
+    );
+
+    expect(code).toBe(1);
+    expect(service.installService).not.toHaveBeenCalled();
+    expect(readConfig()).toBeNull();
+    expect(errs.join("")).toMatch(/Could not resolve Chorus credentials/);
+  });
+
+  it("preserves pre-existing daemon.json fields across the install persist (field-merge)", async () => {
+    // Seed a login file that already carries yoloAckAt + sigintTimeoutMs.
+    updateDaemonConfig({ yoloAckAt: "2026-01-01T00:00:00.000Z", sigintTimeoutMs: 12345 }, { path: loginPath });
+    const service = captureService();
+    const code = await runDaemon(
+      { action: "install", cwd: ["/srv/x"] },
+      {
+        isTTY: false,
+        env: { CHORUS_URL: "https://c.example", CHORUS_API_KEY: "cho_k2" },
+        validate: async () => ({ uuid: "a2", name: "Bot2" }),
+        writeConfig: (partial) => updateDaemonConfig(partial, { path: loginPath }),
+        readJson: () => readConfig(),
+        loginPath,
+        service,
+        lifecycle: fakeLifecycle(),
+        log: () => {},
+        errLog: () => {},
+      }
+    );
+    expect(code).toBe(0);
+    const cfg = readConfig();
+    // credential + cwd fields added, pre-existing fields preserved.
+    expect(cfg).toMatchObject({
+      url: "https://c.example",
+      apiKey: "cho_k2",
+      agentUuid: "a2",
+      yoloAckAt: "2026-01-01T00:00:00.000Z",
+      sigintTimeoutMs: 12345,
+      cwds: ["/srv/x"],
+    });
+  });
+});

--- a/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
+++ b/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
@@ -29,6 +29,13 @@ function fakeService(over = {}) {
     systemctlUser: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
     journalctlUser: vi.fn(() => ({ status: 0, stdout: "journal-body", stderr: "" })),
     resolveServicePaths: vi.fn(() => ({ nodePath: "/node", scriptPath: "/x/chorus.mjs", path: "/bin" })),
+    // The install pre-config phase (credential preflight + cwd wizard). Default:
+    // both succeed offline so the install dispatch tests never touch real
+    // credentials / network / TTY. Individual tests override to exercise abort.
+    installConfig: {
+      resolveInstallCredentials: vi.fn(async () => ({ ok: true, creds: { url: "u", apiKey: "cho_k" }, identity: { uuid: "a", name: "Bot" } })),
+      resolveInstallCwds: vi.fn(async () => ({ cwds: ["/a"] })),
+    },
     ...over,
   };
 }
@@ -232,7 +239,7 @@ describe("runDaemon — supervisor (systemd) delegation", () => {
 });
 
 describe("runDaemon — install / uninstall", () => {
-  it("install passes the invoking --cwd/--agent/--chorus-only into the spec and reports success", async () => {
+  it("install runs the credential + cwd config phase, then passes --agent/--chorus-only into the spec and reports success", async () => {
     const service = fakeService();
     const logs = [];
     const code = await runDaemon(
@@ -240,11 +247,53 @@ describe("runDaemon — install / uninstall", () => {
       { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
     );
     expect(code).toBe(0);
+    // Config phase ran before the unit was written.
+    expect(service.installConfig.resolveInstallCredentials).toHaveBeenCalledOnce();
+    expect(service.installConfig.resolveInstallCwds).toHaveBeenCalledOnce();
     const spec = service.installService.mock.calls[0][0];
-    expect(spec.cwds).toEqual(["/a", "/b"]);
     expect(spec.agent).toBe("claude-code");
     expect(spec.chorusOnly).toBe(true);
     expect(logs.join("")).toMatch(/installed and started/);
+  });
+
+  it("install ABORTS (exit 1, no unit written) when the credential preflight fails", async () => {
+    const service = fakeService({
+      installConfig: {
+        resolveInstallCredentials: vi.fn(async () => ({ ok: false })),
+        resolveInstallCwds: vi.fn(async () => ({ cwds: ["/a"] })),
+      },
+    });
+    const errs = [];
+    const code = await runDaemon(
+      { action: "install" },
+      { lifecycle: fakeLifecycle(), service, log: () => {}, errLog: (m) => errs.push(m), env: {} }
+    );
+    expect(code).toBe(1);
+    // installService must NOT be called on the abort path.
+    expect(service.installService).not.toHaveBeenCalled();
+    // cwd config must not run once credentials aborted.
+    expect(service.installConfig.resolveInstallCwds).not.toHaveBeenCalled();
+    expect(errs.join("")).toMatch(/aborted/i);
+  });
+
+  it("install threads skip=true when --yes is passed", async () => {
+    const service = fakeService();
+    await runDaemon(
+      { action: "install", yes: true },
+      { lifecycle: fakeLifecycle(), service, isTTY: true, log: () => {}, errLog: () => {}, env: {} }
+    );
+    const credOpts = service.installConfig.resolveInstallCredentials.mock.calls[0][2];
+    expect(credOpts.skip).toBe(true);
+  });
+
+  it("install threads skip=true on a non-TTY even without --yes", async () => {
+    const service = fakeService();
+    await runDaemon(
+      { action: "install" },
+      { lifecycle: fakeLifecycle(), service, isTTY: false, log: () => {}, errLog: () => {}, env: {} }
+    );
+    const credOpts = service.installConfig.resolveInstallCredentials.mock.calls[0][2];
+    expect(credOpts.skip).toBe(true);
   });
 
   it("install surfaces a Linux failure as exit 1", async () => {

--- a/cli/__tests__/daemon-service.test.mjs
+++ b/cli/__tests__/daemon-service.test.mjs
@@ -26,29 +26,36 @@ const BASE = {
 };
 
 describe("buildServiceArgs", () => {
-  it("emits the normal daemon argv WITHOUT -d, with repeated --cwd", () => {
+  it("emits the normal daemon argv WITHOUT -d and WITHOUT --cwd", () => {
+    // cwds now live in ~/.chorus/daemon.json `cwds` (single source of truth,
+    // persisted at install time), so the unit must NOT embed --cwd or the two
+    // sources drift (elaboration Q5-A).
     const args = buildServiceArgs({ scriptPath: "/x/chorus.mjs", cwds: ["/a", "/b"] });
-    expect(args).toEqual(["/x/chorus.mjs", "daemon", "--cwd", "/a", "--cwd", "/b"]);
+    expect(args).toEqual(["/x/chorus.mjs", "daemon"]);
     expect(args).not.toContain("-d");
+    expect(args).not.toContain("--cwd");
   });
 
-  it("includes --agent and --chorus-only when set; skips blank cwds", () => {
+  it("includes --agent and --chorus-only when set; never emits --cwd", () => {
     const args = buildServiceArgs({ scriptPath: "/x/chorus.mjs", cwds: ["/a", "", undefined], agent: "codex", chorusOnly: true });
-    expect(args).toEqual(["/x/chorus.mjs", "daemon", "--cwd", "/a", "--agent", "codex", "--chorus-only"]);
+    expect(args).toEqual(["/x/chorus.mjs", "daemon", "--agent", "codex", "--chorus-only"]);
+    expect(args).not.toContain("--cwd");
   });
 });
 
 describe("renderSystemdUnit (pure)", () => {
   const unit = renderSystemdUnit({ ...BASE, cwds: ["/a", "/b"] });
 
-  it("uses Type=simple and NO -d in ExecStart", () => {
+  it("uses Type=simple, NO -d, and NO --cwd in ExecStart", () => {
     expect(unit).toMatch(/^Type=simple$/m);
-    expect(unit).toMatch(/ExecStart=\/usr\/bin\/node \/opt\/chorus\/chorus\.mjs daemon --cwd \/a --cwd \/b$/m);
+    // cwds are read from daemon.json, not the unit — ExecStart is just node + script + daemon.
+    expect(unit).toMatch(/ExecStart=\/usr\/bin\/node \/opt\/chorus\/chorus\.mjs daemon$/m);
     // The self-daemonize flag must never appear ON THE ExecStart LINE — that was
     // the boot-loop cause. (Comment lines legitimately mention "-d".)
     const execLine = unit.split("\n").find((l) => l.startsWith("ExecStart="));
     expect(execLine).not.toMatch(/(\s)-d(\s|$)/);
     expect(execLine).not.toMatch(/--detach/);
+    expect(execLine).not.toMatch(/--cwd/);
     expect(unit).not.toMatch(/Type=forking/);
   });
 
@@ -56,15 +63,20 @@ describe("renderSystemdUnit (pure)", () => {
     expect(unit).not.toMatch(/ExecStop=/);
   });
 
-  it("quotes ExecStart tokens containing whitespace so systemd does not mis-split them", () => {
-    const u = renderSystemdUnit({ ...BASE, cwds: ["/home/u/My Projects/repo", "/plain"] });
+  it("carries --agent / --chorus-only on ExecStart but never --cwd", () => {
+    const u = renderSystemdUnit({ ...BASE, cwds: ["/a"], agent: "codex", chorusOnly: true });
     const execLine = u.split("\n").find((l) => l.startsWith("ExecStart="));
-    // The spaced --cwd value must survive as ONE quoted token; the plain one bare.
-    expect(execLine).toContain('--cwd "/home/u/My Projects/repo"');
-    expect(execLine).toContain("--cwd /plain");
-    // Regression guard: the space inside the path must not appear unquoted (which
-    // systemd would tokenize into `--cwd /home/u/My` + stray `Projects/repo`).
-    expect(execLine).not.toMatch(/--cwd \/home\/u\/My Projects/);
+    expect(execLine).toContain("--agent codex");
+    expect(execLine).toContain("--chorus-only");
+    expect(execLine).not.toMatch(/--cwd/);
+  });
+
+  it("never bakes credentials into the unit (no CHORUS_API_KEY / CHORUS_URL env line)", () => {
+    // Credentials live only in the 0600 ~/.chorus/daemon.json — a systemd
+    // Environment= line carrying the secret would be weaker isolation and is a
+    // regression the review flagged.
+    expect(unit).not.toMatch(/CHORUS_API_KEY/);
+    expect(unit).not.toMatch(/CHORUS_URL/);
   });
 
   it("quotes a node/script path that itself contains a space", () => {
@@ -93,14 +105,20 @@ describe("renderSystemdUnit (pure)", () => {
 describe("renderLaunchdPlist (pure)", () => {
   const plist = renderLaunchdPlist({ ...BASE, cwds: ["/a"], logPath: "/home/u/.chorus/daemon.log" });
 
-  it("emits RunAtLoad + KeepAlive and the daemon argv without -d", () => {
+  it("emits RunAtLoad + KeepAlive and the daemon argv without -d or --cwd", () => {
     expect(plist).toContain("<key>RunAtLoad</key>");
     expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<string>/opt/chorus/chorus.mjs</string>");
     expect(plist).toContain("<string>daemon</string>");
-    expect(plist).toContain("<string>--cwd</string>");
+    // cwds live in daemon.json, never in the plist ProgramArguments.
+    expect(plist).not.toContain("<string>--cwd</string>");
     expect(plist).not.toContain("<string>-d</string>");
     expect(plist).toContain("com.chorus.daemon");
+  });
+
+  it("never bakes credentials into the plist", () => {
+    expect(plist).not.toContain("CHORUS_API_KEY");
+    expect(plist).not.toContain("CHORUS_URL");
   });
 
   it("xml-escapes special characters in paths", () => {
@@ -232,7 +250,8 @@ describe("installService", () => {
     expect(r.installed).toBe(false);
     expect(io.writeFileSync).not.toHaveBeenCalled();
     expect(r.unitText).not.toMatch(/ -d(\s|$)/);
-    expect(r.unitText).toContain("daemon --cwd /a");
+    expect(r.unitText).not.toMatch(/--cwd/);
+    expect(r.unitText).toContain("chorus.mjs daemon");
   });
 });
 

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -39,7 +39,7 @@ export const KNOWN_AGENTS = new Set(["claude-code", "codex", "kiro"]);
  * @returns {{
  *   url?: string, apiKey?: string, yolo?: boolean, sigintTimeout?: string,
  *   agent?: string, chorusOnly?: boolean, verbose?: boolean, detach?: boolean,
- *   cwd?: string[], force?: boolean, help?: boolean,
+ *   cwd?: string[], force?: boolean, yes?: boolean, help?: boolean,
  * }}
  */
 export function parseClientFlags(argv) {
@@ -64,6 +64,7 @@ export function parseClientFlags(argv) {
     else if (a === "--verbose") out.verbose = true;
     else if (a === "-d" || a === "--detach") out.detach = true;
     else if (a === "--force") out.force = true;
+    else if (a === "--yes" || a === "-y") out.yes = true;
     else if (a === "--help" || a === "-h") out.help = true;
   }
   return out;
@@ -131,6 +132,10 @@ OPTIONS
                            local paths at once. Default: the directory it was launched
                            from. (Also configurable as "cwds":[…] in ~/.chorus/daemon.json.)
   -d, --detach             Run detached in the background (pidfile + logfile)
+  -y, --yes                Non-interactive install: skip all 'chorus daemon
+                           install' prompts (credentials still resolved, persisted,
+                           and validated; install aborts if none resolve). A non-TTY
+                           install behaves as if --yes were passed.
   --verbose                More detailed per-wake logging
   --sigint-timeout <ms>    Grace window after SIGINT before a forceful kill
                            (env: CHORUS_DAEMON_SIGINT_TIMEOUT; default 10000)
@@ -148,8 +153,13 @@ SERVICE (install)
   starts at login, restarts on failure, and 'systemctl --user stop' shuts it
   down gracefully. Do NOT hand-write a Type=forking unit around 'chorus daemon
   -d' — the daemon self-daemonizes, which systemd cannot track and which loops
-  on restart. The install captures the --cwd / --agent / --chorus-only flags you
-  pass. On macOS/Windows install prints a correct template you install manually.
+  on restart. Before writing the unit, install resolves + persists + validates
+  your credentials into ~/.chorus/daemon.json (so the clean boot environment can
+  authenticate) and configures the served working directories there too (prompting
+  interactively for one or more when none are set — pass -y/--yes or run non-TTY to
+  skip prompts). The unit captures --agent / --chorus-only but NOT --cwd (cwds live
+  in daemon.json). On macOS/Windows install prints a correct template you install
+  manually.
 
 EXAMPLES
   chorus daemon                        # Foreground, default yolo (TTY confirms once)

--- a/cli/daemon-config.mjs
+++ b/cli/daemon-config.mjs
@@ -107,7 +107,7 @@ export function resolveSigintTimeoutMs(flags = {}, deps = {}) {
 // The Waker/SseListener treat an `undefined` entry as "use process.cwd()".
 
 /** Expand a leading `~` to the home dir and resolve to an absolute path. */
-function normalizeCwd(value, home) {
+export function normalizeCwd(value, home) {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   if (!trimmed) return undefined;
@@ -125,7 +125,7 @@ function normalizeCwd(value, home) {
  * @param {Array<unknown>} list @param {string} home
  * @returns {string[]}
  */
-function cleanCwdList(list, home) {
+export function cleanCwdList(list, home) {
   const seen = new Set();
   const out = [];
   for (const raw of Array.isArray(list) ? list : []) {

--- a/cli/daemon-install-config.mjs
+++ b/cli/daemon-install-config.mjs
@@ -1,0 +1,213 @@
+// cli/daemon-install-config.mjs
+// The `chorus daemon install` pre-install config phase (fix-daemon-install-config,
+// idea d7592c96). Two pure, dependency-injected helpers that run BEFORE the
+// service unit is written, so a boot-time daemon in systemd/launchd's CLEAN
+// environment can always authenticate and knows which working directories to
+// serve:
+//
+//   resolveInstallCredentials — resolve (flags>env>daemon.json>plugin) → persist
+//     into ~/.chorus/daemon.json → validate against the server → abort (write
+//     nothing) if creds cannot be obtained or the key is invalid. This is the
+//     crux of the fix: a systemd --user unit does NOT inherit the operator's
+//     shell-exported CHORUS_URL/CHORUS_API_KEY, so the creds must live in the
+//     0600 login file the clean boot env reads.
+//
+//   resolveInstallCwds — determine the served working-directory set and persist
+//     it to daemon.json `cwds` (the single source of truth; the unit carries no
+//     --cwd — see cli/daemon-service.mjs buildServiceArgs). Prompts an interactive
+//     add-loop only when nothing is configured and stdin is a TTY.
+//
+// All IO (resolve / validate / persist / prompt / readJson / env / cwd) is
+// injected so the helpers unit-test without real disk, network, or TTY — matching
+// the style of cli/credentials.mjs and cli/daemon-config.mjs.
+
+import { homedir } from "node:os";
+import { resolveCredentials, loginFilePath } from "./credentials.mjs";
+import { updateDaemonConfig, prompt as defaultPrompt } from "./login.mjs";
+import { validateAndFetchIdentity } from "./chorus-client.mjs";
+import { normalizeCwd, cleanCwdList } from "./daemon-config.mjs";
+import { readFileSync } from "node:fs";
+
+/** A non-empty trimmed string, or undefined. */
+function nonEmpty(value) {
+  if (typeof value !== "string") return undefined;
+  const t = value.trim();
+  return t.length > 0 ? t : undefined;
+}
+
+/** Read a JSON file, returning null on any error. Mirrors credentials.mjs. */
+function readJsonSafe(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Credential preflight for `chorus daemon install`. Resolves credentials, persists
+ * them (with the fetched identity) into ~/.chorus/daemon.json, and validates the
+ * key against the server — all BEFORE the caller writes any service unit.
+ *
+ * Returns `{ ok: true, creds, identity }` on success, or `{ ok: false }` when the
+ * install must abort (no unit should be written). Never throws.
+ *
+ * Behavior (elaboration Q1/Q2/Q8/Q9):
+ *   - Resolve via resolveCredentials (flags > env > daemon.json > plugin).
+ *   - Unresolved + TTY + !skip → prompt login-style (masked key).
+ *   - Unresolved + (skip || !TTY) → abort with the multi-source hint (no prompt).
+ *   - ALWAYS validate the resolved/entered key; abort on failure.
+ *   - On success persist { url, apiKey, agentUuid, agentName } via the 0600
+ *     field-merge writer (preserves cwds / yoloAckAt / sigintTimeoutMs).
+ *
+ * @param {{ url?: string, apiKey?: string }} flags
+ * @param {Record<string,string|undefined>} env
+ * @param {{
+ *   isTTY?: boolean, skip?: boolean,
+ *   resolve?: typeof resolveCredentials,
+ *   validate?: typeof validateAndFetchIdentity,
+ *   writeConfig?: (partial: Record<string, unknown>) => string,
+ *   prompt?: typeof defaultPrompt,
+ *   log?: (m: string) => void,
+ *   errLog?: (m: string) => void,
+ * }} [opts]
+ * @returns {Promise<{ ok: true, creds: {url:string,apiKey:string}, identity: {uuid:string,name:string} } | { ok: false }>}
+ */
+export async function resolveInstallCredentials(flags = {}, env = {}, opts = {}) {
+  const isTTY = opts.isTTY ?? false;
+  const skip = opts.skip ?? false;
+  const resolve = opts.resolve ?? resolveCredentials;
+  const validate = opts.validate ?? validateAndFetchIdentity;
+  const writeConfig = opts.writeConfig ?? updateDaemonConfig;
+  const ask = opts.prompt ?? defaultPrompt;
+  const log = opts.log ?? (() => {});
+  const errLog = opts.errLog ?? (() => {});
+
+  let url;
+  let apiKey;
+
+  // 1. Try the layered resolver. It THROWS (does not return null) when no source
+  //    yields a complete pair — catch it and decide prompt vs abort.
+  try {
+    const resolved = resolve(flags, { env });
+    url = resolved.url;
+    apiKey = resolved.apiKey;
+    log(`[Chorus] credentials resolved from: ${resolved.source}`);
+  } catch (err) {
+    const hint = err instanceof Error ? err.message : String(err);
+    if (!isTTY || skip) {
+      // No way (or no permission) to prompt — abort with the actionable hint
+      // rather than writing a unit that would crash-loop at boot.
+      errLog(hint);
+      return { ok: false };
+    }
+    // TTY + interactive: complete credentials login-style (masked key).
+    log("[Chorus] no credentials found — configuring them now (saved for the boot service).");
+    url = nonEmpty(await ask("Chorus URL: "));
+    apiKey = nonEmpty(await ask("Chorus API key (cho_...): ", { mask: true }));
+    if (!url || !apiKey) {
+      errLog("[Chorus] both a URL and an API key are required — aborting install.");
+      return { ok: false };
+    }
+  }
+
+  // 2. ALWAYS validate against the server before writing anything (Q2/Q9) — even
+  //    in skip mode. A bad/expired key fails the install instead of at boot.
+  let identity;
+  try {
+    identity = await validate({ url, apiKey });
+  } catch (err) {
+    errLog(`[Chorus] credential validation failed: ${err instanceof Error ? err.message : String(err)}`);
+    errLog("[Chorus] credentials were NOT saved and no service was installed.");
+    return { ok: false };
+  }
+
+  // 3. Persist into the 0600 login file so the clean boot env can read it. The
+  //    field-merge writer preserves cwds / yoloAckAt / sigintTimeoutMs.
+  writeConfig({ url, apiKey, agentUuid: identity.uuid, agentName: identity.name });
+  log(`[Chorus] credentials saved for ${identity.name} (${identity.uuid}).`);
+  return { ok: true, creds: { url, apiKey }, identity };
+}
+
+/**
+ * Determine the set of working directories the daemon serves and persist it to
+ * ~/.chorus/daemon.json `cwds` (the single source of truth — the unit carries no
+ * --cwd). Prompts an interactive add-loop only when nothing is configured and
+ * stdin is a TTY (and skip is false).
+ *
+ * "Configured" ⇔ a `--cwd` flag was passed OR daemon.json already has a non-empty
+ * `cwds` array. Configured, or skip/non-TTY, uses that set (or the process cwd
+ * default) with no prompt.
+ *
+ * Returns `{ cwds: string[] }` — the normalized, de-duplicated set that was
+ * persisted. Never throws.
+ *
+ * @param {{ cwd?: string[] }} flags
+ * @param {{
+ *   isTTY?: boolean, skip?: boolean,
+ *   readJson?: (path: string) => (Record<string, unknown>|null),
+ *   loginPath?: string,
+ *   writeConfig?: (partial: Record<string, unknown>) => string,
+ *   prompt?: typeof defaultPrompt,
+ *   home?: string,
+ *   processCwd?: string,
+ *   log?: (m: string) => void,
+ * }} [opts]
+ * @returns {Promise<{ cwds: string[] }>}
+ */
+export async function resolveInstallCwds(flags = {}, opts = {}) {
+  const isTTY = opts.isTTY ?? false;
+  const skip = opts.skip ?? false;
+  const readJson = opts.readJson ?? readJsonSafe;
+  const loginPath = opts.loginPath ?? loginFilePath();
+  const writeConfig = opts.writeConfig ?? updateDaemonConfig;
+  const ask = opts.prompt ?? defaultPrompt;
+  const home = opts.home ?? homedir();
+  const processCwd = opts.processCwd ?? process.cwd();
+  const log = opts.log ?? (() => {});
+
+  // 1. Explicit --cwd flag(s) → configured; normalize + dedup, no prompt.
+  const flagList = Array.isArray(flags.cwd) ? flags.cwd : typeof flags.cwd === "string" ? [flags.cwd] : [];
+  const fromFlags = cleanCwdList(flagList, home);
+  if (fromFlags.length > 0) {
+    writeConfig({ cwds: fromFlags });
+    return { cwds: fromFlags };
+  }
+
+  // 2. Existing daemon.json `cwds` → configured; use as-is (re-persist is a no-op
+  //    merge, so we skip the write and just return them).
+  const file = readJson(loginPath);
+  const fromFile = file && Array.isArray(file.cwds) ? cleanCwdList(file.cwds, home) : [];
+  if (fromFile.length > 0) {
+    return { cwds: fromFile };
+  }
+
+  // 3. Unconfigured. On a non-TTY or in skip mode, fall back to the process cwd
+  //    default with no prompt.
+  const defaultCwd = normalizeCwd(processCwd, home);
+  if (!isTTY || skip) {
+    const cwds = defaultCwd ? [defaultCwd] : [];
+    if (cwds.length > 0) writeConfig({ cwds });
+    return { cwds };
+  }
+
+  // 4. Unconfigured + TTY + !skip → interactive add-loop. Pre-seed the current
+  //    directory as the suggested first entry (Enter accepts it), then keep
+  //    prompting until a blank line ends the loop.
+  const collected = [];
+  log(`[Chorus] Configure the working directories this daemon serves.`);
+  const first = nonEmpty(await ask(`Working directory [${defaultCwd}] (Enter to accept the default): `));
+  collected.push(first ?? defaultCwd);
+  // subsequent adds
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const next = nonEmpty(await ask("Add another working directory (blank to finish): "));
+    if (!next) break;
+    collected.push(next);
+  }
+  const cwds = cleanCwdList(collected, home);
+  const finalCwds = cwds.length > 0 ? cwds : defaultCwd ? [defaultCwd] : [];
+  if (finalCwds.length > 0) writeConfig({ cwds: finalCwds });
+  return { cwds: finalCwds };
+}

--- a/cli/daemon-service.mjs
+++ b/cli/daemon-service.mjs
@@ -70,17 +70,22 @@ export function resolveScriptPath() {
 
 /**
  * Build the argv the SUPERVISED daemon runs — the normal long-lived daemon
- * (NO `-d`: the supervisor owns the foreground process). Reflects the flags the
- * operator passed to `install` so the boot-time daemon serves the same paths /
- * agent / permission posture. Pure.
+ * (NO `-d`: the supervisor owns the foreground process). Reflects the `--agent`
+ * / `--chorus-only` posture the operator passed to `install`. The served cwd set
+ * is NOT embedded here — it lives in ~/.chorus/daemon.json `cwds` (single source
+ * of truth) and is read by the daemon via resolveDaemonCwds. Pure.
  * @param {{ cwds?: string[], agent?: string, chorusOnly?: boolean, scriptPath: string }} spec
- * @returns {string[]}  e.g. ["/x/chorus.mjs","daemon","--cwd","/a","--cwd","/b"]
+ * @returns {string[]}  e.g. ["/x/chorus.mjs","daemon","--agent","codex"]
  */
 export function buildServiceArgs(spec) {
   const args = [spec.scriptPath, "daemon"];
-  for (const cwd of spec.cwds ?? []) {
-    if (typeof cwd === "string" && cwd) args.push("--cwd", cwd);
-  }
+  // NOTE: --cwd is deliberately NOT emitted. The set of working directories the
+  // daemon serves is persisted to ~/.chorus/daemon.json `cwds` at install time
+  // (the single source of truth) and read back by the daemon via
+  // resolveDaemonCwds. Baking --cwd into the unit too would let the two sources
+  // drift and would hide the paths from a plain `chorus daemon` run
+  // (fix-daemon-install-config, elaboration Q5-A). `spec.cwds` is still accepted
+  // for signature compatibility but ignored here.
   if (spec.agent) args.push("--agent", spec.agent);
   if (spec.chorusOnly) args.push("--chorus-only");
   return args;

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -526,7 +526,14 @@ export async function runDaemon(flags = {}, deps = {}) {
   // The preflight dep bundle — built from the same seams runDaemon resolved, so
   // the detach/restart paths run the SAME (injectable) preflight, not the real
   // implementations. Threaded into startDetached so tests can drive it offline.
-  const pfDeps = { flags, env, isTTY, resolve, validate, writeCreds, askPrompt, log, errLog };
+  // writeConfig / readJson / loginPath are optional injectable IO used by the
+  // `install` config phase — default (undefined) means the real 0600 login file.
+  const pfDeps = {
+    flags, env, isTTY, resolve, validate, writeCreds, askPrompt, log, errLog,
+    writeConfig: deps.writeConfig,
+    readJson: deps.readJson,
+    loginPath: deps.loginPath,
+  };
 
   const action = flags.action ?? "run";
   if (action !== "run") {
@@ -782,10 +789,14 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
 
     // Configure + persist the served cwd set (single source of truth in
     // daemon.json; the unit carries no --cwd). Never blocks on a non-TTY.
+    // readJson / loginPath are optional injectable seams (default to the real
+    // login file) so the config phase can be exercised hermetically in tests.
     await installCfg.resolveInstallCwds(flags, {
       isTTY,
       skip,
       writeConfig: pfDeps?.writeConfig ?? updateDaemonConfig,
+      readJson: pfDeps?.readJson,
+      loginPath: pfDeps?.loginPath,
       prompt: pfDeps?.askPrompt,
       log,
     });

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -13,7 +13,11 @@
 // observability idea.
 
 import { resolveCredentials, loginFilePath } from "./credentials.mjs";
-import { prompt, writeLoginFile } from "./login.mjs";
+import { prompt, writeLoginFile, updateDaemonConfig } from "./login.mjs";
+import {
+  resolveInstallCredentials,
+  resolveInstallCwds,
+} from "./daemon-install-config.mjs";
 import {
   resolvePermissionMode,
   yoloWarningLine,
@@ -746,11 +750,51 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
   const svc = service ?? { detectSupervisor: () => ({ kind: "none" }) };
 
   if (action === "install") {
+    // Pre-install config phase (fix-daemon-install-config): BEFORE writing any
+    // unit, guarantee the clean-env boot service can authenticate and knows which
+    // cwds to serve. --yes/-y OR a non-TTY suppress prompts; neither suppresses
+    // the resolve/persist/validate/abort guarantee.
+    const flags = pfDeps?.flags ?? {};
+    const env = pfDeps?.env ?? {};
+    const isTTY = pfDeps?.isTTY ?? false;
+    const skip = flags.yes === true || !isTTY;
+    const installCfg = svc.installConfig ?? {
+      resolveInstallCredentials,
+      resolveInstallCwds,
+    };
+
+    const credResult = await installCfg.resolveInstallCredentials(flags, env, {
+      isTTY,
+      skip,
+      resolve: pfDeps?.resolve,
+      validate: pfDeps?.validate,
+      writeConfig: pfDeps?.writeConfig ?? updateDaemonConfig,
+      prompt: pfDeps?.askPrompt,
+      log,
+      errLog,
+    });
+    if (!credResult.ok) {
+      // Credentials could not be obtained / validated — never install a service
+      // that would fail to authenticate and crash-loop at boot.
+      errLog("[Chorus] install aborted — no service was written.");
+      return 1;
+    }
+
+    // Configure + persist the served cwd set (single source of truth in
+    // daemon.json; the unit carries no --cwd). Never blocks on a non-TTY.
+    await installCfg.resolveInstallCwds(flags, {
+      isTTY,
+      skip,
+      writeConfig: pfDeps?.writeConfig ?? updateDaemonConfig,
+      prompt: pfDeps?.askPrompt,
+      log,
+    });
+
     const spec = {
       ...svc.resolveServicePaths(),
-      cwds: pfDeps?.flags?.cwd ?? [],
-      agent: pfDeps?.flags?.agent,
-      chorusOnly: pfDeps?.flags?.chorusOnly === true,
+      cwds: flags.cwd ?? [],
+      agent: flags.agent,
+      chorusOnly: flags.chorusOnly === true,
       workingDir: process.cwd(),
     };
     const r = svc.installService(spec);

--- a/openspec/changes/archive/2026-07-15-fix-daemon-install-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-daemon-install-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-daemon-install-config/README.md
+++ b/openspec/changes/archive/2026-07-15-fix-daemon-install-config/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-install-config
+
+Fix chorus daemon install: persist credentials for the clean-env boot service + interactive multi-cwd setup + non-interactive skip flag

--- a/openspec/changes/archive/2026-07-15-fix-daemon-install-config/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-daemon-install-config/design.md
@@ -1,0 +1,79 @@
+# Technical Design: Fix `chorus daemon install` config
+
+## Overview
+
+`chorus daemon install` gains a **pre-install config phase** that runs before the service unit is written, plus a change to the unit generator so working directories are sourced from `~/.chorus/daemon.json` rather than baked into the unit. All new logic reuses existing, unit-tested seams — no new persistence primitive, no new dependency, pure Node.
+
+## Architecture
+
+Today (`cli/daemon.mjs`):
+
+```
+runDaemon → action !== "run" → handleLifecycleAction("install")
+                                   → installService(spec)   // writes unit, enable --now
+```
+
+`preflight` (interactive credential completion) lives only on the `run` path and is never reached by `install`.
+
+After this change:
+
+```
+handleLifecycleAction("install")
+  → resolveInstallCredentials(flags, env, {isTTY, skip})   // NEW: resolve → (prompt?) → validate → persist
+      · abort (non-zero) if creds cannot be obtained/validated
+  → resolveInstallCwds(flags, {isTTY, skip})               // NEW: reuse resolveDaemonCwds; wizard if unconfigured
+      · persist chosen set to daemon.json `cwds`
+  → installService(spec)                                    // unchanged call; spec.cwds no longer flows into the unit
+```
+
+Both new helpers are pure/dependency-injected (env, readJson, prompt, validate, writeConfig) so they unit-test without real disk/network/TTY — matching the existing `cli/*.mjs` style.
+
+## Credential preflight (`resolveInstallCredentials`)
+
+Order of operations:
+
+1. `resolveCredentials(flags, {env})` (existing, `cli/credentials.mjs`) — flags > env > daemon.json > plugin.
+2. **Resolved:** persist `{url, apiKey}` to `~/.chorus/daemon.json` via `updateDaemonConfig` (existing field-merge writer in `cli/login.mjs`, 0600, preserves `cwds`/`yoloAckAt`/`sigintTimeoutMs`). This is the crux of the fix — it moves env/flag creds into the tier the clean boot env reads. When creds already came from `daemon.json`, the persist is an idempotent no-op merge.
+3. **Not resolved + TTY + not skip:** run the `chorus login` masked-prompt flow (reuse `prompt` from `cli/login.mjs`) to collect url + key.
+4. **Not resolved + (non-TTY or skip):** abort non-zero with the existing multi-source hint from `resolveCredentials`. Never write a unit.
+5. **Always validate** the resolved/entered key against the server via `validateAndFetchIdentity` (existing, `cli/chorus-client.mjs`) before writing the unit; on failure, abort non-zero and do not write. Persist the identity (`agentUuid`, `agentName`) alongside the creds, same as `chorus login`.
+
+Q-map: Q1-A (persist any source), Q2-A (always validate), Q8-A (flag OR non-TTY skips prompts but still persist+validate+abort-if-none), Q9-A (validate even in skip mode).
+
+## Interactive multi-cwd config (`resolveInstallCwds`)
+
+1. Compute the already-configured set with `resolveDaemonCwds(flags, {env})` (existing, `cli/daemon-config.mjs`) but distinguish "explicitly configured" from the `[undefined]` process-cwd default. Configured ⇔ a `--cwd` flag was passed OR `daemon.json` has a non-empty `cwds` array.
+2. **Configured, or skip/non-TTY:** use the configured set as-is (no prompt). If neither flag nor file set anything in skip/non-TTY mode, fall back to the current process cwd (today's single-path default).
+3. **Unconfigured + TTY + not skip:** run the wizard —
+   - Pre-seed the current directory as the suggested first entry (operator presses Enter to accept, or types a path).
+   - Loop "Add a working directory (blank to finish):" accumulating entries; blank line ends the loop.
+   - Normalize + de-dup each entry with the same rules `resolveDaemonCwds` uses (`~` expansion, absolute resolution, first-seen de-dup).
+4. Persist the chosen set to `daemon.json` `cwds` via `updateDaemonConfig` (same merge writer). This is the **single source of truth**; the unit gets no `--cwd`.
+
+Q-map: Q3-A (repeat-loop, blank ends, cwd pre-seeded), Q4-A (prompt only when unconfigured), Q5-A (persist to daemon.json cwds only).
+
+## Unit generator change
+
+`buildServiceArgs` (`cli/daemon-service.mjs`) currently appends `--cwd <path>` per configured path; `renderSystemdUnit` / `renderLaunchdPlist` embed that in `ExecStart` / `ProgramArguments`. Because cwds now live in `daemon.json` (which the daemon reads via `resolveDaemonCwds` tier 3), the unit must **stop** emitting `--cwd` so the two sources cannot drift and a plain `chorus daemon` sees the same paths. `--agent` / `--chorus-only` are still captured (they have no config-file equivalent that install writes). The existing "quote every ExecStart token" correctness property is preserved for the node/script paths.
+
+## Module Contracts
+
+- **Credential persistence:** only ever through `updateDaemonConfig` (atomic tmp+rename, 0600, shallow field-merge). Never hand-write `daemon.json`. Never bake the secret key into the unit (rejected design — weaker isolation than a 0600 file).
+- **Cwd normalization:** reuse `resolveDaemonCwds`'s `normalizeCwd` + de-dup semantics so wizard-entered paths and flag/env/file paths are treated identically.
+- **Abort contract:** any install that cannot end with a valid, validated credential in `daemon.json` exits non-zero and writes no unit (`installService` is never called). "No silent errors."
+- **Skip trigger:** `flags.yes === true` OR `!isTTY`. Both suppress every prompt; neither suppresses resolve/persist/validate/abort.
+
+## Implementation Plan
+
+1. `cli/client-args.mjs`: parse `--yes` / `-y` into `flags.yes`; extend `daemonHelpText` SERVICE section + `chorus.mjs` help.
+2. `cli/daemon-service.mjs`: drop `--cwd` from `buildServiceArgs` (keep `--agent` / `--chorus-only`); adjust the two renderers + their tests/scenarios.
+3. `cli/daemon.mjs`: add `resolveInstallCredentials` + `resolveInstallCwds` (pure, injected IO) and call them at the top of the `install` branch before `installService`; thread `isTTY` + `flags.yes`.
+4. Unit tests for every branch (resolve/persist/validate/abort; wizard loop/blank/pre-seed/skip-when-configured; skip-flag + non-TTY).
+5. Docs/help text.
+
+## Risks & Mitigations
+
+- **Validation needs network at install time (Q2/Q9).** Accepted per elaboration; the whole point is to fail at install instead of crash-looping at boot. The error message names the server and the offline-install trade-off was explicitly declined (Q9-A).
+- **Re-install must not clobber existing config.** `updateDaemonConfig` is a field-merge, so persisting creds preserves `cwds`/`yoloAckAt`; persisting cwds preserves creds. Covered by existing merge-writer tests + new ones.
+- **Live-testing `install` restarts the running daemon** (`enable --now` / `systemctl restart`). Do the end-to-end install→boot verification in an isolated env or under a temporary `SERVICE_NAME`, not against the daemon hosting the session.
+- **Dropping `--cwd` from the unit changes an existing scenario** in `daemon-background-lifecycle` (the `--cwd /a --cwd /b` install scenario). That scenario is rewritten in the delta (MODIFIED block) — not left stale.

--- a/openspec/changes/archive/2026-07-15-fix-daemon-install-config/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-daemon-install-config/proposal.md
@@ -1,0 +1,33 @@
+# Fix `chorus daemon install`: persist credentials for the boot service + interactive multi-cwd setup
+
+## Why
+
+`chorus daemon install` sets up a boot-autostart service (a `systemd --user` unit on Linux; a launchd LaunchAgent template on macOS), but the installed service starts in a **clean environment** that does not inherit the operator's shell-exported `CHORUS_URL` / `CHORUS_API_KEY`. The generated unit only captures `HOME` + `PATH` (`renderSystemdUnit` in `cli/daemon-service.mjs`). The install path also short-circuits into `handleLifecycleAction`'s `install` branch **before** the interactive `preflight` credential-completion the normal `chorus daemon` run performs (`cli/daemon.mjs`: `if (action !== "run") return handleLifecycleAction(...)` returns before `preflight`). So install never ensures credentials live in a source the clean boot env can read.
+
+Result: for an operator who only `export`s the two env vars and never ran `chorus login`, the installed service boots, resolves no credentials, and — being non-TTY — hard-errors and restart-loops (`Restart=on-failure`), even though the vars are set in their interactive shell.
+
+**Live-verified on the daemon host** (systemd `--user` `chorus-daemon.service`): `systemctl --user cat` shows the unit carries only `Environment=HOME` + `Environment=PATH`; the running daemon's `/proc/<MainPID>/environ` contains no `CHORUS_*`. The host's own daemon is healthy only because `~/.chorus/daemon.json` already holds `url`+`apiKey` from a prior `chorus login` (credential tier 3). The bug is therefore **conditional**: it bites the "env-vars-only, never-logged-in" operator, exactly the person `install` should serve.
+
+Separately, the operator asked for **interactive cwd configuration** at install time — declare one or more working directories the daemon serves, and be able to add multiple. The multi-cwd engine already exists (repeatable `--cwd`, `CHORUS_DAEMON_CWDS`, `cwds:[…]` in `daemon.json`, `resolveDaemonCwds` in `cli/daemon-config.mjs`); this change wires an interactive wizard into `install` and persists the configured set.
+
+## What Changes
+
+- **Credential preflight at install.** Before writing the service unit, `install` resolves credentials via the existing layered resolver (flags > env > `daemon.json` > plugin). If they resolve from **any** source, it persists them into `~/.chorus/daemon.json` (0600, via the existing field-merge writer) so the clean boot env can read them. If nothing resolves, it prompts login-style on a TTY (masked key); it always validates the key against the server and **aborts the install** on failure or when credentials cannot be obtained — never writing a unit that would crash-loop at boot.
+- **Interactive multi-cwd wizard.** When no cwd is configured (no `--cwd` flag, no `cwds` in `daemon.json`), `install` runs a repeated "add a working directory (blank to finish)" prompt loop, pre-seeding the current directory as the suggested first entry, and persists the resulting set to `daemon.json` `cwds` — the single source of truth. The generated unit carries **no** `--cwd` (so a plain `chorus daemon` and the boot service read the same paths).
+- **Non-interactive skip flag.** A new `--yes` / `-y` flag (and any non-TTY context) suppresses all prompts. In that mode install still resolves + persists credentials and still validates the key, but aborts if nothing resolves — so an unattended install never produces a broken boot service.
+- **All platforms.** The credential-persist + cwd config runs on macOS/Windows too (the clean-env problem hits launchd), and the printed launchd template stops relying on inherited env.
+
+## Capabilities
+
+- **daemon-background-lifecycle** — MODIFIED: the `install` requirement now performs credential preflight/persist + interactive cwd config and stops baking `--cwd` into the unit. ADDED: install credential guarantee, interactive multi-cwd config, and the `--yes`/`-y` non-interactive skip mode.
+
+## Impact
+
+- `cli/daemon.mjs` — `handleLifecycleAction` `install` branch: add credential resolve/persist/validate + cwd wizard before `installService`.
+- `cli/daemon-service.mjs` — `buildServiceArgs` / `renderSystemdUnit` / `renderLaunchdPlist`: stop emitting `--cwd` in the unit (cwds now come from `daemon.json`).
+- `cli/client-args.mjs` — parse `--yes` / `-y`; document it in `daemonHelpText`.
+- `cli/login.mjs` / `cli/credentials.mjs` — reuse `updateDaemonConfig`, `resolveCredentials`, `validateAndFetchIdentity`; no new persistence primitive.
+- `cli/daemon-config.mjs` — reuse `resolveDaemonCwds`; persist the wizard result via the merge writer.
+- Tests: unit coverage for the install preflight (resolve/persist/validate/abort branches), the cwd wizard (loop, blank-terminates, pre-seed, skip-when-configured), and skip-flag/non-TTY behavior.
+- Docs: `chorus.mjs` help text + `cli/client-args.mjs` `daemonHelpText` SERVICE section.
+- No schema, API, or DB changes. No new dependency.

--- a/openspec/changes/archive/2026-07-15-fix-daemon-install-config/specs/daemon-background-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-daemon-install-config/specs/daemon-background-lifecycle/spec.md
@@ -1,0 +1,104 @@
+## MODIFIED Requirements
+
+### Requirement: Supervisor service install / uninstall
+
+The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to manage the daemon as an OS-supervised, boot-autostart service, replacing the prior documentation-templates-only posture. On Linux the CLI SHALL generate a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, `ExecStart` invoking `chorus daemon` WITHOUT `-d`, so systemd owns the process directly as `MainPID`), SHALL capture the `--agent` / `--chorus-only` flags passed to `install` plus absolute node and script paths and the current `PATH`, SHALL write it to `~/.config/systemd/user/chorus-daemon.service`, and SHALL then run `systemctl --user daemon-reload` followed by `systemctl --user enable --now` so the service starts immediately and at every login. The generated unit SHALL NOT embed `--cwd` arguments: the set of working directories the daemon serves is persisted to `~/.chorus/daemon.json` `cwds` at install time (see "Install configures the served working directory set") and read from there by the daemon, so a boot-time service and a plain `chorus daemon` serve the same paths and cannot drift. The generated unit SHALL use `Restart=on-failure` (so a clean stop stays stopped) and SHALL NOT declare an `ExecStop` (a `Type=simple` stop is SIGTERM to the daemon's existing graceful-shutdown handler). The CLI SHALL NOT generate a `Type=forking` unit or an `ExecStart` containing `-d`. Before writing any service unit the CLI SHALL complete the install credential guarantee (see "Install guarantees resolvable credentials for the clean-env boot service") and the working-directory configuration (see "Install configures the served working directory set"); if the credential guarantee cannot be satisfied the CLI SHALL abort without writing a unit. On macOS the CLI SHALL print a correct launchd LaunchAgent plist (foreground, `RunAtLoad` + `KeepAlive`, no `-d`, no embedded `--cwd`) plus manual install steps and exit 0 without writing any file; on other platforms it SHALL print the foreground command to run under the operator's supervisor of choice. `uninstall` on Linux SHALL `disable --now` the unit, remove the unit file, and `daemon-reload`, reporting clearly when nothing was installed; off Linux it SHALL print the manual removal steps. The implementation SHALL be pure Node with no native-binding dependency and SHALL NOT use `shell:true`.
+
+#### Scenario: install generates a correct systemd unit and starts it
+
+- **WHEN** the user runs `chorus daemon install` on a Linux host with `systemctl --user` available, resolvable credentials, and a configured cwd set
+- **THEN** the CLI writes `~/.config/systemd/user/chorus-daemon.service` with `Type=simple`, an `ExecStart` that runs `chorus daemon` with no `-d` and no `--cwd` argument, `Restart=on-failure`, and no `ExecStop`, then runs `daemon-reload` and `enable --now`, so systemd owns the node process as `MainPID` and the service starts at login
+
+#### Scenario: install persists cwds to daemon.json rather than the unit
+
+- **WHEN** the user runs `chorus daemon install --cwd /a --cwd /b` on a Linux host
+- **THEN** the generated unit's `ExecStart` contains no `--cwd` argument, and `~/.chorus/daemon.json` `cwds` contains `/a` and `/b`, so the boot service reads the served paths from the config file
+
+#### Scenario: generated unit never self-daemonizes
+
+- **WHEN** the CLI renders the systemd unit for any set of flags
+- **THEN** the `ExecStart` line contains neither `-d` nor `--detach`, and the unit is not `Type=forking` — so systemd tracks the daemon directly and the boot-time restart loop cannot occur
+
+#### Scenario: install surfaces a failure instead of reporting success
+
+- **WHEN** `chorus daemon install` on Linux fails to write the unit or a `systemctl --user daemon-reload` / `enable --now` returns non-zero
+- **THEN** the CLI reports the failure with the underlying error and exits non-zero (no silent failure)
+
+#### Scenario: install off Linux prints a template and does not write
+
+- **WHEN** the user runs `chorus daemon install` on macOS or Windows
+- **THEN** the CLI prints a correct foreground service template (launchd plist on macOS) carrying no embedded `--cwd`, plus manual steps, writes no service file, and exits 0
+
+#### Scenario: uninstall removes the service or reports nothing to remove
+
+- **WHEN** the user runs `chorus daemon uninstall` on Linux
+- **THEN** the CLI disables and stops the unit, removes the unit file, and reloads systemd — or, when no unit is installed, reports that there was nothing to remove — and off Linux prints the manual removal steps
+
+## ADDED Requirements
+
+### Requirement: Install guarantees resolvable credentials for the clean-env boot service
+
+The CLI SHALL, before writing any service unit during `chorus daemon install`, guarantee that the supervised daemon can authenticate from a source its clean boot environment can read. Because a `systemd --user` unit (and a launchd LaunchAgent) starts in a clean environment that does NOT inherit the operator's shell-exported `CHORUS_URL` / `CHORUS_API_KEY`, install SHALL resolve credentials via the layered resolver (flags > env > `~/.chorus/daemon.json` > plugin fallback) and, when they resolve from ANY source, SHALL persist the `url` + `cho_` API key into `~/.chorus/daemon.json` using the same owner-only field-level merge as `chorus login` (preserving `cwds`, `yoloAckAt`, and `sigintTimeoutMs`). When credentials do NOT resolve and standard input is a TTY (and the non-interactive skip flag is absent), install SHALL prompt login-style for the server URL and a masked API key. Install SHALL always validate the resolved or entered key against the server (fetching the authenticated agent identity) before writing the unit, and SHALL persist the identity (`agentUuid`, `agentName`) alongside the credentials on success. If credentials cannot be obtained, or validation fails, install SHALL abort non-zero and SHALL NOT write a service unit — it SHALL never install a service that would fail to authenticate and restart-loop at boot. Credentials SHALL NOT be baked into the service unit as environment lines (a 0600 `daemon.json` is the persistence surface).
+
+#### Scenario: Exported env credentials are persisted so the clean boot env can read them
+
+- **WHEN** the operator has `CHORUS_URL` / `CHORUS_API_KEY` exported in their shell but no `~/.chorus/daemon.json`, and runs `chorus daemon install` on a Linux host
+- **THEN** install resolves the credentials from the environment, validates the key against the server, writes them (with the fetched identity) into `~/.chorus/daemon.json` at 0600, and only then writes the unit — so the boot service authenticates from the file rather than the un-inherited environment
+
+#### Scenario: No resolvable credentials on a TTY prompts login-style
+
+- **WHEN** the operator runs `chorus daemon install` on a TTY with no resolvable credentials and no skip flag
+- **THEN** install prompts for the URL and a masked API key, validates them, persists them to `~/.chorus/daemon.json`, and proceeds to write the unit
+
+#### Scenario: Invalid key aborts the install without writing a unit
+
+- **WHEN** the credentials resolved or entered during `chorus daemon install` fail server validation
+- **THEN** install reports the authentication failure, writes no service unit, does not run `enable --now`, and exits non-zero
+
+#### Scenario: No credentials and no way to prompt aborts with the multi-source hint
+
+- **WHEN** `chorus daemon install` cannot resolve credentials and either stdin is not a TTY or the skip flag is set
+- **THEN** install emits the single multi-source actionable credential error, writes no service unit, and exits non-zero
+
+#### Scenario: Credentials are never baked into the unit file
+
+- **WHEN** install writes a systemd unit or prints a launchd template after resolving credentials
+- **THEN** the unit/template contains no `CHORUS_API_KEY` or `CHORUS_URL` environment line — the credentials live only in the 0600 `~/.chorus/daemon.json`
+
+### Requirement: Install configures the served working directory set
+
+The CLI SHALL, during `chorus daemon install`, determine the set of working directories the daemon serves and persist it to `~/.chorus/daemon.json` `cwds` as the single source of truth, rather than embedding `--cwd` arguments in the service unit. Install SHALL treat the cwd set as already configured when a `--cwd` flag was passed OR `~/.chorus/daemon.json` already contains a non-empty `cwds` array, and in that case SHALL use that set without prompting. When the cwd set is unconfigured AND standard input is a TTY AND the non-interactive skip flag is absent, install SHALL run an interactive wizard that pre-seeds the current directory as the suggested first entry and then repeatedly prompts "add a working directory (blank to finish)", accumulating one or more paths until a blank line ends the loop. Each entered path SHALL be normalized and de-duplicated using the same rules as the daemon's layered cwd resolver (`~` expansion, resolution to an absolute path, first-seen de-duplication). Install SHALL persist the resulting set to `~/.chorus/daemon.json` `cwds` via the owner-only field-level merge (preserving credentials and other fields). When the set is unconfigured and no wizard runs (non-TTY or skip), install SHALL fall back to the daemon's existing single-path default (the process working directory) without prompting.
+
+#### Scenario: Interactive wizard collects multiple working directories
+
+- **WHEN** the operator runs `chorus daemon install` on a TTY with no `--cwd` flag and no `cwds` in `~/.chorus/daemon.json`
+- **THEN** install pre-seeds the current directory, prompts repeatedly for additional directories until a blank line, and persists the accumulated, normalized, de-duplicated set to `~/.chorus/daemon.json` `cwds`
+
+#### Scenario: Explicit configuration skips the wizard
+
+- **WHEN** the operator runs `chorus daemon install --cwd /a` or already has a non-empty `cwds` array in `~/.chorus/daemon.json`
+- **THEN** install does not prompt for working directories and persists/uses the explicitly configured set
+
+#### Scenario: Configured cwds are the single source of truth, not the unit
+
+- **WHEN** install has determined the served cwd set
+- **THEN** the set is written to `~/.chorus/daemon.json` `cwds` and the generated service unit carries no `--cwd` argument, so a plain `chorus daemon` and the boot service read the same paths
+
+### Requirement: Non-interactive install skip flag
+
+The CLI SHALL accept a `--yes` / `-y` flag on `chorus daemon install` that suppresses all interactive prompts, and SHALL treat a non-TTY standard input as equivalent to that flag. In skip mode install SHALL still resolve and persist credentials, still validate the key against the server, and still abort non-zero when credentials cannot be obtained or validated — the flag suppresses prompting, not the "never install a broken service" guarantee. In skip mode install SHALL NOT run the interactive cwd wizard; it SHALL use the `--cwd` flags, an existing `cwds` array, or the single-path process-cwd default.
+
+#### Scenario: Skip flag installs without prompting when credentials resolve
+
+- **WHEN** the operator runs `chorus daemon install --yes` (or install runs with a non-TTY stdin) and credentials resolve from flags, env, or `~/.chorus/daemon.json`
+- **THEN** install persists and validates the credentials, configures cwds from flags/config/default without prompting, writes the unit, and starts the service — with no interactive prompt
+
+#### Scenario: Skip flag still validates the key against the server
+
+- **WHEN** `chorus daemon install --yes` runs with credentials that fail server validation
+- **THEN** install reports the authentication failure, writes no unit, and exits non-zero — skip mode does not bypass validation
+
+#### Scenario: Skip flag aborts when no credentials resolve
+
+- **WHEN** `chorus daemon install --yes` (or a non-TTY install) cannot resolve credentials from any source
+- **THEN** install emits the multi-source actionable error, writes no unit, and exits non-zero instead of prompting

--- a/openspec/changes/archive/2026-07-15-fix-daemon-install-config/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-daemon-install-config/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## 1. CLI flag + unit generator
+
+- [ ] 1.1 Parse `--yes` / `-y` into `flags.yes` in `cli/client-args.mjs`; document it in `daemonHelpText` SERVICE section and `chorus.mjs` help.
+- [ ] 1.2 Drop `--cwd` emission from `buildServiceArgs` (keep `--agent` / `--chorus-only`); update `renderSystemdUnit` / `renderLaunchdPlist` and their tests/scenarios accordingly.
+
+## 2. Install config phase
+
+- [ ] 2.1 Add `resolveInstallCredentials` (pure, injected env/readJson/prompt/validate/writeConfig): resolve → (TTY prompt when unresolved & not skip) → always validate → persist to daemon.json → abort non-zero on failure/none.
+- [ ] 2.2 Add `resolveInstallCwds` (pure, injected): configured-detection, TTY wizard (pre-seed cwd, blank-terminated loop, normalize+de-dup), persist to daemon.json `cwds`, skip/non-TTY fallback to default.
+- [ ] 2.3 Call both at the top of `handleLifecycleAction`'s `install` branch before `installService`; thread `isTTY` + `flags.yes`.
+
+## 3. Tests + verification
+
+- [ ] 3.1 Unit tests: credential resolve/persist/validate/abort branches; cwd wizard loop/blank/pre-seed/skip-when-configured; `--yes` + non-TTY behavior; unit carries no `--cwd`.
+- [ ] 3.2 Integration checkpoint: end-to-end `install` in an isolated env (temporary `SERVICE_NAME` or container) — verify a clean-env boot service authenticates from persisted daemon.json and serves the configured cwds; verify abort paths write no unit.

--- a/openspec/specs/daemon-background-lifecycle/spec.md
+++ b/openspec/specs/daemon-background-lifecycle/spec.md
@@ -159,12 +159,17 @@ The CLI SHALL accept `chorus daemon stop --force`, which best-effort signals the
 
 ### Requirement: Supervisor service install / uninstall
 
-The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to manage the daemon as an OS-supervised, boot-autostart service, replacing the prior documentation-templates-only posture. On Linux the CLI SHALL generate a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, `ExecStart` invoking `chorus daemon` WITHOUT `-d`, so systemd owns the process directly as `MainPID`), SHALL capture the `--cwd` / `--agent` / `--chorus-only` flags passed to `install` plus absolute node and script paths and the current `PATH`, SHALL write it to `~/.config/systemd/user/chorus-daemon.service`, and SHALL then run `systemctl --user daemon-reload` followed by `systemctl --user enable --now` so the service starts immediately and at every login. The generated unit SHALL use `Restart=on-failure` (so a clean stop stays stopped) and SHALL NOT declare an `ExecStop` (a `Type=simple` stop is SIGTERM to the daemon's existing graceful-shutdown handler). The CLI SHALL NOT generate a `Type=forking` unit or an `ExecStart` containing `-d`. On macOS the CLI SHALL print a correct launchd LaunchAgent plist (foreground, `RunAtLoad` + `KeepAlive`, no `-d`) plus manual install steps and exit 0 without writing any file; on other platforms it SHALL print the foreground command to run under the operator's supervisor of choice. `uninstall` on Linux SHALL `disable --now` the unit, remove the unit file, and `daemon-reload`, reporting clearly when nothing was installed; off Linux it SHALL print the manual removal steps. The implementation SHALL be pure Node with no native-binding dependency and SHALL NOT use `shell:true`.
+The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to manage the daemon as an OS-supervised, boot-autostart service, replacing the prior documentation-templates-only posture. On Linux the CLI SHALL generate a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, `ExecStart` invoking `chorus daemon` WITHOUT `-d`, so systemd owns the process directly as `MainPID`), SHALL capture the `--agent` / `--chorus-only` flags passed to `install` plus absolute node and script paths and the current `PATH`, SHALL write it to `~/.config/systemd/user/chorus-daemon.service`, and SHALL then run `systemctl --user daemon-reload` followed by `systemctl --user enable --now` so the service starts immediately and at every login. The generated unit SHALL NOT embed `--cwd` arguments: the set of working directories the daemon serves is persisted to `~/.chorus/daemon.json` `cwds` at install time (see "Install configures the served working directory set") and read from there by the daemon, so a boot-time service and a plain `chorus daemon` serve the same paths and cannot drift. The generated unit SHALL use `Restart=on-failure` (so a clean stop stays stopped) and SHALL NOT declare an `ExecStop` (a `Type=simple` stop is SIGTERM to the daemon's existing graceful-shutdown handler). The CLI SHALL NOT generate a `Type=forking` unit or an `ExecStart` containing `-d`. Before writing any service unit the CLI SHALL complete the install credential guarantee (see "Install guarantees resolvable credentials for the clean-env boot service") and the working-directory configuration (see "Install configures the served working directory set"); if the credential guarantee cannot be satisfied the CLI SHALL abort without writing a unit. On macOS the CLI SHALL print a correct launchd LaunchAgent plist (foreground, `RunAtLoad` + `KeepAlive`, no `-d`, no embedded `--cwd`) plus manual install steps and exit 0 without writing any file; on other platforms it SHALL print the foreground command to run under the operator's supervisor of choice. `uninstall` on Linux SHALL `disable --now` the unit, remove the unit file, and `daemon-reload`, reporting clearly when nothing was installed; off Linux it SHALL print the manual removal steps. The implementation SHALL be pure Node with no native-binding dependency and SHALL NOT use `shell:true`.
 
 #### Scenario: install generates a correct systemd unit and starts it
 
-- **WHEN** the user runs `chorus daemon install --cwd /a --cwd /b` on a Linux host with `systemctl --user` available
-- **THEN** the CLI writes `~/.config/systemd/user/chorus-daemon.service` with `Type=simple`, an `ExecStart` that runs `chorus daemon --cwd /a --cwd /b` with no `-d`, `Restart=on-failure`, and no `ExecStop`, then runs `daemon-reload` and `enable --now`, so systemd owns the node process as `MainPID` and the service starts at login
+- **WHEN** the user runs `chorus daemon install` on a Linux host with `systemctl --user` available, resolvable credentials, and a configured cwd set
+- **THEN** the CLI writes `~/.config/systemd/user/chorus-daemon.service` with `Type=simple`, an `ExecStart` that runs `chorus daemon` with no `-d` and no `--cwd` argument, `Restart=on-failure`, and no `ExecStop`, then runs `daemon-reload` and `enable --now`, so systemd owns the node process as `MainPID` and the service starts at login
+
+#### Scenario: install persists cwds to daemon.json rather than the unit
+
+- **WHEN** the user runs `chorus daemon install --cwd /a --cwd /b` on a Linux host
+- **THEN** the generated unit's `ExecStart` contains no `--cwd` argument, and `~/.chorus/daemon.json` `cwds` contains `/a` and `/b`, so the boot service reads the served paths from the config file
 
 #### Scenario: generated unit never self-daemonizes
 
@@ -179,10 +184,77 @@ The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to m
 #### Scenario: install off Linux prints a template and does not write
 
 - **WHEN** the user runs `chorus daemon install` on macOS or Windows
-- **THEN** the CLI prints a correct foreground service template (launchd plist on macOS) plus manual steps, writes no service file, and exits 0
+- **THEN** the CLI prints a correct foreground service template (launchd plist on macOS) carrying no embedded `--cwd`, plus manual steps, writes no service file, and exits 0
 
 #### Scenario: uninstall removes the service or reports nothing to remove
 
 - **WHEN** the user runs `chorus daemon uninstall` on Linux
 - **THEN** the CLI disables and stops the unit, removes the unit file, and reloads systemd — or, when no unit is installed, reports that there was nothing to remove — and off Linux prints the manual removal steps
+
+### Requirement: Install guarantees resolvable credentials for the clean-env boot service
+
+The CLI SHALL, before writing any service unit during `chorus daemon install`, guarantee that the supervised daemon can authenticate from a source its clean boot environment can read. Because a `systemd --user` unit (and a launchd LaunchAgent) starts in a clean environment that does NOT inherit the operator's shell-exported `CHORUS_URL` / `CHORUS_API_KEY`, install SHALL resolve credentials via the layered resolver (flags > env > `~/.chorus/daemon.json` > plugin fallback) and, when they resolve from ANY source, SHALL persist the `url` + `cho_` API key into `~/.chorus/daemon.json` using the same owner-only field-level merge as `chorus login` (preserving `cwds`, `yoloAckAt`, and `sigintTimeoutMs`). When credentials do NOT resolve and standard input is a TTY (and the non-interactive skip flag is absent), install SHALL prompt login-style for the server URL and a masked API key. Install SHALL always validate the resolved or entered key against the server (fetching the authenticated agent identity) before writing the unit, and SHALL persist the identity (`agentUuid`, `agentName`) alongside the credentials on success. If credentials cannot be obtained, or validation fails, install SHALL abort non-zero and SHALL NOT write a service unit — it SHALL never install a service that would fail to authenticate and restart-loop at boot. Credentials SHALL NOT be baked into the service unit as environment lines (a 0600 `daemon.json` is the persistence surface).
+
+#### Scenario: Exported env credentials are persisted so the clean boot env can read them
+
+- **WHEN** the operator has `CHORUS_URL` / `CHORUS_API_KEY` exported in their shell but no `~/.chorus/daemon.json`, and runs `chorus daemon install` on a Linux host
+- **THEN** install resolves the credentials from the environment, validates the key against the server, writes them (with the fetched identity) into `~/.chorus/daemon.json` at 0600, and only then writes the unit — so the boot service authenticates from the file rather than the un-inherited environment
+
+#### Scenario: No resolvable credentials on a TTY prompts login-style
+
+- **WHEN** the operator runs `chorus daemon install` on a TTY with no resolvable credentials and no skip flag
+- **THEN** install prompts for the URL and a masked API key, validates them, persists them to `~/.chorus/daemon.json`, and proceeds to write the unit
+
+#### Scenario: Invalid key aborts the install without writing a unit
+
+- **WHEN** the credentials resolved or entered during `chorus daemon install` fail server validation
+- **THEN** install reports the authentication failure, writes no service unit, does not run `enable --now`, and exits non-zero
+
+#### Scenario: No credentials and no way to prompt aborts with the multi-source hint
+
+- **WHEN** `chorus daemon install` cannot resolve credentials and either stdin is not a TTY or the skip flag is set
+- **THEN** install emits the single multi-source actionable credential error, writes no service unit, and exits non-zero
+
+#### Scenario: Credentials are never baked into the unit file
+
+- **WHEN** install writes a systemd unit or prints a launchd template after resolving credentials
+- **THEN** the unit/template contains no `CHORUS_API_KEY` or `CHORUS_URL` environment line — the credentials live only in the 0600 `~/.chorus/daemon.json`
+
+### Requirement: Install configures the served working directory set
+
+The CLI SHALL, during `chorus daemon install`, determine the set of working directories the daemon serves and persist it to `~/.chorus/daemon.json` `cwds` as the single source of truth, rather than embedding `--cwd` arguments in the service unit. Install SHALL treat the cwd set as already configured when a `--cwd` flag was passed OR `~/.chorus/daemon.json` already contains a non-empty `cwds` array, and in that case SHALL use that set without prompting. When the cwd set is unconfigured AND standard input is a TTY AND the non-interactive skip flag is absent, install SHALL run an interactive wizard that pre-seeds the current directory as the suggested first entry and then repeatedly prompts "add a working directory (blank to finish)", accumulating one or more paths until a blank line ends the loop. Each entered path SHALL be normalized and de-duplicated using the same rules as the daemon's layered cwd resolver (`~` expansion, resolution to an absolute path, first-seen de-duplication). Install SHALL persist the resulting set to `~/.chorus/daemon.json` `cwds` via the owner-only field-level merge (preserving credentials and other fields). When the set is unconfigured and no wizard runs (non-TTY or skip), install SHALL fall back to the daemon's existing single-path default (the process working directory) without prompting.
+
+#### Scenario: Interactive wizard collects multiple working directories
+
+- **WHEN** the operator runs `chorus daemon install` on a TTY with no `--cwd` flag and no `cwds` in `~/.chorus/daemon.json`
+- **THEN** install pre-seeds the current directory, prompts repeatedly for additional directories until a blank line, and persists the accumulated, normalized, de-duplicated set to `~/.chorus/daemon.json` `cwds`
+
+#### Scenario: Explicit configuration skips the wizard
+
+- **WHEN** the operator runs `chorus daemon install --cwd /a` or already has a non-empty `cwds` array in `~/.chorus/daemon.json`
+- **THEN** install does not prompt for working directories and persists/uses the explicitly configured set
+
+#### Scenario: Configured cwds are the single source of truth, not the unit
+
+- **WHEN** install has determined the served cwd set
+- **THEN** the set is written to `~/.chorus/daemon.json` `cwds` and the generated service unit carries no `--cwd` argument, so a plain `chorus daemon` and the boot service read the same paths
+
+### Requirement: Non-interactive install skip flag
+
+The CLI SHALL accept a `--yes` / `-y` flag on `chorus daemon install` that suppresses all interactive prompts, and SHALL treat a non-TTY standard input as equivalent to that flag. In skip mode install SHALL still resolve and persist credentials, still validate the key against the server, and still abort non-zero when credentials cannot be obtained or validated — the flag suppresses prompting, not the "never install a broken service" guarantee. In skip mode install SHALL NOT run the interactive cwd wizard; it SHALL use the `--cwd` flags, an existing `cwds` array, or the single-path process-cwd default.
+
+#### Scenario: Skip flag installs without prompting when credentials resolve
+
+- **WHEN** the operator runs `chorus daemon install --yes` (or install runs with a non-TTY stdin) and credentials resolve from flags, env, or `~/.chorus/daemon.json`
+- **THEN** install persists and validates the credentials, configures cwds from flags/config/default without prompting, writes the unit, and starts the service — with no interactive prompt
+
+#### Scenario: Skip flag still validates the key against the server
+
+- **WHEN** `chorus daemon install --yes` runs with credentials that fail server validation
+- **THEN** install reports the authentication failure, writes no unit, and exits non-zero — skip mode does not bypass validation
+
+#### Scenario: Skip flag aborts when no credentials resolve
+
+- **WHEN** `chorus daemon install --yes` (or a non-TTY install) cannot resolve credentials from any source
+- **THEN** install emits the multi-source actionable error, writes no unit, and exits non-zero instead of prompting
 


### PR DESCRIPTION
## Summary

`chorus daemon install` set up a `systemd --user` (or launchd) boot service that started in a **clean environment** and never inherited the operator's shell-exported `CHORUS_URL` / `CHORUS_API_KEY` — the generated unit captured only `HOME` + `PATH`. For an operator who only `export`ed the env vars and never ran `chorus login`, the boot service resolved no credentials and crash-looped (`Restart=on-failure`). Verified live on a daemon host: the unit carried only `HOME`/`PATH`, and the running daemon's `/proc/<pid>/environ` had no `CHORUS_*`.

This adds a **pre-install config phase** that runs before the unit is written:

- **Credential preflight** — resolve credentials (flags > env > `daemon.json` > plugin), persist them (with the fetched identity) into `~/.chorus/daemon.json` (0600 field-merge) so the clean boot env can read them, **always validate** the key against the server, and **abort without writing a unit** if credentials can't be obtained or validated (never install a service that would crash-loop at boot).
- **Interactive multi-cwd setup** — when unconfigured on a TTY, a pre-seeded "add a working directory (blank to finish)" loop; the set is persisted to `daemon.json` `cwds` as the single source of truth, so the unit no longer embeds `--cwd` (a plain `chorus daemon` and the boot service read the same paths).
- **`--yes` / `-y` skip flag** — (and any non-TTY context) suppresses all prompts but keeps the persist + validate + abort guarantee.

All on every platform (the clean-env problem hits launchd too). Elaboration resolved across 2 rounds / 9 questions; reviewed at task, proposal, and idea (aggregate code-review) level.

## Changed files

| File | Change |
|------|--------|
| `cli/daemon-install-config.mjs` | **New** — `resolveInstallCredentials` + `resolveInstallCwds` (pure, dependency-injected) |
| `cli/daemon.mjs` | Install branch runs the config phase before `installService` (skip = `--yes` \|\| non-TTY; abort ⇒ no unit); injectable IO seams |
| `cli/daemon-service.mjs` | `buildServiceArgs` no longer emits `--cwd`; unit/plist inherit the change |
| `cli/client-args.mjs` | Parse `--yes`/`-y`; document it + rewrite the install SERVICE help |
| `chorus.mjs` | Top-level help gains the `-y`/`--yes` line |
| `cli/daemon-config.mjs` | Export `normalizeCwd` / `cleanCwdList` for wizard normalization parity |
| `cli/__tests__/daemon-install-config.test.mjs` | **New** — 11 helper unit tests |
| `cli/__tests__/daemon-install-integration.test.mjs` | **New** — 4 end-to-end install-wiring tests |
| `cli/__tests__/{daemon-service,client-args,daemon-lifecycle-dispatch}.test.mjs` | Updated expectations + no-cwd / no-credential-in-unit regression guards |
| `openspec/...` | Archived change `fix-daemon-install-config`; folded delta into `daemon-background-lifecycle` spec |

## Test plan

- [x] `npx vitest run cli/` — 737/737 pass (52 files)
- [x] `npx tsc --noEmit` — clean
- [x] Live abort-path check of the real binary (temp HOME, no creds, non-TTY): exit 1, no unit, no `daemon.json`
- [ ] **Human, on a throwaway host/container:** the true reboot-persistence e2e (`install` → `systemctl --user enable --now` → reboot → clean-env service authenticates from `daemon.json`). Can't run in the daemon's own session — `enable --now` would cycle the daemon.

## Follow-up (non-blocking)

`resolveInstallCwds` does not bridge the `CHORUS_DAEMON_CWDS` env var into `daemon.json` at install (the run path honors it; install treats only a `--cwd` flag or existing `cwds` as "configured"). Conforms to the elaborated scope, but is an asymmetry with the credential fix — flagged for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)