### PR TITLE
feat(daemon): configure agent backend via daemon.json + install prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ With no `--cwd`, the daemon serves the single directory it was launched from.
   "agentUuid": "00000000-0000-0000-0000-000000000000",
   "agentName": "My Daemon Agent",
   "cwds": ["~/work/repo-a", "~/work/repo-b"],
+  "agent": "codex",
   "sigintTimeoutMs": 10000
 }
 ```
@@ -169,6 +170,7 @@ With no `--cwd`, the daemon serves the single directory it was launched from.
 | `apiKey` | string | Agent API key (`cho_…`) | `--api-key` flag → `CHORUS_API_KEY` → file |
 | `agentUuid` / `agentName` | string | Authenticated identity (recorded at login) | written by `chorus login` |
 | `cwds` | string[] | Working directories the daemon serves (multi-path) | `--cwd` flag(s) → `CHORUS_DAEMON_CWDS` → file → launch dir |
+| `agent` | string | Local agent backend to wake (`claude-code` / `codex` / `kiro`) | `--agent` flag → `CHORUS_AGENT` → file → `claude-code` |
 | `sigintTimeoutMs` | number | Grace window (ms) after SIGINT before a forceful kill (default `10000`) | `--sigint-timeout` flag → `CHORUS_DAEMON_SIGINT_TIMEOUT` → file → `10000` |
 | `yoloAckAt` | string | Internal — timestamp of a TTY yolo confirmation (managed automatically) | — |
 

--- a/cli/__tests__/daemon-agent.test.mjs
+++ b/cli/__tests__/daemon-agent.test.mjs
@@ -6,9 +6,13 @@
 import { describe, it, expect } from "vitest";
 import { resolveAgentType, KNOWN_AGENTS, DEFAULT_AGENT, backendClientType, backendCli } from "../daemon-agent.mjs";
 
+// A deps bundle whose config file is empty — pins the file layer to a no-op so
+// the flag/env/default cases below never touch the operator's real daemon.json.
+const NO_FILE = { readJson: () => null, loginPath: "/tmp/none.json" };
+
 describe("resolveAgentType — known backends", () => {
   it("defaults to claude-code with no flag and no env", () => {
-    expect(resolveAgentType({}, {})).toEqual({ ok: true, agent: "claude-code" });
+    expect(resolveAgentType({}, {}, NO_FILE)).toEqual({ ok: true, agent: "claude-code" });
   });
 
   it("accepts explicit claude-code (flag and env)", () => {
@@ -61,6 +65,72 @@ describe("resolveAgentType — unknown rejected (no silent fallback)", () => {
     const r = resolveAgentType({}, { CHORUS_AGENT: "nope" });
     expect(r.ok).toBe(false);
     expect(r.value).toBe("nope");
+  });
+
+  it("rejects an unknown `agent` in daemon.json", () => {
+    const r = resolveAgentType({}, {}, { readJson: () => ({ agent: "gpt" }), loginPath: "/x" });
+    expect(r.ok).toBe(false);
+    expect(r.value).toBe("gpt");
+    expect(r.error).toContain("codex");
+  });
+});
+
+describe("resolveAgentType — daemon.json config-file layer", () => {
+  it("reads `agent` from daemon.json when no flag and no env", () => {
+    const r = resolveAgentType({}, {}, { readJson: () => ({ agent: "codex" }), loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "codex" });
+  });
+
+  it("accepts kiro from daemon.json", () => {
+    const r = resolveAgentType({}, {}, { readJson: () => ({ agent: "kiro" }), loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "kiro" });
+  });
+
+  it("flag wins over daemon.json", () => {
+    const r = resolveAgentType({ agent: "claude-code" }, {}, { readJson: () => ({ agent: "codex" }), loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "claude-code" });
+  });
+
+  it("env wins over daemon.json", () => {
+    const r = resolveAgentType({}, { CHORUS_AGENT: "kiro" }, { readJson: () => ({ agent: "codex" }), loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "kiro" });
+  });
+
+  it("falls back to the default when daemon.json has no `agent` field", () => {
+    const r = resolveAgentType({}, {}, { readJson: () => ({ cwds: ["/a"] }), loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "claude-code" });
+  });
+
+  it("falls back to the default when daemon.json is missing / unreadable", () => {
+    const r = resolveAgentType({}, {}, { readJson: () => null, loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "claude-code" });
+  });
+
+  it("treats a blank `agent` string in daemon.json as absent (falls through to default)", () => {
+    const r = resolveAgentType({}, {}, { readJson: () => ({ agent: "   " }), loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "claude-code" });
+  });
+
+  it("does NOT read the config file when a flag is present (short-circuit)", () => {
+    let reads = 0;
+    const readJson = () => {
+      reads += 1;
+      return { agent: "codex" };
+    };
+    const r = resolveAgentType({ agent: "kiro" }, {}, { readJson, loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "kiro" });
+    expect(reads).toBe(0);
+  });
+
+  it("does NOT read the config file when the env var is present (short-circuit)", () => {
+    let reads = 0;
+    const readJson = () => {
+      reads += 1;
+      return { agent: "codex" };
+    };
+    const r = resolveAgentType({}, { CHORUS_AGENT: "kiro" }, { readJson, loginPath: "/x" });
+    expect(r).toEqual({ ok: true, agent: "kiro" });
+    expect(reads).toBe(0);
   });
 });
 

--- a/cli/__tests__/daemon-install-config.test.mjs
+++ b/cli/__tests__/daemon-install-config.test.mjs
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   resolveInstallCredentials,
   resolveInstallCwds,
+  resolveInstallAgent,
 } from "../daemon-install-config.mjs";
 
 // ---- resolveInstallCredentials ------------------------------------------
@@ -148,5 +149,128 @@ describe("resolveInstallCwds", () => {
     const r = await resolveInstallCwds({}, { isTTY: false, skip: false, ...d });
     expect(d.prompt).not.toHaveBeenCalled();
     expect(r.cwds).toEqual(["/home/u/proj"]);
+  });
+});
+
+// ---- resolveInstallAgent ------------------------------------------------
+
+describe("resolveInstallAgent", () => {
+  // A base opts bundle: all three CLI probes report "found" so tests that don't
+  // care about the not-found path never trip the warning. Individual tests
+  // override probes / readJson as needed.
+  function baseOpts(over = {}) {
+    return {
+      writeConfig: vi.fn(),
+      readJson: () => null,
+      loginPath: "/tmp/none.json",
+      probes: {
+        resolveClaudePath: () => "/bin/claude",
+        resolveCodexPath: () => "/bin/codex",
+        resolveKiroPath: () => "/bin/kiro-cli",
+      },
+      log: vi.fn(),
+      errLog: vi.fn(),
+      ...over,
+    };
+  }
+
+  it("persists the --agent flag to daemon.json and returns it", async () => {
+    const o = baseOpts();
+    const r = await resolveInstallAgent({ agent: "codex" }, {}, o);
+    expect(r.agent).toBe("codex");
+    expect(o.writeConfig).toHaveBeenCalledWith({ agent: "codex" });
+  });
+
+  it("uses CHORUS_AGENT env when no flag is given", async () => {
+    const o = baseOpts();
+    const r = await resolveInstallAgent({}, { CHORUS_AGENT: "kiro" }, o);
+    expect(r.agent).toBe("kiro");
+    expect(o.writeConfig).toHaveBeenCalledWith({ agent: "kiro" });
+  });
+
+  it("flag wins over env", async () => {
+    const o = baseOpts();
+    const r = await resolveInstallAgent({ agent: "claude-code" }, { CHORUS_AGENT: "codex" }, o);
+    expect(r.agent).toBe("claude-code");
+  });
+
+  it("keeps an existing valid daemon.json `agent` WITHOUT re-writing (idempotent re-install)", async () => {
+    const o = baseOpts({ readJson: () => ({ agent: "codex" }) });
+    const r = await resolveInstallAgent({}, {}, o);
+    expect(r.agent).toBe("codex");
+    expect(o.writeConfig).not.toHaveBeenCalled();
+  });
+
+  it("ignores an invalid stored `agent` and falls back to the default (non-TTY)", async () => {
+    const o = baseOpts({ readJson: () => ({ agent: "gpt" }) });
+    const r = await resolveInstallAgent({}, {}, { ...o, isTTY: false, skip: true });
+    expect(r.agent).toBe("claude-code");
+    expect(o.writeConfig).toHaveBeenCalledWith({ agent: "claude-code" });
+  });
+
+  it("non-TTY / skip with nothing configured persists the claude-code default", async () => {
+    const o = baseOpts();
+    const r = await resolveInstallAgent({}, {}, { ...o, isTTY: false, skip: true });
+    expect(r.agent).toBe("claude-code");
+    expect(o.writeConfig).toHaveBeenCalledWith({ agent: "claude-code" });
+  });
+
+  it("interactive menu: a numeric selection picks the matching backend", async () => {
+    const prompt = vi.fn(async () => "2"); // 2) Codex CLI
+    const o = baseOpts({ prompt });
+    const r = await resolveInstallAgent({}, {}, { ...o, isTTY: true, skip: false });
+    expect(r.agent).toBe("codex");
+    expect(o.writeConfig).toHaveBeenCalledWith({ agent: "codex" });
+    // The menu was actually shown.
+    expect(o.log.mock.calls.flat().join("\n")).toMatch(/Codex CLI/);
+  });
+
+  it("interactive menu: a blank answer accepts the claude-code default (Enter)", async () => {
+    const prompt = vi.fn(async () => "");
+    const o = baseOpts({ prompt });
+    const r = await resolveInstallAgent({}, {}, { ...o, isTTY: true, skip: false });
+    expect(r.agent).toBe("claude-code");
+  });
+
+  it("interactive menu: accepts a backend typed by name", async () => {
+    const prompt = vi.fn(async () => "kiro");
+    const o = baseOpts({ prompt });
+    const r = await resolveInstallAgent({}, {}, { ...o, isTTY: true, skip: false });
+    expect(r.agent).toBe("kiro");
+  });
+
+  it("interactive menu: an out-of-range / garbage answer falls back to the default", async () => {
+    const prompt = vi.fn(async () => "9");
+    const o = baseOpts({ prompt });
+    const r = await resolveInstallAgent({}, {}, { ...o, isTTY: true, skip: false });
+    expect(r.agent).toBe("claude-code");
+  });
+
+  it("does NOT prompt on a TTY when --yes/skip is set (uses default)", async () => {
+    const prompt = vi.fn(async () => "2");
+    const o = baseOpts({ prompt });
+    const r = await resolveInstallAgent({}, {}, { ...o, isTTY: true, skip: true });
+    expect(prompt).not.toHaveBeenCalled();
+    expect(r.agent).toBe("claude-code");
+  });
+
+  it("probes the SELECTED backend's CLI and reports found", async () => {
+    const findCodex = vi.fn(() => "/opt/codex");
+    const o = baseOpts({ probes: { resolveClaudePath: () => "/bin/claude", resolveCodexPath: findCodex, resolveKiroPath: () => "/bin/kiro-cli" } });
+    const r = await resolveInstallAgent({ agent: "codex" }, {}, o);
+    expect(findCodex).toHaveBeenCalled();
+    expect(r.cliFound).toBe(true);
+    expect(r.cliPath).toBe("/opt/codex");
+    expect(o.log.mock.calls.flat().join("\n")).toMatch(/found CLI at \/opt\/codex/);
+  });
+
+  it("warns (non-fatal) when the selected backend's CLI is missing", async () => {
+    const o = baseOpts({ probes: { resolveClaudePath: () => "/bin/claude", resolveCodexPath: () => null, resolveKiroPath: () => "/bin/kiro-cli" } });
+    const r = await resolveInstallAgent({ agent: "codex" }, {}, o);
+    expect(r.cliFound).toBe(false);
+    expect(r.cliPath).toBeNull();
+    expect(o.errLog.mock.calls.flat().join("\n")).toMatch(/codex CLI NOT FOUND/);
+    // Still resolved + persisted — a missing binary never blocks the install.
+    expect(o.writeConfig).toHaveBeenCalledWith({ agent: "codex" });
   });
 });

--- a/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
+++ b/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
@@ -35,6 +35,7 @@ function fakeService(over = {}) {
     installConfig: {
       resolveInstallCredentials: vi.fn(async () => ({ ok: true, creds: { url: "u", apiKey: "cho_k" }, identity: { uuid: "a", name: "Bot" } })),
       resolveInstallCwds: vi.fn(async () => ({ cwds: ["/a"] })),
+      resolveInstallAgent: vi.fn(async () => ({ ok: true, agent: "claude-code", cliPath: "/bin/claude", cliFound: true })),
     },
     ...over,
   };
@@ -239,21 +240,40 @@ describe("runDaemon — supervisor (systemd) delegation", () => {
 });
 
 describe("runDaemon — install / uninstall", () => {
-  it("install runs the credential + cwd config phase, then passes --agent/--chorus-only into the spec and reports success", async () => {
+  it("install runs the credential + cwd + agent config phase, passes --chorus-only into the spec (NOT --agent), and reports success", async () => {
     const service = fakeService();
     const logs = [];
     const code = await runDaemon(
-      { action: "install", cwd: ["/a", "/b"], agent: "claude-code", chorusOnly: true },
+      { action: "install", cwd: ["/a", "/b"], agent: "codex", chorusOnly: true },
       { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
     );
     expect(code).toBe(0);
     // Config phase ran before the unit was written.
     expect(service.installConfig.resolveInstallCredentials).toHaveBeenCalledOnce();
     expect(service.installConfig.resolveInstallCwds).toHaveBeenCalledOnce();
+    expect(service.installConfig.resolveInstallAgent).toHaveBeenCalledOnce();
+    // The agent phase receives the flag; the value is persisted to daemon.json by
+    // that helper, NOT baked into the unit spec.
+    expect(service.installConfig.resolveInstallAgent.mock.calls[0][0]).toMatchObject({ agent: "codex" });
     const spec = service.installService.mock.calls[0][0];
-    expect(spec.agent).toBe("claude-code");
+    expect(spec.agent).toBeUndefined();
     expect(spec.chorusOnly).toBe(true);
     expect(logs.join("")).toMatch(/installed and started/);
+  });
+
+  it("install ABORTS (exit 1, no unit written, no config phase) when --agent is an unknown value", async () => {
+    // resolveAgentType gates EVERY action up front, so an unknown --agent is
+    // rejected before the install config phase even begins.
+    const service = fakeService();
+    const errs = [];
+    const code = await runDaemon(
+      { action: "install", agent: "gemini" },
+      { lifecycle: fakeLifecycle(), service, log: () => {}, errLog: (m) => errs.push(m), env: {} }
+    );
+    expect(code).toBe(1);
+    expect(service.installService).not.toHaveBeenCalled();
+    expect(service.installConfig.resolveInstallAgent).not.toHaveBeenCalled();
+    expect(errs.join("")).toMatch(/Unknown --agent "gemini"/);
   });
 
   it("install ABORTS (exit 1, no unit written) when the credential preflight fails", async () => {

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -120,6 +120,8 @@ OPTIONS
   --api-key <cho_...>      Agent API key                       (env: CHORUS_API_KEY)
   --agent <type>           Local agent backend to wake         (env: CHORUS_AGENT)
                            (claude-code | codex | kiro; default: claude-code)
+                           (Also configurable as "agent":"…" in ~/.chorus/daemon.json;
+                           'chorus daemon install' prompts for it interactively.)
   --yolo                   Full autonomy for the woken agent   (env: CHORUS_YOLO=1)
                            (--dangerously-skip-permissions: Bash, file writes, any
                            command). This is the DEFAULT permission mode.
@@ -133,9 +135,12 @@ OPTIONS
                            from. (Also configurable as "cwds":[…] in ~/.chorus/daemon.json.)
   -d, --detach             Run detached in the background (pidfile + logfile)
   -y, --yes                Non-interactive install: skip all 'chorus daemon
-                           install' prompts (credentials still resolved, persisted,
-                           and validated; install aborts if none resolve). A non-TTY
-                           install behaves as if --yes were passed.
+                           install' prompts (credentials, served cwds, and agent
+                           backend). Credentials are still resolved, persisted, and
+                           validated; install aborts if none resolve. The agent
+                           backend defaults to claude-code unless --agent/CHORUS_AGENT
+                           is set or one is already stored. A non-TTY install behaves
+                           as if --yes were passed.
   --verbose                More detailed per-wake logging
   --sigint-timeout <ms>    Grace window after SIGINT before a forceful kill
                            (env: CHORUS_DAEMON_SIGINT_TIMEOUT; default 10000)
@@ -155,11 +160,13 @@ SERVICE (install)
   -d' — the daemon self-daemonizes, which systemd cannot track and which loops
   on restart. Before writing the unit, install resolves + persists + validates
   your credentials into ~/.chorus/daemon.json (so the clean boot environment can
-  authenticate) and configures the served working directories there too (prompting
-  interactively for one or more when none are set — pass -y/--yes or run non-TTY to
-  skip prompts). The unit captures --agent / --chorus-only but NOT --cwd (cwds live
-  in daemon.json). On macOS/Windows install prints a correct template you install
-  manually.
+  authenticate), configures the served working directories there too, and prompts
+  for the agent backend to wake (claude-code | codex | kiro — Enter accepts the
+  claude-code default), then checks that backend's CLI is on PATH. Pass -y/--yes or
+  run non-TTY to skip all prompts (credentials are still validated). The served
+  cwds AND the chosen agent live in daemon.json — the unit captures only
+  --chorus-only, NOT --cwd or --agent. On macOS/Windows install prints a correct
+  template you install manually.
 
 EXAMPLES
   chorus daemon                        # Foreground, default yolo (TTY confirms once)

--- a/cli/daemon-agent.mjs
+++ b/cli/daemon-agent.mjs
@@ -3,7 +3,18 @@
 // `claude-code` (the default), `codex`, and `kiro` are all implemented backends
 // (add-daemon-codex-backend cashed in the reserved `codex` slot;
 // add-daemon-kiro-backend adds `kiro`). Resolving an unknown value is a hard
-// error (no silent fallback). Zero dependencies.
+// error (no silent fallback).
+//
+// Resolution is layered like resolveSigintTimeoutMs / resolveDaemonCwds in
+// daemon-config.mjs — first defined source wins:
+//   --agent flag > CHORUS_AGENT env > ~/.chorus/daemon.json `agent` > claude-code.
+// The config-file layer lets an operator persist a default backend (e.g.
+// `"agent": "codex"`) once instead of re-passing --agent / re-exporting the env
+// on every start. IO (file read) is injectable so this stays unit-testable
+// without real disk.
+
+import { readFileSync } from "node:fs";
+import { loginFilePath } from "./credentials.mjs";
 
 /** The agent backends the daemon recognizes. All are implemented (claude-code
  * via ClaudeSpawner, codex via CodexSpawner, kiro via KiroSpawner — see
@@ -42,19 +53,58 @@ export function backendClientType(agentType) {
 }
 
 /**
- * Resolve the agent type from flag → env → default, and validate it.
- * Precedence: explicit `--agent` flag > CHORUS_AGENT env > DEFAULT_AGENT.
+ * Read a JSON file, returning `null` on any error (missing / unreadable /
+ * malformed). Never throws — mirrors daemon-config.mjs readJsonSafe.
+ * @param {string} path
+ * @returns {Record<string, unknown> | null}
+ */
+function readJsonSafe(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A non-empty trimmed string, or undefined. */
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Resolve the agent type from flag → env → config file → default, and validate it.
+ * Precedence (first defined source wins, mirroring resolveSigintTimeoutMs /
+ * resolveDaemonCwds): explicit `--agent` flag > CHORUS_AGENT env >
+ * ~/.chorus/daemon.json `agent` > DEFAULT_AGENT.
+ *
+ * An unknown value from ANY source (flag, env, or file) is a hard error — no
+ * silent fallback. The config file lets an operator persist a default backend
+ * without re-passing --agent on every start.
  *
  * @param {{ agent?: string }} flags
  * @param {Record<string, string|undefined>} env
+ * @param {{
+ *   readJson?: (path: string) => (Record<string, unknown>|null),
+ *   loginPath?: string,
+ * }} [deps]
  * @returns {{ ok: true, agent: string } | { ok: false, value: string, error: string }}
  *   `ok:false` carries the offending value and a human-actionable error naming
  *   the accepted types — the caller exits non-zero and prints `error`.
  */
-export function resolveAgentType(flags, env) {
+export function resolveAgentType(flags, env, deps = {}) {
+  const readJson = deps.readJson ?? readJsonSafe;
+  const loginPath = deps.loginPath ?? loginFilePath();
+
+  const fromFile = () => {
+    const file = readJson(loginPath);
+    return file ? nonEmpty(file.agent) : undefined;
+  };
+
   const raw =
-    (typeof flags.agent === "string" && flags.agent.trim()) ||
-    (typeof env.CHORUS_AGENT === "string" && env.CHORUS_AGENT.trim()) ||
+    nonEmpty(flags.agent) ||
+    nonEmpty(env.CHORUS_AGENT) ||
+    fromFile() ||
     DEFAULT_AGENT;
   if (!KNOWN_AGENTS.includes(raw)) {
     return {

--- a/cli/daemon-install-config.mjs
+++ b/cli/daemon-install-config.mjs
@@ -26,6 +26,11 @@ import { resolveCredentials, loginFilePath } from "./credentials.mjs";
 import { updateDaemonConfig, prompt as defaultPrompt } from "./login.mjs";
 import { validateAndFetchIdentity } from "./chorus-client.mjs";
 import { normalizeCwd, cleanCwdList } from "./daemon-config.mjs";
+import { KNOWN_AGENTS, DEFAULT_AGENT } from "./daemon-agent.mjs";
+import { agentNotFoundWarningLine } from "./daemon-banner.mjs";
+import { resolveClaudePath } from "./claude-spawner.mjs";
+import { resolveCodexPath } from "./codex-spawner.mjs";
+import { resolveKiroPath } from "./kiro-spawner.mjs";
 import { readFileSync } from "node:fs";
 
 /** A non-empty trimmed string, or undefined. */
@@ -210,4 +215,128 @@ export async function resolveInstallCwds(flags = {}, opts = {}) {
   const finalCwds = cwds.length > 0 ? cwds : defaultCwd ? [defaultCwd] : [];
   if (finalCwds.length > 0) writeConfig({ cwds: finalCwds });
   return { cwds: finalCwds };
+}
+
+/**
+ * The interactive agent-backend menu. Order mirrors KNOWN_AGENTS with claude-code
+ * first (it is the default). Kept beside the resolver so the numbered prompt and
+ * the accepted values never drift.
+ */
+const AGENT_MENU = [
+  { value: "claude-code", label: "Claude Code (default)" },
+  { value: "codex", label: "Codex CLI" },
+  { value: "kiro", label: "Kiro CLI" },
+];
+
+/** Probe the selected backend's CLI on PATH. Returns the resolved path or null.
+ * Injectable per backend so the check is testable without a real PATH. */
+function probeAgentCli(agent, probes = {}) {
+  const findClaude = probes.resolveClaudePath ?? resolveClaudePath;
+  const findCodex = probes.resolveCodexPath ?? resolveCodexPath;
+  const findKiro = probes.resolveKiroPath ?? resolveKiroPath;
+  if (agent === "codex") return findCodex();
+  if (agent === "kiro") return findKiro();
+  return findClaude();
+}
+
+/**
+ * Determine which local agent backend the installed daemon wakes and persist it
+ * to ~/.chorus/daemon.json `agent` (the single source of truth — the unit carries
+ * no --agent, exactly like `cwds`). AFTER resolving, probe the selected backend's
+ * CLI on PATH and warn (non-fatal) when it is missing, so the operator learns at
+ * install time rather than when the first wake fails.
+ *
+ * Resolution (first defined source wins):
+ *   1. --agent flag        — the operator's explicit choice.
+ *   2. CHORUS_AGENT env     — matches the daemon's own resolution precedence.
+ *   3. existing daemon.json `agent` — a prior valid choice is kept (re-install is
+ *      idempotent and does not re-prompt); an invalid stored value is ignored.
+ *   4. TTY + !skip         — interactive numbered menu (Enter = claude-code default).
+ *   5. non-TTY / skip      — DEFAULT_AGENT (claude-code), persisted so the config
+ *      is explicit about the backend the boot service runs.
+ *
+ * Never fails: --agent / CHORUS_AGENT are already validated upstream by
+ * resolveAgentType (runDaemon rejects an unknown value before dispatch), the menu
+ * is constrained to KNOWN_AGENTS, and default/stored-invalid fall back to
+ * claude-code. Returns the resolved `{ agent, cliPath, cliFound }`. Never throws.
+ *
+ * @param {{ agent?: string }} flags
+ * @param {Record<string, string|undefined>} [env]
+ * @param {{
+ *   isTTY?: boolean, skip?: boolean,
+ *   readJson?: (path: string) => (Record<string, unknown>|null),
+ *   loginPath?: string,
+ *   writeConfig?: (partial: Record<string, unknown>) => string,
+ *   prompt?: typeof defaultPrompt,
+ *   probes?: { resolveClaudePath?: Function, resolveCodexPath?: Function, resolveKiroPath?: Function },
+ *   log?: (m: string) => void,
+ *   errLog?: (m: string) => void,
+ * }} [opts]
+ * @returns {Promise<{ agent: string, cliPath: string|null, cliFound: boolean }>}
+ */
+export async function resolveInstallAgent(flags = {}, env = {}, opts = {}) {
+  const isTTY = opts.isTTY ?? false;
+  const skip = opts.skip ?? false;
+  const readJson = opts.readJson ?? readJsonSafe;
+  const loginPath = opts.loginPath ?? loginFilePath();
+  const writeConfig = opts.writeConfig ?? updateDaemonConfig;
+  const ask = opts.prompt ?? defaultPrompt;
+  const log = opts.log ?? (() => {});
+  const errLog = opts.errLog ?? (() => {});
+
+  // Only a KNOWN backend is ever accepted; anything else is treated as absent.
+  const known = (v) => (v && KNOWN_AGENTS.includes(v) ? v : undefined);
+
+  let agent;
+  let persist = true; // write unless we reuse an already-stored value (no-op)
+
+  // 1/2. Explicit --agent flag or CHORUS_AGENT env (both pre-validated upstream).
+  agent = known(nonEmpty(flags.agent)) ?? known(nonEmpty(env.CHORUS_AGENT));
+
+  // 3. Existing daemon.json `agent` — a prior valid choice is authoritative; keep
+  //    it and do not re-prompt (re-install stays idempotent). Skip the re-write.
+  if (!agent) {
+    const file = readJson(loginPath);
+    const stored = known(file ? nonEmpty(file.agent) : undefined);
+    if (stored) {
+      agent = stored;
+      persist = false; // already on disk — no-op write avoided
+    }
+  }
+
+  // 4. Interactive numbered menu on a TTY (Enter accepts the claude-code default).
+  if (!agent && isTTY && !skip) {
+    log("[Chorus] Which local agent backend should this daemon wake?");
+    for (let i = 0; i < AGENT_MENU.length; i += 1) {
+      log(`[Chorus]   ${i + 1}) ${AGENT_MENU[i].label}`);
+    }
+    const answer = nonEmpty(await ask(`Select [1-${AGENT_MENU.length}] (Enter for 1): `));
+    if (!answer) {
+      agent = DEFAULT_AGENT;
+    } else {
+      const n = Number(answer);
+      const byNumber = Number.isInteger(n) && n >= 1 && n <= AGENT_MENU.length ? AGENT_MENU[n - 1].value : undefined;
+      // Also accept the value typed by name (e.g. "codex") for muscle memory.
+      agent = byNumber ?? known(answer) ?? DEFAULT_AGENT;
+    }
+  }
+
+  // 5. Non-TTY / skip with nothing configured → the default, persisted so the boot
+  //    service config is explicit about the backend it runs.
+  if (!agent) agent = DEFAULT_AGENT;
+
+  if (persist) writeConfig({ agent });
+
+  // Probe the selected backend's CLI (non-fatal). A missing binary warns loudly so
+  // the operator fixes PATH before the first wake, but never blocks the install.
+  const cliPath = probeAgentCli(agent, opts.probes);
+  const cliFound = cliPath !== null;
+  if (cliFound) {
+    log(`[Chorus] agent backend: ${agent} (found CLI at ${cliPath}).`);
+  } else {
+    log(`[Chorus] agent backend: ${agent}.`);
+    errLog(`[Chorus] ${agentNotFoundWarningLine(agent)}`);
+  }
+
+  return { agent, cliPath, cliFound };
 }

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -17,6 +17,7 @@ import { prompt, writeLoginFile, updateDaemonConfig } from "./login.mjs";
 import {
   resolveInstallCredentials,
   resolveInstallCwds,
+  resolveInstallAgent,
 } from "./daemon-install-config.mjs";
 import {
   resolvePermissionMode,
@@ -777,6 +778,7 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
     const installCfg = svc.installConfig ?? {
       resolveInstallCredentials,
       resolveInstallCwds,
+      resolveInstallAgent,
     };
 
     const credResult = await installCfg.resolveInstallCredentials(flags, env, {
@@ -810,10 +812,30 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
       log,
     });
 
+    // Configure + persist the agent backend to daemon.json `agent` (single source
+    // of truth; the unit carries no --agent, exactly like --cwd). Prompts an
+    // interactive menu on a TTY (Enter = claude-code); reuses a --agent flag /
+    // CHORUS_AGENT env / a prior stored choice; probes the selected CLI and warns
+    // (non-fatal) when it is missing. An unknown --agent was already rejected by
+    // resolveAgentType above, so this phase never fails.
+    await installCfg.resolveInstallAgent(flags, env, {
+      isTTY,
+      skip,
+      writeConfig: pfDeps?.writeConfig ?? updateDaemonConfig,
+      readJson: pfDeps?.readJson,
+      loginPath: pfDeps?.loginPath,
+      prompt: pfDeps?.askPrompt,
+      log,
+      errLog,
+    });
+
     const spec = {
       ...svc.resolveServicePaths(),
       cwds: flags.cwd ?? [],
-      agent: flags.agent,
+      // NOTE: agent is deliberately NOT passed into the unit. The selected backend
+      // is persisted to daemon.json `agent` (single source of truth) and read back
+      // by the daemon via resolveAgentType — mirroring how --cwd is handled. Baking
+      // --agent into ExecStart too would let the two sources drift.
       chorusOnly: flags.chorusOnly === true,
       workingDir: process.cwd(),
     };

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -102,17 +102,34 @@ per-wake detail.
 
 ## Agent backend (`--agent`)
 
-`--agent <type>` (env `CHORUS_AGENT`) selects which local agent backend the
-daemon wakes. The default — and currently the only implemented backend — is
-`claude-code`. An unknown value is a hard error (no silent fallback):
+`--agent <type>` selects which local agent backend the daemon wakes. Three
+backends are implemented: `claude-code` (the default), `codex`, and `kiro`. An
+unknown value is a hard error (no silent fallback).
+
+The backend is resolved in this precedence (first defined source wins):
+
+1. `--agent <type>` flag
+2. `CHORUS_AGENT` environment variable
+3. `~/.chorus/daemon.json` `agent` field
+4. default `claude-code`
 
 ```bash
 chorus daemon --agent claude-code   # explicit (same as default)
-chorus daemon --agent codex         # error: only claude-code is implemented
+chorus daemon --agent codex         # wake a local Codex CLI
+chorus daemon --agent kiro          # wake a local Kiro CLI
 ```
 
-The flag reserves the extension point for future backends; it does not change
-how `claude-code` is spawned.
+To make a backend the persistent default without re-passing the flag or
+exporting the env var on every start, set it once in `~/.chorus/daemon.json`:
+
+```json
+{ "agent": "codex" }
+```
+
+The daemon `install` command writes the chosen backend to this same file (it
+prompts interactively, or takes `--agent` / `CHORUS_AGENT` non-interactively), so
+an installed boot service picks it up from `daemon.json` — the unit itself carries
+no `--agent`.
 
 ---
 
@@ -166,12 +183,21 @@ chorus daemon uninstall                      # disable + remove the unit
 ```
 
 `install` generates a correct `systemd --user` unit and starts it — you never
-hand-write the file. It captures the `--cwd` / `--agent` / `--chorus-only` flags
-you pass, plus absolute `node` / `chorus.mjs` paths and your current `PATH`, and
-runs `systemctl --user daemon-reload` then `enable --now`. After install, the
-lifecycle subcommands **delegate to systemd** automatically — `chorus daemon
-status` / `stop` / `restart` / `logs` drive `systemctl` / `journalctl`, so a
-supervised daemon is never misreported as "not running".
+hand-write the file. It captures the `--chorus-only` flag you pass, plus absolute
+`node` / `chorus.mjs` paths and your current `PATH`, and runs `systemctl --user
+daemon-reload` then `enable --now`. The served working directories (`cwds`) and
+the chosen agent backend (`agent`) are **persisted to `~/.chorus/daemon.json`**
+rather than baked into the unit — the daemon reads them back at start, so a single
+source of truth stays in one place. After install, the lifecycle subcommands
+**delegate to systemd** automatically — `chorus daemon status` / `stop` /
+`restart` / `logs` drive `systemctl` / `journalctl`, so a supervised daemon is
+never misreported as "not running".
+
+On a terminal, `install` prompts interactively for the agent backend (Claude Code
+/ Codex / Kiro — Enter accepts the Claude Code default) unless you pass `--agent`
+(or export `CHORUS_AGENT`, or already have one stored), then checks the selected
+CLI is on `PATH` and warns if it is missing. Pass `-y` / `--yes` — or run on a
+non-TTY — to skip the prompt and take the default.
 
 > **Why a command instead of a hand-written unit?** The generated unit runs the
 > daemon in the **foreground** (`Type=simple`, no `-d`) so systemd owns the


### PR DESCRIPTION
## Summary
- Make `resolveAgentType` read the `agent` field from `~/.chorus/daemon.json`, closing the gap with its siblings (`resolveSigintTimeoutMs` / `resolveDaemonCwds`) which already consult the file. Precedence is now `--agent` flag → `CHORUS_AGENT` env → `daemon.json` `agent` → `claude-code`. An unknown value from **any** source is still a hard error (no silent fallback).
- Make `chorus daemon install` interactive: a numbered menu (`1) Claude Code (default) / 2) Codex CLI / 3) Kiro CLI`, Enter = default) selects the backend. The choice is **persisted to `daemon.json` `agent`** as the single source of truth — the systemd/launchd unit no longer bakes `--agent` into `ExecStart`, exactly mirroring how `--cwd` / `cwds` is handled.
- After selecting, probe the chosen backend's CLI on `PATH` (`resolveClaudePath` / `resolveCodexPath` / `resolveKiroPath`) and emit a loud but **non-fatal** `⚠ … CLI NOT FOUND` warning when it is missing — matches the daemon `run` path's behavior.
- `-y` / `--yes` and non-TTY installs skip the prompt and take the default. Unknown `--agent` is rejected up front by `resolveAgentType` (the per-action gate), so the install phase itself never fails.
- Docs: fix stale `docs/DAEMON.md` (it still claimed codex "errors" and only claude-code was implemented — codex/kiro are live), and update README / `--help` / DAEMON everywhere they said the unit "captures --agent" → now "persisted to daemon.json".

## Changed files
| File | Change |
|------|--------|
| `cli/daemon-agent.mjs` | `resolveAgentType` gains an injectable `daemon.json` file layer |
| `cli/daemon-install-config.mjs` | new `resolveInstallAgent` — menu, persist, CLI probe |
| `cli/daemon.mjs` | install action calls the agent phase; `agent` dropped from unit spec |
| `cli/client-args.mjs` | `--agent` / `-y` / SERVICE help text updated |
| `README.md` | `daemon.json` config table + example gain the `agent` field |
| `docs/DAEMON.md` | `--agent` precedence + install prompt documented; stale text fixed |
| `cli/__tests__/daemon-agent.test.mjs` | config-file layer + short-circuit + unknown-from-file coverage |
| `cli/__tests__/daemon-install-config.test.mjs` | full `resolveInstallAgent` unit coverage |
| `cli/__tests__/daemon-lifecycle-dispatch.test.mjs` | install dispatch asserts agent phase + no `--agent` in unit |

## Test plan
- [x] `pnpm test cli/__tests__/` — 841 pass (14 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint cli/` — 0 errors
- [ ] Manual: run `chorus daemon install` on a TTY, confirm the menu + CLI-found/​missing lines

Generated with [Claude Code](https://claude.com/claude-code)