### PR TITLE
feat(plugin): SessionStart nudges `/chorus enable openspec` when OpenSpec off

### DIFF
--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -319,6 +319,19 @@ The plugin bundles three independent **review skills**: `/proposal-reviewer`, `/
 
 Results are advisory — they do not hard-block approval, verification, or ship (the code-review gateway is behavioral — it does not change the Idea's stored status), but you should act on a FAIL by fixing the listed BLOCKERs before proceeding. For a code-review FAIL, fix it via the **quick-dev** workflow (`/quick-dev`): `chorus_create_tasks` with `proposalUuid` set to the current approved proposal so the fix tasks attach to it (do not reopen old tasks), then execute → verify and re-run.
 
+### 6. Enable OpenSpec Mode (Optional)
+
+Opt-in spec-driven path: `/proposal`, `/develop`, `/yolo` write `proposal.md` / `design.md` / spec deltas on disk and mirror them into Chorus drafts. Fully optional — free-form authoring works without it. The stage skills re-check the three activation signals inline (OpenClaw has no SessionStart hook): `CHORUS_OPENSPEC_MODE` ≠ `off`, an `openspec/` directory at the project root, and the `openspec` CLI on `PATH`.
+
+**When the user wants it on**, actually **enable it for them** — run whichever steps are missing, don't just describe them:
+
+```bash
+npm i -g @fission-ai/openspec       # 1. install the CLI if it's not on PATH (global, pure Node)
+openspec init --tools none          # 2. scaffold the openspec/ directory
+```
+
+OpenSpec has no OpenClaw integration (it's not in the `--tools` list), so `--tools none` is correct — Chorus's detection only needs the `openspec/` directory and the stage skills drive the CLI directly. There's no SessionStart banner on OpenClaw — the stage skills re-check the three signals inline, so once the directory and CLI are both present they fold in `/openspec-aware` automatically. To turn it off, set `CHORUS_OPENSPEC_MODE=off`.
+
 ---
 
 ## SSE Event-Driven Model (Bidirectional Daemon Host)

--- a/plugins/chorus/hooks/on-session-start.sh
+++ b/plugins/chorus/hooks/on-session-start.sh
@@ -37,10 +37,19 @@ CHECKIN=$("${DIR}/chorus-mcp-call.sh" chorus_checkin '{}' 2>/dev/null) || {
 # signals are present — same precedence as the original detection contract).
 # Codex doesn't expose a project-dir env var, so we use $PWD (Codex hooks
 # run from the project root).
+#
+# The inactive states split into two user-facing kinds (same as the Claude
+# Code hook, minus the plugin toggle Codex doesn't have):
+#   - OPENSPEC_OPTOUT=1 — CHORUS_OPENSPEC_MODE=off, an explicit choice. Show a
+#     neutral note, no nag.
+#   - OPENSPEC_OPTOUT=0 — OpenSpec is simply not set up. Point the user at
+#     `$chorus enable openspec`, which walks the actual install/init steps.
 PROJECT_ROOT="$PWD"
 OPENSPEC_HINT=""
+OPENSPEC_OPTOUT=0
 if [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
   CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_OPTOUT=1
   OPENSPEC_REASON="CHORUS_OPENSPEC_MODE=off (explicit opt-out)"
 elif [ ! -d "${PROJECT_ROOT}/openspec" ]; then
   CHORUS_OPENSPEC_ACTIVE=0
@@ -76,10 +85,18 @@ else
   CTX="${CTX}
 
 OpenSpec mode is **inactive** for this session. The proposal / develop / yolo skills follow their free-form path; do NOT scaffold \`openspec/changes/\`, do NOT add an \`OpenSpec change slug:\` line to proposal descriptions, and do NOT route document mirror calls through \`chorus-mcp-call.sh\`."
-  if [ -n "$OPENSPEC_HINT" ]; then
+  if [ "$OPENSPEC_OPTOUT" = "1" ]; then
     CTX="${CTX}
 
-Note: this repo has an \`openspec/\` directory, so the user likely intends to use OpenSpec mode but the \`openspec\` CLI is not installed. Surface this to the user (e.g. \"This repo is OpenSpec-init'd but the \\\`openspec\\\` CLI isn't installed locally — ${OPENSPEC_HINT}\") before authoring documents so they can install it and re-launch the session if they want spec-driven mode."
+OpenSpec was **explicitly turned off** (${OPENSPEC_REASON}), so this is a deliberate choice — do NOT nag the user to enable it. If they ask to turn it back on, point them at unsetting \`CHORUS_OPENSPEC_MODE\`, then the OpenSpec setup section in the \`\$chorus\` skill."
+  elif [ -n "$OPENSPEC_HINT" ]; then
+    CTX="${CTX}
+
+Note: this repo has an \`openspec/\` directory, so the user likely intends to use OpenSpec mode but the \`openspec\` CLI is not installed. Surface this to the user (e.g. \"This repo is OpenSpec-init'd but the \\\`openspec\\\` CLI isn't installed locally — ${OPENSPEC_HINT}\") before authoring documents. To set it up, run \`\$chorus enable openspec\` (§6 walks the install + restart)."
+  else
+    CTX="${CTX}
+
+Note: OpenSpec is not set up in this repo (${OPENSPEC_REASON}). Spec-driven authoring is optional — free-form works fine. If the user wants spec-driven mode (proposal.md / design.md / spec deltas mirrored into Chorus), run \`\$chorus enable openspec\` — §6 walks the \`npm i -g @fission-ai/openspec\` + \`openspec init\` steps and the restart."
   fi
 fi
 
@@ -92,11 +109,17 @@ CTX="${CTX}
 - **Skills**: use \`\$chorus\`, \`\$idea\`, \`\$proposal\`, \`\$develop\`, \`\$review\`, \`\$quick-dev\`, or \`\$yolo\` to load the stage-specific workflow.
 - **Reviewer sub-agents**: mount the reviewer skill into a default sub-agent — \`spawn_agent(agent_type=\"default\", items=[{type:\"skill\", path:\"chorus:chorus-proposal-reviewer\"}, {type:\"text\", text:\"Review proposal <uuid>.\"}])\` after \`chorus_pm_submit_proposal\`; same pattern with \`chorus:chorus-task-reviewer\` after \`chorus_submit_for_verify\`. Codex 0.125 only ships three built-in roles (default / explorer / worker) — custom agent_types like \`chorus-proposal-reviewer\` will be rejected. Remember \`close_agent\` after \`wait_agent\`; completed ≠ closed, 6 concurrent max."
 
+# User-visible parens (mirrors the Claude Code hook; Codex skill prefix is $chorus):
+#   active            -> (OpenSpec Enabled)
+#   not set up        -> (OpenSpec off — run `$chorus enable openspec` to set it up)
+#   explicit opt-out  -> (OpenSpec off)  [neutral, no nag]
 USER_MSG="Chorus connected at ${CHORUS_URL}"
 if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
   USER_MSG="${USER_MSG} (OpenSpec Enabled)"
-elif [ -n "$OPENSPEC_HINT" ]; then
-  USER_MSG="${USER_MSG} (OpenSpec repo detected — ${OPENSPEC_HINT})"
+elif [ "$OPENSPEC_OPTOUT" = "1" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec off)"
+else
+  USER_MSG="${USER_MSG} (OpenSpec off — run \`\$chorus enable openspec\` to set it up)"
 fi
 
 hook_output "$USER_MSG" "$CTX" "SessionStart"

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -317,6 +317,21 @@ To disable in the Codex port, open `/hooks` and disable the matching Chorus plug
 
 When enabled, reviewers run as read-only sub-agents and post a VERDICT comment on the proposal/task/idea. Three possible outcomes: **PASS** (no issues), **PASS WITH NOTES** (minor non-blocking notes), or **FAIL** (BLOCKERs found). Results are advisory — they do not block approval, verification, or ship; the code-review gateway in particular is behavioral (it does not change the Idea's stored status). On a code-review FAIL, fix it via the **quick-dev** workflow (`$quick-dev`): `chorus_create_tasks` with `proposalUuid` set to the current approved proposal so the fix tasks attach to it, then execute → verify and re-run the gateway. Disabling reduces token usage but removes the independent quality gate.
 
+### 6. Enable OpenSpec Mode (Optional)
+
+Opt-in spec-driven path: `$proposal`, `$develop`, `$yolo` write `proposal.md` / `design.md` / spec deltas on disk and mirror them into Chorus drafts. Fully optional — free-form authoring works without it. Activates only when all three hold: `CHORUS_OPENSPEC_MODE` ≠ `off`, an `openspec/` directory exists at the project root, and the `openspec` CLI is on `PATH`.
+
+**When the user wants it on** (e.g. they ran `$chorus enable openspec` after the `(OpenSpec off — …)` banner), actually **enable it for them** — run whichever steps are missing, don't just describe them:
+
+```bash
+npm i -g @fission-ai/openspec       # 1. install the CLI if it's not on PATH (global, pure Node)
+openspec init --tools codex         # 2. scaffold openspec/ + wire up Codex's native commands/skills
+```
+
+`openspec init` is interactive if you omit `--tools`; pass `--tools codex` to run it unattended. Chorus's detection only needs the `openspec/` directory, but wiring up Codex also gives OpenSpec its own commands + skills. The OpenSpec signal is read **once at SessionStart**, so it can't flip mid-session — after the steps succeed, tell the user to **restart Codex**; the banner then reads `(OpenSpec Enabled)` and the stage skills fold in the `openspec-aware` skill automatically.
+
+To turn it off, set `CHORUS_OPENSPEC_MODE=off` — the banner then reads a neutral `(OpenSpec off)`.
+
 ---
 
 ## Execution Rules

--- a/public/chorus-plugin/bin/on-session-start.sh
+++ b/public/chorus-plugin/bin/on-session-start.sh
@@ -71,13 +71,23 @@ fi
 # When the folder is present but the CLI is missing, surface that as a
 # specific reason so the user-visible toast can hint at the install step
 # instead of silently falling back.
+#
+# The inactive states split into two user-facing kinds:
+#   - OPENSPEC_OPTOUT=1 — the user explicitly turned OpenSpec off (plugin
+#     toggle or env var). Respect it: show a neutral note, no nag.
+#   - OPENSPEC_OPTOUT=0 — OpenSpec is simply not set up (no folder, or folder
+#     without the CLI). Point the user at `/chorus enable openspec`, which walks
+#     the actual install/init steps — the banner stays a one-liner.
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 OPENSPEC_HINT=""
+OPENSPEC_OPTOUT=0
 if [ "${CLAUDE_PLUGIN_OPTION_ENABLEOPENSPEC:-true}" != "true" ]; then
   CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_OPTOUT=1
   OPENSPEC_REASON="enableOpenSpec userConfig=false (plugin-level opt-out)"
 elif [ "${CHORUS_OPENSPEC_MODE:-}" = "off" ]; then
   CHORUS_OPENSPEC_ACTIVE=0
+  OPENSPEC_OPTOUT=1
   OPENSPEC_REASON="CHORUS_OPENSPEC_MODE=off (explicit opt-out)"
 elif [ ! -d "${PROJECT_ROOT}/openspec" ]; then
   CHORUS_OPENSPEC_ACTIVE=0
@@ -114,10 +124,18 @@ else
   CONTEXT="${CONTEXT}
 
 OpenSpec mode is **inactive** for this session. The proposal / develop / yolo skills follow their free-form path; do NOT scaffold \`openspec/changes/\`, do NOT add an \`OpenSpec change slug:\` line to proposal descriptions, and do NOT route document mirror calls through \`chorus-api.sh\`."
-  if [ -n "$OPENSPEC_HINT" ]; then
+  if [ "$OPENSPEC_OPTOUT" = "1" ]; then
     CONTEXT="${CONTEXT}
 
-Note: this repo has an \`openspec/\` directory, so the user likely intends to use OpenSpec mode but the \`openspec\` CLI is not installed. Surface this to the user (e.g. \"This repo is OpenSpec-init'd but the \\\`openspec\\\` CLI isn't installed locally — ${OPENSPEC_HINT}\") before authoring documents so they can install it and re-launch the session if they want spec-driven mode."
+OpenSpec was **explicitly turned off** (${OPENSPEC_REASON}), so this is a deliberate choice — do NOT nag the user to enable it. If they ask to turn it back on, point them at re-enabling the plugin's \`enableOpenSpec\` toggle / unsetting \`CHORUS_OPENSPEC_MODE\`, then the OpenSpec setup section in the \`/chorus\` skill."
+  elif [ -n "$OPENSPEC_HINT" ]; then
+    CONTEXT="${CONTEXT}
+
+Note: this repo has an \`openspec/\` directory, so the user likely intends to use OpenSpec mode but the \`openspec\` CLI is not installed. Surface this to the user (e.g. \"This repo is OpenSpec-init'd but the \\\`openspec\\\` CLI isn't installed locally — ${OPENSPEC_HINT}\") before authoring documents. To set it up, run \`/chorus enable openspec\` (§6 walks the install + re-launch)."
+  else
+    CONTEXT="${CONTEXT}
+
+Note: OpenSpec is not set up in this repo (${OPENSPEC_REASON}). Spec-driven authoring is optional — free-form works fine. If the user wants spec-driven mode (proposal.md / design.md / spec deltas mirrored into Chorus), run \`/chorus enable openspec\` — §6 walks the \`npm i -g @fission-ai/openspec\` + \`openspec init\` steps and the re-launch."
   fi
 fi
 
@@ -139,12 +157,18 @@ Resuming with existing Chorus session: ${MAIN_SESSION}"
   "$API" mcp-tool "chorus_session_heartbeat" "$(printf '{"sessionUuid":"%s"}' "$MAIN_SESSION")" >/dev/null 2>&1 || true
 fi
 
-# Build user-visible message
+# Build user-visible message. When OpenSpec is off-but-enable-able, point the
+# user at `/chorus enable openspec` — the skill walks the actual install/init.
+#   active            -> (OpenSpec Enabled)
+#   not set up        -> (OpenSpec off — run `/chorus enable openspec` to set it up)
+#   explicit opt-out  -> (OpenSpec off)  [neutral, no nag — respects the choice]
 USER_MSG="Chorus connected at ${CHORUS_URL}"
 if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
   USER_MSG="${USER_MSG} (OpenSpec Enabled)"
-elif [ -n "$OPENSPEC_HINT" ]; then
-  USER_MSG="${USER_MSG} (OpenSpec repo detected — ${OPENSPEC_HINT})"
+elif [ "$OPENSPEC_OPTOUT" = "1" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec off)"
+else
+  USER_MSG="${USER_MSG} (OpenSpec off — run \`/chorus enable openspec\` to set it up)"
 fi
 if [ -n "$MAIN_SESSION" ]; then
   USER_MSG="${USER_MSG} (resumed session)"

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -342,6 +342,21 @@ To disable, reconfigure the plugin via `/plugin` settings or manually edit `~/.c
 
 When enabled, reviewers run as read-only sub-agents and post a VERDICT comment on the proposal/task/idea. Three possible outcomes: **PASS** (no issues), **PASS WITH NOTES** (minor non-blocking notes), or **FAIL** (BLOCKERs found). Results are advisory — they do not block approval, verification, or ship; the code-review gateway in particular is behavioral (it does not change the Idea's stored status). On a code-review FAIL, fix it via the `/chorus:quick-dev` workflow: `chorus_create_tasks` with `proposalUuid` set to the current approved proposal so the fix tasks attach to it, then execute → verify and re-run the gateway. Disabling reduces token usage but removes the independent quality gate.
 
+### 6. Enable OpenSpec Mode (Optional)
+
+Opt-in spec-driven path: `/proposal`, `/develop`, `/yolo` write `proposal.md` / `design.md` / spec deltas on disk and mirror them into Chorus drafts. Fully optional — free-form authoring works without it. Activates only when all three hold: the `enableOpenSpec` toggle is on (default) and `CHORUS_OPENSPEC_MODE` ≠ `off`, an `openspec/` directory exists at the project root, and the `openspec` CLI is on `PATH`.
+
+**When the user wants it on** (e.g. they ran `/chorus enable openspec` after the `(OpenSpec off — …)` banner), actually **enable it for them** — run whichever steps are missing, don't just describe them:
+
+```bash
+npm i -g @fission-ai/openspec       # 1. install the CLI if it's not on PATH (global, pure Node)
+openspec init --tools claude        # 2. scaffold openspec/ + wire up Claude Code's native commands/skills
+```
+
+`openspec init` is interactive if you omit `--tools`; pass `--tools claude` to run it unattended. Chorus's detection only needs the `openspec/` directory, but wiring up Claude Code also gives OpenSpec its own commands + skills. The OpenSpec signal is read **once at SessionStart**, so it can't flip mid-session — after the steps succeed, tell the user to **re-launch the session**; the banner then reads `(OpenSpec Enabled)` and the stage skills fold in the `openspec-aware` skill automatically.
+
+To turn it off, flip `enableOpenSpec` to `false` or set `CHORUS_OPENSPEC_MODE=off` — the banner then reads a neutral `(OpenSpec off)`.
+
 ---
 
 ## Execution Rules

--- a/public/kiro-plugin/.kiro/steering/chorus.md
+++ b/public/kiro-plugin/.kiro/steering/chorus.md
@@ -320,6 +320,19 @@ The plugin ships three read-only reviewer subagents (`chorus-code-reviewer`, `ch
 
 Reviewers post a VERDICT comment with one of three outcomes: **PASS** (no issues), **PASS WITH NOTES** (minor non-blocking notes), or **FAIL** (BLOCKERs found). Results are advisory — they do not block approval, verification, or ship; the code-review gateway in particular is behavioral (it does not change the Idea's stored status). On a code-review FAIL, fix it via the `/chorus-quick-dev` workflow: `chorus_create_tasks` with `proposalUuid` set to the current approved proposal so the fix tasks attach to it, then execute → verify and re-run the gateway.
 
+### 6. Enable OpenSpec Mode (Optional)
+
+Opt-in spec-driven path: `/chorus-proposal`, `/chorus-develop`, `/chorus-yolo` write `proposal.md` / `design.md` / spec deltas on disk and mirror them into Chorus drafts. Fully optional — free-form authoring works without it. The stage skills re-check the three activation signals inline (the Kiro spawn hook shows no OpenSpec banner): `CHORUS_OPENSPEC_MODE` ≠ `off`, an `openspec/` directory at the project root, and the `openspec` CLI on `PATH`.
+
+**When the user wants it on**, actually **enable it for them** — run whichever steps are missing, don't just describe them:
+
+```bash
+npm i -g @fission-ai/openspec       # 1. install the CLI if it's not on PATH (global, pure Node)
+openspec init --tools kiro          # 2. scaffold openspec/ + wire up Kiro's native integration
+```
+
+`openspec init` is interactive if you omit `--tools`; pass `--tools kiro` to run it unattended. Chorus's detection only needs the `openspec/` directory, but wiring up Kiro also gives OpenSpec its own integration. There's no SessionStart banner on Kiro — the stage skills re-check the three signals inline, so once the directory and CLI are both present they fold in `/chorus-openspec-aware` automatically (no re-launch needed). To turn it off, set `CHORUS_OPENSPEC_MODE=off`.
+
 ---
 
 ## Execution Rules


### PR DESCRIPTION
## Summary

When OpenSpec mode is inactive because it's simply **not set up** (no `openspec/` directory, or the directory exists but the `openspec` CLI isn't on `PATH`), the SessionStart banner previously showed nothing in the parens — the user had no signal that spec-driven mode was available or how to enable it.

Now the banner carries a single actionable directive, and the actual install/init steps live in the `/chorus` skill (not stuffed into the hook).

**Banner (both Claude Code + Codex hooks):**
| State | Parens |
|---|---|
| Active | `(OpenSpec Enabled)` — unchanged |
| Not set up (no dir, or dir-but-no-CLI) | `` (OpenSpec off — run `/chorus enable openspec` to set it up) `` — `$chorus` on Codex |
| Explicit opt-out (`enableOpenSpec=false` / `CHORUS_OPENSPEC_MODE=off`) | `(OpenSpec off)` — neutral, **no nag** |

**Skill (`### 6. Enable OpenSpec Mode`, all 4 surfaces):** instructs the agent to actually run `npm i -g @fission-ai/openspec` + `openspec init --tools <surface>` for the user, then re-launch so the once-per-startup detection picks it up. The matching `--tools` value (`claude` / `codex` / `kiro`) both skips `openspec init`'s interactive prompt and wires up that agent's native OpenSpec commands/skills. OpenClaw uses `--tools none` — OpenSpec has no OpenClaw integration.

## Changed files

| File | Change |
|------|--------|
| `public/chorus-plugin/bin/on-session-start.sh` | CC hook: opt-out vs not-set-up split; banner directive |
| `plugins/chorus/hooks/on-session-start.sh` | Codex hook: same, `$chorus` prefix |
| `public/chorus-plugin/skills/chorus/SKILL.md` | §6 enable-OpenSpec section (Claude Code) |
| `plugins/chorus/skills/chorus/SKILL.md` | §6 (Codex) |
| `public/kiro-plugin/.kiro/steering/chorus.md` | §6 (Kiro) |
| `packages/openclaw-plugin/skills/chorus/SKILL.md` | §6 (OpenClaw) |

Standalone `public/skill/` bundle intentionally untouched (no SessionStart hook, ships no OpenSpec content). No version bump (0.14.2 unreleased).

## Test plan

- [x] Ran both hooks end-to-end (real MCP checkin) across all states: active → `(OpenSpec Enabled)`; opt-out (toggle + env) → `(OpenSpec off)`; not-set-up + repo-no-CLI → the enable directive
- [x] Active-branch `additionalContext` confirmed byte-identical (no regression)
- [x] `bash public/chorus-plugin/bin/test-syntax.sh` → 15 passed, 0 failed (Bash 3.2 clean); Codex hook `bash -n` OK
- [x] `openspec init` behavior validated against the real CLI (interactive; `--tools <name>` non-interactive; `--tools none` = bare `openspec/` dir)
- [x] §6 present on all 4 surfaces with per-surface command prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)