### PR TITLE
fix(daemon): recover idle-session transcript relay + surface upload failures (#444)

### DIFF
--- a/cli/__tests__/daemon-rest-client.test.mjs
+++ b/cli/__tests__/daemon-rest-client.test.mjs
@@ -71,6 +71,27 @@ describe("createDaemonRestClient — payload shapes (single source of truth)", (
     expect(body).not.toHaveProperty("entityType");
   });
 
+  it("turnAdvance sends transcriptRelayError on the wire when set (fix #444 follow-up)", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+
+    await client.turnAdvance({
+      sessionId: "idea-1",
+      status: "ended",
+      transcriptRelayError: "transcript upload returned 502",
+    });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.transcriptRelayError).toBe("transcript upload returned 502");
+  });
+
+  it("turnAdvance omits transcriptRelayError when falsy (clean relay)", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+
+    await client.turnAdvance({ sessionId: "idea-1", status: "ended", transcriptRelayError: null });
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).not.toHaveProperty("transcriptRelayError");
+  });
+
   it("transcript POSTs { sessionId, messages } and needs no connectionUuid", async () => {
     const fetchImpl = okFetch();
     // No getConnectionUuid wired — transcript must still POST (agent key + sessionId

--- a/cli/__tests__/transcript-upload-hooks.test.mjs
+++ b/cli/__tests__/transcript-upload-hooks.test.mjs
@@ -434,27 +434,276 @@ describe("createTranscriptUploadHooks — warn-not-throw (fire-and-forget)", () 
     expect(warns.join("")).toMatch(/transcript upload returned 404/);
   });
 
-  it("an upload failure does not wedge the chain — a later batch still posts", async () => {
+  it("a permanently failing batch does not wedge the chain — a later batch still posts", async () => {
     let call = 0;
     const posts = [];
+    // First batch fails EVERY retry attempt (3), so it is dropped; later calls succeed.
     const fetchImpl = vi.fn(async (url, init) => {
       call += 1;
-      if (call === 1) throw new Error("boom");
+      if (call <= 3) throw new Error("boom");
       posts.push(JSON.parse(init.body));
       return { ok: true, status: 200, async json() { return {}; } };
     });
-    const hooks = createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl });
+    // retryBackoffMs: 0 keeps the test fast under fake timers.
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      retryBackoffMs: 0,
+    });
 
     await hooks.onSessionStart({ sessionId: SID, isNew: true });
     await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
     await vi.runAllTimersAsync();
-    // Second turn/batch after the first failed.
+    // Second turn/batch after the first was dropped — the chain must not be wedged.
     await hooks.onTranscriptMessage({ sessionId: SID, message: USER_TEXT_STRING });
     await vi.runAllTimersAsync();
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // batch 1: 3 failed attempts (then dropped). batch 2: 1 successful attempt.
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
     expect(posts).toHaveLength(1);
     expect(posts[0].messages).toEqual([{ role: "user", text: "Please read /etc/hostname." }]);
+  });
+});
+
+describe("createTranscriptUploadHooks — flush-on-exit (onSessionEnd, fix #444)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("onSessionEnd flushes a still-buffered batch and awaits it (no lost trailing transcript)", async () => {
+    const { posts, fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      batchDelayMs: 50,
+    });
+
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    // A trailing reply arrives; the subprocess then exits WITHIN the debounce window
+    // (nothing posted yet).
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    // The waker calls onSessionEnd BEFORE advancing the turn to ended. Awaiting it must
+    // drain the buffered batch — without needing the debounce timer to fire.
+    await hooks.onSessionEnd({ sessionId: SID });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body).toEqual({
+      sessionId: SID,
+      messages: [{ role: "assistant", text: "The hostname is `ip-172`." }],
+    });
+  });
+
+  it("onSessionEnd cancels the pending debounce timer (no duplicate POST when timers later run)", async () => {
+    const { posts, fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      batchDelayMs: 50,
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await hooks.onSessionEnd({ sessionId: SID });
+    // Any leftover debounce timer must have been cancelled by the flush.
+    await vi.runAllTimersAsync();
+    expect(posts).toHaveLength(1);
+  });
+
+  it("onSessionEnd re-affirms the session id when the stream never set one", async () => {
+    const { posts, fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl });
+    // No onSessionStart, and the message carries no session id — but the waker knows it.
+    await hooks.onTranscriptMessage({ message: ASSISTANT_TEXT });
+    await hooks.onSessionEnd({ sessionId: SID });
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.sessionId).toBe(SID);
+  });
+
+  it("onSessionEnd is a no-op (no POST) when nothing is buffered", async () => {
+    const { fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({ url: "https://c", apiKey: "k", logger: silent, fetchImpl });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    // Nothing buffered → no upload happened → no relay error to surface.
+    await expect(hooks.onSessionEnd({ sessionId: SID })).resolves.toEqual({ relayError: null });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("onSessionEnd never throws even when the flush POST fails", async () => {
+    const warns = [];
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+      retryBackoffMs: 0,
+      // Resolve the backoff synchronously — under fake timers a setTimeout-backed sleep
+      // would never fire while we await the flush chain directly (no runAllTimers here).
+      sleepImpl: () => Promise.resolve(),
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    // Never throws; resolves with the relay error (a network cause) rather than crashing.
+    const outcome = await hooks.onSessionEnd({ sessionId: SID });
+    expect(outcome.relayError).toMatch(/transcript upload request failed/i);
+    // The failure is surfaced (no silent errors) but never crashes the wake exit path.
+    expect(warns.join("")).toMatch(/transcript upload/i);
+  });
+});
+
+describe("createTranscriptUploadHooks — bounded upload retry (fix #444)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("retries a transient failure and then succeeds (no transcript lost)", async () => {
+    let call = 0;
+    const posts = [];
+    // First attempt returns a transient 502; the retry succeeds.
+    const fetchImpl = vi.fn(async (url, init) => {
+      call += 1;
+      if (call === 1) return { ok: false, status: 502, async json() { return {}; } };
+      posts.push(JSON.parse(init.body));
+      return { ok: true, status: 200, async json() { return {}; } };
+    });
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      retryBackoffMs: 0,
+      sleepImpl: () => Promise.resolve(),
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await hooks.onSessionEnd({ sessionId: SID });
+    expect(fetchImpl).toHaveBeenCalledTimes(2); // 1 failed + 1 retry that succeeded
+    expect(posts).toHaveLength(1);
+    expect(posts[0].messages).toEqual([{ role: "assistant", text: "The hostname is `ip-172`." }]);
+  });
+
+  it("gives up after the attempt cap and drops with a loud warn naming the message count", async () => {
+    const warns = [];
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 502, async json() { return {}; } }));
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      fetchImpl,
+      maxUploadAttempts: 3,
+      retryBackoffMs: 0,
+      sleepImpl: () => Promise.resolve(),
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: USER_TEXT_STRING });
+    await hooks.onSessionEnd({ sessionId: SID });
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // exhausted the 3-attempt budget
+    // Dropped loudly, naming how many messages were lost (the batch had 2).
+    expect(warns.join("")).toMatch(/gave up after 3 attempt\(s\).*dropping 2 message\(s\)/i);
+  });
+
+  it("maxUploadAttempts: 1 disables retry (single-shot)", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 502, async json() { return {}; } }));
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      maxUploadAttempts: 1,
+      retryBackoffMs: 0,
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await hooks.onSessionEnd({ sessionId: SID });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createTranscriptUploadHooks — onSessionEnd surfaces the relay error (fix #444 follow-up)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns the final failure reason (non-2xx status) after retries are exhausted", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 502, async json() { return {}; } }));
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      maxUploadAttempts: 3,
+      retryBackoffMs: 0,
+      sleepImpl: () => Promise.resolve(),
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    const { relayError } = await hooks.onSessionEnd({ sessionId: SID });
+    // The client's structured error carries the status so the UI can name the cause.
+    expect(relayError).toMatch(/transcript upload returned 502/i);
+  });
+
+  it("returns null when the upload succeeds (no false relay error)", async () => {
+    const { fetchImpl } = fakeServer();
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    const { relayError } = await hooks.onSessionEnd({ sessionId: SID });
+    expect(relayError).toBeNull();
+  });
+
+  it("a later successful batch CLEARS an earlier transient failure (not surfaced)", async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      // Attempt 1 fails, its retry (attempt 2) succeeds → the reply DID land.
+      if (call === 1) return { ok: false, status: 502, async json() { return {}; } };
+      return { ok: true, status: 200, async json() { return {}; } };
+    });
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      maxUploadAttempts: 3,
+      retryBackoffMs: 0,
+      sleepImpl: () => Promise.resolve(),
+    });
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    const { relayError } = await hooks.onSessionEnd({ sessionId: SID });
+    expect(relayError).toBeNull();
+  });
+
+  it("onSessionStart resets a relay error carried from a prior session", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 502, async json() { return {}; } }));
+    const hooks = createTranscriptUploadHooks({
+      url: "https://c",
+      apiKey: "k",
+      logger: silent,
+      fetchImpl,
+      maxUploadAttempts: 1,
+      retryBackoffMs: 0,
+    });
+    // First session fails.
+    await hooks.onSessionStart({ sessionId: SID, isNew: true });
+    await hooks.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    expect((await hooks.onSessionEnd({ sessionId: SID })).relayError).toMatch(/502/);
+    // A fresh session that produced NO transcript must not inherit the prior error.
+    await hooks.onSessionStart({ sessionId: "other-session", isNew: true });
+    expect((await hooks.onSessionEnd({ sessionId: "other-session" })).relayError).toBeNull();
   });
 });
 
@@ -465,6 +714,7 @@ describe("mergeUploadHooks — compose execution + transcript concerns", () => {
       ...createNoopUploadHooks(),
       onSessionStart: async () => calls.push("ts:start"),
       onTranscriptMessage: async () => calls.push("ts:msg"),
+      onSessionEnd: async () => calls.push("ts:end"),
     };
     const execution = {
       ...createNoopUploadHooks(),
@@ -474,9 +724,10 @@ describe("mergeUploadHooks — compose execution + transcript concerns", () => {
 
     await merged.onSessionStart({ sessionId: SID });
     await merged.onTranscriptMessage({ sessionId: SID, message: ASSISTANT_TEXT });
+    await merged.onSessionEnd({ sessionId: SID });
     merged.onExecutionChange();
 
-    expect(calls).toEqual(["ts:start", "ts:msg", "ex:change"]);
+    expect(calls).toEqual(["ts:start", "ts:msg", "ts:end", "ex:change"]);
   });
 
   it("a throwing delegate never breaks the others or the caller", async () => {

--- a/cli/__tests__/turn-reporter.test.mjs
+++ b/cli/__tests__/turn-reporter.test.mjs
@@ -57,6 +57,42 @@ describe("createTurnReporter", () => {
     expect(body).not.toHaveProperty("entityType");
   });
 
+  it("forwards transcriptRelayError into the POST body on a terminal edge (fix #444 follow-up)", async () => {
+    // Guards the daemon→server hop end-to-end: the reporter MUST NOT drop the relay-error
+    // field (an earlier version destructured only 5 fields, so it never reached the wire).
+    const fetchImpl = okFetch();
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: silent,
+      fetchImpl,
+    });
+
+    await advance({
+      sessionId: "idea-1",
+      status: "ended",
+      transcriptRelayError: "transcript upload returned 502",
+    });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.transcriptRelayError).toBe("transcript upload returned 502");
+  });
+
+  it("omits transcriptRelayError from the body when null/absent (clean relay)", async () => {
+    const fetchImpl = okFetch();
+    const advance = createTurnReporter({
+      url: "https://c",
+      apiKey: "cho_x",
+      getConnectionUuid: () => "conn-1",
+      logger: silent,
+      fetchImpl,
+    });
+
+    await advance({ sessionId: "idea-1", status: "ended", transcriptRelayError: null });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body).not.toHaveProperty("transcriptRelayError");
+  });
+
   it("skips (logged, no fetch) when the connection uuid is not known yet", async () => {
     const fetchImpl = okFetch();
     const warns = [];

--- a/cli/__tests__/waker-turn-lifecycle.test.mjs
+++ b/cli/__tests__/waker-turn-lifecycle.test.mjs
@@ -196,6 +196,142 @@ describe("Waker turn lifecycle (子1)", () => {
     expect(warns.join("")).toMatch(/advanceTurn failed/);
   });
 
+  it("flushes the transcript (onSessionEnd) BEFORE advancing the turn to ended (fix #444)", async () => {
+    // The order guarantee: the server attaches transcript to the RUNNING turn, so the
+    // flush must land before running→ended. We record an ordered log of both events.
+    const order = [];
+    const advanceTurn = vi.fn(async ({ status }) => {
+      order.push(`advance:${status}`);
+    });
+    const hooks = {
+      onSessionEnd: vi.fn(async ({ sessionId }) => {
+        order.push(`flush:${sessionId}`);
+      }),
+    };
+    const { waker } = makeWaker({ advanceTurn, hooks });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(hooks.onSessionEnd).toHaveBeenCalledWith({ sessionId: DIRECT_IDEA });
+    // running → flush → ended: the flush is strictly between the running and ended advances.
+    expect(order).toEqual([`advance:running`, `flush:${DIRECT_IDEA}`, "advance:ended"]);
+  });
+
+  it("flushes the transcript before advancing to interrupted on a dirty exit (fix #444)", async () => {
+    const order = [];
+    const advanceTurn = vi.fn(async ({ status }) => {
+      order.push(`advance:${status}`);
+    });
+    const hooks = { onSessionEnd: vi.fn(async () => order.push("flush")) };
+    const { waker } = makeWaker({ advanceTurn, hooks, spawner: spawnerThatSpawns(2) });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(order).toEqual(["advance:running", "flush", "advance:interrupted"]);
+  });
+
+  it("flushes the transcript during shutdown, before interrupted(shutdown) — so daemon.stop()'s queue.drain covers the flush (fix #444 AC4)", async () => {
+    // daemon.stop() interrupts each wake then awaits queue.drain(...). The flush rides the
+    // SAME exit path as the turn-advance report, so draining the wake drains the flush too.
+    // Here we prove the flush happens (before the shutdown terminal advance) when the waker
+    // is shutting down and the subprocess is killed (dirty exit).
+    const order = [];
+    const advanceTurn = vi.fn(async ({ status, interruptedReason }) => {
+      order.push(`advance:${status}${interruptedReason ? `(${interruptedReason})` : ""}`);
+    });
+    const hooks = { onSessionEnd: vi.fn(async () => order.push("flush")) };
+    const { waker } = makeWaker({ advanceTurn, hooks, spawner: spawnerThatSpawns(130) });
+    waker.shuttingDown = true;
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(hooks.onSessionEnd).toHaveBeenCalledWith({ sessionId: DIRECT_IDEA });
+    expect(order).toEqual(["advance:running", "flush", "advance:interrupted(shutdown)"]);
+  });
+
+  it("a throwing onSessionEnd never crashes the wake and still advances the turn (fix #444)", async () => {
+    const warns = [];
+    const advanceTurn = vi.fn(async () => {});
+    const hooks = {
+      onSessionEnd: vi.fn(async () => {
+        throw new Error("flush boom");
+      }),
+    };
+    const { waker } = makeWaker({
+      advanceTurn,
+      hooks,
+      logger: { ...silent, warn: (m) => warns.push(m) },
+    });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await expect(waker.wake(TASK_NOTIF, resolved.key, resolved)).resolves.toBeUndefined();
+    // The flush failure is surfaced, and the turn still reached its terminal state.
+    expect(warns.join("")).toMatch(/onSessionEnd flush failed/);
+    expect(advanceTurn.mock.calls.map((c) => c[0].status)).toEqual(["running", "ended"]);
+  });
+
+  it("threads onSessionEnd's relayError onto the ended turn-advance (fix #444 follow-up)", async () => {
+    // A clean exit whose transcript upload finally failed: the reply ran but never landed.
+    // The waker must forward the KNOWN relay error onto the (still-clean) ended advance.
+    const advanceTurn = vi.fn(async () => {});
+    const hooks = {
+      onSessionEnd: vi.fn(async () => ({ relayError: "transcript upload returned 502" })),
+    };
+    const { waker } = makeWaker({ advanceTurn, hooks });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const endedCall = advanceTurn.mock.calls.find((c) => c[0].status === "ended")[0];
+    expect(endedCall.transcriptRelayError).toBe("transcript upload returned 502");
+  });
+
+  it("threads relayError onto the interrupted edge too (a dirty exit can still lose transcript)", async () => {
+    const advanceTurn = vi.fn(async () => {});
+    const hooks = {
+      onSessionEnd: vi.fn(async () => ({ relayError: "transcript upload returned 502" })),
+    };
+    const { waker } = makeWaker({ advanceTurn, hooks, spawner: spawnerThatSpawns(2) });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const terminal = advanceTurn.mock.calls.find((c) => c[0].status === "interrupted")[0];
+    expect(terminal.transcriptRelayError).toBe("transcript upload returned 502");
+  });
+
+  it("omits transcriptRelayError from the turn-advance when the relay succeeded (null)", async () => {
+    const advanceTurn = vi.fn(async () => {});
+    const hooks = { onSessionEnd: vi.fn(async () => ({ relayError: null })) };
+    const { waker } = makeWaker({ advanceTurn, hooks });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const endedCall = advanceTurn.mock.calls.find((c) => c[0].status === "ended")[0];
+    // A clean relay leaves the field absent from the payload (not sent as null noise).
+    expect(endedCall).not.toHaveProperty("transcriptRelayError");
+  });
+
+  it("tolerates a legacy onSessionEnd that returns undefined (no relay error surfaced)", async () => {
+    const advanceTurn = vi.fn(async () => {});
+    const hooks = { onSessionEnd: vi.fn(async () => undefined) };
+    const { waker } = makeWaker({ advanceTurn, hooks });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    const endedCall = advanceTurn.mock.calls.find((c) => c[0].status === "ended")[0];
+    expect(endedCall).not.toHaveProperty("transcriptRelayError");
+  });
+
+  it("does not attempt a transcript flush when the subprocess never spawned (no sessionId turn ran)", async () => {
+    // A never-spawned wake leaves the turn pending; onSessionEnd is keyed on sessionId,
+    // which is still resolved, so the flush is harmlessly a no-op batch. Assert it does
+    // not throw and no terminal advance happens.
+    const hooks = { onSessionEnd: vi.fn(async () => {}) };
+    const { waker, advanceTurn } = makeWaker({ spawner: spawnerThatNeverSpawns(), hooks });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+    // No running turn ⇒ no ended; the flush still runs (best-effort) but advances nothing.
+    expect(advanceTurn).not.toHaveBeenCalled();
+  });
+
   it("defaults to a no-op-with-log reporter when none is injected (existing Wakers keep working)", async () => {
     const infos = [];
     // Build a Waker WITHOUT advanceTurn — the default no-op-with-log must be used.

--- a/cli/daemon-rest-client.mjs
+++ b/cli/daemon-rest-client.mjs
@@ -136,10 +136,12 @@ export function createDaemonRestClient(opts) {
      * server resolves the turn by the session BUSINESS KEY (`sessionId`); the optional
      * `entityType`/`entityUuid` stamp the weak executionUuid link. An `interrupted`
      * status may carry `interruptedReason` (`user`/`crash`/`shutdown` — the server
-     * rejects `offline`, which is its own reconcile verdict). Requires the
+     * rejects `offline`, which is its own reconcile verdict). A terminal edge may also
+     * carry `transcriptRelayError` — the daemon-known reason its transcript upload
+     * finally failed (fix #444 follow-up), persisted as a turn annotation. Requires the
      * connectionUuid (the server addresses the turn against a connection the agent owns).
      */
-    async turnAdvance({ sessionId, status, entityType, entityUuid, interruptedReason }) {
+    async turnAdvance({ sessionId, status, entityType, entityUuid, interruptedReason, transcriptRelayError }) {
       const connectionUuid = getConnectionUuid();
       if (!connectionUuid) {
         const error = `cannot advance turn for session ${sessionId} → ${status} — no connection uuid yet`;
@@ -154,6 +156,9 @@ export function createDaemonRestClient(opts) {
         ...(entityType && entityUuid ? { entityType, entityUuid } : {}),
         // Only meaningful alongside status=interrupted; never sent otherwise.
         ...(status === "interrupted" && interruptedReason ? { interruptedReason } : {}),
+        // Transcript-relay failure annotation (fix #444 follow-up): only sent when the
+        // daemon actually knows the upload failed (a truthy reason on a terminal edge).
+        ...(transcriptRelayError ? { transcriptRelayError } : {}),
       };
       return post(
         "turn-advance",

--- a/cli/turn-reporter.mjs
+++ b/cli/turn-reporter.mjs
@@ -46,7 +46,7 @@ export const TURN_INTERRUPT_REASONS = new Set(["user", "crash", "shutdown"]);
  *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
  *   fetchImpl?: typeof fetch,             Injectable for tests.
  * }} opts
- * @returns {(params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown"|null }) => Promise<void>}
+ * @returns {(params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown"|null, transcriptRelayError?: string|null }) => Promise<void>}
  */
 export function createTurnReporter(opts) {
   const logger = opts.logger ?? NOOP_LOGGER;
@@ -67,6 +67,7 @@ export function createTurnReporter(opts) {
     entityType,
     entityUuid,
     interruptedReason,
+    transcriptRelayError,
   }) {
     if (typeof sessionId !== "string" || !sessionId || !TURN_STATUSES.has(status)) {
       logger.warn(
@@ -88,9 +89,16 @@ export function createTurnReporter(opts) {
     }
     // The client resolves the connectionUuid lazily, validates it (logging
     // "no connection uuid yet" when absent), POSTs the exact server payload — sending
-    // entityType/entityUuid only when both are present — and logs the failure cause on a
-    // network error / non-2xx. We swallow the structured result so a failed report can
-    // never crash the wake path.
-    await client.turnAdvance({ sessionId, status, entityType, entityUuid, interruptedReason });
+    // entityType/entityUuid only when both are present, and transcriptRelayError only when
+    // truthy (fix #444 follow-up) — and logs the failure cause on a network error / non-2xx.
+    // We swallow the structured result so a failed report can never crash the wake path.
+    await client.turnAdvance({
+      sessionId,
+      status,
+      entityType,
+      entityUuid,
+      interruptedReason,
+      transcriptRelayError,
+    });
   };
 }

--- a/cli/upload-hooks.mjs
+++ b/cli/upload-hooks.mjs
@@ -42,6 +42,17 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
  * @property {(info: { host: string, agentUuid?: string }) => Promise<void>} onConnect
  * @property {(info: { rootIdeaKey: string, sessionId: string, isNew: boolean }) => Promise<void>} onSessionStart
  * @property {(info: { rootIdeaKey: string, sessionId: string, message: any }) => Promise<void>} onTranscriptMessage
+ * @property {(info: { sessionId: string }) => Promise<{ relayError: string|null }>} [onSessionEnd]
+ *   Fire-and-forget + await-able: the wake's subprocess has exited. FLUSH any buffered
+ *   (debounced) transcript for the session NOW and await it, so a turn's trailing
+ *   user/assistant text is persisted BEFORE the waker advances the turn to a terminal
+ *   status (fix #444 — transcript-relay flush-on-exit). Best-effort + non-throwing.
+ *   RETURNS `{ relayError }`: the final terminal upload failure reason for this session
+ *   (retry exhausted / non-2xx / network) when the reply was produced but never reached
+ *   Chorus, else `null` (a later success clears it). The waker forwards this onto the
+ *   exit-path turn-advance so the UI can say "reply couldn't be uploaded (reason)" rather
+ *   than the misleading "no reply received". No-op (`{ relayError: null }`) in the noop
+ *   hooks and in the execution-only hooks.
  * @property {() => void} [onExecutionChange]  Fire-and-forget: upload a fresh
  *   execution snapshot. The waker calls this on every lifecycle transition
  *   (enqueue / wake start / wake finish). No-op in the noop hooks.
@@ -58,6 +69,9 @@ export function createNoopUploadHooks() {
     async onConnect() {},
     async onSessionStart() {},
     async onTranscriptMessage() {},
+    async onSessionEnd() {
+      return { relayError: null };
+    },
     onExecutionChange() {},
   };
 }
@@ -87,6 +101,7 @@ export function mergeUploadHooks(...args) {
       typeof a.onConnect === "function" ||
       typeof a.onSessionStart === "function" ||
       typeof a.onTranscriptMessage === "function" ||
+      typeof a.onSessionEnd === "function" ||
       typeof a.onExecutionChange === "function";
     if (!looksLikeHooks && a.logger) {
       logger = a.logger;
@@ -96,23 +111,43 @@ export function mergeUploadHooks(...args) {
   }
 
   async function fanOutAsync(name, info) {
-    await Promise.all(
+    const results = await Promise.all(
       sets.map(async (s) => {
         const fn = s[name];
-        if (typeof fn !== "function") return;
+        if (typeof fn !== "function") return undefined;
         try {
-          await fn.call(s, info);
+          return await fn.call(s, info);
         } catch (err) {
           logger.warn(`[Chorus] ${name} hook failed: ${err}`);
+          return undefined;
         }
       })
     );
+    return results;
   }
 
   return {
-    onConnect: (info) => fanOutAsync("onConnect", info),
-    onSessionStart: (info) => fanOutAsync("onSessionStart", info),
-    onTranscriptMessage: (info) => fanOutAsync("onTranscriptMessage", info),
+    // The void-returning hooks discard the internal results array (they resolve to
+    // `undefined`, matching the single-hook contract — nothing downstream reads them).
+    onConnect: async (info) => {
+      await fanOutAsync("onConnect", info);
+    },
+    onSessionStart: async (info) => {
+      await fanOutAsync("onSessionStart", info);
+    },
+    onTranscriptMessage: async (info) => {
+      await fanOutAsync("onTranscriptMessage", info);
+    },
+    // Fan out to every set, then AGGREGATE the transcript relay outcome: the first
+    // set that reports a non-null `relayError` wins (only the transcript hook produces
+    // one; others resolve `{ relayError: null }` or undefined). The waker forwards this
+    // onto the exit-path turn-advance (fix #444 follow-up — surface a KNOWN relay drop).
+    onSessionEnd: async (info) => {
+      const results = await fanOutAsync("onSessionEnd", info);
+      const relayError =
+        results.find((r) => r && r.relayError)?.relayError ?? null;
+      return { relayError };
+    },
     onExecutionChange: () => {
       for (const s of sets) {
         if (typeof s.onExecutionChange !== "function") continue;
@@ -286,6 +321,15 @@ export function extractTranscriptText(obj) {
  *                                 (default 50ms). 0 → flush on the next microtask.
  *   setTimeoutImpl?: typeof setTimeout,  Injectable timer for tests.
  *   clearTimeoutImpl?: typeof clearTimeout,
+ *   maxUploadAttempts?: number,   Bounded retry for a failed transcript POST (transient
+ *                                 network error / non-2xx). Total attempts including the
+ *                                 first (default 3). ≤1 disables retry. fix #444 — a
+ *                                 transient Docker-proxy 502 must not silently drop a turn's
+ *                                 transcript.
+ *   retryBackoffMs?: number,      Base backoff between attempts (default 200ms); the Nth
+ *                                 retry waits `retryBackoffMs * N`.
+ *   sleepImpl?: (ms: number) => Promise<void>,  Injectable backoff sleep for tests (default
+ *                                 a real setTimeout-based delay).
  * }} opts
  * @returns {UploadHooks}
  */
@@ -294,6 +338,13 @@ export function createTranscriptUploadHooks(opts) {
   const batchDelayMs = opts.batchDelayMs ?? 50;
   const setTimeoutImpl = opts.setTimeoutImpl ?? setTimeout;
   const clearTimeoutImpl = opts.clearTimeoutImpl ?? clearTimeout;
+  // Bounded retry for a failed transcript POST (fix #444 — no more silent drops on a
+  // transient non-2xx / network blip). Retry lives HERE, in the host-side hook, NOT in
+  // the shared daemon-rest-client (which stays a single-shot transport by contract).
+  const maxUploadAttempts = Math.max(1, opts.maxUploadAttempts ?? 3);
+  const retryBackoffMs = opts.retryBackoffMs ?? 200;
+  const sleepImpl =
+    opts.sleepImpl ?? ((ms) => new Promise((resolve) => setTimeoutImpl(resolve, ms)));
   // Transport via the shared client (transcript has no connectionUuid concern — the agent
   // key + sessionId resolve the turn server-side, so getConnectionUuid is unused here).
   const client = createDaemonRestClient({
@@ -312,15 +363,50 @@ export function createTranscriptUploadHooks(opts) {
   let timer = null;
   // Serialize POSTs so an earlier batch can never land after a later one on the wire.
   let chain = Promise.resolve();
+  // The final upload failure reason for the CURRENT session's most recent batch, or null
+  // when the last upload succeeded/was skipped (fix #444 follow-up). `onSessionEnd`
+  // returns this so the waker can annotate the terminal turn with WHY its transcript is
+  // missing. Reset per session in `onSessionStart`; set only when a batch exhausts its
+  // retry budget (a transient failure that a later batch recovers is NOT surfaced).
+  let lastRelayError = null;
 
-  /** POST one batch for a session via the shared client. Never throws. */
+  /**
+   * POST one batch for a session via the shared client, with bounded retry. Never throws.
+   *
+   * The client POSTs `{ sessionId, messages }` to /api/daemon/transcript with Bearer auth
+   * and returns a structured `{ ok }` result (it logs its own request-failed / non-2xx /
+   * success lines). A transient failure (`ok === false`) is retried up to
+   * `maxUploadAttempts` total with an increasing backoff; on the final failure the batch
+   * is dropped with ONE loud warn naming the lost message count (fix #444 — a Docker-proxy
+   * 502 previously dropped the turn's transcript silently on the first try). A `skipped`
+   * result (empty batch / no session) is a success no-op, never retried.
+   */
   async function upload(sessionId, messages) {
     if (!sessionId || messages.length === 0) return;
-    // The client POSTs `{ sessionId, messages }` to /api/daemon/transcript with Bearer
-    // auth and logs "transcript upload request failed" / "transcript upload returned N"
-    // on failure (no-silent-errors) and "transcript uploaded (N msg) ..." on success. We
-    // swallow the structured result so a failed upload never breaks the wake path.
-    await client.transcript({ sessionId, messages });
+    for (let attempt = 1; attempt <= maxUploadAttempts; attempt += 1) {
+      const result = await client.transcript({ sessionId, messages });
+      // ok (2xx) or an intentional skip → done. A success CLEARS any prior relay error
+      // (a transient failure that a later batch recovered must not be surfaced as a drop).
+      if (!result || result.ok || result.skipped) {
+        lastRelayError = null;
+        return;
+      }
+      if (attempt < maxUploadAttempts) {
+        // Wait then retry — the client already logged the failure cause for this attempt.
+        await sleepImpl(retryBackoffMs * attempt);
+        continue;
+      }
+      // Exhausted the budget: drop LOUDLY (no silent errors), naming what was lost, AND
+      // record the reason so `onSessionEnd` can surface it on the turn (fix #444 follow-up).
+      // Prefer the client's structured `error` (e.g. "transcript upload returned 502");
+      // fall back to a generic phrasing so the field is never an empty string.
+      lastRelayError =
+        result.error ?? `transcript upload failed for session ${sessionId}`;
+      logger.warn(
+        `[Chorus] transcript upload gave up after ${maxUploadAttempts} attempt(s) — ` +
+          `dropping ${messages.length} message(s) for session ${sessionId}`,
+      );
+    }
   }
 
   /** Drain `pending` for `currentSessionId` into a serialized fire-and-forget POST. */
@@ -366,6 +452,9 @@ export function createTranscriptUploadHooks(opts) {
       // so its messages don't get re-tagged to the new session.
       if (currentSessionId && currentSessionId !== sessionId) flush();
       currentSessionId = sessionId || currentSessionId || null;
+      // Fresh wake → clear any relay error carried from a prior session's uploads so it
+      // can't leak onto this turn (fix #444 follow-up).
+      lastRelayError = null;
     },
     /**
      * One stream-json object. Keep only user/assistant text; queue it for a batched
@@ -386,6 +475,40 @@ export function createTranscriptUploadHooks(opts) {
       if (!extracted) return; // not a keepable conversation text message
       pending.push(extracted);
       scheduleFlush();
+    },
+    /**
+     * The wake's subprocess has exited (fix #444 — flush-on-exit). Cancel the debounce
+     * timer, drain the buffered batch onto the serialized chain NOW, and AWAIT the chain
+     * so the trailing transcript is persisted BEFORE the waker advances the turn to a
+     * terminal status. Awaiting matters: the server attaches transcript to the session's
+     * `running` turn, so the flush must land while the turn is still `running`. Best-effort
+     * + non-throwing — a flush failure is already logged inside `upload`, and we swallow
+     * anything else so a flush error never crashes the wake exit path.
+     *
+     * `sessionId` (from the caller — the waker's session anchor) re-affirms the batch's
+     * attribution in case no stream line ever set `currentSessionId` (e.g. a run that
+     * produced only a trailing message right before exit).
+     *
+     * Returns `{ relayError }`: the final terminal upload failure reason (retry exhausted)
+     * after the flush settles, or null when every batch landed. The waker forwards it onto
+     * the exit-path turn-advance so a KNOWN relay drop is surfaced on the turn (fix #444
+     * follow-up) rather than misread as "no reply received".
+     * @param {{ sessionId?: string }} info
+     * @returns {Promise<{ relayError: string|null }>}
+     */
+    async onSessionEnd({ sessionId } = {}) {
+      if (sessionId) currentSessionId = sessionId;
+      try {
+        flush();
+        // Await the serialized chain so all queued POSTs (this batch + any still in flight)
+        // settle before we return. `chain` never rejects (upload swallows), but guard anyway.
+        await chain;
+      } catch (err) {
+        logger.warn(`[Chorus] transcript flush on session end failed: ${err}`);
+      }
+      // `lastRelayError` reflects the outcome of the FINAL batch's upload (set on retry
+      // exhaustion, cleared on success) — read it AFTER the chain settles.
+      return { relayError: lastRelayError };
     },
     onExecutionChange() {},
   };

--- a/cli/upload-hooks.mjs
+++ b/cli/upload-hooks.mjs
@@ -354,6 +354,16 @@ export function createTranscriptUploadHooks(opts) {
     logger,
   });
 
+  // NOTE ON SCOPE: this instance's `currentSessionId` / `pending` / `chain` /
+  // `lastRelayError` are per-hook-instance, and the daemon builds ONE transcript-hook
+  // instance per connection (per cwd) — see daemon.mjs. The per-(agent,session) WakeQueue
+  // serializes wakes of the SAME session, but different sessions (root-idea keys) on the
+  // same cwd can run concurrently (maxConcurrency). This single-session-batching state
+  // therefore assumes at most one ACTIVE session producing transcript at a time on a given
+  // cwd, which holds for today's usage (one dispatched conversation per cwd at a time); it
+  // is NOT a general guarantee. `lastRelayError` inherits exactly this scope — no stronger,
+  // no weaker — so it is only as isolated as the batching state it rides alongside.
+  //
   // The session this batch belongs to (set by onSessionStart, and re-affirmed by each
   // message's observed session id from the stream). Messages queued for one session
   // are flushed before the session changes, so they always target the right turn.
@@ -363,11 +373,12 @@ export function createTranscriptUploadHooks(opts) {
   let timer = null;
   // Serialize POSTs so an earlier batch can never land after a later one on the wire.
   let chain = Promise.resolve();
-  // The final upload failure reason for the CURRENT session's most recent batch, or null
+  // The final upload failure reason for the current session's most recent batch, or null
   // when the last upload succeeded/was skipped (fix #444 follow-up). `onSessionEnd`
   // returns this so the waker can annotate the terminal turn with WHY its transcript is
-  // missing. Reset per session in `onSessionStart`; set only when a batch exhausts its
-  // retry budget (a transient failure that a later batch recovers is NOT surfaced).
+  // missing. Reset in `onSessionStart`; set only when a batch exhausts its retry budget
+  // (a transient failure that a later batch recovers is NOT surfaced). Its isolation is
+  // exactly the single-active-session scope described above.
   let lastRelayError = null;
 
   /**
@@ -452,8 +463,10 @@ export function createTranscriptUploadHooks(opts) {
       // so its messages don't get re-tagged to the new session.
       if (currentSessionId && currentSessionId !== sessionId) flush();
       currentSessionId = sessionId || currentSessionId || null;
-      // Fresh wake → clear any relay error carried from a prior session's uploads so it
-      // can't leak onto this turn (fix #444 follow-up).
+      // A new wake starts → clear the previous wake's relay error so a stale drop from an
+      // earlier turn isn't re-reported here (fix #444 follow-up). This is sequential-reuse
+      // hygiene; it does NOT defend against two sessions overlapping on one hook instance
+      // (see the scope note where `lastRelayError` is declared).
       lastRelayError = null;
     },
     /**

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -469,6 +469,30 @@ export class Waker {
       const wasInterrupting = entity && execKey ? this.interrupting.has(execKey) : false;
       const cleanExit = result && result.exitCode === 0;
 
+      // Transcript flush-on-exit (fix #444): the subprocess has exited, but the transcript
+      // hook batches user/assistant text on a short debounce — the LAST batch may still be
+      // buffered right now. Flush it and AWAIT it BEFORE advancing the turn to a terminal
+      // status, so the trailing reply is persisted while the turn is still `running` (the
+      // server attaches transcript to the running turn). Without this, a clean-exiting wake
+      // advanced straight to `ended` and the buffered reply was dropped → the "该回合没有
+      // 保留对话记录" empty turn in #444. Guarded + non-throwing (onSessionEnd swallows its
+      // own failures; this try is belt-and-braces) so a flush error never crashes the wake.
+      // `onSessionEnd` returns `{ relayError }` — the final transcript-upload failure
+      // reason (retry exhausted / non-2xx / network) when the reply was produced but never
+      // reached Chorus, else null. Forwarded onto the terminal turn-advance below so the UI
+      // can say "reply couldn't be uploaded (reason)" rather than the misleading "no reply
+      // received" (fix #444 follow-up). Guarded — a hook failure never crashes the exit path
+      // and simply leaves the annotation absent.
+      let transcriptRelayError = null;
+      if (sessionId) {
+        try {
+          const outcome = await this.hooks?.onSessionEnd?.({ sessionId });
+          transcriptRelayError = outcome?.relayError ?? null;
+        } catch (err) {
+          this.logger.warn(`[Chorus] onSessionEnd flush failed for ${key}: ${err}`);
+        }
+      }
+
       // Turn lifecycle: the subprocess has exited — advance the server turn from
       // `running` to its OUTCOME-AWARE terminal state (fix-daemon-exit-orphan-running-
       // turn): `ended` on a clean exit, `interrupted` with the classified reason
@@ -478,10 +502,12 @@ export class Waker {
       // rejected server-side as invalid_transition). Swallow-safe; never throws.
       if (sessionId && turnAdvancedToRunning) {
         if (cleanExit) {
-          await this.#advanceTurn(sessionId, "ended", entity);
+          // A clean exit with a KNOWN relay drop is the exact #444 signature: the reply
+          // ran but its transcript never landed. Annotate the (still-clean) `ended` turn.
+          await this.#advanceTurn(sessionId, "ended", entity, null, transcriptRelayError);
         } else {
           const reason = wasInterrupting ? "user" : this.shuttingDown ? "shutdown" : "crash";
-          await this.#advanceTurn(sessionId, "interrupted", entity, reason);
+          await this.#advanceTurn(sessionId, "interrupted", entity, reason, transcriptRelayError);
         }
       }
 
@@ -565,11 +591,16 @@ export class Waker {
    * its classified `interruptedReason` (user/crash/shutdown). Never throws into the
    * wake path — a reporter failure is logged and swallowed (the REST reporter
    * already swallows; this is belt-and-braces, matching #report).
+   *
+   * `transcriptRelayError` (fix #444 follow-up) annotates a terminal turn whose transcript
+   * upload finally failed — the reply was produced but never reached Chorus. Forwarded only
+   * when set (a clean relay leaves it null so the field stays absent from the payload).
    * @param {string} sessionId @param {"running"|"ended"|"interrupted"} status
    * @param {{ entityType: string, entityUuid: string }|null} entity
    * @param {"user"|"crash"|"shutdown"|null} [interruptedReason]
+   * @param {string|null} [transcriptRelayError]
    */
-  async #advanceTurn(sessionId, status, entity, interruptedReason = null) {
+  async #advanceTurn(sessionId, status, entity, interruptedReason = null, transcriptRelayError = null) {
     try {
       await this.advanceTurn({
         sessionId,
@@ -577,6 +608,7 @@ export class Waker {
         entityType: entity?.entityType ?? null,
         entityUuid: entity?.entityUuid ?? null,
         ...(status === "interrupted" && interruptedReason ? { interruptedReason } : {}),
+        ...(transcriptRelayError ? { transcriptRelayError } : {}),
       });
     } catch (err) {
       this.logger.warn(

--- a/messages/en.json
+++ b/messages/en.json
@@ -1513,7 +1513,6 @@
     "send": "Send",
     "instructionHint": "Press Cmd/Ctrl + Enter to send.",
     "instructionCounter": "{count} / {max}",
-    "instructionSent": "Instruction sent.",
     "instructionError": "Couldn't send the instruction. Please try again.",
     "instructionEmpty": "Type an instruction before sending.",
     "instructionTooLong": "Instruction is too long. Trim it to {max} characters or fewer.",
@@ -1571,6 +1570,8 @@
     "roleYou": "You",
     "roleAgent": "Agent",
     "turnNoMessages": "No transcript retained for this turn.",
+    "turnEndedNoReply": "No reply was received from the agent on this turn.",
+    "turnRelayFailed": "The agent replied, but the reply could not be uploaded to Chorus:",
     "privacyNote": "Transcript text is reported by the agent's daemon and may include local file paths. Only the most recent messages are kept.",
     "noAgents": {
       "title": "No conversations yet",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1513,7 +1513,6 @@
     "send": "送信",
     "instructionHint": "Cmd/Ctrl + Enter で送信します。",
     "instructionCounter": "{count} / {max}",
-    "instructionSent": "指示を送信しました。",
     "instructionError": "指示を送信できませんでした。もう一度お試しください。",
     "instructionEmpty": "送信する前に指示を入力してください。",
     "instructionTooLong": "指示が長すぎます。{max} 文字以内に収めてください。",
@@ -1571,6 +1570,8 @@
     "roleYou": "あなた",
     "roleAgent": "エージェント",
     "turnNoMessages": "このターンのトランスクリプトは保持されていません。",
+    "turnEndedNoReply": "このターンではエージェントからの返信がありませんでした。",
+    "turnRelayFailed": "エージェントは返信しましたが、返信を Chorus にアップロードできませんでした:",
     "privacyNote": "トランスクリプトのテキストはエージェントのデーモンから報告され、ローカルのファイルパスを含む場合があります。保持されるのは最新のメッセージのみです。",
     "noAgents": {
       "title": "まだ会話はありません",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1513,7 +1513,6 @@
     "send": "보내기",
     "instructionHint": "Cmd/Ctrl + Enter를 눌러 전송하세요.",
     "instructionCounter": "{count} / {max}",
-    "instructionSent": "지시가 전송되었습니다.",
     "instructionError": "지시를 전달하지 못했습니다. 다시 시도해 주세요.",
     "instructionEmpty": "전송하기 전에 지시를 입력하세요.",
     "instructionTooLong": "지시가 너무 깁니다. {max}자 이하로 줄여 주세요.",
@@ -1571,6 +1570,8 @@
     "roleYou": "회원님",
     "roleAgent": "에이전트",
     "turnNoMessages": "이 턴에 대해 보존된 기록이 없습니다.",
+    "turnEndedNoReply": "이 턴에서 에이전트의 응답을 받지 못했습니다.",
+    "turnRelayFailed": "에이전트가 응답했지만 응답을 Chorus에 업로드하지 못했습니다:",
     "privacyNote": "대화 기록은 에이전트의 데몬이 보고한 것으로, 로컬 파일 경로가 포함될 수 있습니다. 가장 최근 메시지만 보관됩니다.",
     "noAgents": {
       "title": "아직 대화가 없습니다",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1513,7 +1513,6 @@
     "send": "发送",
     "instructionHint": "按 Cmd/Ctrl + Enter 发送。",
     "instructionCounter": "{count} / {max}",
-    "instructionSent": "指令已发送。",
     "instructionError": "指令发送失败，请重试。",
     "instructionEmpty": "请先输入指令再发送。",
     "instructionTooLong": "指令过长。请精简到 {max} 个字符以内。",
@@ -1571,6 +1570,8 @@
     "roleYou": "你",
     "roleAgent": "智能体",
     "turnNoMessages": "该回合没有保留对话记录。",
+    "turnEndedNoReply": "本回合未收到 agent 的回复。",
+    "turnRelayFailed": "agent 已回复，但回复未能上传到 Chorus：",
     "privacyNote": "对话记录由智能体的守护进程上报，可能包含本地文件路径。仅保留最近的消息。",
     "noAgents": {
       "title": "暂无对话",

--- a/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/README.md
+++ b/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-idle-session-transcript-relay
+
+Fix #444: daemon idle-session continuation shows empty/duplicate turns — make transcript relay reliable (flush-on-exit + retry + drain-on-stop), idempotent human_instruction, and honest empty-turn UI

--- a/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/design.md
+++ b/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/design.md
@@ -1,0 +1,156 @@
+# Design — fix daemon idle-session transcript relay (#444)
+
+## Context
+
+Daemon-mode session continuation. Two "session" concepts exist; the bug is in the
+**`DaemonSession` + `DaemonSessionTurn`** durable conversation (not the swarm
+`AgentSession`). A wake runs headless `claude -p --output-format stream-json`; the
+daemon parses NDJSON, relays user/assistant text to `POST /api/daemon/transcript`, and
+advances the turn lifecycle `pending → running → ended|interrupted` via
+`POST /api/daemon/turn-advance`.
+
+Key invariant that anchors the diagnosis (`cli/waker.mjs`, `turn-band.tsx`): a turn only
+reaches **`ended`** when the daemon actually spawned `claude` and it **exited code 0**;
+the daemon reports `ended` in the subprocess-exit path. A never-spawned wake stays
+`pending`; a dirty exit / server orphan-reconcile is `interrupted`. So the screenshot's
+clean-`ended` + empty turns prove the daemon **ran** the turns and the
+`turn-advance` channel was healthy — the transcript is what went missing.
+
+## Reproduction
+
+`/tmp/repro444.mjs` drove the REAL `cli/upload-hooks.mjs` (`createTranscriptUploadHooks`)
+with an injected `fetchImpl`. Findings:
+
+```
+hook keys: [ onConnect, onSessionStart, onTranscriptMessage, onExecutionChange ]
+has flush()?: undefined   has onSessionEnd()?: undefined
+posted immediately after exit (before debounce fires): []   ← turn ends with transcript UNSENT
+posted after debounce w/ failing POST: [{ ok:false, n:1 }]
+total upload attempts (retry would be >1): 1                ← single 502 → transcript DROPPED
+warn logs: ["[Chorus] transcript upload returned 502"]
+```
+
+Two confirmed defects:
+
+1. **No flush-on-exit.** The hooks expose no `flush()` / `onSessionEnd()`. Transcript is
+   POSTed on a 50 ms debounce (`createTranscriptUploadHooks`, `batchDelayMs = 50`), but
+   `waker.wake()` advances the turn to `ended` the instant the subprocess exits — the last
+   batch is still in the debounce buffer. `daemon.stop()` drains the wake queue
+   (`queue.drain`) but never the transcript buffer.
+2. **No retry.** `daemon-rest-client.transcript()` → `post()` returns `{ ok:false }` on a
+   non-2xx and logs one `warn`; the caller (`upload()`) swallows it. A single 502 (Docker
+   reverse-proxy hiccup) permanently loses the turn's transcript.
+
+Duplicate turns 2 / 3 / 4: `send-instruction-box.tsx` `send()` shows **no success
+feedback** ("the sent turn appears in the transcript live (SSE)"), so an empty-ended turn
+reads as "nothing happened" → the user retries → each retry mints a new `human_instruction`
+`pending` turn (`createInstructionTurn` → `createReturningTurn`, no idempotency).
+
+## Goals / Non-Goals
+
+**Goals**
+- A turn's trailing transcript is reliably persisted before the turn is marked terminal.
+- A transient transcript POST failure is retried, not silently dropped.
+- A daemon shutdown/restart flushes the active session's transcript buffer.
+- Retried identical instructions collapse instead of minting duplicate empty turns.
+- An empty terminal `human_instruction` turn reads honestly and offers retry.
+
+**Non-Goals**
+- Pending-turn watchdog/timeout (turns reached `ended`, not stuck) — out of scope.
+- Re-work of `claude --resume` cold-start (already probes disk + cold-starts) — kept.
+- No wire-contract change to `/api/daemon/*`, no Prisma migration, no new dependency.
+
+## Decisions
+
+### D1 — Flush-before-terminal in the waker (root cause, primary)
+
+Add `onSessionEnd({ sessionId })` to `UploadHooks`. In `createTranscriptUploadHooks` it
+**cancels the debounce timer and awaits the in-flight + pending batch** (drains `pending`
+through the serialized `chain`). `waker.wake()`, in its subprocess-exit path, **awaits
+`hooks.onSessionEnd({ sessionId })` BEFORE** calling `advanceTurn(ended|interrupted)`.
+
+Why this ordering is correct: the server's `appendTranscriptMessages` attaches transcript
+to the session's **`running`** turn (falling back to most-recent seq). Flushing while the
+turn is still `running` guarantees the trailing text lands on the correct turn — before
+the `→ ended` transition. It also naturally covers **shutdown**: `interruptAll()` kills the
+subprocess, the wake-exit path runs, flushes, then advances to `interrupted(shutdown)`, and
+`daemon.stop()`'s existing `queue.drain(...)` already awaits that wake — so the transcript
+buffer is drained within the same bounded window (no separate stop-path plumbing needed;
+`mergeUploadHooks` gains a fan-out `onSessionEnd` for completeness).
+
+`onSessionEnd` is **best-effort + non-throwing** (mirrors the fire-and-forget contract):
+a flush failure is logged, never crashes the wake. Old daemons without it are unaffected
+(the merged hooks simply have nothing to fan out to).
+
+### D2 — Bounded retry in the transcript upload (root cause, primary)
+
+`createTranscriptUploadHooks.upload()` retries a failed `client.transcript(...)` with a
+small bounded backoff (default **3 attempts**, ~200 ms × attempt), then drops-with-a-loud
+`warn` naming the dropped message count. Retry lives in the hook (host-side), NOT in the
+shared `daemon-rest-client` (which stays a single-shot transport by contract). Injectable
+`sleepImpl` + attempt cap keep it unit-testable with no real timers.
+
+### D3 — Idempotent `human_instruction` turn creation (stop duplicates, server)
+
+In the `human_instruction` turn-creation path (`createTurnAndResolveTarget` step 6, reached
+via `sendInstruction → createInstructionTurn → createReturningTurn`), before
+`createPendingTurn`, look for an existing **`pending`** `human_instruction` turn on the same
+session whose `promptText` **equals** the new instruction text. If found, **return that turn**
+(and re-issue the `deliver_turn` ping) instead of creating a second one. Scope is tight:
+same session, `status = "pending"` (never a `running`/terminal turn), `trigger =
+human_instruction`, exact text match — so distinct instructions and legitimate re-sends
+after a turn has started are unaffected. This directly collapses retry-storm turns 2/3/4.
+
+### D4 — Send-success feedback (stop-the-bleed, frontend)
+
+`ConversationReplyBox.send()` (and the shared `send-instruction-box` compose path) shows an
+explicit success signal on a 2xx (a subtle inline "已发送 / Sent" confirmation via the
+existing toast/inline affordance) so the user knows the instruction was accepted even
+before the agent's reply streams in. Keeps the existing error toast.
+
+### D5 — Honest empty terminal turn + retry (stop-the-bleed, frontend)
+
+In `turn-band.tsx`, a turn that is **terminal** (`ended` / `interrupted`), of trigger
+**`human_instruction`**, with **zero visible messages**, renders a comprehensible band —
+**"回合结束，但未收到回复"** (turn ended without a reply) — plus a **Retry** action that
+re-sends the same `promptText` as a new instruction (reusing the send endpoint; the D3
+idempotency guard means a double-tap can't duplicate). Autonomous empty turns keep the
+existing neutral "no messages" placeholder (they legitimately may produce only tool calls).
+New i18n keys added to **all 4 locales** (en / zh / ko / ja).
+
+## Module contracts
+
+| Site | Change |
+|---|---|
+| `cli/upload-hooks.mjs` | `UploadHooks` gains `onSessionEnd?`. `createTranscriptUploadHooks` implements `onSessionEnd` (cancel timer + await drain) and bounded retry in `upload()`. `mergeUploadHooks` fans out `onSessionEnd`. `createNoopUploadHooks` gains a no-op `onSessionEnd`. |
+| `cli/waker.mjs` | Exit path awaits `hooks.onSessionEnd({ sessionId })` before `advanceTurn(ended|interrupted)` (guarded, non-throwing). |
+| `cli/daemon.mjs` | No new stop plumbing needed (queue.drain already awaits the flushing wake); confirm the active-session flush is covered by a shutdown test. |
+| `src/services/notification-turn.ts` | `createTurnAndResolveTarget`: idempotent collapse of a duplicate unconsumed `human_instruction` pending turn (D3). |
+| `src/components/agent-presence/send-instruction-box.tsx` | Success feedback on send (D4). |
+| `src/components/agent-presence/chat/turn-band.tsx` | Empty terminal human_instruction turn → "ended without reply" + Retry (D5). |
+| `messages/{en,zh,ko,ja}.json` | New keys for D4/D5 strings. |
+
+## Risks
+
+- **Flush adds latency to the wake-exit path.** Bounded by the retry cap × backoff; the
+  wake is already async and the turn-advance is not user-blocking. Acceptable.
+- **Idempotency false-collapse.** Mitigated by the tight match (same session + `pending`
+  + `human_instruction` + exact text). A user deliberately sending the identical text
+  twice while the first is still `pending` (un-started) is exactly the case we WANT to
+  collapse (the agent hasn't consumed it yet).
+- **Frontend verification is browser + theme-sensitive** (D4/D5 touch UI in both light
+  and dark). Automated tests cover logic; the live-browser + `design.pen` acceptance is a
+  headless-daemon gap — flagged for human sign-off in the task ACs.
+
+## Test strategy
+
+- **cli**: extend `transcript-upload-hooks.test.mjs` — `onSessionEnd` drains a pending
+  batch; `upload()` retries a transient failure then succeeds; gives up after the cap with
+  a warn. `waker` test: exit path awaits flush before `advanceTurn(ended)` (assert order).
+- **server**: `notification-turn` / `daemon-instruction` test — a second identical
+  `human_instruction` on a session with an unconsumed pending turn returns the SAME turn
+  (no duplicate row); a different text, or a text whose prior turn is already `running`,
+  creates a new turn.
+- **frontend**: `turn-band` renders the "ended without reply" + Retry only for terminal,
+  empty, `human_instruction` turns; send box shows success feedback on 2xx. Logic via
+  Vitest; live-browser both-theme check flagged for human.

--- a/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/proposal.md
+++ b/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/proposal.md
@@ -1,0 +1,99 @@
+# Fix #444 — daemon idle-session continuation: empty turns + duplicate instructions
+
+## Why
+
+GitHub issue **#444** (reporter: expoli): in daemon mode, after a session has been
+idle for a long time (reporter: ~1 day), continuing the conversation produces a bug —
+the same instruction appears repeated across turns 2 / 3 / 4, each turn is immediately
+marked **"已结束" (ended)**, and each shows **"该回合没有保留对话记录" (this turn kept
+no conversation record)**. The user's read is "无法拉起新回合 / 闲置之后无法发送指令".
+
+Reporter environment: server ~0.14.3 **Docker**, **Linux**, agent **cc** (Claude Code),
+daemon started with bare `npx @chorus-aidlc/chorus daemon`, idle **~1 day**. Reporter
+log note: *"有报错…当时上传好像没上传上来。有日志，但是看着不像是报错"* (there was
+something; an upload seemed to not get uploaded; the logs don't look like errors).
+
+### Verified root cause (not a wake/delivery failure)
+
+The UI **"已结束"** state is reachable ONLY via `pending → running → ended`, and the
+daemon reports `ended` **only after it actually spawned `claude` AND the subprocess
+exited cleanly (code 0)** (`cli/waker.mjs`; a never-spawned wake leaves the turn
+`pending`; a dirty exit or the server orphan-reconcile yields `interrupted`, not
+`ended`). Because the turns reached `ended`, the daemon→server `turn-advance` REST
+channel was healthy — so the daemon **did** wake, run, and cleanly finish each turn.
+The lost piece is the **transcript**: the agent's reply never became visible in Chorus.
+
+Two deterministic defects in the daemon's transcript relay were **reproduced** against
+the real `cli/upload-hooks.mjs` (see `design.md` §Reproduction):
+
+1. **No flush-on-exit / no drain-on-stop.** The transcript hooks expose only
+   `onConnect / onSessionStart / onTranscriptMessage / onExecutionChange` — there is
+   **no `flush()` / `onSessionEnd()`**. Transcript messages are POSTed on a 50 ms
+   debounce, but `waker.wake()` advances the turn to `ended` the instant the subprocess
+   exits, and `daemon.stop()` drains the wake queue but never the transcript buffer. A
+   batch still in the debounce window when the wake exits (or when the daemon restarts
+   after a long idle) is silently lost.
+2. **No retry on a failed POST.** A single non-2xx transcript POST (e.g. a 502 from the
+   Docker reverse proxy — exactly the reporter's setup) **permanently drops** the turn's
+   transcript: one `warn` log, no retry — which is why the reporter's logs "don't look
+   like errors."
+
+The **duplicate turns 2 / 3 / 4** are a separate, compounding defect: the send box gives
+**zero success feedback** (`send-instruction-box.tsx` — "the sent turn appears live via
+SSE"), so when the turn ends empty the user sees nothing happen and retries, each retry
+minting a fresh `human_instruction` `pending` turn with identical text.
+
+## What Changes
+
+Three coordinated fixes, one per capability area, matching the elaboration decisions
+(scope = **both** root-cause + stop-the-bleed):
+
+- **Daemon transcript-relay reliability (root cause).**
+  - Add an `onSessionEnd` hook (with a synchronous-capable `flush`) to the transcript
+    upload hooks; `waker.wake()` **awaits the flush BEFORE** advancing the turn to
+    `ended` / `interrupted`, so a turn's trailing transcript is always attached while the
+    turn is still `running` (the server attaches transcript to the `running` turn).
+  - Add **bounded retry with backoff** to the transcript upload (a transient non-2xx /
+    network error is retried a few times before the batch is dropped-with-a-loud-warn).
+  - `daemon.stop()` **drains the transcript buffer** (awaits `onSessionEnd`/flush for the
+    active session) alongside the existing wake-queue drain.
+
+- **Idempotent `human_instruction` (stop the duplicates).** When a `human_instruction`
+  turn is created for a session that already has an **unconsumed (`pending`)
+  `human_instruction` turn with identical `promptText`**, collapse to the existing turn
+  (return it, re-ping it) instead of minting a duplicate — so a user's retries never pile
+  up empty turns 2 / 3 / 4.
+
+- **Honest send + empty-turn UX (stop-the-bleed).**
+  - The send box shows explicit **success feedback** after a send lands (so the user
+    knows it was accepted and doesn't retry blindly).
+  - A **terminal** (`ended` / `interrupted`) `human_instruction` turn that produced **no
+    visible messages** renders as a comprehensible **"回合结束，但未收到回复"** state
+    with a **one-click retry**, instead of the dead-end neutral "该回合没有保留对话记录".
+    All new strings localized in **4 locales** (en / zh / ko / ja).
+
+### Out of scope
+
+- **Pending-turn timeout / auto-reconcile.** The reported turns reached `ended` (they were
+  not stuck `pending`), so a pending-turn watchdog does not address #444; deferred.
+- **`claude --resume` cold-start-on-missing-transcript.** The daemon already probes the
+  on-disk transcript and cold-starts (`--session-id`) when it is absent, and the evidence
+  points at relay loss, not resume failure. The existing behavior is kept; not re-worked.
+
+## Capabilities
+
+- `daemon-session-conversation` — the daemon session / turn / transcript relay machinery
+  and its send + empty-turn presentation. (ADDED requirements below; the existing
+  capability spec is extended, not replaced.)
+
+## Impact
+
+- **Daemon CLI** (`cli/upload-hooks.mjs`, `cli/waker.mjs`, `cli/daemon.mjs`,
+  `cli/daemon-rest-client.mjs`): additive hook + retry + drain; no wire-contract change.
+- **Server** (`src/services/notification-turn.ts` / `notification.service.ts`):
+  idempotent `human_instruction` turn creation; no schema change, no migration.
+- **Frontend** (`src/components/agent-presence/…`, `messages/{en,zh,ko,ja}.json`):
+  send-success feedback + empty-terminal-turn retry affordance.
+- **No Prisma schema / migration changes.** No new dependency.
+- **Backward compatible:** old daemons (without the new `onSessionEnd`) keep working —
+  the flush is best-effort and the server idempotency + UI changes stand alone.

--- a/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/specs/daemon-session-conversation/spec.md
+++ b/openspec/changes/archive/2026-07-23-fix-daemon-idle-session-transcript-relay/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,140 @@
+## ADDED Requirements
+
+### Requirement: Daemon flushes a turn's transcript before marking it terminal
+
+The daemon SHALL flush any buffered (debounced) transcript for a wake's session to the
+server BEFORE it advances that turn to a terminal status (`ended` or `interrupted`), so a
+turn's trailing user/assistant text is persisted while the turn is still `running` and
+attaches to the correct turn. The transcript upload hooks SHALL expose an `onSessionEnd`
+operation that cancels the pending debounce timer and awaits the in-flight and buffered
+batch. The flush SHALL be best-effort and non-throwing: a flush failure is logged and
+never crashes or blocks the wake's exit path.
+
+#### Scenario: Trailing transcript is flushed on clean subprocess exit
+
+- **WHEN** a woken `claude` subprocess emits an assistant text message and then exits
+  cleanly (code 0) within the transcript debounce window
+- **THEN** the daemon flushes the buffered transcript to `POST /api/daemon/transcript`
+  before it advances the turn to `ended`
+- **AND** the turn shows the assistant's reply rather than "no conversation record".
+
+#### Scenario: Active-session transcript is flushed on daemon shutdown
+
+- **WHEN** the daemon is shutting down and a wake subprocess is interrupted mid-turn
+- **THEN** the wake's exit path flushes the session's buffered transcript before advancing
+  the turn to `interrupted`, within the bounded shutdown drain window.
+
+### Requirement: Daemon retries a failed transcript upload before dropping it
+
+The daemon's transcript upload SHALL retry a failed POST (transient network error or
+non-2xx response) with a bounded number of attempts and backoff before giving up. If all
+attempts fail, the daemon SHALL drop the batch with a single loud warning that names the
+number of lost messages. The retry SHALL live in the transcript upload hook, not in the
+shared single-shot REST client.
+
+#### Scenario: Transient upload failure is retried and succeeds
+
+- **WHEN** the first transcript POST for a turn returns a transient error (e.g. HTTP 502)
+  and a subsequent attempt would succeed
+- **THEN** the daemon retries within the attempt budget and the transcript is persisted
+- **AND** no transcript is lost.
+
+#### Scenario: Persistent upload failure is dropped loudly, not silently
+
+- **WHEN** every attempt in the retry budget fails
+- **THEN** the daemon logs a warning naming the dropped message count
+- **AND** does not crash the wake.
+
+### Requirement: Duplicate unconsumed human instructions collapse to one turn
+
+The server SHALL NOT create a duplicate `human_instruction` turn when the same session
+already has an unconsumed (`status = "pending"`) `human_instruction` turn with identical
+instruction text; it SHALL instead return the existing turn and re-issue its delivery
+ping. The collapse SHALL apply ONLY to the same session, a `pending` turn (never a
+`running` or terminal turn), the `human_instruction` trigger, and an exact text match — so
+distinct instructions, and re-sends after the prior turn has started, still create new
+turns.
+
+#### Scenario: Retrying the same instruction does not pile up empty turns
+
+- **WHEN** a user sends an instruction, sees no visible response, and sends the identical
+  instruction text again while the first turn is still `pending`
+- **THEN** the server returns the existing pending turn rather than creating a second one
+- **AND** the conversation does not accumulate duplicate empty turns 2 / 3 / 4.
+
+#### Scenario: A different instruction still creates a new turn
+
+- **WHEN** a user sends an instruction whose text differs from any pending instruction on
+  the session, or whose prior identical turn has already advanced to `running`
+- **THEN** the server creates a new `human_instruction` turn.
+
+### Requirement: Sending an instruction gives explicit success feedback
+
+The daemon-session reply UI SHALL give the user an explicit success signal when an
+instruction send is accepted by the server (HTTP 2xx), so the user is not left guessing
+whether the send worked and does not blindly retry. Send failures SHALL continue to
+surface their server-provided reason.
+
+#### Scenario: A successful send is confirmed to the user
+
+- **WHEN** the user sends an instruction and the server responds 2xx
+- **THEN** the UI shows an explicit success confirmation
+- **AND** the compose input is cleared.
+
+### Requirement: An empty terminal instruction turn reads honestly and offers retry
+
+The UI SHALL present a `human_instruction` turn that has reached a terminal status
+(`ended` or `interrupted`) and produced no visible messages as a comprehensible "turn
+ended without a reply" state with a one-click retry that re-sends the same instruction
+text — rather than a neutral dead-end "this turn kept no conversation record". Autonomous
+turns (non-`human_instruction`) SHALL keep the existing neutral no-messages placeholder.
+All new user-facing strings SHALL be localized in every supported locale (en, zh, ko, ja).
+
+#### Scenario: Empty ended human-instruction turn offers a retry
+
+- **WHEN** a `human_instruction` turn is terminal and has no visible messages
+- **THEN** the turn band shows a "turn ended without a reply" message and a Retry action
+- **AND** activating Retry re-sends the same instruction text as a new turn.
+
+#### Scenario: Empty autonomous turn keeps the neutral placeholder
+
+- **WHEN** an autonomous (non-`human_instruction`) turn has no visible messages
+- **THEN** the turn band shows the existing neutral no-messages placeholder without a
+  retry action.
+
+### Requirement: A known transcript-relay failure is surfaced on the turn
+
+The system SHALL record and surface a KNOWN transcript-relay failure on the turn it
+belongs to, so a turn whose reply was produced but never uploaded reads as "the reply
+could not be uploaded" rather than the misleading "no reply received". When the daemon's
+transcript upload finally fails for a turn (retry budget exhausted / non-2xx / network),
+the daemon SHALL forward the failure reason on the same exit-path turn-advance report it
+already sends, on the terminal edge. The server SHALL persist this reason as an annotation
+on the turn WITHOUT changing the turn's terminal status (a clean exit stays `ended`), and
+SHALL expose it in the turn view. The annotation SHALL be written only on a terminal edge
+(never on `running`), and SHALL be absent when the upload succeeded. The UI SHALL, for a
+terminal turn that carries a relay-failure annotation and shows no messages, present a
+distinct honest message (with the raw reason available on hover) and — for a
+`human_instruction` turn — a one-click retry; a turn that DID relay text SHALL render its
+messages normally. All new user-facing strings SHALL be localized in every supported
+locale (en, zh, ko, ja).
+
+#### Scenario: A relay-failed reply is reported honestly, not as "no reply"
+
+- **WHEN** a turn's transcript upload fails after the retry budget is exhausted and the
+  wake exits
+- **THEN** the daemon forwards the failure reason on the terminal turn-advance, the server
+  persists it on the (still-`ended`) turn, and the UI shows "the reply could not be
+  uploaded" with the reason on hover — not "no reply received".
+
+#### Scenario: A successful relay leaves no annotation
+
+- **WHEN** a turn's transcript upload succeeds (possibly after a retry)
+- **THEN** no relay-failure annotation is recorded on the turn
+- **AND** the turn renders its messages normally.
+
+#### Scenario: The annotation never alters turn status
+
+- **WHEN** a relay-failure reason accompanies a `→ running` transition
+- **THEN** the server ignores it (the annotation is terminal-only), so a resumed turn
+  never carries a stale relay failure.

--- a/openspec/specs/daemon-session-conversation/spec.md
+++ b/openspec/specs/daemon-session-conversation/spec.md
@@ -324,3 +324,141 @@ The server SHALL reconcile orphaned `running` turns — turns whose owning sessi
 - **WHEN** both writes reach the transition chokepoint
 - **THEN** exactly one MUST win and the loser MUST be rejected as an invalid transition that writes nothing
 
+### Requirement: Daemon flushes a turn's transcript before marking it terminal
+
+The daemon SHALL flush any buffered (debounced) transcript for a wake's session to the
+server BEFORE it advances that turn to a terminal status (`ended` or `interrupted`), so a
+turn's trailing user/assistant text is persisted while the turn is still `running` and
+attaches to the correct turn. The transcript upload hooks SHALL expose an `onSessionEnd`
+operation that cancels the pending debounce timer and awaits the in-flight and buffered
+batch. The flush SHALL be best-effort and non-throwing: a flush failure is logged and
+never crashes or blocks the wake's exit path.
+
+#### Scenario: Trailing transcript is flushed on clean subprocess exit
+
+- **WHEN** a woken `claude` subprocess emits an assistant text message and then exits
+  cleanly (code 0) within the transcript debounce window
+- **THEN** the daemon flushes the buffered transcript to `POST /api/daemon/transcript`
+  before it advances the turn to `ended`
+- **AND** the turn shows the assistant's reply rather than "no conversation record".
+
+#### Scenario: Active-session transcript is flushed on daemon shutdown
+
+- **WHEN** the daemon is shutting down and a wake subprocess is interrupted mid-turn
+- **THEN** the wake's exit path flushes the session's buffered transcript before advancing
+  the turn to `interrupted`, within the bounded shutdown drain window.
+
+### Requirement: Daemon retries a failed transcript upload before dropping it
+
+The daemon's transcript upload SHALL retry a failed POST (transient network error or
+non-2xx response) with a bounded number of attempts and backoff before giving up. If all
+attempts fail, the daemon SHALL drop the batch with a single loud warning that names the
+number of lost messages. The retry SHALL live in the transcript upload hook, not in the
+shared single-shot REST client.
+
+#### Scenario: Transient upload failure is retried and succeeds
+
+- **WHEN** the first transcript POST for a turn returns a transient error (e.g. HTTP 502)
+  and a subsequent attempt would succeed
+- **THEN** the daemon retries within the attempt budget and the transcript is persisted
+- **AND** no transcript is lost.
+
+#### Scenario: Persistent upload failure is dropped loudly, not silently
+
+- **WHEN** every attempt in the retry budget fails
+- **THEN** the daemon logs a warning naming the dropped message count
+- **AND** does not crash the wake.
+
+### Requirement: Duplicate unconsumed human instructions collapse to one turn
+
+The server SHALL NOT create a duplicate `human_instruction` turn when the same session
+already has an unconsumed (`status = "pending"`) `human_instruction` turn with identical
+instruction text; it SHALL instead return the existing turn and re-issue its delivery
+ping. The collapse SHALL apply ONLY to the same session, a `pending` turn (never a
+`running` or terminal turn), the `human_instruction` trigger, and an exact text match — so
+distinct instructions, and re-sends after the prior turn has started, still create new
+turns.
+
+#### Scenario: Retrying the same instruction does not pile up empty turns
+
+- **WHEN** a user sends an instruction, sees no visible response, and sends the identical
+  instruction text again while the first turn is still `pending`
+- **THEN** the server returns the existing pending turn rather than creating a second one
+- **AND** the conversation does not accumulate duplicate empty turns 2 / 3 / 4.
+
+#### Scenario: A different instruction still creates a new turn
+
+- **WHEN** a user sends an instruction whose text differs from any pending instruction on
+  the session, or whose prior identical turn has already advanced to `running`
+- **THEN** the server creates a new `human_instruction` turn.
+
+### Requirement: A successful instruction send clears the composer
+
+When an instruction send is accepted by the server (HTTP 2xx), the daemon-session reply UI
+SHALL clear the compose input as the success signal. It SHALL NOT show a success toast
+(that was tried and read as noise); blind re-sends are made harmless server-side by the
+idempotent-collapse requirement rather than discouraged by a toast. Send failures SHALL
+continue to surface their server-provided reason.
+
+#### Scenario: A successful send clears the composer without a toast
+
+- **WHEN** the user sends an instruction and the server responds 2xx
+- **THEN** the compose input is cleared
+- **AND** no success toast is shown.
+
+### Requirement: An empty terminal instruction turn reads honestly
+
+The UI SHALL present a `human_instruction` turn that has reached a terminal status
+(`ended` or `interrupted`) and produced no visible messages as a comprehensible "turn
+ended without a reply" state — rather than a neutral dead-end "this turn kept no
+conversation record". The user re-asks through the normal reply box; the band itself
+carries no retry control. Autonomous turns (non-`human_instruction`) SHALL keep the
+existing neutral no-messages placeholder. All new user-facing strings SHALL be localized
+in every supported locale (en, zh, ko, ja).
+
+#### Scenario: Empty ended human-instruction turn reads honestly
+
+- **WHEN** a `human_instruction` turn is terminal and has no visible messages
+- **THEN** the turn band shows a "turn ended without a reply" message (no retry button).
+
+#### Scenario: Empty autonomous turn keeps the neutral placeholder
+
+- **WHEN** an autonomous (non-`human_instruction`) turn has no visible messages
+- **THEN** the turn band shows the existing neutral no-messages placeholder.
+
+### Requirement: A known transcript-relay failure is surfaced on the turn
+
+The system SHALL record and surface a KNOWN transcript-relay failure on the turn it
+belongs to, so a turn whose reply was produced but never uploaded reads as "the reply
+could not be uploaded" rather than the misleading "no reply received". When the daemon's
+transcript upload finally fails for a turn (retry budget exhausted / non-2xx / network),
+the daemon SHALL forward the failure reason on the same exit-path turn-advance report it
+already sends, on the terminal edge. The server SHALL persist this reason as an annotation
+on the turn WITHOUT changing the turn's terminal status (a clean exit stays `ended`), and
+SHALL expose it in the turn view. The annotation SHALL be written only on a terminal edge
+(never on `running`), and SHALL be absent when the upload succeeded. The UI SHALL, for a
+terminal turn that carries a relay-failure annotation and shows no messages, present a
+distinct honest message with the raw failure reason shown DIRECTLY (inline, not behind a
+hover); a turn that DID relay text SHALL render its messages normally. All new user-facing
+strings SHALL be localized in every supported locale (en, zh, ko, ja).
+
+#### Scenario: A relay-failed reply is reported honestly, not as "no reply"
+
+- **WHEN** a turn's transcript upload fails after the retry budget is exhausted and the
+  wake exits
+- **THEN** the daemon forwards the failure reason on the terminal turn-advance, the server
+  persists it on the (still-`ended`) turn, and the UI shows "the reply could not be
+  uploaded" with the reason displayed inline — not "no reply received".
+
+#### Scenario: A successful relay leaves no annotation
+
+- **WHEN** a turn's transcript upload succeeds (possibly after a retry)
+- **THEN** no relay-failure annotation is recorded on the turn
+- **AND** the turn renders its messages normally.
+
+#### Scenario: The annotation never alters turn status
+
+- **WHEN** a relay-failure reason accompanies a `→ running` transition
+- **THEN** the server ignores it (the annotation is terminal-only), so a resumed turn
+  never carries a stale relay failure.
+

--- a/prisma/migrations/20260723014810_add_turn_relay_error/migration.sql
+++ b/prisma/migrations/20260723014810_add_turn_relay_error/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DaemonSessionTurn" ADD COLUMN     "relayError" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -637,6 +637,13 @@ model DaemonSessionTurn {
   // `interrupted` (resumable), a turn's `interrupted` is TERMINAL — it is durable
   // conversation history, never resumed or auto-retried.
   interruptedReason String?
+  // Transcript-relay failure annotation (fix #444 follow-up). Non-null when the daemon
+  // KNEW the turn's transcript upload finally failed (retry exhausted / non-2xx / network)
+  // even though the wake itself exited cleanly — the reply WAS produced but never reached
+  // Chorus. Orthogonal to `status`: the turn is still a clean `ended`; this only records
+  // WHY its transcript is missing so the UI can say "reply couldn't be uploaded (reason)"
+  // instead of the misleading "no reply received". Null on a successful/skipped upload.
+  relayError    String?
   // Weak ref to the live DaemonExecution row this turn corresponds to (no DB FK;
   // execution rows are reconciled/transient).
   executionUuid String?

--- a/src/app/api/daemon/turn-advance/__tests__/route.test.ts
+++ b/src/app/api/daemon/turn-advance/__tests__/route.test.ts
@@ -142,6 +142,42 @@ describe("POST /api/daemon/turn-advance", () => {
     expect(arg.interruptedReason).toBe("shutdown");
   });
 
+  it("passes transcriptRelayError through as relayError on a terminal edge (fix #444 follow-up)", async () => {
+    const res = await POST(
+      postRequest({
+        connectionUuid,
+        sessionId,
+        status: "ended",
+        transcriptRelayError: "transcript upload returned 502",
+      }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(200);
+    const arg = mockAdvanceTurnForWake.mock.calls[0][0];
+    expect(arg.status).toBe("ended");
+    expect(arg.relayError).toBe("transcript upload returned 502");
+  });
+
+  it("omits relayError (undefined) when the body carries no transcriptRelayError", async () => {
+    await POST(postRequest({ connectionUuid, sessionId, status: "ended" }), emptyCtx);
+    const arg = mockAdvanceTurnForWake.mock.calls[0][0];
+    expect(arg.relayError).toBeUndefined();
+  });
+
+  it("rejects a transcriptRelayError over the length bound (422)", async () => {
+    const res = await POST(
+      postRequest({
+        connectionUuid,
+        sessionId,
+        status: "ended",
+        transcriptRelayError: "x".repeat(501),
+      }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
   it("rejects interruptedReason=offline (server-reconcile verdict, not daemon-reportable) at the zod boundary", async () => {
     const res = await POST(
       postRequest({ connectionUuid, sessionId, status: "interrupted", interruptedReason: "offline" }),

--- a/src/app/api/daemon/turn-advance/route.ts
+++ b/src/app/api/daemon/turn-advance/route.ts
@@ -49,6 +49,12 @@ const bodySchema = z
     startedAt: z.coerce.date().nullish(),
     endedAt: z.coerce.date().nullish(),
     interruptedReason: z.enum([...DAEMON_REPORTABLE_INTERRUPT_REASONS]).nullish(),
+    // Transcript-relay failure annotation (fix #444 follow-up): the daemon KNEW this turn's
+    // transcript upload finally failed (retry exhausted / non-2xx / network) even though the
+    // wake exited. Free-text cause (e.g. "transcript upload returned 502"); bounded so a
+    // malformed/huge value can't bloat the row. Meaningful only on a terminal edge — the
+    // service ignores it on → running.
+    transcriptRelayError: z.string().min(1).max(500).nullish(),
   })
   .refine((b) => b.status === "interrupted" || b.interruptedReason == null, {
     message: "interruptedReason is only valid with status=interrupted",
@@ -86,6 +92,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     startedAt,
     endedAt,
     interruptedReason,
+    transcriptRelayError,
   } = parsed.data;
 
   // Ownership fence: the connection must belong to the authenticated agent within its
@@ -108,6 +115,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     startedAt: startedAt ?? undefined,
     endedAt: endedAt ?? undefined,
     interruptedReason: interruptedReason ?? undefined,
+    relayError: transcriptRelayError ?? undefined,
   });
 
   if (!result.ok) {

--- a/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
+++ b/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
@@ -28,6 +28,7 @@ function turn(
     promptText: null,
     status: "pending",
     interruptedReason: null,
+    relayError: null,
     executionUuid: null,
     startedAt: null,
     endedAt: null,

--- a/src/components/agent-presence/__tests__/send-instruction-box.test.tsx
+++ b/src/components/agent-presence/__tests__/send-instruction-box.test.tsx
@@ -8,8 +8,8 @@
 //
 // Covers the 5-AC scope:
 //   1. A send box (Textarea + Button) renders in the detail pane; a direct send
-//      POSTs to /api/daemon-sessions/{uuid}/instruction, clears the input, and
-//      shows a success toast.
+//      POSTs to /api/daemon-sessions/{uuid}/instruction and clears the input
+//      (clearing IS the success signal — no success toast).
 //   2. The direct send is DISABLED with a visible localized reason when the
 //      target session's origin is offline; a 409/400 response surfaces its
 //      localized server reason (not a generic failure).

--- a/src/components/agent-presence/__tests__/turn-band.test.tsx
+++ b/src/components/agent-presence/__tests__/turn-band.test.tsx
@@ -56,6 +56,7 @@ function turn(overrides: Partial<TurnWithMessagesView> = {}): TurnWithMessagesVi
     promptText: null,
     status: "ended",
     interruptedReason: null,
+    relayError: null,
     executionUuid: null,
     startedAt: "2026-07-04T03:00:00.000Z",
     endedAt: "2026-07-04T03:05:00.000Z",
@@ -111,5 +112,201 @@ describe("TurnBand interrupted presentation", () => {
     renderBand(turn({ status: "interrupted", interruptedReason: null }));
     const badge = screen.getByText("Interrupted");
     expect(badge.closest("[title]")).toBeNull();
+  });
+});
+
+describe("TurnBand empty-terminal instruction (fix #444)", () => {
+  const emptyInstruction = (overrides: Partial<TurnWithMessagesView> = {}) =>
+    turn({
+      trigger: "human_instruction",
+      promptText: "does app/samples exist?",
+      status: "ended",
+      messages: [],
+      ...overrides,
+    });
+
+  it("renders the 'ended without a reply' band (no retry button) for an empty terminal human_instruction turn", () => {
+    render(<TurnBand turn={emptyInstruction()} agentName="Alpha" linkedExecution={null} />);
+    expect(screen.getByText("No reply was received from the agent on this turn.")).toBeTruthy();
+    // The neutral placeholder is NOT shown for this case, and there is no retry button
+    // (the user simply re-asks in the reply box below).
+    expect(screen.queryByText("No transcript retained for this turn.")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Retry/ })).toBeNull();
+  });
+
+  it("also covers an INTERRUPTED empty human_instruction turn (terminal)", () => {
+    render(
+      <TurnBand
+        turn={emptyInstruction({ status: "interrupted", interruptedReason: "offline" })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.getByText("No reply was received from the agent on this turn.")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Retry/ })).toBeNull();
+  });
+
+  it("keeps the neutral placeholder for an empty AUTONOMOUS turn", () => {
+    render(
+      <TurnBand
+        turn={turn({ trigger: "task_assigned", promptText: null, status: "ended", messages: [] })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.getByText("No transcript retained for this turn.")).toBeTruthy();
+    expect(screen.queryByText("No reply was received from the agent on this turn.")).toBeNull();
+  });
+
+  it("does NOT show the no-reply band for a still-RUNNING instruction turn (not terminal)", () => {
+    render(
+      <TurnBand
+        turn={emptyInstruction({ status: "running", endedAt: null })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.queryByText("No reply was received from the agent on this turn.")).toBeNull();
+  });
+});
+
+describe("TurnBand transcript-relay failure (fix #444 follow-up)", () => {
+  const RELAY_MSG = "The agent replied, but the reply could not be uploaded to Chorus:";
+  const NO_REPLY_MSG = "No reply was received from the agent on this turn.";
+
+  it("shows the 'reply couldn't be uploaded' band (not 'no reply') when relayError is set", () => {
+    render(
+      <TurnBand
+        turn={turn({
+          trigger: "human_instruction",
+          promptText: "does app/samples exist?",
+          status: "ended",
+          relayError: "transcript upload returned 502",
+          messages: [],
+        })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.getByText(RELAY_MSG)).toBeTruthy();
+    // The KNOWN-cause copy REPLACES the misleading "no reply received" wording.
+    expect(screen.queryByText(NO_REPLY_MSG)).toBeNull();
+  });
+
+  it("shows the raw daemon reason DIRECTLY (inline, no hover)", () => {
+    render(
+      <TurnBand
+        turn={turn({
+          trigger: "human_instruction",
+          promptText: "p",
+          status: "ended",
+          relayError: "transcript upload returned 502",
+          messages: [],
+        })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    // The error text is rendered as its own visible line, not tucked behind a title attr.
+    expect(screen.getByText("transcript upload returned 502")).toBeTruthy();
+  });
+
+  it("never offers a Retry for a relay-drop (the produced reply can't be recovered)", () => {
+    render(
+      <TurnBand
+        turn={turn({
+          trigger: "human_instruction",
+          promptText: "does app/samples exist?",
+          status: "ended",
+          relayError: "network error",
+          messages: [],
+        })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Retry/ })).toBeNull();
+  });
+
+  it("covers a relay-drop on an INTERRUPTED terminal turn too", () => {
+    render(
+      <TurnBand
+        turn={turn({
+          trigger: "human_instruction",
+          promptText: "p",
+          status: "interrupted",
+          interruptedReason: "crash",
+          relayError: "transcript upload returned 502",
+          messages: [],
+        })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.getByText(RELAY_MSG)).toBeTruthy();
+    expect(screen.getByText("transcript upload returned 502")).toBeTruthy();
+  });
+
+  it("shows the relay-drop band for an autonomous turn too (cause reported, no retry)", () => {
+    render(
+      <TurnBand
+        turn={turn({
+          trigger: "task_assigned",
+          promptText: null,
+          status: "ended",
+          relayError: "transcript upload returned 502",
+          messages: [],
+        })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.getByText(RELAY_MSG)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Retry/ })).toBeNull();
+  });
+
+  it("does NOT show the relay band when the turn actually has messages (partial drop out of scope)", () => {
+    render(
+      <TurnBand
+        turn={turn({
+          trigger: "human_instruction",
+          promptText: "p",
+          status: "ended",
+          relayError: "transcript upload returned 502",
+          messages: [
+            {
+              uuid: "m1",
+              turnUuid: "t1",
+              role: "assistant",
+              text: "partial reply that did land",
+              seq: 1,
+              createdAt: "2026-07-04T03:01:00.000Z",
+            },
+          ],
+        })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.queryByText(RELAY_MSG)).toBeNull();
+    expect(screen.getByText("partial reply that did land")).toBeTruthy();
+  });
+
+  it("does NOT show the relay band on a still-RUNNING turn (not terminal)", () => {
+    render(
+      <TurnBand
+        turn={turn({
+          trigger: "human_instruction",
+          promptText: "p",
+          status: "running",
+          endedAt: null,
+          relayError: "transcript upload returned 502",
+          messages: [],
+        })}
+        agentName="Alpha"
+        linkedExecution={null}
+      />,
+    );
+    expect(screen.queryByText(RELAY_MSG)).toBeNull();
   });
 });

--- a/src/components/agent-presence/chat/turn-band.tsx
+++ b/src/components/agent-presence/chat/turn-band.tsx
@@ -75,6 +75,8 @@ export function TurnBand({
   // stopped — structurally quiet like `ended` (no pulse, no spinner, no timer) but
   // labeled distinctly so an abnormal termination never masquerades as a clean end.
   const interrupted = turn.status === "interrupted";
+  // A turn is TERMINAL once it has ended or been interrupted — no more output will come.
+  const terminal = turn.status === "ended" || interrupted;
 
   // Live status label (pending → Queued, running → Running, interrupted →
   // Interrupted, ended → Ended). One generic "Interrupted" label covers every
@@ -101,6 +103,29 @@ export function TurnBand({
   // (proposal/document also route through execHref but read as task-shaped work).
   const linkLabel =
     linkedExecution?.entityType === "idea" ? t("openIdea") : t("openTask");
+
+  // fix #444 — a terminal `human_instruction` turn that produced NO visible messages is
+  // the "该回合没有保留对话记录" dead-end the user hit. Present it honestly as "ended
+  // without a reply" (the user can simply re-ask in the reply box below). Autonomous turns
+  // (no promptText) legitimately may produce only tool calls, so they keep the neutral
+  // placeholder.
+  const promptText = turn.promptText?.trim() ?? "";
+  const isEmptyTerminalInstruction =
+    terminal &&
+    turn.trigger === "human_instruction" &&
+    visibleMessages.length === 0 &&
+    promptText.length > 0;
+
+  // fix #444 follow-up — the daemon reported that THIS turn's transcript upload finally
+  // failed: the agent DID reply, but it never reached Chorus (a Docker-proxy 502, a
+  // network blip, retry exhausted). This is a KNOWN cause, distinct from "the agent
+  // produced nothing" — so when it's set on a terminal turn that shows no messages, we
+  // say so honestly (with the reason) instead of the misleading "no reply received".
+  // Guarded on `terminal` + empty so a turn that DID relay some text (a partial drop is
+  // out of scope) still renders its messages normally.
+  const relayError = turn.relayError?.trim() ?? "";
+  const hasRelayError =
+    terminal && visibleMessages.length === 0 && relayError.length > 0;
 
   return (
     <div className="flex gap-3">
@@ -190,6 +215,29 @@ export function TurnBand({
             visibleMessages.map((m) => (
               <Message key={m.uuid} message={m} agentName={agentName} />
             ))
+          ) : hasRelayError ? (
+            // Honest KNOWN-relay-drop state (fix #444 follow-up): the agent replied but the
+            // reply could not be uploaded. Same warning-muted band; the localized
+            // explanation plus the daemon's raw reason shown DIRECTLY beneath it (no hover,
+            // no retry — the already-produced reply can't be recovered, so we simply report
+            // the cause so it never masquerades as "the agent said nothing").
+            <div className="flex flex-col gap-1 rounded-lg border border-[#EADFCB] dark:border-[#3a3222] bg-[#FBF5EA] dark:bg-[#221d14] px-3 py-2.5">
+              <p className="text-[12px] leading-relaxed text-[#8A6D3B] dark:text-[#D9B473]">
+                {t("turnRelayFailed")}
+              </p>
+              <p className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-[#A98B54] dark:text-[#B89355]">
+                {relayError}
+              </p>
+            </div>
+          ) : isEmptyTerminalInstruction ? (
+            // Honest empty-terminal instruction state (fix #444): the turn ended without a
+            // reply. Warning-muted tint (matches the interrupted styling); it simply reads
+            // honestly — no retry button (the user can re-ask in the reply box below).
+            <div className="flex flex-col gap-2 rounded-lg border border-[#EADFCB] dark:border-[#3a3222] bg-[#FBF5EA] dark:bg-[#221d14] px-3 py-2.5">
+              <p className="text-[12px] leading-relaxed text-[#8A6D3B] dark:text-[#D9B473]">
+                {t("turnEndedNoReply")}
+              </p>
+            </div>
           ) : (
             <p className="text-[12px] italic text-muted-foreground">
               {t("turnNoMessages")}

--- a/src/components/agent-presence/send-instruction-box.tsx
+++ b/src/components/agent-presence/send-instruction-box.tsx
@@ -354,8 +354,10 @@ export function ConversationReplyBox({
         toast.error(await extractError(res, t("instructionError")));
         return;
       }
-      // No success toast: the sent turn appears in the transcript live (SSE), so a
-      // toast would be redundant noise. Errors still toast (no silent failure).
+      // Clearing the composer is the success signal — a success toast was tried but read
+      // as annoying noise. Duplicate sends are already made safe server-side by the T2
+      // idempotency collapse (fix #444), so we don't need a toast to discourage re-sends.
+      // Errors still toast (no silent failure).
       setValue("");
     } catch (error) {
       clientLogger.error("Failed to send daemon instruction:", error);
@@ -812,7 +814,7 @@ export function SendInstructionBox({
         toast.error(await extractError(res, t("instructionError")));
         return;
       }
-      toast.success(t("instructionSent"));
+      // Clearing the composer is the success signal (no success toast — read as noise).
       setValue("");
     } catch (error) {
       clientLogger.error("Failed to send daemon instruction:", error);

--- a/src/contexts/__tests__/agent-presence-context.test.tsx
+++ b/src/contexts/__tests__/agent-presence-context.test.tsx
@@ -122,6 +122,7 @@ function transcriptEvent(over: Partial<TranscriptEvent> = {}): TranscriptEvent {
       promptText: null,
       status: "running",
       interruptedReason: null,
+      relayError: null,
       executionUuid: null,
       startedAt: null,
       endedAt: null,

--- a/src/services/__tests__/daemon-instruction-injection.integration.test.ts
+++ b/src/services/__tests__/daemon-instruction-injection.integration.test.ts
@@ -568,6 +568,47 @@ describe("AC1 — instruction lands on the SAME idea-anchored DaemonSession (ses
     expect(store.data.notification[0].entityType).toBe("idea");
     expect(store.data.notification[0].entityUuid).toBe(IDEA);
   });
+
+  // fix #444 — idempotent human_instruction: a retry of the identical instruction while the
+  // first is still UNCONSUMED (pending) must NOT mint a duplicate empty turn (the 2/3/4 bug).
+  it("collapses a re-sent identical instruction to the SAME pending turn (no duplicate 2/3/4); a different text or a started turn still creates a new one", async () => {
+    const { uuid: sessionUuid } = seedIdeaAnchoredSession();
+    const INSTRUCTION = "does app/samples exist? is it repo-managed?";
+
+    // First send → one pending human_instruction turn.
+    const first = await instructionService.sendInstruction(agentAuth, {
+      sessionUuid,
+      instructionText: INSTRUCTION,
+    });
+    expect(store.data.daemonSessionTurn).toHaveLength(1);
+    expect(store.data.daemonSessionTurn[0].status).toBe("pending");
+
+    // Re-send the IDENTICAL text while the first is still pending → reuse, no new turn.
+    const second = await instructionService.sendInstruction(agentAuth, {
+      sessionUuid,
+      instructionText: INSTRUCTION,
+    });
+    expect(store.data.daemonSessionTurn).toHaveLength(1); // still ONE — collapsed
+    expect(second.turn.uuid).toBe(first.turn.uuid); // same turn returned
+
+    // A DIFFERENT instruction still creates a new turn.
+    await instructionService.sendInstruction(agentAuth, {
+      sessionUuid,
+      instructionText: "actually, also check app/lib",
+    });
+    expect(store.data.daemonSessionTurn).toHaveLength(2);
+
+    // Once the original turn has STARTED (running), a re-send of its text is NOT collapsed
+    // — the agent already consumed it, so the user genuinely wants it run again.
+    const firstTurnRow = store.data.daemonSessionTurn.find((t) => t.uuid === first.turn.uuid);
+    if (!firstTurnRow) throw new Error("seed error: first turn row missing");
+    firstTurnRow.status = "running";
+    await instructionService.sendInstruction(agentAuth, {
+      sessionUuid,
+      instructionText: INSTRUCTION,
+    });
+    expect(store.data.daemonSessionTurn).toHaveLength(3);
+  });
 });
 
 // ===== AC2: origin-only delivery — live control event targets ONLY the origin =====

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -69,6 +69,7 @@ import {
   resolveOrCreateSession,
   resolveDirectIdeaUuid,
   createPendingTurn,
+  findReusablePendingInstructionTurn,
   advanceTurn,
   getVisibleSessions,
   getSessionTurns,
@@ -118,6 +119,7 @@ function turnRow(overrides: Partial<Record<string, unknown>> = {}) {
     promptText: null,
     status: "pending",
     interruptedReason: null,
+    relayError: null,
     executionUuid: null,
     startedAt: null,
     endedAt: null,
@@ -461,6 +463,41 @@ describe("createPendingTurn", () => {
   });
 });
 
+// ===== findReusablePendingInstructionTurn (fix #444 idempotency) =====
+describe("findReusablePendingInstructionTurn", () => {
+  it("returns the matching pending human_instruction turn's view when one exists", async () => {
+    const existing = turnRow({
+      seq: 3,
+      trigger: "human_instruction",
+      promptText: "does app/samples exist?",
+      status: "pending",
+    });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue(existing);
+
+    const view = await findReusablePendingInstructionTurn(sessionUuid, "does app/samples exist?");
+
+    // Scoped query: same session + pending + human_instruction + exact text, oldest-first.
+    expect(mockPrisma.daemonSessionTurn.findFirst).toHaveBeenCalledWith({
+      where: {
+        sessionUuid,
+        status: "pending",
+        trigger: "human_instruction",
+        promptText: "does app/samples exist?",
+      },
+      orderBy: { seq: "asc" },
+    });
+    expect(view).not.toBeNull();
+    expect(view?.uuid).toBe(turnUuid);
+    expect(view?.status).toBe("pending");
+  });
+
+  it("returns null when no matching pending instruction turn exists (different text / already running / none)", async () => {
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue(null);
+    const view = await findReusablePendingInstructionTurn(sessionUuid, "a fresh instruction");
+    expect(view).toBeNull();
+  });
+});
+
 // ===== advanceTurn (strict pending → running → ended | interrupted) =====
 describe("advanceTurn", () => {
   it("running → interrupted: persists status + interruptedReason + endedAt, emits turn_status_changed", async () => {
@@ -560,6 +597,61 @@ describe("advanceTurn", () => {
     const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
     expect(data.status).toBe("ended");
     expect(data).not.toHaveProperty("interruptedReason");
+  });
+
+  it("PERSISTS relayError on a → ended edge and surfaces it in the view (fix #444 follow-up)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ status: "ended", relayError: "transcript upload returned 502" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    const res = await advanceTurn(turnUuid, "ended", {
+      relayError: "transcript upload returned 502",
+    });
+    expect(res).toMatchObject({ ok: true });
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data.relayError).toBe("transcript upload returned 502");
+    // Surfaced in the emitted view so a live viewer patches the row without a refetch.
+    const [, payload] = mockEventBus.emit.mock.calls[0];
+    expect(payload.turn.relayError).toBe("transcript upload returned 502");
+  });
+
+  it("PERSISTS relayError on a → interrupted edge too (a dirty exit can still lose transcript)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "running",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(
+      turnRow({ status: "interrupted", interruptedReason: "crash", relayError: "boom" }),
+    );
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    await advanceTurn(turnUuid, "interrupted", {
+      interruptedReason: "crash",
+      relayError: "boom",
+    });
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data.relayError).toBe("boom");
+  });
+
+  it("IGNORES relayError on a → running edge (annotation is terminal-only)", async () => {
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({
+      uuid: turnUuid,
+      sessionUuid,
+      status: "pending",
+    });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow({ status: "running" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    await advanceTurn(turnUuid, "running", { relayError: "should be ignored" });
+    const data = mockPrisma.daemonSessionTurn.update.mock.calls[0][0].data;
+    expect(data).not.toHaveProperty("relayError");
   });
 
   it("pending → running: updates status, records startedAt + executionUuid, emits turn_status_changed", async () => {
@@ -1905,6 +1997,24 @@ describe("advanceTurnForWake", () => {
     expect(updateArg.data.status).toBe("interrupted");
     expect(updateArg.data.interruptedReason).toBe("shutdown");
     expect(updateArg.data.endedAt).toBeInstanceOf(Date);
+  });
+
+  it("forwards relayError onto the terminal turn-advance (fix #444 follow-up)", async () => {
+    ownedSessionWithLatestTurn("running");
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "ended",
+      relayError: "transcript upload returned 502",
+    });
+
+    expect(res).toMatchObject({ ok: true });
+    const updateArg = mockPrisma.daemonSessionTurn.update.mock.calls[0][0];
+    expect(updateArg.data.status).toBe("ended");
+    expect(updateArg.data.relayError).toBe("transcript upload returned 502");
   });
 
   it("returns not_found when the agent has no such session (non-disclosure)", async () => {

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -12,10 +12,15 @@ vi.mock("@/services/daemon-connection.service", () => ({
 const mockResolveOrCreateSession = vi.hoisted(() => vi.fn());
 const mockCreatePendingTurn = vi.hoisted(() => vi.fn());
 const mockResolveDirectIdeaUuid = vi.hoisted(() => vi.fn());
+// fix #444 — idempotent human_instruction: the bridge now checks for a reusable pending
+// instruction turn before creating one. Default null ⇒ no reuse ⇒ createPendingTurn runs
+// (byte-identical to pre-change behavior for these tests); a specific test may override.
+const mockFindReusablePendingInstructionTurn = vi.hoisted(() => vi.fn());
 vi.mock("@/services/daemon-session.service", () => ({
   resolveOrCreateSession: mockResolveOrCreateSession,
   createPendingTurn: mockCreatePendingTurn,
   resolveDirectIdeaUuid: mockResolveDirectIdeaUuid,
+  findReusablePendingInstructionTurn: mockFindReusablePendingInstructionTurn,
 }));
 
 // The assignment pin is now INSTANCE-based (T11): the bridge reads the wake's Task row
@@ -216,6 +221,9 @@ beforeEach(() => {
   mockCreatePendingTurn.mockImplementation(async (p: { trigger: string; promptText?: string | null }) =>
     turnView({ trigger: p.trigger, promptText: p.promptText ?? null }),
   );
+  // Default: no reusable pending instruction turn (fix #444 idempotency) → createPendingTurn
+  // runs as before. A dedicated idempotency test overrides this to return an existing turn.
+  mockFindReusablePendingInstructionTurn.mockResolvedValue(null);
   // Default: the assigned Task is a plain `agent` (un-pinned) — the unchanged online-first
   // path, no instance pin. Pin-honoring tests override per-case.
   mockTaskFindFirst.mockResolvedValue({ assigneeType: "agent", assigneeUuid: agentUuid });
@@ -1226,6 +1234,37 @@ describe("maybeCreateTurnForWakeNotification — human_instruction promptText", 
 
     expect(mockCreatePendingTurn).toHaveBeenCalledWith(
       expect.objectContaining({ trigger: "human_instruction", promptText: null }),
+    );
+  });
+
+  // fix #444 — idempotency: a re-sent identical instruction with an unconsumed pending turn
+  // reuses it instead of creating a duplicate (the empty turns 2/3/4 bug).
+  it("REUSES an existing unconsumed pending instruction turn instead of creating a duplicate", async () => {
+    const existing = turnView({ trigger: "human_instruction", promptText: "does app/samples exist?" });
+    mockFindReusablePendingInstructionTurn.mockResolvedValue(existing);
+
+    const result = await maybeCreateTurnForWakeNotification(
+      ctx({ action: "human_instruction", instructionText: "does app/samples exist?" }),
+    );
+
+    // The reusable-turn lookup ran with the session + instruction text; NO new turn was made.
+    expect(mockFindReusablePendingInstructionTurn).toHaveBeenCalledWith(
+      expect.any(String),
+      "does app/samples exist?",
+    );
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+    expect(result?.uuid).toBe(existing.uuid);
+  });
+
+  it("creates a NEW turn when no reusable pending instruction turn exists (default)", async () => {
+    mockFindReusablePendingInstructionTurn.mockResolvedValue(null);
+
+    await maybeCreateTurnForWakeNotification(
+      ctx({ action: "human_instruction", instructionText: "a fresh instruction" }),
+    );
+
+    expect(mockCreatePendingTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: "human_instruction", promptText: "a fresh instruction" }),
     );
   });
 });

--- a/src/services/daemon-instruction.service.ts
+++ b/src/services/daemon-instruction.service.ts
@@ -846,6 +846,7 @@ export async function createConversationalIdeaSession(
     promptText: turnRow.promptText,
     status: turnRow.status,
     interruptedReason: turnRow.interruptedReason,
+    relayError: turnRow.relayError,
     executionUuid: turnRow.executionUuid,
     startedAt: turnRow.startedAt ? turnRow.startedAt.toISOString() : null,
     endedAt: turnRow.endedAt ? turnRow.endedAt.toISOString() : null,

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -139,6 +139,11 @@ export interface TurnView {
   promptText: string | null;
   status: string; // pending | running | ended | interrupted
   interruptedReason: string | null; // user | crash | shutdown | offline; set iff interrupted
+  // Transcript-relay failure annotation (fix #444 follow-up): non-null when the daemon KNEW
+  // this turn's transcript upload finally failed (retry exhausted / non-2xx / network) even
+  // though the wake exited — the reply was produced but never reached Chorus. Orthogonal to
+  // `status`; lets the UI say "reply couldn't be uploaded (reason)" vs "no reply received".
+  relayError: string | null;
   executionUuid: string | null;
   startedAt: string | null; // ISO-8601
   endedAt: string | null; // ISO-8601
@@ -198,6 +203,7 @@ interface DaemonSessionTurnRow {
   promptText: string | null;
   status: string;
   interruptedReason: string | null;
+  relayError: string | null;
   executionUuid: string | null;
   startedAt: Date | null;
   endedAt: Date | null;
@@ -230,6 +236,7 @@ function toTurnView(row: DaemonSessionTurnRow): TurnView {
     promptText: row.promptText,
     status: row.status,
     interruptedReason: row.interruptedReason,
+    relayError: row.relayError,
     executionUuid: row.executionUuid,
     startedAt: row.startedAt ? row.startedAt.toISOString() : null,
     endedAt: row.endedAt ? row.endedAt.toISOString() : null,
@@ -468,6 +475,35 @@ export async function createPendingTurn(params: {
   return view;
 }
 
+/**
+ * Idempotency guard for `human_instruction` turns (fix #444 — duplicate empty turns
+ * 2/3/4). Find an existing UNCONSUMED (`status = "pending"`) `human_instruction` turn on
+ * this session whose `promptText` EXACTLY matches `promptText`, and return its view — so a
+ * user who re-sends the identical instruction while the first is still queued does not mint
+ * a second turn. Returns null when there is no such turn (a different text, or the prior
+ * identical turn has already advanced to `running`/terminal, still creates a new turn).
+ *
+ * Scope is deliberately tight — same session + `pending` + `human_instruction` + exact text
+ * — so autonomous triggers and legitimate re-sends after a turn has started are unaffected.
+ * Returns the OLDEST match (`seq asc`) for determinism. A query failure propagates to the
+ * caller, which runs inside the notification chokepoint's failure-isolation try/catch.
+ */
+export async function findReusablePendingInstructionTurn(
+  sessionUuid: string,
+  promptText: string,
+): Promise<TurnView | null> {
+  const row = await prisma.daemonSessionTurn.findFirst({
+    where: {
+      sessionUuid,
+      status: "pending",
+      trigger: "human_instruction",
+      promptText,
+    },
+    orderBy: { seq: "asc" },
+  });
+  return row ? toTurnView(row) : null;
+}
+
 /** Outcome of an attempted turn status transition, so the route maps a precise code. */
 export type AdvanceTurnResult =
   | { ok: true; turn: TurnView }
@@ -520,6 +556,10 @@ export async function advanceTurn(
     endedAt?: Date | null;
     executionUuid?: string | null;
     interruptedReason?: string | null;
+    // Transcript-relay failure annotation (fix #444 follow-up). Written on a terminal edge
+    // when the daemon reports the turn's transcript upload finally failed. Meaningful only
+    // on → ended/interrupted; ignored on → running (the run hasn't produced transcript yet).
+    relayError?: string | null;
   } = {},
 ): Promise<AdvanceTurnResult> {
   const turn = await prisma.daemonSessionTurn.findUnique({
@@ -544,6 +584,7 @@ export async function advanceTurn(
     endedAt?: Date | null;
     executionUuid?: string | null;
     interruptedReason?: string | null;
+    relayError?: string | null;
   } = { status };
   if (opts.startedAt !== undefined) data.startedAt = opts.startedAt;
   if (opts.endedAt !== undefined) data.endedAt = opts.endedAt;
@@ -552,6 +593,15 @@ export async function advanceTurn(
   // keeps the "non-null iff interrupted" column invariant without trusting callers.
   if (status === "interrupted" && opts.interruptedReason !== undefined) {
     data.interruptedReason = opts.interruptedReason;
+  }
+  // The relay-error annotation is meaningful only on a TERMINAL edge (the daemon reports it
+  // at subprocess exit). Persist it on → ended/interrupted; ignore on → running so a resume
+  // can't carry a stale drop forward. Only write when the caller passed a value.
+  if (
+    (status === "ended" || status === "interrupted") &&
+    opts.relayError !== undefined
+  ) {
+    data.relayError = opts.relayError;
   }
 
   const updated = await prisma.daemonSessionTurn.update({
@@ -1521,6 +1571,9 @@ export async function advanceTurnForWake(params: {
   startedAt?: Date | null;
   endedAt?: Date | null;
   interruptedReason?: string | null;
+  // Transcript-relay failure annotation forwarded from the daemon's exit-path report
+  // (fix #444 follow-up). Persisted on the terminal edge only.
+  relayError?: string | null;
 }): Promise<AdvanceTurnForWakeResult> {
   // Resolve the agent's OWN session by its business key (company + agent fenced).
   const session = await prisma.daemonSession.findFirst({
@@ -1604,6 +1657,7 @@ export async function advanceTurnForWake(params: {
     ...(params.interruptedReason !== undefined
       ? { interruptedReason: params.interruptedReason }
       : {}),
+    ...(params.relayError !== undefined ? { relayError: params.relayError } : {}),
   });
 
   if (result.ok) return { ok: true, turn: result.turn };

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -55,6 +55,7 @@ import { prisma } from "@/lib/prisma";
 import {
   resolveOrCreateSession,
   createPendingTurn,
+  findReusablePendingInstructionTurn,
   resolveDirectIdeaUuid,
   type TurnTrigger,
   type TurnView,
@@ -788,11 +789,24 @@ export async function createTurnAndResolveTarget(
     const promptText =
       trigger === "human_instruction" ? ctx.instructionText ?? null : null;
 
-    const turn = await createPendingTurn({
-      sessionUuid: session.uuid,
-      trigger,
-      promptText,
-    });
+    // Idempotency (fix #444 — duplicate empty turns 2/3/4): a `human_instruction` whose
+    // identical text already has an UNCONSUMED (`pending`) turn on this session is a user
+    // re-send (they saw no reply and hit send again). Reuse that turn instead of minting a
+    // duplicate — the re-issued deliver_turn ping below still nudges the daemon. Scoped to
+    // pending + human_instruction + exact text, so a distinct instruction, or a re-send
+    // after the prior turn has already started (`running`), still creates a new turn.
+    // Autonomous triggers (promptText === null) skip this entirely.
+    let turn =
+      trigger === "human_instruction" && promptText
+        ? await findReusablePendingInstructionTurn(session.uuid, promptText)
+        : null;
+    if (!turn) {
+      turn = await createPendingTurn({
+        sessionUuid: session.uuid,
+        trigger,
+        promptText,
+      });
+    }
 
     // (7) DIRECTED wake: deliver to ONLY the resolved target via the human_instruction
     // keystone — a `deliver_turn` control ping on control:{connectionUuid} carrying the


### PR DESCRIPTION
## Summary

Fixes #444 — in daemon mode, after a session sits idle for a long time (reporter: ~1 day, Docker/Linux), continuing the conversation showed the **same instruction repeated across turns 2/3/4**, each marked **"已结束"** with **"该回合没有保留对话记录"**.

**Root cause (reproduced against the real code, not guessed):** the turns *actually ran and exited cleanly* — the UI "已结束" state is only reachable via a clean `exit 0`, and the server never auto-produces `ended`. So the daemon woke, ran, and the daemon↔server channel was healthy. What was lost is the **transcript relay**:

1. **No flush-on-exit** — the transcript is batched on a 50ms debounce; the last batch was never sent when the turn ended.
2. **No retry** — a single non-2xx POST (e.g. a Docker reverse-proxy 502) permanently dropped the batch with only a warn log.

The duplication (turns 2/3/4) followed from the send box giving zero success feedback → the user re-sent.

## What this PR does

- **Daemon reliability** — flush the debounced transcript *before* advancing a turn to a terminal status (`onSessionEnd`, awaited so it lands on the still-`running` turn) + **bounded retry with backoff** in the upload hook + drain-on-stop via the existing wake queue.
- **Server idempotency** — a duplicate *unconsumed* `human_instruction` (same session, `pending`, exact text) collapses onto the existing turn instead of minting a new one, so a blind re-send can't pile up empty turns.
- **Relay-error surfacing** (owner follow-up) — when the daemon *knows* the upload finally failed, it forwards the reason on the exit-path `turn-advance` it already sends (**no new channel**). A new nullable `DaemonSessionTurn.relayError` column stores it (persisted terminal-only, never mutates the clean `ended` status). The turn then reads **"the reply could not be uploaded"** with the reason shown **inline** — distinct from the honest **"no reply received"** for a genuinely empty turn.
- **UX** — a successful send just clears the composer (no success toast — read as noise); the empty/error bands carry **no retry button** (the user re-asks via the reply box). i18n in all 4 locales.

## Changed files

| Area | Files |
|------|-------|
| Daemon | `cli/upload-hooks.mjs`, `cli/waker.mjs` (+ tests) |
| Server | `prisma/schema.prisma` + migration, `src/app/api/daemon/turn-advance/route.ts`, `src/services/daemon-session.service.ts`, `notification-turn.ts`, `daemon-instruction.service.ts` (+ tests) |
| UI | `src/components/agent-presence/chat/turn-band.tsx`, `send-instruction-box.tsx` |
| i18n | `messages/{en,zh,ko,ja}.json` |
| Spec | OpenSpec change `fix-daemon-idle-session-transcript-relay` **archived** + `openspec/specs/daemon-session-conversation/spec.md` |

## Test plan

- [x] `npx vitest run` → **4463 passed / 0 failed** (16 pre-existing skips)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on changed files clean
- [x] locale-parity green (keys present in all 4 locales)
- [x] Live both-theme (light + dark) verification of the relay-error band + the no-reply band via Playwright — reason shown inline, no retry button
- [ ] design.pen not updated for the new band (flagged; screenshots stand in)

Generated with [Claude Code](https://claude.com/claude-code)