### PR TITLE
fix: make OpenSpec round-trip verification exact

### DIFF
--- a/docs/OPENSPEC_MODE.md
+++ b/docs/OPENSPEC_MODE.md
@@ -130,7 +130,7 @@ When `CHORUS_OPENSPEC_ACTIVE=1`, **every** call to `chorus_pm_add_document_draft
 Calling these tools directly from the agent's MCP harness with a hand-typed `content` field is a **protocol violation** in OpenSpec mode and will fail review. Three reasons (full version in skill §2 Rule 1):
 
 1. **Token cost.** Re-typing thousands of lines of markdown body through the LLM burns 20k+ content tokens per proposal. The wrapper streams bytes through `jq -Rs '.'`; content never enters LLM context.
-2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder. LLM re-emission of long markdown drifts (table alignment, fence escapes, long-URL wraps). The byte-equality guarantee (modulo trailing `\n`) holds **only** on the wrapper path.
+2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder. LLM re-emission of long markdown drifts (table alignment, fence escapes, long-URL wraps). The exact byte-equality guarantee holds **only** on the wrapper path.
 3. **Single source of truth.** With the wrapper, the local `openspec/changes/<slug>/*.md` is authoritative; Chorus is a mirror. With agent re-typing, authority splits and a future diff cannot tell which side is correct.
 
 Free-form mode (`CHORUS_OPENSPEC_ACTIVE=0`) is unaffected — there's no local file to mirror, so direct MCP calls with inline `content` are still the right pattern.
@@ -145,7 +145,7 @@ The local file under `openspec/changes/<slug>/` is the working copy. The Chorus 
 
 To resync, re-run the relevant mirror snippet from `openspec-aware` §3.7. Same wrapper, same `json_encode_file`, same `chorus_check_response` halt-on-error.
 
-The Chorus backend appends a single trailing `\n` on write, so a round-trip is byte-equal **modulo a trailing newline**. Don't read that 1-byte diff as content drift.
+Round-trip verification is exact. A trailing newline difference is content drift and must not be normalized or ignored.
 
 After approval the draft becomes a Document with a fresh `documentUuid`. Use `chorus_pm_update_document` (skill §3.8) instead of `chorus_pm_update_document_draft`.
 

--- a/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/README.md
+++ b/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/README.md
@@ -1,0 +1,3 @@
+# fix-codex-openspec-roundtrip-verifier
+
+Add a deterministic Codex-first OpenSpec Document round-trip verifier and assess portability to other Chorus plugins.

--- a/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/design.md
+++ b/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/design.md
@@ -1,0 +1,90 @@
+# Technical Design: Codex OpenSpec Round-Trip Verifier
+
+## Context
+
+Codex's `chorus-mcp-call.sh` unwraps JSON-RPC and emits the text returned by a
+Chorus tool. For `chorus_get_document`, that text is a JSON object whose
+top-level `content` is the Document body. The archive instruction currently
+leaves the second parsing step to the model. Recursive key discovery is unsafe
+because the response can contain other `content` fields, while line-oriented
+post-processing corrupts decoded multiline strings.
+
+## Goals
+
+- Provide one supported, target-field extraction path for Codex.
+- Preserve exact content bytes, including the presence or absence of a final
+  newline.
+- Make mismatches diagnosable without logging document bodies.
+- Keep mirror writes on `chorus-mcp-call.sh` plus `json_encode_file`.
+
+## Non-Goals
+
+- Changing Chorus backend newline behavior.
+- Normalizing line endings or trailing newlines.
+- Redesigning the MCP transport wrappers.
+- Requiring Claude Code or Kiro to adopt a Codex-specific response contract.
+
+## Design
+
+### Helper Contract
+
+A shell helper owned by the Codex plugin accepts:
+
+1. a local file path; and
+2. the complete stdout produced by
+   `chorus-mcp-call.sh chorus_get_document ...`.
+
+It parses stdout once as JSON and requires a top-level string `.content`.
+Missing, null, non-string, malformed, or ambiguous responses fail closed.
+It writes the decoded string to a temporary file so command substitution cannot
+strip trailing newlines.
+
+The helper compares files with a byte-preserving primitive such as `cmp`.
+Success is silent. Failure emits local and remote byte counts and SHA-256
+hashes, never either body, and returns non-zero so archive closeout halts.
+
+### Response Boundaries
+
+Transport-envelope extraction remains the wrapper's responsibility. Document
+field extraction remains the verifier's responsibility. The verifier MUST NOT
+use recursive descent (`..`), select the first discovered `content`, pipe
+decoded content through `head`, or store decoded content in a shell variable.
+
+### Skill Integration
+
+The Codex OpenSpec-aware skill will include the concrete helper invocation in
+section 3.9. The Codex post-verification reminder will direct agents to that
+helper rather than restating an underspecified byte-equality goal.
+
+### Portability Assessment
+
+Claude Code and Kiro wrappers currently emit the same tool text after unwrapping
+JSON-RPC, but their wrapper implementations and distribution layout differ.
+Implementation will run the same fixture suite against each wrapper contract.
+Equivalent helpers and instruction updates may be copied only when the tests
+prove the same top-level Document JSON contract; otherwise the implementation
+records the incompatibility without broadening the Codex fix.
+
+## Testing
+
+Shell tests use fixture responses and temporary files to prove:
+
+- multiline content is not truncated;
+- empty content round-trips;
+- with-newline and without-newline bodies remain distinct;
+- unrelated nested `content` fields are ignored;
+- a one-byte difference fails;
+- malformed or missing target fields fail closed; and
+- mismatch output contains counts and hashes but not document bodies.
+
+An integration-oriented test verifies the archive reminder names the supported
+helper flow.
+
+## Risks
+
+- Shell command substitution silently removes final newlines.
+  Mitigation: decode directly to a temporary file.
+- Wrapper output contracts may drift.
+  Mitigation: strict parsing, fixture tests, and a clear ownership boundary.
+- Diagnostic output could disclose content.
+  Mitigation: emit metadata only.

--- a/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/proposal.md
+++ b/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/proposal.md
@@ -1,0 +1,38 @@
+# Fix Codex OpenSpec Round-Trip Verification
+
+## Why
+
+The OpenSpec archive closeout tells agents to verify mirrored Chorus Documents
+for byte equality, but it does not define how to extract Document content from
+the MCP wrapper response. A Codex agent used a recursive `content` search
+followed by `head -1`, truncating multiline Markdown and halting a successful
+archive as a false mismatch.
+
+## What Changes
+
+- Add a deterministic Codex helper that extracts the intended Document
+  `content` field from the wrapper's actual response shape without recursive
+  key search or line-based truncation.
+- Compare local and remote bytes without newline normalization, and report only
+  byte counts and SHA-256 hashes when they differ.
+- Cover multiline Markdown, empty content, trailing-newline differences,
+  unrelated `content` fields, malformed responses, and true byte drift.
+- Replace the Codex OpenSpec skill and archive reminder's underspecified
+  verification prose with the supported helper flow.
+- Assess the helper contract against Claude Code and Kiro wrappers; copy the
+  implementation only where response contracts are compatible.
+
+## Capabilities
+
+### New Capabilities
+
+- `openspec-document-roundtrip-verification`: deterministic and diagnosable
+  verification of local OpenSpec files against mirrored Chorus Documents.
+
+## Impact
+
+The primary implementation surface is the Codex plugin source, generated
+OpenSpec-aware skill, archive reminder, and their shell tests. Claude Code and
+Kiro templates may receive equivalent changes after compatibility is proven.
+The existing wrapper-only mirror and `json_encode_file` requirements remain
+unchanged.

--- a/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/specs/openspec-document-roundtrip-verification/spec.md
+++ b/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/specs/openspec-document-roundtrip-verification/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Targeted Document content extraction
+The Codex OpenSpec archive workflow MUST extract the mirrored Document body from
+the documented target field of the `chorus_get_document` tool result and MUST
+NOT discover content through recursive key search or line-oriented selection.
+
+#### Scenario: Multiline Document body
+- **WHEN** the wrapper result contains a top-level `content` string with multiple lines
+- **THEN** the verifier preserves every byte of the string for comparison
+
+#### Scenario: Unrelated nested content field
+- **WHEN** the result also contains another object's `content` field
+- **THEN** the verifier compares only the Document's top-level `content`
+
+#### Scenario: Invalid response shape
+- **WHEN** the result is malformed or its top-level `content` is absent or not a string
+- **THEN** verification fails closed without selecting a fallback field
+
+### Requirement: Exact byte comparison
+The verifier MUST compare local and remote content as exact bytes and MUST NOT
+normalize line endings or trailing newlines.
+
+#### Scenario: Equal multiline content
+- **WHEN** local and remote content contain identical bytes
+- **THEN** verification succeeds
+
+#### Scenario: Single-byte drift
+- **WHEN** local and remote content differ by one byte
+- **THEN** verification fails and archive closeout halts
+
+#### Scenario: Trailing newline drift
+- **WHEN** one side has a trailing newline and the other does not
+- **THEN** verification treats the values as different
+
+#### Scenario: Empty content
+- **WHEN** local and remote content are both empty
+- **THEN** verification succeeds
+
+### Requirement: Non-sensitive mismatch diagnostics
+On mismatch, the verifier MUST report each side's byte count and SHA-256 hash
+and MUST NOT print either complete content body.
+
+#### Scenario: Mismatch report
+- **WHEN** exact comparison fails
+- **THEN** stderr identifies local and remote byte counts and hashes without reproducing the document text
+
+### Requirement: Mirror-write constraints remain intact
+The verification change MUST preserve the requirement that OpenSpec Document
+mirror writes use `chorus-mcp-call.sh` with content produced by
+`json_encode_file`.
+
+#### Scenario: Archive mirror followed by verification
+- **WHEN** an agent mirrors an archived cumulative spec and verifies it
+- **THEN** the write uses the existing wrapper and encoder while the read uses the deterministic verifier
+
+### Requirement: Host portability is evidence-based
+Claude Code and Kiro variants MUST receive equivalent verifier behavior only
+after their wrapper output contracts pass the shared response fixtures.
+
+#### Scenario: Compatible host wrapper
+- **WHEN** another host emits the same top-level Document JSON contract
+- **THEN** the helper and instruction pattern may be copied with host-specific invocation changes
+
+#### Scenario: Incompatible host wrapper
+- **WHEN** another host emits a different response contract
+- **THEN** the Codex fix remains valid and the incompatibility is documented rather than hidden by permissive parsing

--- a/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/tasks.md
+++ b/openspec/changes/archive/2026-07-25-fix-codex-openspec-roundtrip-verifier/tasks.md
@@ -1,0 +1,11 @@
+## 1. Codex-first implementation
+
+- [ ] 1.1 Add a strict Codex Document-content extraction and exact-byte comparison helper.
+- [ ] 1.2 Add regression fixtures for multiline, empty, newline drift, decoy fields, malformed responses, and one-byte drift.
+- [ ] 1.3 Update the Codex OpenSpec-aware skill and archive reminder to use the helper and metadata-only mismatch diagnostics.
+- [ ] 1.4 Run the helper and plugin test suites, including an archive closeout regression.
+
+## 2. Portability assessment
+
+- [ ] 2.1 Run the shared response fixtures against Claude Code and Kiro wrapper contracts.
+- [ ] 2.2 Copy the helper and instruction pattern to compatible plugins, or document concrete contract differences that prevent copying.

--- a/openspec/specs/openspec-document-roundtrip-verification/spec.md
+++ b/openspec/specs/openspec-document-roundtrip-verification/spec.md
@@ -1,0 +1,70 @@
+# openspec-document-roundtrip-verification Specification
+
+## Purpose
+TBD - created by archiving change fix-codex-openspec-roundtrip-verifier. Update Purpose after archive.
+## Requirements
+### Requirement: Targeted Document content extraction
+The Codex OpenSpec archive workflow MUST extract the mirrored Document body from
+the documented target field of the `chorus_get_document` tool result and MUST
+NOT discover content through recursive key search or line-oriented selection.
+
+#### Scenario: Multiline Document body
+- **WHEN** the wrapper result contains a top-level `content` string with multiple lines
+- **THEN** the verifier preserves every byte of the string for comparison
+
+#### Scenario: Unrelated nested content field
+- **WHEN** the result also contains another object's `content` field
+- **THEN** the verifier compares only the Document's top-level `content`
+
+#### Scenario: Invalid response shape
+- **WHEN** the result is malformed or its top-level `content` is absent or not a string
+- **THEN** verification fails closed without selecting a fallback field
+
+### Requirement: Exact byte comparison
+The verifier MUST compare local and remote content as exact bytes and MUST NOT
+normalize line endings or trailing newlines.
+
+#### Scenario: Equal multiline content
+- **WHEN** local and remote content contain identical bytes
+- **THEN** verification succeeds
+
+#### Scenario: Single-byte drift
+- **WHEN** local and remote content differ by one byte
+- **THEN** verification fails and archive closeout halts
+
+#### Scenario: Trailing newline drift
+- **WHEN** one side has a trailing newline and the other does not
+- **THEN** verification treats the values as different
+
+#### Scenario: Empty content
+- **WHEN** local and remote content are both empty
+- **THEN** verification succeeds
+
+### Requirement: Non-sensitive mismatch diagnostics
+On mismatch, the verifier MUST report each side's byte count and SHA-256 hash
+and MUST NOT print either complete content body.
+
+#### Scenario: Mismatch report
+- **WHEN** exact comparison fails
+- **THEN** stderr identifies local and remote byte counts and hashes without reproducing the document text
+
+### Requirement: Mirror-write constraints remain intact
+The verification change MUST preserve the requirement that OpenSpec Document
+mirror writes use `chorus-mcp-call.sh` with content produced by
+`json_encode_file`.
+
+#### Scenario: Archive mirror followed by verification
+- **WHEN** an agent mirrors an archived cumulative spec and verifies it
+- **THEN** the write uses the existing wrapper and encoder while the read uses the deterministic verifier
+
+### Requirement: Host portability is evidence-based
+Claude Code and Kiro variants MUST receive equivalent verifier behavior only
+after their wrapper output contracts pass the shared response fixtures.
+
+#### Scenario: Compatible host wrapper
+- **WHEN** another host emits the same top-level Document JSON contract
+- **THEN** the helper and instruction pattern may be copied with host-specific invocation changes
+
+#### Scenario: Incompatible host wrapper
+- **WHEN** another host emits a different response contract
+- **THEN** the Codex fix remains valid and the incompatibility is documented rather than hidden by permissive parsing

--- a/plugins/chorus/hooks/on-post-verify-task.sh
+++ b/plugins/chorus/hooks/on-post-verify-task.sh
@@ -189,7 +189,7 @@ ACTION REQUIRED: archive the OpenSpec change locally and mirror updated specs ba
 
 3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: "proposal", targetUuid: "${PROPOSAL_UUID}", content: "..."})\`), and HALT. No retry, no silent skip.
 
-4. Confirm success by listing \`openspec/specs/<capability>/spec.md\` files and verifying they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+4. Resolve \`CHORUS_PLUGIN_DIR\` with canonical §2.1, then confirm each updated spec with \`"\$CHORUS_PLUGIN_DIR/hooks/verify-document-roundtrip.sh" <local-spec-path> <document-uuid>\`. It performs exact-byte comparison and reports only byte counts and SHA-256 hashes on mismatch. Do not use recursive \`jq\`, \`head\`, command substitution, or newline normalization.
 
 References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors).
 CTX

--- a/plugins/chorus/hooks/tests/test-verify-document-roundtrip.sh
+++ b/plugins/chorus/hooks/tests/test-verify-document-roundtrip.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_ROOT="$(cd "$ROOT/../.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cat >"$TMP/mcp-call" <<'SH'
+#!/usr/bin/env bash
+printf '%s' "$FIXTURE"
+SH
+chmod +x "$TMP/mcp-call"
+
+pass=0
+fail=0
+
+expect_ok() {
+  local name="$1"
+  if CHORUS_MCP_CALL_BIN="$TMP/mcp-call" FIXTURE="$FIXTURE" "$VERIFIER" "$TMP/local" doc-1 >"$TMP/out" 2>"$TMP/err"; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $name" >&2
+    cat "$TMP/err" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+expect_fail() {
+  local name="$1"
+  if CHORUS_MCP_CALL_BIN="$TMP/mcp-call" FIXTURE="$FIXTURE" "$VERIFIER" "$TMP/local" doc-1 >"$TMP/out" 2>"$TMP/err"; then
+    echo "FAIL: $name unexpectedly succeeded" >&2
+    fail=$((fail + 1))
+  else
+    pass=$((pass + 1))
+  fi
+}
+
+run_suite() {
+  local variant="$1"
+
+  printf 'first\nsecond\n' >"$TMP/local"
+  FIXTURE='{"content":"first\nsecond\n","metadata":{"content":"decoy"}}'
+  expect_ok "$variant: multiline content with decoy"
+
+  : >"$TMP/local"
+  FIXTURE='{"content":""}'
+  expect_ok "$variant: empty content"
+
+  printf 'same\n' >"$TMP/local"
+  FIXTURE='{"content":"same"}'
+  expect_fail "$variant: trailing newline drift"
+
+  printf 'same' >"$TMP/local"
+  FIXTURE='{"content":"sAme"}'
+  expect_fail "$variant: single-byte drift"
+  grep -q 'local  bytes=4 sha256=' "$TMP/err"
+  grep -q 'remote bytes=4 sha256=' "$TMP/err"
+  ! grep -q 'sAme' "$TMP/err"
+
+  FIXTURE='{"metadata":{"content":"same"}}'
+  expect_fail "$variant: missing top-level content"
+
+  FIXTURE='{"content":null}'
+  expect_fail "$variant: non-string content"
+
+  FIXTURE='not-json'
+  expect_fail "$variant: malformed response"
+}
+
+for entry in \
+  "codex:$ROOT/hooks/verify-document-roundtrip.sh" \
+  "claude:$REPO_ROOT/public/chorus-plugin/bin/verify-document-roundtrip.sh" \
+  "kiro:$REPO_ROOT/public/kiro-plugin/bin/verify-document-roundtrip.sh"; do
+  variant="${entry%%:*}"
+  VERIFIER="${entry#*:}"
+  run_suite "$variant"
+done
+
+grep -q 'HOOK_SCRIPTS=.*verify-document-roundtrip.sh' "$REPO_ROOT/public/install-kiro.sh" || {
+  echo "FAIL: Kiro installer omits verify-document-roundtrip.sh" >&2
+  fail=$((fail + 1))
+}
+
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/plugins/chorus/hooks/verify-document-roundtrip.sh
+++ b/plugins/chorus/hooks/verify-document-roundtrip.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Verify a local file against a Chorus Document without normalizing bytes.
+
+set -euo pipefail
+
+LOCAL_FILE="${1:?local file required}"
+DOCUMENT_UUID="${2:?document UUID required}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_CALL="${CHORUS_MCP_CALL_BIN:-$SCRIPT_DIR/chorus-mcp-call.sh}"
+
+[ -f "$LOCAL_FILE" ] || {
+  echo "round-trip verification: local file not found: $LOCAL_FILE" >&2
+  exit 2
+}
+command -v jq >/dev/null 2>&1 || {
+  echo "round-trip verification: jq is required" >&2
+  exit 2
+}
+
+RESPONSE_FILE=$(mktemp)
+REMOTE_FILE=$(mktemp)
+trap 'rm -f "$RESPONSE_FILE" "$REMOTE_FILE"' EXIT
+
+PAYLOAD=$(jq -cn --arg documentUuid "$DOCUMENT_UUID" '{documentUuid: $documentUuid}')
+"$MCP_CALL" chorus_get_document "$PAYLOAD" >"$RESPONSE_FILE"
+
+if ! jq -je 'if (.content | type) == "string" then .content else error("top-level .content must be a string") end' \
+  "$RESPONSE_FILE" >"$REMOTE_FILE"; then
+  echo "round-trip verification: invalid chorus_get_document response" >&2
+  exit 3
+fi
+
+if cmp -s "$LOCAL_FILE" "$REMOTE_FILE"; then
+  exit 0
+fi
+
+byte_count() {
+  wc -c <"$1" | tr -d '[:space:]'
+}
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+echo "round-trip mismatch:" >&2
+echo "  local  bytes=$(byte_count "$LOCAL_FILE") sha256=$(sha256 "$LOCAL_FILE")" >&2
+echo "  remote bytes=$(byte_count "$REMOTE_FILE") sha256=$(sha256 "$REMOTE_FILE")" >&2
+exit 4

--- a/plugins/chorus/skills/openspec-aware/SKILL.md
+++ b/plugins/chorus/skills/openspec-aware/SKILL.md
@@ -131,7 +131,7 @@ Document/draft mirror calls (`chorus_pm_add_document_draft`, `chorus_pm_update_d
 with `$PAYLOAD` built using `json_encode_file` (defined in §3.4). Calling these tools directly from Codex's MCP harness with a hand-typed `content` field is a **protocol violation** for OpenSpec mode and will fail review. Reasons:
 
 1. **Token cost.** Re-typing a multi-thousand-line markdown body through the model burns input + output tokens for every draft. The wrapper streams bytes through `jq -Rs '.'` — content never enters model context. A typical 3-doc proposal mirror via the script costs roughly zero content-tokens; via direct MCP it routinely costs 20k+.
-2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. Model re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The byte-equality guarantee (modulo trailing `\n`) holds **only** on the wrapper path.
+2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. Model re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The exact byte-equality guarantee holds **only** on the wrapper path.
 3. **Single source of truth.** With the wrapper, the local `openspec/changes/<slug>/*.md` is authoritative and Chorus is a mirror. With agent re-typing, authority splits between local file and whatever the model happened to output — a future diff cannot tell which one is correct.
 
 ### Rule 2 — Halt on error via `chorus_check_response`
@@ -267,7 +267,7 @@ json_encode_file() {
 }
 ```
 
-Round-trip: the Chorus backend appends a single `\n` to draft content on write, so server `content` is **byte-equal modulo a trailing newline**. Reviewers diffing local file vs server should ignore that one byte.
+Round-trip verification is exact: a trailing newline difference is real drift and MUST NOT be normalized or ignored.
 
 ### 3.5 Create the proposal container with the slug provenance line
 
@@ -369,7 +369,20 @@ The hook is read-only; you (the agent) perform the archive:
 
 3. **Halt on any error** from `openspec archive` or `chorus_pm_update_document`. Print stderr verbatim, post a comment on the proposal recording the failure (`chorus_add_comment` with `targetType: "proposal"`, `targetUuid: <proposalUuid>`), then stop. No retry. Matches §6 "no silent errors." (Comment on the proposal, not the idea: the failure is in archiving proposal-derived specs, and proposals can be `inputType: "document"` with no idea attached.)
 
-4. **Confirm success.** List `openspec/specs/<capability>/spec.md` files and verify they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+4. **Confirm success with the supported verifier.** List each updated
+   `openspec/specs/<capability>/spec.md`, resolve its matching Document UUID,
+   then run:
+
+   ```bash
+   "$CHORUS_PLUGIN_DIR/hooks/verify-document-roundtrip.sh" \
+     "openspec/specs/<capability>/spec.md" "$SPEC_DOCUMENT_UUID"
+   ```
+
+   The verifier reads the exact top-level Document `.content`, preserves
+   multiline and trailing-newline bytes via temporary files, and exits non-zero
+   on malformed responses or any byte difference. On mismatch it prints only
+   local/remote byte counts and SHA-256 hashes. Do not replace it with recursive
+   `jq` searches, `head`, command substitution, or newline normalization.
 
 **Strict opt-in:** if the verified task is not the last of its idea, OR the proposal description carries no `OpenSpec change slug: <slug>` line, OR the local shell has no `openspec` CLI, the hook exits 0 silently and no archive reminder is injected. Existing free-form behavior is preserved.
 

--- a/public/chorus-plugin/bin/on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/on-post-verify-task.sh
@@ -195,7 +195,7 @@ ACTION REQUIRED: archive the OpenSpec change locally and mirror updated specs ba
 
 3. On any error from \`openspec archive\` or \`chorus_pm_update_document\`: print stderr verbatim, post a comment on the proposal recording the failure (\`chorus_add_comment({targetType: "proposal", targetUuid: "${PROPOSAL_UUID}", content: "..."})\`), and HALT. No retry, no silent skip.
 
-4. Confirm success by listing \`openspec/specs/<capability>/spec.md\` files and verifying they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+4. Confirm each updated spec with \`verify-document-roundtrip.sh <local-spec-path> <document-uuid>\`; do not use recursive \`jq\`, \`head\`, command substitution, or newline normalization.
 
 References: canonical openspec-aware §3.8 (mirror-back contract), §3.9 (this archive trigger), §6 (no silent errors).
 CTX

--- a/public/chorus-plugin/bin/verify-document-roundtrip.sh
+++ b/public/chorus-plugin/bin/verify-document-roundtrip.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCAL_FILE="${1:?local file required}"
+DOCUMENT_UUID="${2:?document UUID required}"
+[ -f "$LOCAL_FILE" ] || { echo "round-trip verification: local file not found" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "round-trip verification: jq is required" >&2; exit 2; }
+
+RESPONSE_FILE=$(mktemp)
+REMOTE_FILE=$(mktemp)
+trap 'rm -f "$RESPONSE_FILE" "$REMOTE_FILE"' EXIT
+PAYLOAD=$(jq -cn --arg documentUuid "$DOCUMENT_UUID" '{documentUuid: $documentUuid}')
+
+if [ -n "${CHORUS_MCP_CALL_BIN:-}" ]; then
+  "$CHORUS_MCP_CALL_BIN" chorus_get_document "$PAYLOAD" >"$RESPONSE_FILE"
+else
+  chorus-api.sh mcp-tool chorus_get_document "$PAYLOAD" >"$RESPONSE_FILE"
+fi
+
+jq -je 'if (.content | type) == "string" then .content else error("top-level .content must be a string") end' \
+  "$RESPONSE_FILE" >"$REMOTE_FILE" || { echo "round-trip verification: invalid chorus_get_document response" >&2; exit 3; }
+cmp -s "$LOCAL_FILE" "$REMOTE_FILE" && exit 0
+
+hash_file() { command -v sha256sum >/dev/null 2>&1 && sha256sum "$1" | awk '{print $1}' || shasum -a 256 "$1" | awk '{print $1}'; }
+echo "round-trip mismatch:" >&2
+echo "  local  bytes=$(wc -c <"$LOCAL_FILE" | tr -d '[:space:]') sha256=$(hash_file "$LOCAL_FILE")" >&2
+echo "  remote bytes=$(wc -c <"$REMOTE_FILE" | tr -d '[:space:]') sha256=$(hash_file "$REMOTE_FILE")" >&2
+exit 4

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -90,7 +90,7 @@ chorus-api.sh mcp-tool <tool_name> "$PAYLOAD"
 with `$PAYLOAD` built using `json_encode_file` (defined in §3.4). Calling these tools directly from the agent's MCP harness with a hand-typed `content` field is a **protocol violation** for OpenSpec mode and will fail review. Reasons:
 
 1. **Token cost.** Re-typing a multi-thousand-line markdown body through the LLM burns input + output tokens for every draft. The wrapper streams bytes through `jq -Rs '.'` — content never enters LLM context. A typical 3-doc proposal mirror via the script costs roughly zero content-tokens; via direct MCP it routinely costs 20k+.
-2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. LLM re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The byte-equality guarantee (modulo trailing `\n`) holds **only** on the wrapper path.
+2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. LLM re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The exact byte-equality guarantee holds **only** on the wrapper path.
 3. **Single source of truth.** With the wrapper, the local `openspec/changes/<slug>/*.md` is authoritative and Chorus is a mirror. With agent re-typing, authority splits between local file and whatever the LLM happened to output — a future diff cannot tell which one is correct.
 
 ### Rule 2 — Halt on error via `chorus_check_response`
@@ -226,7 +226,7 @@ json_encode_file() {
 }
 ```
 
-Round-trip: the Chorus backend appends a single `\n` to draft content on write, so server `content` is **byte-equal modulo a trailing newline**. Reviewers diffing local file vs server should ignore that one byte.
+Round-trip verification is exact: a trailing newline difference is real drift and MUST NOT be normalized or ignored.
 
 ### 3.5 Create the proposal container with the slug provenance line
 
@@ -329,7 +329,11 @@ The hook is read-only; you (the agent) perform the archive:
 
 3. **Halt on any error** from `openspec archive` or `chorus_pm_update_document`. Print stderr verbatim, post a comment on the proposal recording the failure (`chorus_add_comment` with `targetType: "proposal"`, `targetUuid: <proposalUuid>`), then stop. No retry. Matches §6 "no silent errors." (Comment on the proposal, not the idea: the failure is in archiving proposal-derived specs, and proposals can be `inputType: "document"` with no idea attached.)
 
-4. **Confirm success.** List `openspec/specs/<capability>/spec.md` files and verify they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+4. **Confirm success.** Resolve each matching Document UUID and run
+   `verify-document-roundtrip.sh <local-spec-path> <document-uuid>`. This
+   performs exact-byte comparison and metadata-only mismatch diagnostics. Do
+   not replace it with recursive `jq`, `head`, command substitution, or newline
+   normalization.
 
 **Strict opt-in:** if the verified task is not the last of its idea, OR the proposal description carries no `OpenSpec change slug: <slug>` line, OR the local shell has no `openspec` CLI, the hook exits 0 silently and no archive reminder is injected. Existing free-form behavior is preserved.
 

--- a/public/install-kiro.sh
+++ b/public/install-kiro.sh
@@ -44,7 +44,7 @@ is_tty() { [ -t 0 ] && [ -t 1 ]; }
 # source modes can never diverge.
 SKILLS="chorus-idea chorus-proposal chorus-develop chorus-yolo chorus-review chorus-quick-dev chorus-brainstorm chorus-openspec-aware"
 REVIEWER_AGENTS="chorus-code-reviewer chorus-proposal-reviewer chorus-task-reviewer"
-HOOK_SCRIPTS="on-agent-spawn.sh on-stop.sh on-post-submit-proposal.sh on-post-submit-for-verify.sh on-post-verify-task.sh chorus-api.sh test-syntax.sh"
+HOOK_SCRIPTS="on-agent-spawn.sh on-stop.sh on-post-submit-proposal.sh on-post-submit-for-verify.sh on-post-verify-task.sh chorus-api.sh verify-document-roundtrip.sh test-syntax.sh"
 
 CHORUS_URL_DEFAULT="${CHORUS_URL_DEFAULT:-http://localhost:8637/api/mcp}"
 

--- a/public/kiro-plugin/.kiro/skills/chorus-openspec-aware/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-openspec-aware/SKILL.md
@@ -88,7 +88,7 @@ chorus-api.sh mcp-tool <tool_name> "$PAYLOAD"
 with `$PAYLOAD` built using `json_encode_file` (defined in §3.4). Calling these tools directly from the agent's MCP harness with a hand-typed `content` field is a **protocol violation** for OpenSpec mode and will fail review. Reasons:
 
 1. **Token cost.** Re-typing a multi-thousand-line markdown body through the LLM burns input + output tokens for every draft. The wrapper streams bytes through `jq -Rs '.'` — content never enters LLM context. A typical 3-doc proposal mirror via the script costs roughly zero content-tokens; via direct MCP it routinely costs 20k+.
-2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. LLM re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The byte-equality guarantee (modulo trailing `\n`) holds **only** on the wrapper path.
+2. **Byte-equality.** `jq -Rs '.'` is a byte-faithful encoder: backslashes, quotes, newlines, code-fence content, zero-width chars all survive. LLM re-emission has a non-zero failure rate on long markdown — table alignment drifts, fence escapes get "fixed", long URLs wrap. The exact byte-equality guarantee holds **only** on the wrapper path.
 3. **Single source of truth.** With the wrapper, the local `openspec/changes/<slug>/*.md` is authoritative and Chorus is a mirror. With agent re-typing, authority splits between local file and whatever the LLM happened to output — a future diff cannot tell which one is correct.
 
 ### Rule 2 — Halt on error via `chorus_check_response`
@@ -224,7 +224,7 @@ json_encode_file() {
 }
 ```
 
-Round-trip: the Chorus backend appends a single `\n` to draft content on write, so server `content` is **byte-equal modulo a trailing newline**. Reviewers diffing local file vs server should ignore that one byte.
+Round-trip verification is exact: a trailing newline difference is real drift and MUST NOT be normalized or ignored.
 
 ### 3.5 Create the proposal container with the slug provenance line
 
@@ -327,7 +327,11 @@ The hook is read-only; you (the agent) perform the archive:
 
 3. **Halt on any error** from `openspec archive` or `chorus_pm_update_document`. Print stderr verbatim, post a comment on the proposal recording the failure (`chorus_add_comment` with `targetType: "proposal"`, `targetUuid: <proposalUuid>`), then stop. No retry. Matches §6 "no silent errors." (Comment on the proposal, not the idea: the failure is in archiving proposal-derived specs, and proposals can be `inputType: "document"` with no idea attached.)
 
-4. **Confirm success.** List `openspec/specs/<capability>/spec.md` files and verify they round-trip byte-equal (modulo trailing newline) with their Chorus Document counterparts.
+4. **Confirm success.** Resolve each matching Document UUID and run
+   `verify-document-roundtrip.sh <local-spec-path> <document-uuid>`. This
+   performs exact-byte comparison and metadata-only mismatch diagnostics. Do
+   not replace it with recursive `jq`, `head`, command substitution, or newline
+   normalization.
 
 **Strict opt-in:** if the verified task is not the last of its idea, OR the proposal description carries no `OpenSpec change slug: <slug>` line, OR the local shell has no `openspec` CLI, the hook exits 0 silently and no archive reminder is injected. Existing free-form behavior is preserved.
 

--- a/public/kiro-plugin/bin/verify-document-roundtrip.sh
+++ b/public/kiro-plugin/bin/verify-document-roundtrip.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCAL_FILE="${1:?local file required}"
+DOCUMENT_UUID="${2:?document UUID required}"
+[ -f "$LOCAL_FILE" ] || { echo "round-trip verification: local file not found" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "round-trip verification: jq is required" >&2; exit 2; }
+
+RESPONSE_FILE=$(mktemp)
+REMOTE_FILE=$(mktemp)
+trap 'rm -f "$RESPONSE_FILE" "$REMOTE_FILE"' EXIT
+PAYLOAD=$(jq -cn --arg documentUuid "$DOCUMENT_UUID" '{documentUuid: $documentUuid}')
+
+if [ -n "${CHORUS_MCP_CALL_BIN:-}" ]; then
+  "$CHORUS_MCP_CALL_BIN" chorus_get_document "$PAYLOAD" >"$RESPONSE_FILE"
+else
+  chorus-api.sh mcp-tool chorus_get_document "$PAYLOAD" >"$RESPONSE_FILE"
+fi
+
+jq -je 'if (.content | type) == "string" then .content else error("top-level .content must be a string") end' \
+  "$RESPONSE_FILE" >"$REMOTE_FILE" || { echo "round-trip verification: invalid chorus_get_document response" >&2; exit 3; }
+cmp -s "$LOCAL_FILE" "$REMOTE_FILE" && exit 0
+
+hash_file() { command -v sha256sum >/dev/null 2>&1 && sha256sum "$1" | awk '{print $1}' || shasum -a 256 "$1" | awk '{print $1}'; }
+echo "round-trip mismatch:" >&2
+echo "  local  bytes=$(wc -c <"$LOCAL_FILE" | tr -d '[:space:]') sha256=$(hash_file "$LOCAL_FILE")" >&2
+echo "  remote bytes=$(wc -c <"$REMOTE_FILE" | tr -d '[:space:]') sha256=$(hash_file "$REMOTE_FILE")" >&2
+exit 4


### PR DESCRIPTION
## Summary
- add deterministic exact-byte Chorus Document verification for Codex OpenSpec archive closeout
- apply the verified response contract to Claude Code and Kiro, including Kiro installer deployment
- replace ambiguous/newline-normalizing guidance and add cross-host regression coverage

## Tests
- `plugins/chorus/hooks/tests/test-verify-document-roundtrip.sh` (21 passed)
- `public/chorus-plugin/bin/tests/test-on-post-verify-task.sh` (34 passed)
- `openspec validate fix-codex-openspec-roundtrip-verifier` before archive

## Chorus
Idea: `3e5fc9a0-6812-4ba3-b1f9-d6b7432128e2`
Aggregate code review Round 2: PASS