### PR TITLE
fix(daemon): session running indicator agrees with Interrupt + warn on lineage gap

### DIFF
--- a/cli/__tests__/lineage.test.mjs
+++ b/cli/__tests__/lineage.test.mjs
@@ -206,3 +206,69 @@ describe("LineageResolver.rootIdeaFor (REST)", () => {
     expect(infos.some((m) => /lineage: idea:x → root r, direct none \(root_idea\)/.test(m))).toBe(true);
   });
 });
+
+describe("LineageResolver missing-directIdeaUuid diagnostic", () => {
+  /** A logger that records info + warn lines separately. */
+  function capturingLogger() {
+    const infos = [];
+    const warns = [];
+    return {
+      logger: { info: (m) => infos.push(m), warn: (m) => warns.push(m), error() {} },
+      infos,
+      warns,
+    };
+  }
+
+  it("warns when a non-null root idea resolves with NO directIdeaUuid (older-server fingerprint)", async () => {
+    const { logger, warns } = capturingLogger();
+    // root present, direct absent — the lineage gap this diagnostic targets.
+    const fetchImpl = fakeFetch(() => rootIdeaData({ rootIdeaUuid: "root-x", lineage: [] }));
+    const r = makeResolver(fetchImpl, logger);
+    const res = await r.resolve({ entityType: "task", entityUuid: "t1" });
+
+    // Return value is UNCHANGED — no fallback substitution of root for the missing direct.
+    expect(res).toEqual({ rootIdeaUuid: "root-x", directIdeaUuid: null });
+    // Exactly one warn, naming the entity + directIdeaUuid + the likely cause.
+    const hit = warns.find((m) => /task:t1/.test(m) && /directIdeaUuid/.test(m));
+    expect(hit).toBeTruthy();
+    expect(/root-x/.test(hit)).toBe(true);
+    expect(/predates|upgrade/.test(hit)).toBe(true);
+  });
+
+  it("also warns when directIdeaUuid is explicitly null (not just absent)", async () => {
+    const { logger, warns } = capturingLogger();
+    const fetchImpl = fakeFetch(() =>
+      rootIdeaData({ rootIdeaUuid: "root-x", directIdeaUuid: null, lineage: [] })
+    );
+    const r = makeResolver(fetchImpl, logger);
+    await r.resolve({ entityType: "proposal", entityUuid: "p9" });
+    expect(warns.some((m) => /proposal:p9/.test(m) && /directIdeaUuid/.test(m))).toBe(true);
+  });
+
+  it("does NOT warn when the entity legitimately has no idea ancestor (root null)", async () => {
+    const { logger, warns, infos } = capturingLogger();
+    const fetchImpl = fakeFetch(() =>
+      rootIdeaData({ rootIdeaUuid: null, lineage: [], resolvedVia: "no_proposal" })
+    );
+    const r = makeResolver(fetchImpl, logger);
+    const res = await r.resolve({ entityType: "task", entityUuid: "t2" });
+
+    expect(res).toEqual({ rootIdeaUuid: null, directIdeaUuid: null });
+    // No missing-direct warning for the normal no-ancestor case…
+    expect(warns.some((m) => /directIdeaUuid/.test(m))).toBe(false);
+    // …but still a (non-alarming) success info line.
+    expect(infos.some((m) => /lineage: task:t2 → root none, direct none/.test(m))).toBe(true);
+  });
+
+  it("does NOT warn when BOTH root and direct are present", async () => {
+    const { logger, warns } = capturingLogger();
+    const fetchImpl = fakeFetch(() =>
+      rootIdeaData({ rootIdeaUuid: "root-x", directIdeaUuid: "direct-y", lineage: [] })
+    );
+    const r = makeResolver(fetchImpl, logger);
+    const res = await r.resolve({ entityType: "idea", entityUuid: "child-1" });
+
+    expect(res).toEqual({ rootIdeaUuid: "root-x", directIdeaUuid: "direct-y" });
+    expect(warns.some((m) => /directIdeaUuid/.test(m))).toBe(false);
+  });
+});

--- a/cli/lineage.mjs
+++ b/cli/lineage.mjs
@@ -146,6 +146,26 @@ export class LineageResolver {
         `[Chorus] lineage: non-string directIdeaUuid for ${entityType}:${entityUuid}`
       );
     }
+    // A non-null ROOT idea with a null/absent DIRECT idea is a lineage gap: the wake will
+    // anchor the execution on the entity (task/proposal), never on the idea conversation,
+    // so its run shows no running indicator / Interrupt on the idea chat — permanently, for
+    // this class of wake. The overwhelmingly likely cause is a Chorus server that predates
+    // the `directIdeaUuid` field on the /root-idea endpoint. Surface it as a visible WARN
+    // rather than folding it into the generic success `info` below (where it is
+    // indistinguishable from the legitimate "no idea ancestor" outcome, root=direct=null).
+    // Diagnostic ONLY — we do NOT substitute the root for the missing direct idea: for a
+    // DERIVED child idea root ≠ direct, so falling back to root would light the PARENT
+    // conversation and leave the child (which owns the woken session) idle. The correct fix
+    // is server-side; this warn points the operator straight at it.
+    if (root !== null && direct === null) {
+      this.logger.warn(
+        `[Chorus] lineage: ${entityType}:${entityUuid} resolved a root idea (${root}) but NO ` +
+          `directIdeaUuid — this wake will anchor on the entity, not the idea conversation, ` +
+          `so its run will not show a running indicator / Interrupt on the idea chat. Most ` +
+          `likely the Chorus server predates the directIdeaUuid field on /root-idea; upgrade ` +
+          `the server to restore child-wake → idea-conversation matching.`
+      );
+    }
     this.logger.info(
       `[Chorus] lineage: ${entityType}:${entityUuid} → root ${root ?? "none"}, direct ${direct ?? "none"}` +
         (typeof data.resolvedVia === "string" ? ` (${data.resolvedVia})` : "")

--- a/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/README.md
+++ b/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-session-running-indicator
+
+Make the daemon conversation-list running indicator agree with the composer's Interrupt (cross-connection match), and surface a visible warning when the lineage resolver gets a null/absent directIdeaUuid for an idea-attributable entity.

--- a/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/design.md
+++ b/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/design.md
@@ -1,0 +1,177 @@
+# Design — Fix daemon session running indicator / Interrupt disagreement
+
+## Context
+
+Two independent, small fixes for one reported symptom ("online session I'm
+talking to shows no running indicator and no Interrupt button"). They touch
+disjoint layers (React client vs. daemon Node CLI) and share no state, so they
+are two independent tasks with no ordering dependency.
+
+The root-cause trace and file:line evidence are recorded on the source idea
+(044692e0). Prior art:
+
+- PR #428 — threaded `directIdeaUuid` end-to-end so a child-idea wake lights the
+  correct chat (the precedent P1 hardens).
+- PR #429 — introduced the composer's cross-connection Interrupt fallback
+  (`sessionExecutionsForComposer`); the list dot was **not** given the same
+  fallback — that gap is P0.
+
+## P0 — Conversation-list status uses the composer's cross-connection match
+
+### Current behavior
+
+`daemon-chat.tsx` builds each list row's `status` from:
+
+```ts
+status: sessionExecStatus(
+  executionsByConnection[session.originConnectionUuid] ?? [],
+  session,
+),
+```
+
+i.e. only the origin connection's execution slice. The composer, by contrast,
+uses:
+
+```ts
+const sessionExecutions = sessionExecutionsForComposer(executionsByConnection, s);
+```
+
+`sessionExecutionsForComposer` (in `session-execution.ts`) prefers the origin
+slice but falls back to searching **all** connection slices for this
+conversation's executions when the origin slice yields nothing. After a
+cwd/agent switch or a session re-point, the running turn lives on a *different*
+connection, so the composer finds it but the row does not → the dot reads idle
+while Interrupt works.
+
+### Change
+
+Add a pure helper that derives the row's display status from the SAME
+cross-connection execution set the composer resolves, then reduces it with the
+existing `sessionExecStatus` logic:
+
+```ts
+// session-execution.ts
+export function sessionExecStatusForRow(
+  executionsByConnection: Record<string, ExecutionView[]>,
+  session: { sessionId: string; directIdeaUuid: string | null; originConnectionUuid: string },
+): SessionExecStatus {
+  const execs = sessionExecutionsForComposer(executionsByConnection, session);
+  // sessionExecStatus re-filters by executionMatchesSession; passing the already-
+  // matched composer set is safe (idempotent) and keeps the reduce rule in one place.
+  return sessionExecStatus(execs, session);
+}
+```
+
+Call site in `daemon-chat.tsx` becomes:
+
+```ts
+status: sessionExecStatusForRow(executionsByConnection, session),
+```
+
+`ConversationRow.session` (a `SessionTarget`) already carries
+`originConnectionUuid`, `directIdeaUuid`, and `sessionId`, so no new data needs
+threading into the row map.
+
+### Why the reduce stays correct
+
+`sessionExecStatus` internally calls `executionsForSession` again, which filters
+by `executionMatchesSession`. `sessionExecutionsForComposer` returns executions
+already matched to this conversation, so the second filter is a no-op pass-through
+— the composed helper is equivalent to "reduce the composer's matched set to one
+status", with the match rule and the reduce rule each defined exactly once. No
+behavior change for the common case (origin slice has the match); the only
+observable change is the re-pointed / agent-switched case now lighting the dot,
+which is the whole point.
+
+### Cross-borrowing safety
+
+The fallback matches strictly by this conversation's own idea
+(`directIdeaUuid`, or the `::`-prefix heal) or its `daemon_session:<sessionId>`.
+A different conversation's execution on another connection cannot satisfy that
+predicate, so the row cannot show another conversation's run. This is the same
+guarantee the composer already relies on.
+
+### Tests
+
+`session-execution` currently has no `__tests__`; add one covering
+`sessionExecStatusForRow`:
+
+- origin slice has a `running` exec → `"running"` (parity with old behavior);
+- origin slice empty but ANOTHER connection slice has this idea's `running` exec
+  → `"running"` (the fix; old `sessionExecStatus(origin-only)` returned `null`);
+- an unrelated idea's exec on another slice → `null` (no cross-borrow);
+- user-interrupted on the fallback slice → `"interrupted"`; crash → `"error"`.
+
+## P1 — Visible warning on null directIdeaUuid with non-null root
+
+### Current behavior
+
+`cli/lineage.mjs#resolveViaServer` logs one `info` line on success:
+
+```
+[Chorus] lineage: <type>:<uuid> → root <root|none>, direct <direct|none> (<resolvedVia>)
+```
+
+Both "legitimately no idea ancestor" (`root=none, direct=none`) and the anomalous
+"has a root but no direct idea" (`root=<uuid>, direct=none`) render as ordinary
+`info`. The second is the fingerprint of a lineage gap (most often a server
+predating the `directIdeaUuid` field on the root-idea endpoint) that permanently
+breaks child-wake → idea-conversation matching, but there is no distinct signal.
+
+### Change
+
+Keep the existing success `info` line. Add, immediately before it, a `warn` that
+fires **only** when `root` is non-null AND `direct` is null:
+
+```js
+if (root !== null && direct === null) {
+  this.logger.warn(
+    `[Chorus] lineage: ${entityType}:${entityUuid} resolved a root idea (${root}) but NO ` +
+    `directIdeaUuid — this wake will anchor on the entity, not the idea conversation, so its ` +
+    `run will not show a running indicator / Interrupt on the idea chat. Most likely the Chorus ` +
+    `server predates the directIdeaUuid field on /root-idea; upgrade the server to restore ` +
+    `child-wake → idea-conversation matching.`
+  );
+}
+```
+
+Placement is after the existing non-string `directIdeaUuid` warn (so a malformed
+value is still reported on its own) and before the success `info`. No control
+flow changes — resolution still returns `{ rootIdeaUuid: root, directIdeaUuid:
+direct }` exactly as before. This is **diagnostic only**: no client-side
+root-idea fallback is introduced (owner's explicit "guard + log, not fallback"
+choice), so the daemon's behavior when `direct` is null is unchanged — it just
+becomes visible.
+
+### Why warn, not fix-forward
+
+A client-side fallback (anchoring on `rootIdeaUuid` when `direct` is null) was
+explicitly declined: for a *derived child* idea, root ≠ direct, so falling back
+to root would light the PARENT conversation and leave the child (the one that
+actually owns the woken session) idle — re-introducing the very bug PR #428
+fixed. The correct fix is server-side (return `directIdeaUuid`), and the warning
+points the operator straight at it.
+
+### Tests
+
+`cli/__tests__/lineage.test.mjs` uses an injectable `fetchImpl` + a capturing
+logger. Add cases:
+
+- server returns `{ rootIdeaUuid: "root-x", directIdeaUuid: null }` → resolves
+  `{ rootIdeaUuid: "root-x", directIdeaUuid: null }` AND the logger recorded a
+  `warn` mentioning the entity and `directIdeaUuid`;
+- server returns both null (`root=null, direct=null`) → NO warn (normal
+  no-ancestor case), still an `info`;
+- server returns both present → NO warn.
+
+## Risks & alternatives
+
+- **Risk:** the composed P0 helper double-filters. Mitigated — the second filter
+  is idempotent over an already-matched set; a unit test pins the equivalence.
+- **Alternative considered (P0):** inline the fallback at the row call site
+  instead of a named helper. Rejected — a named, tested helper keeps the row and
+  the composer provably in sync and documents the intent.
+- **Alternative considered (P1):** raise to `error`. Rejected — the daemon still
+  functions (it just anchors sub-optimally); `warn` is the right severity for a
+  degraded-but-not-broken, operator-actionable condition, consistent with the
+  file's other `warn`s.

--- a/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/proposal.md
+++ b/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/proposal.md
@@ -1,0 +1,101 @@
+# Fix: online daemon session sometimes shows no "running" indicator / no Interrupt
+
+## Why
+
+An owner reported that a live daemon conversation they were actively talking to
+could not be interrupted — the chat UI showed neither a "running" indicator nor
+an Interrupt button, even though the agent was demonstrably working. A read-only
+trace found **four** contributing causes; the owner scoped this change to the two
+that are genuine, fixable defects (the other two are by-design and were explicitly
+accepted as-is):
+
+**P0 — the conversation-list running dot disagrees with the composer's Interrupt
+(confirmed UI bug).** Both the list-row status dot and the composer's Interrupt
+control are meant to reflect the same thing: is there a live `running`
+`DaemonExecution` for this conversation? But they resolve it from different data:
+
+- The composer (`daemon-chat.tsx` → `sessionExecutionsForComposer`) searches the
+  conversation's origin-connection slice **and falls back to every other
+  connection slice** when the origin has no match — so after a `cwd`/agent switch
+  or a session re-point, it still finds the running turn on whatever connection
+  now owns it (introduced in PR #429).
+- The list row (`daemon-chat.tsx:332-335` → `sessionExecStatus`) reads **only**
+  `executionsByConnection[session.originConnectionUuid]` — the origin slice, no
+  cross-connection fallback.
+
+So in exactly the re-pointed / agent-switched case, the dot reads idle while the
+Interrupt button still works — the two disagree, and the user sees "no running
+indicator" for a conversation that is in fact interruptible. This is the reported
+symptom.
+
+**P1 — a null `directIdeaUuid` for an idea-attributable entity is silent
+(robustness / observability).** Autonomous child wakes (a `task_assigned` /
+`proposal_*` wake on a child of an idea) only anchor to the idea conversation via
+`directIdeaUuid` (PR #428 threaded this end-to-end). The daemon's lineage
+resolver (`cli/lineage.mjs`) resolves each entity against
+`GET /api/entities/{type}/{uuid}/root-idea`, which returns both `rootIdeaUuid`
+and `directIdeaUuid`. When the resolver gets a **non-null** `rootIdeaUuid` but a
+**null/absent** `directIdeaUuid`, that is the fingerprint of a lineage gap — most
+often a *server older than the `directIdeaUuid` field*. The wake then anchors the
+execution on the task/proposal instead of the idea, so it never matches the idea
+conversation → no dot, no Interrupt, permanently, for that class of wake. Today
+this anomalous case is folded into a generic `info` log line, indistinguishable
+from the normal "this entity legitimately has no idea ancestor" outcome
+(`rootIdeaUuid` also null). Operators have no visible signal.
+
+The other two causes are **out of scope** by the owner's explicit decision:
+
+- **Cause #1 (dominant, by design):** an ephemeral `claude -p` wake IS the whole
+  lifetime of its execution row; between turns there is no running row to
+  interrupt even while the connection is "online". Owner chose **accept as-is** —
+  no tooltip, no distinct idle/running UI.
+- **Cause #2 (~15s SSE catch-up):** a turn started after the viewer's SSE stream
+  opened surfaces only via the 15s poll. Owner chose **no code** — the poll
+  remains the safety net; dynamic channel subscription is not worth the
+  complexity here.
+
+## What Changes
+
+- **P0.** The daemon conversation-list row's running/interrupted status is
+  resolved with the **same cross-connection match** the composer's Interrupt
+  control already uses, so the dot and the Interrupt button can never disagree.
+  The origin-connection slice is still preferred (the common, scoped case); the
+  fallback to other connection slices only engages when the origin slice has no
+  matching execution — matching strictly by this conversation's own idea /
+  session id, so a cross-connection match still belongs to this conversation
+  only (it cannot borrow another conversation's run). A new pure helper composes
+  the existing `sessionExecutionsForComposer` + `sessionExecStatus` and is unit
+  tested.
+- **P1.** The lineage resolver emits a **visible `warn`** — not a buried `info` —
+  precisely when it resolves a **non-null** `rootIdeaUuid` together with a
+  **null/absent** `directIdeaUuid` for an idea-attributable entity, naming the
+  entity and stating the consequence (child/task wakes will anchor on the entity,
+  not the idea conversation) and the most likely cause (a server predating the
+  `directIdeaUuid` field). The normal "no idea ancestor at all" case
+  (`rootIdeaUuid` null) stays a non-alarming `info`. This is **guard + visible
+  log only** — no client-side root-idea fallback is added (owner's explicit
+  choice).
+
+## Capabilities
+
+- `daemon-session-transcript-read` — ADDED requirement: the conversation-list
+  running indicator SHALL be resolved by the same cross-connection match as the
+  composer's Interrupt control, so the two never disagree.
+- `root-idea-resolution` — ADDED requirement: the daemon lineage resolver SHALL
+  emit a visible warning when it resolves a non-null root idea with a null direct
+  idea for an idea-attributable entity.
+
+## Impact
+
+- **Affected code:**
+  - P0: `src/components/agent-presence/chat/session-execution.ts` (new pure
+    helper), `src/components/agent-presence/chat/daemon-chat.tsx` (list-row status
+    call site, line ~332), plus unit tests for the new helper.
+  - P1: `cli/lineage.mjs` (`#resolveViaServer` diagnostic log), plus
+    `cli/__tests__/lineage.test.mjs`.
+- **No** server, service, API, data-model, schema, or migration change.
+- **No** i18n change (P0 changes only which executions feed an existing status
+  glyph; no new user-facing string). No `design.pen` screen change (the dot and
+  Interrupt already exist — this only makes them agree).
+- **Out of scope (accepted as-is):** the between-turns idle state (cause #1) and
+  the ~15s SSE catch-up window (cause #2).

--- a/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/specs/daemon-session-transcript-read/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: The conversation-list running indicator SHALL agree with the composer's Interrupt control
+
+The daemon conversation-list row's live status indicator (running / interrupted / error / idle) SHALL be derived from the SAME set of executions that the conversation's composer resolves for its Interrupt control — i.e. the origin-connection slice PREFERRED, with a fallback to every other connection slice when the origin slice has no execution matching this conversation. The match SHALL be strictly by this conversation's own idea anchor (`directIdeaUuid`, or the `::`-prefix heal for a legacy residual session) or its `daemon_session:<sessionId>` id, so a cross-connection match still belongs to this conversation only and SHALL NOT borrow another conversation's execution. As a result, the list row's indicator and the composer's Interrupt control SHALL never disagree: whenever the composer can offer Interrupt for a running turn, the list row SHALL show the running indicator, including after a `cwd`/agent switch or a session re-point that moved the running turn to a connection other than the conversation's origin.
+
+#### Scenario: Running turn on the origin connection lights the row
+
+- **GIVEN** an open agent's conversation whose running `DaemonExecution` is on the conversation's own origin connection
+- **WHEN** the conversation list renders that row
+- **THEN** the row's status indicator MUST read `running`
+
+#### Scenario: Running turn on a non-origin connection still lights the row
+
+- **GIVEN** a conversation whose origin-connection slice has NO matching execution but whose idea's running `DaemonExecution` lives on a DIFFERENT connection of the agent (after a cwd/agent switch or a session re-point)
+- **WHEN** the conversation list renders that row
+- **THEN** the row's status indicator MUST read `running` (agreeing with the composer's Interrupt control), NOT idle
+
+#### Scenario: The row never borrows an unrelated conversation's run
+
+- **GIVEN** another conversation's running `DaemonExecution` on a different connection, with no execution matching THIS conversation on any connection
+- **WHEN** the conversation list renders THIS conversation's row
+- **THEN** the row's status indicator MUST read idle (null) — the unrelated run MUST NOT be borrowed
+
+#### Scenario: A user-interrupt on the fallback connection is reflected
+
+- **GIVEN** a conversation whose origin slice has no match but whose matching execution on another connection is `interrupted` with reason `user`
+- **WHEN** the conversation list renders that row
+- **THEN** the row's status indicator MUST read `interrupted` (resumable); a crash-interrupt MUST read `error`

--- a/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/specs/root-idea-resolution/spec.md
+++ b/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/specs/root-idea-resolution/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: The daemon lineage resolver SHALL emit a visible warning when a root idea resolves with no direct idea
+
+When the daemon's lineage resolver resolves an entity against `GET /api/entities/{type}/{uuid}/root-idea` and receives a NON-NULL `rootIdeaUuid` together with a NULL or absent `directIdeaUuid`, it SHALL emit a `warn`-level log line that names the entity (`{type}:{uuid}`), states the consequence (the wake will anchor on the entity rather than the idea conversation, so its run will not surface a running indicator / Interrupt on the idea chat), and names the most likely cause (a Chorus server predating the `directIdeaUuid` field on the `/root-idea` endpoint). This warning is diagnostic ONLY: the resolver SHALL still return `{ rootIdeaUuid, directIdeaUuid }` exactly as resolved and SHALL NOT substitute the root idea for the missing direct idea (no client-side fallback). The normal outcome where the entity legitimately has NO idea ancestor (`rootIdeaUuid` is null) SHALL NOT emit this warning — it stays a non-alarming `info`.
+
+#### Scenario: Non-null root with null direct idea warns
+
+- **WHEN** the resolver receives `{ rootIdeaUuid: <non-null>, directIdeaUuid: null }` (or `directIdeaUuid` absent) for an idea-attributable entity
+- **THEN** it MUST emit a `warn` naming the entity and mentioning `directIdeaUuid`
+- **AND** it MUST still return the resolved `rootIdeaUuid` with `directIdeaUuid: null` — no fallback substitution
+
+#### Scenario: No idea ancestor does not warn
+
+- **WHEN** the resolver receives `{ rootIdeaUuid: null, directIdeaUuid: null }` (the entity has no idea lineage)
+- **THEN** it MUST NOT emit the missing-direct-idea warning
+- **AND** it MUST still emit its normal success `info` line
+
+#### Scenario: Both ids present does not warn
+
+- **WHEN** the resolver receives a non-null `rootIdeaUuid` and a non-null `directIdeaUuid`
+- **THEN** it MUST NOT emit the missing-direct-idea warning

--- a/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/tasks.md
+++ b/openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/tasks.md
@@ -1,0 +1,20 @@
+# Tasks — Fix daemon session running indicator / Interrupt disagreement
+
+## P0 — Conversation-list status uses the composer's cross-connection match
+
+- [ ] Add `sessionExecStatusForRow(executionsByConnection, session)` to
+      `src/components/agent-presence/chat/session-execution.ts` — composes
+      `sessionExecutionsForComposer` + `sessionExecStatus`.
+- [ ] Switch the list-row status in `daemon-chat.tsx` (~line 332) to call it.
+- [ ] Add `session-execution` unit tests (origin match, non-origin fallback,
+      no cross-borrow, interrupted/error on fallback).
+- [ ] `pnpm test` (new tests) + `npx tsc --noEmit` + `pnpm lint` green.
+
+## P1 — Visible warning on null directIdeaUuid with non-null root
+
+- [ ] Add the `root != null && direct == null` `warn` in
+      `cli/lineage.mjs#resolveViaServer`, before the success `info`.
+- [ ] Extend `cli/__tests__/lineage.test.mjs` (warns on root-without-direct;
+      no warn on both-null; no warn on both-present).
+- [ ] `pnpm test` green (the lineage suite is a vitest `.test.mjs`, matched by
+      `vitest.config.ts` `cli/**/__tests__/**/*.test.mjs` — not `node --test`).

--- a/openspec/specs/daemon-session-transcript-read/spec.md
+++ b/openspec/specs/daemon-session-transcript-read/spec.md
@@ -371,3 +371,31 @@ The conversation surface SHALL treat `status = "interrupted"` as a terminal turn
 - **THEN** the two MUST be distinguishable (the interrupted band carries the "Interrupted" label)
 - **AND** neither shows a spinner or running pulse
 
+### Requirement: The conversation-list running indicator SHALL agree with the composer's Interrupt control
+
+The daemon conversation-list row's live status indicator (running / interrupted / error / idle) SHALL be derived from the SAME set of executions that the conversation's composer resolves for its Interrupt control — i.e. the origin-connection slice PREFERRED, with a fallback to every other connection slice when the origin slice has no execution matching this conversation. The match SHALL be strictly by this conversation's own idea anchor (`directIdeaUuid`, or the `::`-prefix heal for a legacy residual session) or its `daemon_session:<sessionId>` id, so a cross-connection match still belongs to this conversation only and SHALL NOT borrow another conversation's execution. As a result, the list row's indicator and the composer's Interrupt control SHALL never disagree: whenever the composer can offer Interrupt for a running turn, the list row SHALL show the running indicator, including after a `cwd`/agent switch or a session re-point that moved the running turn to a connection other than the conversation's origin.
+
+#### Scenario: Running turn on the origin connection lights the row
+
+- **GIVEN** an open agent's conversation whose running `DaemonExecution` is on the conversation's own origin connection
+- **WHEN** the conversation list renders that row
+- **THEN** the row's status indicator MUST read `running`
+
+#### Scenario: Running turn on a non-origin connection still lights the row
+
+- **GIVEN** a conversation whose origin-connection slice has NO matching execution but whose idea's running `DaemonExecution` lives on a DIFFERENT connection of the agent (after a cwd/agent switch or a session re-point)
+- **WHEN** the conversation list renders that row
+- **THEN** the row's status indicator MUST read `running` (agreeing with the composer's Interrupt control), NOT idle
+
+#### Scenario: The row never borrows an unrelated conversation's run
+
+- **GIVEN** another conversation's running `DaemonExecution` on a different connection, with no execution matching THIS conversation on any connection
+- **WHEN** the conversation list renders THIS conversation's row
+- **THEN** the row's status indicator MUST read idle (null) — the unrelated run MUST NOT be borrowed
+
+#### Scenario: A user-interrupt on the fallback connection is reflected
+
+- **GIVEN** a conversation whose origin slice has no match but whose matching execution on another connection is `interrupted` with reason `user`
+- **WHEN** the conversation list renders that row
+- **THEN** the row's status indicator MUST read `interrupted` (resumable); a crash-interrupt MUST read `error`
+

--- a/openspec/specs/root-idea-resolution/spec.md
+++ b/openspec/specs/root-idea-resolution/spec.md
@@ -177,3 +177,24 @@ exactly one idea node, `directIdeaUuid` SHALL equal `rootIdeaUuid`.
   `ambiguous` and `candidates` carry exactly the values they did before this field was
   added — `directIdeaUuid` adds information without altering them
 
+### Requirement: The daemon lineage resolver SHALL emit a visible warning when a root idea resolves with no direct idea
+
+When the daemon's lineage resolver resolves an entity against `GET /api/entities/{type}/{uuid}/root-idea` and receives a NON-NULL `rootIdeaUuid` together with a NULL or absent `directIdeaUuid`, it SHALL emit a `warn`-level log line that names the entity (`{type}:{uuid}`), states the consequence (the wake will anchor on the entity rather than the idea conversation, so its run will not surface a running indicator / Interrupt on the idea chat), and names the most likely cause (a Chorus server predating the `directIdeaUuid` field on the `/root-idea` endpoint). This warning is diagnostic ONLY: the resolver SHALL still return `{ rootIdeaUuid, directIdeaUuid }` exactly as resolved and SHALL NOT substitute the root idea for the missing direct idea (no client-side fallback). The normal outcome where the entity legitimately has NO idea ancestor (`rootIdeaUuid` is null) SHALL NOT emit this warning — it stays a non-alarming `info`.
+
+#### Scenario: Non-null root with null direct idea warns
+
+- **WHEN** the resolver receives `{ rootIdeaUuid: <non-null>, directIdeaUuid: null }` (or `directIdeaUuid` absent) for an idea-attributable entity
+- **THEN** it MUST emit a `warn` naming the entity and mentioning `directIdeaUuid`
+- **AND** it MUST still return the resolved `rootIdeaUuid` with `directIdeaUuid: null` — no fallback substitution
+
+#### Scenario: No idea ancestor does not warn
+
+- **WHEN** the resolver receives `{ rootIdeaUuid: null, directIdeaUuid: null }` (the entity has no idea lineage)
+- **THEN** it MUST NOT emit the missing-direct-idea warning
+- **AND** it MUST still emit its normal success `info` line
+
+#### Scenario: Both ids present does not warn
+
+- **WHEN** the resolver receives a non-null `rootIdeaUuid` and a non-null `directIdeaUuid`
+- **THEN** it MUST NOT emit the missing-direct-idea warning
+

--- a/src/components/agent-presence/chat/__tests__/session-execution.test.ts
+++ b/src/components/agent-presence/chat/__tests__/session-execution.test.ts
@@ -1,0 +1,133 @@
+// Unit tests for the per-conversation execution matching helpers, focused on
+// `sessionExecStatusForRow` — the conversation-LIST row status that must agree with
+// the composer's Interrupt control (origin slice preferred, all-slice fallback,
+// strict per-conversation match, no cross-borrow).
+
+import { describe, it, expect } from "vitest";
+import type { ExecutionView } from "@/services/daemon-execution.service";
+import {
+  sessionExecStatus,
+  sessionExecStatusForRow,
+  sessionExecutionsForComposer,
+} from "../session-execution";
+
+// Minimal ExecutionView factory — only the fields the matchers read matter; the rest
+// are filled with inert defaults so the object satisfies the type.
+function exec(over: Partial<ExecutionView> & { connectionUuid: string }): ExecutionView {
+  return {
+    uuid: `exec-${Math.random().toString(36).slice(2)}`,
+    agentUuid: "agent-1",
+    entityType: "idea",
+    entityUuid: "idea-A",
+    rootIdeaUuid: null,
+    directIdeaUuid: "idea-A",
+    status: "running",
+    interruptedReason: null,
+    startedAt: null,
+    createdAt: "2026-07-18T00:00:00.000Z",
+    updatedAt: "2026-07-18T00:00:00.000Z",
+    entityTitle: null,
+    projectUuid: null,
+    rootIdeaTitle: null,
+    ...over,
+  };
+}
+
+const ideaSession = {
+  sessionId: "idea-A",
+  directIdeaUuid: "idea-A",
+  originConnectionUuid: "conn-origin",
+};
+
+describe("sessionExecStatusForRow", () => {
+  it("reads a running execution on the conversation's own origin connection (parity with the old behavior)", () => {
+    const byConn: Record<string, ExecutionView[]> = {
+      "conn-origin": [exec({ connectionUuid: "conn-origin", entityType: "idea", entityUuid: "idea-A", status: "running" })],
+    };
+    expect(sessionExecStatusForRow(byConn, ideaSession)).toBe("running");
+  });
+
+  it("lights the row when the running execution lives on a NON-origin connection (the fix)", () => {
+    // Origin slice has nothing; the idea's running turn is on another connection
+    // (a re-point / agent switch). The OLD row logic (origin-only) returned null here.
+    const byConn: Record<string, ExecutionView[]> = {
+      "conn-origin": [],
+      "conn-other": [exec({ connectionUuid: "conn-other", entityType: "idea", entityUuid: "idea-A", status: "running" })],
+    };
+    expect(sessionExecStatusForRow(byConn, ideaSession)).toBe("running");
+    // Prove the divergence the fix removes: the old origin-only read is idle.
+    expect(sessionExecStatus(byConn["conn-origin"], ideaSession)).toBeNull();
+  });
+
+  it("never borrows an unrelated conversation's execution on another connection", () => {
+    const byConn: Record<string, ExecutionView[]> = {
+      "conn-origin": [],
+      "conn-other": [exec({ connectionUuid: "conn-other", entityType: "idea", entityUuid: "idea-OTHER", directIdeaUuid: "idea-OTHER", status: "running" })],
+    };
+    expect(sessionExecStatusForRow(byConn, ideaSession)).toBeNull();
+  });
+
+  it("reflects a user-interrupt found on the fallback connection as 'interrupted' (resumable)", () => {
+    const byConn: Record<string, ExecutionView[]> = {
+      "conn-origin": [],
+      "conn-other": [
+        exec({
+          connectionUuid: "conn-other",
+          entityType: "idea",
+          entityUuid: "idea-A",
+          status: "interrupted",
+          interruptedReason: "user",
+        }),
+      ],
+    };
+    expect(sessionExecStatusForRow(byConn, ideaSession)).toBe("interrupted");
+  });
+
+  it("reflects a crash-interrupt on the fallback connection as 'error'", () => {
+    const byConn: Record<string, ExecutionView[]> = {
+      "conn-origin": [],
+      "conn-other": [
+        exec({
+          connectionUuid: "conn-other",
+          entityType: "idea",
+          entityUuid: "idea-A",
+          status: "interrupted",
+          interruptedReason: "crash",
+        }),
+      ],
+    };
+    expect(sessionExecStatusForRow(byConn, ideaSession)).toBe("error");
+  });
+
+  it("is idle (null) when no connection has any matching execution", () => {
+    const byConn: Record<string, ExecutionView[]> = { "conn-origin": [], "conn-other": [] };
+    expect(sessionExecStatusForRow(byConn, ideaSession)).toBeNull();
+  });
+
+  it("matches an ad-hoc conversation by its daemon_session id across slices", () => {
+    const adhoc = { sessionId: "sess-xyz", directIdeaUuid: null, originConnectionUuid: "conn-origin" };
+    const byConn: Record<string, ExecutionView[]> = {
+      "conn-origin": [],
+      "conn-other": [
+        exec({
+          connectionUuid: "conn-other",
+          entityType: "daemon_session",
+          entityUuid: "sess-xyz",
+          directIdeaUuid: null,
+          status: "running",
+        }),
+      ],
+    };
+    expect(sessionExecStatusForRow(byConn, adhoc)).toBe("running");
+  });
+
+  it("composes exactly the composer's matched set reduced to one status", () => {
+    // Guard the composition contract: sessionExecStatusForRow === sessionExecStatus(composer set).
+    const byConn: Record<string, ExecutionView[]> = {
+      "conn-origin": [],
+      "conn-other": [exec({ connectionUuid: "conn-other", entityType: "idea", entityUuid: "idea-A", status: "running" })],
+    };
+    const composerSet = sessionExecutionsForComposer(byConn, ideaSession);
+    expect(sessionExecStatusForRow(byConn, ideaSession)).toBe(sessionExecStatus(composerSet, ideaSession));
+  });
+});

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -53,7 +53,7 @@ import {
 import { TranscriptView } from "./transcript-view";
 import { NewConversationPane } from "./new-conversation-pane";
 import {
-  sessionExecStatus,
+  sessionExecStatusForRow,
   sessionExecutionsForComposer,
 } from "./session-execution";
 import { DaemonConnectCta } from "../daemon-connect-cta";
@@ -328,11 +328,13 @@ export function DaemonChat() {
         // An idea-anchored conversation gets a resource badge before its name; an ad-hoc
         // one (named by the human's opening message) does not.
         ideaAnchored: session.directIdeaUuid != null,
-        // This conversation's own live status from its origin connection's slice.
-        status: sessionExecStatus(
-          executionsByConnection[session.originConnectionUuid] ?? [],
-          session,
-        ),
+        // This conversation's own live status — resolved from the SAME cross-connection
+        // match the composer's Interrupt uses (origin slice preferred, all-slice fallback),
+        // so the row's dot and the composer's Interrupt button can never disagree after a
+        // cwd/agent switch or a session re-point moved the running turn off the origin
+        // connection. Matched strictly by this conversation's own idea/session id (no
+        // cross-borrow).
+        status: sessionExecStatusForRow(executionsByConnection, session),
       }));
   }, [sessions, selectedAgentUuid, executionsByConnection, conversationName]);
 

--- a/src/components/agent-presence/chat/session-execution.ts
+++ b/src/components/agent-presence/chat/session-execution.ts
@@ -110,3 +110,25 @@ export function sessionExecStatus(
   }
   return null;
 }
+
+// The conversation-LIST row's display status, resolved from the SAME cross-connection
+// execution set the composer's Interrupt control uses (`sessionExecutionsForComposer`),
+// then reduced by `sessionExecStatus`. This is what keeps the list-row running dot and
+// the composer's Interrupt button in agreement: previously the row read ONLY the origin
+// connection's slice, so after a cwd/agent switch or a session re-point (the running turn
+// living on a DIFFERENT connection) the composer could still offer Interrupt while the
+// row showed idle. Composing the two helpers means both derive from the exact same matched
+// set — with the same origin-preferred, all-slice-fallback rule and the same strict
+// direct-idea / session-id match (never the root idea, so it can't borrow another
+// conversation's run).
+//
+// The second filter inside `sessionExecStatus` (via `executionsForSession`) is idempotent
+// over an already-matched set, so this is exactly "reduce the composer's matched
+// executions to one status" — the match rule and the reduce rule each live in one place.
+export function sessionExecStatusForRow(
+  executionsByConnection: Record<string, ExecutionView[]>,
+  session: { sessionId: string; directIdeaUuid: string | null; originConnectionUuid: string },
+): SessionExecStatus {
+  const execs = sessionExecutionsForComposer(executionsByConnection, session);
+  return sessionExecStatus(execs, session);
+}


### PR DESCRIPTION
## Summary

Fixes a reported symptom — a live daemon conversation showing **no "running" indicator and no Interrupt button** — with two independent changes (Chorus idea `044692e0`).

- **P0 (UI bug).** The conversation-list running dot read only the origin-connection execution slice (`daemon-chat.tsx`), while the composer's Interrupt control searches every connection slice (`sessionExecutionsForComposer`). After a cwd/agent switch or a session re-point, the running turn lives on a different connection → the composer found it but the row did not → the dot read idle while Interrupt still worked. A new pure helper `sessionExecStatusForRow` composes `sessionExecutionsForComposer` + `sessionExecStatus`, and the list row now routes through it, so the dot and the Interrupt button derive from the same matched set and can never disagree.
- **P1 (observability).** The daemon lineage resolver (`cli/lineage.mjs`) folded the "non-null `rootIdeaUuid`, null/absent `directIdeaUuid`" case — the fingerprint of a server predating the `directIdeaUuid` field, which permanently breaks child-wake → idea-conversation matching — into a generic `info` line. It now emits a visible `warn` in that case only. Guard + log **only**: the return value is unchanged, no client-side root fallback (falling back to root would light the *parent* conversation for a derived child and re-break #428).

**Out of scope by the idea owner's explicit decision:** the between-turns idle-online state (by design — an ephemeral `claude -p` turn has no running row to interrupt between turns) and the ~15s SSE catch-up window (the 15s poll remains the safety net).

## Changed files
| File | Change |
|------|--------|
| `src/components/agent-presence/chat/session-execution.ts` | New pure helper `sessionExecStatusForRow` (P0) |
| `src/components/agent-presence/chat/daemon-chat.tsx` | List-row status routes through the new helper (P0) |
| `src/components/agent-presence/chat/__tests__/session-execution.test.ts` | New — 8 tests (P0) |
| `cli/lineage.mjs` | Visible `warn` on null `directIdeaUuid` with non-null root (P1) |
| `cli/__tests__/lineage.test.mjs` | +4 tests (P1) |
| `openspec/specs/{daemon-session-transcript-read,root-idea-resolution}/spec.md` | Cumulative spec updates (archived OpenSpec change) |
| `openspec/changes/archive/2026-07-18-fix-daemon-session-running-indicator/` | Archived OpenSpec change |

## Test plan
- [x] `pnpm test` on both affected suites → 30/30 (8 new P0 + 22 lineage incl. 4 new P1)
- [x] Pre-existing sibling suite `agent-presence/__tests__/session-execution.test.ts` → 19/19 (no regression)
- [x] `npx tsc --noEmit` → exit 0
- [x] `pnpm lint` → 0 errors (no warnings in changed files)
- [x] Independent task review (both tasks PASS) + ship-time code-review gateway (PASS, no blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)