### PR TITLE
feat(sidebar): manual "remove from recent" for quick-access recent projects

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1730,6 +1730,9 @@
     "pin": "Pin",
     "unpin": "Unpin",
     "pinProject": "Pin {name}",
-    "unpinProject": "Unpin {name}"
+    "unpinProject": "Unpin {name}",
+    "pinToSidebar": "Pin to sidebar",
+    "removeFromRecent": "Remove from recent",
+    "moreActions": "More actions for {name}"
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1730,6 +1730,9 @@
     "pin": "ピン留め",
     "unpin": "ピン留め解除",
     "pinProject": "{name} をピン留め",
-    "unpinProject": "{name} のピン留めを解除"
+    "unpinProject": "{name} のピン留めを解除",
+    "pinToSidebar": "サイドバーにピン留め",
+    "removeFromRecent": "最近から削除",
+    "moreActions": "{name} のその他の操作"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1730,6 +1730,9 @@
     "pin": "고정",
     "unpin": "고정 해제",
     "pinProject": "{name} 고정",
-    "unpinProject": "{name} 고정 해제"
+    "unpinProject": "{name} 고정 해제",
+    "pinToSidebar": "사이드바에 고정",
+    "removeFromRecent": "최근에서 제거",
+    "moreActions": "{name} 추가 작업"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1730,6 +1730,9 @@
     "pin": "置顶",
     "unpin": "取消置顶",
     "pinProject": "置顶 {name}",
-    "unpinProject": "取消置顶 {name}"
+    "unpinProject": "取消置顶 {name}",
+    "pinToSidebar": "置顶到侧边栏",
+    "removeFromRecent": "从最近移除",
+    "moreActions": "{name} 的更多操作"
   }
 }

--- a/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/README.md
+++ b/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/README.md
@@ -1,0 +1,3 @@
+# add-sidebar-remove-from-recent
+
+Manual remove-from-recent for sidebar Recent Projects via a per-row overflow menu (soft-remove)

--- a/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/design.md
+++ b/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/design.md
@@ -1,0 +1,164 @@
+# Design: Remove from recent (sidebar quick-access)
+
+## Context
+
+The parent feature (`add-sidebar-project-quick-access`) shipped these building blocks,
+all of which this change reuses:
+
+- **`ProjectVisit` model** — one row per `(user, project)` with `lastVisitedAt` and a
+  nullable `pinnedAt`. `pinnedAt != null` ⇒ pinned; `pinnedAt == null` ⇒ recent-eligible.
+- **`project-visit.service.ts`** — `recordVisit`, `pinProject`, `unpinProject`,
+  `getSidebarQuickAccess` (filter-then-cap: resolve visits against live company-scoped
+  projects, then cap recent at 5). All scoped by `companyUuid + userUuid`.
+- **REST** — `GET /api/project-visits` (aggregate), `POST /api/project-visits/visit`,
+  `PUT` + `DELETE /api/project-visits/pin`. All human-only (agent → 403).
+- **`ProjectQuickAccessProvider`** — the single source of truth mounted once at the
+  dashboard shell. `pin` / `unpin` call the pin route, which returns the **fresh
+  aggregate**, and replace state in one round-trip so every consumer re-renders with no
+  reload. `recordVisit` re-reads after posting.
+- **`SidebarProjectQuickAccess` + `QuickAccessRow`** — renders pinned rows first (filled
+  pin, always-actionable) then up to 5 recent rows (outline pin, hover/focus-revealed).
+
+## Decisions (from elaboration Round 1)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Q1 | Interaction | **⋯ overflow menu** (shadcn `DropdownMenu`) on recent rows |
+| Q2 | Semantics | **Soft-remove** — delete the `ProjectVisit` row; no `dismissedAt`, no migration |
+| Q3 | Undo toast | **None** — silent remove, no confirm dialog |
+| Q4 | Pinned rows | **Keep the direct unpin button** — only recent rows get the ⋯ menu |
+| Q5 | Mobile trigger | **⋯ always visible** on mobile (desktop hover/focus-revealed) |
+
+## Backend
+
+### Service: `forgetVisit`
+
+```ts
+// src/services/project-visit.service.ts
+/**
+ * Forget a project's visit for the user — the "remove from recent" action.
+ * Deletes the (user, project) ProjectVisit row ONLY when it is not pinned, so a
+ * pinned project's state is never lost by a remove. No-op-safe: a missing row or
+ * a pinned row deletes zero rows. Scoped by company + user.
+ */
+export async function forgetVisit(
+  companyUuid: string,
+  userUuid: string,
+  projectUuid: string,
+): Promise<void> {
+  await prisma.projectVisit.deleteMany({
+    where: { companyUuid, userUuid, projectUuid, pinnedAt: null },
+  });
+}
+```
+
+- **Pinned-guard is in the `where` clause** (`pinnedAt: null`), not a read-then-delete —
+  atomic, and matches the idempotent style of `unpinProject`.
+- Uses `deleteMany` (not `delete`) so an absent row is a zero-row no-op rather than a
+  throw — same defensive posture as `unpinProject`'s `updateMany`.
+- No `projectInCompany` pre-check needed: the `companyUuid` in the `where` already scopes
+  the delete, and deleting a non-existent row is harmless (unlike `recordVisit`/`pin`
+  which *create* rows and must reject forged UUIDs).
+
+### Route: `DELETE /api/project-visits`
+
+The bare collection route currently has only `GET`. Add a `DELETE` that mirrors the
+pin route's shape — parse + validate `projectUuid`, call `forgetVisit`, then return the
+**fresh aggregate** (`getSidebarQuickAccess`) so the provider updates in one round-trip,
+exactly like `PUT`/`DELETE /pin`.
+
+```ts
+// DELETE /api/project-visits  { projectUuid }  → { success, data:{ pinned, recent } }
+export const DELETE = withErrorHandler(async (request) => {
+  const auth = await getAuthContext(request);
+  if (!auth) return errors.unauthorized();
+  if (!isUser(auth)) return errors.forbidden("This operation requires user authentication");
+  const body = await parseBody<{ projectUuid?: string }>(request);
+  if (!body.projectUuid || body.projectUuid.trim() === "")
+    return errors.validationError({ projectUuid: "projectUuid is required" });
+  await forgetVisit(auth.companyUuid, auth.actorUuid, body.projectUuid);
+  const aggregate = await getSidebarQuickAccess(auth.companyUuid, auth.actorUuid);
+  return success(aggregate);
+});
+```
+
+**Why `DELETE /api/project-visits` (bare collection) and not a new sub-path:** the
+resource being deleted is "my visit record for this project." `DELETE` on the
+collection with a body identifying the project is consistent with how `/pin` already
+takes `{ projectUuid }` in the body for `PUT`/`DELETE`. No new folder needed.
+
+## Frontend
+
+### Provider: `remove`
+
+Add a `remove(projectUuid)` method to `ProjectQuickAccessProvider`, structured exactly
+like `unpin` — `DELETE /api/project-visits` with `{ projectUuid }`, and on success
+replace `aggregate` with the returned fresh `{ pinned, recent }`. Best-effort error
+logging via `clientLogger` (never surfaces to the user), consistent with the siblings.
+Expose it on the context value + interface.
+
+### Component: recent rows get the ⋯ menu, pinned rows unchanged
+
+`QuickAccessRow` currently renders a single pin `<Button>` for every row. Split by
+`pinnedRow`:
+
+- **Pinned row (`pinnedRow === true`):** unchanged — the existing filled-pin `<Button>`
+  that calls `onUnpin`. Always visible (it already is, via `text-primary` with no
+  `opacity-0`).
+- **Recent row (`pinnedRow === false`):** replace the outline-pin button with a shadcn
+  `DropdownMenu`:
+  - **Trigger:** a `⋯` (`MoreHorizontal` from lucide) icon `<Button variant="ghost"
+    size="icon">`. Desktop: `opacity-0 group-hover:opacity-100
+    group-focus-within:opacity-100 focus-visible:opacity-100` (same reveal as the old
+    pin button). Mobile (`mobile === true`): always visible (no `opacity-0`).
+  - **Items:** `Pin to sidebar` (calls `onPin`) and `Remove from recent` (calls
+    `onRemove`). Both with `aria-label`-friendly text; the trigger has an
+    `aria-label={t("quickAccess.moreActions", { name })}`.
+
+The `⋯` trigger and menu items must **not** be nested inside the row's `<Link>` (that
+would make the whole row a link-with-a-button-inside anti-pattern and swallow clicks).
+The current markup already places the action button as a sibling of the `<Link>`, so the
+`DropdownMenu` slots into that same sibling position — clicking the kebab opens the menu
+without navigating.
+
+Wire `onRemove={remove}` from the provider through `SidebarProjectQuickAccess` →
+`QuickAccessRow`, alongside the existing `onPin`/`onUnpin`.
+
+### i18n
+
+Add to all four locales (en / zh / ko / ja), keeping ICU parity (the
+`locale-key-parity` AST test enforces identical key sets + placeholders):
+
+| Key | en | zh | ko | ja |
+|-----|----|----|----|----|
+| `quickAccess.removeFromRecent` | Remove from recent | 从最近移除 | 최근에서 제거 | 最近から削除 |
+| `quickAccess.pinToSidebar` | Pin to sidebar | 固定到侧边栏 | 사이드바에 고정 | サイドバーに固定 |
+| `quickAccess.moreActions` | More actions for {name} | {name} 的更多操作 | {name} 추가 작업 | {name} のその他の操作 |
+
+(Existing `quickAccess.pin/unpin/pinProject/unpinProject/title` are retained; `pin` and
+`unpin` still label the pinned-row button.)
+
+## Theming
+
+`DropdownMenu` (shadcn) already uses semantic tokens (`bg-popover`, `text-popover-
+foreground`, `border`), so light + dark work with no extra classes. The `⋯` trigger
+reuses `text-muted-foreground hover:text-primary` like the pin button. No hardcoded hex.
+
+## Risks / edge cases
+
+- **Removing a project that is currently open.** Soft-remove only clears recency; the
+  user is still on the page, and the next visit-record (or navigation) re-adds it. No
+  special handling — acceptable per "zero regret" semantics.
+- **Race with visit recording.** If a remove and a `recordVisit` for the same project
+  interleave, last-writer-wins on the row; both are idempotent and the aggregate re-read
+  reflects the final state. Not a correctness problem.
+- **Pinned project via ⋯?** Not possible — pinned rows never render the menu, and
+  `forgetVisit`'s `pinnedAt: null` guard means even a forged `DELETE` on a pinned project
+  deletes nothing.
+
+## Out of scope
+
+- Hard-hide / "don't show again" (`dismissedAt`) — explicitly rejected in Q2.
+- Undo toast / confirm dialog — explicitly rejected in Q3.
+- Bulk "clear all recent" — not requested.
+- Swipe-to-remove gesture on mobile — rejected in Q5 in favor of the always-visible ⋯.

--- a/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/proposal.md
+++ b/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/proposal.md
@@ -1,0 +1,59 @@
+# Add "Remove from recent" to the sidebar Recent Projects list
+
+## Why
+
+The sidebar project quick-access region (shipped in `add-sidebar-project-quick-access`)
+maintains the **Recent Projects** list fully automatically: the top five projects by
+`lastVisitedAt`, with pinned projects excluded. The only manual control a user has over
+that list today is **pin / unpin** — there is no way to say "I don't want this project
+showing up in Recent."
+
+Users want to curate the list: drop a project they visited once by accident, or clear
+out a project they're done with, without having to pin something else to push it out.
+This change adds a lightweight, thought-through **manual remove** affordance.
+
+## What Changes
+
+- **New row action — "Remove from recent".** Each **recent (unpinned)** row gets a
+  per-row overflow menu (a `⋯` kebab) exposing `{ Pin to sidebar, Remove from recent }`.
+  The kebab replaces the always-hover-revealed pin button on recent rows only.
+- **Pinned rows are unchanged.** Pinned rows keep their existing one-tap pin (unpin)
+  button — they do NOT get the overflow menu. The two row types intentionally differ:
+  recent rows carry a menu, pinned rows carry a direct unpin toggle.
+- **Soft-remove semantics.** "Remove from recent" deletes the user's `ProjectVisit` row
+  for that project (only when it is not pinned). The project is simply forgotten from
+  recency — the next time the user visits it, it naturally returns to the recent list.
+  No permanent "hidden" state, no `dismissedAt` field, no schema migration.
+- **No undo toast, no confirm dialog.** Removal is silent — the row just disappears. The
+  safety net is the soft-remove semantics themselves (re-visiting brings it back).
+- **Mobile parity.** In the mobile drawer, the `⋯` button is always visible (desktop
+  reveals it on hover/focus), tapped to open the same menu. The pinned-row pin button is
+  likewise always visible on mobile, matching the existing behavior.
+- **New "forget visit" backend action.** A `DELETE /api/project-visits` route + a
+  `forgetVisit` service function delete the `(user, project)` visit row — gated so a
+  **pinned** project's row is never deleted. The shared quick-access provider gains a
+  `remove(projectUuid)` method that calls it and replaces state with the fresh aggregate,
+  so every surface (sidebar, `/projects` cards) stays in sync with no reload.
+
+## Capabilities
+
+- `sidebar-project-quick-access` — extended with a "Remove a project from the recent
+  list" requirement (ADDED).
+
+## Impact
+
+- **Frontend:** `src/components/sidebar-project-quick-access.tsx` (recent-row action area
+  → shadcn `DropdownMenu`; pinned rows untouched);
+  `src/contexts/project-quick-access-context.tsx` (new `remove` method); i18n keys
+  `quickAccess.removeFromRecent`, `quickAccess.pinToSidebar`, `quickAccess.moreActions`
+  added to all four locales (en / zh / ko / ja), locale-parity test must pass.
+- **Backend:** `src/app/api/project-visits/route.ts` (new `DELETE`);
+  `src/services/project-visit.service.ts` (new `forgetVisit`). No schema change — the
+  existing `ProjectVisit` model is sufficient (delete the row).
+- **Tests:** service unit tests for `forgetVisit` (pinned-guard, no-op safety,
+  company-scope); route tests for `DELETE` (200 fresh aggregate, 401, 403 agent, 422
+  missing uuid).
+- **Verification:** light + dark theme, desktop aside + mobile drawer, all four
+  combinations. design.pen per owner convention (the parent feature waived it).
+- **No breaking changes.** Pin / unpin / visit routes and the merged-list rendering are
+  preserved; this is purely additive.

--- a/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/specs/sidebar-project-quick-access/spec.md
+++ b/openspec/changes/archive/2026-07-18-add-sidebar-remove-from-recent/specs/sidebar-project-quick-access/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Remove a project from the recent list
+
+A user SHALL be able to manually remove a non-pinned project from the sidebar
+Recent Projects list. Removal is a **soft-remove**: it SHALL delete that user's
+visit record for the project (scoped by company and user) so the project is
+forgotten from recency, and the project SHALL naturally reappear in the recent
+list the next time the user visits it. Removal SHALL NOT create any permanent
+"hidden" state and SHALL NOT require a schema change. Removal SHALL apply only to
+recent (non-pinned) rows; a pinned project's visit record SHALL NEVER be deleted
+by a remove action — a pinned project is removed from the sidebar only by
+unpinning it. The remove action SHALL be silent: no confirmation dialog and no
+undo toast are shown. Removal SHALL be reflected immediately across every surface
+that renders quick-access state, with no page reload.
+
+#### Scenario: Remove a recent project from the sidebar
+
+- **WHEN** a user opens the overflow menu on a recent (non-pinned) quick-access
+  row and chooses "Remove from recent"
+- **THEN** the project's visit record for that user is deleted and the row
+  disappears from the recent list immediately, with no confirmation dialog and no
+  undo toast
+
+#### Scenario: A removed project returns on the next visit
+
+- **WHEN** a user removes a project from recent and later navigates to that
+  project again
+- **THEN** a visit is recorded and the project reappears in the recent list
+
+#### Scenario: Removing a project does not affect its pin state
+
+- **WHEN** a remove request targets a project that is currently pinned
+- **THEN** no visit record is deleted and the project remains pinned and visible
+  in the pinned portion of the sidebar
+
+#### Scenario: Remove is a human-only, company-scoped action
+
+- **WHEN** a remove request is made without user authentication, or by an agent
+  API key, or for a project outside the caller's company
+- **THEN** the request is rejected (unauthenticated → 401, agent → 403) or has no
+  effect, and no other user's or company's visit records are affected
+
+### Requirement: Per-row overflow menu for recent quick-access rows
+
+Each recent (non-pinned) quick-access row SHALL present its row actions through a
+single overflow menu (a "⋯" kebab trigger) rather than inline action icons. The
+menu SHALL offer, at minimum, "Pin to sidebar" and "Remove from recent". Pinned
+rows SHALL retain their existing one-tap pin (unpin) control and SHALL NOT use the
+overflow menu. On the desktop sidebar the overflow trigger SHALL be revealed on
+row hover or keyboard focus; in the mobile drawer it SHALL be persistently
+visible. The trigger and menu SHALL be keyboard-accessible and carry accessible
+labels, and SHALL render correctly in both light and dark themes.
+
+#### Scenario: Recent row exposes actions via the overflow menu
+
+- **WHEN** a user hovers or focuses a recent quick-access row on desktop, or views
+  the mobile drawer
+- **THEN** a "⋯" overflow trigger is available that opens a menu containing "Pin
+  to sidebar" and "Remove from recent"
+
+#### Scenario: Pinned row keeps its direct pin control
+
+- **WHEN** a quick-access row is a pinned project
+- **THEN** it shows the existing one-tap pin (unpin) button and does not show the
+  overflow menu
+
+#### Scenario: Opening the menu does not navigate
+
+- **WHEN** a user activates the "⋯" trigger on a recent row
+- **THEN** the overflow menu opens and the user is not navigated to the project
+  dashboard

--- a/openspec/specs/sidebar-project-quick-access/spec.md
+++ b/openspec/specs/sidebar-project-quick-access/spec.md
@@ -126,3 +126,74 @@ storage is unavailable.
 - **THEN** it renders with correct, readable contrast using the design-system
   tokens in all four combinations
 
+### Requirement: Remove a project from the recent list
+
+A user SHALL be able to manually remove a non-pinned project from the sidebar
+Recent Projects list. Removal is a **soft-remove**: it SHALL delete that user's
+visit record for the project (scoped by company and user) so the project is
+forgotten from recency, and the project SHALL naturally reappear in the recent
+list the next time the user visits it. Removal SHALL NOT create any permanent
+"hidden" state and SHALL NOT require a schema change. Removal SHALL apply only to
+recent (non-pinned) rows; a pinned project's visit record SHALL NEVER be deleted
+by a remove action — a pinned project is removed from the sidebar only by
+unpinning it. The remove action SHALL be silent: no confirmation dialog and no
+undo toast are shown. Removal SHALL be reflected immediately across every surface
+that renders quick-access state, with no page reload.
+
+#### Scenario: Remove a recent project from the sidebar
+
+- **WHEN** a user opens the overflow menu on a recent (non-pinned) quick-access
+  row and chooses "Remove from recent"
+- **THEN** the project's visit record for that user is deleted and the row
+  disappears from the recent list immediately, with no confirmation dialog and no
+  undo toast
+
+#### Scenario: A removed project returns on the next visit
+
+- **WHEN** a user removes a project from recent and later navigates to that
+  project again
+- **THEN** a visit is recorded and the project reappears in the recent list
+
+#### Scenario: Removing a project does not affect its pin state
+
+- **WHEN** a remove request targets a project that is currently pinned
+- **THEN** no visit record is deleted and the project remains pinned and visible
+  in the pinned portion of the sidebar
+
+#### Scenario: Remove is a human-only, company-scoped action
+
+- **WHEN** a remove request is made without user authentication, or by an agent
+  API key, or for a project outside the caller's company
+- **THEN** the request is rejected (unauthenticated → 401, agent → 403) or has no
+  effect, and no other user's or company's visit records are affected
+
+### Requirement: Per-row overflow menu for recent quick-access rows
+
+Each recent (non-pinned) quick-access row SHALL present its row actions through a
+single overflow menu (a "⋯" kebab trigger) rather than inline action icons. The
+menu SHALL offer, at minimum, "Pin to sidebar" and "Remove from recent". Pinned
+rows SHALL retain their existing one-tap pin (unpin) control and SHALL NOT use the
+overflow menu. On the desktop sidebar the overflow trigger SHALL be revealed on
+row hover or keyboard focus; in the mobile drawer it SHALL be persistently
+visible. The trigger and menu SHALL be keyboard-accessible and carry accessible
+labels, and SHALL render correctly in both light and dark themes.
+
+#### Scenario: Recent row exposes actions via the overflow menu
+
+- **WHEN** a user hovers or focuses a recent quick-access row on desktop, or views
+  the mobile drawer
+- **THEN** a "⋯" overflow trigger is available that opens a menu containing "Pin
+  to sidebar" and "Remove from recent"
+
+#### Scenario: Pinned row keeps its direct pin control
+
+- **WHEN** a quick-access row is a pinned project
+- **THEN** it shows the existing one-tap pin (unpin) button and does not show the
+  overflow menu
+
+#### Scenario: Opening the menu does not navigate
+
+- **WHEN** a user activates the "⋯" trigger on a recent row
+- **THEN** the overflow menu opens and the user is not navigated to the project
+  dashboard
+

--- a/src/app/api/project-visits/__tests__/route.test.ts
+++ b/src/app/api/project-visits/__tests__/route.test.ts
@@ -7,6 +7,7 @@ const mockGetSidebarQuickAccess = vi.fn();
 const mockRecordVisit = vi.fn();
 const mockPinProject = vi.fn();
 const mockUnpinProject = vi.fn();
+const mockForgetVisit = vi.fn();
 
 vi.mock("@/lib/auth", async () => {
   const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
@@ -21,9 +22,10 @@ vi.mock("@/services/project-visit.service", () => ({
   recordVisit: (...args: unknown[]) => mockRecordVisit(...args),
   pinProject: (...args: unknown[]) => mockPinProject(...args),
   unpinProject: (...args: unknown[]) => mockUnpinProject(...args),
+  forgetVisit: (...args: unknown[]) => mockForgetVisit(...args),
 }));
 
-import { GET } from "@/app/api/project-visits/route";
+import { GET, DELETE as DELETE_VISIT } from "@/app/api/project-visits/route";
 import { POST } from "@/app/api/project-visits/visit/route";
 import { PUT, DELETE } from "@/app/api/project-visits/pin/route";
 
@@ -65,6 +67,7 @@ beforeEach(() => {
   mockRecordVisit.mockResolvedValue(undefined);
   mockPinProject.mockResolvedValue(undefined);
   mockUnpinProject.mockResolvedValue(undefined);
+  mockForgetVisit.mockResolvedValue(undefined);
 });
 
 describe("GET /api/project-visits", () => {
@@ -205,5 +208,48 @@ describe("DELETE /api/project-visits/pin", () => {
     const res = await DELETE(req("DELETE", "/api/project-visits/pin", {}), emptyCtx);
     expect(res.status).toBe(422);
     expect(mockUnpinProject).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/project-visits (forget visit — remove from recent)", () => {
+  it("forgets the visit and returns the fresh aggregate", async () => {
+    const res = await DELETE_VISIT(req("DELETE", "/api/project-visits", { projectUuid }), emptyCtx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual(aggregate);
+    expect(mockForgetVisit).toHaveBeenCalledWith(companyUuid, userUuid, projectUuid);
+    expect(mockGetSidebarQuickAccess).toHaveBeenCalledWith(companyUuid, userUuid);
+  });
+
+  it("401 when unauthenticated; no forget", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+    const res = await DELETE_VISIT(req("DELETE", "/api/project-visits", { projectUuid }), emptyCtx);
+    expect(res.status).toBe(401);
+    expect(mockForgetVisit).not.toHaveBeenCalled();
+  });
+
+  it("403 for an agent API key (human-only surface); no forget", async () => {
+    mockGetAuthContext.mockResolvedValue(agentAuth);
+    const res = await DELETE_VISIT(req("DELETE", "/api/project-visits", { projectUuid }), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(mockForgetVisit).not.toHaveBeenCalled();
+  });
+
+  it("422 when projectUuid is missing; no forget", async () => {
+    const res = await DELETE_VISIT(req("DELETE", "/api/project-visits", {}), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(422);
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(mockForgetVisit).not.toHaveBeenCalled();
+  });
+
+  it("422 when projectUuid is blank; no forget", async () => {
+    const res = await DELETE_VISIT(req("DELETE", "/api/project-visits", { projectUuid: "  " }), emptyCtx);
+    expect(res.status).toBe(422);
+    expect(mockForgetVisit).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/project-visits/route.ts
+++ b/src/app/api/project-visits/route.ts
@@ -1,13 +1,18 @@
 // src/app/api/project-visits/route.ts
 // Project quick-access REST surface — user-authenticated (human-only).
 // GET returns the sidebar quick-access aggregate for the signed-in user.
+// DELETE forgets a project's visit ("remove from recent") and returns the fresh
+// aggregate so the client updates in one round-trip (mirrors the /pin route).
 // UUID-Based Architecture: scoped by companyUuid + actorUuid.
 
 import { NextRequest } from "next/server";
-import { withErrorHandler } from "@/lib/api-handler";
+import { withErrorHandler, parseBody } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
 import { getAuthContext, isUser } from "@/lib/auth";
-import { getSidebarQuickAccess } from "@/services/project-visit.service";
+import {
+  getSidebarQuickAccess,
+  forgetVisit,
+} from "@/services/project-visit.service";
 
 // GET /api/project-visits — sidebar quick-access aggregate ({ pinned, recent })
 export const GET = withErrorHandler(async (request: NextRequest) => {
@@ -20,6 +25,29 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     return errors.forbidden("This operation requires user authentication");
   }
 
+  const aggregate = await getSidebarQuickAccess(auth.companyUuid, auth.actorUuid);
+  return success(aggregate);
+});
+
+// DELETE /api/project-visits — forget a project's visit ("remove from recent"),
+// return the fresh { pinned, recent } aggregate. Soft-remove: the visit row is
+// deleted only when the project is NOT pinned (guarded in the service), so the
+// project simply drops out of recent and returns on the next visit.
+export const DELETE = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) {
+    return errors.unauthorized();
+  }
+  if (!isUser(auth)) {
+    return errors.forbidden("This operation requires user authentication");
+  }
+
+  const body = await parseBody<{ projectUuid?: string }>(request);
+  if (!body.projectUuid || body.projectUuid.trim() === "") {
+    return errors.validationError({ projectUuid: "projectUuid is required" });
+  }
+
+  await forgetVisit(auth.companyUuid, auth.actorUuid, body.projectUuid);
   const aggregate = await getSidebarQuickAccess(auth.companyUuid, auth.actorUuid);
   return success(aggregate);
 });

--- a/src/components/sidebar-project-quick-access.tsx
+++ b/src/components/sidebar-project-quick-access.tsx
@@ -27,8 +27,14 @@
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { Pin, ChevronDown, ChevronRight } from "lucide-react";
+import { Pin, MoreHorizontal, ChevronDown, ChevronRight, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   useProjectQuickAccess,
   type QuickAccessProjectRef,
@@ -58,13 +64,15 @@ function QuickAccessRow({
   mobile,
   onPin,
   onUnpin,
+  onRemove,
 }: {
   project: QuickAccessProjectRef;
-  /** True when this row is a pinned project (filled marker + unpin toggle). */
+  /** True when this row is a pinned project (filled marker + direct unpin). */
   pinnedRow: boolean;
   mobile: boolean;
   onPin: (uuid: string) => void;
   onUnpin: (uuid: string) => void;
+  onRemove: (uuid: string) => void;
 }) {
   const t = useTranslations();
   const nameSize = mobile ? "text-[14px]" : "text-[13px]";
@@ -77,10 +85,16 @@ function QuickAccessRow({
     ? "h-6 w-6 rounded-md text-[9px]"
     : "h-5 w-5 rounded text-[8px]";
 
-  const handleToggle = () => {
-    if (pinnedRow) onUnpin(project.uuid);
-    else onPin(project.uuid);
-  };
+  // The action control lives OUTSIDE the <Link> (sibling), so activating it
+  // never navigates. Pinned rows keep a one-tap unpin button; recent rows get
+  // a ⋯ overflow menu ({ Pin to sidebar, Remove from recent }).
+  //
+  // Reveal rules: mobile has no hover, so the trigger is always visible there;
+  // on desktop it fades in on row hover / keyboard focus (matching the prior
+  // pin button's affordance).
+  const revealClass = mobile
+    ? ""
+    : "opacity-0 focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100";
 
   return (
     <div className="group relative flex items-center rounded-md transition-colors hover:bg-secondary">
@@ -106,24 +120,42 @@ function QuickAccessRow({
           )}
         </span>
       </Link>
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={handleToggle}
-        aria-label={
-          pinnedRow
-            ? t("quickAccess.unpinProject", { name: project.name })
-            : t("quickAccess.pinProject", { name: project.name })
-        }
-        title={pinnedRow ? t("quickAccess.unpin") : t("quickAccess.pin")}
-        className={`mr-1 h-6 w-6 shrink-0 hover:text-primary ${
-          pinnedRow
-            ? "text-primary"
-            : "text-muted-foreground opacity-0 focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
-        }`}
-      >
-        <Pin className={`h-3.5 w-3.5 ${pinnedRow ? "fill-current" : ""}`} />
-      </Button>
+
+      {pinnedRow ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => onUnpin(project.uuid)}
+          aria-label={t("quickAccess.unpinProject", { name: project.name })}
+          title={t("quickAccess.unpin")}
+          className="mr-1 h-6 w-6 shrink-0 text-primary hover:text-primary"
+        >
+          <Pin className="h-3.5 w-3.5 fill-current" />
+        </Button>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={t("quickAccess.moreActions", { name: project.name })}
+              className={`mr-1 h-6 w-6 shrink-0 text-muted-foreground hover:text-primary data-[state=open]:opacity-100 ${revealClass}`}
+            >
+              <MoreHorizontal className="h-3.5 w-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[10rem]">
+            <DropdownMenuItem onClick={() => onPin(project.uuid)}>
+              <Pin className="h-4 w-4" />
+              {t("quickAccess.pinToSidebar")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onRemove(project.uuid)}>
+              <X className="h-4 w-4" />
+              {t("quickAccess.removeFromRecent")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }
@@ -133,7 +165,7 @@ export function SidebarProjectQuickAccess({
   collapsedInProject = false,
 }: SidebarProjectQuickAccessProps) {
   const t = useTranslations();
-  const { pinned, recent, pin, unpin } = useProjectQuickAccess();
+  const { pinned, recent, pin, unpin, remove } = useProjectQuickAccess();
 
   // In-project: seed collapsed (the SSR-safe default so server/first-client
   // markup agree), then hydrate the persisted choice after mount. Global pages
@@ -198,6 +230,7 @@ export function SidebarProjectQuickAccess({
               mobile={mobile}
               onPin={pin}
               onUnpin={unpin}
+              onRemove={remove}
             />
           ))}
           {recentCapped.map((project) => (
@@ -208,6 +241,7 @@ export function SidebarProjectQuickAccess({
               mobile={mobile}
               onPin={pin}
               onUnpin={unpin}
+              onRemove={remove}
             />
           ))}
         </div>

--- a/src/contexts/project-quick-access-context.tsx
+++ b/src/contexts/project-quick-access-context.tsx
@@ -56,6 +56,12 @@ interface ProjectQuickAccessContextValue {
   pin: (projectUuid: string) => Promise<void>;
   /** Unpin a project — persists then replaces state with the fresh aggregate. */
   unpin: (projectUuid: string) => Promise<void>;
+  /**
+   * Forget a project's visit ("remove from recent") — persists then replaces
+   * state with the fresh aggregate. Soft-remove: only affects non-pinned rows
+   * (the server guards pinned rows), so the project returns on the next visit.
+   */
+  remove: (projectUuid: string) => Promise<void>;
   /** Record a visit (best-effort) then re-read the aggregate so recent updates live. */
   recordVisit: (projectUuid: string) => Promise<void>;
   /** True when the project is currently in the pinned list. */
@@ -148,6 +154,28 @@ export function ProjectQuickAccessProvider({ children }: { children: ReactNode }
     }
   }, []);
 
+  const remove = useCallback(async (projectUuid: string) => {
+    try {
+      const res = await authFetch("/api/project-visits", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectUuid }),
+      });
+      if (!res.ok) return;
+      const json = await res.json();
+      // The DELETE endpoint returns the FRESH aggregate — replace state in one
+      // round-trip so the removed row disappears from every consumer immediately.
+      if (json?.success && json.data) {
+        setAggregate({
+          pinned: json.data.pinned ?? [],
+          recent: json.data.recent ?? [],
+        });
+      }
+    } catch (error) {
+      clientLogger.error("Failed to remove project from recent:", error);
+    }
+  }, []);
+
   const recordVisit = useCallback(
     async (projectUuid: string) => {
       try {
@@ -190,10 +218,11 @@ export function ProjectQuickAccessProvider({ children }: { children: ReactNode }
       loaded,
       pin,
       unpin,
+      remove,
       recordVisit,
       isPinned,
     }),
-    [aggregate.pinned, aggregate.recent, loaded, pin, unpin, recordVisit, isPinned],
+    [aggregate.pinned, aggregate.recent, loaded, pin, unpin, remove, recordVisit, isPinned],
   );
 
   return (

--- a/src/services/__tests__/project-visit.service.test.ts
+++ b/src/services/__tests__/project-visit.service.test.ts
@@ -13,6 +13,7 @@ const mockPrisma = vi.hoisted(() => ({
     upsert: vi.fn(),
     findUnique: vi.fn(),
     updateMany: vi.fn(),
+    deleteMany: vi.fn(),
     findMany: vi.fn(),
   },
 }));
@@ -22,6 +23,7 @@ import {
   recordVisit,
   pinProject,
   unpinProject,
+  forgetVisit,
   getSidebarQuickAccess,
 } from "@/services/project-visit.service";
 
@@ -152,6 +154,40 @@ describe("unpinProject", () => {
 
     await expect(unpinProject(companyUuid, userUuid, projectUuid)).resolves.toBeUndefined();
     expect(mockPrisma.projectVisit.updateMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===== forgetVisit =====
+describe("forgetVisit", () => {
+  it("deletes the (user,project) row with a pinnedAt:null guard, scoped by company + user", async () => {
+    mockPrisma.projectVisit.deleteMany.mockResolvedValue({ count: 1 });
+
+    await forgetVisit(companyUuid, userUuid, projectUuid);
+
+    // The pinnedAt:null predicate lives in the WHERE clause — this is the
+    // pinned-guard that ensures a pinned project's row is never deleted.
+    expect(mockPrisma.projectVisit.deleteMany).toHaveBeenCalledWith({
+      where: { companyUuid, userUuid, projectUuid, pinnedAt: null },
+    });
+  });
+
+  it("does NOT delete a pinned row (pinnedAt guard ⇒ zero rows deleted)", async () => {
+    // A pinned row has pinnedAt != null, so the pinnedAt:null WHERE predicate
+    // matches nothing — the DB deletes zero rows. We assert the query is always
+    // issued with the guard so a pinned project can never be forgotten.
+    mockPrisma.projectVisit.deleteMany.mockResolvedValue({ count: 0 });
+
+    await expect(forgetVisit(companyUuid, userUuid, projectUuid)).resolves.toBeUndefined();
+    const args = mockPrisma.projectVisit.deleteMany.mock.calls[0][0];
+    expect(args.where.pinnedAt).toBeNull();
+    expect(args.where).toMatchObject({ companyUuid, userUuid, projectUuid });
+  });
+
+  it("is no-op-safe when the row is absent (deletes zero rows, does not throw)", async () => {
+    mockPrisma.projectVisit.deleteMany.mockResolvedValue({ count: 0 });
+
+    await expect(forgetVisit(companyUuid, userUuid, projectUuid)).resolves.toBeUndefined();
+    expect(mockPrisma.projectVisit.deleteMany).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/services/project-visit.service.ts
+++ b/src/services/project-visit.service.ts
@@ -100,6 +100,29 @@ export async function unpinProject(
 }
 
 /**
+ * Forget a project's visit for the user — the "remove from recent" action.
+ * Deletes the (user, project) row so the project drops out of recent; the next
+ * visit re-creates it (soft-remove: zero regret, no permanent hidden state).
+ *
+ * PINNED-GUARD: the `pinnedAt: null` predicate is in the WHERE clause, so a
+ * pinned project's row is NEVER deleted by a remove — a pinned project only
+ * leaves the sidebar via unpin. Uses `deleteMany` (not `delete`) so an absent or
+ * pinned row is a zero-row no-op rather than a throw, matching `unpinProject`'s
+ * idempotent posture. Scoped by company + user; no forged-UUID pre-check is
+ * needed because the scope predicate already bounds the delete and removing a
+ * non-existent row is harmless (unlike the create paths).
+ */
+export async function forgetVisit(
+  companyUuid: string,
+  userUuid: string,
+  projectUuid: string
+): Promise<void> {
+  await prisma.projectVisit.deleteMany({
+    where: { companyUuid, userUuid, projectUuid, pinnedAt: null },
+  });
+}
+
+/**
  * Read the sidebar quick-access aggregate for a user:
  *   - `pinned`: rows with `pinnedAt` set, ordered by pin time ascending (unlimited).
  *   - `recent`: rows with `pinnedAt` null, ordered by `lastVisitedAt` descending,


### PR DESCRIPTION
## Summary

Adds a manual **"Remove from recent"** affordance to the sidebar Recent Projects quick-access region (follow-on to PR #438). Recent (unpinned) rows now expose a shadcn `⋯` overflow menu with `{Pin to sidebar, Remove from recent}`; pinned rows keep their existing one-tap unpin button.

Removal is a **soft-remove**: it deletes the user's `ProjectVisit` row (guarded so a pinned row is never touched), so the project drops out of Recent immediately and naturally returns the next time the user visits it. No `dismissedAt` field, no schema migration, no undo toast, no confirm dialog. On mobile the `⋯` is always visible; on desktop it reveals on row hover/focus.

Derived from idea `8b4a9367` (child of the parent quick-access idea `f9d0cdb7`). Elaboration decisions: ⋯ menu (not dual icons), soft-remove (not hard-hide), no undo toast, pinned rows keep the direct unpin button, mobile ⋯ always-visible.

## Changed files

| File | Change |
|------|--------|
| `src/services/project-visit.service.ts` | New `forgetVisit()` — `deleteMany` with a `pinnedAt: null` WHERE-clause guard (pinned/forged row = zero-row no-op) |
| `src/app/api/project-visits/route.ts` | New `DELETE` — auth (401) / human-only isUser (403) / validate (422) / return fresh aggregate |
| `src/contexts/project-quick-access-context.tsx` | New provider `remove()` — DELETEs then swaps in the fresh aggregate (cross-surface, no reload) |
| `src/components/sidebar-project-quick-access.tsx` | `QuickAccessRow` branches on `pinnedRow`: recent = ⋯ `DropdownMenu` (sibling of the row `<Link>`, never navigates); pinned = unchanged unpin button |
| `messages/{en,zh,ko,ja}.json` | i18n keys `quickAccess.removeFromRecent` / `pinToSidebar` / `moreActions` |
| `src/**/__tests__/*` | +3 service tests (pinned-guard) + 5 route tests (200/401/403/422) |
| `openspec/...` | Archive of change `add-sidebar-remove-from-recent` → +2 requirements merged into the `sidebar-project-quick-access` cumulative spec |

## Test plan

- [x] `npx vitest run` — full suite 4419 passed / 16 skipped
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors
- [x] locale-parity AST test — 15/15
- [x] Service + route coverage — 100% on both touched backend files
- [x] Manual e2e (Playwright) — light + dark × desktop aside + mobile drawer: remove is instant with no reload, soft-remove returns on re-visit, pinned rows unaffected, ⋯ never navigates
- [x] Deployed to live and verified (`DELETE /api/project-visits` unauth → 401 in prod bundle)

Generated with [Claude Code](https://claude.com/claude-code)