### PR TITLE
fix(ci): exclude chorus-pi from dashboard typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
   ],
   "exclude": [
     "node_modules",
-    "packages"
+    "packages",
+    "chorus-pi"
   ]
 }


### PR DESCRIPTION
## Summary

- exclude the independently tooled `chorus-pi` package from the Dashboard root TypeScript project
- prevent Pi SDK and Bun-only types from breaking the Next.js typecheck when PR #457 is merged

## Verification

- `npx prisma generate`
- `npx tsc --noEmit`
- isolated full Vitest coverage run (temporary `HOME`, exit 0)
- `git diff --check`