### PR TITLE
fix(daemon): recover silent SSE partitions

### DIFF
--- a/cli/__tests__/daemon-rest-client.test.mjs
+++ b/cli/__tests__/daemon-rest-client.test.mjs
@@ -195,6 +195,25 @@ describe("createDaemonRestClient — payload shapes (single source of truth)", (
     });
   });
 
+  it("heartbeat POSTs the explicit connection generation with Bearer auth", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+
+    const result = await client.heartbeat({
+      connectionUuid: "conn-old",
+      connectedAt: "2026-07-25T08:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    const [endpoint, init] = fetchImpl.mock.calls[0];
+    expect(endpoint).toBe("https://chorus.example.com/api/daemon/connection-heartbeat");
+    expect(init.headers.Authorization).toBe("Bearer cho_secret");
+    expect(JSON.parse(init.body)).toEqual({
+      connectionUuid: "conn-old",
+      connectedAt: "2026-07-25T08:00:00.000Z",
+    });
+  });
+
   it("readPendingTurns GETs ?connectionUuid=… (encoded) and returns the parsed turns", async () => {
     const turns = [
       { turnUuid: "t-1", sessionId: "idea-1", directIdeaUuid: "idea-1", trigger: "human_instruction", promptText: "do it" },
@@ -369,6 +388,7 @@ describe("createDaemonRestClient — error surfacing (no silent errors)", () => 
     await expect(client.transcript({ sessionId: "s", messages: [{ role: "user", text: "x" }] })).resolves.toBeTruthy();
     await expect(client.executionState({ executions: [] })).resolves.toBeTruthy();
     await expect(client.reportInterrupt({ entityType: "task", entityUuid: "t", reason: "crash" })).resolves.toBeTruthy();
+    await expect(client.heartbeat({ connectionUuid: "c", connectedAt: "g" })).resolves.toBeTruthy();
     await expect(client.readPendingTurns()).resolves.toBeTruthy();
   });
 });

--- a/cli/__tests__/sse-listener.test.mjs
+++ b/cli/__tests__/sse-listener.test.mjs
@@ -64,6 +64,65 @@ describe("SseListener parsing", () => {
       /^https:\/\/chorus\.example\/api\/events\/notifications\?/
     );
     expect(calledInit.headers).toMatchObject({ Authorization: "Bearer cho_x" });
+    expect(new URL(calledUrl).searchParams.get("livenessAck")).toBe("v1");
+  });
+
+  it("acknowledges heartbeat comments only after a generation-bearing registration", async () => {
+    const events = [];
+    const acknowledgeHeartbeat = vi.fn(async () => ({ ok: true, status: 200 }));
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse([
+        ": heartbeat\n\n",
+        'data: {"type":"connection_registered","connectionUuid":"conn-42","connectedAt":"2026-07-25T08:00:00.000Z"}\n\n',
+        ": heartbeat\n\n",
+      ])
+    );
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (event) => events.push(event),
+      acknowledgeHeartbeat,
+      logger: silentLogger,
+      fetchImpl,
+    });
+
+    await listener.connect();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(acknowledgeHeartbeat).toHaveBeenCalledTimes(1);
+    expect(acknowledgeHeartbeat).toHaveBeenCalledWith({
+      connectionUuid: "conn-42",
+      connectedAt: "2026-07-25T08:00:00.000Z",
+    });
+    expect(events).toEqual([]);
+    listener.disconnect();
+  });
+
+  it("logs a thrown heartbeat acknowledgment failure without stopping parsing", async () => {
+    const warns = [];
+    const events = [];
+    const fetchImpl = vi.fn(async () =>
+      streamingResponse([
+        'data: {"type":"connection_registered","connectionUuid":"c","connectedAt":"g"}\n\n',
+        ": heartbeat\n\n",
+        'data: {"type":"new_notification","notificationUuid":"after"}\n\n',
+      ])
+    );
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: (event) => events.push(event),
+      acknowledgeHeartbeat: async () => { throw new Error("offline"); },
+      logger: { ...silentLogger, warn: (message) => warns.push(message) },
+      fetchImpl,
+    });
+
+    await listener.connect();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(events).toEqual([{ type: "new_notification", notificationUuid: "after" }]);
+    expect(warns.join(" ")).toMatch(/heartbeat acknowledgment failed.*offline/);
+    listener.disconnect();
   });
 
   it("strips trailing CR so CRLF transports parse", async () => {
@@ -369,6 +428,149 @@ describe("SseListener self-report URL", () => {
 });
 
 describe("SseListener reconnect", () => {
+  function controlledResponse() {
+    let controller;
+    const body = new ReadableStream({
+      start(value) {
+        controller = value;
+      },
+    });
+    return {
+      response: { ok: true, status: 200, body },
+      push(text) {
+        controller.enqueue(new TextEncoder().encode(text));
+      },
+      close() {
+        controller.close();
+      },
+    };
+  }
+
+  it("aborts a byte-silent stream and reconnects through the existing backfill path", async () => {
+    vi.useFakeTimers();
+    const first = controlledResponse();
+    const second = controlledResponse();
+    const signals = [];
+    const onReconnect = vi.fn(async () => {});
+    const fetchImpl = vi.fn(async (_url, init) => {
+      signals.push(init.signal);
+      return signals.length === 1 ? first.response : second.response;
+    });
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: () => {},
+      onReconnect,
+      logger: silentLogger,
+      fetchImpl,
+      watchdogTimeoutMs: 75_000,
+      initialDelayMs: 1_000,
+    });
+
+    await listener.connect();
+    await vi.advanceTimersByTimeAsync(75_000);
+    expect(signals[0].aborted).toBe(true);
+    expect(listener.status).toBe("reconnecting");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+
+    listener.disconnect();
+    vi.useRealTimers();
+  });
+
+  it("refreshes the watchdog on partial bytes before an SSE frame can be parsed", async () => {
+    vi.useFakeTimers();
+    const stream = controlledResponse();
+    const fetchImpl = vi.fn(async () => stream.response);
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: () => {},
+      logger: silentLogger,
+      fetchImpl,
+      watchdogTimeoutMs: 75_000,
+    });
+
+    await listener.connect();
+    await vi.advanceTimersByTimeAsync(74_000);
+    stream.push("data: {");
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(74_000);
+    expect(fetchImpl.mock.calls[0][1].signal.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fetchImpl.mock.calls[0][1].signal.aborted).toBe(true);
+
+    listener.disconnect();
+    vi.useRealTimers();
+  });
+
+  it("disconnect clears the watchdog so it cannot schedule a later reconnect", async () => {
+    vi.useFakeTimers();
+    const stream = controlledResponse();
+    const fetchImpl = vi.fn(async () => stream.response);
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: () => {},
+      logger: silentLogger,
+      fetchImpl,
+      watchdogTimeoutMs: 100,
+      initialDelayMs: 10,
+    });
+
+    await listener.connect();
+    listener.disconnect();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(listener.status).toBe("disconnected");
+    vi.useRealTimers();
+  });
+
+  it("an obsolete watchdog cannot abort its replacement stream or schedule a duplicate reconnect", async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const first = controlledResponse();
+    const replacement = controlledResponse();
+    const signals = [];
+    const fetchImpl = vi.fn(async (_url, init) => {
+      signals.push(init.signal);
+      return signals.length === 1 ? first.response : replacement.response;
+    });
+    const listener = new SseListener({
+      url: "https://c",
+      apiKey: "k",
+      onEvent: () => {},
+      logger: silentLogger,
+      fetchImpl,
+      watchdogTimeoutMs: 100,
+      initialDelayMs: 10,
+    });
+
+    await listener.connect();
+    const obsoleteWatchdog = timeoutSpy.mock.calls.find(([, delay]) => delay === 100)?.[0];
+    expect(obsoleteWatchdog).toBeTypeOf("function");
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(signals[1].aborted).toBe(false);
+    expect(listener.status).toBe("connected");
+
+    obsoleteWatchdog();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(signals[1].aborted).toBe(false);
+    expect(listener.status).toBe("connected");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    listener.disconnect();
+    timeoutSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
   it("schedules a backoff reconnect on non-ok response without crashing", async () => {
     vi.useFakeTimers();
     let call = 0;

--- a/cli/__tests__/sse-silent-partition.integration.test.mjs
+++ b/cli/__tests__/sse-silent-partition.integration.test.mjs
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createTcpServer, connect as connectTcp } from "node:net";
+import { once } from "node:events";
+import { SseListener } from "../sse-listener.mjs";
+
+const WATCHDOG_MS = 140;
+const RECONNECT_MS = 20;
+const STALE_MS = 70;
+const HEARTBEAT_MS = 15;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(predicate, timeoutMs, label) {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    if (predicate()) return;
+    await delay(5);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function listen(server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return server.address().port;
+}
+
+describe("SSE silent-partition recovery", () => {
+  const cleanup = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(cleanup.splice(0).reverse().map((close) => close()));
+  });
+
+  it("recovers through a TCP blackhole and rejects work after ack freshness expires", async () => {
+    const state = {
+      generation: 0,
+      active: null,
+      lastSeenAt: 0,
+      heartbeatWrites: 0,
+      heartbeatAcks: 0,
+      pending: [],
+      backfillReads: 0,
+      turnsCreated: 0,
+      firstStreamClosedAt: null,
+    };
+    const streams = new Set();
+
+    const origin = createHttpServer(async (req, res) => {
+      const requestUrl = new URL(req.url, "http://origin.test");
+      if (requestUrl.pathname === "/api/events/notifications") {
+        const generation = ++state.generation;
+        const connectedAt = new Date().toISOString();
+        state.active = { connectionUuid: "conn-1", connectedAt };
+        state.lastSeenAt = performance.now();
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        res.write(
+          `data: ${JSON.stringify({
+            type: "connection_registered",
+            connectionUuid: "conn-1",
+            connectedAt,
+          })}\n\n`,
+        );
+        const heartbeat = setInterval(() => {
+          state.heartbeatWrites += 1;
+          res.write(": heartbeat\n\n");
+        }, HEARTBEAT_MS);
+        streams.add(res);
+        req.on("close", () => {
+          clearInterval(heartbeat);
+          streams.delete(res);
+          if (generation === 1) state.firstStreamClosedAt = performance.now();
+        });
+        return;
+      }
+
+      if (requestUrl.pathname === "/api/daemon/connection-heartbeat") {
+        let body = "";
+        for await (const chunk of req) body += chunk;
+        const ack = JSON.parse(body);
+        if (
+          state.active &&
+          ack.connectionUuid === state.active.connectionUuid &&
+          ack.connectedAt === state.active.connectedAt
+        ) {
+          state.lastSeenAt = performance.now();
+          state.heartbeatAcks += 1;
+          res.writeHead(200).end();
+        } else {
+          res.writeHead(409).end();
+        }
+        return;
+      }
+
+      if (requestUrl.pathname === "/api/daemon/pending-turns") {
+        state.backfillReads += 1;
+        const notifications = state.pending.splice(0);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ notifications }));
+        return;
+      }
+
+      if (requestUrl.pathname === "/api/daemon-sessions/session-1/instruction") {
+        if (performance.now() - state.lastSeenAt > STALE_MS) {
+          res.writeHead(409).end();
+        } else {
+          state.turnsCreated += 1;
+          res.writeHead(201).end();
+        }
+        return;
+      }
+
+      res.writeHead(404).end();
+    });
+    const originPort = await listen(origin);
+    cleanup.push(
+      () =>
+        new Promise((resolve) => {
+          for (const stream of streams) stream.destroy();
+          origin.close(resolve);
+        }),
+    );
+
+    let blackholeFirstStream = false;
+    let firstResponseSocket = null;
+    let firstResponseBytesAtBlackhole = 0;
+    let firstResponseBytes = 0;
+    const proxySockets = new Set();
+    const proxy = createTcpServer((downstream) => {
+      const upstream = connectTcp(originPort, "127.0.0.1");
+      proxySockets.add(downstream);
+      proxySockets.add(upstream);
+      downstream.pipe(upstream);
+      const isFirst = firstResponseSocket === null;
+      if (isFirst) firstResponseSocket = downstream;
+      upstream.on("data", (chunk) => {
+        if (isFirst) {
+          firstResponseBytes += chunk.byteLength;
+          if (blackholeFirstStream) return;
+        }
+        if (!downstream.destroyed) downstream.write(chunk);
+      });
+      const closePeer = (socket) => {
+        proxySockets.delete(socket);
+        if (!socket.destroyed) socket.destroy();
+      };
+      downstream.on("close", () => closePeer(upstream));
+      upstream.on("close", () => closePeer(downstream));
+      downstream.on("error", () => {});
+      upstream.on("error", () => {});
+    });
+    const proxyPort = await listen(proxy);
+    cleanup.push(
+      () =>
+        new Promise((resolve) => {
+          for (const socket of proxySockets) socket.destroy();
+          proxy.close(resolve);
+        }),
+    );
+
+    const baseUrl = `http://127.0.0.1:${proxyPort}`;
+    const received = [];
+    const recoveryTimings = {};
+    let listener;
+    const listenerCleanup = () => listener?.disconnect();
+    cleanup.push(async () => listenerCleanup());
+
+    listener = new SseListener({
+      url: baseUrl,
+      apiKey: "cho_test",
+      watchdogTimeoutMs: WATCHDOG_MS,
+      initialDelayMs: RECONNECT_MS,
+      maxDelayMs: RECONNECT_MS,
+      logger: { info() {}, warn() {}, error() {} },
+      onEvent: (event) => received.push(event),
+      acknowledgeHeartbeat: async (registration) =>
+        fetch(`${baseUrl}/api/daemon/connection-heartbeat`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(registration),
+        }),
+      onReconnect: async () => {
+        recoveryTimings.reconnectedAt = performance.now();
+        const response = await fetch(`${baseUrl}/api/daemon/pending-turns`);
+        const body = await response.json();
+        received.push(...body.notifications);
+      },
+    });
+
+    await listener.connect();
+    await waitFor(() => state.heartbeatAcks > 0, 500, "initial heartbeat acknowledgment");
+
+    blackholeFirstStream = true;
+    firstResponseBytesAtBlackhole = firstResponseBytes;
+    const blackholedAt = performance.now();
+    const lastSeenAtBlackhole = state.lastSeenAt;
+    state.pending.push({ type: "new_notification", notificationUuid: "during-gap" });
+    for (const stream of streams) {
+      stream.write(
+        `data: ${JSON.stringify({
+          type: "new_notification",
+          notificationUuid: "during-gap",
+        })}\n\n`,
+      );
+    }
+
+    await delay(STALE_MS + 25);
+    expect(firstResponseBytes).toBeGreaterThan(firstResponseBytesAtBlackhole);
+    expect(state.firstStreamClosedAt).toBeNull();
+    expect(received).toEqual([]);
+    expect(state.heartbeatWrites).toBeGreaterThan(1);
+    expect(state.lastSeenAt).toBe(lastSeenAtBlackhole);
+
+    const instruction = await fetch(
+      `${baseUrl}/api/daemon-sessions/session-1/instruction`,
+      { method: "POST" },
+    );
+    expect(instruction.status).toBe(409);
+    expect(state.turnsCreated).toBe(0);
+
+    await waitFor(() => state.generation === 2 && state.backfillReads === 1, 700, "watchdog reconnect");
+    await waitFor(() => received.length === 1, 300, "notification backfill");
+    recoveryTimings.firstStreamClosedAt = state.firstStreamClosedAt;
+
+    expect(state.firstStreamClosedAt).not.toBeNull();
+    expect(state.firstStreamClosedAt - blackholedAt).toBeGreaterThanOrEqual(WATCHDOG_MS - 30);
+    expect(recoveryTimings.reconnectedAt - blackholedAt).toBeLessThan(WATCHDOG_MS + RECONNECT_MS + 180);
+    expect(received).toEqual([
+      { type: "new_notification", notificationUuid: "during-gap" },
+    ]);
+    expect(state.backfillReads).toBe(1);
+
+    // Keep measured bounds visible in verbose CI output without making them assertions-only.
+    // eslint-disable-next-line no-console
+    console.info(
+      `[silent-partition] watchdog abort=${Math.round(
+        state.firstStreamClosedAt - blackholedAt,
+      )}ms reconnect+backfill=${Math.round(
+        recoveryTimings.reconnectedAt - blackholedAt,
+      )}ms`,
+    );
+  }, 3_000);
+});

--- a/cli/__tests__/sse-silent-partition.integration.test.mjs
+++ b/cli/__tests__/sse-silent-partition.integration.test.mjs
@@ -4,9 +4,9 @@ import { createServer as createTcpServer, connect as connectTcp } from "node:net
 import { once } from "node:events";
 import { SseListener } from "../sse-listener.mjs";
 
-const WATCHDOG_MS = 140;
+const WATCHDOG_MS = 300;
 const RECONNECT_MS = 20;
-const STALE_MS = 70;
+const STALE_MS = 80;
 const HEARTBEAT_MS = 15;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -198,7 +198,6 @@ describe("SSE silent-partition recovery", () => {
     blackholeFirstStream = true;
     firstResponseBytesAtBlackhole = firstResponseBytes;
     const blackholedAt = performance.now();
-    const lastSeenAtBlackhole = state.lastSeenAt;
     state.pending.push({ type: "new_notification", notificationUuid: "during-gap" });
     for (const stream of streams) {
       stream.write(
@@ -209,6 +208,11 @@ describe("SSE silent-partition recovery", () => {
       );
     }
 
+    // An ACK triggered by bytes delivered immediately before the blackhole may
+    // still be in flight on its separate REST connection. Let it drain before
+    // measuring whether server-side freshness remains frozen.
+    await delay(HEARTBEAT_MS * 2);
+    const lastSeenAtBlackhole = state.lastSeenAt;
     await delay(STALE_MS + 25);
     expect(firstResponseBytes).toBeGreaterThan(firstResponseBytesAtBlackhole);
     expect(state.firstStreamClosedAt).toBeNull();

--- a/cli/daemon-rest-client.mjs
+++ b/cli/daemon-rest-client.mjs
@@ -16,6 +16,8 @@
 //                                                       startedAt|null }] }
 //   reportInterrupt  → POST /api/daemon/report-interrupt
 //                      { connectionUuid, entityType, entityUuid, reason }
+//   heartbeat        → POST /api/daemon/connection-heartbeat
+//                      { connectionUuid, connectedAt }
 //   readPendingTurns → GET  /api/daemon/pending-turns?connectionUuid=…
 //                      → { turns: [{ turnUuid, sessionId, directIdeaUuid, trigger,
 //                                    promptText }] }
@@ -72,6 +74,7 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
  *   transcript: (p: { sessionId: string, messages: Array<{ role: string, text: string }> }) => Promise<DaemonRestResult>,
  *   executionState: (p: { executions: Array<Record<string, unknown>> }) => Promise<DaemonRestResult>,
  *   reportInterrupt: (p: { entityType: string, entityUuid: string, reason: string }) => Promise<DaemonRestResult>,
+ *   heartbeat: (p: { connectionUuid: string, connectedAt: string }) => Promise<DaemonRestResult>,
  *   readPendingTurns: () => Promise<DaemonRestResult>,
  * }}
  */
@@ -234,6 +237,20 @@ export function createDaemonRestClient(opts) {
         // standalone interrupt reporter used to emit) without altering the asserted
         // `report-interrupt request failed` / `report-interrupt returned <status>` prefix.
         ` for ${entityType}:${entityUuid}`,
+      );
+    },
+
+    /**
+     * POST /api/daemon/connection-heartbeat — acknowledge receipt of one SSE heartbeat.
+     * The values come directly from the active stream's registration handshake; unlike
+     * other connection-scoped operations this must not resolve the uuid lazily, because
+     * a delayed acknowledgment must retain its original generation fence.
+     */
+    async heartbeat({ connectionUuid, connectedAt }) {
+      return post(
+        "connection-heartbeat",
+        "/api/daemon/connection-heartbeat",
+        { connectionUuid, connectedAt },
       );
     },
 

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -43,6 +43,7 @@ import {
 import { WAKE_ACTIONS } from "./prompts.mjs";
 import { createInterruptReporter } from "./interrupt-reporter.mjs";
 import { createTurnReporter } from "./turn-reporter.mjs";
+import { createDaemonRestClient } from "./daemon-rest-client.mjs";
 import { createControlHandler } from "./control-handler.mjs";
 import { resolveSigintTimeoutMs, resolveDaemonCwds } from "./daemon-config.mjs";
 import {
@@ -205,6 +206,13 @@ export function buildDaemon(creds, deps = {}) {
     // doesn't matter. Per-connection so each path's wakes report against the right row.
     /** @type {{ connectionUuid: string|null }} */
     const connectionState = { connectionUuid: null };
+    const daemonRestClient = createDaemonRestClient({
+      url: creds.url,
+      apiKey: creds.apiKey,
+      getConnectionUuid: () => connectionState.connectionUuid,
+      logger,
+      fetchImpl: deps.fetchImpl,
+    });
 
     // Per-connection terminal-outcome bookkeeping (add-daemon-connection-conflict-skip).
     // `resolved` guards recordConnectionOutcome against double-counting a reconnect's
@@ -389,6 +397,7 @@ export function buildDaemon(creds, deps = {}) {
           recordConnectionOutcome(outcome, false);
         },
         onControl,
+        acknowledgeHeartbeat: (registration) => daemonRestClient.heartbeat(registration),
         onReconnect: backfill,
         logger,
       });

--- a/cli/sse-listener.mjs
+++ b/cli/sse-listener.mjs
@@ -29,6 +29,7 @@ import { fileURLToPath } from "node:url";
 
 const INITIAL_DELAY_MS = 1_000;
 const MAX_DELAY_MS = 30_000;
+const WATCHDOG_TIMEOUT_MS = 75_000;
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 
@@ -78,6 +79,8 @@ const PROCESS_STARTED_AT = new Date();
  *   The event carries `{ host, cwd }` of the conflicting identity.
  * @property {() => Promise<void>} [onReconnect]  Called after a reconnect so the
  *   caller can back-fill notifications missed during the gap.
+ * @property {(registration: {connectionUuid:string,connectedAt:string}) => Promise<unknown>} [acknowledgeHeartbeat]
+ *   Best-effort REST acknowledgment for a parsed heartbeat comment.
  * @property {string} [cwd]  The working directory THIS connection serves (T3 — 单
  *   daemon 多路径). A multi-path daemon runs one SseListener per declared path, each
  *   self-reporting its own cwd so the server registers them as distinct connections
@@ -88,6 +91,7 @@ const PROCESS_STARTED_AT = new Date();
  * @property {typeof fetch} [fetchImpl]  Injectable for tests.
  * @property {number} [initialDelayMs]
  * @property {number} [maxDelayMs]
+ * @property {number} [watchdogTimeoutMs] Injectable for deterministic tests only.
  */
 
 export class SseListener {
@@ -100,12 +104,14 @@ export class SseListener {
     this.onControl = opts.onControl ?? (() => {});
     this.onConflict = opts.onConflict ?? (() => {});
     this.onReconnect = opts.onReconnect ?? (async () => {});
+    this.acknowledgeHeartbeat = opts.acknowledgeHeartbeat ?? (async () => {});
     /** @type {string|null} The connection this stream registered as (once reported). */
     this.connectionUuid = null;
     this.logger = opts.logger ?? NOOP_LOGGER;
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
     this.initialDelayMs = opts.initialDelayMs ?? INITIAL_DELAY_MS;
     this.maxDelayMs = opts.maxDelayMs ?? MAX_DELAY_MS;
+    this.watchdogTimeoutMs = opts.watchdogTimeoutMs ?? WATCHDOG_TIMEOUT_MS;
 
     // Build the self-reporting endpoint URL once and reuse it across every
     // (re)connect, so the reconnect path always re-sends the same params.
@@ -128,6 +134,7 @@ export class SseListener {
       host: hostname(),
       cwd: this.cwd,
       startedAt: PROCESS_STARTED_AT.toISOString(),
+      livenessAck: "v1",
     });
     this.endpoint = `${this.url}/api/events/notifications?${params.toString()}`;
 
@@ -136,14 +143,20 @@ export class SseListener {
     this.abortController = null;
     /** @type {ReturnType<typeof setTimeout> | null} */
     this.reconnectTimer = null;
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    this.watchdogTimer = null;
+    /** @type {{connectionUuid:string,connectedAt:string}|null} */
+    this.activeRegistration = null;
     this.reconnectDelay = this.initialDelayMs;
   }
 
   /** Open the SSE connection. On failure, schedules a backoff reconnect. */
   async connect() {
     this.#clearReconnectTimer();
+    this.#clearWatchdog();
     const abortController = new AbortController();
     this.abortController = abortController;
+    this.activeRegistration = null;
 
     let response;
     try {
@@ -173,6 +186,7 @@ export class SseListener {
     this.status = "connected";
     this.reconnectDelay = this.initialDelayMs;
     this.logger.info("[Chorus] SSE connection established");
+    this.#refreshWatchdog(abortController);
 
     if (wasReconnect) {
       try {
@@ -182,22 +196,25 @@ export class SseListener {
       }
     }
 
-    this.#consumeStream(response.body, abortController.signal);
+    this.#consumeStream(response.body, abortController);
   }
 
   /** Gracefully close the connection (no reconnect). */
   disconnect() {
     this.#clearReconnectTimer();
+    this.#clearWatchdog();
     if (this.abortController) {
       this.abortController.abort();
       this.abortController = null;
     }
     this.status = "disconnected";
+    this.activeRegistration = null;
     this.logger.info("[Chorus] SSE connection closed");
   }
 
-  /** @param {ReadableStream<Uint8Array>} body @param {AbortSignal} signal */
-  async #consumeStream(body, signal) {
+  /** @param {ReadableStream<Uint8Array>} body @param {AbortController} abortController */
+  async #consumeStream(body, abortController) {
+    const signal = abortController.signal;
     const decoder = new TextDecoder();
     const reader = body.getReader();
     let buffer = "";
@@ -205,6 +222,12 @@ export class SseListener {
       while (true) {
         const { done, value } = await reader.read();
         if (done || signal.aborted) break;
+        // Transport activity is byte arrival, not successful SSE parsing. Refresh before
+        // decode so comments, partial frames, and malformed payloads all prove the stream
+        // is still delivering bytes.
+        if (value && value.byteLength > 0) {
+          this.#refreshWatchdog(abortController);
+        }
         // Strip CR on ingest so CRLF transports (`\r\n\r\n` boundaries) parse the
         // same as LF — the `\n\n` boundary scan below would otherwise never match.
         buffer += decoder.decode(value, { stream: true }).replace(/\r/g, "");
@@ -219,6 +242,7 @@ export class SseListener {
       if (signal.aborted) return;
       this.logger.warn(`[Chorus] SSE stream error: ${err}`);
     } finally {
+      if (this.abortController === abortController) this.#clearWatchdog();
       try {
         reader.releaseLock();
       } catch {
@@ -235,7 +259,24 @@ export class SseListener {
   #processMessage(raw) {
     for (const line of raw.split("\n")) {
       // CR already stripped on ingest. Heartbeat / comment lines start with ":".
-      if (line.startsWith(":")) continue;
+      if (line.startsWith(":")) {
+        if (line.slice(1).trim() === "heartbeat" && this.activeRegistration) {
+          const registration = this.activeRegistration;
+          Promise.resolve()
+            .then(() => this.acknowledgeHeartbeat(registration))
+            .then((result) => {
+              if (result && typeof result === "object" && result.ok === false) {
+                // The REST client already logged the transport cause. Keep listener
+                // behavior best-effort and avoid adding a retry loop here.
+                return;
+              }
+            })
+            .catch((err) => {
+              this.logger.warn(`[Chorus] heartbeat acknowledgment failed: ${err}`);
+            });
+        }
+        continue;
+      }
       if (line.startsWith("data: ")) {
         const jsonStr = line.slice(6);
         let event;
@@ -248,8 +289,16 @@ export class SseListener {
         // The server's first data event tells us which DaemonConnection this
         // stream registered as. Capture it (for execution-state attribution) and
         // do NOT forward it as a notification — it isn't one.
-        if (event && event.type === "connection_registered" && typeof event.connectionUuid === "string") {
+        if (
+          event &&
+          event.type === "connection_registered" &&
+          typeof event.connectionUuid === "string"
+        ) {
           this.connectionUuid = event.connectionUuid;
+          this.activeRegistration =
+            typeof event.connectedAt === "string"
+              ? { connectionUuid: event.connectionUuid, connectedAt: event.connectedAt }
+              : null;
           try {
             this.onConnectionId(event.connectionUuid);
           } catch (err) {
@@ -303,6 +352,34 @@ export class SseListener {
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+  }
+
+  /** @param {AbortController|null} abortController */
+  #refreshWatchdog(abortController) {
+    this.#clearWatchdog();
+    if (!abortController || abortController.signal.aborted || this.abortController !== abortController) return;
+    this.watchdogTimer = setTimeout(() => {
+      this.watchdogTimer = null;
+      if (
+        this.abortController !== abortController ||
+        abortController.signal.aborted ||
+        this.status !== "connected"
+      ) {
+        return;
+      }
+      this.logger.warn(
+        `[Chorus] SSE stream received no bytes for ${this.watchdogTimeoutMs}ms; reconnecting`
+      );
+      abortController.abort();
+      this.#scheduleReconnect();
+    }, this.watchdogTimeoutMs);
+  }
+
+  #clearWatchdog() {
+    if (this.watchdogTimer !== null) {
+      clearTimeout(this.watchdogTimer);
+      this.watchdogTimer = null;
     }
   }
 }

--- a/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/README.md
+++ b/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/README.md
@@ -1,0 +1,3 @@
+# fix-daemon-sse-silent-zombie
+
+Detect silent daemon SSE partitions with a client watchdog and truthful server liveness acknowledgments

--- a/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/design.md
+++ b/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The notification SSE stream is the daemon's only permanently open connection. The server emits a comment every 30 seconds, but `SseListener` ignores comments and waits indefinitely in `reader.read()` when a network device silently blackholes the socket. Undici normally raises `UND_ERR_BODY_TIMEOUT` after about 300 seconds, but that implicit default is too slow and does not cover every half-open failure mode.
+
+The server currently calls `touchConnection` from the same timer that writes the outbound heartbeat. That proves only that the server timer ran. If the peer disappeared without an observable abort, the timer continues refreshing `lastSeenAt`; `assertContinuable` therefore sees a fresh origin and permits a turn that no daemon can receive. The existing stale-origin behavior is already correct: after 90 seconds without a valid touch, instruction submission returns a structured 409 before creating a turn.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect an SSE stream that has delivered no bytes for 75 seconds.
+- Reuse the existing abort, reconnect backoff, and notification backfill flow.
+- Make server-side connection freshness depend on proof that the daemon received a heartbeat.
+- Fence delayed acknowledgments so an obsolete stream cannot refresh a newer registration generation.
+- Prove recovery with deterministic tests and a no-FIN/no-RST network fault.
+
+**Non-Goals:**
+
+- Retrying `turnAdvance`, `executionState`, `reportInterrupt`, or `readPendingTurns`.
+- Adding limits or TTLs to the event-router `seen` set or lineage cache.
+- Changing the 30-second heartbeat cadence, 90-second server staleness threshold, instruction API error shape, or origin-pinning semantics.
+- Guaranteeing delivery of an instruction accepted immediately before a connection becomes stale; reconnect backfill remains the durability mechanism.
+
+## Decisions
+
+### Use a byte-arrival watchdog in `SseListener`
+
+Each successful stream starts a 75-second deadline. Every non-empty chunk returned by `reader.read()` refreshes it before decoding, so comments, partial frames, and data events all count as transport activity. On expiry, the listener logs a distinct warning and aborts that connection. The normal stream-exit logic schedules reconnect, and `onReconnect` performs backfill.
+
+The watchdog is connection-generation local: reconnect and explicit `disconnect()` clear the prior timer, and a stale timer may not abort a replacement controller. The timeout is injectable for tests but is not exposed as user configuration in this change.
+
+Alternative considered: rely on undici's 300-second `bodyTimeout`. It is implicit, slower, and transport-implementation dependent.
+
+### Negotiate acknowledgment liveness explicitly
+
+An upgraded daemon adds `livenessAck=v1` to its SSE self-report. The server treats only this exact capability value as acknowledgment-aware. For an opted-in stream, the server does not call `touchConnection` from its outbound timer and expects client acknowledgments. For a stream without the capability, including every old daemon, the server retains legacy timer-side touches.
+
+This supports a server-first rolling deployment: deploying the server changes no legacy client's liveness, then each upgraded daemon opts into truthful liveness when it reconnects. Unknown capability values fall back to legacy behavior. After the minimum supported CLI version includes acknowledgments, a later independent cleanup may remove the compatibility branch.
+
+Alternative considered: infer support from `clientVersion`. Explicit protocol negotiation avoids semver parsing, prerelease ambiguity, and coupling transport behavior to packaging metadata.
+
+### Make heartbeat receipt produce a generation-fenced acknowledgment
+
+The `connection_registered` handshake includes the connection UUID and its registration-generation timestamp (or an equivalent opaque lease token). After parsing each `: heartbeat` comment, the daemon sends a best-effort authenticated acknowledgment carrying both values to a narrow daemon connection heartbeat endpoint.
+
+The endpoint reconstructs the existing `ConnectionHandle` fence and calls `touchConnection`; an acknowledgment from an older stream therefore updates zero rows after a newer generation has registered. Authentication and company/agent ownership checks are applied before the write. The acknowledgment does not enter the notification router or wake path.
+
+Acknowledgment failure is logged at a bounded cadence and is not retried by this change. If the network is broken, failures stop `lastSeenAt` from advancing, which is the desired liveness result. A transient failure may temporarily age the row, but the next 30-second heartbeat can refresh it before the 90-second threshold.
+
+Alternative considered: continue touching from the server heartbeat timer and inspect `controller.enqueue`. Enqueue success only proves that a local stream buffer accepted bytes, not that the remote daemon received them, so it cannot close the false-online gap.
+
+### Preserve the existing server refusal path
+
+For opted-in streams, the server removes the timer-side `touchConnection` call but keeps heartbeat emission and abort cleanup. Legacy streams retain timer-side touches during the rolling compatibility window. All effective-online readers continue using `status === "online" && age <= 90s`. `assertContinuable` and the instruction route therefore already provide the selected behavior for upgraded daemons: stale origin means the existing read-only 409 and no turn mutation.
+
+### Verify the actual half-open failure
+
+Unit tests use fake timers and controlled streams to cover chunk refresh, heartbeat parsing and acknowledgment, timeout abort, timer cleanup, stale-generation fencing, and 409-before-mutation behavior. An integration fault test places a TCP proxy between listener and SSE server, establishes the stream, then blackholes traffic without closing either socket. It must observe watchdog expiry, reconnect, backfill of a notification created during the gap, and server staleness/refusal while acknowledgments are absent.
+
+## Module Contracts
+
+- `SseListener` owns the 75-second byte watchdog and clears all connection-local timers on replacement or disconnect.
+- SSE heartbeat comments remain invisible to `onEvent`; they additionally trigger a best-effort liveness acknowledgment.
+- The SSE handshake provides a generation fence. A heartbeat acknowledgment must identify both connection UUID and generation.
+- `livenessAck=v1` selects acknowledgment-driven liveness; absent or unknown values select the legacy timer-touch behavior.
+- For opted-in streams, only a valid acknowledgment for the active generation advances `lastSeenAt`; outbound server heartbeat ticks never do.
+- Existing `STALE_THRESHOLD_MS`, `SessionReadOnlyError`, HTTP 409 mapping, origin pinning, reconnect backoff, and backfill semantics remain authoritative.
+
+## Risks / Trade-offs
+
+- [Risk] A transient heartbeat-acknowledgment failure makes a live daemon appear stale. -> Three 30-second opportunities fit within the inclusive 90-second threshold; subsequent successful acknowledgments restore freshness.
+- [Risk] A delayed request from an obsolete stream refreshes the active row. -> Fence every update on the generation value emitted by registration.
+- [Risk] The watchdog timer from an old connection aborts a new one. -> Capture the controller/generation in the timer closure and clear it on every lifecycle transition.
+- [Risk] Fault-injection tests are timing-sensitive. -> Keep unit coverage on fake timers and use generous bounded assertions only for the network-level proof.
+
+## Migration Plan
+
+Deploy the server first. Streams without `livenessAck=v1` continue using legacy timer-side touches, so existing daemons remain online. Deploy the new CLI next; each upgraded daemon advertises the capability on connect and enters acknowledgment-driven liveness. Rollback of the CLI reconnects without the capability and automatically restores legacy behavior; rollback of the server ignores the extra query parameter. No data migration or atomic release is required.
+
+## Open Questions
+
+None. Implementation must choose either the existing `connectedAt` value or a new opaque lease token as the wire fence without adding persistent schema state.

--- a/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/proposal.md
+++ b/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+A daemon can become deaf after an idle network path silently drops its long-lived SSE socket without FIN or RST. The client then waits in `reader.read()` until an implicit undici timeout, while the server's own heartbeat timer falsely keeps the connection online and accepts instructions that the daemon cannot receive.
+
+## What Changes
+
+- Add a fixed 75-second client-side SSE byte watchdog. Any received bytes, including SSE comments, refresh the deadline; expiry aborts the current stream and enters the existing reconnect and backfill path.
+- Let upgraded daemons advertise `livenessAck=v1`, then replace server-generated liveness writes for those streams with authenticated, generation-fenced acknowledgments sent after receiving an SSE heartbeat.
+- Preserve legacy timer-side touches for clients that do not advertise the capability, enabling server-first rolling deployment without making old daemons stale.
+- Preserve the existing 90-second effective-online threshold and 409 read-only response, but make `lastSeenAt` evidence that the daemon is alive rather than evidence that a server timer is running.
+- Add deterministic stream tests plus a network fault-injection test that blackholes an established connection without FIN or RST.
+- Do not add retries to unrelated daemon REST calls and do not address unbounded CLI caches in this change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli-daemon`: Detect silent notification-stream stalls and recover through the existing reconnect and backfill path.
+- `daemon-connection-registry`: Base connection freshness on client acknowledgments fenced to the active connection generation.
+
+## Impact
+
+- CLI: `cli/sse-listener.mjs`, daemon REST transport wiring, and focused listener/backfill tests.
+- Server: notification SSE handshake payload, a daemon-authenticated connection heartbeat endpoint, connection registry liveness writes, and route/service tests.
+- Contract: upgraded clients opt in with `livenessAck=v1`, and the handshake gains an opaque generation value used only to fence heartbeat acknowledgments; no database migration or external dependency is required.
+- User-visible behavior: an origin that stops acknowledging heartbeats becomes read-only under the existing 90-second rule, so instruction submission returns the existing structured 409 instead of creating a pending turn.

--- a/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/specs/cli-daemon/spec.md
+++ b/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/specs/cli-daemon/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Reconnect with backfill
+
+When the notification subscription drops, ends, errors, or delivers no bytes for 75 seconds, the daemon SHALL abort that stream, reconnect with its existing bounded backoff, fetch notifications that arrived while it was disconnected, and re-fire any wakes that were missed. Any non-empty byte chunk, including an SSE comment heartbeat or partial frame, SHALL refresh the 75-second deadline. Reconnect and explicit disconnect SHALL clear the prior connection's watchdog so an obsolete timer cannot affect a replacement stream.
+
+#### Scenario: Missed dispatch is recovered on reconnect
+
+- **WHEN** the subscription drops, a `task_assigned` notification is created during the gap, and the subscription then reconnects
+- **THEN** the daemon backfills the unhandled notification and wakes Claude Code for it
+
+#### Scenario: Silent stream triggers deterministic reconnect
+
+- **GIVEN** an established notification stream that remains open at the API level
+- **WHEN** no bytes arrive for 75 seconds
+- **THEN** the daemon MUST abort that stream and enter the normal reconnect flow
+- **AND** a successful reconnect MUST invoke notification backfill
+
+#### Scenario: Heartbeat bytes refresh the watchdog
+
+- **GIVEN** an established notification stream
+- **WHEN** an SSE comment heartbeat arrives before the 75-second deadline
+- **THEN** the daemon MUST refresh the deadline even though the comment is not forwarded as a notification
+
+#### Scenario: Obsolete watchdog cannot abort a replacement stream
+
+- **WHEN** a stream is replaced by reconnect or closed by explicit daemon shutdown
+- **THEN** its watchdog MUST be cleared
+- **AND** a later callback from that obsolete generation MUST NOT abort the current stream or schedule another reconnect
+
+## ADDED Requirements
+
+### Requirement: Daemon acknowledges notification heartbeat receipt
+
+The daemon SHALL advertise `livenessAck=v1` when opening its SSE subscription. After the handshake identifies the registered connection generation, the daemon SHALL send a best-effort authenticated liveness acknowledgment after receiving each `: heartbeat` comment. The acknowledgment SHALL identify both the connection UUID and registration generation, SHALL NOT be forwarded into the notification or wake pipeline, and SHALL NOT be retried by the generic daemon REST client.
+
+#### Scenario: Upgraded daemon opts into acknowledgment liveness
+
+- **WHEN** an upgraded daemon opens or reopens its notification subscription
+- **THEN** the request URL MUST include `livenessAck=v1`
+- **AND** all existing self-report and authentication fields MUST remain unchanged
+
+#### Scenario: Received heartbeat is acknowledged but not routed
+
+- **GIVEN** a daemon has received a valid connection registration handshake
+- **WHEN** it receives an SSE heartbeat comment
+- **THEN** it MUST send one liveness acknowledgment for that connection generation
+- **AND** it MUST NOT pass the heartbeat to `onEvent` or create a wake
+
+#### Scenario: Failed acknowledgment does not crash the listener
+
+- **WHEN** a liveness acknowledgment fails because the network or server is unavailable
+- **THEN** the listener MUST remain non-throwing and log the failure
+- **AND** the failed acknowledgment MUST NOT advance server-side liveness

--- a/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/specs/daemon-connection-registry/spec.md
+++ b/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/specs/daemon-connection-registry/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Connection liveness SHALL use abort as the primary signal with a heartbeat-driven staleness safety net
+
+The SSE route SHALL treat the stream's `abort` event as the primary disconnect signal: on `abort` (graceful client disconnect, process exit, or network close) the server SHALL mark the connection `offline` and set `disconnectedAt`. A daemon advertising `livenessAck=v1` SHALL acknowledge receipt of periodic SSE heartbeat comments through an authenticated endpoint. For such an opted-in stream, only a valid acknowledgment fenced to the active registration generation SHALL update `lastSeenAt`, and the server's outbound heartbeat timer SHALL NOT update connection liveness. A legacy stream with an absent or unknown capability value SHALL retain timer-side `lastSeenAt` updates for rolling compatibility. The model SHALL retain the documented 90-second staleness threshold so a consumer treats a connection as effectively offline when `status = "online"` but `lastSeenAt` is older than that threshold.
+
+#### Scenario: Graceful disconnect marks the row offline immediately
+
+- **GIVEN** a registered `online` `DaemonConnection`
+- **WHEN** the client disconnects gracefully and the stream's `abort` event fires
+- **THEN** the row MUST be updated to `status = "offline"` with `disconnectedAt` set to the current time
+
+#### Scenario: Valid client acknowledgment advances lastSeenAt
+
+- **GIVEN** a registered `online` connection and its active registration generation
+- **WHEN** the authenticated daemon acknowledges receiving an SSE heartbeat for that generation
+- **THEN** the row's `lastSeenAt` MUST be advanced to the current time
+
+#### Scenario: Outbound server heartbeat does not prove client liveness
+
+- **GIVEN** an opted-in `livenessAck=v1` SSE route whose remote daemon is silently unreachable
+- **WHEN** the server's periodic heartbeat timer emits a comment
+- **THEN** the timer MUST NOT advance the connection's `lastSeenAt`
+
+#### Scenario: Legacy daemon retains timer-side liveness during rolling deployment
+
+- **GIVEN** a daemon stream whose self-report omits `livenessAck` or supplies an unknown value
+- **WHEN** the server's periodic heartbeat timer emits a comment
+- **THEN** the server MUST retain the legacy `lastSeenAt` update for that stream
+- **AND** deploying the new server MUST NOT make the legacy daemon stale after 90 seconds
+
+#### Scenario: Obsolete generation cannot refresh a newer registration
+
+- **GIVEN** a connection row has been refreshed by a newer registration generation
+- **WHEN** a delayed acknowledgment arrives from an older generation
+- **THEN** the update MUST match zero rows and MUST NOT advance `lastSeenAt`
+
+#### Scenario: Silent partition becomes read-only
+
+- **GIVEN** a registered connection whose socket is blackholed without an observable abort
+- **WHEN** no valid client acknowledgment arrives for more than 90 seconds
+- **THEN** consumers applying the liveness rule MUST treat the connection as effectively offline
+- **AND** continuation of a session pinned to that origin MUST return the existing structured read-only 409 before creating a turn
+
+#### Scenario: Authentication and ownership fence the acknowledgment
+
+- **WHEN** an unauthenticated caller or a caller outside the connection's company and agent ownership attempts to acknowledge a heartbeat
+- **THEN** the server MUST reject the request
+- **AND** it MUST NOT update the connection row

--- a/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/tasks.md
+++ b/openspec/changes/archive/2026-07-25-fix-daemon-sse-silent-zombie/tasks.md
@@ -1,0 +1,16 @@
+## 1. Client Watchdog and Acknowledgment
+
+- [ ] 1.1 Add the generation-local 75-second byte watchdog to `SseListener`, including refresh-on-chunk, abort-to-reconnect, and lifecycle cleanup.
+- [ ] 1.2 Advertise `livenessAck=v1`, parse the registration generation, and acknowledge received heartbeat comments through a narrow best-effort daemon REST call without forwarding them into the event router.
+- [ ] 1.3 Add fake-timer and controlled-stream tests for timeout, refresh, reconnect/backfill, acknowledgment failure, and obsolete-timer isolation.
+
+## 2. Truthful Server Liveness
+
+- [ ] 2.1 Extend the connection handshake with a generation fence and add an authenticated heartbeat-acknowledgment route that calls the existing generation-fenced registry touch.
+- [ ] 2.2 Disable timer-side `lastSeenAt` updates only for `livenessAck=v1` streams; preserve legacy touches for absent/unknown capabilities plus SSE emission, abort cleanup, the 90-second rule, and existing 409 mapping.
+- [ ] 2.3 Add route and service regressions for valid, unauthorized, cross-owner, and stale-generation acknowledgments plus 409-before-turn-creation behavior.
+
+## 3. Half-Open Network Verification
+
+- [ ] 3.1 Add a bounded fault-injection harness that blackholes an established SSE connection without FIN or RST.
+- [ ] 3.2 Verify watchdog-triggered reconnect, missed-notification backfill, absence of false server freshness, and stale-origin 409 end to end; record observed recovery timing.

--- a/openspec/specs/cli-daemon/spec.md
+++ b/openspec/specs/cli-daemon/spec.md
@@ -160,12 +160,31 @@ The daemon's subprocess spawning SHALL work on Linux, macOS, and Windows without
 
 ### Requirement: Reconnect with backfill
 
-When the notification subscription drops and reconnects, the daemon SHALL fetch notifications that arrived while it was disconnected and re-fire any wakes that were missed, so a dispatch that occurred during a brief disconnection is not silently lost.
+When the notification subscription drops, ends, errors, or delivers no bytes for 75 seconds, the daemon SHALL abort that stream, reconnect with its existing bounded backoff, fetch notifications that arrived while it was disconnected, and re-fire any wakes that were missed. Any non-empty byte chunk, including an SSE comment heartbeat or partial frame, SHALL refresh the 75-second deadline. Reconnect and explicit disconnect SHALL clear the prior connection's watchdog so an obsolete timer cannot affect a replacement stream.
 
 #### Scenario: Missed dispatch is recovered on reconnect
 
 - **WHEN** the subscription drops, a `task_assigned` notification is created during the gap, and the subscription then reconnects
 - **THEN** the daemon backfills the unhandled notification and wakes Claude Code for it
+
+#### Scenario: Silent stream triggers deterministic reconnect
+
+- **GIVEN** an established notification stream that remains open at the API level
+- **WHEN** no bytes arrive for 75 seconds
+- **THEN** the daemon MUST abort that stream and enter the normal reconnect flow
+- **AND** a successful reconnect MUST invoke notification backfill
+
+#### Scenario: Heartbeat bytes refresh the watchdog
+
+- **GIVEN** an established notification stream
+- **WHEN** an SSE comment heartbeat arrives before the 75-second deadline
+- **THEN** the daemon MUST refresh the deadline even though the comment is not forwarded as a notification
+
+#### Scenario: Obsolete watchdog cannot abort a replacement stream
+
+- **WHEN** a stream is replaced by reconnect or closed by explicit daemon shutdown
+- **THEN** its watchdog MUST be cleared
+- **AND** a later callback from that obsolete generation MUST NOT abort the current stream or schedule another reconnect
 
 ### Requirement: Reserved upload hooks for observability
 
@@ -350,4 +369,27 @@ During shutdown, the waker SHALL NOT report a `DaemonExecution` interrupt for th
 - **WHEN** the shutdown's hard cap elapses
 - **THEN** the daemon MUST exit anyway
 - **AND** the orphaned turn is left to server-side offline reconcile
+
+### Requirement: Daemon acknowledges notification heartbeat receipt
+
+The daemon SHALL advertise `livenessAck=v1` when opening its SSE subscription. After the handshake identifies the registered connection generation, the daemon SHALL send a best-effort authenticated liveness acknowledgment after receiving each `: heartbeat` comment. The acknowledgment SHALL identify both the connection UUID and registration generation, SHALL NOT be forwarded into the notification or wake pipeline, and SHALL NOT be retried by the generic daemon REST client.
+
+#### Scenario: Upgraded daemon opts into acknowledgment liveness
+
+- **WHEN** an upgraded daemon opens or reopens its notification subscription
+- **THEN** the request URL MUST include `livenessAck=v1`
+- **AND** all existing self-report and authentication fields MUST remain unchanged
+
+#### Scenario: Received heartbeat is acknowledged but not routed
+
+- **GIVEN** a daemon has received a valid connection registration handshake
+- **WHEN** it receives an SSE heartbeat comment
+- **THEN** it MUST send one liveness acknowledgment for that connection generation
+- **AND** it MUST NOT pass the heartbeat to `onEvent` or create a wake
+
+#### Scenario: Failed acknowledgment does not crash the listener
+
+- **WHEN** a liveness acknowledgment fails because the network or server is unavailable
+- **THEN** the listener MUST remain non-throwing and log the failure
+- **AND** the failed acknowledgment MUST NOT advance server-side liveness
 

--- a/openspec/specs/daemon-connection-registry/spec.md
+++ b/openspec/specs/daemon-connection-registry/spec.md
@@ -125,18 +125,7 @@ SHALL be distinct rows.
 
 ### Requirement: Connection liveness SHALL use abort as the primary signal with a heartbeat-driven staleness safety net
 
-The SSE route SHALL treat the stream's `abort` event as the primary
-disconnect signal: on `abort` (graceful client disconnect, process exit, or
-network close) the server SHALL mark the connection `offline` and set
-`disconnectedAt`. As a safety net for the case where the server instance itself
-dies (and therefore cannot run its `abort` handler), the SSE route's existing
-periodic heartbeat interval SHALL also update the connection's `lastSeenAt` on
-each tick. No client-to-server heartbeat SHALL be added — the daemon sends
-nothing after connecting, and the server-side interval is the sole liveness
-updater. The model SHALL define a documented staleness threshold (approximately
-three heartbeat intervals) such that a consumer treats a connection as
-effectively offline when `status = "online"` but `lastSeenAt` is older than that
-threshold.
+The SSE route SHALL treat the stream's `abort` event as the primary disconnect signal: on `abort` (graceful client disconnect, process exit, or network close) the server SHALL mark the connection `offline` and set `disconnectedAt`. A daemon advertising `livenessAck=v1` SHALL acknowledge receipt of periodic SSE heartbeat comments through an authenticated endpoint. For such an opted-in stream, only a valid acknowledgment fenced to the active registration generation SHALL update `lastSeenAt`, and the server's outbound heartbeat timer SHALL NOT update connection liveness. A legacy stream with an absent or unknown capability value SHALL retain timer-side `lastSeenAt` updates for rolling compatibility. The model SHALL retain the documented 90-second staleness threshold so a consumer treats a connection as effectively offline when `status = "online"` but `lastSeenAt` is older than that threshold.
 
 #### Scenario: Graceful disconnect marks the row offline immediately
 
@@ -144,24 +133,43 @@ threshold.
 - **WHEN** the client disconnects gracefully and the stream's `abort` event fires
 - **THEN** the row MUST be updated to `status = "offline"` with `disconnectedAt` set to the current time
 
-#### Scenario: Heartbeat tick advances lastSeenAt
+#### Scenario: Valid client acknowledgment advances lastSeenAt
 
-- **GIVEN** a registered `online` `DaemonConnection`
-- **WHEN** the SSE route's periodic heartbeat interval fires for that connection
+- **GIVEN** a registered `online` connection and its active registration generation
+- **WHEN** the authenticated daemon acknowledges receiving an SSE heartbeat for that generation
 - **THEN** the row's `lastSeenAt` MUST be advanced to the current time
 
-#### Scenario: An instance crash leaves a row that reads as stale
+#### Scenario: Outbound server heartbeat does not prove client liveness
 
-- **GIVEN** a registered `online` `DaemonConnection` whose holding instance hard-crashes so its `abort` never fires
-- **WHEN** more than the staleness threshold elapses with no heartbeat tick
-- **THEN** the row MUST remain `status = "online"` with a `lastSeenAt` no longer being advanced
-- **AND** a consumer applying the liveness rule (`status = "online"` AND `lastSeenAt` fresh) MUST treat it as effectively offline
+- **GIVEN** an opted-in `livenessAck=v1` SSE route whose remote daemon is silently unreachable
+- **WHEN** the server's periodic heartbeat timer emits a comment
+- **THEN** the timer MUST NOT advance the connection's `lastSeenAt`
 
-#### Scenario: No client-to-server heartbeat is introduced
+#### Scenario: Legacy daemon retains timer-side liveness during rolling deployment
 
-- **WHEN** the change is implemented
-- **THEN** the daemon clients MUST NOT send any periodic request to the server after the initial SSE connection
-- **AND** `lastSeenAt` MUST be advanced solely by the server-side heartbeat interval
+- **GIVEN** a daemon stream whose self-report omits `livenessAck` or supplies an unknown value
+- **WHEN** the server's periodic heartbeat timer emits a comment
+- **THEN** the server MUST retain the legacy `lastSeenAt` update for that stream
+- **AND** deploying the new server MUST NOT make the legacy daemon stale after 90 seconds
+
+#### Scenario: Obsolete generation cannot refresh a newer registration
+
+- **GIVEN** a connection row has been refreshed by a newer registration generation
+- **WHEN** a delayed acknowledgment arrives from an older generation
+- **THEN** the update MUST match zero rows and MUST NOT advance `lastSeenAt`
+
+#### Scenario: Silent partition becomes read-only
+
+- **GIVEN** a registered connection whose socket is blackholed without an observable abort
+- **WHEN** no valid client acknowledgment arrives for more than 90 seconds
+- **THEN** consumers applying the liveness rule MUST treat the connection as effectively offline
+- **AND** continuation of a session pinned to that origin MUST return the existing structured read-only 409 before creating a turn
+
+#### Scenario: Authentication and ownership fence the acknowledgment
+
+- **WHEN** an unauthenticated caller or a caller outside the connection's company and agent ownership attempts to acknowledge a heartbeat
+- **THEN** the server MUST reject the request
+- **AND** it MUST NOT update the connection row
 
 ### Requirement: A registry write SHALL never block or break SSE event delivery
 

--- a/src/app/api/daemon/connection-heartbeat/__tests__/route.test.ts
+++ b/src/app/api/daemon/connection-heartbeat/__tests__/route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+const mockTouchConnection = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+vi.mock("@/services/daemon-connection.service", () => ({
+  touchConnection: (...args: unknown[]) => mockTouchConnection(...args),
+}));
+
+import { POST } from "@/app/api/daemon/connection-heartbeat/route";
+
+const companyUuid = "company-1";
+const agentUuid = "agent-1";
+const connectionUuid = "connection-1";
+const connectedAt = "2026-07-25T08:00:00.000Z";
+const emptyCtx = { params: Promise.resolve({}) };
+
+function request(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/daemon/connection-heartbeat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthContext.mockResolvedValue({
+    type: "agent",
+    companyUuid,
+    actorUuid: agentUuid,
+    permissions: [],
+  });
+  mockTouchConnection.mockResolvedValue(true);
+});
+
+describe("POST /api/daemon/connection-heartbeat", () => {
+  it("acknowledges the authenticated agent's active generation", async () => {
+    const res = await POST(request({ connectionUuid, connectedAt }), emptyCtx);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      data: { acknowledged: true },
+      meta: undefined,
+    });
+    expect(mockTouchConnection).toHaveBeenCalledWith(
+      companyUuid,
+      { uuid: connectionUuid, connectedAt: new Date(connectedAt) },
+      agentUuid,
+    );
+  });
+
+  it("rejects unauthenticated and non-daemon callers without touching", async () => {
+    mockGetAuthContext.mockResolvedValueOnce(null);
+    expect((await POST(request({ connectionUuid, connectedAt }), emptyCtx)).status).toBe(401);
+
+    mockGetAuthContext.mockResolvedValueOnce({
+      type: "user",
+      companyUuid,
+      actorUuid: "owner-1",
+    });
+    expect((await POST(request({ connectionUuid, connectedAt }), emptyCtx)).status).toBe(401);
+    expect(mockTouchConnection).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {},
+    { connectionUuid },
+    { connectedAt },
+    { connectionUuid: "", connectedAt },
+    { connectionUuid, connectedAt: "not-a-date" },
+  ])("rejects malformed payload %#", async (body) => {
+    const res = await POST(request(body), emptyCtx);
+    expect(res.status).toBe(422);
+    expect(mockTouchConnection).not.toHaveBeenCalled();
+  });
+
+  it("returns non-disclosing 404 for another owner, company, or obsolete generation", async () => {
+    mockTouchConnection.mockResolvedValue(false);
+    const res = await POST(request({ connectionUuid, connectedAt }), emptyCtx);
+
+    expect(res.status).toBe(404);
+    expect(mockTouchConnection).toHaveBeenCalledWith(
+      companyUuid,
+      { uuid: connectionUuid, connectedAt: new Date(connectedAt) },
+      agentUuid,
+    );
+  });
+});

--- a/src/app/api/daemon/connection-heartbeat/route.ts
+++ b/src/app/api/daemon/connection-heartbeat/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import { touchConnection } from "@/services/daemon-connection.service";
+
+const bodySchema = z.object({
+  connectionUuid: z.string().min(1),
+  connectedAt: z.string().datetime({ offset: true }),
+});
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth || auth.type !== "agent") {
+    return errors.unauthorized();
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return errors.badRequest("Invalid JSON body");
+  }
+
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return errors.validationError(parsed.error.flatten());
+  }
+
+  const acknowledged = await touchConnection(
+    auth.companyUuid,
+    {
+      uuid: parsed.data.connectionUuid,
+      connectedAt: new Date(parsed.data.connectedAt),
+    },
+    auth.actorUuid,
+  );
+
+  if (!acknowledged) {
+    return errors.notFound("Connection");
+  }
+
+  return success({ acknowledged: true });
+});

--- a/src/app/api/events/notifications/__tests__/route.test.ts
+++ b/src/app/api/events/notifications/__tests__/route.test.ts
@@ -133,6 +133,21 @@ describe("GET /api/events/notifications (notification SSE)", () => {
     // (needed to attribute POST /api/daemon/execution-state snapshots).
     expect(joined).toContain('"type":"connection_registered"');
     expect(joined).toContain(`"connectionUuid":"${connectionUuid}"`);
+    expect(joined).not.toContain('"connectedAt"');
+  });
+
+  it("negotiates exactly livenessAck=v1 and exposes the active generation fence", async () => {
+    mockParseSelfReport.mockReturnValue({
+      clientType: "openclaw",
+      host: "h",
+      livenessAck: "v1",
+    });
+    const res = await GET(makeRequest("clientType=openclaw&livenessAck=v1"));
+    const { chunks } = await startStream(res);
+
+    const joined = chunks.join("");
+    expect(joined).toContain(`"connectionUuid":"${connectionUuid}"`);
+    expect(joined).toContain(`"connectedAt":"${connHandle.connectedAt.toISOString()}"`);
   });
 
   it("subscribes to the per-user notification channel and delivers events", async () => {
@@ -206,6 +221,43 @@ describe("GET /api/events/notifications (notification SSE)", () => {
 
     await vi.advanceTimersByTimeAsync(30_000);
     expect(mockTouchConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([undefined, "v2", "V1", ""])(
+    "retains legacy timer touches for absent or unknown livenessAck=%s",
+    async (livenessAck) => {
+      vi.useFakeTimers();
+      mockParseSelfReport.mockReturnValue({
+        clientType: "openclaw",
+        host: "h",
+        livenessAck,
+      });
+      const query =
+        livenessAck === undefined
+          ? "clientType=openclaw"
+          : `clientType=openclaw&livenessAck=${encodeURIComponent(livenessAck)}`;
+      const res = await GET(makeRequest(query));
+      const { chunks } = await startStream(res);
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(chunks.join("")).toContain(": heartbeat");
+      expect(mockTouchConnection).toHaveBeenCalledTimes(4);
+    },
+  );
+
+  it("keeps emitting heartbeat comments but does not timer-touch an opted-in stream", async () => {
+    vi.useFakeTimers();
+    mockParseSelfReport.mockReturnValue({
+      clientType: "openclaw",
+      host: "h",
+      livenessAck: "v1",
+    });
+    const res = await GET(makeRequest("clientType=openclaw&livenessAck=v1"));
+    const { chunks } = await startStream(res);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(chunks.join("")).toContain(": heartbeat");
+    expect(mockTouchConnection).not.toHaveBeenCalled();
   });
 
   it("marks disconnected on abort and unsubscribes the handler", async () => {

--- a/src/app/api/events/notifications/route.ts
+++ b/src/app/api/events/notifications/route.ts
@@ -33,6 +33,7 @@ export async function GET(request: NextRequest) {
   // null, the lifecycle below is skipped and the route behaves exactly as before
   // (no DaemonConnection row is written).
   const report = parseSelfReport(request.nextUrl.searchParams);
+  const acknowledgmentAware = report.livenessAck === "v1";
   const registration = await registerConnection(auth.companyUuid, auth.actorUuid, report);
   // Split the tri-state result into two narrow bindings:
   //  - `conflict`: a live different-process daemon already holds this (agent, host, cwd).
@@ -76,7 +77,11 @@ export async function GET(request: NextRequest) {
         );
       } else if (conn) {
         send(
-          `data: ${JSON.stringify({ type: "connection_registered", connectionUuid: conn.uuid })}\n\n`,
+          `data: ${JSON.stringify({
+            type: "connection_registered",
+            connectionUuid: conn.uuid,
+            ...(acknowledgmentAware ? { connectedAt: conn.connectedAt.toISOString() } : {}),
+          })}\n\n`,
         );
       }
 
@@ -108,7 +113,7 @@ export async function GET(request: NextRequest) {
         send(": heartbeat\n\n");
         // Liveness safety net: bump lastSeenAt. Fire-and-forget — the service
         // swallows + logs its own errors and never throws.
-        if (conn) void touchConnection(auth.companyUuid, conn);
+        if (conn && !acknowledgmentAware) void touchConnection(auth.companyUuid, conn);
       }, 30_000);
 
       // Cleanup on abort (client disconnect)

--- a/src/services/__tests__/daemon-connection.service.test.ts
+++ b/src/services/__tests__/daemon-connection.service.test.ts
@@ -127,6 +127,7 @@ describe("parseSelfReport", () => {
   it("parses all params including cwd and a valid ISO-8601 startedAt", () => {
     const params = new URLSearchParams({
       clientType: "claude_code",
+      livenessAck: "v1",
       clientVersion: "0.11.0",
       host: "mac.local",
       cwd: "/Users/me/projects/alpha",
@@ -134,6 +135,7 @@ describe("parseSelfReport", () => {
     });
     const report = parseSelfReport(params);
     expect(report.clientType).toBe("claude_code");
+    expect(report.livenessAck).toBe("v1");
     expect(report.clientVersion).toBe("0.11.0");
     expect(report.host).toBe("mac.local");
     expect(report.cwd).toBe("/Users/me/projects/alpha");
@@ -144,6 +146,7 @@ describe("parseSelfReport", () => {
   it("defaults missing string params: clientType='' and nullable fields null (cwd→null for an old daemon)", () => {
     const report = parseSelfReport(new URLSearchParams());
     expect(report.clientType).toBe("");
+    expect(report.livenessAck).toBeNull();
     expect(report.clientVersion).toBeNull();
     expect(report.host).toBeNull();
     // HARD-1: a daemon that does not report cwd → cwd:null (NOT ""). This is the
@@ -969,14 +972,30 @@ describe("touchConnection", () => {
 
   it("matches 0 rows (no-op) when a newer generation has refreshed connectedAt", async () => {
     mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 0 });
-    await expect(touchConnection(companyUuid, handle)).resolves.toBeUndefined();
+    await expect(touchConnection(companyUuid, handle)).resolves.toBe(false);
     expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
   it("swallows + logs a persistence error (never throws)", async () => {
     mockPrisma.daemonConnection.updateMany.mockRejectedValue(new Error("db down"));
-    await expect(touchConnection(companyUuid, handle)).resolves.toBeUndefined();
+    await expect(touchConnection(companyUuid, handle)).resolves.toBe(false);
     expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("atomically scopes an authenticated acknowledgment to the owning agent", async () => {
+    mockPrisma.daemonConnection.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(touchConnection(companyUuid, handle, agentUuid)).resolves.toBe(true);
+
+    expect(mockPrisma.daemonConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        uuid: connectionUuid,
+        companyUuid,
+        connectedAt,
+        agentUuid,
+      },
+      data: { status: "online", lastSeenAt: expect.any(Date) },
+    });
   });
 });
 

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -39,6 +39,7 @@ export const STALE_THRESHOLD_MS = 90_000;
 
 export interface SelfReport {
   clientType: string; // raw query value; gated against DAEMON_CLIENT_TYPES
+  livenessAck?: string | null;
   clientVersion?: string | null;
   host?: string | null;
   // Working directory this connection serves. The self-reporting representation
@@ -305,6 +306,7 @@ export function sortConnectionViews(views: ConnectionView[]): ConnectionView[] {
  */
 export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
   const clientType = searchParams.get("clientType") ?? "";
+  const livenessAck = searchParams.get("livenessAck");
   const clientVersion = searchParams.get("clientVersion");
   const host = searchParams.get("host");
   // `cwd` is the working directory the connection serves. An absent param
@@ -325,6 +327,7 @@ export function parseSelfReport(searchParams: URLSearchParams): SelfReport {
 
   return {
     clientType,
+    livenessAck: livenessAck ?? null,
     clientVersion: clientVersion ?? null,
     host: host ?? null,
     cwd: cwd ?? null,
@@ -775,17 +778,25 @@ export async function markDisconnected(
 export async function touchConnection(
   companyUuid: string,
   handle: ConnectionHandle,
-): Promise<void> {
+  agentUuid?: string,
+): Promise<boolean> {
   try {
-    await prisma.daemonConnection.updateMany({
-      where: { uuid: handle.uuid, companyUuid, connectedAt: handle.connectedAt },
+    const result = await prisma.daemonConnection.updateMany({
+      where: {
+        uuid: handle.uuid,
+        companyUuid,
+        connectedAt: handle.connectedAt,
+        ...(agentUuid ? { agentUuid } : {}),
+      },
       data: { status: "online", lastSeenAt: new Date() },
     });
+    return result.count > 0;
   } catch (err) {
     logger.error(
       { err, companyUuid, connectionUuid: handle.uuid },
       "Failed to touch daemon connection",
     );
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

- add a 75-second byte watchdog so silently blackholed daemon SSE streams abort and reconnect with backfill
- add negotiated `livenessAck=v1` client heartbeat acknowledgments with registration-generation fencing, while preserving legacy client compatibility
- keep stale-origin 409 behavior and add real TCP no-FIN/no-RST fault-injection coverage
- archive the approved OpenSpec change and update cumulative specs

Fixes #444.

## Verification

- aggregate Vitest suites: 166/166 passed
- TCP blackhole integration: watchdog abort and reconnect/backfill passed
- `tsc --noEmit` passed
- changed production files lint clean
- `git diff --check` passed

## Chorus

Idea: `a1665e03-ecbc-4919-b35e-dce3c5b3de8f`
Proposal: `8b6b1f88-1b32-44d0-9043-04dc759c4071`

Deployment order: server first, then daemon clients.