### PR TITLE
feat(mcp): slim tool descriptions + strict-enum filter params

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -262,7 +262,7 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
-| status | string | No | Filter by status: open, elaborating, proposal_created, completed, closed |
+| status | enum | No | Filter by status: `open` \| `elaborating` \| `elaborated` (the 3 stored states; post-elaboration progress is derived, not filterable) |
 | page | number | No | Page number (default 1) |
 | pageSize | number | No | Items per page (default 20) |
 
@@ -297,7 +297,7 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
-| type | string | No | Filter by type: prd, tech_design, adr, spec, guide, report |
+| type | enum | No | Filter by type: `prd` \| `tech_design` \| `adr` \| `spec` \| `guide` \| `report` |
 | page | number | No | Page number |
 | pageSize | number | No | Items per page |
 
@@ -322,7 +322,7 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
-| status | string | No | Filter by status: draft, pending, approved, rejected, revised |
+| status | enum | No | Filter by status: `draft` \| `pending` \| `approved` \| `closed` (a rejected proposal returns to `draft`, so there is no stored `rejected`/`revised` value) |
 | page | number | No | Page number |
 | pageSize | number | No | Items per page |
 
@@ -356,8 +356,8 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
-| status | string | No | Filter by status: open, assigned, in_progress, to_verify, done, closed |
-| priority | string | No | Filter by priority: low, medium, high |
+| status | enum | No | Filter by status: `open` \| `assigned` \| `in_progress` \| `to_verify` \| `done` \| `closed` |
+| priority | enum | No | Filter by priority: `low` \| `medium` \| `high` |
 | proposalUuids | string[] | No | Filter tasks by proposal UUIDs |
 | page | number | No | Page number |
 | pageSize | number | No | Items per page |
@@ -1197,7 +1197,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | proposalUuid | string | Yes | Proposal UUID |
-| type | string | Yes | Document type |
+| type | enum | Yes | Document type: `prd` \| `tech_design` \| `adr` \| `spec` \| `guide` \| `report` |
 | title | string | Yes | Document title |
 | content | string | Yes | Document content (Markdown) |
 
@@ -1235,7 +1235,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 |-----------|------|----------|-------------|
 | proposalUuid | string | Yes | Proposal UUID |
 | draftUuid | string | Yes | Document draft UUID |
-| type | string | No | Document type |
+| type | enum | No | Document type: `prd` \| `tech_design` \| `adr` \| `spec` \| `guide` \| `report` |
 | title | string | No | Document title |
 | content | string | No | Document content |
 

--- a/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/README.md
+++ b/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/README.md
@@ -1,0 +1,3 @@
+# slim-mcp-tool-descriptions-enums
+
+Compress 7 long MCP tool descriptions to 1-2 sentences and convert 6 filter/type params from z.string().describe to strict z.enum

--- a/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/design.md
+++ b/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/design.md
@@ -1,0 +1,65 @@
+# Design — Slim MCP tool descriptions + enum params
+
+## Context
+
+MCP tools are registered in `src/mcp/tools/*.ts` via `server.registerTool(name, { description, inputSchema }, handler)` and `registerPermissionedTool(...)`. The `description` string and the zod `inputSchema` (including every param's `.describe()`) are serialized into `tools/list` and re-sent every turn. This change touches only `public.ts` and `pm.ts`, and only the `description` strings + the zod definitions of 6 filter/type params — no handler or service code changes.
+
+## Decision 1 — Enum value domains (strict)
+
+Per elaboration answer `strict`: enums list only the **real current stored values**, verified from Prisma schema + service writes, not the (partly stale) describe-strings.
+
+| Tool.param | File:line | New `z.enum([...])` domain | Rationale / ground truth |
+|---|---|---|---|
+| `get_ideas.status` | public.ts:97 | `open, elaborating, elaborated` | `Idea.status` is a 3-state model (`prisma/schema.prisma:187`); `proposal_created/completed/closed` are legacy values normalized **on read only** (`normalizeIdeaStatus`) and never a valid filter target. |
+| `list_tasks.status` | public.ts:247 | `open, assigned, in_progress, to_verify, done, closed` | Matches `Task.status` comment (schema:244) and all service writes. |
+| `list_tasks.priority` | public.ts:248 | `low, medium, high` | Matches `Task.priority` (schema:245); already an enum on the write paths. |
+| `get_documents.type` | public.ts:131 | `prd, tech_design, adr, spec, guide, report` | Filter domain; `report` **is** a valid document type (written 29× in src). |
+| `get_proposals.status` | public.ts:185 | `draft, pending, approved, closed` | Proposal statuses actually written: `draft/pending/approved/closed`. **`rejected` and `revised` are never written** — `rejectProposal` sets status back to `draft`. Drop them. |
+| `add_document_draft.type` | pm.ts:508 | `prd, tech_design, adr, spec, guide, report` | Draft type currently a free string listing 6 values; keep all 6 (drafts can be `report`). NOTE: distinct from `pm_create_document`'s 5-value enum (no `report`) — do not "align" them; the domains legitimately differ. |
+| `update_document_draft.type` | pm.ts:587 | `prd, tech_design, adr, spec, guide, report` (optional) | Currently `z.string().optional()` with no advertised list; give it the same 6-value domain as add, kept `.optional()`. |
+
+**Filter params stay `.optional()`** — adding `z.enum` narrows the *value* domain but must not make a previously-optional filter required. `update_document_draft.type` also stays `.optional()`.
+
+### Backward-compat check
+
+Filter params flow straight into a Prisma `where` clause (`ideaService.listIdeas`, `taskService.listTasks`, etc.) as `...(status && { status })`. Tightening to an enum means an out-of-domain value is rejected at the zod layer (a clear validation error) instead of silently returning zero rows. Verified no first-party skill/daemon passes the dropped values (`proposal_created`, `completed`, `rejected`, `revised`) as filter arguments.
+
+## Decision 2 — Description compression + behavior-rule placement
+
+Per elaboration answer (custom "2+3"): **global red-line one-liner in the description; parameter-bound red-lines into that param's `.describe()`; the rest into skill docs.**
+
+Rewrite principle for each of the 7: the description answers only "**what is this / when do I pick it**" in ≤ 2 sentences. Everything else relocates:
+- A behavior red-line that applies to the **whole call** → keep as **one** short clause in the description (survives for headless/no-skill agents).
+- A red-line **bound to a specific parameter** → into that parameter's `.describe()`.
+- Multi-step usage procedure, state-machine preconditions, section-by-section field contracts → skill docs (`public/skill/`, `public/chorus-plugin/skills/chorus/`) + `docs/MCP_TOOLS.md`.
+
+Per-tool relocation plan:
+
+| Tool | Global red-line kept in desc | Moved to param `.describe()` | Moved to skill docs |
+|---|---|---|---|
+| `chorus_pm_start_elaboration` | "Record decisions even when discussed outside the tool." | "Do NOT add an 'Other' option — the UI adds it" → `questions[].options`; "present via an interactive prompt, not plain text" → `questions` | full elaboration-loop procedure (already in idea skill) |
+| `chorus_create_report` | "Write once every task in the proposal is complete." | 3-section `## Summary / ## Decisions / ## Follow-ups` contract → `content.describe()`; `force` overwrite semantics → `force.describe()` | report authoring guidance |
+| `chorus_create_tasks` | "Acceptance criteria are required on every task." | two-mode (Quick vs Proposal) note → `proposalUuid.describe()`; AC requirement → `acceptanceCriteriaItems.describe()` | full flow steps |
+| `chorus_update_task` | (multi-purpose: one-sentence "edit fields / deps / status") | status transition rule → `status.describe()`; incremental dep note → `addDependsOn/removeDependsOn.describe()` | quick-task flow |
+| `chorus_get_proposal` | (already mostly what/when — trim to 1–2 sentences) | per-`section` view meanings → `section.describe()` | — |
+| `chorus_pm_assign_task` | precondition "task must be open/assigned" | instance-pin `instanceUuid` semantics → `instanceUuid.describe()` | — |
+| `chorus_add_reference` | (one sentence: attach external evidence to idea/proposal/task) | `type` domain meanings → `type.describe()`; "attach at creation via references[] instead" → tool desc one-liner | reference guidance (already in idea skill §4.4) |
+
+`chorus_get_proposal.section` is already a `z.enum` (basic/documents/tasks/full) with a spec requirement — leave the enum, only trim the top-level description prose.
+
+## Decision 3 — Test strategy
+
+Vitest suite under `src/mcp/__tests__/`. Add/extend tests that:
+1. For each converted param, assert the built `inputSchema` **rejects** an out-of-domain value (e.g. `get_proposals.status = "revised"`) and **accepts** each valid value. Prefer asserting on the zod schema shape directly (parse a sample), independent of a live DB.
+2. Assert each of the 7 descriptions is ≤ a sentence bound (e.g. ≤ 2 sentences / ≤ ~240 chars) — a guard so the slimming does not silently regress.
+3. Existing server registration/permission tests still pass unchanged (no tool added/removed, no permission change).
+
+## Decision 4 — Token delta (record only)
+
+After the edits, capture the `tools/list` serialized size (or the sum of description + schema char length for the 7 tools) before/after and record the delta in the completion report. No threshold gates acceptance (elaboration `struct_plus_record`).
+
+## Risks
+
+- **Over-trimming loses a load-bearing rule** for headless agents. Mitigation: the "global red-line in desc" rule preserves exactly the rules that must survive without skill context; a description-length test guards the floor but review confirms nothing essential was dropped.
+- **Enum too strict rejects a legitimate historical query.** Mitigation: domains verified against schema + service writes; dropped values are provably non-writable or read-only-normalized.
+- **`create_report` overlap with P0.** Mitigation: P1 only compresses the description in place; if P0 later folds/deletes the tool, that is a clean superset change (accepted per elaboration).

--- a/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/proposal.md
+++ b/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/proposal.md
@@ -1,0 +1,33 @@
+# Slim MCP tool descriptions + enum-type filter params
+
+## Why
+
+Chorus exposes ~82 MCP tools. An admin-preset daemon identity sees nearly all of them, and **every conversation turn re-sends each tool's name + description + full zod schema** into the model's context. Long, prose-heavy descriptions and free-text enum params are two of the top drivers of long-context tool-call degradation (wrong tool picked, wrong param filled): the cost is paid on every turn and scales linearly with conversation length.
+
+This is the **P1** child of theme "简化 MCP 工具调用表面" (`32611091`). It is deliberately the lowest-risk layer — purely "literal" changes to descriptions and schema, no tool merges (that is P0) and no signature/behavior changes (that is P2).
+
+## What Changes
+
+1. **Compress 7 over-long tool descriptions to 1–2 sentences** ("what it is / when to pick it"), pushing detail down to parameter-level `.describe()` and skill docs:
+   - `chorus_create_report`, `chorus_get_proposal`, `chorus_pm_start_elaboration`, `chorus_create_tasks`, `chorus_update_task`, `chorus_pm_assign_task`, `chorus_add_reference`.
+   - **Behavior-rule placement (per elaboration decision):** a single **global red-line** stays in the tool description (so a headless / no-skill agent still sees it); **parameter-bound red-lines** move into that parameter's `.describe()` (e.g. "no Other option" belongs to the `questions[].options` param); the remaining long procedural prose moves into the skill docs.
+
+2. **Convert 6 filter/type params from `z.string().describe("...: a,b,c")` to strict `z.enum`** using the **real current stored value domain** (elaboration decision: `strict` — no legacy/derived values):
+   - `chorus_get_ideas.status`, `chorus_list_tasks.status`, `chorus_list_tasks.priority`, `chorus_get_documents.type`, `chorus_get_proposals.status`, `chorus_pm_add_document_draft.type` + `chorus_pm_update_document_draft.type`.
+   - Several current describe-strings advertise **stale** values (e.g. `get_ideas.status` lists `proposal_created/completed/closed` but the model only stores `open/elaborating/elaborated`; `get_proposals.status` lists `rejected/revised` which are **never written** — reject returns a proposal to `draft`). The enums use verified domains, not the stale strings.
+
+## Capabilities
+
+- `mcp-tool-surface` — adds requirements for description brevity and strict enum-typing of filter/type params.
+
+## Impact
+
+- **Code:** `src/mcp/tools/public.ts`, `src/mcp/tools/pm.ts` (schema + description edits only; no service/handler logic change).
+- **Tests:** `src/mcp/__tests__/server.test.ts` (or sibling) — assert enum rejection of unknown values and acceptance of valid ones; assert description length bounds.
+- **Docs:** `docs/MCP_TOOLS.md` + both skill roots (`public/skill/`, `public/chorus-plugin/skills/chorus/`) — relocate the behavior-rule prose that leaves the descriptions.
+- **Backward-compat risk (bounded):** a client passing a now-illegal filter value (a stale/derived status) will get a schema-layer rejection instead of an empty result set. This is the intended `strict` behavior; verified that no first-party caller relies on the removed values.
+- **Not in scope:** merging `create_report` into `create_document` (P0 owns that; per elaboration P1 only compresses its description and accepts minor rework if P0 later deletes it).
+
+## Acceptance (P1-specific, per elaboration `struct_plus_record`)
+
+Hard gate: enums live and reject unknown values; all 7 descriptions ≤ 2 sentences; both skill docs synced; tests pass; typecheck + lint clean. Tool-area token before/after delta is **recorded only** (no threshold).

--- a/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/specs/mcp-tool-surface/spec.md
+++ b/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/specs/mcp-tool-surface/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Filter and type parameters SHALL be strictly enum-typed
+
+The MCP filter/type parameters listed below SHALL be declared as `z.enum([...])` (rather than `z.string().describe(...)`), with the enum domain limited to the **currently valid stored values** — legacy, derived, or never-written values are excluded. Optional parameters MUST remain optional after the conversion (the enum narrows the value domain, not the required-ness).
+
+The parameters and their exact enum domains are:
+
+- `chorus_get_ideas.status` → `open`, `elaborating`, `elaborated`
+- `chorus_list_tasks.status` → `open`, `assigned`, `in_progress`, `to_verify`, `done`, `closed`
+- `chorus_list_tasks.priority` → `low`, `medium`, `high`
+- `chorus_get_documents.type` → `prd`, `tech_design`, `adr`, `spec`, `guide`, `report`
+- `chorus_get_proposals.status` → `draft`, `pending`, `approved`, `closed`
+- `chorus_pm_add_document_draft.type` → `prd`, `tech_design`, `adr`, `spec`, `guide`, `report`
+- `chorus_pm_update_document_draft.type` → `prd`, `tech_design`, `adr`, `spec`, `guide`, `report`
+
+#### Scenario: An out-of-domain filter value is rejected at the schema layer
+
+- **GIVEN** the `chorus_get_proposals` tool's input schema
+- **WHEN** it is asked to parse arguments where `status` is `"revised"` (a value never written to `Proposal.status`)
+- **THEN** schema validation MUST fail
+- **AND** the failure MUST occur before any service call (no query is executed)
+
+#### Scenario: Every advertised enum value is accepted
+
+- **GIVEN** each converted parameter above
+- **WHEN** its input schema parses an argument object whose value equals any single member of that parameter's enum domain
+- **THEN** validation MUST succeed
+
+#### Scenario: Stale filter values are absent from the enum domains
+
+- **GIVEN** the converted parameters
+- **WHEN** their enum members are enumerated
+- **THEN** `chorus_get_ideas.status` MUST NOT include `proposal_created`, `completed`, or `closed`
+- **AND** `chorus_get_proposals.status` MUST NOT include `rejected` or `revised`
+
+#### Scenario: Optional filter parameters remain optional
+
+- **GIVEN** each converted parameter that was optional before this change (`chorus_get_ideas.status`, `chorus_list_tasks.status`, `chorus_list_tasks.priority`, `chorus_get_documents.type`, `chorus_get_proposals.status`, `chorus_pm_update_document_draft.type`)
+- **WHEN** its tool's input schema parses an argument object that omits the parameter
+- **THEN** validation MUST succeed
+
+### Requirement: Over-long tool descriptions SHALL be compressed to what/when text
+
+The top-level `description` string of each of these seven MCP tools SHALL state only what the tool is and when to pick it, in at most two sentences: `chorus_create_report`, `chorus_get_proposal`, `chorus_pm_start_elaboration`, `chorus_create_tasks`, `chorus_update_task`, `chorus_pm_assign_task`, `chorus_add_reference`. Multi-step usage procedures and section-by-section field contracts MUST NOT remain in the top-level description; they MUST be relocated to parameter-level `.describe()` text and/or the skill documentation.
+
+#### Scenario: Each targeted description is concise
+
+- **GIVEN** the registered input metadata for each of the seven tools
+- **WHEN** its top-level `description` is measured
+- **THEN** the description MUST contain at most two sentences
+- **AND** it MUST NOT contain a multi-step numbered or bulleted usage procedure
+
+#### Scenario: Parameter detail moves to parameter describe text
+
+- **GIVEN** `chorus_create_report` after this change
+- **WHEN** its schema is inspected
+- **THEN** the `## Summary` / `## Decisions` / `## Follow-ups` section contract MUST appear in the `content` parameter's `.describe()` text rather than in the top-level description
+
+### Requirement: Agent behavior red-lines SHALL survive description slimming
+
+When an over-long description is compressed, any behavior rule that must hold even for an agent that has not loaded the corresponding skill SHALL be preserved. A rule that applies to the whole call MUST remain as a short clause in the top-level description; a rule bound to a specific parameter MUST move into that parameter's `.describe()` text. No such red-line may be dropped entirely.
+
+#### Scenario: The "no Other option" rule stays attached to the options parameter
+
+- **GIVEN** `chorus_pm_start_elaboration` after this change
+- **WHEN** its schema is inspected
+- **THEN** the instruction not to add an "Other" option MUST appear in the `.describe()` text of the `questions` (or nested `options`) parameter
+- **AND** the instruction to record decisions even when requirements were discussed outside the tool MUST remain present in the top-level description
+
+### Requirement: First-party documentation SHALL absorb the relocated procedural content
+
+The behavior rules and usage procedures removed from the seven tool descriptions SHALL be present in the first-party skill documentation so that no guidance is lost. The skill-documentation surfaces in scope are `public/skill/**/SKILL.md` and `public/chorus-plugin/skills/chorus/SKILL.md`, and the internal reference `docs/MCP_TOOLS.md`.
+
+#### Scenario: Relocated elaboration guidance is present in both skill roots
+
+- **GIVEN** the elaboration usage guidance removed from `chorus_pm_start_elaboration`'s description
+- **WHEN** `public/skill/idea-chorus/SKILL.md` and `public/chorus-plugin/skills/chorus/SKILL.md` are read
+- **THEN** the interactive-presentation and record-outside-conversation guidance MUST be present in the skill documentation
+
+#### Scenario: The internal MCP reference reflects the trimmed descriptions
+
+- **WHEN** `docs/MCP_TOOLS.md` is read for the seven affected tools
+- **THEN** its entries MUST be consistent with the trimmed tool descriptions (no contradicting stale procedure that was removed from the schema without a documented home)

--- a/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/tasks.md
+++ b/openspec/changes/archive/2026-07-17-slim-mcp-tool-descriptions-enums/tasks.md
@@ -1,0 +1,19 @@
+# Tasks — Slim MCP tool descriptions + enum params
+
+## 1. Convert 6 filter/type params to strict z.enum
+- [ ] 1.1 `public.ts`: convert `get_ideas.status`, `list_tasks.status`, `list_tasks.priority`, `get_documents.type`, `get_proposals.status` to `z.enum([...])` with the verified strict domains (keep `.optional()`).
+- [ ] 1.2 `pm.ts`: convert `add_document_draft.type` and `update_document_draft.type` to `z.enum([...])` (6-value domain; keep update's `.optional()`).
+- [ ] 1.3 Extend `src/mcp/__tests__/` to assert each enum rejects an out-of-domain value, accepts each valid value, and stays optional where it was.
+- [ ] 1.4 `pnpm test`, `npx tsc --noEmit`, `pnpm lint` clean.
+
+## 2. Compress 7 tool descriptions + relocate behavior red-lines
+- [ ] 2.1 Rewrite the 7 descriptions (`create_report`, `get_proposal`, `pm_start_elaboration`, `create_tasks`, `update_task`, `pm_assign_task`, `add_reference`) to ≤ 2 sentences (what/when).
+- [ ] 2.2 Move parameter-bound detail into each param's `.describe()` (report 3-section contract → `content`; "no Other" → elaboration `questions/options`; two-mode note → `create_tasks.proposalUuid`; etc.).
+- [ ] 2.3 Keep whole-call red-lines as one short clause in the description (survives headless/no-skill agents).
+- [ ] 2.4 Add a description-length guard test (≤ 2 sentences / char bound) for the 7 tools.
+- [ ] 2.5 `pnpm test`, `npx tsc --noEmit`, `pnpm lint` clean.
+
+## 3. Sync documentation
+- [ ] 3.1 Update `docs/MCP_TOOLS.md` entries for the 7 tools + the enum params to match the trimmed schema.
+- [ ] 3.2 Ensure the relocated procedural prose lives in `public/skill/` and `public/chorus-plugin/skills/chorus/` (idea/proposal/develop skills as applicable); keep both roots in sync.
+- [ ] 3.3 Record the tool-area token before/after delta (description + schema char length for the 7 tools) for the completion report.

--- a/openspec/specs/mcp-tool-surface/spec.md
+++ b/openspec/specs/mcp-tool-surface/spec.md
@@ -311,3 +311,86 @@ Entries of type `user` SHALL NOT carry these fields.
 - **THEN** the tool MUST remain exposed under its existing gate with no new permission bit
 - **AND** no existing result field MUST be removed or renamed
 
+### Requirement: Filter and type parameters SHALL be strictly enum-typed
+
+The MCP filter/type parameters listed below SHALL be declared as `z.enum([...])` (rather than `z.string().describe(...)`), with the enum domain limited to the **currently valid stored values** — legacy, derived, or never-written values are excluded. Optional parameters MUST remain optional after the conversion (the enum narrows the value domain, not the required-ness).
+
+The parameters and their exact enum domains are:
+
+- `chorus_get_ideas.status` → `open`, `elaborating`, `elaborated`
+- `chorus_list_tasks.status` → `open`, `assigned`, `in_progress`, `to_verify`, `done`, `closed`
+- `chorus_list_tasks.priority` → `low`, `medium`, `high`
+- `chorus_get_documents.type` → `prd`, `tech_design`, `adr`, `spec`, `guide`, `report`
+- `chorus_get_proposals.status` → `draft`, `pending`, `approved`, `closed`
+- `chorus_pm_add_document_draft.type` → `prd`, `tech_design`, `adr`, `spec`, `guide`, `report`
+- `chorus_pm_update_document_draft.type` → `prd`, `tech_design`, `adr`, `spec`, `guide`, `report`
+
+#### Scenario: An out-of-domain filter value is rejected at the schema layer
+
+- **GIVEN** the `chorus_get_proposals` tool's input schema
+- **WHEN** it is asked to parse arguments where `status` is `"revised"` (a value never written to `Proposal.status`)
+- **THEN** schema validation MUST fail
+- **AND** the failure MUST occur before any service call (no query is executed)
+
+#### Scenario: Every advertised enum value is accepted
+
+- **GIVEN** each converted parameter above
+- **WHEN** its input schema parses an argument object whose value equals any single member of that parameter's enum domain
+- **THEN** validation MUST succeed
+
+#### Scenario: Stale filter values are absent from the enum domains
+
+- **GIVEN** the converted parameters
+- **WHEN** their enum members are enumerated
+- **THEN** `chorus_get_ideas.status` MUST NOT include `proposal_created`, `completed`, or `closed`
+- **AND** `chorus_get_proposals.status` MUST NOT include `rejected` or `revised`
+
+#### Scenario: Optional filter parameters remain optional
+
+- **GIVEN** each converted parameter that was optional before this change (`chorus_get_ideas.status`, `chorus_list_tasks.status`, `chorus_list_tasks.priority`, `chorus_get_documents.type`, `chorus_get_proposals.status`, `chorus_pm_update_document_draft.type`)
+- **WHEN** its tool's input schema parses an argument object that omits the parameter
+- **THEN** validation MUST succeed
+
+### Requirement: Over-long tool descriptions SHALL be compressed to what/when text
+
+The top-level `description` string of each of these seven MCP tools SHALL state only what the tool is and when to pick it, in at most two sentences: `chorus_create_report`, `chorus_get_proposal`, `chorus_pm_start_elaboration`, `chorus_create_tasks`, `chorus_update_task`, `chorus_pm_assign_task`, `chorus_add_reference`. Multi-step usage procedures and section-by-section field contracts MUST NOT remain in the top-level description; they MUST be relocated to parameter-level `.describe()` text and/or the skill documentation.
+
+#### Scenario: Each targeted description is concise
+
+- **GIVEN** the registered input metadata for each of the seven tools
+- **WHEN** its top-level `description` is measured
+- **THEN** the description MUST contain at most two sentences
+- **AND** it MUST NOT contain a multi-step numbered or bulleted usage procedure
+
+#### Scenario: Parameter detail moves to parameter describe text
+
+- **GIVEN** `chorus_create_report` after this change
+- **WHEN** its schema is inspected
+- **THEN** the `## Summary` / `## Decisions` / `## Follow-ups` section contract MUST appear in the `content` parameter's `.describe()` text rather than in the top-level description
+
+### Requirement: Agent behavior red-lines SHALL survive description slimming
+
+When an over-long description is compressed, any behavior rule that must hold even for an agent that has not loaded the corresponding skill SHALL be preserved. A rule that applies to the whole call MUST remain as a short clause in the top-level description; a rule bound to a specific parameter MUST move into that parameter's `.describe()` text. No such red-line may be dropped entirely.
+
+#### Scenario: The "no Other option" rule stays attached to the options parameter
+
+- **GIVEN** `chorus_pm_start_elaboration` after this change
+- **WHEN** its schema is inspected
+- **THEN** the instruction not to add an "Other" option MUST appear in the `.describe()` text of the `questions` (or nested `options`) parameter
+- **AND** the instruction to record decisions even when requirements were discussed outside the tool MUST remain present in the top-level description
+
+### Requirement: First-party documentation SHALL absorb the relocated procedural content
+
+The behavior rules and usage procedures removed from the seven tool descriptions SHALL be present in the first-party skill documentation so that no guidance is lost. The skill-documentation surfaces in scope are `public/skill/**/SKILL.md` and `public/chorus-plugin/skills/chorus/SKILL.md`, and the internal reference `docs/MCP_TOOLS.md`.
+
+#### Scenario: Relocated elaboration guidance is present in both skill roots
+
+- **GIVEN** the elaboration usage guidance removed from `chorus_pm_start_elaboration`'s description
+- **WHEN** `public/skill/idea-chorus/SKILL.md` and `public/chorus-plugin/skills/chorus/SKILL.md` are read
+- **THEN** the interactive-presentation and record-outside-conversation guidance MUST be present in the skill documentation
+
+#### Scenario: The internal MCP reference reflects the trimmed descriptions
+
+- **WHEN** `docs/MCP_TOOLS.md` is read for the seven affected tools
+- **THEN** its entries MUST be consistent with the trimmed tool descriptions (no contradicting stale procedure that was removed from the schema without a documented home)
+

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -130,7 +130,7 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 
 ### Reports
 
-A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `/yolo` writes one mandatorily; `/develop` offers it advisorily on last-task verify.
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The `content` parameter's description carries the section template — read it there. `/yolo` writes one mandatorily; `/develop` offers it advisorily on last-task verify.
 
 ### References
 

--- a/packages/openclaw-plugin/skills/develop/SKILL.md
+++ b/packages/openclaw-plugin/skills/develop/SKILL.md
@@ -279,7 +279,7 @@ Once Admin verifies (status: `done`), move to the next available task (back to S
 
 ### Step 11: Idea Completion Report (advisory)
 
-If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, offer to call `chorus_create_report`. On OpenClaw, ask the user as a plain-text prompt (e.g. "This was the last task of the idea. Want me to write a completion report? Reply yes/no.") — there is no `AskUserQuestion` primitive. The tool description carries the section template. Skip on decline.
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, offer to call `chorus_create_report`. On OpenClaw, ask the user as a plain-text prompt (e.g. "This was the last task of the idea. Want me to write a completion report? Reply yes/no.") — there is no `AskUserQuestion` primitive. The `content` parameter's description carries the section template. Skip on decline.
 
 ---
 

--- a/packages/openclaw-plugin/skills/yolo/SKILL.md
+++ b/packages/openclaw-plugin/skills/yolo/SKILL.md
@@ -485,7 +485,7 @@ After all waves complete, output a markdown summary:
 
 ### Phase 5b: Idea Completion Report (mandatory)
 
-A successful `/yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The tool's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
+A successful `/yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The `content` parameter's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
 
 > **Order:** write the completion report only **after** the Phase 4.5 code-review gateway returns PASS / PASS WITH NOTES — never while a code-review FAIL is outstanding.
 

--- a/plugins/chorus/hooks/on-post-verify-task.sh
+++ b/plugins/chorus/hooks/on-post-verify-task.sh
@@ -248,7 +248,7 @@ branch_idea_report_reminder() {
 [Chorus — Idea-Completion Report Trigger]
 All tasks of proposal ${PROPOSAL_UUID} are now done; no completion report yet.
 
-ACTION REQUESTED: create idea-completion report for this Idea. Call \`chorus_create_report\` with proposalUuid="${PROPOSAL_UUID}". The tool description carries the Summary / Decisions / Follow-ups template.
+ACTION REQUESTED: create idea-completion report for this Idea. Call \`chorus_create_report\` with proposalUuid="${PROPOSAL_UUID}". The \`content\` parameter's description carries the Summary / Decisions / Follow-ups template.
 CTX
 }
 

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -142,7 +142,7 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 
 ### Reports
 
-A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `$yolo` writes one mandatorily; `$develop` offers it advisorily on last-task verify; a post-verify hook reminds if neither fired.
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The `content` parameter's description carries the section template — read it there. `$yolo` writes one mandatorily; `$develop` offers it advisorily on last-task verify; a post-verify hook reminds if neither fired.
 
 ### References
 

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -271,7 +271,7 @@ Once Admin verifies (status: `done`), move to the next available task (back to S
 
 ### Step 11: Idea Completion Report (advisory)
 
-If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, prompt the user and call `chorus_create_report` on accept. The tool description carries the section template. Skip on decline — the PostToolUse hook will remind on the next run.
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, prompt the user and call `chorus_create_report` on accept. The `content` parameter's description carries the section template. Skip on decline — the PostToolUse hook will remind on the next run.
 
 ---
 

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -540,7 +540,7 @@ After all waves complete, output a markdown summary:
 
 ### Phase 5b: Idea Completion Report (mandatory)
 
-A successful `$yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The tool's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
+A successful `$yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The `content` parameter's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
 
 > **Order:** write the completion report only **after** the Phase 4.5 code-review gateway returns PASS / PASS WITH NOTES — never while a code-review FAIL is outstanding.
 

--- a/public/chorus-plugin/bin/on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/on-post-verify-task.sh
@@ -254,7 +254,7 @@ branch_idea_report_reminder() {
 [Chorus Plugin — Idea-Completion Report Trigger]
 All tasks of proposal ${PROPOSAL_UUID} are now done; no completion report yet.
 
-ACTION REQUESTED: create idea-completion report for this Idea. Call \`chorus_create_report\` with proposalUuid="${PROPOSAL_UUID}". The tool description carries the Summary / Decisions / Follow-ups template.
+ACTION REQUESTED: create idea-completion report for this Idea. Call \`chorus_create_report\` with proposalUuid="${PROPOSAL_UUID}". The \`content\` parameter's description carries the Summary / Decisions / Follow-ups template.
 CTX
 }
 

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -149,7 +149,7 @@ Projects can be organized into **Project Groups** — a single-level grouping th
 
 ### Reports
 
-A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `/yolo` writes one mandatorily; `/develop` offers it advisorily on last-task verify; a PostToolUse hook reminds if neither fired.
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The `content` parameter's description carries the three-section template (`## Summary` / `## Decisions` / `## Follow-ups`) — read it there. `/yolo` writes one mandatorily; `/develop` offers it advisorily on last-task verify; a PostToolUse hook reminds if neither fired.
 
 ### References
 

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -259,7 +259,7 @@ Once Admin verifies (status: `done`), move to the next available task (back to S
 
 ### Step 11: Idea Completion Report (advisory)
 
-If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, offer to call `chorus_create_report` via `AskUserQuestion`. The tool description carries the section template. Skip on decline — the PostToolUse hook will remind on the next run.
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, offer to call `chorus_create_report` via `AskUserQuestion`. The `content` parameter's description carries the section template. Skip on decline — the PostToolUse hook will remind on the next run.
 
 ---
 

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -508,7 +508,7 @@ After all waves complete, output a markdown summary:
 
 ### Phase 5b: Idea Completion Report (mandatory)
 
-A successful `/yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The tool's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
+A successful `/yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The `content` parameter's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
 
 > **Order:** the completion report is written only **after** the Phase 4.5 code-review gateway returns PASS / PASS WITH NOTES. Never write it while a code-review FAIL is outstanding — the report is a ship-time summary, and the gateway is what clears the feature to ship.
 

--- a/public/kiro-plugin/.kiro/skills/chorus-develop/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-develop/SKILL.md
@@ -259,7 +259,7 @@ Once Admin verifies (status: `done`), move to the next available task (back to S
 
 ### Step 11: Idea Completion Report (advisory)
 
-If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, offer to call `chorus_create_report` (ask the user first with a clear interactive question). The tool description carries the section template. Skip on decline.
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, offer to call `chorus_create_report` (ask the user first with a clear interactive question). The `content` parameter's description carries the section template. Skip on decline.
 
 ---
 

--- a/public/kiro-plugin/.kiro/skills/chorus-yolo/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-yolo/SKILL.md
@@ -508,7 +508,7 @@ After all waves complete, output a markdown summary:
 
 ### Phase 5b: Idea Completion Report (mandatory)
 
-A successful `/chorus-yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The tool's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
+A successful `/chorus-yolo` run always finishes the Idea — call `chorus_create_report` once with `proposalUuid` set to the last verified proposal. The `content` parameter's description carries the section template; follow it. Surface the returned `documentUuid` in the Phase 5 summary. Skipping is a protocol violation.
 
 > **Order:** the completion report is written only **after** the Phase 4.5 code-review gateway returns PASS / PASS WITH NOTES. Never write it while a code-review FAIL is outstanding — the report is a ship-time summary, and the gateway is what clears the feature to ship.
 

--- a/public/kiro-plugin/.kiro/steering/chorus.md
+++ b/public/kiro-plugin/.kiro/steering/chorus.md
@@ -143,7 +143,7 @@ Main agent: no session needed — call tools without `sessionUuid`. See `/chorus
 
 ### Reports
 
-A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. `/chorus-yolo` writes one mandatorily; `/chorus-develop` offers it advisorily on last-task verify.
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The `content` parameter's description carries the section template — read it there. `/chorus-yolo` writes one mandatorily; `/chorus-develop` offers it advisorily on last-task verify.
 
 ### References
 

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -196,7 +196,7 @@ Results can be filtered by project(s) using optional HTTP headers in your MCP co
 
 ### Reports
 
-A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The tool's description carries the section template — read it there. The `yolo` skill writes one mandatorily; the `develop` skill offers it advisorily on last-task verify.
+A **report** is a short idea-completion summary persisted as a `type="report"` Document at end-of-Idea, authored via `chorus_create_report` (gated on `document:write`). The `content` parameter's description carries the three-section template (`## Summary` / `## Decisions` / `## Follow-ups`) — read it there. The `yolo` skill writes one mandatorily; the `develop` skill offers it advisorily on last-task verify.
 
 ### References
 

--- a/public/skill/develop-chorus/SKILL.md
+++ b/public/skill/develop-chorus/SKILL.md
@@ -203,7 +203,7 @@ Once Admin verifies (status: `done`), move to the next available task (back to S
 
 ### Step 11: Idea Completion Report (advisory)
 
-If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, prompt the user and call `chorus_create_report` on accept. The tool description carries the section template. Skip on decline.
+If the task you just self-verified was the LAST one of its Idea (every Task across every approved Proposal is now `done`/`closed`) and you have `document:write`, prompt the user and call `chorus_create_report` on accept. The `content` parameter's description carries the section template. Skip on decline.
 
 ---
 

--- a/public/skill/yolo-chorus/SKILL.md
+++ b/public/skill/yolo-chorus/SKILL.md
@@ -514,14 +514,14 @@ When all waves complete, output a markdown summary:
 
 ### Phase 5b: Idea Completion Report (mandatory)
 
-A successful yolo run always finishes the Idea. Call `chorus_create_report` **exactly once**, with `proposalUuid` set to the **last verified proposal**. The tool's own description carries the section template — follow it. Surface the returned `documentUuid` in the Phase 5 summary table. Skipping this is a protocol violation.
+A successful yolo run always finishes the Idea. Call `chorus_create_report` **exactly once**, with `proposalUuid` set to the **last verified proposal**. The `content` parameter's description carries the three-section template (`## Summary` / `## Decisions` / `## Follow-ups`) — follow it. Surface the returned `documentUuid` in the Phase 5 summary table. Skipping this is a protocol violation.
 
 > **Order:** write the completion report only **after** the Phase 4.5 code-review gateway returns PASS / PASS WITH NOTES. Never write it while a code-review FAIL is outstanding — the report is a ship-time summary, and the gateway is what clears the feature to ship.
 
 ```
 result = chorus_create_report({
   proposalUuid: "<last-verified-proposal-uuid>",
-  // ... follow the tool description's section template ...
+  // ... follow the content parameter's section template ...
 })
 # Surface result.documentUuid in the Phase 5 summary.
 ```

--- a/src/mcp/__tests__/filter-enum-params.test.ts
+++ b/src/mcp/__tests__/filter-enum-params.test.ts
@@ -1,0 +1,212 @@
+// Strict-enum coverage for the MCP filter/type params converted from
+// z.string().describe("...: a,b,c") to z.enum([...]) (slim-mcp-tool-descriptions-enums, P1).
+//
+// The elaboration chose `strict`: each enum lists only the CURRENT stored value
+// domain — no legacy/derived/never-written values. This test asserts, per param:
+//   1. every in-domain value parses,
+//   2. an out-of-domain value is REJECTED at the schema layer (before any service call),
+//   3. the previously-optional params stay optional (omitting them parses),
+//   4. the dropped stale values (idea proposal_created/completed/closed;
+//      proposal rejected/revised) are absent from the enum domain.
+//
+// Mirrors the tool-registration harness from reference-notes-describe.test.ts:
+// register the tool modules against a capturing fake server, then read each
+// tool's inputSchema and drive it with safeParse (accept/reject) + project to
+// JSON Schema (enum-membership introspection).
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("@/services/project.service", () => ({}));
+vi.mock("@/services/task.service", () => ({}));
+vi.mock("@/services/proposal.service", () => ({}));
+vi.mock("@/services/activity.service", () => ({}));
+vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/checkin.service", () => ({}));
+vi.mock("@/services/idea.service", () => ({}));
+vi.mock("@/services/document.service", () => ({}));
+vi.mock("@/services/comment.service", () => ({}));
+vi.mock("@/services/assignment.service", () => ({}));
+vi.mock("@/services/notification.service", () => ({}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/project-group.service", () => ({}));
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/search.service", () => ({}));
+vi.mock("@/services/agent.service", () => ({ getAgentByUuid: vi.fn() }));
+vi.mock("@/services/reference-artifact.service", () => ({
+  createReferences: vi.fn(),
+  REFERENCE_TYPES: ["docs", "repo", "issue_pr", "paper_blog"],
+  REFERENCE_TARGET_TYPES: ["proposal", "task", "idea"],
+}));
+
+import type { AgentAuthContext } from "@/types/auth";
+import type { Permission } from "@/lib/authz/types";
+import { registerPmTools } from "@/mcp/tools/pm";
+import { registerPublicTools } from "@/mcp/tools/public";
+
+const toolMeta: Record<string, { inputSchema: z.ZodType }> = {};
+const fakeMcpServer = {
+  registerTool: (name: string, meta: unknown) => {
+    toolMeta[name] = meta as never;
+  },
+};
+
+function buildAuth(): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid: "company-1",
+    actorUuid: "agent-1",
+    ownerUuid: "owner-1",
+    roles: ["pm_agent"],
+    permissions: [
+      "idea:write",
+      "proposal:write",
+      "document:write",
+      "task:write",
+    ] as Permission[],
+    agentName: "PM Agent",
+  };
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(toolMeta)) delete toolMeta[k];
+  registerPmTools(
+    fakeMcpServer as unknown as Parameters<typeof registerPmTools>[0],
+    buildAuth(),
+  );
+  registerPublicTools(
+    fakeMcpServer as unknown as Parameters<typeof registerPublicTools>[0],
+    buildAuth(),
+  );
+});
+
+function schemaOf(tool: string): z.ZodType {
+  const s = toolMeta[tool]?.inputSchema;
+  if (!s) throw new Error(`tool not registered: ${tool}`);
+  return s;
+}
+
+type JsonSchemaNode = {
+  enum?: string[];
+  properties?: Record<string, JsonSchemaNode>;
+};
+
+// enum members for a given tool.param, robust across optional() wrappers.
+function enumMembers(tool: string, param: string): string[] {
+  const js = z.toJSONSchema(schemaOf(tool), { io: "input" }) as JsonSchemaNode;
+  const node = js.properties?.[param];
+  if (!node) throw new Error(`no param ${param} on ${tool}`);
+  if (!node.enum) throw new Error(`param ${param} on ${tool} is not an enum`);
+  return node.enum;
+}
+
+// Each row: tool, param, the base (valid-required) args, the strict domain,
+// one out-of-domain value, and whether the param is optional.
+const CASES: Array<{
+  tool: string;
+  param: string;
+  base: Record<string, unknown>;
+  domain: string[];
+  bad: string;
+  optional: boolean;
+}> = [
+  {
+    tool: "chorus_get_ideas",
+    param: "status",
+    base: { projectUuid: "p-1" },
+    domain: ["open", "elaborating", "elaborated"],
+    bad: "proposal_created",
+    optional: true,
+  },
+  {
+    tool: "chorus_list_tasks",
+    param: "status",
+    base: { projectUuid: "p-1" },
+    domain: ["open", "assigned", "in_progress", "to_verify", "done", "closed"],
+    bad: "verifying",
+    optional: true,
+  },
+  {
+    tool: "chorus_list_tasks",
+    param: "priority",
+    base: { projectUuid: "p-1" },
+    domain: ["low", "medium", "high"],
+    bad: "urgent",
+    optional: true,
+  },
+  {
+    tool: "chorus_get_documents",
+    param: "type",
+    base: { projectUuid: "p-1" },
+    domain: ["prd", "tech_design", "adr", "spec", "guide", "report"],
+    bad: "runbook",
+    optional: true,
+  },
+  {
+    tool: "chorus_get_proposals",
+    param: "status",
+    base: { projectUuid: "p-1" },
+    domain: ["draft", "pending", "approved", "closed"],
+    bad: "rejected",
+    optional: true,
+  },
+  {
+    tool: "chorus_pm_add_document_draft",
+    param: "type",
+    base: { proposalUuid: "pr-1", title: "t", content: "c" },
+    domain: ["prd", "tech_design", "adr", "spec", "guide", "report"],
+    bad: "runbook",
+    optional: false,
+  },
+  {
+    tool: "chorus_pm_update_document_draft",
+    param: "type",
+    base: { proposalUuid: "pr-1", draftUuid: "d-1" },
+    domain: ["prd", "tech_design", "adr", "spec", "guide", "report"],
+    bad: "runbook",
+    optional: true,
+  },
+];
+
+describe("filter/type params — strict enum domains", () => {
+  for (const c of CASES) {
+    describe(`${c.tool}.${c.param}`, () => {
+      it("declares exactly the strict enum domain", () => {
+        expect(new Set(enumMembers(c.tool, c.param))).toEqual(new Set(c.domain));
+      });
+
+      it("accepts every in-domain value", () => {
+        for (const v of c.domain) {
+          const r = schemaOf(c.tool).safeParse({ ...c.base, [c.param]: v });
+          expect(r.success, `${c.param}=${v}`).toBe(true);
+        }
+      });
+
+      it("rejects an out-of-domain value at the schema layer", () => {
+        const r = schemaOf(c.tool).safeParse({ ...c.base, [c.param]: c.bad });
+        expect(r.success, `${c.param}=${c.bad} should be rejected`).toBe(false);
+      });
+
+      it(c.optional ? "is optional (omitting parses)" : "is required (omitting fails)", () => {
+        const r = schemaOf(c.tool).safeParse({ ...c.base });
+        expect(r.success).toBe(c.optional);
+      });
+    });
+  }
+});
+
+describe("dropped stale values are absent from the enum domain", () => {
+  it("chorus_get_ideas.status excludes proposal_created/completed/closed", () => {
+    const m = new Set(enumMembers("chorus_get_ideas", "status"));
+    for (const stale of ["proposal_created", "completed", "closed"]) {
+      expect(m.has(stale), stale).toBe(false);
+    }
+  });
+
+  it("chorus_get_proposals.status excludes rejected/revised", () => {
+    const m = new Set(enumMembers("chorus_get_proposals", "status"));
+    for (const stale of ["rejected", "revised"]) {
+      expect(m.has(stale), stale).toBe(false);
+    }
+  });
+});

--- a/src/mcp/__tests__/get-proposal-section.test.ts
+++ b/src/mcp/__tests__/get-proposal-section.test.ts
@@ -1,4 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
+import { z } from "zod";
 
 // ===== Module mocks (hoisted) =====
 
@@ -162,12 +163,18 @@ describe("chorus_get_proposal — section parameter", () => {
     expect(proposalGetTools).toEqual(["chorus_get_proposal"]);
   });
 
-  it("documents all four sections and the basic default in its description", () => {
-    const desc = toolMeta["chorus_get_proposal"].description;
-    expect(desc).toContain("basic");
-    expect(desc).toContain("documents");
-    expect(desc).toContain("tasks");
-    expect(desc).toContain("full");
-    expect(desc).toMatch(/default/i);
+  it("documents all four sections and the basic default in the section param describe", () => {
+    // After description slimming (slim-mcp-tool-descriptions-enums), the per-section
+    // detail lives in the `section` param's .describe(), not the top-level description.
+    // The description is trimmed to what/when; the section values remain enumerated on the param.
+    const schema = toolMeta["chorus_get_proposal"].inputSchema as unknown as z.ZodType;
+    const sectionDesc =
+      (z.toJSONSchema(schema, { io: "input" }) as { properties?: Record<string, { description?: string }> })
+        .properties?.section?.description ?? "";
+    expect(sectionDesc).toContain("basic");
+    expect(sectionDesc).toContain("documents");
+    expect(sectionDesc).toContain("tasks");
+    expect(sectionDesc).toContain("full");
+    expect(sectionDesc).toMatch(/default/i);
   });
 });

--- a/src/mcp/__tests__/tool-description-slimming.test.ts
+++ b/src/mcp/__tests__/tool-description-slimming.test.ts
@@ -1,0 +1,160 @@
+// Guard test for the 7 slimmed MCP tool descriptions
+// (slim-mcp-tool-descriptions-enums, P1). Asserts:
+//   1. each top-level description is ≤2 sentences and carries no multi-step
+//      numbered/bulleted usage procedure (a floor guard against regressing to
+//      the old prose-heavy descriptions),
+//   2. relocated red-lines landed where the elaboration decided:
+//      - create_report's 3-section contract → content param .describe(),
+//      - pm_start_elaboration "no Other option" → questions/options param,
+//        while the record-outside-conversation rule STAYS in the description.
+//
+// Uses the same registration harness as reference-notes-describe.test.ts:
+// register the tool modules against a capturing fake server, read each tool's
+// description + inputSchema (projected to JSON Schema for nested param text).
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("@/services/project.service", () => ({}));
+vi.mock("@/services/task.service", () => ({}));
+vi.mock("@/services/proposal.service", () => ({}));
+vi.mock("@/services/activity.service", () => ({}));
+vi.mock("@/services/session.service", () => ({}));
+vi.mock("@/services/checkin.service", () => ({}));
+vi.mock("@/services/idea.service", () => ({}));
+vi.mock("@/services/document.service", () => ({}));
+vi.mock("@/services/comment.service", () => ({}));
+vi.mock("@/services/assignment.service", () => ({}));
+vi.mock("@/services/notification.service", () => ({}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/project-group.service", () => ({}));
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/search.service", () => ({}));
+vi.mock("@/services/agent.service", () => ({ getAgentByUuid: vi.fn() }));
+vi.mock("@/services/reference-artifact.service", () => ({
+  createReferences: vi.fn(),
+  REFERENCE_TYPES: ["docs", "repo", "issue_pr", "paper_blog"],
+  REFERENCE_TARGET_TYPES: ["proposal", "task", "idea"],
+}));
+
+import type { AgentAuthContext } from "@/types/auth";
+import type { Permission } from "@/lib/authz/types";
+import { registerPmTools } from "@/mcp/tools/pm";
+import { registerPublicTools } from "@/mcp/tools/public";
+
+const toolMeta: Record<string, { description: string; inputSchema: z.ZodType }> = {};
+const fakeMcpServer = {
+  registerTool: (name: string, meta: unknown) => {
+    toolMeta[name] = meta as never;
+  },
+};
+
+function buildAuth(): AgentAuthContext {
+  return {
+    type: "agent",
+    companyUuid: "company-1",
+    actorUuid: "agent-1",
+    ownerUuid: "owner-1",
+    roles: ["pm_agent"],
+    permissions: [
+      "idea:write",
+      "proposal:write",
+      "document:write",
+      "task:write",
+    ] as Permission[],
+    agentName: "PM Agent",
+  };
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(toolMeta)) delete toolMeta[k];
+  registerPmTools(
+    fakeMcpServer as unknown as Parameters<typeof registerPmTools>[0],
+    buildAuth(),
+  );
+  registerPublicTools(
+    fakeMcpServer as unknown as Parameters<typeof registerPublicTools>[0],
+    buildAuth(),
+  );
+});
+
+const SLIMMED_TOOLS = [
+  "chorus_create_report",
+  "chorus_get_proposal",
+  "chorus_pm_start_elaboration",
+  "chorus_create_tasks",
+  "chorus_update_task",
+  "chorus_pm_assign_task",
+  "chorus_add_reference",
+];
+
+function descOf(tool: string): string {
+  const d = toolMeta[tool]?.description;
+  if (d === undefined) throw new Error(`tool not registered: ${tool}`);
+  return d;
+}
+
+// Count sentences by terminal punctuation (. ! ?), ignoring the "." inside
+// common non-terminal tokens we use (e.g. "http://", "chorus_get_idea /").
+// Heuristic floor guard, not a grammar parser.
+function sentenceCount(s: string): number {
+  const matches = s.match(/[.!?](\s|$)/g);
+  return matches ? matches.length : (s.trim() ? 1 : 0);
+}
+
+type JsonSchemaNode = {
+  description?: string;
+  properties?: Record<string, JsonSchemaNode>;
+  items?: JsonSchemaNode;
+};
+
+function jsonSchema(tool: string): JsonSchemaNode {
+  const schema = toolMeta[tool]?.inputSchema;
+  if (!schema) throw new Error(`tool not registered: ${tool}`);
+  return z.toJSONSchema(schema, { io: "input" }) as JsonSchemaNode;
+}
+
+describe("slimmed tool descriptions — concise what/when", () => {
+  for (const tool of SLIMMED_TOOLS) {
+    it(`${tool} description is ≤2 sentences`, () => {
+      expect(sentenceCount(descOf(tool)), descOf(tool)).toBeLessThanOrEqual(2);
+    });
+
+    it(`${tool} description has no multi-step numbered/bulleted procedure`, () => {
+      const d = descOf(tool);
+      // No markdown bullets ("\n- " / "\n* ") and no "1." / "2." numbered steps.
+      expect(/\n\s*[-*]\s/.test(d), `bullet in ${tool}`).toBe(false);
+      expect(/\b[1-9]\.\s/.test(d), `numbered step in ${tool}`).toBe(false);
+    });
+  }
+});
+
+describe("relocated red-lines landed in the right place", () => {
+  it("create_report: 3-section contract moved OUT of description, INTO content param", () => {
+    const d = descOf("chorus_create_report");
+    // The section headers must not remain in the top-level description...
+    expect(d).not.toMatch(/## Summary/);
+    expect(d).not.toMatch(/## Decisions/);
+    expect(d).not.toMatch(/## Follow-ups/);
+    // ...but must be present in the content param's describe.
+    const content = jsonSchema("chorus_create_report").properties?.content;
+    expect(content?.description).toMatch(/## Summary/);
+    expect(content?.description).toMatch(/## Decisions/);
+    expect(content?.description).toMatch(/## Follow-ups/);
+  });
+
+  it("pm_start_elaboration: 'no Other option' on options param, record-outside rule in description", () => {
+    // The whole-call red-line survives in the description.
+    expect(descOf("chorus_pm_start_elaboration")).toMatch(/outside the tool|discussed outside|audit trail/i);
+    // The param-bound red-line lives on the nested options param.
+    const options =
+      jsonSchema("chorus_pm_start_elaboration").properties?.questions?.items?.properties?.options;
+    expect(options?.description).toMatch(/other/i);
+    expect(options?.description).toMatch(/do not include|don't include|do not add/i);
+  });
+
+  it("pm_assign_task: instance-pin detail moved into instanceUuid param", () => {
+    const instanceUuid = jsonSchema("chorus_pm_assign_task").properties?.instanceUuid;
+    expect(instanceUuid?.description).toMatch(/agent_instance/);
+  });
+});

--- a/src/mcp/tools/__tests__/create-report.test.ts
+++ b/src/mcp/tools/__tests__/create-report.test.ts
@@ -5,6 +5,7 @@
 // drives it directly.
 
 import { vi, describe, it, expect, beforeEach } from "vitest";
+import { z } from "zod";
 
 // ===== Module mocks (hoisted) =====
 
@@ -139,19 +140,26 @@ describe("chorus_create_report registration gating", () => {
 // ============================================================
 
 describe("chorus_create_report description (template constraint)", () => {
-  it("description carries the three report section headers", () => {
+  it("the three report section headers live in the content param describe", () => {
     const server = makeServer();
     registerPublicTools(server as never, makeAuth(["document:write"]));
-    const desc = tools["chorus_create_report"].config.description ?? "";
 
-    // Each header must appear verbatim in the LLM-visible description so the
-    // calling agent has a single source of truth for the report shape.
-    expect(desc).toContain("Summary");
-    expect(desc).toContain("Decisions");
-    expect(desc).toContain("Follow-ups");
-    // Description must teach the agent about the default-reject duplicate
-    // behavior — pointing at `force: true` as the explicit opt-in.
-    expect(desc.toLowerCase()).toContain("force");
+    // After description slimming (slim-mcp-tool-descriptions-enums), the 3-section
+    // contract moved OUT of the top-level description INTO the `content` param's
+    // .describe() — still LLM-visible, but no longer bloating every-turn tool text.
+    const schema = tools["chorus_create_report"].config.inputSchema as unknown as z.ZodType;
+    const props = (z.toJSONSchema(schema, { io: "input" }) as {
+      properties?: Record<string, { description?: string }>;
+    }).properties;
+    const contentDesc = props?.content?.description ?? "";
+    expect(contentDesc).toContain("Summary");
+    expect(contentDesc).toContain("Decisions");
+    expect(contentDesc).toContain("Follow-ups");
+
+    // The default-reject duplicate behavior (force: true opt-in) stays taught on
+    // the `force` param's describe.
+    const forceDesc = props?.force?.description ?? "";
+    expect(forceDesc.toLowerCase()).toContain("force");
   });
 });
 

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -390,12 +390,12 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "chorus_add_reference",
     {
       description:
-        "Attach a first-class reference artifact (external evidence — a web link + optional notes) to an idea, proposal, or task. `type` is one of docs (official documentation), repo (reference implementation), issue_pr (issue/PR thread), paper_blog (paper/blog post). `url` must be an http:// or https:// web link (no local files). Notes are stored verbatim; the URL is never fetched. Agents read references back inline via chorus_get_idea / chorus_get_proposal / chorus_get_task — there is no separate reference-read tool. References can also be attached at creation via the optional `references[]` param on chorus_pm_create_idea / chorus_pm_create_proposal / chorus_create_tasks; use this tool for post-hoc attach.",
+        "Attach external evidence (a web link + optional notes) to an idea, proposal, or task, for post-hoc attach. Prefer the inline `references[]` param on chorus_pm_create_idea / chorus_pm_create_proposal / chorus_create_tasks when attaching at creation time; references are read back inline via chorus_get_idea / _get_proposal / _get_task (no separate read tool).",
       inputSchema: z.object({
         targetType: referenceTargetTypeEnum.describe("Target type: idea, proposal, or task"),
         targetUuid: z.string().describe("UUID of the idea, proposal, or task to attach to"),
-        type: referenceTypeEnum.describe("Reference type: docs, repo, issue_pr, or paper_blog"),
-        url: z.string().describe("Web URL (http:// or https://)"),
+        type: referenceTypeEnum.describe("Reference type: docs (official documentation), repo (reference implementation), issue_pr (issue/PR thread), or paper_blog (paper/blog post)"),
+        url: z.string().describe("Web URL (http:// or https://; no local files — never fetched)"),
         title: z.string().describe("Reference title"),
         notes: z.string().optional().describe("Optional one-line summary of why this reference is relevant — keep it to a single concise sentence (~200 chars, ≤2 lines); the UI clamps the display to 2 lines. Stored verbatim; no fetch."),
       }),
@@ -505,7 +505,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
       description: "Add a document draft to a pending Proposal container",
       inputSchema: z.object({
         proposalUuid: z.string().describe("Proposal UUID"),
-        type: z.string().describe("Document type (prd, tech_design, adr, spec, guide, report)"),
+        type: z.enum(["prd", "tech_design", "adr", "spec", "guide", "report"]).describe("Document type"),
         title: z.string().describe("Document title"),
         content: z.string().describe("Document content (Markdown)"),
       }),
@@ -584,7 +584,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
       inputSchema: z.object({
         proposalUuid: z.string().describe("Proposal UUID"),
         draftUuid: z.string().describe("Document draft UUID"),
-        type: z.string().optional().describe("Document type"),
+        type: z.enum(["prd", "tech_design", "adr", "spec", "guide", "report"]).optional().describe("Document type"),
         title: z.string().optional().describe("Document title"),
         content: z.string().optional().describe("Document content (Markdown)"),
       }),
@@ -735,14 +735,14 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "proposal:write",
     "chorus_pm_assign_task",
     {
-      description: "Assign a task to an agent that has task:write permission (task must be in open or assigned status). Optionally pin the task to a specific AgentInstance by passing its `instanceUuid` (the durable (agent, host, cwd) identity from chorus presence/daemon tools): when provided the task is assigned as `agent_instance` and the autonomous wake targets that instance; when omitted the task is a plain `agent` assignment whose wake-time instance is inherited from the root idea. The instance must belong to the target agent's company, else the call is rejected.",
+      description: "Assign a task to an agent that has task:write permission; the task must be in open or assigned status. Optionally pin it to a specific AgentInstance via `instanceUuid`.",
       inputSchema: z.object({
         taskUuid: z.string().describe("Task UUID"),
         agentUuid: z.string().describe("Target Agent UUID (must have task:write permission)"),
         instanceUuid: z
           .string()
           .nullish()
-          .describe("Optional AgentInstance UUID to pin the task to (assigns as agent_instance). Omit for a plain agent assignment (backward-compatible)."),
+          .describe("Optional AgentInstance UUID — the durable (agent, host, cwd) identity from chorus presence/daemon tools. When provided the task is assigned as `agent_instance` and the autonomous wake targets that instance; omit for a plain `agent` assignment whose wake-time instance is inherited from the root idea. The instance must belong to the target agent's company, else the call is rejected."),
       }),
     },
     async ({ taskUuid, agentUuid, instanceUuid }) => {
@@ -886,7 +886,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "idea:write",
     "chorus_pm_start_elaboration",
     {
-      description: "Start an elaboration round for an Idea. Creates structured questions for the Idea creator/stakeholder to answer, clarifying requirements before proposal creation. Recommended for every Idea. Structured elaboration improves Proposal quality and reduces rejection cycles. IMPORTANT: After this tool returns pending_answers, you MUST use an interactive prompt tool (e.g., AskUserQuestion in Claude Code) to present the questions to the user — do NOT display questions as plain text. Collect answers interactively, then call chorus_answer_elaboration. IMPORTANT: Even if the user discusses requirements with you outside of elaboration (e.g., in chat), you should still record key decisions and clarifications as elaboration rounds so they are persisted to the Idea as an audit trail. Do NOT include an 'Other' option — the UI automatically adds a free-text 'Other' option to every question.",
+      description: "Open a round of structured questions on an Idea to clarify requirements before a proposal is written; recommended for every Idea. Record decisions here even when requirements were discussed outside the tool (chat) — this round is the persisted audit trail.",
       inputSchema: z.object({
         ideaUuid: z.string().describe("Idea UUID"),
         depth: z.enum(["minimal", "standard", "comprehensive"]).describe("Elaboration depth level"),
@@ -898,9 +898,9 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
             id: z.string().describe("Option identifier"),
             label: z.string().describe("Option label"),
             description: z.string().optional().describe("Option description"),
-          })).describe("Answer options (2-5). Do NOT include 'Other' — the UI adds it automatically."),
+          })).describe("Answer options (2-5). Do NOT include an 'Other' option — the UI adds a free-text 'Other' to every question automatically."),
           required: z.boolean().optional().describe("Whether the question is required (default: true)"),
-        })).describe("Questions to ask (1-15 per round)"),
+        })).describe("Questions to ask (1-15 per round). Present these to the user via an interactive prompt (not plain text), then submit their answers with chorus_answer_elaboration."),
       }),
     },
     async ({ ideaUuid, depth, questions }) => {

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -94,7 +94,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       description: "Get the list of Ideas for a project. Each row includes `reportCount` — number of completion reports for the idea.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        status: z.string().optional().describe("Filter by status: open, elaborating, proposal_created, completed, closed"),
+        status: z.enum(["open", "elaborating", "elaborated"]).optional().describe("Filter by status"),
         page: z.number().optional().default(1).describe("Page number"),
         pageSize: z.number().optional().default(20).describe("Items per page"),
       }),
@@ -128,7 +128,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       description: "Get the list of Documents for a project",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        type: z.string().optional().describe("Filter by type: prd, tech_design, adr, spec, guide, report"),
+        type: z.enum(["prd", "tech_design", "adr", "spec", "guide", "report"]).optional().describe("Filter by type"),
         page: z.number().optional().default(1),
         pageSize: z.number().optional().default(20),
       }),
@@ -182,7 +182,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       description: "Get the list of Proposals and their statuses for a project",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        status: z.string().optional().describe("Filter by status: pending, approved, rejected, revised"),
+        status: z.enum(["draft", "pending", "approved", "closed"]).optional().describe("Filter by status"),
         page: z.number().optional().default(1),
         pageSize: z.number().optional().default(20),
       }),
@@ -244,8 +244,8 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       description: "List Tasks for a project",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        status: z.string().optional().describe("Filter by status: open, assigned, in_progress, to_verify, done, closed"),
-        priority: z.string().optional().describe("Filter by priority: low, medium, high"),
+        status: z.enum(["open", "assigned", "in_progress", "to_verify", "done", "closed"]).optional().describe("Filter by status"),
+        priority: z.enum(["low", "medium", "high"]).optional().describe("Filter by priority"),
         proposalUuids: zArray(z.string()).optional().describe("Filter tasks by proposal UUIDs"),
         page: z.number().optional().default(1),
         pageSize: z.number().optional().default(20),
@@ -481,24 +481,14 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     "chorus_get_proposal",
     {
       description:
-        "Get a single Proposal, sliced into one section to avoid oversized payloads. " +
-        "The `section` parameter selects the view (default `basic`):\n" +
-        "- `basic` (default): proposal metadata + a lightweight index of document drafts " +
-        "(uuid, type, title, contentLength) and task drafts (uuid, title, priority, storyPoints, " +
-        "acceptanceCriteriaCount, dependsOnDraftUuids). No document content or full task descriptions.\n" +
-        "- `documents`: proposal metadata + the FULL document drafts (with content).\n" +
-        "- `tasks`: proposal metadata + the FULL task drafts (with descriptions and acceptance criteria).\n" +
-        "- `full`: the entire proposal (all document and task drafts) in one payload.\n" +
-        "Start with `basic` to see what exists, then drill into `documents` or `tasks` " +
-        "using the same `proposalUuid`. Every response includes a `section` field echoing the view returned.",
+        "Get a single Proposal, sliced into one section to avoid oversized payloads. Start with the default `basic` view to see what exists, then drill into a heavier section using the same `proposalUuid`.",
       inputSchema: z.object({
         proposalUuid: z.string().describe("Proposal UUID"),
         section: z
           .enum(["basic", "documents", "tasks", "full"])
           .optional()
           .describe(
-            "Which slice to return. Default `basic` (metadata + lightweight draft index). " +
-              "Use `documents`/`tasks` for full drafts of one kind, or `full` for everything."
+            "Which slice to return (default `basic`). `basic`: metadata + a lightweight index of document drafts (uuid, type, title, contentLength) and task drafts (uuid, title, priority, storyPoints, acceptanceCriteriaCount, dependsOnDraftUuids) — no content. `documents`: metadata + FULL document drafts (with content). `tasks`: metadata + FULL task drafts (descriptions + acceptance criteria). `full`: everything in one payload. Every response echoes the view in a `section` field."
           ),
       }),
     },
@@ -826,15 +816,10 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     "chorus_create_tasks",
     {
       description:
-        "Batch create tasks in a project. Two modes:\n\n" +
-        "**Quick Task** (skip Idea→Proposal): omit proposalUuid. Ideal for bug fixes, small features, post-delivery patches. Flow: create → claim → execute → verify → done.\n\n" +
-        "**Proposal-linked** (traditional AI-DLC): pass proposalUuid to associate with an approved proposal.\n\n" +
-        "Supports batch creation with intra-batch dependencies (draftUuid + dependsOnDraftUuids) and dependencies on existing tasks (dependsOnTaskUuids).\n\n" +
-        "Acceptance criteria are REQUIRED: every task must include at least one acceptanceCriteriaItems entry with a non-blank description, or the entire batch is rejected (no task is created).\n\n" +
-        "Optional per-task `references[]` attaches reference artifacts (external evidence — web link + optional notes) to each created task inline; a bad reference is skipped and reported in the response `referenceErrors` without failing task creation.",
+        "Batch-create tasks in a project — either Quick Task mode (omit proposalUuid) or linked to an approved proposal (pass proposalUuid). Every task must include at least one acceptance criterion, or the whole batch is rejected.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        proposalUuid: z.string().optional().describe("Associated Proposal UUID (optional — omit for Quick Task mode)"),
+        proposalUuid: z.string().optional().describe("Associated Proposal UUID. Omit for Quick Task mode (bug fixes, small features, post-delivery patches; flow: create → claim → execute → verify → done); pass it to link to an approved proposal in the traditional AI-DLC flow. Intra-batch dependencies use draftUuid + dependsOnDraftUuids; dependencies on existing tasks use dependsOnTaskUuids."),
         tasks: zArray(z.object({
           title: z.string().describe("Task title"),
           description: z.string().optional().describe("Task description"),
@@ -992,14 +977,10 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     "chorus_update_task",
     {
       description:
-        "Update a task — edit fields, manage dependencies, or change status.\n\n" +
-        "**Field editing** (any role): title, description, priority, storyPoints, addDependsOn/removeDependsOn (incremental dependency management).\n\n" +
-        "**Acceptance criteria editing** (any role): pass acceptanceCriteriaItems to REPLACE the task's acceptance criteria with the provided non-empty set. Omit it to leave AC untouched. It cannot be used to clear AC — an empty or all-blank array is rejected. Replacing discards any prior dev/admin verification marks on the old criteria.\n\n" +
-        "**Status update** (assignee only): in_progress (requires all dependencies resolved), to_verify.\n\n" +
-        "For Quick Tasks: create → claim → edit details → execute → verify → done.",
+        "Update a task: edit fields (title, description, priority, storyPoints), manage dependencies, replace acceptance criteria, or change status. Field/AC/dependency edits are open to any role; status changes are assignee-only.",
       inputSchema: z.object({
         taskUuid: z.string().describe("Task UUID"),
-        status: z.enum(["in_progress", "to_verify"]).optional().describe("New status (assignee only)"),
+        status: z.enum(["in_progress", "to_verify"]).optional().describe("New status (assignee only). `in_progress` requires all dependencies resolved; `to_verify` submits for verification."),
         sessionUuid: z.string().optional().describe("Session UUID for sub-agent identification"),
         title: z.string().optional().describe("New task title"),
         description: z.string().optional().describe("New task description (supports @mentions)"),
@@ -1008,9 +989,9 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         acceptanceCriteriaItems: zArray(z.object({
           description: z.string().describe("Criterion description"),
           required: z.boolean().optional().describe("Whether this criterion is required (default: true)"),
-        })).optional().describe("Replace the task's acceptance criteria with this non-empty set. Omit to leave AC unchanged; cannot be used to clear AC (empty/all-blank is rejected)."),
-        addDependsOn: zArray(z.string()).optional().describe("Task UUIDs to add as dependencies"),
-        removeDependsOn: zArray(z.string()).optional().describe("Task UUIDs to remove from dependencies"),
+        })).optional().describe("Replace the task's acceptance criteria with this non-empty set. Omit to leave AC unchanged; cannot be used to clear AC (empty/all-blank is rejected). Replacing discards any prior dev/admin verification marks on the old criteria."),
+        addDependsOn: zArray(z.string()).optional().describe("Task UUIDs to add as dependencies (incremental)"),
+        removeDependsOn: zArray(z.string()).optional().describe("Task UUIDs to remove from dependencies (incremental)"),
       }),
     },
     async ({ taskUuid, status, sessionUuid, title, description, priority, storyPoints, acceptanceCriteriaItems, addDependsOn, removeDependsOn }) => {
@@ -1184,25 +1165,23 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     "chorus_create_report",
     {
       description:
-        "Persist an idea-completion summary as a Document (type=\"report\") under the given Proposal. Only write a report once every Task in the Proposal is complete. By default a proposal already carrying a report rejects further calls — pass `force: true` to add another deliberately. Keep it short — this is a summary, not a write-up.\n\n" +
-        "Markdown `content` MUST use these three sections in this order:\n\n" +
-        "## Summary\n" +
-        "1-3 sentences on what shipped. Plain prose. No bullet lists here.\n\n" +
-        "## Decisions\n" +
-        "Terse bullets — the key calls made during elaboration / proposal review and why this option not the alternative. Skip obvious / trivial decisions; capture the ones a future reader would want context on.\n\n" +
-        "## Follow-ups\n" +
-        "What's still open — link to a new Idea / blog / doc-update if tracked elsewhere; write \"None\" if there are no follow-ups.\n\n" +
-        "Section bodies are free-form Markdown (links and inline code are fine). The three headers are the contract — keep them verbatim, top-level (`##`), in this order.",
+        "Persist an idea-completion summary as a Document (type=\"report\") under the given Proposal, once every Task in the Proposal is complete. Keep it short — a summary, not a write-up.",
       inputSchema: z.object({
         proposalUuid: z.string().uuid().describe("Proposal UUID whose tasks have all reached a terminal state"),
         title: z.string().min(1).max(200).describe("Report title (e.g. 'Idea X — completion report')"),
-        content: z.string().min(1).describe("Markdown body — Summary / Decisions / Follow-ups"),
+        content: z.string().min(1).describe(
+          "Markdown body. MUST use these three top-level headers verbatim, in this order:\n" +
+          "## Summary — 1-3 sentences on what shipped (plain prose, no bullets).\n" +
+          "## Decisions — terse bullets: the key calls made during elaboration / proposal review and why this option not the alternative; skip trivial ones.\n" +
+          "## Follow-ups — what's still open (link a new Idea / blog / doc-update if tracked elsewhere); write \"None\" if there are none.\n" +
+          "Section bodies are free-form Markdown (links and inline code fine); the three headers are the contract."
+        ),
         force: z
           .boolean()
           .optional()
           .default(false)
           .describe(
-            "Default false. When false, calls against a proposal that already has a report return an error and create nothing. Set true only to deliberately add another report to the same proposal."
+            "Default false. When false, calls against a proposal that already has a report return an error and create nothing. Set force true only to deliberately add another report to the same proposal."
           ),
       }),
     },


### PR DESCRIPTION
## Summary

Slims the Chorus MCP tool surface (P1 of theme *简化 MCP 工具调用表面*, idea `f86c9ddb`) to cut the every-turn `tools/list` cost that drives long-context tool-call degradation:

- **6 filter/type params → strict `z.enum`** (`get_ideas.status`, `list_tasks.status`/`priority`, `get_documents.type`, `get_proposals.status`, `pm_add/update_document_draft.type`). Domains are the **verified current stored values**, not the stale describe-strings — drops `get_ideas.status` `proposal_created/completed/closed` (derived, not stored) and `get_proposals.status` `rejected/revised` (never written; reject → `draft`).
- **7 over-long tool descriptions → ≤2 sentences** (what/when). Behavior red-lines split per the idea's elaboration: whole-call rules stay as a one-line clause in the description (so headless / no-skill agents still see them); param-bound rules move into that param's `.describe()` (create_report's 3-section contract → `content`; "no Other option" → elaboration `options`; instance-pin → `instanceUuid`; …).
- **Docs synced**: `MCP_TOOLS.md` enum value lists corrected; the create_report section-template pointer updated across all four plugin skill surfaces + both `on-post-verify-task.sh` hooks (backticks escaped inside the unquoted heredoc).

**Token delta** (proxy metric, recorded per elaboration `struct_plus_record`, no threshold): every-turn top-level descriptions **5555 → 1599 chars (−71.2%)**; net schema text incl. relocated `.describe()` **−26.0%**.

## Changed files

| File | Change |
|------|--------|
| `src/mcp/tools/public.ts` | 5 enums + 4 slimmed descriptions |
| `src/mcp/tools/pm.ts` | 2 enums + 3 slimmed descriptions |
| `src/mcp/__tests__/filter-enum-params.test.ts` | **new** — 30 tests: reject/accept/optionality per enum |
| `src/mcp/__tests__/tool-description-slimming.test.ts` | **new** — 17 tests: ≤2-sentence guard + relocation checks |
| `src/mcp/__tests__/get-proposal-section.test.ts` | assertion moved to `section` param `.describe()` |
| `src/mcp/tools/__tests__/create-report.test.ts` | assertion moved to `content`/`force` param `.describe()` |
| `docs/MCP_TOOLS.md` | corrected enum value lists |
| `public/skill/**`, `public/chorus-plugin/**`, `plugins/chorus/**`, `public/kiro-plugin/**` | create_report section-template pointer → `content` param |
| `openspec/specs/mcp-tool-surface/spec.md` + `openspec/changes/archive/2026-07-17-slim-…` | OpenSpec change archived (4 ADDED requirements merged) |

## Test plan

- [x] `npx vitest run` — 4365 passed, 3 skipped (live-DB), 0 failures (the one full-suite flaky `daemon-integration.test.mjs 子3` passes 16/16 in isolation, unrelated)
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` clean on changed source
- [x] bash-3.2 syntax test 15/15; hook regression 34/34; heredoc emits literal text (no command substitution)
- [x] Reviewed by proposal-reviewer, per-task task-reviewer, and the ship-time code-reviewer (all PASS / PASS WITH NOTES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)