### PR TITLE
fix(daemon): propagate Chorus env to headless agents

### DIFF
--- a/cli/__tests__/claude-spawner.test.mjs
+++ b/cli/__tests__/claude-spawner.test.mjs
@@ -285,6 +285,8 @@ describe("ClaudeSpawner.wake", () => {
 // CHORUS_DAEMON_HEADLESS=1 (merged over inherited env) as a machine-checkable headless
 // signal. buildArgs stays free of --append-system-prompt (the rule rides the wake prompt).
 describe("ClaudeSpawner.wake — CHORUS_DAEMON_HEADLESS env signal", () => {
+  const creds = { url: "https://chorus.test", apiKey: "cho_secret" };
+
   async function spawnAndGetOpts(permissionMode) {
     const child = makeFakeChild();
     const spawnImpl = vi.fn(() => child);
@@ -293,6 +295,7 @@ describe("ClaudeSpawner.wake — CHORUS_DAEMON_HEADLESS env signal", () => {
       spawnImpl,
       logger: silent,
       platform: "linux",
+      creds,
       ...(permissionMode ? { permissionMode } : {}),
     });
     const p = spawner.wake({ prompt: "go", sessionId: SID, isNew: true, mcpConfigPath: "/m.json" });
@@ -305,6 +308,8 @@ describe("ClaudeSpawner.wake — CHORUS_DAEMON_HEADLESS env signal", () => {
     const opts = await spawnAndGetOpts();
     expect(opts.env).toBeDefined();
     expect(opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
+    expect(opts.env.CHORUS_URL).toBe("https://chorus.test");
+    expect(opts.env.CHORUS_API_KEY).toBe("cho_secret");
   });
 
   it("sets CHORUS_DAEMON_HEADLESS=1 in yolo mode too (unconditional)", async () => {
@@ -323,6 +328,23 @@ describe("ClaudeSpawner.wake — CHORUS_DAEMON_HEADLESS env signal", () => {
       expect(opts.env.PATH).toBe(process.env.PATH);
     } finally {
       delete process.env[sentinel];
+    }
+  });
+
+  it("overwrites stale inherited Chorus credentials with the daemon pair", async () => {
+    const previousUrl = process.env.CHORUS_URL;
+    const previousKey = process.env.CHORUS_API_KEY;
+    process.env.CHORUS_URL = "https://stale.test";
+    process.env.CHORUS_API_KEY = "cho_stale";
+    try {
+      const opts = await spawnAndGetOpts();
+      expect(opts.env.CHORUS_URL).toBe("https://chorus.test");
+      expect(opts.env.CHORUS_API_KEY).toBe("cho_secret");
+    } finally {
+      if (previousUrl === undefined) delete process.env.CHORUS_URL;
+      else process.env.CHORUS_URL = previousUrl;
+      if (previousKey === undefined) delete process.env.CHORUS_API_KEY;
+      else process.env.CHORUS_API_KEY = previousKey;
     }
   });
 

--- a/cli/__tests__/codex-backend-integration.test.mjs
+++ b/cli/__tests__/codex-backend-integration.test.mjs
@@ -10,7 +10,7 @@
 //   3. Codex backend end-to-end — buildDaemon with agentType:"codex" injects a
 //      CodexSpawner; driving its wake() through a fake spawn yields the expected
 //      `codex exec --json` (new) and `codex exec resume <id>` (known anchor) argv,
-//      prompt on stdin, daemon key in the child env (never argv).
+//      prompt on stdin, daemon URL/key in the child env (never argv).
 import { describe, it, expect, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -131,7 +131,7 @@ describe("codex backend end-to-end argv (via the daemon-selected spawner)", () =
     return { spawner, calls };
   }
 
-  it("NEW anchor → `codex exec --json …`, prompt on stdin, daemon key in env not argv", async () => {
+  it("NEW anchor → prompt on stdin, daemon connection pair in env not argv", async () => {
     const { spawner, calls } = codexSpawnerWithFakeSpawn({ getThreadId: () => null });
     const child = makeFakeChild();
     spawner.spawnImpl = (command, argv, opts) => {
@@ -151,6 +151,7 @@ describe("codex backend end-to-end argv (via the daemon-selected spawner)", () =
     expect(calls.argv).not.toContain("resume");
     expect(child.stdin.writes.join("")).toBe("wake up codex");
     expect(calls.argv.join(" ")).not.toContain("wake up codex");
+    expect(calls.opts.env.CHORUS_URL).toBe("https://chorus.test");
     expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_daemonkey");
     expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
     expect(calls.argv.join(" ")).not.toContain("cho_daemonkey");

--- a/cli/__tests__/codex-session-start-hook.test.mjs
+++ b/cli/__tests__/codex-session-start-hook.test.mjs
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { chmodSync, cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const sourceDir = resolve("plugins/chorus/hooks");
+const tempDirs = [];
+
+function makeHooks(checkinBody = '{"agent":{"name":"test"}}') {
+  const dir = mkdtempSync(join(tmpdir(), "chorus-session-hook-"));
+  tempDirs.push(dir);
+  cpSync(join(sourceDir, "on-session-start.sh"), join(dir, "on-session-start.sh"));
+  cpSync(join(sourceDir, "hook-output.sh"), join(dir, "hook-output.sh"));
+  writeFileSync(
+    join(dir, "chorus-mcp-call.sh"),
+    `#!/usr/bin/env bash\nprintf '%s\\n' '${checkinBody}'\n`,
+  );
+  chmodSync(join(dir, "on-session-start.sh"), 0o755);
+  chmodSync(join(dir, "chorus-mcp-call.sh"), 0o755);
+  return join(dir, "on-session-start.sh");
+}
+
+function runHook(script, env) {
+  const result = spawnSync(script, {
+    input: '{"hook_event_name":"SessionStart"}',
+    encoding: "utf8",
+    env: { PATH: process.env.PATH, ...env },
+  });
+  expect(result.status).toBe(0);
+  return JSON.parse(result.stdout);
+}
+
+afterEach(() => {
+  while (tempDirs.length) rmSync(tempDirs.pop(), { recursive: true, force: true });
+});
+
+describe("Codex SessionStart Chorus diagnostics", () => {
+  it("injects connected context through one output channel", () => {
+    const output = runHook(makeHooks(), {
+      CHORUS_URL: "https://chorus.test",
+      CHORUS_API_KEY: "cho_test",
+    });
+    expect(output.systemMessage).toBe("");
+    expect(output.hookSpecificOutput.additionalContext).toContain("Chorus Plugin");
+    expect(output.hookSpecificOutput.additionalContext.match(/Chorus is connected/g)).toHaveLength(1);
+    expect(JSON.stringify(output)).not.toContain("environment not configured");
+  });
+
+  it("emits a missing-config warning through one output channel", () => {
+    const output = runHook(makeHooks(), {});
+    const serialized = JSON.stringify(output);
+    expect(output.systemMessage).toContain("Chorus environment not configured");
+    expect(output.hookSpecificOutput).toBeUndefined();
+    expect(serialized.match(/Chorus environment not configured/g)).toHaveLength(1);
+  });
+
+  it("emits a connection-failure warning through one output channel", () => {
+    const script = makeHooks();
+    writeFileSync(join(resolve(script, ".."), "chorus-mcp-call.sh"), "#!/usr/bin/env bash\nexit 1\n");
+    chmodSync(join(resolve(script, ".."), "chorus-mcp-call.sh"), 0o755);
+    const output = runHook(script, {
+      CHORUS_URL: "https://chorus.test",
+      CHORUS_API_KEY: "cho_test",
+    });
+    expect(output.systemMessage).toContain("Unable to reach Chorus");
+    expect(output.hookSpecificOutput).toBeUndefined();
+    expect(JSON.stringify(output).match(/Unable to reach Chorus/g)).toHaveLength(1);
+  });
+
+  it("allows an independent startup to emit its own warning", () => {
+    const script = makeHooks();
+    expect(runHook(script, {}).systemMessage).toContain("environment not configured");
+    expect(runHook(script, {}).systemMessage).toContain("environment not configured");
+  });
+});

--- a/cli/__tests__/codex-spawner.test.mjs
+++ b/cli/__tests__/codex-spawner.test.mjs
@@ -15,6 +15,7 @@ import {
   sandboxFlags,
   resolveCodexPath,
   extractThreadId,
+  hasChorusMcpServer,
 } from "../codex-spawner.mjs";
 
 const ANCHOR = "11111111-1111-4111-8111-111111111111";
@@ -147,6 +148,19 @@ describe("resolveCodexPath", () => {
   });
 });
 
+describe("hasChorusMcpServer", () => {
+  it("detects the configured Chorus MCP section", () => {
+    const readFile = vi.fn(() => '[mcp_servers.chorus]\nurl = "https://chorus.test/api/mcp"\n');
+    expect(hasChorusMcpServer({ env: { CODEX_HOME: "/codex" }, readFile })).toBe(true);
+    expect(readFile).toHaveBeenCalledWith("/codex/config.toml", "utf8");
+  });
+
+  it("returns false for missing, unreadable, or unrelated config", () => {
+    expect(hasChorusMcpServer({ readFile: () => '[mcp_servers.other]\nurl = "x"\n' })).toBe(false);
+    expect(hasChorusMcpServer({ readFile: () => { throw new Error("missing"); } })).toBe(false);
+  });
+});
+
 describe("CodexSpawner.wake — spawn orchestration", () => {
   const creds = { url: "https://chorus.test", apiKey: "cho_secret" };
 
@@ -178,11 +192,12 @@ describe("CodexSpawner.wake — spawn orchestration", () => {
       setThreadIdFn: setThreadId ?? (() => {}),
       getUsageSnapshotFn: getUsageSnapshot ?? (() => null),
       setUsageSnapshotFn: setUsageSnapshot ?? (() => {}),
+      hasChorusMcpServerFn: () => true,
     });
     return { spawner, spawnImpl, calls };
   }
 
-  it("new wake: spawns `codex exec --json …`, prompt over stdin, key in env (not argv)", async () => {
+  it("new wake: spawns codex with the resolved Chorus pair in env, never argv", async () => {
     const child = makeFakeChild();
     const { spawner, calls } = makeSpawner({ child });
     const onChild = vi.fn();
@@ -197,7 +212,8 @@ describe("CodexSpawner.wake — spawn orchestration", () => {
     // prompt only on stdin, never argv
     expect(child.stdin.writes.join("")).toBe("do the thing");
     expect(calls.argv.join(" ")).not.toContain("do the thing");
-    // daemon key exported via env, headless flag set, key absent from argv
+    // daemon connection pair exported via env, headless flag set, key absent from argv
+    expect(calls.opts.env.CHORUS_URL).toBe("https://chorus.test");
     expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_secret");
     expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
     expect(calls.argv.join(" ")).not.toContain("cho_secret");
@@ -209,6 +225,56 @@ describe("CodexSpawner.wake — spawn orchestration", () => {
     // returns the captured thread id as the session id
     expect(result.exitCode).toBe(0);
     expect(result.sessionId).toBe(TID);
+  });
+
+  it("overwrites stale inherited Chorus connection values", async () => {
+    const child = makeFakeChild();
+    const { spawner, calls } = makeSpawner({ child });
+    const previousUrl = process.env.CHORUS_URL;
+    const previousKey = process.env.CHORUS_API_KEY;
+    process.env.CHORUS_URL = "https://stale.test";
+    process.env.CHORUS_API_KEY = "cho_stale";
+    try {
+      const p = spawner.wake({ prompt: "x", sessionId: ANCHOR });
+      child.emit("close", 0);
+      await p;
+      expect(calls.opts.env.CHORUS_URL).toBe("https://chorus.test");
+      expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_secret");
+    } finally {
+      if (previousUrl === undefined) delete process.env.CHORUS_URL;
+      else process.env.CHORUS_URL = previousUrl;
+      if (previousKey === undefined) delete process.env.CHORUS_API_KEY;
+      else process.env.CHORUS_API_KEY = previousKey;
+    }
+  });
+
+  it("logs a missing Chorus MCP entry once and still completes later wakes", async () => {
+    const first = makeFakeChild();
+    const second = makeFakeChild();
+    const children = [first, second];
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const spawner = new CodexSpawner({
+      codexPath: "/usr/bin/codex",
+      platform: "linux",
+      creds: { url: "https://chorus.test", apiKey: "cho_secret" },
+      logger,
+      hasChorusMcpServerFn: () => false,
+      getThreadIdFn: () => null,
+      setThreadIdFn: () => {},
+      getUsageSnapshotFn: () => null,
+      setUsageSnapshotFn: () => {},
+      spawnImpl: () => children.shift(),
+    });
+
+    const wake1 = spawner.wake({ prompt: "first", sessionId: "first" });
+    first.emit("close", 0);
+    await wake1;
+    const wake2 = spawner.wake({ prompt: "second", sessionId: "second" });
+    second.emit("close", 0);
+    await wake2;
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toContain("no [mcp_servers.chorus] entry");
   });
 
   it("persists anchor→thread_id immediately when a new run emits thread.started", async () => {

--- a/cli/__tests__/kiro-backend-integration.test.mjs
+++ b/cli/__tests__/kiro-backend-integration.test.mjs
@@ -121,7 +121,7 @@ describe("kiro backend end-to-end argv (via the daemon-selected spawner)", () =>
     return { spawner, calls, child };
   }
 
-  it("NEW anchor → `kiro-cli chat --no-interactive --agent chorus …`, prompt on stdin, daemon key in env not argv", async () => {
+  it("NEW anchor → prompt on stdin, daemon connection pair in env not argv", async () => {
     const { spawner, calls, child } = kiroSpawnerWithFakeSpawn({ getSessionId: () => null });
     const p = spawner.wake({ prompt: "wake up kiro", sessionId: ANCHOR, isNew: true });
     child.stdout.emit("data", "plain text turn output\n");
@@ -135,6 +135,7 @@ describe("kiro backend end-to-end argv (via the daemon-selected spawner)", () =>
     expect(calls.argv).not.toContain("--v3");
     expect(child.stdin.writes.join("")).toBe("wake up kiro");
     expect(calls.argv.join(" ")).not.toContain("wake up kiro");
+    expect(calls.opts.env.CHORUS_URL).toBe("https://chorus.test");
     expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_daemonkey");
     expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
     expect(calls.argv.join(" ")).not.toContain("cho_daemonkey");

--- a/cli/__tests__/kiro-spawner.test.mjs
+++ b/cli/__tests__/kiro-spawner.test.mjs
@@ -186,7 +186,7 @@ describe("KiroSpawner.wake — spawn orchestration", () => {
     return { spawner, spawnImpl, calls };
   }
 
-  it("new wake: spawns `kiro-cli chat --no-interactive --agent chorus`, prompt over stdin, key in env (not argv)", async () => {
+  it("new wake: spawns Kiro with the resolved Chorus pair in env, never argv", async () => {
     const child = makeFakeChild();
     const { spawner, calls } = makeSpawner({
       child,
@@ -204,7 +204,7 @@ describe("KiroSpawner.wake — spawn orchestration", () => {
     // prompt only on stdin, never argv
     expect(child.stdin.writes.join("")).toBe("do the thing");
     expect(calls.argv.join(" ")).not.toContain("do the thing");
-    // daemon key exported via env, headless flag set, key absent from argv
+    expect(calls.opts.env.CHORUS_URL).toBe("https://chorus.test");
     expect(calls.opts.env.CHORUS_API_KEY).toBe("cho_secret");
     expect(calls.opts.env.CHORUS_DAEMON_HEADLESS).toBe("1");
     expect(calls.argv.join(" ")).not.toContain("cho_secret");

--- a/cli/__tests__/spawner-select.test.mjs
+++ b/cli/__tests__/spawner-select.test.mjs
@@ -16,6 +16,7 @@ describe("selectSpawner", () => {
   it("returns a ClaudeSpawner for claude-code", () => {
     const s = selectSpawner("claude-code", { logger, permissionMode: "yolo", creds });
     expect(s).toBeInstanceOf(ClaudeSpawner);
+    expect(s.creds).toEqual(creds);
   });
 
   it("returns a CodexSpawner for codex", () => {
@@ -34,9 +35,10 @@ describe("selectSpawner", () => {
     expect(selectSpawner("kiro", { logger, permissionMode: "chorus", creds }).permissionMode).toBe("chorus");
   });
 
-  it("threads creds into the KiroSpawner (Codex-style: MCP from plugin config + daemon key via env)", () => {
-    const s = selectSpawner("kiro", { logger, permissionMode: "yolo", creds });
-    expect(s.creds).toEqual(creds);
+  it("threads creds into every backend spawner", () => {
+    expect(selectSpawner("claude-code", { logger, creds }).creds).toEqual(creds);
+    expect(selectSpawner("codex", { logger, creds }).creds).toEqual(creds);
+    expect(selectSpawner("kiro", { logger, creds }).creds).toEqual(creds);
   });
 
   it("defaults to claude-code when the agent type is unrecognized (no throw — selection is post-validation)", () => {

--- a/cli/claude-spawner.mjs
+++ b/cli/claude-spawner.mjs
@@ -241,6 +241,8 @@ export function parseNdjsonChunk(buffer, chunk, onObject, onWarn = () => {}) {
  * @property {(o: object) => { stdin: any, stdout: any, stderr: any, on: Function, kill?: Function }} [spawnImpl]
  * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
  * @property {PermissionMode} [permissionMode]  How much the woken Claude may do (default "chorus").
+ * @property {{ url: string, apiKey: string }} [creds] Daemon credentials exported
+ *   to the child for plugin hooks and shell-based Chorus tooling.
  * @property {NodeJS.Platform} [platform]  Injectable for tests; gates `detached` (POSIX-only).
  */
 
@@ -255,6 +257,7 @@ export class ClaudeSpawner {
     this.spawnImpl = opts.spawnImpl ?? spawn;
     this.logger = opts.logger ?? NOOP_LOGGER;
     this.permissionMode = opts.permissionMode ?? "chorus";
+    this.creds = opts.creds ?? null;
     // POSIX spawns `detached: true` (process-group leader) so the interrupt path
     // can group-kill the tree; Windows does not. Injectable so a POSIX test host
     // can exercise the Windows branch and vice versa.
@@ -318,6 +321,11 @@ export class ClaudeSpawner {
     // stream and observe the exit. On Windows `detached` is NOT used: taskkill /T
     // walks the tree by pid, and detached there only spawns a new console window.
     const detached = (this.platform ?? process.platform) !== "win32";
+    const childEnv = { ...process.env, CHORUS_DAEMON_HEADLESS: "1" };
+    if (this.creds) {
+      if (this.creds.url) childEnv.CHORUS_URL = this.creds.url;
+      if (this.creds.apiKey) childEnv.CHORUS_API_KEY = this.creds.apiKey;
+    }
 
     return new Promise((resolve) => {
       let child;
@@ -325,14 +333,9 @@ export class ClaudeSpawner {
         child = this.spawnImpl(command, argv, {
           cwd: cwd ?? process.cwd(),
           stdio: ["pipe", "pipe", "pipe"],
-          // Mark the child as a headless daemon-woken session (add-daemon-headless-
-          // interaction-guard). Merged OVER the inherited env so PATH, the Bedrock /
-          // credential vars, CLAUDE_CONFIG_DIR, etc. all survive — only this one var is
-          // added. It is a machine-checkable signal (the wake prompt also states it in
-          // text); this change only LAYS IT DOWN — no code here reads it back. Set
-          // unconditionally: the spawner only ever runs headless daemon wakes, so both
-          // "chorus" and "yolo" permission modes get it.
-          env: { ...process.env, CHORUS_DAEMON_HEADLESS: "1" },
+          // Preserve the inherited runtime environment while giving hooks and
+          // shell-based Chorus tooling the daemon's authoritative connection pair.
+          env: childEnv,
           // No shell:true — command is either the real executable or cmd.exe
           // with the script as an argv element. Avoids shell word-splitting /
           // injection; .cmd is handled explicitly via cmd.exe above.

--- a/cli/codex-spawner.mjs
+++ b/cli/codex-spawner.mjs
@@ -13,17 +13,18 @@
 //     it and persist anchor→thread_id (codex-session-map.mjs) so a later wake can
 //     `resume <thread_id>`. (serde: ThreadEvent tag="type", rename="thread.started";
 //     ThreadStartedEvent.thread_id: String — codex-rs/exec/src/exec_events.rs.)
-//   • No `--mcp-config`: MCP comes from the user's ~/.codex/config.toml; the daemon
-//     key reaches it via the configured bearer_token_env_var (default
-//     CHORUS_API_KEY) exported into the child ENV — never argv.
+//   • No `--mcp-config`: MCP comes from the user's ~/.codex/config.toml. The daemon
+//     exports its resolved URL for SessionStart hooks and its key for the configured
+//     bearer_token_env_var (default CHORUS_API_KEY) — never argv.
 //   • Permission is a SANDBOX mode, not a tool allowlist.
 //
 // Reuses claude-spawner's platform-neutral helpers: parseNdjsonChunk (NDJSON
 // stream parse) and the PATH-walk shape of resolveClaudePath.
 
 import { spawn } from "node:child_process";
-import { statSync } from "node:fs";
-import { win32 as pathWin32, posix as pathPosix } from "node:path";
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, win32 as pathWin32, posix as pathPosix } from "node:path";
 import { parseNdjsonChunk } from "./claude-spawner.mjs";
 import { getThreadId as defaultGetThreadId, setThreadId as defaultSetThreadId } from "./codex-session-map.mjs";
 import {
@@ -33,6 +34,25 @@ import {
 } from "./codex-usage-map.mjs";
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
+
+/**
+ * Check whether the user's Codex config declares the Chorus MCP server.
+ * This is diagnostic only: a missing or unreadable config must never block a wake.
+ * @param {{ env?: NodeJS.ProcessEnv, readFile?: typeof readFileSync, home?: string }} [deps]
+ * @returns {boolean}
+ */
+export function hasChorusMcpServer(deps = {}) {
+  const env = deps.env ?? process.env;
+  const readFile = deps.readFile ?? readFileSync;
+  const home = deps.home ?? homedir();
+  const configPath = join(env.CODEX_HOME || join(home, ".codex"), "config.toml");
+  try {
+    const config = readFile(configPath, "utf8");
+    return /^\s*\[mcp_servers\.chorus\]\s*(?:#.*)?$/m.test(config);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * @typedef {Object} Spawner
@@ -165,13 +185,14 @@ export function resolveSpawnCommand(codexPath, args, platform = process.platform
  * @property {(o: object) => any} [spawnImpl]   Injectable spawn (tests).
  * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
  * @property {"chorus"|"yolo"} [permissionMode]  Maps to a Codex sandbox posture.
- * @property {{ url: string, apiKey: string }} [creds]  Daemon creds — apiKey is exported
- *   into the child env under the user config's bearer_token_env_var (default CHORUS_API_KEY).
+ * @property {{ url: string, apiKey: string }} [creds] Daemon creds exported into
+ *   the child env for SessionStart hooks and the user-configured MCP bearer token.
  * @property {NodeJS.Platform} [platform]  Injectable for tests; gates POSIX `detached`.
  * @property {(anchor: string) => string|null} [getThreadIdFn]  Injectable session-map read.
  * @property {(anchor: string, threadId: string) => void} [setThreadIdFn]  Injectable session-map write.
  * @property {(anchor: string, threadId: string) => object|null} [getUsageSnapshotFn]
  * @property {(anchor: string, threadId: string, usage: object) => void} [setUsageSnapshotFn]
+ * @property {() => boolean} [hasChorusMcpServerFn] Injectable config probe.
  */
 
 export class CodexSpawner {
@@ -189,6 +210,8 @@ export class CodexSpawner {
     this.getUsageSnapshotFn = opts.getUsageSnapshotFn ?? defaultGetUsageSnapshot;
     this.setUsageSnapshotFn = opts.setUsageSnapshotFn ?? defaultSetUsageSnapshot;
     this.resolveCodexPathFn = opts.resolveCodexPathFn ?? resolveCodexPath;
+    this.hasChorusMcpServerFn = opts.hasChorusMcpServerFn ?? hasChorusMcpServer;
+    this.mcpConfigChecked = false;
   }
 
   /**
@@ -225,6 +248,15 @@ export class CodexSpawner {
       return { sessionId: anchor, exitCode: null, isNew };
     }
 
+    if (!this.mcpConfigChecked) {
+      this.mcpConfigChecked = true;
+      if (!this.hasChorusMcpServerFn()) {
+        this.logger.warn(
+          "[Chorus] Codex config has no [mcp_servers.chorus] entry; wake will continue without Chorus MCP tools",
+        );
+      }
+    }
+
     const args = buildCodexArgs({ isNew, threadId: knownThreadId, permissionMode: this.permissionMode });
     const { command, argv } = resolveSpawnCommand(codexPath, args, this.platform);
 
@@ -233,11 +265,14 @@ export class CodexSpawner {
     // stays piped — prompt over stdin + NDJSON stdout parse are unaffected.
     const detached = this.platform !== "win32";
 
-    // Daemon key via ENV under the var the user's [mcp_servers.chorus] references
-    // (bearer_token_env_var, default CHORUS_API_KEY) — NEVER argv. Merged over the
-    // inherited env so PATH / model auth (Bedrock profile) / CODEX_HOME survive.
+    // Export the daemon's resolved connection pair for both Codex MCP auth and
+    // SessionStart hooks. Explicitly overwrite inherited values so the hook and
+    // daemon cannot disagree about which Chorus instance this wake belongs to.
     const childEnv = { ...process.env, CHORUS_DAEMON_HEADLESS: "1" };
-    if (this.creds && this.creds.apiKey) childEnv.CHORUS_API_KEY = this.creds.apiKey;
+    if (this.creds) {
+      if (this.creds.url) childEnv.CHORUS_URL = this.creds.url;
+      if (this.creds.apiKey) childEnv.CHORUS_API_KEY = this.creds.apiKey;
+    }
 
     return new Promise((resolve) => {
       let child;

--- a/cli/kiro-spawner.mjs
+++ b/cli/kiro-spawner.mjs
@@ -209,8 +209,8 @@ export function pickNewSessionId(before, after) {
  * @property {(o: object) => any} [spawnImpl]   Injectable spawn (tests).
  * @property {{info(m:string):void,warn(m:string):void,error(m:string):void}} [logger]
  * @property {"chorus"|"yolo"} [permissionMode]  Maps to a Kiro tool-trust posture.
- * @property {{ url: string, apiKey: string }} [creds]  Daemon creds — apiKey is exported
- *   into the child env as CHORUS_API_KEY (the var the plugin's .kiro/settings/mcp.json references).
+ * @property {{ url: string, apiKey: string }} [creds] Daemon credentials exported
+ *   into the child env for plugin hooks, shell tooling, and MCP authentication.
  * @property {NodeJS.Platform} [platform]  Injectable for tests; gates POSIX `detached`.
  * @property {(anchor: string) => string|null} [getSessionIdFn]  Injectable session-map read.
  * @property {(anchor: string, id: string) => void} [setSessionIdFn]  Injectable session-map write.
@@ -274,11 +274,13 @@ export class KiroSpawner {
     // stays piped — prompt over stdin + stdout capture are unaffected.
     const detached = this.platform !== "win32";
 
-    // Daemon key via ENV as CHORUS_API_KEY — the var the plugin's
-    // [mcpServers.chorus] header references (${env:CHORUS_API_KEY}). NEVER argv.
-    // Merged over the inherited env so PATH / model auth / KIRO_* survive.
+    // Export the daemon's authoritative connection pair. CHORUS_API_KEY is also
+    // referenced by the plugin's MCP config; neither value is placed in argv.
     const childEnv = { ...process.env, CHORUS_DAEMON_HEADLESS: "1" };
-    if (this.creds && this.creds.apiKey) childEnv.CHORUS_API_KEY = this.creds.apiKey;
+    if (this.creds) {
+      if (this.creds.url) childEnv.CHORUS_URL = this.creds.url;
+      if (this.creds.apiKey) childEnv.CHORUS_API_KEY = this.creds.apiKey;
+    }
 
     // Snapshot the session store BEFORE the run so we can identify the sessionId
     // this run creates (Kiro has no id-bearing stream event). On resume we already

--- a/cli/spawner-select.mjs
+++ b/cli/spawner-select.mjs
@@ -25,12 +25,7 @@ export function selectSpawner(agentType, opts = {}) {
     return new CodexSpawner({ logger, permissionMode, creds });
   }
   if (agentType === "kiro") {
-    // Kiro follows the Codex model — MCP from the user's plugin config, daemon key
-    // via env — so it takes the same { logger, permissionMode, creds } shape.
     return new KiroSpawner({ logger, permissionMode, creds });
   }
-  // Default / "claude-code": construction byte-identical to the prior daemon
-  // (ClaudeSpawner takes only { logger, permissionMode } — creds are not used by
-  // the Claude backend, which gets its key via the --mcp-config file).
-  return new ClaudeSpawner({ logger, permissionMode });
+  return new ClaudeSpawner({ logger, permissionMode, creds });
 }

--- a/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/README.md
+++ b/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/README.md
@@ -1,0 +1,3 @@
+# fix-codex-headless-chorus-env-warning
+
+Fix false and duplicate Chorus environment warnings in Codex headless daemon sessions

--- a/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/design.md
+++ b/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The daemon resolves a complete credential pair `{ url, apiKey }` before constructing `CodexSpawner`. Codex MCP connectivity is declared separately in the user's `~/.codex/config.toml`: the URL is stored in that config, while `bearer_token_env_var` reads the API key from the spawned process environment.
+
+`CodexSpawner.wake` currently copies the daemon environment, sets `CHORUS_DAEMON_HEADLESS=1`, and overwrites `CHORUS_API_KEY` from the resolved daemon credentials. It does not set `CHORUS_URL`. The Codex SessionStart hook checks both `CHORUS_URL` and `CHORUS_API_KEY` before calling `chorus_checkin`, so it emits a false "environment not configured" message even though Codex MCP can connect through `config.toml`. The observed message can also be surfaced more than once during one startup, so diagnostics need an explicit idempotency boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give the SessionStart hook the same resolved URL and API key pair used by the daemon wake.
+- Suppress configuration warnings when Chorus check-in succeeds.
+- Emit a given configuration warning no more than once during one Codex headless startup.
+- Preserve a visible generic warning for genuinely missing configuration or failed connectivity.
+- Keep the API key out of argv and logs.
+
+**Non-Goals:**
+
+- Changing how normal interactive Codex sessions configure MCP.
+- Replacing the user's `[mcp_servers.chorus]` configuration.
+- Expanding connection errors into new diagnostic categories.
+- Changing Claude, Kiro, or OpenClaw daemon backends.
+
+## Decisions
+
+### Inject the complete resolved credential context
+
+`CodexSpawner` will set both `CHORUS_URL` and `CHORUS_API_KEY` from `this.creds` in the child environment, in addition to `CHORUS_DAEMON_HEADLESS=1`. The resolved daemon credentials are authoritative for a daemon wake and already contain both values. Explicit assignment also prevents stale inherited values from disagreeing with the daemon connection.
+
+Alternative considered: teach the hook to parse `~/.codex/config.toml`. This would duplicate Codex config parsing, still would not reliably recover secrets referenced through arbitrary environment-variable names, and would couple a shell hook to Codex's configuration schema.
+
+Alternative considered: skip the environment check whenever `CHORUS_DAEMON_HEADLESS=1`. This would hide real daemon misconfiguration and prevent the hook's check-in context from loading.
+
+### Keep the existing hook diagnostic contract
+
+Once both values are present, the hook will continue to call `chorus_checkin`. Missing values retain the existing generic not-configured warning, and a failed check-in retains the existing generic connection warning. The fix changes the inputs to this contract rather than introducing a second source of connectivity truth.
+
+### Put deduplication at the diagnostic emission boundary
+
+Implementation will first reproduce whether duplicate output is caused by duplicate hook invocation or duplicate rendering of one hook result. The narrowest stable emission boundary will guard a diagnostic identity for the lifetime of one headless startup, without suppressing warnings in later independent starts. Tests must demonstrate one visible warning after two equivalent triggers and a fresh warning in a separate startup.
+
+If investigation shows that the same hook result is rendered twice outside the hook process, deduplication belongs in that caller rather than a process-local shell variable. The implementation must document the observed trigger path in the test name or code comment.
+
+## Risks / Trade-offs
+
+- [Child environment exposes the URL to subprocesses] -> The URL is non-secret and the API key is already intentionally present; tests continue to assert that the key never enters argv.
+- [Inherited credentials could differ from daemon credentials] -> Always overwrite both variables from the resolved `this.creds` pair.
+- [A global dedupe marker could suppress later valid warnings] -> Scope any marker or state to one startup identity and test independent starts.
+- [Hook and installed plugin copies can drift] -> Update source tests around the repository hook and rely on the normal plugin packaging path rather than patching cached installations.
+
+## Migration Plan
+
+No data migration is required. Ship the spawner and hook changes together. Rollback is a code revert; the user's Codex MCP configuration remains unchanged.
+
+## Open Questions
+
+- Which layer duplicates the warning in the reproduced headless startup: repeated SessionStart execution, duplicate plugin registration, or duplicate rendering of one hook result? This is an implementation investigation item and determines the narrowest dedupe location.

--- a/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/proposal.md
+++ b/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Codex headless sessions spawned by the Chorus daemon can use Chorus MCP successfully while the SessionStart hook reports that Chorus is not configured. The daemon currently injects the resolved API key but not the resolved Chorus URL into the Codex child environment, so the hook's environment check disagrees with the MCP connection configured in `config.toml`.
+
+## What Changes
+
+- Propagate the daemon's resolved Chorus URL and API key into each Codex headless child process while keeping secrets out of process arguments.
+- Make the Codex SessionStart diagnostic reflect the daemon-provided connection context, so a usable Chorus session does not emit a false configuration warning.
+- Ensure the same Chorus configuration warning is emitted at most once per headless startup.
+- Preserve the existing generic warning when Chorus is genuinely not configured or unavailable.
+- Add regression coverage for configured, unconfigured, connection-failure, and duplicate-trigger startup paths.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `daemon-codex-backend`: Extend the spawned Codex environment contract and its startup-diagnostic behavior for Chorus connectivity.
+
+## Impact
+
+The change affects `cli/codex-spawner.mjs`, the Codex SessionStart hook under `plugins/chorus/hooks/`, and their focused tests. It does not change MCP configuration format, credential resolution precedence, public APIs, or non-Codex daemon backends.

--- a/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/specs/daemon-codex-backend/spec.md
+++ b/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/specs/daemon-codex-backend/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Codex MCP comes from the user config with the daemon key via env
+
+The daemon SHALL NOT synthesize a Codex MCP configuration. It SHALL rely on the user's existing `~/.codex/config.toml` to declare the Chorus MCP server (`[mcp_servers.chorus]`). To make the woken Codex authenticate as the daemon's own agent and allow startup hooks to inspect the same resolved connection context, the spawner SHALL export both the daemon's resolved Chorus URL as `CHORUS_URL` and its resolved API key as `CHORUS_API_KEY` into the child process environment. The API key SHALL be passed through the environment and SHALL NOT appear in process arguments or logs. When the complete context is present and Chorus is reachable, the SessionStart hook SHALL complete check-in without emitting a not-configured warning. When configuration is genuinely incomplete or check-in fails, the existing generic warning SHALL remain visible. Equivalent Chorus configuration warnings SHALL appear at most once during one headless startup, while an independent later startup SHALL be able to emit its own warning. When the user's config declares no Chorus MCP server, the woken Codex SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail.
+
+#### Scenario: Complete daemon connection context reaches the Codex child
+
+- **WHEN** the daemon has resolved a Chorus URL and API key and wakes the Codex backend
+- **THEN** the spawned Codex receives the resolved values as `CHORUS_URL` and `CHORUS_API_KEY`
+- **AND** the API key does not appear in process arguments or logs
+
+#### Scenario: Configured and reachable Chorus does not produce a false warning
+
+- **WHEN** a Codex headless child receives the complete daemon connection context and Chorus check-in succeeds
+- **THEN** the SessionStart hook MUST NOT report that the Chorus environment is unconfigured
+- **AND** Chorus MCP remains available through the user's Codex configuration
+
+#### Scenario: Genuine missing configuration retains the generic warning
+
+- **WHEN** the SessionStart hook runs without a complete Chorus URL and API key pair
+- **THEN** it emits the existing generic not-configured warning
+- **AND** it exits without attempting an authenticated check-in
+
+#### Scenario: Genuine connection failure retains the generic warning
+
+- **WHEN** the SessionStart hook receives complete configuration but Chorus check-in fails
+- **THEN** it emits the existing generic connection-failure warning
+
+#### Scenario: Equivalent startup warning is emitted once
+
+- **WHEN** the same Chorus configuration warning is triggered more than once during one Codex headless startup
+- **THEN** the user-visible warning appears at most once
+- **AND** an independent later startup can emit the warning again if the failure still exists
+
+#### Scenario: No Chorus MCP configured still runs
+
+- **WHEN** the user's Codex config declares no Chorus MCP server
+- **THEN** the wake still spawns and completes, the woken Codex simply lacks Chorus tools, and the daemon logs the absence instead of crashing

--- a/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/tasks.md
+++ b/openspec/changes/archive/2026-07-27-fix-codex-headless-chorus-env-warning/tasks.md
@@ -1,0 +1,4 @@
+## 1. Codex Headless Connection Diagnostics
+
+- [x] 1.1 Reproduce and trace the duplicate SessionStart warning to its emission or rendering boundary, then update `CodexSpawner` and the affected hook/caller so the child receives the daemon's resolved URL and API key and equivalent warnings are scoped to one emission per startup.
+- [x] 1.2 Add focused regression tests for complete credential propagation, secret exclusion from argv/logs, successful check-in without false warning, genuine missing configuration, connection failure, duplicate triggers in one startup, and warning reset across independent startups; run the relevant CLI and hook test suites.

--- a/openspec/specs/daemon-codex-backend/spec.md
+++ b/openspec/specs/daemon-codex-backend/spec.md
@@ -70,12 +70,36 @@ The daemon's backend-agnostic permission mode SHALL map to a Codex sandbox postu
 
 ### Requirement: Codex MCP comes from the user config with the daemon key via env
 
-The daemon SHALL NOT synthesize a Codex MCP configuration. It SHALL rely on the user's existing `~/.codex/config.toml` to declare the Chorus MCP server (`[mcp_servers.chorus]`). To make the woken Codex authenticate as the daemon's own agent, the spawner SHALL export the daemon's resolved API key into the child process environment under the variable the user's config references via `bearer_token_env_var` (default `CHORUS_API_KEY`); the key SHALL be passed through the environment and SHALL NOT appear in the process arguments. When the user's config declares no Chorus MCP server, the woken Codex SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail.
+The daemon SHALL NOT synthesize a Codex MCP configuration. It SHALL rely on the user's existing `~/.codex/config.toml` to declare the Chorus MCP server (`[mcp_servers.chorus]`). To make the woken Codex authenticate as the daemon's own agent and allow startup hooks to inspect the same resolved connection context, the spawner SHALL export both the daemon's resolved Chorus URL as `CHORUS_URL` and its resolved API key as `CHORUS_API_KEY` into the child process environment. The API key SHALL be passed through the environment and SHALL NOT appear in process arguments or logs. When the complete context is present and Chorus is reachable, the SessionStart hook SHALL complete check-in without emitting a not-configured warning. When configuration is genuinely incomplete or check-in fails, the existing generic warning SHALL remain visible. Equivalent Chorus configuration warnings SHALL appear at most once during one headless startup, while an independent later startup SHALL be able to emit its own warning. When the user's config declares no Chorus MCP server, the woken Codex SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail.
 
-#### Scenario: Daemon key reaches the user-configured Chorus MCP server via env
+#### Scenario: Complete daemon connection context reaches the Codex child
 
-- **WHEN** the user's `~/.codex/config.toml` declares `[mcp_servers.chorus]` with `bearer_token_env_var = "CHORUS_API_KEY"` and the daemon wakes the codex backend
-- **THEN** the spawned Codex receives the daemon's resolved API key in its `CHORUS_API_KEY` environment variable (never in argv), so its Chorus MCP calls authenticate as the daemon's agent
+- **WHEN** the daemon has resolved a Chorus URL and API key and wakes the Codex backend
+- **THEN** the spawned Codex receives the resolved values as `CHORUS_URL` and `CHORUS_API_KEY`
+- **AND** the API key does not appear in process arguments or logs
+
+#### Scenario: Configured and reachable Chorus does not produce a false warning
+
+- **WHEN** a Codex headless child receives the complete daemon connection context and Chorus check-in succeeds
+- **THEN** the SessionStart hook MUST NOT report that the Chorus environment is unconfigured
+- **AND** Chorus MCP remains available through the user's Codex configuration
+
+#### Scenario: Genuine missing configuration retains the generic warning
+
+- **WHEN** the SessionStart hook runs without a complete Chorus URL and API key pair
+- **THEN** it emits the existing generic not-configured warning
+- **AND** it exits without attempting an authenticated check-in
+
+#### Scenario: Genuine connection failure retains the generic warning
+
+- **WHEN** the SessionStart hook receives complete configuration but Chorus check-in fails
+- **THEN** it emits the existing generic connection-failure warning
+
+#### Scenario: Equivalent startup warning is emitted once
+
+- **WHEN** the same Chorus configuration warning is triggered more than once during one Codex headless startup
+- **THEN** the user-visible warning appears at most once
+- **AND** an independent later startup can emit the warning again if the failure still exists
 
 #### Scenario: No Chorus MCP configured still runs
 

--- a/openspec/specs/daemon-headless-interaction-guard/spec.md
+++ b/openspec/specs/daemon-headless-interaction-guard/spec.md
@@ -54,12 +54,13 @@ Prepending the headless preamble SHALL NOT turn a non-wake notification into a w
 
 ### Requirement: The spawner SHALL mark headless daemon sessions with an environment signal
 
-`ClaudeSpawner.wake()` SHALL spawn the headless Claude subprocess with `CHORUS_DAEMON_HEADLESS` set to `"1"` in the child process environment. The variable SHALL be added on top of the inherited environment so all other inherited variables (PATH, credential/Bedrock vars, `CLAUDE_CONFIG_DIR`, etc.) are preserved. This change in this proposal SHALL NOT add any code that reads the variable back — it is a forward-looking, machine-checkable signal.
+`ClaudeSpawner.wake()` SHALL spawn the headless Claude subprocess with `CHORUS_DAEMON_HEADLESS` set to `"1"` in the child process environment. It SHALL also export the daemon's resolved Chorus URL and API key as `CHORUS_URL` and `CHORUS_API_KEY` so plugin hooks and shell-based Chorus tooling use the same connection context as the daemon. These values SHALL be added on top of the inherited environment, with the resolved daemon values overriding stale inherited Chorus values, so all other inherited variables (PATH, credential/Bedrock vars, `CLAUDE_CONFIG_DIR`, etc.) are preserved. The API key SHALL NOT appear in process arguments or logs.
 
 #### Scenario: Spawned child environment carries the signal
 
 - **WHEN** the daemon spawns a headless wake via `ClaudeSpawner.wake()`
 - **THEN** the child process environment contains `CHORUS_DAEMON_HEADLESS=1`
+- **AND** it contains the daemon's resolved `CHORUS_URL` and `CHORUS_API_KEY`
 - **AND** environment variables inherited from the daemon process are still present in the child environment
 
 #### Scenario: The signal is independent of permission mode
@@ -82,4 +83,3 @@ The headless interaction guard SHALL be implemented entirely on the daemon path 
 - **WHEN** a human runs Claude Code interactively (not via the daemon)
 - **THEN** the headless preamble and `CHORUS_DAEMON_HEADLESS` env var are absent
 - **AND** `AskUserQuestion` continues to work as before
-

--- a/openspec/specs/daemon-kiro-backend/spec.md
+++ b/openspec/specs/daemon-kiro-backend/spec.md
@@ -47,12 +47,12 @@ The daemon's backend-agnostic permission mode SHALL map to a Kiro tool-trust pos
 
 ### Requirement: Kiro MCP comes from the plugin config with the daemon key via env
 
-The daemon SHALL NOT synthesize a Kiro MCP configuration. It SHALL rely on the Kiro plugin's `.kiro/settings/mcp.json` (loaded via `--agent chorus`) to declare the Chorus MCP server. To make the woken Kiro authenticate as the daemon's own agent, the spawner SHALL export the daemon's resolved API key into the child process environment as `CHORUS_API_KEY` (the variable the plugin's MCP config references via `${env:CHORUS_API_KEY}`); the key SHALL be passed through the environment and SHALL NOT appear in the process arguments. When no Chorus MCP server is configured, the woken Kiro SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail. Because headless MCP loading requires a Node.js runtime present in the workspace, the daemon SHALL document node ≥ 22 as a prerequisite for the kiro backend.
+The daemon SHALL NOT synthesize a Kiro MCP configuration. It SHALL rely on the Kiro plugin's `.kiro/settings/mcp.json` (loaded via `--agent chorus`) to declare the Chorus MCP server. The spawner SHALL export the daemon's resolved Chorus URL and API key into the child process environment as `CHORUS_URL` and `CHORUS_API_KEY`, allowing plugin hooks and shell tooling to use the same connection context while the MCP config references `${env:CHORUS_API_KEY}` for authentication. The resolved pair SHALL override stale inherited Chorus values, and the key SHALL NOT appear in process arguments or logs. When no Chorus MCP server is configured, the woken Kiro SHALL still run (without Chorus tools), and the daemon SHALL log this rather than fail. Because headless MCP loading requires a Node.js runtime present in the workspace, the daemon SHALL document node ≥ 22 as a prerequisite for the kiro backend.
 
 #### Scenario: Daemon key reaches the plugin-configured Chorus MCP server via env
 
 - **WHEN** the Kiro plugin's `.kiro/settings/mcp.json` declares the `chorus` server with an `Authorization: Bearer ${env:CHORUS_API_KEY}` header and the daemon wakes the kiro backend
-- **THEN** the spawned Kiro receives the daemon's resolved API key in its `CHORUS_API_KEY` environment variable (never in argv), so its Chorus MCP calls authenticate as the daemon's agent
+- **THEN** the spawned Kiro receives the daemon's resolved URL and API key in `CHORUS_URL` and `CHORUS_API_KEY` (never in argv or logs), so hooks and Chorus MCP calls use the daemon's connection context
 
 #### Scenario: No Chorus MCP configured still runs
 
@@ -86,4 +86,3 @@ The Kiro backend SHALL spawn its subprocess in a detached POSIX process group (s
 
 - **WHEN** a Kiro wake was interrupted after its `sessionId` had been captured and persisted, and a new wake fires for the same anchor
 - **THEN** the daemon resumes that `sessionId` via `kiro-cli chat --no-interactive --resume-id` rather than starting a fresh session
-

--- a/plugins/chorus/hooks/on-session-start.sh
+++ b/plugins/chorus/hooks/on-session-start.sh
@@ -14,17 +14,20 @@ source "${DIR}/hook-output.sh"
 if [ ! -t 0 ]; then cat > /dev/null; fi
 
 if [ -z "${CHORUS_URL:-}" ] || [ -z "${CHORUS_API_KEY:-}" ]; then
+  # Failure diagnostics use one output channel. Repeating the same text in
+  # additionalContext makes Codex surface one hook result as duplicate startup
+  # messages; successful check-in still injects its detailed context below.
   hook_output \
-    "Chorus plugin: not configured (set CHORUS_URL and CHORUS_API_KEY)" \
     "Chorus environment not configured. Set CHORUS_URL and CHORUS_API_KEY to enable Chorus integration." \
+    "" \
     "SessionStart"
   exit 0
 fi
 
 CHECKIN=$("${DIR}/chorus-mcp-call.sh" chorus_checkin '{}' 2>/dev/null) || {
   hook_output \
-    "Chorus: connection failed (${CHORUS_URL})" \
     "WARNING: Unable to reach Chorus at ${CHORUS_URL}. MCP tools may still work if reachable during the session." \
+    "" \
     "SessionStart"
   exit 0
 }
@@ -109,17 +112,7 @@ CTX="${CTX}
 - **Skills**: use \`\$chorus\`, \`\$idea\`, \`\$proposal\`, \`\$develop\`, \`\$review\`, \`\$quick-dev\`, or \`\$yolo\` to load the stage-specific workflow.
 - **Reviewer sub-agents**: mount the reviewer skill into a default sub-agent — \`spawn_agent(agent_type=\"default\", items=[{type:\"skill\", path:\"chorus:chorus-proposal-reviewer\"}, {type:\"text\", text:\"Review proposal <uuid>.\"}])\` after \`chorus_pm_submit_proposal\`; same pattern with \`chorus:chorus-task-reviewer\` after \`chorus_submit_for_verify\`. Codex 0.125 only ships three built-in roles (default / explorer / worker) — custom agent_types like \`chorus-proposal-reviewer\` will be rejected. Remember \`close_agent\` after \`wait_agent\`; completed ≠ closed, 6 concurrent max."
 
-# User-visible parens (mirrors the Claude Code hook; Codex skill prefix is $chorus):
-#   active            -> (OpenSpec Enabled)
-#   not set up        -> (OpenSpec off — run `$chorus enable openspec` to set it up)
-#   explicit opt-out  -> (OpenSpec off)  [neutral, no nag]
-USER_MSG="Chorus connected at ${CHORUS_URL}"
-if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
-  USER_MSG="${USER_MSG} (OpenSpec Enabled)"
-elif [ "$OPENSPEC_OPTOUT" = "1" ]; then
-  USER_MSG="${USER_MSG} (OpenSpec off)"
-else
-  USER_MSG="${USER_MSG} (OpenSpec off — run \`\$chorus enable openspec\` to set it up)"
-fi
-
-hook_output "$USER_MSG" "$CTX" "SessionStart"
+# The connected state already appears in additionalContext, which the model needs
+# for checkin and OpenSpec routing. A second systemMessage makes Codex display the
+# same startup state twice, so successful starts use only the context channel.
+hook_output "" "$CTX" "SessionStart"


### PR DESCRIPTION
## Summary
- propagate the daemon-resolved `CHORUS_URL` and `CHORUS_API_KEY` into Claude, Codex, and Kiro headless sessions
- override stale inherited Chorus values while keeping the API key out of argv and logs
- emit Codex SessionStart success and failure information through a single visible channel
- keep missing Codex Chorus MCP configuration non-fatal and log it once
- archive the OpenSpec change and update the affected daemon backend specifications

## Verification
- focused spawner, backend integration, selection, and SessionStart tests: 125 passed
- full CLI suite with isolated HOME: 850 passed
- relevant ESLint checks
- `git diff --check`
- OpenSpec validation and document round-trip verification

Chorus Idea: `9a7170a3-63d4-42fe-83ca-d5ab103da822`
Chorus Task: `e3c4ebef-75d8-45b6-afed-8bff91c8bbce`