### PR TITLE
feat(references): clamp notes to 2 lines with hover tooltip + tap-to-expand; nudge concise notes in MCP docs

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1149,7 +1149,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 | type | enum | Yes | Reference type: `docs` (official documentation), `repo` (reference implementation), `issue_pr` (issue/PR thread), `paper_blog` (paper/blog post) |
 | url | string | Yes | Web URL — must start with `http://` or `https://` (no local files) |
 | title | string | Yes | Reference title |
-| notes | string | No | Optional human/agent-authored summary (stored verbatim; no fetch) |
+| notes | string | No | Optional one-line summary of why this reference is relevant — keep it to a single concise sentence (~200 chars, ≤2 lines); the UI clamps the display to 2 lines. Stored verbatim; no fetch. |
 
 **Output**: Created ReferenceArtifact JSON (`{ uuid, targetType, targetUuid, type, url, title, notes, createdBy, createdAt, updatedAt }`)
 
@@ -1170,7 +1170,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 | type | enum | No | New reference type: `docs`, `repo`, `issue_pr`, `paper_blog` |
 | url | string | No | New web URL (`http://` or `https://`) |
 | title | string | No | New title |
-| notes | string \| null | No | New notes (`null` clears; omit to leave unchanged) |
+| notes | string \| null | No | New notes — one concise sentence (~200 chars, ≤2 lines; the UI clamps the display to 2 lines). `null` clears; omit to leave unchanged. |
 
 **Output**: Updated ReferenceArtifact JSON
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -709,7 +709,8 @@
     "addFailed": "Failed to add reference",
     "updateFailed": "Failed to update reference",
     "deleteFailed": "Failed to delete reference",
-    "countLabel": "{count, plural, one {# reference} other {# references}}"
+    "countLabel": "{count, plural, one {# reference} other {# references}}",
+    "toggleNotes": "Show full notes"
   },
   "export": {
     "exportDocument": "Export",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -709,7 +709,8 @@
     "addFailed": "参考資料の追加に失敗しました",
     "updateFailed": "参考資料の更新に失敗しました",
     "deleteFailed": "参考資料の削除に失敗しました",
-    "countLabel": "参考資料 {count} 件"
+    "countLabel": "参考資料 {count} 件",
+    "toggleNotes": "概要を全文表示"
   },
   "export": {
     "exportDocument": "エクスポート",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -709,7 +709,8 @@
     "addFailed": "참고 자료 추가에 실패했습니다",
     "updateFailed": "참고 자료 업데이트에 실패했습니다",
     "deleteFailed": "참고 자료 삭제에 실패했습니다",
-    "countLabel": "참고 자료 {count}개"
+    "countLabel": "참고 자료 {count}개",
+    "toggleNotes": "전체 메모 보기"
   },
   "export": {
     "exportDocument": "내보내기",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -709,7 +709,8 @@
     "addFailed": "添加参考资料失败",
     "updateFailed": "更新参考资料失败",
     "deleteFailed": "删除参考资料失败",
-    "countLabel": "{count, plural, other {# 条参考资料}}"
+    "countLabel": "{count, plural, other {# 条参考资料}}",
+    "toggleNotes": "显示完整说明"
   },
   "export": {
     "exportDocument": "导出",

--- a/openspec/changes/archive/2026-07-16-clamp-reference-notes/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-16-clamp-reference-notes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/archive/2026-07-16-clamp-reference-notes/README.md
+++ b/openspec/changes/archive/2026-07-16-clamp-reference-notes/README.md
@@ -1,0 +1,3 @@
+# clamp-reference-notes
+
+Clamp reference notes to 2 lines with hover tooltip + tap-to-expand; nudge agents to concise notes via MCP param docs

--- a/openspec/changes/archive/2026-07-16-clamp-reference-notes/design.md
+++ b/openspec/changes/archive/2026-07-16-clamp-reference-notes/design.md
@@ -1,0 +1,70 @@
+# Design: Clamp reference notes to 2 lines with hover tooltip + tap-to-expand
+
+## Context
+
+The `notes` field of a `ReferenceArtifact` (`ReferenceArtifactResponse.notes: string | null`) renders today as the exact same JSX in two components:
+
+- `src/components/references-section.tsx:236-240` (editable; idea/proposal/task detail panels)
+- `src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx:73-77` (read-only dashboard idea-card)
+
+Both:
+
+```tsx
+{ref.notes && (
+  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+    {ref.notes}
+  </p>
+)}
+```
+
+No clamp, no truncation, no tooltip. A `line-clamp-2` precedent already exists (`proposals/[proposalUuid]/proposal-editor.tsx`), and a shadcn/Radix `Tooltip` primitive is available at `src/components/ui/tooltip.tsx` (there is **no** app-global `TooltipProvider` — each consumer wraps its own).
+
+MCP side: the `notes` describe string appears 4 times (all `z.string()`, no length rule):
+- `src/mcp/tools/pm.ts:48` — shared `referenceInlineItemSchema` (reused by `chorus_pm_create_idea`, `chorus_pm_create_proposal`)
+- `src/mcp/tools/pm.ts:400` — `chorus_add_reference`
+- `src/mcp/tools/pm.ts:442` — `chorus_update_reference`
+- `src/mcp/tools/public.ts:44` — shared `referenceInlineItemSchema` used by `chorus_create_tasks`
+
+## Decisions
+
+### D1 — One shared `ReferenceNotes` component, not two edits
+
+Extract `src/components/reference-notes.tsx` (client component) and use it from both surfaces, rather than duplicating clamp+tooltip+toggle logic. Single source of truth, single render-test target. Signature: `<ReferenceNotes notes={ref.notes} />` — it internally guards on empty/null and renders nothing when there is no text (preserving the current `{ref.notes && …}` behavior at each call site).
+
+### D2 — Clamp + reveal interaction model (elaboration q1=all surfaces, q4=tap-to-toggle)
+
+- **Default:** the `<p>` keeps its current classes plus `line-clamp-2` when collapsed. The clamp itself is display-only; the DOM still contains the full text.
+- **Desktop hover:** wrap the collapsed `<p>` in a `Tooltip`/`TooltipTrigger`; `TooltipContent` shows the full `notes`. The component renders its own `TooltipProvider` (no global one exists). Constrain tooltip width (`max-w-xs`/`max-w-sm`) and allow wrapping so long notes stay readable.
+- **Tap/click:** clicking the notes toggles an `expanded` state; expanded removes the clamp (full text inline) and the tooltip is suppressed while expanded (nothing hidden to preview). This is the touch fallback — tap works without hover. Clicking again collapses.
+- The trigger is a `<button type="button">` styled to look like the current paragraph (`text-left`, inherits the muted/xs styling), so it is keyboard-focusable and accessible; it carries an `aria-expanded` and an aria-label from i18n (e.g. `references.toggleNotes`).
+- **Tooltip-only-when-clamped nicety:** if the text is short enough not to overflow 2 lines, the tooltip/expand still function harmlessly; we do not add JS overflow-measurement in v1 (keeps it dependency-free and deterministic for tests). Interaction is always available but is a no-op visual when text already fits.
+
+### D3 — Docs nudge only, no cap (elaboration q2=docs-only, q3=~200 chars)
+
+Reword the 4 `notes` describe strings to a single consistent sentence that:
+- states it is an optional short summary,
+- asks for **one concise sentence (~200 characters, ≤2 lines)**,
+- keeps the existing "stored verbatim; no fetch" fact where present.
+
+Example new wording (create/add path):
+`"Optional one-line summary of why this reference is relevant — keep it to a single concise sentence (~200 chars, ≤2 lines); the UI clamps to 2 lines. Stored verbatim; no fetch."`
+
+Update path keeps its clear-semantics note:
+`"New notes — one concise sentence (~200 chars, ≤2 lines; the UI clamps to 2 lines). null clears; omit to leave unchanged."`
+
+No `.max()` is added — `notes` stays `z.string()`; over-long text is accepted and simply clamped in the UI.
+
+### D4 — Theme + i18n
+
+- The component uses only semantic tokens already in the `<p>` (`text-muted-foreground`) and the shared `TooltipContent` (which is `bg-foreground text-background`), so both light and dark themes are correct with no new color.
+- Any new label goes into all four locale files (`en`, `zh`, `ja`, `ko`), per project i18n rule.
+
+## Risks / trade-offs
+
+- **jsdom + Radix Tooltip:** Radix popper needs `ResizeObserver` / pointer-capture stubs in jsdom (existing pattern in `yolo-button.test.tsx`). The render test stubs those and asserts on the trigger + expand toggle rather than the portalled hover content (hover-open is timing/portal heavy); tooltip *wiring* is asserted structurally.
+- **No overflow measurement:** interaction is always present even for short notes. Accepted for v1 simplicity; the visual result for short notes is identical (nothing to reveal).
+- **design.pen:** this is a user-facing UI change, so `docs/design.pen` should reflect the clamped-notes state. `.pen` is encrypted and only editable via Pencil MCP tools; in a headless run this is captured as an acceptance criterion and handed to a human if it cannot be completed automatically.
+
+## Migration / rollout
+
+Pure display + docs change; no data migration. Ships behind no flag. Verified by: `pnpm test` (new component test + describe-nudge test), `npx tsc --noEmit`, `pnpm lint`, and an e2e/browser check of a reference with long notes in both themes.

--- a/openspec/changes/archive/2026-07-16-clamp-reference-notes/proposal.md
+++ b/openspec/changes/archive/2026-07-16-clamp-reference-notes/proposal.md
@@ -1,0 +1,39 @@
+# Proposal: Clamp reference notes to 2 lines with hover tooltip + tap-to-expand; nudge agents to concise notes
+
+## Why
+
+The first-class external-reference feature (ReferenceArtifact) stores an optional `notes` field — a human/agent-authored summary of why a link is relevant. In practice, agents write long, paragraph-length `notes`. Today those render as an **un-clamped `<p>`** in every reference list, so a single verbose reference can dominate the card and push everything else out of view, hurting the scannability the reference list exists to provide.
+
+Two complementary fixes:
+
+1. **Display-side:** clamp the visible `notes` to 2 lines everywhere it renders, with the full text still reachable — hover tooltip on desktop, tap-to-expand inline (which also works on touch, where hover never fires).
+2. **Authoring-side:** reword the MCP `notes` parameter docs (`.describe(...)`) so agents are reminded, at write time, to keep each reference's intro to one concise sentence (~200 characters / about two lines).
+
+The stored text is never altered — this is a display clamp plus a documentation nudge. Elaboration resolved (1 round, 4 questions): **all surfaces / docs-only soft nudge / ~200-char target / tap-to-toggle mobile fallback**.
+
+## What Changes
+
+- **New shared `ReferenceNotes` component** renders the `notes` text with `line-clamp-2`, a desktop hover tooltip carrying the full text, and click/tap to expand-and-collapse inline. Empty/null notes render nothing and expose no interaction.
+- **Both reference-list surfaces adopt it** — the editable `ReferencesSection` (idea / proposal / task detail panels) and the read-only `IdeaReferencesContent` (dashboard idea-card), replacing their identical inline `<p>{ref.notes}</p>`.
+- **MCP `notes` param docs reworded** in all four occurrences (shared inline `referenceInlineItemSchema`, `chorus_add_reference`, `chorus_update_reference`) to nudge a single concise sentence (~200 chars / ≤2 lines).
+- **`docs/MCP_TOOLS.md`** `notes` rows updated to match the new wording.
+- **i18n** — any new user-facing string (e.g. an expand/collapse aria-label) is added to all four locales (`en`, `zh`, `ja`, `ko`).
+
+Out of scope (per elaboration): no DB change, no `notes` length validation / server-side cap (`z.string()` stays unbounded), no reference section on Documents (they have none).
+
+## Capabilities
+
+- **reference-display** (MODIFIED) — add the 2-line clamp + full-text reveal (hover tooltip + tap-to-expand) to the `notes` text on all reference-list surfaces, alongside the existing title-truncation requirement.
+- **reference-association-guidance** (MODIFIED) — the MCP `notes` parameter documentation nudges agents toward one concise sentence, extending the existing reference-attachment guidance to cover *how long* a note should be.
+
+## Impact
+
+- Affected code:
+  - `src/components/reference-notes.tsx` (new shared component)
+  - `src/components/references-section.tsx` (use it)
+  - `src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx` (use it)
+  - `src/mcp/tools/pm.ts` (3 `notes` describe strings)
+  - `src/mcp/tools/public.ts` (1 `notes` describe string)
+  - `docs/MCP_TOOLS.md` (notes rows)
+  - `messages/{en,zh,ja,ko}.json` (only if a new key is introduced)
+- No schema, migration, or API-contract change. Behavior is display + docs only; both light and dark themes must remain correct.

--- a/openspec/changes/archive/2026-07-16-clamp-reference-notes/specs/reference-association-guidance/spec.md
+++ b/openspec/changes/archive/2026-07-16-clamp-reference-notes/specs/reference-association-guidance/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: MCP notes parameter docs nudge concise summaries
+The MCP tool documentation for a reference's `notes` parameter SHALL instruct agents to keep the summary to a single concise sentence (about 200 characters, at most two lines), noting that the UI clamps the displayed text to two lines. This wording SHALL appear in every place the `notes` parameter is described: the shared inline `referenceInlineItemSchema` (reused by `chorus_pm_create_idea`, `chorus_pm_create_proposal`, and — via `public.ts` — `chorus_create_tasks`), the `chorus_add_reference` tool, and the `chorus_update_reference` tool. The nudge SHALL be documentation-only: `notes` remains an unconstrained string with no server-side length cap or validation. The `docs/MCP_TOOLS.md` reference rows for `notes` SHALL be updated to match.
+
+#### Scenario: Inline references[] notes describe carries the concise nudge
+- **WHEN** the `notes` field of the shared inline reference schema is inspected (`.describe(...)`)
+- **THEN** its text asks for one concise sentence and states a ~200-character / two-line target
+
+#### Scenario: add_reference and update_reference notes describe carry the nudge
+- **WHEN** the `notes` parameter description of `chorus_add_reference` and of `chorus_update_reference` is inspected
+- **THEN** each asks for a concise one-sentence summary with the ~200-character / two-line target, and `chorus_update_reference` still documents that `null` clears and omission leaves it unchanged
+
+#### Scenario: No length validation is introduced
+- **WHEN** an over-long `notes` value is submitted to any reference create/update tool
+- **THEN** it is accepted and stored verbatim (no `.max()` rejection); the length guidance is advisory only
+
+#### Scenario: MCP tool reference doc matches
+- **WHEN** `docs/MCP_TOOLS.md` `notes` rows are read
+- **THEN** they carry the same concise-summary guidance as the tool `.describe()` strings

--- a/openspec/changes/archive/2026-07-16-clamp-reference-notes/specs/reference-display/spec.md
+++ b/openspec/changes/archive/2026-07-16-clamp-reference-notes/specs/reference-display/spec.md
@@ -1,22 +1,4 @@
-# reference-display Specification
-
-## Purpose
-TBD - created by archiving change strengthen-reference-association. Update Purpose after archive.
-## Requirements
-### Requirement: Reference links truncate instead of overflowing
-The reference-list UI SHALL keep an over-long reference URL or title within the bounds of its card by truncating the visible link text, in both the editable references section and the read-only idea-tracker references panel, and in both light and dark themes. The link anchor SHALL be width-constrained (a block-level, `min-w-0` flex container) so the inner truncating span engages against the card width, while the external-link icon remains visible.
-
-#### Scenario: Long title truncates in the references section
-- **WHEN** a reference whose title (or a title that is a pasted long URL) exceeds the card width is rendered in `references-section.tsx`
-- **THEN** the title is truncated with an ellipsis and the card width is unchanged (no horizontal overflow), and the external-link icon stays visible
-
-#### Scenario: Long title truncates in the idea references panel
-- **WHEN** such a reference is rendered in the read-only `idea-references-panel.tsx`
-- **THEN** the title is truncated with an ellipsis and the card does not widen or overflow
-
-#### Scenario: Both themes render correctly
-- **WHEN** the truncation fix is viewed in light and in dark theme
-- **THEN** the layout is correct in both, with no color regression (the fix changes layout classes only, using existing semantic tokens)
+## ADDED Requirements
 
 ### Requirement: Reference notes clamp to two lines with full-text reveal
 The reference-list UI SHALL display a reference's `notes` text clamped to at most two lines by default, and SHALL make the full text reachable without altering the stored value — via a hover tooltip on hover-capable (desktop) pointers AND via a tap/click that expands the notes inline (the touch fallback, since hover does not fire on touch). This behavior SHALL apply on all reference-list surfaces: the editable references section (`references-section.tsx`, used on idea/proposal/task detail panels) and the read-only idea-tracker references panel (`idea-references-panel.tsx`). When a reference has no notes, nothing SHALL be rendered and no reveal interaction SHALL be exposed. The clamp and reveal SHALL be implemented by a single shared component so both surfaces behave identically, and SHALL render correctly in both light and dark themes using existing semantic tokens.
@@ -44,4 +26,3 @@ The reference-list UI SHALL display a reference's `notes` text clamped to at mos
 #### Scenario: Both themes render correctly
 - **WHEN** the clamped notes and the full-text reveal are viewed in light and in dark theme
 - **THEN** the layout and colors are correct in both, using existing semantic tokens (no fixed-light-only color)
-

--- a/openspec/specs/reference-association-guidance/spec.md
+++ b/openspec/specs/reference-association-guidance/spec.md
@@ -44,3 +44,22 @@ Both daemon wake-prompt surfaces SHALL carry a one-line reflex nudge to attach e
 - **WHEN** the CLI↔OpenClaw wake-parity guard runs
 - **THEN** it continues to pass on action-coverage only, and the OpenClaw event-router remains without a headless preamble (no reference nudge is added there)
 
+### Requirement: MCP notes parameter docs nudge concise summaries
+The MCP tool documentation for a reference's `notes` parameter SHALL instruct agents to keep the summary to a single concise sentence (about 200 characters, at most two lines), noting that the UI clamps the displayed text to two lines. This wording SHALL appear in every place the `notes` parameter is described: the shared inline `referenceInlineItemSchema` (reused by `chorus_pm_create_idea`, `chorus_pm_create_proposal`, and — via `public.ts` — `chorus_create_tasks`), the `chorus_add_reference` tool, and the `chorus_update_reference` tool. The nudge SHALL be documentation-only: `notes` remains an unconstrained string with no server-side length cap or validation. The `docs/MCP_TOOLS.md` reference rows for `notes` SHALL be updated to match.
+
+#### Scenario: Inline references[] notes describe carries the concise nudge
+- **WHEN** the `notes` field of the shared inline reference schema is inspected (`.describe(...)`)
+- **THEN** its text asks for one concise sentence and states a ~200-character / two-line target
+
+#### Scenario: add_reference and update_reference notes describe carry the nudge
+- **WHEN** the `notes` parameter description of `chorus_add_reference` and of `chorus_update_reference` is inspected
+- **THEN** each asks for a concise one-sentence summary with the ~200-character / two-line target, and `chorus_update_reference` still documents that `null` clears and omission leaves it unchanged
+
+#### Scenario: No length validation is introduced
+- **WHEN** an over-long `notes` value is submitted to any reference create/update tool
+- **THEN** it is accepted and stored verbatim (no `.max()` rejection); the length guidance is advisory only
+
+#### Scenario: MCP tool reference doc matches
+- **WHEN** `docs/MCP_TOOLS.md` `notes` rows are read
+- **THEN** they carry the same concise-summary guidance as the tool `.describe()` strings
+

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx
@@ -17,6 +17,7 @@ import {
   referenceTypeConfig as typeConfig,
   isKnownReferenceType as isKnownType,
 } from "@/components/reference-type-config";
+import { ReferenceNotes } from "@/components/reference-notes";
 import type { ReferenceArtifactResponse } from "@/services/reference-artifact.service";
 
 interface IdeaReferencesContentProps {
@@ -70,11 +71,7 @@ export function IdeaReferencesContent({
                 <span className="truncate">{ref.title}</span>
                 <ExternalLink className="h-3 w-3 shrink-0" />
               </a>
-              {ref.notes && (
-                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                  {ref.notes}
-                </p>
-              )}
+              <ReferenceNotes notes={ref.notes} />
             </div>
           );
         })

--- a/src/components/__tests__/reference-notes.test.tsx
+++ b/src/components/__tests__/reference-notes.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// UI tests for the shared ReferenceNotes renderer (clamp-reference-notes).
+// Covers:
+//  - collapsed default clamps to 2 lines (line-clamp-2 class present),
+//  - empty / null / whitespace notes render nothing and expose no control,
+//  - click toggles expanded (clamp removed) and collapses back,
+//  - the collapsed state wires a tooltip trigger (full text reachable on hover).
+
+import React from "react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+// The shared Tooltip is a shadcn (Radix) primitive whose Popper uses
+// ResizeObserver + pointer-capture — absent from jsdom. Stub them so mounting
+// the collapsed (tooltip-wrapped) state doesn't throw.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+if (typeof Element !== "undefined" && !Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// Resolve real i18n strings from en.json, mirroring the yolo-button test setup.
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../messages/en.json")).default as Record<string, unknown>;
+  return {
+    useTranslations: (ns?: string) => (key: string) => {
+      const full = ns ? `${ns}.${key}` : key;
+      let node: unknown = en;
+      for (const p of full.split(".")) {
+        node =
+          node && typeof node === "object" && p in (node as Record<string, unknown>)
+            ? (node as Record<string, unknown>)[p]
+            : undefined;
+      }
+      return typeof node === "string" ? node : full;
+    },
+  };
+});
+
+import { ReferenceNotes } from "@/components/reference-notes";
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe("ReferenceNotes", () => {
+  it("clamps to 2 lines when collapsed (default)", () => {
+    render(<ReferenceNotes notes="A fairly long note that would wrap over many lines in the card." />);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("line-clamp-2");
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("collapsed variant does NOT carry `block` (it would override line-clamp's display)", () => {
+    // Regression guard: `line-clamp-2` needs `display:-webkit-box`; Tailwind
+    // emits `.block` after `.line-clamp-2`, so a co-present `block` wins the
+    // cascade and the height clamp silently stops working (only the tooltip
+    // would remain). jsdom applies no CSS, so we assert the class list instead:
+    // collapsed must have line-clamp-2 and must NOT have a `block` token.
+    render(<ReferenceNotes notes="Long note text that must actually clamp in height." />);
+    const btn = screen.getByRole("button");
+    const tokens = btn.className.split(/\s+/);
+    expect(tokens).toContain("line-clamp-2");
+    expect(tokens).not.toContain("block");
+  });
+
+  it("renders nothing for null / empty / whitespace notes", () => {
+    const { container: c1 } = render(<ReferenceNotes notes={null} />);
+    expect(c1.querySelector("button")).toBeNull();
+    cleanup();
+    const { container: c2 } = render(<ReferenceNotes notes="" />);
+    expect(c2.querySelector("button")).toBeNull();
+    cleanup();
+    const { container: c3 } = render(<ReferenceNotes notes="   " />);
+    expect(c3.querySelector("button")).toBeNull();
+  });
+
+  it("click expands (removes clamp, uses block) and clicking again collapses", () => {
+    render(<ReferenceNotes notes="Some note text." />);
+    const btn = screen.getByRole("button");
+    // collapsed → clamped, no block
+    expect(btn.className.split(/\s+/)).toContain("line-clamp-2");
+    expect(btn.className.split(/\s+/)).not.toContain("block");
+
+    fireEvent.click(btn);
+    const expanded = screen.getByRole("button");
+    // expanded → no clamp; `block` is safe here (nothing to clamp) and lets the
+    // full text fill the width.
+    expect(expanded.className).not.toContain("line-clamp-2");
+    expect(expanded.className.split(/\s+/)).toContain("block");
+    expect(expanded.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(expanded);
+    const recollapsed = screen.getByRole("button");
+    expect(recollapsed.className.split(/\s+/)).toContain("line-clamp-2");
+    expect(recollapsed.className.split(/\s+/)).not.toContain("block");
+    expect(recollapsed.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("wires a tooltip trigger while collapsed (full text reachable on hover)", () => {
+    render(<ReferenceNotes notes="Full note body." />);
+    const btn = screen.getByRole("button");
+    // Radix TooltipTrigger tags the trigger element with this data-slot.
+    expect(btn.getAttribute("data-slot")).toBe("tooltip-trigger");
+    // The visible text is present in the DOM (clamp is display-only).
+    expect(btn.textContent).toContain("Full note body.");
+  });
+});

--- a/src/components/reference-notes.tsx
+++ b/src/components/reference-notes.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+// Shared renderer for a reference artifact's `notes` summary text, used by both
+// reference-list surfaces (the editable ReferencesSection on idea/proposal/task
+// detail panels and the read-only IdeaReferencesContent dashboard card).
+//
+// Agents sometimes write long, paragraph-length notes; rendered raw they'd
+// dominate the card. So the notes are clamped to 2 lines by default, with the
+// full text reachable two ways (elaboration q4 = tap-to-toggle):
+//   - desktop hover  → a tooltip carrying the full text
+//   - tap / click    → expands the notes inline (the touch fallback, since hover
+//                      never fires on touch); tapping again collapses
+// The clamp is display-only — the stored `notes` value is never altered.
+//
+// Empty/null notes render nothing and expose no control (preserves the previous
+// `{ref.notes && …}` guard at each call site).
+//
+// Dark-mode: uses only semantic tokens (`text-muted-foreground` on the text,
+// and the shared TooltipContent's `bg-foreground text-background`), so it reads
+// correctly in both light and dark themes with no fixed-light-only color.
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface ReferenceNotesProps {
+  notes: string | null | undefined;
+}
+
+export function ReferenceNotes({ notes }: ReferenceNotesProps) {
+  const t = useTranslations();
+  const [expanded, setExpanded] = useState(false);
+
+  const text = notes?.trim();
+  if (!text) return null;
+
+  // The visible text: a left-aligned button styled to look exactly like the
+  // former paragraph, so it stays keyboard-focusable and accessible while
+  // reading as body text. Collapsed → clamp to 2 lines; expanded → full text.
+  //
+  // IMPORTANT: do NOT add `block` to the collapsed variant. `line-clamp-2`
+  // relies on `display: -webkit-box`, and Tailwind emits `.block` AFTER
+  // `.line-clamp-2` at equal specificity — so a co-present `block` wins the
+  // cascade, `display` reverts to `block`, and `-webkit-line-clamp` silently
+  // does nothing (the text is no longer height-clamped). The clamp must own
+  // `display`. `w-full` still makes the box fill the card width.
+  const trigger = (
+    <button
+      type="button"
+      onClick={() => setExpanded((v) => !v)}
+      aria-expanded={expanded}
+      aria-label={t("references.toggleNotes")}
+      className={`mt-1 w-full cursor-pointer text-left text-xs leading-relaxed text-muted-foreground ${
+        expanded ? "block" : "line-clamp-2"
+      }`}
+    >
+      {text}
+    </button>
+  );
+
+  // While expanded the whole text is already visible inline, so the hover
+  // tooltip has nothing to add — render the bare trigger. When collapsed, wrap
+  // it so desktop hover reveals the full notes.
+  if (expanded) return trigger;
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+        <TooltipContent className="max-w-xs whitespace-pre-wrap break-words">
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/references-section.tsx
+++ b/src/components/references-section.tsx
@@ -62,6 +62,7 @@ import {
   referenceTypeConfig as typeConfig,
   isKnownReferenceType as isKnownType,
 } from "@/components/reference-type-config";
+import { ReferenceNotes } from "@/components/reference-notes";
 
 interface ReferencesSectionProps {
   targetType: "proposal" | "task" | "idea";
@@ -233,11 +234,7 @@ export function ReferencesSection({
                       <span className="truncate">{ref.title}</span>
                       <ExternalLink className="h-3 w-3 shrink-0" />
                     </a>
-                    {ref.notes && (
-                      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                        {ref.notes}
-                      </p>
-                    )}
+                    <ReferenceNotes notes={ref.notes} />
                   </div>
 
                   {canWrite && (

--- a/src/mcp/__tests__/reference-notes-describe.test.ts
+++ b/src/mcp/__tests__/reference-notes-describe.test.ts
@@ -1,0 +1,174 @@
+// Docs-nudge coverage for the reference `notes` MCP parameter
+// (clamp-reference-notes). The elaboration chose a docs-only soft nudge
+// (~200 chars / ≤2 lines) with NO server-side length cap, so this test asserts:
+//   1. the concise-summary wording is present on the shared inline schema, on
+//      chorus_add_reference, and on chorus_update_reference `notes` describe,
+//   2. `notes` stays an optional, UNBOUNDED string (no maxLength introduced)
+//      — an arbitrarily long value still parses.
+// It mirrors the tool-registration harness from inline-references-create.test.ts,
+// then reads descriptions via zod's JSON-Schema projection (robust across the
+// z.preprocess/optional wrappers that zArray/optional add).
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
+
+vi.mock("@/services/reference-artifact.service", () => ({
+  createReferences: vi.fn(),
+  REFERENCE_TYPES: ["docs", "repo", "issue_pr", "paper_blog"],
+  REFERENCE_TARGET_TYPES: ["proposal", "task", "idea"],
+}));
+vi.mock("@/services/idea.service", () => ({ createIdea: vi.fn() }));
+vi.mock("@/services/proposal.service", () => ({
+  createProposal: vi.fn(),
+  checkIdeasAssignee: vi.fn(),
+  checkIdeasAvailability: vi.fn(),
+  getProposalByUuid: vi.fn(),
+}));
+vi.mock("@/services/project.service", () => ({
+  projectExists: vi.fn(),
+  getProjectByUuid: vi.fn(),
+}));
+vi.mock("@/services/task.service", () => ({
+  createTask: vi.fn(),
+  addTaskDependency: vi.fn(),
+  createAcceptanceCriteria: vi.fn(),
+}));
+vi.mock("@/services/activity.service", () => ({ createActivity: vi.fn() }));
+vi.mock("@/services/document.service", () => ({}));
+vi.mock("@/services/agent.service", () => ({ getAgentByUuid: vi.fn() }));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/comment.service", () => ({}));
+vi.mock("@/services/assignment.service", () => ({}));
+vi.mock("@/services/notification.service", () => ({}));
+vi.mock("@/services/project-group.service", () => ({}));
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/search.service", () => ({}));
+vi.mock("@/services/checkin.service", () => ({}));
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+import type { AgentAuthContext } from "@/types/auth";
+import type { Permission } from "@/lib/authz/types";
+import { registerPmTools } from "@/mcp/tools/pm";
+import { registerPublicTools } from "@/mcp/tools/public";
+
+const toolMeta: Record<string, { inputSchema: z.ZodType }> = {};
+const fakeMcpServer = {
+  registerTool: (name: string, meta: unknown) => {
+    toolMeta[name] = meta as never;
+  },
+};
+
+function buildAuth(): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid: "company-1",
+    actorUuid: "agent-1",
+    ownerUuid: "owner-1",
+    roles: ["pm_agent"],
+    permissions: [
+      "idea:write",
+      "proposal:write",
+      "document:write",
+      "task:write",
+    ] as Permission[],
+    agentName: "PM Agent",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const k of Object.keys(toolMeta)) delete toolMeta[k];
+  registerPmTools(
+    fakeMcpServer as unknown as Parameters<typeof registerPmTools>[0],
+    buildAuth(),
+  );
+  registerPublicTools(
+    fakeMcpServer as unknown as Parameters<typeof registerPublicTools>[0],
+    buildAuth(),
+  );
+});
+
+type JsonSchemaNode = {
+  description?: string;
+  maxLength?: number;
+  properties?: Record<string, JsonSchemaNode>;
+  items?: JsonSchemaNode;
+};
+
+// Project a registered tool's input schema to input-side JSON Schema so nested
+// descriptions survive the z.preprocess/optional wrappers.
+function jsonSchema(tool: string): JsonSchemaNode {
+  const schema = toolMeta[tool]?.inputSchema;
+  if (!schema) throw new Error(`tool not registered: ${tool}`);
+  return z.toJSONSchema(schema, { io: "input" }) as JsonSchemaNode;
+}
+
+// Top-level `notes` param (chorus_add_reference / chorus_update_reference).
+function topNotes(tool: string): JsonSchemaNode {
+  const n = jsonSchema(tool).properties?.notes;
+  if (!n) throw new Error(`no top-level notes on ${tool}`);
+  return n;
+}
+
+// Inline `references[].notes` item. On chorus_pm_create_idea / _create_proposal
+// the references[] param is top-level; on chorus_create_tasks it is nested under
+// each task (tasks[].references[]).
+function inlineNotes(tool: string): JsonSchemaNode {
+  const root = jsonSchema(tool).properties;
+  const refs =
+    root?.references?.items?.properties?.notes ??
+    root?.tasks?.items?.properties?.references?.items?.properties?.notes;
+  if (!refs) throw new Error(`no references[].notes on ${tool}`);
+  return refs;
+}
+
+const CONCISE = /concise/i;
+const TWO_HUNDRED = /200/;
+
+describe("reference notes describe — concise nudge", () => {
+  it("chorus_add_reference notes describe nudges a concise ~200-char summary", () => {
+    const n = topNotes("chorus_add_reference");
+    expect(n.description).toMatch(CONCISE);
+    expect(n.description).toMatch(TWO_HUNDRED);
+  });
+
+  it("chorus_update_reference notes describe nudges concise + keeps clear/omit semantics", () => {
+    const n = topNotes("chorus_update_reference");
+    expect(n.description).toMatch(CONCISE);
+    expect(n.description).toMatch(TWO_HUNDRED);
+    expect(n.description).toMatch(/null clears/i);
+    expect(n.description).toMatch(/omit to leave unchanged/i);
+  });
+
+  it("shared inline references[] notes describe (create idea/proposal/tasks) nudges concise", () => {
+    for (const tool of [
+      "chorus_pm_create_idea",
+      "chorus_pm_create_proposal",
+      "chorus_create_tasks",
+    ]) {
+      const n = inlineNotes(tool);
+      expect(n.description, `${tool} inline notes`).toMatch(CONCISE);
+      expect(n.description, `${tool} inline notes`).toMatch(TWO_HUNDRED);
+    }
+  });
+});
+
+describe("reference notes — no length cap introduced (docs-only nudge)", () => {
+  it("chorus_add_reference notes has no maxLength", () => {
+    expect(topNotes("chorus_add_reference").maxLength).toBeUndefined();
+  });
+
+  it("chorus_update_reference notes has no maxLength", () => {
+    expect(topNotes("chorus_update_reference").maxLength).toBeUndefined();
+  });
+
+  it("inline references[] notes has no maxLength on every create tool", () => {
+    for (const tool of [
+      "chorus_pm_create_idea",
+      "chorus_pm_create_proposal",
+      "chorus_create_tasks",
+    ]) {
+      expect(inlineNotes(tool).maxLength, `${tool} inline notes`).toBeUndefined();
+    }
+  });
+});

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -45,7 +45,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     type: referenceTypeEnum.describe("Reference type: docs, repo, issue_pr, or paper_blog"),
     url: z.string().describe("Web URL (http:// or https://)"),
     title: z.string().describe("Reference title"),
-    notes: z.string().optional().describe("Optional human/agent-authored summary (stored verbatim; no fetch)"),
+    notes: z.string().optional().describe("Optional one-line summary of why this reference is relevant — keep it to a single concise sentence (~200 chars, ≤2 lines); the UI clamps the display to 2 lines. Stored verbatim; no fetch."),
   });
 
   // chorus_claim_idea - Claim an Idea
@@ -397,7 +397,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         type: referenceTypeEnum.describe("Reference type: docs, repo, issue_pr, or paper_blog"),
         url: z.string().describe("Web URL (http:// or https://)"),
         title: z.string().describe("Reference title"),
-        notes: z.string().optional().describe("Optional human/agent-authored summary (stored verbatim; no fetch)"),
+        notes: z.string().optional().describe("Optional one-line summary of why this reference is relevant — keep it to a single concise sentence (~200 chars, ≤2 lines); the UI clamps the display to 2 lines. Stored verbatim; no fetch."),
       }),
     },
     async ({ targetType, targetUuid, type, url, title, notes }) => {
@@ -439,7 +439,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         type: referenceTypeEnum.optional().describe("New reference type"),
         url: z.string().optional().describe("New web URL (http:// or https://)"),
         title: z.string().optional().describe("New title"),
-        notes: z.string().nullable().optional().describe("New notes (null clears; omit to leave unchanged)"),
+        notes: z.string().nullable().optional().describe("New notes — one concise sentence (~200 chars, ≤2 lines; the UI clamps the display to 2 lines). null clears; omit to leave unchanged."),
       }),
     },
     async ({ uuid, type, url, title, notes }) => {

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -41,7 +41,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     type: z.enum(REFERENCE_TYPES as unknown as [string, ...string[]]).describe("Reference type: docs, repo, issue_pr, or paper_blog"),
     url: z.string().describe("Web URL (http:// or https://)"),
     title: z.string().describe("Reference title"),
-    notes: z.string().optional().describe("Optional human/agent-authored summary (stored verbatim; no fetch)"),
+    notes: z.string().optional().describe("Optional one-line summary of why this reference is relevant — keep it to a single concise sentence (~200 chars, ≤2 lines); the UI clamps the display to 2 lines. Stored verbatim; no fetch."),
   });
 
   // chorus_get_project - Get project details and context


### PR DESCRIPTION
## Summary

Reference `notes` (the optional human/agent-authored summary on a ReferenceArtifact) rendered as an un-clamped paragraph, so a verbose agent-written note could dominate a reference card and hurt list scannability. This clamps the displayed notes to **2 lines** everywhere, keeps the full text reachable, and nudges agents to write shorter notes at the source.

- **New shared `ReferenceNotes` component** — `line-clamp-2` when collapsed, full text via a **desktop hover tooltip**, and **tap/click to expand inline** (the touch fallback, since hover never fires on touch). Empty/null notes render nothing. Adopted by both the editable `ReferencesSection` (idea/proposal/task panels) and the read-only dashboard idea-card, replacing their identical inline `<p>`.
- **MCP `notes` param docs reworded** — the shared inline `referenceInlineItemSchema`, `chorus_add_reference`, and `chorus_update_reference` now nudge one concise sentence (~200 chars / ≤2 lines). Docs-only: `notes` stays an unbounded `z.string()`, no server-side length cap. `docs/MCP_TOOLS.md` rows updated to match.
- **i18n** — new `references.toggleNotes` key in all four locales (en/zh/ja/ko).

Elaboration resolved (1 round, 4 Qs): all surfaces / docs-only soft nudge / ~200-char target / tap-to-toggle mobile fallback.

### The cascade gotcha (why the first cut didn't clamp)
`line-clamp-2` relies on `display: -webkit-box`, but Tailwind v4 emits `.block` **after** `.line-clamp-2` at equal specificity. An initial version put `block` on the same element, so `block` won the cascade, `display` reverted to `block`, and `-webkit-line-clamp` was silently inert — the tooltip worked but the height was never clamped. Fixed by keeping `block` off the collapsed variant (line-clamp owns `display`; `w-full` still fills width), and regression-guarded in the component test.

## Changed files
| File | Change |
|------|--------|
| `src/components/reference-notes.tsx` | **New** shared clamp + tooltip + tap-to-expand component |
| `src/components/references-section.tsx` | Adopt `ReferenceNotes` (editable panels) |
| `src/app/(dashboard)/projects/[uuid]/dashboard/idea-references-panel.tsx` | Adopt `ReferenceNotes` (read-only card) |
| `src/mcp/tools/pm.ts` | Reword 3 `notes` `.describe()` strings (inline schema, add, update) |
| `src/mcp/tools/public.ts` | Reword inline-schema `notes` `.describe()` |
| `docs/MCP_TOOLS.md` | Update `notes` rows to match |
| `messages/{en,zh,ja,ko}.json` | Add `references.toggleNotes` |
| `src/components/__tests__/reference-notes.test.tsx` | **New** jsdom test + `block`/clamp regression guard |
| `src/mcp/__tests__/reference-notes-describe.test.ts` | **New** asserts the concise nudge + no length cap |
| `openspec/specs/reference-display/spec.md`, `openspec/specs/reference-association-guidance/spec.md`, `openspec/changes/archive/2026-07-16-clamp-reference-notes/` | OpenSpec deltas + archived change |

## Test plan
- [x] `pnpm test` — 279 files / 4318 pass, 3 pre-existing live-PG skips (incl. 5 component + 6 describe new tests)
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors (no warnings in changed files)
- [x] Clamp measured in a real browser against the project's compiled Tailwind: collapsed ≈ 2 lines (39px) vs unclamped (137px); expanded shows full text
- [ ] Human: final two-theme (light/dark) visual pass on a running server + `docs/design.pen` update via Pencil MCP (deferred — headless run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)