### PR TITLE
fix(codex): restore distinct hook output channels

### DIFF
--- a/cli/__tests__/codex-session-start-hook.test.mjs
+++ b/cli/__tests__/codex-session-start-hook.test.mjs
@@ -36,26 +36,26 @@ afterEach(() => {
 });
 
 describe("Codex SessionStart Chorus diagnostics", () => {
-  it("injects connected context through one output channel", () => {
+  it("returns connected user status and model context through separate channels", () => {
     const output = runHook(makeHooks(), {
       CHORUS_URL: "https://chorus.test",
       CHORUS_API_KEY: "cho_test",
     });
-    expect(output.systemMessage).toBe("");
+    expect(output.systemMessage).toContain("Chorus connected at https://chorus.test");
     expect(output.hookSpecificOutput.additionalContext).toContain("Chorus Plugin");
     expect(output.hookSpecificOutput.additionalContext.match(/Chorus is connected/g)).toHaveLength(1);
     expect(JSON.stringify(output)).not.toContain("environment not configured");
   });
 
-  it("emits a missing-config warning through one output channel", () => {
+  it("returns missing-config user status and model context through separate channels", () => {
     const output = runHook(makeHooks(), {});
-    const serialized = JSON.stringify(output);
-    expect(output.systemMessage).toContain("Chorus environment not configured");
-    expect(output.hookSpecificOutput).toBeUndefined();
-    expect(serialized.match(/Chorus environment not configured/g)).toHaveLength(1);
+    expect(output.systemMessage).toContain("Chorus plugin: not configured");
+    expect(output.hookSpecificOutput.additionalContext).toContain(
+      "Chorus environment not configured",
+    );
   });
 
-  it("emits a connection-failure warning through one output channel", () => {
+  it("returns connection-failure user status and model context through separate channels", () => {
     const script = makeHooks();
     writeFileSync(join(resolve(script, ".."), "chorus-mcp-call.sh"), "#!/usr/bin/env bash\nexit 1\n");
     chmodSync(join(resolve(script, ".."), "chorus-mcp-call.sh"), 0o755);
@@ -63,14 +63,18 @@ describe("Codex SessionStart Chorus diagnostics", () => {
       CHORUS_URL: "https://chorus.test",
       CHORUS_API_KEY: "cho_test",
     });
-    expect(output.systemMessage).toContain("Unable to reach Chorus");
-    expect(output.hookSpecificOutput).toBeUndefined();
-    expect(JSON.stringify(output).match(/Unable to reach Chorus/g)).toHaveLength(1);
+    expect(output.systemMessage).toContain("Chorus: connection failed");
+    expect(output.hookSpecificOutput.additionalContext).toContain("Unable to reach Chorus");
   });
 
   it("allows an independent startup to emit its own warning", () => {
     const script = makeHooks();
-    expect(runHook(script, {}).systemMessage).toContain("environment not configured");
-    expect(runHook(script, {}).systemMessage).toContain("environment not configured");
+    for (let index = 0; index < 2; index += 1) {
+      const output = runHook(script, {});
+      expect(output.systemMessage).toContain("Chorus plugin: not configured");
+      expect(output.hookSpecificOutput.additionalContext).toContain(
+        "Chorus environment not configured",
+      );
+    }
   });
 });

--- a/plugins/chorus/hooks/on-session-start.sh
+++ b/plugins/chorus/hooks/on-session-start.sh
@@ -14,20 +14,17 @@ source "${DIR}/hook-output.sh"
 if [ ! -t 0 ]; then cat > /dev/null; fi
 
 if [ -z "${CHORUS_URL:-}" ] || [ -z "${CHORUS_API_KEY:-}" ]; then
-  # Failure diagnostics use one output channel. Repeating the same text in
-  # additionalContext makes Codex surface one hook result as duplicate startup
-  # messages; successful check-in still injects its detailed context below.
   hook_output \
+    "Chorus plugin: not configured (set CHORUS_URL and CHORUS_API_KEY)" \
     "Chorus environment not configured. Set CHORUS_URL and CHORUS_API_KEY to enable Chorus integration." \
-    "" \
     "SessionStart"
   exit 0
 fi
 
 CHECKIN=$("${DIR}/chorus-mcp-call.sh" chorus_checkin '{}' 2>/dev/null) || {
   hook_output \
+    "Chorus: connection failed (${CHORUS_URL})" \
     "WARNING: Unable to reach Chorus at ${CHORUS_URL}. MCP tools may still work if reachable during the session." \
-    "" \
     "SessionStart"
   exit 0
 }
@@ -112,7 +109,14 @@ CTX="${CTX}
 - **Skills**: use \`\$chorus\`, \`\$idea\`, \`\$proposal\`, \`\$develop\`, \`\$review\`, \`\$quick-dev\`, or \`\$yolo\` to load the stage-specific workflow.
 - **Reviewer sub-agents**: mount the reviewer skill into a default sub-agent — \`spawn_agent(agent_type=\"default\", items=[{type:\"skill\", path:\"chorus:chorus-proposal-reviewer\"}, {type:\"text\", text:\"Review proposal <uuid>.\"}])\` after \`chorus_pm_submit_proposal\`; same pattern with \`chorus:chorus-task-reviewer\` after \`chorus_submit_for_verify\`. Codex 0.125 only ships three built-in roles (default / explorer / worker) — custom agent_types like \`chorus-proposal-reviewer\` will be rejected. Remember \`close_agent\` after \`wait_agent\`; completed ≠ closed, 6 concurrent max."
 
-# The connected state already appears in additionalContext, which the model needs
-# for checkin and OpenSpec routing. A second systemMessage makes Codex display the
-# same startup state twice, so successful starts use only the context channel.
-hook_output "" "$CTX" "SessionStart"
+# User-visible status (mirrors the Claude Code hook; Codex skill prefix is $chorus).
+USER_MSG="Chorus connected at ${CHORUS_URL}"
+if [ "$CHORUS_OPENSPEC_ACTIVE" = "1" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec Enabled)"
+elif [ "$OPENSPEC_OPTOUT" = "1" ]; then
+  USER_MSG="${USER_MSG} (OpenSpec off)"
+else
+  USER_MSG="${USER_MSG} (OpenSpec off — run \`\$chorus enable openspec\` to set it up)"
+fi
+
+hook_output "$USER_MSG" "$CTX" "SessionStart"


### PR DESCRIPTION
## Summary
- restore Codex SessionStart systemMessage as concise user-facing status
- preserve additionalContext as model-facing Chorus/checkin context
- keep daemon-resolved Chorus environment injection unchanged
- update focused hook tests to assert both distinct channels

## Verification
- pnpm vitest run cli/__tests__/codex-session-start-hook.test.mjs cli/__tests__/codex-spawner.test.mjs cli/__tests__/claude-spawner.test.mjs cli/__tests__/kiro-spawner.test.mjs (101 passed)
- pnpm eslint cli/__tests__/codex-session-start-hook.test.mjs
- git diff --check