### PR TITLE
fix(daemon): preserve Codex session across interrupts

### DIFF
--- a/cli/__tests__/codex-backend-integration.test.mjs
+++ b/cli/__tests__/codex-backend-integration.test.mjs
@@ -13,9 +13,13 @@
 //      prompt on stdin, daemon key in the child env (never argv).
 import { describe, it, expect, vi } from "vitest";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { buildDaemon } from "../daemon.mjs";
 import { ClaudeSpawner } from "../claude-spawner.mjs";
 import { CodexSpawner } from "../codex-spawner.mjs";
+import { getThreadId, setThreadId } from "../codex-session-map.mjs";
 import { Waker } from "../waker.mjs";
 import { createTranscriptUploadHooks } from "../upload-hooks.mjs";
 import { killProcessTree } from "../process-killer.mjs";
@@ -164,6 +168,86 @@ describe("codex backend end-to-end argv (via the daemon-selected spawner)", () =
     child.emit("close", 0);
     await p;
     expect(calls.argv.slice(0, 4)).toEqual(["exec", "resume", TID, "--json"]);
+  });
+
+  it("resumes an interrupted first turn from persisted state in a fresh spawner", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "chorus-codex-interrupt-"));
+    const path = join(dir, "codex-sessions.json");
+    const children = [];
+    const calls = [];
+    const makeSpawner = () =>
+      new CodexSpawner({
+        codexPath: "/usr/bin/codex",
+        platform: "linux",
+        permissionMode: "yolo",
+        creds: CREDS,
+        logger: silent,
+        getThreadIdFn: (anchor) => getThreadId(anchor, { path, logger: silent }),
+        setThreadIdFn: (anchor, threadId) => setThreadId(anchor, threadId, { path, logger: silent }),
+        spawnImpl: (_command, argv) => {
+          calls.push(argv);
+          const child = makeFakeChild();
+          children.push(child);
+          return child;
+        },
+      });
+
+    try {
+      const first = makeSpawner().wake({ prompt: "first", sessionId: ANCHOR });
+      children[0].stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+      children[0].emit("close", 130);
+      await first;
+
+      const resumed = makeSpawner().wake({ prompt: "resume after restart", sessionId: ANCHOR });
+      children[1].emit("close", 0);
+      await resumed;
+
+      expect(calls[0].slice(0, 2)).toEqual(["exec", "--json"]);
+      expect(calls[1].slice(0, 4)).toEqual(["exec", "resume", TID, "--json"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps resuming the same known thread after an interrupted resumed wake", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "chorus-codex-reinterrupt-"));
+    const path = join(dir, "codex-sessions.json");
+    setThreadId(ANCHOR, TID, { path, logger: silent });
+    const calls = [];
+    const children = [];
+    const makeSpawner = () =>
+      new CodexSpawner({
+        codexPath: "/usr/bin/codex",
+        platform: "linux",
+        permissionMode: "yolo",
+        creds: CREDS,
+        logger: silent,
+        getThreadIdFn: (anchor) => getThreadId(anchor, { path, logger: silent }),
+        setThreadIdFn: (anchor, threadId) => setThreadId(anchor, threadId, { path, logger: silent }),
+        spawnImpl: (_command, argv) => {
+          calls.push(argv);
+          const child = makeFakeChild();
+          children.push(child);
+          return child;
+        },
+      });
+
+    try {
+      const interruptedResume = makeSpawner().wake({ prompt: "continue", sessionId: ANCHOR });
+      children[0].emit("close", 130);
+      await interruptedResume;
+
+      const resumedAgain = makeSpawner().wake({ prompt: "continue again", sessionId: ANCHOR });
+      children[1].emit("close", 0);
+      await resumedAgain;
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0].slice(0, 4)).toEqual(["exec", "resume", TID, "--json"]);
+      expect(calls[1].slice(0, 4)).toEqual(["exec", "resume", TID, "--json"]);
+      expect(getThreadId(ANCHOR, { path, logger: silent })).toBe(TID);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/cli/__tests__/codex-spawner.test.mjs
+++ b/cli/__tests__/codex-spawner.test.mjs
@@ -117,6 +117,8 @@ describe("extractThreadId — capture from the thread.started event", () => {
   it("returns null for unrelated events", () => {
     expect(extractThreadId({ type: "turn.completed" })).toBeNull();
     expect(extractThreadId({ type: "item.completed", item: {} })).toBeNull();
+    expect(extractThreadId({ type: "thread.started", thread_id: "  " })).toBeNull();
+    expect(extractThreadId({ type: "session_meta", payload: { id: "" } })).toBeNull();
     expect(extractThreadId(null)).toBeNull();
   });
 });
@@ -209,23 +211,62 @@ describe("CodexSpawner.wake — spawn orchestration", () => {
     expect(result.sessionId).toBe(TID);
   });
 
-  it("captures thread_id and persists anchor→thread_id on a successful new run", async () => {
+  it("persists anchor→thread_id immediately when a new run emits thread.started", async () => {
     const child = makeFakeChild();
     const setThreadId = vi.fn();
     const { spawner } = makeSpawner({ child, setThreadId });
     const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
     child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    expect(setThreadId).toHaveBeenCalledWith(ANCHOR, TID);
     child.emit("close", 0);
     await p;
+    expect(setThreadId).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the mapping when a new run establishes a thread then exits non-zero", async () => {
+    const child = makeFakeChild();
+    const setThreadId = vi.fn();
+    const { spawner } = makeSpawner({ child, setThreadId });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.emit("close", 1);
+    await p;
+    expect(setThreadId).toHaveBeenCalledTimes(1);
     expect(setThreadId).toHaveBeenCalledWith(ANCHOR, TID);
   });
 
-  it("does NOT persist on a non-zero exit (failed run)", async () => {
+  it("persists exactly once when duplicate compatible identifier events arrive", async () => {
     const child = makeFakeChild();
     const setThreadId = vi.fn();
     const { spawner } = makeSpawner({ child, setThreadId });
-    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR, isNew: true });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR });
     child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.stdout.emit("data", JSON.stringify({ type: "session_meta", payload: { id: TID } }) + "\n");
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: TID }) + "\n");
+    child.emit("close", 0);
+    await p;
+    expect(setThreadId).toHaveBeenCalledTimes(1);
+    expect(setThreadId).toHaveBeenCalledWith(ANCHOR, TID);
+  });
+
+  it("persists a compatible session_meta identifier before child close", async () => {
+    const child = makeFakeChild();
+    const setThreadId = vi.fn();
+    const { spawner } = makeSpawner({ child, setThreadId });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR });
+    child.stdout.emit("data", JSON.stringify({ type: "session_meta", payload: { id: TID } }) + "\n");
+    expect(setThreadId).toHaveBeenCalledWith(ANCHOR, TID);
+    child.emit("close", 0);
+    await p;
+  });
+
+  it("does not persist when a new process fails before emitting a valid thread id", async () => {
+    const child = makeFakeChild();
+    const setThreadId = vi.fn();
+    const { spawner } = makeSpawner({ child, setThreadId });
+    const p = spawner.wake({ prompt: "x", sessionId: ANCHOR });
+    child.stdout.emit("data", JSON.stringify({ type: "thread.started", thread_id: " " }) + "\n");
+    child.stdout.emit("data", JSON.stringify({ type: "turn.failed", thread_id: ANCHOR }) + "\n");
     child.emit("close", 1);
     await p;
     expect(setThreadId).not.toHaveBeenCalled();

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -398,6 +398,23 @@ describe("Waker.wake full loop", () => {
     expect(spawner.wake.mock.calls[0][0].sessionId).toBe(DIRECT_IDEA);
   });
 
+  it("logs the backend's actual session decision instead of the transcript probe hint", async () => {
+    const messages = [];
+    const spawner = {
+      sessionDecision: { probeIsAuthoritative: false },
+      wake: vi.fn(async () => ({ sessionId: "codex-thread-1", exitCode: 0, isNew: false })),
+    };
+    const { waker } = makeWaker({ spawner, isNewSessionFn: vi.fn(() => true) });
+    waker.logger = { ...silent, info: (message) => messages.push(message) };
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(spawner.wake.mock.calls[0][0].isNew).toBe(true);
+    expect(messages).toContain(`[Chorus] dispatching session ${DIRECT_IDEA}`);
+    expect(messages).toContain("[Chorus] backend resumed session codex-thread-1");
+    expect(messages.join("\n")).not.toMatch(/spawning new|resuming session/);
+  });
+
   it("falls back to a per-entity key when there's no direct idea", async () => {
     const { waker } = makeWaker({
       lineage: { resolve: async () => ({ rootIdeaUuid: null, directIdeaUuid: null }) },

--- a/cli/claude-spawner.mjs
+++ b/cli/claude-spawner.mjs
@@ -247,6 +247,10 @@ export function parseNdjsonChunk(buffer, chunk, onObject, onWarn = () => {}) {
 export class ClaudeSpawner {
   /** @param {ClaudeSpawnerOptions} [opts] */
   constructor(opts = {}) {
+    this.sessionDecision = {
+      probeIsAuthoritative: true,
+      takeoverCommand: "claude --resume",
+    };
     this.claudePath = opts.claudePath ?? null;
     this.spawnImpl = opts.spawnImpl ?? spawn;
     this.logger = opts.logger ?? NOOP_LOGGER;

--- a/cli/codex-spawner.mjs
+++ b/cli/codex-spawner.mjs
@@ -93,9 +93,11 @@ export function buildCodexArgs({ isNew, threadId, permissionMode }) {
  */
 export function extractThreadId(obj) {
   if (!obj || typeof obj !== "object") return null;
-  if (obj.type === "thread.started" && typeof obj.thread_id === "string") return obj.thread_id;
+  if (obj.type === "thread.started" && typeof obj.thread_id === "string") {
+    return obj.thread_id.trim() || null;
+  }
   if (obj.type === "session_meta" && obj.payload && typeof obj.payload.id === "string") {
-    return obj.payload.id;
+    return obj.payload.id.trim() || null;
   }
   return null;
 }
@@ -175,6 +177,7 @@ export function resolveSpawnCommand(codexPath, args, platform = process.platform
 export class CodexSpawner {
   /** @param {CodexSpawnerOptions} [opts] */
   constructor(opts = {}) {
+    this.sessionDecision = { probeIsAuthoritative: false };
     this.codexPath = opts.codexPath ?? null;
     this.spawnImpl = opts.spawnImpl ?? spawn;
     this.logger = opts.logger ?? NOOP_LOGGER;
@@ -265,6 +268,7 @@ export class CodexSpawner {
 
       let stdoutBuf = "";
       let observedThreadId = knownThreadId || null;
+      let threadIdPersisted = false;
 
       child.stdout?.setEncoding?.("utf8");
       child.stdout?.on("data", (chunk) => {
@@ -273,7 +277,13 @@ export class CodexSpawner {
           String(chunk),
           (obj) => {
             const tid = extractThreadId(obj);
-            if (tid) observedThreadId = tid;
+            if (tid) {
+              observedThreadId = tid;
+              if (isNew && anchor && !threadIdPersisted) {
+                threadIdPersisted = true;
+                this.setThreadIdFn(anchor, tid);
+              }
+            }
             let delivered = obj;
             if (obj?.type === "turn.completed" && obj.usage) {
               delivered = needsUsageSeed
@@ -311,12 +321,6 @@ export class CodexSpawner {
       child.on("close", (code) => {
         if (code !== 0) {
           this.logger.warn(`[Chorus] codex exited with code ${code}`);
-        }
-        // Persist anchor→thread_id only on a fresh, successful run that produced a
-        // new id — so a later wake for this anchor resumes it. Best-effort; the
-        // session map swallows its own IO errors.
-        if (code === 0 && isNew && anchor && observedThreadId) {
-          this.setThreadIdFn(anchor, observedThreadId);
         }
         resolve({ sessionId: observedThreadId || anchor, exitCode: code, isNew });
       });

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -1,7 +1,7 @@
 // cli/waker.mjs
 // Executes a single wake: resolve the event to its idea attribution, derive the
 // deterministic session id (= the DIRECT idea uuid), build the --mcp-config, spawn
-// headless Claude (new vs resume decided by probing the on-disk transcript), and
+// the configured headless agent, and
 // fire the (no-op) upload hooks. The WakeQueue schedules these per DIRECT idea so
 // two wakes for the same idea never run concurrently against the same session.
 //
@@ -56,7 +56,7 @@ export class Waker {
     this.lineage = opts.lineage;
     this.spawner = opts.spawner;
     // Verbose per-wake logging (daemon-startup-output). Default: one compact
-    // line per lifecycle event (arrival / spawn new-vs-resume / completion).
+    // line per lifecycle event (arrival / session decision / completion).
     // When true, additional detail is emitted alongside those lines.
     this.verbose = opts.verbose ?? false;
     // The connection/session-bound working directory this Waker serves (T3 — 单
@@ -385,13 +385,20 @@ export class Waker {
       const cwd = this.resolveCwd();
       const isNew = sessionId ? this.isNewSessionFn(sessionId, cwd) : true;
 
-      // Lifecycle line 2 — spawn: new vs resume, plus the (otherwise hidden)
-      // `claude --resume <id>` takeover hint so an operator can attach to the
-      // session from this daemon's working directory.
-      this.logger.info(
-        `[Chorus] ${isNew ? "spawning new" : "resuming"} session ${sessionId ?? "(none)"}` +
-          (sessionId ? ` — take over with: claude --resume ${sessionId}` : "")
-      );
+      // Spawners declare whether the shared transcript probe is authoritative
+      // for their session decision. Missing metadata preserves the established
+      // Claude-compatible logging contract for injected/third-party spawners.
+      const sessionDecision = this.spawner.sessionDecision;
+      const probeIsAuthoritative = sessionDecision?.probeIsAuthoritative !== false;
+      if (probeIsAuthoritative) {
+        const takeoverCommand = sessionDecision?.takeoverCommand ?? "claude --resume";
+        this.logger.info(
+          `[Chorus] ${isNew ? "spawning new" : "resuming"} session ${sessionId ?? "(none)"}` +
+            (sessionId && takeoverCommand ? ` — take over with: ${takeoverCommand} ${sessionId}` : "")
+        );
+      } else {
+        this.logger.info(`[Chorus] dispatching session ${sessionId ?? "(none)"}`);
+      }
       if (this.verbose) {
         this.logger.info(`[Chorus]   cwd=${cwd} action=${notification.action} root=${rootIdeaUuid ?? "(none)"}`);
       }
@@ -447,6 +454,12 @@ export class Waker {
             .catch(() => {});
         },
       });
+
+      if (result && !probeIsAuthoritative) {
+        this.logger.info(
+          `[Chorus] backend ${result.isNew ? "started new" : "resumed"} session ${result.sessionId ?? sessionId ?? "(none)"}`
+        );
+      }
 
       // No session map to persist anymore — the id is deterministic (= direct idea
       // uuid) and the next wake re-derives new-vs-resume from disk. Just log a

--- a/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/README.md
+++ b/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/README.md
@@ -1,0 +1,3 @@
+# fix-codex-interrupt-session-resume
+
+Persist Codex thread identity before interrupted exits so daemon wakes resume the same session

--- a/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/design.md
+++ b/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Codex generates its own thread identifier. `CodexSpawner` therefore maps the deterministic Chorus anchor to the `thread_id` emitted by `thread.started`, then uses that map to build later `codex exec resume <thread_id>` commands.
+
+The current implementation holds the observed identifier in memory and writes the map only from the child `close` handler when `code === 0`. Chorus UI interrupt sends SIGINT to the detached process group and Codex exits with code 1. A fresh turn interrupted after `thread.started` consequently leaves a valid rollout on disk but no daemon mapping. The next wake treats the anchor as new and loses conversation continuity.
+
+The Waker also computes and logs new/resume using the Claude transcript probe before invoking the backend. Codex ignores that input and makes its own map-based decision, so the current lifecycle line can contradict the command actually spawned.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the Codex thread identity as soon as the stream establishes it.
+- Resume the same thread after an interrupted first turn and across daemon restart.
+- Preserve best-effort persistence and no-throw wake behavior.
+- Report Codex new/resume state from the decision that built the actual command.
+- Add deterministic regression coverage without invoking a real model.
+
+**Non-Goals:**
+
+- Changing interrupt authorization, control transport, process-tree killing, or server execution state.
+- Introducing automatic fallback to a new thread when a recorded resume fails.
+- Changing the session-map file format or migrating existing entries.
+- Generalizing Kiro or Claude session handling.
+
+## Decisions
+
+### Persist on first valid identifier
+
+For a fresh Codex run with a non-empty anchor, the stdout event handler will call the injected mapping writer when it observes the first valid thread identifier. A local guard will ensure duplicate `thread.started` or compatible `session_meta` events result in exactly one persistence call for that wake.
+
+This point is authoritative because Codex has emitted the generated identifier and created its rollout before a user can interrupt the process. Waiting for `turn.completed` or exit code 0 conflates successful turn completion with successful session creation.
+
+Alternative considered: persist from the child `close` handler for every exit code. This still leaves a crash window between identifier observation and close processing and makes identity durability depend on process teardown.
+
+### Do not write without an observed identifier
+
+Spawn errors, stdin failures, or exits before an identifier event will not create a mapping. The daemon must not map an anchor to the Chorus UUID or infer a Codex thread identifier from unrelated output.
+
+### Keep the session-map contract unchanged
+
+The existing atomic temp-file rename, preservation of unrelated anchors, visible warnings, and swallowed persistence errors remain unchanged. Immediate persistence uses the same injected `setThreadIdFn`; no new storage layer is introduced.
+
+### Surface the backend's actual decision
+
+The spawner result already returns `isNew`, which for Codex is derived from its persisted map. Waker lifecycle logging will avoid presenting its pre-spawn Claude probe as authoritative for Codex. The implementation may log a backend-neutral dispatch line before spawn and the actual new/resume result after the spawner resolves, or expose a synchronous backend decision through the existing spawner boundary. It must not add agent-type branching to orchestration behavior.
+
+The spawner exposes session-decision metadata through the shared boundary. Claude marks the transcript probe authoritative and supplies its `claude --resume` takeover command, preserving the existing new/resume lifecycle contract. Codex marks the probe non-authoritative, so Waker emits a neutral pre-spawn dispatch line and logs the map-based `result.isNew` decision after completion. Missing metadata retains the established Claude-compatible behavior for injected or third-party spawners.
+
+## Module Contracts
+
+- `CodexSpawner.wake()` owns Codex new/resume selection from `getThreadIdFn(anchor)`.
+- Spawners expose whether the shared transcript probe is authoritative through backend capability metadata; Waker does not branch on agent type.
+- Claude's existing `spawning new` / `resuming session` and `claude --resume <id>` takeover logging contract remains unchanged.
+- A fresh run persists exactly once after the first valid generated thread ID is observed.
+- `wake()` resolves `{ sessionId, exitCode, isNew }`, where `isNew` is the decision used to build argv.
+- Mapping persistence failures are logged by the session-map implementation and never reject the wake.
+- Waker must not claim a backend-specific new/resume state that differs from `result.isNew`.
+
+## Risks / Trade-offs
+
+- **Risk: An identifier is persisted before Codex has fully flushed its rollout.** Mitigation: `thread.started` is Codex's session establishment event; regression tests cover resume command selection, and no fallback hides a genuine resume failure.
+- **Risk: Duplicate identifier events cause unnecessary disk writes.** Mitigation: guard the first successful observation and assert exactly one persistence call per fresh wake.
+- **Risk: Moving Codex lifecycle detail later reduces pre-spawn operator information.** Mitigation: retain the anchor in a neutral dispatch line, then log actual backend state from the result; Claude keeps its existing pre-spawn takeover hint.
+- **Risk: Existing stale mappings remain stale.** Mitigation: this change is forward-fixing and does not alter the deliberate no-silent-fallback policy.
+
+## Migration Plan
+
+No data migration is required. Deploy the daemon code and restart running daemons to pick it up. Existing valid mappings continue to work unchanged. Rollback restores the previous persistence timing but does not invalidate mappings written by the new version.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/proposal.md
+++ b/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Chorus UI interrupt stops a fresh Codex turn with a non-zero exit after Codex has already created and reported its thread. The daemon currently persists the anchor-to-thread mapping only after exit code 0, so the next wake cannot reliably resume the interrupted conversation.
+
+## What Changes
+
+- Persist a fresh Codex thread mapping as soon as the first valid thread identifier is observed.
+- Keep mapping persistence exactly-once per fresh wake, atomic, best-effort, and independent of the child process exit code.
+- Ensure a wake after interrupt resumes the captured thread instead of silently starting a new conversation.
+- Make Codex new/resume lifecycle logging reflect the backend's actual map-based decision.
+- Add focused unit and daemon integration regression coverage for interrupted first turns and repeated interrupts of already-known threads.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `daemon-codex-backend`: Strengthen Codex session anchoring so a thread captured before an interrupted exit remains resumable, and require accurate map-based lifecycle observability.
+
+## Impact
+
+- Affected modules: `cli/codex-spawner.mjs`, `cli/waker.mjs`, and their focused tests.
+- Persisted format: unchanged `~/.chorus/codex-sessions.json` anchor-to-thread map.
+- APIs, database schema, dependencies, and UI contracts: unchanged.

--- a/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/specs/daemon-codex-backend/spec.md
+++ b/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/specs/daemon-codex-backend/spec.md
@@ -1,21 +1,4 @@
-# daemon-codex-backend Specification
-
-## Purpose
-TBD - created by archiving change add-daemon-codex-backend. Update Purpose after archive.
-## Requirements
-### Requirement: Headless Codex wake over `codex exec --json`
-
-When the resolved backend is `codex`, the daemon SHALL wake the local Codex by spawning `codex exec --json` as a headless subprocess, feeding the wake prompt over **stdin** (never as a command-line argument), and parsing the JSONL event stream from stdout. The spawned child SHALL carry `CHORUS_DAEMON_HEADLESS=1` in its environment, matching the Claude backend's headless signal. The spawner SHALL resolve the `codex` executable without a shell (PATH walk for the platform's candidate names, a `.cmd`/`.bat` shim run via `cmd.exe` on Windows), honoring a `CHORUS_CODEX_PATH` override when set, and SHALL refuse to spawn with a visible log if it cannot locate the executable.
-
-#### Scenario: New wake spawns codex exec with the prompt on stdin
-
-- **WHEN** the daemon wakes the codex backend for an anchor that has no recorded Codex thread id
-- **THEN** it spawns `codex exec --json` (plus the resolved sandbox flag) with the prompt written to stdin, and no part of the prompt appears in the process arguments
-
-#### Scenario: Missing codex executable fails visibly without crashing
-
-- **WHEN** no `codex` executable can be resolved on PATH and `CHORUS_CODEX_PATH` is unset or invalid
-- **THEN** the wake resolves without spawning, emits a visible error log, and the daemon keeps running
+## MODIFIED Requirements
 
 ### Requirement: Codex session anchoring via a persisted idea→thread-id map
 
@@ -54,34 +37,6 @@ Because Codex generates its own `thread_id` rather than accepting a client-suppl
 - **THEN** the Codex command MUST follow the thread map
 - **AND** daemon lifecycle logs MUST NOT claim that the contradictory Claude-probe answer was used
 
-### Requirement: Permission mode maps to a Codex sandbox posture, defaulting to YOLO
-
-The daemon's backend-agnostic permission mode SHALL map to a Codex sandbox posture: `yolo` SHALL run `codex exec` with `--dangerously-bypass-approvals-and-sandbox` (full autonomy for code-writing work), and the restricted `chorus` posture SHALL run with `--sandbox read-only` (MCP tool calls permitted; no shell execution or file writes). Consistent with the daemon's existing default, an unconfigured daemon SHALL wake Codex in `yolo`.
-
-#### Scenario: Default codex wake runs with full-autonomy sandbox bypass
-
-- **WHEN** the daemon wakes the codex backend with no permission flags overriding the default
-- **THEN** the `codex exec` invocation includes `--dangerously-bypass-approvals-and-sandbox`
-
-#### Scenario: Restricted posture runs codex read-only
-
-- **WHEN** the daemon is run in the restricted `chorus` posture and wakes the codex backend
-- **THEN** the `codex exec` invocation includes `--sandbox read-only` so the woken Codex can call MCP tools but cannot run shell commands or write files
-
-### Requirement: Codex MCP comes from the user config with the daemon key via env
-
-The daemon SHALL NOT synthesize a Codex MCP configuration. It SHALL rely on the user's existing `~/.codex/config.toml` to declare the Chorus MCP server (`[mcp_servers.chorus]`). To make the woken Codex authenticate as the daemon's own agent, the spawner SHALL export the daemon's resolved API key into the child process environment under the variable the user's config references via `bearer_token_env_var` (default `CHORUS_API_KEY`); the key SHALL be passed through the environment and SHALL NOT appear in the process arguments. When the user's config declares no Chorus MCP server, the woken Codex SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail.
-
-#### Scenario: Daemon key reaches the user-configured Chorus MCP server via env
-
-- **WHEN** the user's `~/.codex/config.toml` declares `[mcp_servers.chorus]` with `bearer_token_env_var = "CHORUS_API_KEY"` and the daemon wakes the codex backend
-- **THEN** the spawned Codex receives the daemon's resolved API key in its `CHORUS_API_KEY` environment variable (never in argv), so its Chorus MCP calls authenticate as the daemon's agent
-
-#### Scenario: No Chorus MCP configured still runs
-
-- **WHEN** the user's Codex config declares no Chorus MCP server
-- **THEN** the wake still spawns and completes, the woken Codex simply lacks Chorus tools, and the daemon logs the absence instead of crashing
-
 ### Requirement: Codex interrupt via detached process-group kill
 
 The Codex backend SHALL spawn its subprocess in a detached POSIX process group (so it leads its own group and a group-directed signal reaches the child shells `codex exec` forks for tool calls), and the daemon's existing two-stage process-tree killer (graceful SIGINT, then forceful SIGKILL of the group after a timeout; `taskkill /T /F` on Windows) SHALL be reused unchanged to interrupt a running Codex wake. After an interrupt, a subsequent wake for the same anchor SHALL resume the recorded Codex `thread_id` whenever a valid identifier was emitted before the interrupt, including when the interrupted turn was the first turn for that anchor.
@@ -101,4 +56,3 @@ The Codex backend SHALL spawn its subprocess in a detached POSIX process group (
 - **WHEN** a wake resumes an already-mapped Codex thread, that resumed wake is interrupted, and another wake fires for the same anchor
 - **THEN** the daemon MUST retain the existing mapping
 - **AND** the later wake MUST again invoke `codex exec resume` with the same `thread_id`
-

--- a/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/tasks.md
+++ b/openspec/changes/archive/2026-07-24-fix-codex-interrupt-session-resume/tasks.md
@@ -1,0 +1,10 @@
+## 1. Thread Identity Durability
+
+- [x] 1.1 Persist a fresh Codex anchor-to-thread mapping on the first valid identifier event, with exactly one write per fresh wake and no writes before thread establishment.
+- [x] 1.2 Add focused CodexSpawner tests for interrupted/non-zero exits, exactly-once duplicate identifier handling, successful exits, missing identifiers, and best-effort write failures.
+
+## 2. Resume Integration And Observability
+
+- [x] 2.1 Align backend-neutral Waker lifecycle logging with the Codex spawner's actual map-based new/resume result.
+- [x] 2.2 Add daemon integration regressions proving that a first turn interrupted after `thread.started` resumes the same thread on the next wake, a resumed known-thread wake can be interrupted and resumed again with the same ID, and persisted mapping survives a spawner/daemon restart.
+- [x] 2.3 Run the focused CLI test suites and OpenSpec validation.


### PR DESCRIPTION
## Summary

- persist a fresh Codex thread mapping as soon as the first valid thread identifier is observed, before an interrupted process exits non-zero
- expose backend session-decision metadata so Codex logs its map-based new/resume result while Claude keeps its existing takeover hint
- cover first-turn interrupt recovery, daemon restart persistence, repeated interruption of known threads, duplicate events, and pre-ID failures
- archive and merge the OpenSpec change into `daemon-codex-backend`

## Root cause

`CodexSpawner` previously wrote `anchor -> thread_id` only when a fresh process exited with code 0. Chorus UI interrupt terminates Codex with a non-zero exit after `thread.started`, so the valid thread ID was discarded and the next daemon wake could not resume the conversation.

## Verification

- `pnpm exec vitest run cli/__tests__` (53 files, 809 tests)
- focused Codex/wake suites (95 tests)
- focused ESLint
- `git diff --check`
- OpenSpec validation
- Chorus task reviews and aggregate code-review gateway: PASS

Chorus Idea: `7d96ae5f-69e1-4743-ae61-80733ed23644`