### PR TITLE
feat(plugin): move Claude Code plugin state to global ~/.chorus/plugin

### DIFF
--- a/docs/blogs/building-claude-code-plugin-for-agent-teams.md
+++ b/docs/blogs/building-claude-code-plugin-for-agent-teams.md
@@ -407,7 +407,7 @@ Chorus does three things here:
 
 1. Calls the `chorus_checkin()` MCP tool to get the current Agent's identity (role, name, persona), assigned Ideas and Tasks, and unread notifications
 2. Injects the complete checkin result into Claude's context via `additionalContext` — the Agent knows who it is and what to do from the very first turn
-3. Scans the `.chorus/sessions/` directory to list existing Sub-Agent session metadata — this handles the case where a Claude Code session is interrupted and resumed: previous session files may still exist, and the Team Lead needs to know which sessions are still present after recovery
+3. Scans this session's `sessions/` directory (under `~/.chorus/plugin/<cwd-slug>/<sessionId>/`) to list existing Sub-Agent session metadata — this handles the case where a Claude Code session is interrupted and resumed: previous session files may still exist, and the Team Lead needs to know which sessions are still present after recovery
 
 ```bash
 # on-session-start.sh core logic
@@ -432,7 +432,7 @@ Triggered on every user input, so it must be extremely fast (<100ms). Chorus mak
 
 ```bash
 # on-user-prompt.sh — pure local operation, no MCP calls
-# Count json files in .chorus/sessions/
+# Count json files in this session's sessions/ dir (~/.chorus/plugin/<cwd-slug>/<sessionId>/sessions/)
 CONTEXT="[Chorus Plugin Active]
 - Active sub-agent sessions (3): frontend-worker, backend-worker, test-runner"
 ```
@@ -467,9 +467,9 @@ Async + `suppressOutput: true`. Does just one thing: calls `chorus_session_heart
 
 When a Claude Code internal Task is marked complete, Chorus checks whether the task description contains a `chorus:task:<uuid>` tag. If so, it automatically executes `chorus_session_checkout_task`. This is an elegant **metadata bridging** pattern — by embedding a Chorus task UUID in the CC Task description, the two systems' Task lifecycles are linked.
 
-**`SessionEnd` — Clean Up .chorus/ Directory**
+**`SessionEnd` — Clean Up This Session's State Directory**
 
-When the session ends, checks whether all session files have been cleaned up and state.json is empty. If so, deletes the entire `.chorus/` directory, leaving no leftover files.
+When the session ends, it removes this session's own state directory (`~/.chorus/plugin/<cwd-slug>/<sessionId>/`), leaving no leftover files. Because each Claude Code session has its own directory, this delete is unconditional and never races a concurrent session on the same project.
 
 ---
 
@@ -483,7 +483,7 @@ Now for the main topic — how the Chorus plugin uses the above mechanisms to so
 Team Lead calls Task tool to spawn Sub-Agent
   │
   ├─ [PreToolUse:Task] on-pre-spawn-agent.sh
-  │    Write .chorus/pending/<name> file (capture agent name)
+  │    Write <sessionId>/pending/<name> file (capture agent name)
   │
   ├─ [SubagentStart] on-subagent-start.sh    ← Core
   │    Claim pending file (atomic mv, handles concurrency)
@@ -509,12 +509,12 @@ Team Lead calls Task tool to spawn Sub-Agent
        Query and display newly unblocked tasks
 ```
 
-### 5.2 The `.chorus/` Directory: The Bridge Connecting Everything
+### 5.2 The State Directory: The Bridge Connecting Everything
 
-We've mentioned "shared filesystem" multiple times — let's expand on this. The Chorus plugin maintains a `.chorus/` directory (gitignored) at the project root, serving as the information hub between the Team Lead, Sub-Agents, and all hooks:
+We've mentioned "shared filesystem" multiple times — let's expand on this. The Chorus plugin maintains a per-session state directory, serving as the information hub between the Team Lead, Sub-Agents, and all hooks. It lives under a single **global** root — `~/.chorus/plugin/` (aligned with the Chorus daemon's `~/.chorus/` convention) — partitioned by a readable project slug and the Claude Code session id, so there's no per-project `.chorus/` folder to create or gitignore:
 
 ```
-.chorus/                              # Plugin runtime state (gitignored)
+~/.chorus/plugin/<cwd-slug>/<sessionId>/   # <cwd-slug> = project dir, '/'→'-' (like ~/.claude/projects)
 ├── state.json                        # Global state KV store
 ├── state.json.lock                   # flock exclusive lock file
 ├── sessions/                         # Sub-Agent session metadata (for hook state lookup)
@@ -526,6 +526,8 @@ We've mentioned "shared filesystem" multiple times — let's expand on this. The
 └── claimed/                          # Files claimed by SubagentStart
     └── <agent-id>
 ```
+
+A single shared `bin/chorus-paths.sh` module resolves this path for `chorus-api.sh` and every hook, so the layout is defined in exactly one place. Each hook lifts the Claude Code `session_id` (identical across the whole session — sub-agents differ only by `agent_id`) from its stdin event and exports it, so every hook in a session resolves to the same `<sessionId>` directory.
 
 #### Core: `state.json` — Cross-Hook State Sharing
 
@@ -580,8 +582,8 @@ The solution is a relay between two hooks:
 
 ```
 Timeline:
-  T1  PreToolUse:Task fires → write .chorus/pending/frontend-worker
-  T2  PreToolUse:Task fires → write .chorus/pending/backend-worker
+  T1  PreToolUse:Task fires → write <sessionId>/pending/frontend-worker
+  T2  PreToolUse:Task fires → write <sessionId>/pending/backend-worker
   T3  SubagentStart(agent_id=a0e) fires → mv pending/frontend-worker → claimed/a0e ✓
   T4  SubagentStart(agent_id=b1f) fires → mv pending/backend-worker → claimed/b1f ✓
   T4' SubagentStart(agent_id=c2g) fires → mv pending/frontend-worker → fails (already claimed by a0e)
@@ -598,17 +600,17 @@ Session files now contain only minimal metadata (sessionUuid, agentId, agentName
 #### Lifecycle: Creation to Cleanup
 
 ```
-SessionStart  → mkdir -p .chorus/ (if not exists)
-PreToolUse    → write .chorus/pending/<name>
+SessionStart  → resolve ~/.chorus/plugin/<cwd-slug>/<sessionId>/ (created lazily)
+PreToolUse    → write <sessionId>/pending/<name>
 SubagentStart → mv pending → claimed, write sessions/<name>.json (metadata only),
                 inject workflow via additionalContext → Sub-Agent, update state.json
 TeammateIdle  → read state.json (lookup session_uuid), no writes
 TaskCompleted → read state.json (lookup session_uuid), no writes
 SubagentStop  → delete sessions/<name>.json, delete claimed/<agent_id>, clean state.json entries
-SessionEnd    → if sessions/ is empty and state.json is empty → rm -rf .chorus/
+SessionEnd    → rm -rf this session's dir (~/.chorus/plugin/<cwd-slug>/<sessionId>/)
 ```
 
-The entire directory's lifecycle matches the Claude Code session — created at start, cleaned up at end, leaving no trace.
+Because the directory is keyed by the Claude Code session id, its lifecycle matches the session exactly — resolved at start, removed at end — and concurrent sessions on the same project each get their own directory, so `SessionEnd` can delete its own without racing siblings. Nothing is left in the project tree.
 
 ### 5.3 The Core Challenge: Sub-Agent Context Injection
 
@@ -723,7 +725,7 @@ SubagentStart hook  →  additionalContext  →  Sub-Agent's context
 
 ### Pattern 2: Filesystem for Cross-Hook State (Not Sub-Agent Communication)
 
-The shared filesystem (`.chorus/` directory) is valuable for **hook-to-hook** state passing (e.g., `pending/` files relay agent names from `PreToolUse` to `SubagentStart`), but should not be the primary mechanism for Sub-Agent context injection. Use `SubagentStart`'s `additionalContext` for that instead.
+The shared filesystem (the plugin's per-session state directory under `~/.chorus/plugin/`) is valuable for **hook-to-hook** state passing (e.g., `pending/` files relay agent names from `PreToolUse` to `SubagentStart`), but should not be the primary mechanism for Sub-Agent context injection. Use `SubagentStart`'s `additionalContext` for that instead.
 
 ### Pattern 3: PreToolUse Captures + SubagentStart Executes
 

--- a/docs/chorus-plugin.md
+++ b/docs/chorus-plugin.md
@@ -27,20 +27,20 @@ Team Lead spawns sub-agent "frontend-worker"
   │
   ├─ [Hook: SubagentStart] fires SYNCHRONOUSLY before sub-agent runs
   │   ├─ Creates Chorus session via MCP
-  │   ├─ Writes .chorus/sessions/frontend-worker.json
+  │   ├─ Writes <sessionId>/sessions/frontend-worker.json (under ~/.chorus/plugin/<cwd-slug>/)
   │   └─ Output to Team Lead: "Session UUID: xxx"
   │
   └─ Sub-agent starts
       ├─ [Hook: SessionStart] fires (if applicable)
-      │   └─ Scans .chorus/sessions/ → outputs "Your session: xxx"
+      │   └─ Scans this session's sessions/ dir → outputs "Your session: xxx"
       │
-      └─ OR: Sub-agent reads .chorus/sessions/frontend-worker.json
+      └─ OR: Sub-agent reads <sessionId>/sessions/frontend-worker.json
           (instructed by skill docs or Team Lead prompt)
 ```
 
 The sub-agent gets its session UUID via **two redundant paths**:
 1. **SessionStart hook** scans session files and outputs them as context
-2. **File read** — the sub-agent reads `.chorus/sessions/<my-name>.json` directly
+2. **File read** — the sub-agent reads its session's `sessions/<my-name>.json` directly
 
 ### Auto-cleanup on Sub-agent Exit (Plan D)
 
@@ -118,13 +118,24 @@ public/chorus-plugin/                # Plugin root
 .claude/skills/
 └── chorus → ../../public/chorus-plugin/skills/chorus  (symlink, local dev)
 
-Runtime state (gitignored):
-.chorus/
+Runtime state (global, not per-project):
+~/.chorus/plugin/<cwd-slug>/<sessionId>/   # <cwd-slug> = project dir with '/'→'-'
 ├── state.json                       # Hook state: agent→session mappings
-└── sessions/                        # Per-agent session files (Plan A)
-    ├── frontend-worker.json
-    └── backend-worker.json
+├── sessions/                        # Per-agent session files (Plan A)
+│   ├── frontend-worker.json
+│   └── backend-worker.json
+├── pending/                         # PreToolUse:Task → SubagentStart handoff
+└── claimed/                         # claimed pending files, keyed by agent_id
 ```
+
+Local hook state lives under the **global** `~/.chorus/plugin/` root (aligned with
+the daemon's `~/.chorus/` convention), partitioned by a readable project slug and
+the Claude Code session id — so there is no per-project `.chorus/` folder to create
+or gitignore. Path resolution is centralized in `bin/chorus-paths.sh`. This holds
+only hook-to-hook scratchpad state (session mappings, cached owner/permissions,
+sub-agent handoff files) — never credentials, and never a project↔directory binding
+(project scoping is server-side via the `X-Chorus-Project` header / explicit
+`projectUuid` args).
 
 ## Hooks
 
@@ -137,7 +148,7 @@ Runtime state (gitignored):
 2. Calls `chorus_checkin` via MCP to verify connectivity and inject agent context
 3. Outputs hook status and usage hints
 4. If resuming with existing state, sends a heartbeat
-5. **Session discovery (Plan A):** Scans `.chorus/sessions/` for pre-created session files and outputs them. If the current agent is a sub-agent, it can identify its own session by name.
+5. **Session discovery (Plan A):** Scans this session's `sessions/` dir (under `~/.chorus/plugin/<cwd-slug>/<sessionId>/`) for pre-created session files and outputs them. If the current agent is a sub-agent, it can identify its own session by name.
 
 ### SubagentStart
 
@@ -150,7 +161,7 @@ Runtime state (gitignored):
 2. Skips non-worker types (Explore, Plan, haiku, etc.)
 3. Creates a Chorus session via MCP (`chorus_create_session`)
 4. Stores mappings in `state.json` (by agent_id and agent_name)
-5. **Writes session file** to `.chorus/sessions/<agent_name>.json` with full session info
+5. **Writes session file** to `<sessionId>/sessions/<agent_name>.json` (under `~/.chorus/plugin/<cwd-slug>/`) with full session info
 6. Outputs session UUID and file path to Team Lead's context
 
 ### SubagentStop
@@ -186,7 +197,7 @@ This prevents Chorus sessions from being marked inactive during long-running age
 
 ## State File
 
-The plugin stores session mapping state in `$CLAUDE_PROJECT_DIR/.chorus/state.json`. This file is automatically created and should be gitignored.
+The plugin stores session mapping state in `~/.chorus/plugin/<cwd-slug>/<sessionId>/state.json` (global, per Claude Code session — not per-project). `<cwd-slug>` is the project directory with non-alphanumeric characters replaced by `-` (mirroring Claude Code's own `~/.claude/projects/` encoding). The file is created automatically; being outside the repo, it never needs gitignoring.
 
 **Format:**
 ```json
@@ -200,7 +211,7 @@ The plugin stores session mapping state in `$CLAUDE_PROJECT_DIR/.chorus/state.js
 
 ## Session Files (Plan A)
 
-Per-agent session files live in `$CLAUDE_PROJECT_DIR/.chorus/sessions/<agent_name>.json`:
+Per-agent session files live in `~/.chorus/plugin/<cwd-slug>/<sessionId>/sessions/<agent_name>.json`:
 
 ```json
 {
@@ -286,13 +297,13 @@ The hook skips read-only agent types (Explore, Plan, haiku). Only worker agents 
 
 ### Sub-agent can't find its session
 
-1. Check that `.chorus/sessions/<agent-name>.json` exists
+1. Check that `~/.chorus/plugin/<cwd-slug>/<sessionId>/sessions/<agent-name>.json` exists
 2. Verify SubagentStart hook ran (check Team Lead's context for "Chorus session auto-created" message)
 3. Ensure the sub-agent name matches the filename
 
 ### State file not updating
 
-Check that `$CLAUDE_PROJECT_DIR` is set and writable. The state file is at `$CLAUDE_PROJECT_DIR/.chorus/state.json`.
+Check that `$HOME` is set and writable. The state file is at `~/.chorus/plugin/<cwd-slug>/<sessionId>/state.json` (if `$HOME` is unset it falls back to `/tmp`; if the Claude Code session id is unavailable it uses a shared `<cwd-slug>/no-session/` bucket).
 
 ### Heartbeat failures
 

--- a/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/README.md
+++ b/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/README.md
@@ -1,0 +1,3 @@
+# move-plugin-state-to-global-chorus
+
+Move Claude Code plugin local hook state from per-project .chorus/ to global ~/.chorus/plugin/<cwd-slug>/<sessionId>/

--- a/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/design.md
+++ b/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/design.md
@@ -1,0 +1,147 @@
+# Design — global plugin state layout
+
+## Context
+
+The Claude Code plugin's hooks (`public/chorus-plugin/bin/*.sh`) coordinate through files under `${CLAUDE_PROJECT_DIR:-.}/.chorus/`. The anchor is defined in two places today:
+
+- `chorus-api.sh:17` — `STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus"` (+ `STATE_FILE`, `SESSIONS_DIR`).
+- `on-session-end.sh:8` — a second, independent copy of the same expression.
+
+Four more hooks build sub-paths inline off the same base: `on-subagent-start.sh` (`pending/`, `claimed/`, `sessions/`), `on-subagent-stop.sh` (`sessions/`, `claimed/`), `on-pre-spawn-agent.sh` (`pending/`), `on-user-prompt.sh` (`sessions/`).
+
+`chorus-api.sh` itself **never reads the hook event JSON** — it only sees environment variables. The Claude Code session id lives in each hook's stdin payload (`.session_id`), so it must be lifted by the hooks and passed down.
+
+### Which hooks touch STATE_DIR (verified enumeration)
+
+Not every hook uses on-disk state. A hook touches STATE_DIR only if it calls `chorus-api.sh` in a mode that reaches `ensure_state` — i.e. `state-get` / `state-set` / `state-delete` / `mcp-tool` / `session-*` — or builds a `pending/`/`claimed/`/`sessions/` path itself. `hook-output` does **not** call `ensure_state`, so hooks that only emit output never touch STATE_DIR.
+
+| Hook | Touches STATE_DIR? | Why / how |
+|---|---|---|
+| `on-session-start.sh` | yes | `state-set` owner/permissions + `mcp-tool` checkin |
+| `on-user-prompt.sh` | yes | reads `sessions/` for a local count |
+| `on-pre-spawn-agent.sh` | yes | writes `pending/<name>` |
+| `on-subagent-start.sh` | yes | `pending/`→`claimed/`, writes `sessions/`, `state-set` mappings |
+| `on-subagent-stop.sh` | yes | `state-get`/`state-delete` mappings, removes `sessions/`+`claimed/` |
+| **`on-teammate-idle.sh`** | **yes** | **`state-get "session_<teammateName>"`** then heartbeat — cross-hook read |
+| **`on-task-completed.sh`** | **yes** | **`state-get "session_<agentId>"`** then checkout — cross-hook read |
+| **`on-post-verify-task.sh`** | **yes** | `mcp-tool` calls → `ensure_state` writes `.mcp_*` temp files under STATE_DIR |
+| `on-post-submit-proposal.sh` | no | `hook-output` only — never calls `ensure_state` |
+| `on-post-submit-for-verify.sh` | no | `hook-output` only |
+| `on-pre-enter-plan.sh` / `on-pre-exit-plan.sh` | no | no state / no `ensure_state` |
+
+**Every hook in the "yes" rows MUST export `CHORUS_SESSION_ID`** before calling `chorus-api.sh` or building a sub-path. The three bolded rows were the review BLOCKER/NOTE: `on-teammate-idle.sh` and `on-task-completed.sh` read `session_<key>` mappings that `on-subagent-start.sh` wrote — if they resolved to a different (`no-session`) partition than the writer, the lookup would miss and heartbeats / auto-checkout would silently stop. They resolve consistently only because all three now export the same top-level `session_id`.
+
+### The universal-`session_id` assumption is doc-confirmed
+
+The design depends on Claude Code emitting the **same** top-level `session_id` on **every** hook event (SessionStart, UserPromptSubmit, Pre/PostToolUse, SubagentStart/Stop, TeammateIdle, TaskCompleted, SessionEnd). This is confirmed by the official Agent SDK hooks reference (`code.claude.com/docs/en/agent-sdk/hooks.md`, "Inputs" §, lines 255–256): *"All hook inputs share `session_id`, `cwd`, and `hook_event_name`."* Sub-agents/teammates do **not** get a different top-level `session_id` — they are distinguished by a separate `agent_id` / `teammate_name` field. Therefore extracting `.session_id` from stdin is reliable on all "yes" rows with zero exceptions, and no session-id discovery fallback is required (the `no-session` bucket exists only for the degenerate no-stdin case, e.g. a manual invocation).
+
+## Goals / Non-Goals
+
+**Goals**
+- One global root `~/.chorus/plugin/`, physically disjoint from the daemon's top-level `~/.chorus/{daemon.json,daemon.pid,daemon.log,*-sessions.json}`.
+- Human-readable per-project grouping (`<cwd-slug>`) so `ls ~/.chorus/plugin/` tells you which projects have state, without decoding a hash.
+- Per-session isolation (`<sessionId>`) so concurrent CC sessions on the same project never share files — restoring a clean `rm -rf` on session end.
+- **Fail-soft everywhere.** No new failure mode may abort a hook or block development. This is the owner's explicit constraint.
+
+**Non-Goals**
+- Migrating existing per-project `.chorus/` folders (left in place).
+- Cross-session shared files or a global lock (each session owns its own `state.json`; existing per-file `flock` is unchanged).
+- Touching non-Claude-Code plugins (they write nothing to disk).
+- A mtime-based GC of crash-leftover session dirs (noted as optional; not built here).
+
+## Layout
+
+```
+~/.chorus/                         # daemon's root (unchanged)
+├── daemon.json                    # daemon — untouched
+├── daemon.pid / daemon.log        # daemon — untouched
+├── codex-sessions.json …          # daemon — untouched
+└── plugin/                        # NEW — Claude Code plugin namespace
+    └── <cwd-slug>/                # e.g. -home-ubuntu-dev-ai-pm
+        └── <sessionId>/           # CC session id (one dir per CC session)
+            ├── state.json         # + state.json.lock
+            ├── sessions/          # <agentName>.json
+            ├── pending/           # PreToolUse:Task → SubagentStart handoff
+            ├── claimed/           # claimed pending files, keyed by agent_id
+            └── .mcp_headers.* / .mcp_response.*   # MCP handshake temp files
+```
+
+## `bin/chorus-paths.sh` — the single source of truth
+
+A tiny sourced library (not an executable subcommand). Sourcing it defines the resolved paths as variables in the caller's shell, given `CHORUS_SESSION_ID` and a project dir in the environment. Pseudocode:
+
+```bash
+# chorus-paths.sh — resolve the plugin's global state directory.
+# Sourced by chorus-api.sh and every state-touching hook.
+# Inputs (env):  CHORUS_SESSION_ID (optional), CLAUDE_PROJECT_DIR (optional)
+# Outputs (vars): CHORUS_PLUGIN_ROOT, CHORUS_CWD_SLUG, CHORUS_STATE_DIR
+
+# 1. Global root. Honor an override for tests / unusual homes.
+CHORUS_PLUGIN_ROOT="${CHORUS_PLUGIN_STATE_ROOT:-${HOME:-/tmp}/.chorus/plugin}"
+
+# 2. cwd -> readable slug, mirroring ~/.claude/projects encoding.
+#    Absolute path, strip trailing slash, replace every non-alnum
+#    ([^A-Za-z0-9]) with '-'. "/home/ubuntu/dev/ai-pm" -> "-home-ubuntu-dev-ai-pm".
+chorus_slug_for_dir() {
+  local d="${1:-$PWD}"
+  case "$d" in /*) ;; *) d="$PWD/$d" ;; esac      # make absolute (no realpath dep)
+  printf '%s' "$d" | sed -e 's#/*$##' -e 's#[^A-Za-z0-9]#-#g'
+}
+CHORUS_CWD_SLUG="$(chorus_slug_for_dir "${CLAUDE_PROJECT_DIR:-$PWD}")"
+
+# 3. Session partition. Fall back through a chain that NEVER yields empty.
+_sid="${CHORUS_SESSION_ID:-}"
+[ -z "$_sid" ] && _sid="no-session"              # last-resort shared bucket
+CHORUS_STATE_DIR="${CHORUS_PLUGIN_ROOT}/${CHORUS_CWD_SLUG}/${_sid}"
+```
+
+Key robustness properties:
+
+- **Never empty.** If `HOME` is unset it falls to `/tmp`; if `CHORUS_SESSION_ID` is unset it falls to a literal `no-session` bucket. The resolved dir is always a valid, writable-intent path — sourcing cannot fail the caller.
+- **`CHORUS_PLUGIN_STATE_ROOT` override** lets `test-syntax.sh` (and any future test) point the root at a throwaway `/tmp` dir instead of the real `~/.chorus`.
+- **Bash 3.2 safe:** uses `sed` for slug (no `${var//}` global-replace surprises across shells), no associative arrays, no `realpath`.
+
+## Session-id acquisition in hooks
+
+Each hook that already does `EVENT=$(cat)` gains one line before it calls `chorus-api.sh` or touches sub-paths:
+
+```bash
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+```
+
+This line goes into **every** hook in the "touches STATE_DIR" table above — including `on-teammate-idle.sh`, `on-task-completed.sh`, and `on-post-verify-task.sh`. All Claude Code hook events for one session carry the **same** top-level `session_id` (sub-agents are distinguished by `agent_id`, a separate field — see doc citation above). Therefore `pending/` (written by PreToolUse:Task) and `claimed/`/`sessions/` (written by SubagentStart) resolve to the same `<sessionId>` dir, and — critically — the `session_<key>` mappings that `on-subagent-start.sh` writes are read back by `on-subagent-stop.sh`, `on-teammate-idle.sh`, and `on-task-completed.sh` from that same `<sessionId>/state.json`. The handoff and all cross-hook lookups keep working exactly as before.
+
+`on-user-prompt.sh` must stay MCP-free and fast; it still extracts `session_id` (a cheap `jq` on already-read stdin) purely to locate `sessions/` for its count — no network.
+
+### Fallback chain (why the handoff can't silently break)
+
+| Situation | `CHORUS_SESSION_ID` | Result |
+|---|---|---|
+| Normal hook with stdin event | real CC session id | per-session dir, isolated |
+| Hook with no stdin / missing field | `no-session` | shared per-cwd bucket; still works within one project, just not isolated across concurrent sessions |
+| `chorus-api.sh` called by a hook that forgot to export | inherited env or `no-session` | resolves to a valid dir; worst case a pending file lands in the `no-session` bucket and SubagentStart looks there too (same resolution), so the FIFO claim still finds it |
+
+The design deliberately keeps PreToolUse:Task and SubagentStart resolving through the **same** `chorus-paths.sh`, so whatever bucket one writes to, the other reads from — the handoff is resolution-consistent by construction.
+
+## Cleanup (`on-session-end.sh`)
+
+Rewritten to source `chorus-paths.sh` and operate on `CHORUS_STATE_DIR` (the current session's dir). Because the dir is now session-scoped, the previous "is it safe to delete?" guards (non-empty `sessions/`, non-empty `state.json`) are no longer needed to protect sibling sessions — a session may `rm -rf` its own dir unconditionally. We keep a light guard: only remove when `CHORUS_SESSION_ID` resolved to a real id (not the `no-session` shared bucket), so a degenerate session never wipes the shared fallback out from under a concurrent one. Best-effort `rmdir` the now-possibly-empty `<cwd-slug>/` parent (ignore failure if other sessions remain).
+
+## Fail-soft contract
+
+- Every hook already begins with `set -euo pipefail` **but** guards each external call with `|| true` / `2>/dev/null` and `exit 0` on the unhappy path. Sourcing `chorus-paths.sh` is pure variable assignment (no external command that can non-zero the script) — but we still `source … || true`-guard it and provide inline defaults so a missing/renamed file degrades to the old `${CLAUDE_PROJECT_DIR:-.}/.chorus` behavior rather than crashing.
+- `mkdir -p "$CHORUS_STATE_DIR"` failures (e.g. read-only `$HOME`) are already tolerated by `ensure_state`'s callers via the existing `flock -w` timeout + `return 0` warning path; we extend the same "warn, don't die" stance to directory creation.
+- Net: **no path in this change can turn a previously-succeeding development action into a failure.** The worst degradation is "session not tracked in the UI," which the code already treats as non-fatal (see `on-subagent-start.sh:150` warning branch).
+
+## Testing
+
+- `bin/test-syntax.sh` extended: set `CHORUS_PLUGIN_STATE_ROOT=/tmp/chorus-test-$$/global`, feed each hook a synthetic event with a known `session_id`, assert files land under `…/global/<slug>/<sessionId>/…` and NOT under `${CLAUDE_PROJECT_DIR}/.chorus`. Assert `chorus_slug_for_dir` output for a known path. Assert the `no-session` fallback when `session_id` is absent. Must pass under `/bin/bash` (3.2) on macOS.
+- Manual smoke: run a real sub-agent spawn in a scratch repo, confirm `~/.chorus/plugin/<slug>/<sessionId>/sessions/` populates and SessionEnd removes it.
+
+## Alternatives considered (from elaboration)
+
+- **cwd-hash partition** (opaque `<hash(cwd)>`): rejected — the owner wants a directory name they can eyeball. Readable slug chosen.
+- **cwd-only partition** (no session level): rejected — concurrent CC sessions on one project would share `state.json`/`sessions/` and could not `rm -rf` on end without racing siblings. Session level restores clean teardown.
+- **Migrate old folders on startup**: rejected — extra code for a one-time cosmetic gain; old dirs are gitignored and harmless.
+- **Separate `~/.chorus-plugin/` root**: rejected — two `chorus` dirs is worse than one namespaced subdir; `~/.chorus/plugin/` is disjoint enough.

--- a/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/proposal.md
+++ b/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/proposal.md
@@ -1,0 +1,35 @@
+# Move Claude Code plugin local state to global `~/.chorus/plugin/`
+
+## Why
+
+The Claude Code plugin writes its hook coordination state into a `.chorus/` folder **inside every project working directory** (`bin/chorus-api.sh:17` — `STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus"`). Consequences:
+
+- Every new project that an agent touches grows its own `.chorus/` directory that must be `.gitignore`d and cleaned up separately — friction the owner explicitly wants gone.
+- It diverges from the **daemon**, which already keeps all of its state under a single user-global `~/.chorus/` (`daemon.json`, `daemon.pid`, `codex-sessions.json`, …). Two different conventions for "where Chorus keeps local state" is confusing.
+
+Crucially, this folder holds **only hook-to-hook scratchpad state** — session UUID mappings, a cached owner/permissions blob, an opportunistically-cached `project_uuid`, the `pending/`→`claimed/`→`sessions/` sub-agent handoff files, and MCP-handshake temp files. It is **not** credentials, and it is **not** a project↔directory binding. Project scoping is entirely server-side (the `X-Chorus-Project` header in `.mcp.json` / explicit `projectUuid` tool arguments). So relocating the folder loses no association logic — it is a pure move.
+
+## What Changes
+
+- **New shared path module** `bin/chorus-paths.sh`, sourced by `chorus-api.sh` and every state-touching hook. It is the single source of truth for:
+  - the global root `~/.chorus/plugin/`,
+  - the human-readable `<cwd-slug>` derived from the project directory (mirrors Claude Code's own `~/.claude/projects/-home-ubuntu-dev-ai-pm` encoding — `/` → `-`, **not** a hash),
+  - the per-session partition `<cwd-slug>/<sessionId>/`.
+- **`chorus-api.sh`** resolves `STATE_DIR` / `STATE_FILE` / `SESSIONS_DIR` from `chorus-paths.sh` using a `CHORUS_SESSION_ID` exported by the calling hook, instead of the hardcoded `${CLAUDE_PROJECT_DIR}/.chorus`.
+- **Every hook that touches STATE_DIR** extracts the Claude Code `session_id` from its stdin payload and exports `CHORUS_SESSION_ID` before invoking `chorus-api.sh` or building `pending/`/`claimed/`/`sessions/` paths, so all hooks in one CC session resolve to the same session directory. This set is broader than the sub-agent-lifecycle hooks: it also includes `on-teammate-idle.sh` and `on-task-completed.sh` (which read the `session_<key>` mappings written by `on-subagent-start.sh` — a miss here would silently break teammate heartbeats and auto-checkout) and `on-post-verify-task.sh` (whose `mcp-tool` calls write handshake temp files under STATE_DIR). Hooks that only emit `hook-output` (`on-post-submit-proposal.sh`, `on-post-submit-for-verify.sh`, `on-pre-enter-plan.sh`, `on-pre-exit-plan.sh`) never reach `ensure_state`, so they are correctly untouched.
+- **`on-session-end.sh`** `rm -rf`s only the current session's directory (`~/.chorus/plugin/<cwd-slug>/<sessionId>/`), preserving the existing "clean up on end" semantics without touching sibling concurrent sessions on the same project.
+- **Docs** (`docs/chorus-plugin.md` and the two plugin blog posts) updated to describe the global layout.
+
+Explicitly **out of scope** (per elaboration): no migration of pre-existing per-project `.chorus/` folders (they are left in place, already gitignored); no cross-session shared files or global locks; no changes to Codex/OpenClaw/Kiro plugins (they write nothing to disk). A crash-leftover mtime sweep is noted as a nice-to-have, not built.
+
+## Capabilities
+
+- **plugin-local-state** — where and how the Claude Code plugin stores its hook coordination state, its partitioning scheme, cleanup, and fail-soft guarantees.
+
+## Impact
+
+- **Affected code:** `public/chorus-plugin/bin/chorus-api.sh`, `bin/chorus-paths.sh` (new), `bin/on-session-start.sh`, `bin/on-session-end.sh`, `bin/on-subagent-start.sh`, `bin/on-subagent-stop.sh`, `bin/on-pre-spawn-agent.sh`, `bin/on-user-prompt.sh`, `bin/on-teammate-idle.sh`, `bin/on-task-completed.sh`, `bin/on-post-verify-task.sh`, `bin/test-syntax.sh`.
+- **Affected docs:** `docs/chorus-plugin.md`, `docs/blogs/building-claude-code-plugin-for-agent-teams.md`, `packages/landing/src/content/blog/claude-code-vs-codex-plugin-systems.md`.
+- **Behavioral risk:** the plugin's own session lifecycle. Fully mitigated by fail-soft design — any path-resolution or session-id failure falls back to a safe default and NEVER aborts a hook (hooks already `exit 0` on error; this change keeps that contract). This is the owner's hard constraint: script/session-file failures must not block the development flow.
+- **No user-data migration, no DB, no API surface change.** `.gitignore`'s `.chorus/` entry stays (still valid for any residual per-project folders).
+- **Cross-platform:** Bash 3.2 compatible (macOS), pure shell + `jq`/`sed` fallbacks — no new dependencies.

--- a/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/specs/plugin-local-state/spec.md
+++ b/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/specs/plugin-local-state/spec.md
@@ -1,0 +1,72 @@
+# Spec delta — plugin-local-state
+
+## ADDED Requirements
+
+### Requirement: Global plugin state root
+
+The Claude Code plugin SHALL store all of its hook-coordination state under a single user-global root `~/.chorus/plugin/`, and SHALL NOT create a `.chorus/` directory inside the project working directory for new sessions. The global root MUST be physically disjoint from the daemon's top-level `~/.chorus/` files (`daemon.json`, `daemon.pid`, `daemon.log`, `*-sessions.json`) so the two never collide.
+
+#### Scenario: State written to global root, not project dir
+
+- **WHEN** a Claude Code session with the Chorus plugin performs any hook action that persists state (checkin caching, sub-agent session mapping, MCP handshake)
+- **THEN** the resulting files are created under `~/.chorus/plugin/<cwd-slug>/<sessionId>/`
+- **AND** no new `.chorus/` directory is created inside `${CLAUDE_PROJECT_DIR}`
+
+#### Scenario: Daemon files are never touched
+
+- **WHEN** the plugin creates or removes its state directory
+- **THEN** the daemon's `~/.chorus/daemon.json`, `~/.chorus/daemon.pid`, `~/.chorus/daemon.log`, and `~/.chorus/*-sessions.json` are neither read nor modified nor deleted
+
+### Requirement: Readable per-project, per-session partitioning
+
+The plugin SHALL partition state by project and by session using the path `~/.chorus/plugin/<cwd-slug>/<sessionId>/`. The `<cwd-slug>` MUST be a human-readable encoding of the absolute project directory (mirroring Claude Code's own `~/.claude/projects/` encoding — non-alphanumeric characters replaced with `-`), NOT an opaque hash. The `<sessionId>` MUST be the Claude Code session id so that concurrent sessions on the same project occupy distinct directories.
+
+#### Scenario: cwd encoded to a legible slug
+
+- **WHEN** the project directory is `/home/ubuntu/dev/ai-pm`
+- **THEN** the resolved `<cwd-slug>` is `-home-ubuntu-dev-ai-pm`
+- **AND** the slug contains no hash digest
+
+#### Scenario: Concurrent sessions on one project are isolated
+
+- **WHEN** two Claude Code sessions run in the same project directory at the same time
+- **THEN** each writes to its own `~/.chorus/plugin/<cwd-slug>/<sessionId>/` directory keyed by its distinct session id
+- **AND** neither session's `state.json`, `sessions/`, `pending/`, or `claimed/` files overwrite the other's
+
+#### Scenario: Sub-agent handoff resolves within one session
+
+- **WHEN** the PreToolUse:Task hook writes a pending file and the SubagentStart hook later claims it
+- **THEN** both resolve to the same `<sessionId>` directory (they share the session's top-level Claude Code `session_id`)
+- **AND** the pending → claimed → sessions handoff completes as before the migration
+
+#### Scenario: Cross-hook state lookups resolve to the writer's partition
+
+- **WHEN** the SubagentStart hook writes `session_<agentId>` / `session_<teammateName>` mappings into its session's `state.json`, and later the TeammateIdle, TaskCompleted, or SubagentStop hook reads those mappings back
+- **THEN** the reading hook resolves to the same `<sessionId>` partition as the writing hook (all share the one top-level Claude Code `session_id`)
+- **AND** teammate heartbeats and task auto-checkout continue to function — no lookup silently misses because a reader landed in a different partition than the writer
+
+### Requirement: Session-scoped cleanup
+
+On session end the plugin SHALL remove only the current session's directory (`~/.chorus/plugin/<cwd-slug>/<sessionId>/`), and MUST NOT delete directories belonging to other concurrent sessions of the same project.
+
+#### Scenario: End removes own session directory
+
+- **WHEN** a Claude Code session ends and its session id resolved to a real id
+- **THEN** its `~/.chorus/plugin/<cwd-slug>/<sessionId>/` directory is removed
+- **AND** any sibling session directory under the same `<cwd-slug>/` is left intact
+
+### Requirement: Fail-soft state resolution
+
+Path resolution and session-id acquisition SHALL be fail-soft: any missing input (unset `HOME`, unset or absent session id, unreadable event payload, missing path module) MUST degrade to a safe default and MUST NOT cause a hook to abort or block a development action. A failure to resolve, create, or clean up the state directory MUST at worst leave the session untracked — never fail the underlying user operation.
+
+#### Scenario: Missing session id falls back without failing
+
+- **WHEN** a hook cannot extract a Claude Code session id from its event payload
+- **THEN** state resolves to a stable fallback bucket (a `no-session` directory under the project's `<cwd-slug>`)
+- **AND** the hook still exits successfully and the development action proceeds
+
+#### Scenario: State directory creation failure does not block work
+
+- **WHEN** the global state directory cannot be created (e.g. read-only `$HOME`)
+- **THEN** the hook logs a non-fatal warning and exits 0
+- **AND** the sub-agent spawn, task work, or user prompt it was attached to is not blocked

--- a/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/tasks.md
+++ b/openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/tasks.md
@@ -1,0 +1,17 @@
+# Tasks — move-plugin-state-to-global-chorus
+
+## 1. Shared path module
+- [ ] 1.1 Add `bin/chorus-paths.sh` — global root, `chorus_slug_for_dir`, `CHORUS_STATE_DIR` resolution, `CHORUS_PLUGIN_STATE_ROOT` override, `no-session` fallback. Bash 3.2 safe.
+
+## 2. chorus-api.sh + hook wiring
+- [ ] 2.1 `chorus-api.sh` sources `chorus-paths.sh`; `STATE_DIR`/`STATE_FILE`/`SESSIONS_DIR`/MCP temp files resolve from it.
+- [ ] 2.2 Every STATE_DIR-touching hook extracts `session_id` from stdin and exports `CHORUS_SESSION_ID`; sub-path builders (`pending/`/`claimed/`/`sessions/`) source `chorus-paths.sh`. Set = on-session-start, on-user-prompt, on-pre-spawn-agent, on-subagent-start, on-subagent-stop, **on-teammate-idle, on-task-completed, on-post-verify-task**. Verify the three bolded cross-hook/temp-file hooks resolve to the same partition as the writer.
+
+## 3. Cleanup
+- [ ] 3.1 `on-session-end.sh` removes only the current session dir (guard against wiping the `no-session` bucket); best-effort `rmdir` empty parent.
+
+## 4. Tests
+- [ ] 4.1 Extend `bin/test-syntax.sh` — assert global placement, slug encoding, `no-session` fallback; passes under Bash 3.2.
+
+## 5. Docs
+- [ ] 5.1 Update `docs/chorus-plugin.md` + the two plugin blog posts to the global layout.

--- a/openspec/specs/plugin-local-state/spec.md
+++ b/openspec/specs/plugin-local-state/spec.md
@@ -1,0 +1,74 @@
+# plugin-local-state Specification
+
+## Purpose
+TBD - created by archiving change move-plugin-state-to-global-chorus. Update Purpose after archive.
+## Requirements
+### Requirement: Global plugin state root
+
+The Claude Code plugin SHALL store all of its hook-coordination state under a single user-global root `~/.chorus/plugin/`, and SHALL NOT create a `.chorus/` directory inside the project working directory for new sessions. The global root MUST be physically disjoint from the daemon's top-level `~/.chorus/` files (`daemon.json`, `daemon.pid`, `daemon.log`, `*-sessions.json`) so the two never collide.
+
+#### Scenario: State written to global root, not project dir
+
+- **WHEN** a Claude Code session with the Chorus plugin performs any hook action that persists state (checkin caching, sub-agent session mapping, MCP handshake)
+- **THEN** the resulting files are created under `~/.chorus/plugin/<cwd-slug>/<sessionId>/`
+- **AND** no new `.chorus/` directory is created inside `${CLAUDE_PROJECT_DIR}`
+
+#### Scenario: Daemon files are never touched
+
+- **WHEN** the plugin creates or removes its state directory
+- **THEN** the daemon's `~/.chorus/daemon.json`, `~/.chorus/daemon.pid`, `~/.chorus/daemon.log`, and `~/.chorus/*-sessions.json` are neither read nor modified nor deleted
+
+### Requirement: Readable per-project, per-session partitioning
+
+The plugin SHALL partition state by project and by session using the path `~/.chorus/plugin/<cwd-slug>/<sessionId>/`. The `<cwd-slug>` MUST be a human-readable encoding of the absolute project directory (mirroring Claude Code's own `~/.claude/projects/` encoding — non-alphanumeric characters replaced with `-`), NOT an opaque hash. The `<sessionId>` MUST be the Claude Code session id so that concurrent sessions on the same project occupy distinct directories.
+
+#### Scenario: cwd encoded to a legible slug
+
+- **WHEN** the project directory is `/home/ubuntu/dev/ai-pm`
+- **THEN** the resolved `<cwd-slug>` is `-home-ubuntu-dev-ai-pm`
+- **AND** the slug contains no hash digest
+
+#### Scenario: Concurrent sessions on one project are isolated
+
+- **WHEN** two Claude Code sessions run in the same project directory at the same time
+- **THEN** each writes to its own `~/.chorus/plugin/<cwd-slug>/<sessionId>/` directory keyed by its distinct session id
+- **AND** neither session's `state.json`, `sessions/`, `pending/`, or `claimed/` files overwrite the other's
+
+#### Scenario: Sub-agent handoff resolves within one session
+
+- **WHEN** the PreToolUse:Task hook writes a pending file and the SubagentStart hook later claims it
+- **THEN** both resolve to the same `<sessionId>` directory (they share the session's top-level Claude Code `session_id`)
+- **AND** the pending → claimed → sessions handoff completes as before the migration
+
+#### Scenario: Cross-hook state lookups resolve to the writer's partition
+
+- **WHEN** the SubagentStart hook writes `session_<agentId>` / `session_<teammateName>` mappings into its session's `state.json`, and later the TeammateIdle, TaskCompleted, or SubagentStop hook reads those mappings back
+- **THEN** the reading hook resolves to the same `<sessionId>` partition as the writing hook (all share the one top-level Claude Code `session_id`)
+- **AND** teammate heartbeats and task auto-checkout continue to function — no lookup silently misses because a reader landed in a different partition than the writer
+
+### Requirement: Session-scoped cleanup
+
+On session end the plugin SHALL remove only the current session's directory (`~/.chorus/plugin/<cwd-slug>/<sessionId>/`), and MUST NOT delete directories belonging to other concurrent sessions of the same project.
+
+#### Scenario: End removes own session directory
+
+- **WHEN** a Claude Code session ends and its session id resolved to a real id
+- **THEN** its `~/.chorus/plugin/<cwd-slug>/<sessionId>/` directory is removed
+- **AND** any sibling session directory under the same `<cwd-slug>/` is left intact
+
+### Requirement: Fail-soft state resolution
+
+Path resolution and session-id acquisition SHALL be fail-soft: any missing input (unset `HOME`, unset or absent session id, unreadable event payload, missing path module) MUST degrade to a safe default and MUST NOT cause a hook to abort or block a development action. A failure to resolve, create, or clean up the state directory MUST at worst leave the session untracked — never fail the underlying user operation.
+
+#### Scenario: Missing session id falls back without failing
+
+- **WHEN** a hook cannot extract a Claude Code session id from its event payload
+- **THEN** state resolves to a stable fallback bucket (a `no-session` directory under the project's `<cwd-slug>`)
+- **AND** the hook still exits successfully and the development action proceeds
+
+#### Scenario: State directory creation failure does not block work
+
+- **WHEN** the global state directory cannot be created (e.g. read-only `$HOME`)
+- **THEN** the hook logs a non-fatal warning and exits 0
+- **AND** the sub-agent spawn, task work, or user prompt it was attached to is not blocked
+

--- a/packages/landing/src/content/blog/building-claude-code-plugin-for-agent-teams.md
+++ b/packages/landing/src/content/blog/building-claude-code-plugin-for-agent-teams.md
@@ -415,7 +415,7 @@ Chorus does three things here:
 
 1. Calls the `chorus_checkin()` MCP tool to get the current Agent's identity (role, name, persona), assigned Ideas and Tasks, and unread notifications
 2. Injects the complete checkin result into Claude's context via `additionalContext` — the Agent knows who it is and what to do from the very first turn
-3. Scans the `.chorus/sessions/` directory to list existing Sub-Agent session metadata — this handles the case where a Claude Code session is interrupted and resumed: previous session files may still exist, and the Team Lead needs to know which sessions are still present after recovery
+3. Scans this session's `sessions/` directory (under `~/.chorus/plugin/<cwd-slug>/<sessionId>/`) to list existing Sub-Agent session metadata — this handles the case where a Claude Code session is interrupted and resumed: previous session files may still exist, and the Team Lead needs to know which sessions are still present after recovery
 
 ```bash
 # on-session-start.sh core logic
@@ -440,7 +440,7 @@ Triggered on every user input, so it must be extremely fast (<100ms). Chorus mak
 
 ```bash
 # on-user-prompt.sh — pure local operation, no MCP calls
-# Count json files in .chorus/sessions/
+# Count json files in this session's sessions/ dir (~/.chorus/plugin/<cwd-slug>/<sessionId>/sessions/)
 CONTEXT="[Chorus Plugin Active]
 - Active sub-agent sessions (3): frontend-worker, backend-worker, test-runner"
 ```
@@ -475,9 +475,9 @@ Async + `suppressOutput: true`. Does just one thing: calls `chorus_session_heart
 
 When a Claude Code internal Task is marked complete, Chorus checks whether the task description contains a `chorus:task:<uuid>` tag. If so, it automatically executes `chorus_session_checkout_task`. This is an elegant **metadata bridging** pattern — by embedding a Chorus task UUID in the CC Task description, the two systems' Task lifecycles are linked.
 
-**`SessionEnd` — Clean Up .chorus/ Directory**
+**`SessionEnd` — Clean Up This Session's State Directory**
 
-When the session ends, checks whether all session files have been cleaned up and state.json is empty. If so, deletes the entire `.chorus/` directory, leaving no leftover files.
+When the session ends, it removes this session's own state directory (`~/.chorus/plugin/<cwd-slug>/<sessionId>/`), leaving no leftover files. Because each Claude Code session has its own directory, this delete is unconditional and never races a concurrent session on the same project.
 
 ---
 
@@ -491,7 +491,7 @@ Now for the main topic — how the Chorus plugin uses the above mechanisms to so
 Team Lead calls Task tool to spawn Sub-Agent
   │
   ├─ [PreToolUse:Task] on-pre-spawn-agent.sh
-  │    Write .chorus/pending/<name> file (capture agent name)
+  │    Write <sessionId>/pending/<name> file (capture agent name)
   │
   ├─ [SubagentStart] on-subagent-start.sh    ← Core
   │    Claim pending file (atomic mv, handles concurrency)
@@ -517,12 +517,12 @@ Team Lead calls Task tool to spawn Sub-Agent
        Query and display newly unblocked tasks
 ```
 
-### 5.2 The `.chorus/` Directory: The Bridge Connecting Everything
+### 5.2 The State Directory: The Bridge Connecting Everything
 
-We've mentioned "shared filesystem" multiple times — let's expand on this. The Chorus plugin maintains a `.chorus/` directory (gitignored) at the project root, serving as the information hub between the Team Lead, Sub-Agents, and all hooks:
+We've mentioned "shared filesystem" multiple times — let's expand on this. The Chorus plugin maintains a per-session state directory, serving as the information hub between the Team Lead, Sub-Agents, and all hooks. It lives under a single **global** root — `~/.chorus/plugin/` (aligned with the Chorus daemon's `~/.chorus/` convention) — partitioned by a readable project slug and the Claude Code session id, so there's no per-project `.chorus/` folder to create or gitignore:
 
 ```
-.chorus/                              # Plugin runtime state (gitignored)
+~/.chorus/plugin/<cwd-slug>/<sessionId>/   # <cwd-slug> = project dir, '/'→'-' (like ~/.claude/projects)
 ├── state.json                        # Global state KV store
 ├── state.json.lock                   # flock exclusive lock file
 ├── sessions/                         # Sub-Agent session metadata (for hook state lookup)
@@ -534,6 +534,8 @@ We've mentioned "shared filesystem" multiple times — let's expand on this. The
 └── claimed/                          # Files claimed by SubagentStart
     └── <agent-id>
 ```
+
+A single shared `bin/chorus-paths.sh` module resolves this path for `chorus-api.sh` and every hook, so the layout is defined in exactly one place. Each hook lifts the Claude Code `session_id` (identical across the whole session — sub-agents differ only by `agent_id`) from its stdin event and exports it, so every hook in a session resolves to the same `<sessionId>` directory.
 
 #### Core: `state.json` — Cross-Hook State Sharing
 
@@ -588,8 +590,8 @@ The solution is a relay between two hooks:
 
 ```
 Timeline:
-  T1  PreToolUse:Task fires → write .chorus/pending/frontend-worker
-  T2  PreToolUse:Task fires → write .chorus/pending/backend-worker
+  T1  PreToolUse:Task fires → write <sessionId>/pending/frontend-worker
+  T2  PreToolUse:Task fires → write <sessionId>/pending/backend-worker
   T3  SubagentStart(agent_id=a0e) fires → mv pending/frontend-worker → claimed/a0e ✓
   T4  SubagentStart(agent_id=b1f) fires → mv pending/backend-worker → claimed/b1f ✓
   T4' SubagentStart(agent_id=c2g) fires → mv pending/frontend-worker → fails (already claimed by a0e)
@@ -606,17 +608,17 @@ Session files now contain only minimal metadata (sessionUuid, agentId, agentName
 #### Lifecycle: Creation to Cleanup
 
 ```
-SessionStart  → mkdir -p .chorus/ (if not exists)
-PreToolUse    → write .chorus/pending/<name>
+SessionStart  → resolve ~/.chorus/plugin/<cwd-slug>/<sessionId>/ (created lazily)
+PreToolUse    → write <sessionId>/pending/<name>
 SubagentStart → mv pending → claimed, write sessions/<name>.json (metadata only),
                 inject workflow via additionalContext → Sub-Agent, update state.json
 TeammateIdle  → read state.json (lookup session_uuid), no writes
 TaskCompleted → read state.json (lookup session_uuid), no writes
 SubagentStop  → delete sessions/<name>.json, delete claimed/<agent_id>, clean state.json entries
-SessionEnd    → if sessions/ is empty and state.json is empty → rm -rf .chorus/
+SessionEnd    → rm -rf this session's dir (~/.chorus/plugin/<cwd-slug>/<sessionId>/)
 ```
 
-The entire directory's lifecycle matches the Claude Code session — created at start, cleaned up at end, leaving no trace.
+Because the directory is keyed by the Claude Code session id, its lifecycle matches the session exactly — resolved at start, removed at end — and concurrent sessions on the same project each get their own directory, so `SessionEnd` can delete its own without racing siblings. Nothing is left in the project tree.
 
 ### 5.3 The Core Challenge: Sub-Agent Context Injection
 
@@ -731,7 +733,7 @@ SubagentStart hook  →  additionalContext  →  Sub-Agent's context
 
 ### Pattern 2: Filesystem for Cross-Hook State (Not Sub-Agent Communication)
 
-The shared filesystem (`.chorus/` directory) is valuable for **hook-to-hook** state passing (e.g., `pending/` files relay agent names from `PreToolUse` to `SubagentStart`), but should not be the primary mechanism for Sub-Agent context injection. Use `SubagentStart`'s `additionalContext` for that instead.
+The shared filesystem (the plugin's per-session state directory under `~/.chorus/plugin/`) is valuable for **hook-to-hook** state passing (e.g., `pending/` files relay agent names from `PreToolUse` to `SubagentStart`), but should not be the primary mechanism for Sub-Agent context injection. Use `SubagentStart`'s `additionalContext` for that instead.
 
 ### Pattern 3: PreToolUse Captures + SubagentStart Executes
 

--- a/packages/landing/src/content/blog/claude-code-vs-codex-plugin-systems.md
+++ b/packages/landing/src/content/blog/claude-code-vs-codex-plugin-systems.md
@@ -135,12 +135,12 @@ Claude Code's hook event list is thorough:
 |---|---|
 | `SessionStart` | Call `chorus_checkin`, inject identity and pending work into context |
 | `UserPromptSubmit` | Lightweight status reminders (no network calls) |
-| `PreToolUse:Task` | Capture the subagent's name, write to `.chorus/pending/<name>` |
+| `PreToolUse:Task` | Capture the subagent's name, write to the session's `pending/<name>` (under global `~/.chorus/plugin/<cwd-slug>/<sessionId>/`) |
 | `SubagentStart` | **Core**: create or reuse a session, inject the UUID and workflow into the subagent |
 | `TeammateIdle` | Send a session heartbeat to keep it alive |
 | `TaskCompleted` | Auto-checkout by task tag |
 | `SubagentStop` | Close the session, fetch newly-unblocked downstream tasks and surface them to the Team Lead |
-| `SessionEnd` | Clean up `.chorus/` |
+| `SessionEnd` | Clean up this session's state directory |
 
 The most important one is `SubagentStart`: before the subagent actually starts working, the plugin can create the session and inject the UUID directly into its context. Observability becomes something the harness guarantees, rather than something the agent has to remember to report via MCP.
 

--- a/packages/landing/src/content/blog/zh-building-claude-code-plugin-for-agent-teams.md
+++ b/packages/landing/src/content/blog/zh-building-claude-code-plugin-for-agent-teams.md
@@ -415,7 +415,7 @@ Chorus 在这里做三件事：
 
 1. 调用 `chorus_checkin()` MCP 工具，获取当前 Agent 的身份（角色、名称、人格）、已分配的 Idea 和 Task、未读通知
 2. 将完整的 checkin 结果通过 `additionalContext` 注入到 Claude 的上下文中——Agent 一启动就知道自己是谁、该做什么
-3. 扫描 `.chorus/sessions/` 目录，列出已有的 Sub-Agent session 元数据——这是为了处理 Claude Code 会话中断后恢复的情况：上次的 session 文件可能还在，Team Lead 恢复后需要知道哪些 session 仍然存在
+3. 扫描本会话的 `sessions/` 目录（位于 `~/.chorus/plugin/<cwd-slug>/<sessionId>/` 下），列出已有的 Sub-Agent session 元数据——这是为了处理 Claude Code 会话中断后恢复的情况：上次的 session 文件可能还在，Team Lead 恢复后需要知道哪些 session 仍然存在
 
 ```bash
 # on-session-start.sh 核心逻辑
@@ -440,7 +440,7 @@ Do NOT call chorus_create_session for sub-agents."
 
 ```bash
 # on-user-prompt.sh — 纯本地操作，不调 MCP
-# 统计 .chorus/sessions/ 下的 json 文件数量
+# 统计本会话 sessions/ 目录下的 json 文件数量（~/.chorus/plugin/<cwd-slug>/<sessionId>/sessions/）
 CONTEXT="[Chorus Plugin Active]
 - Active sub-agent sessions (3): frontend-worker, backend-worker, test-runner"
 ```
@@ -475,9 +475,9 @@ Chorus 注册了 3 个 `PreToolUse` Hook，分别匹配不同的工具：
 
 当 Claude Code 内部的 Task 标记完成时，Chorus 检查 task 描述中是否包含 `chorus:task:<uuid>` 标签。如果有，自动执行 `chorus_session_checkout_task`。这是一个优雅的**元数据桥接**模式——通过在 CC Task 描述中嵌入 Chorus task UUID，让两个系统的 Task 生命周期联动。
 
-**`SessionEnd` — 清理 .chorus/ 目录**
+**`SessionEnd` — 清理本会话的状态目录**
 
-会话结束时，检查是否所有 session 文件都已清理、state.json 是否为空。如果是，删除整个 `.chorus/` 目录，不留垃圾文件。
+会话结束时，删除本会话自己的状态目录（`~/.chorus/plugin/<cwd-slug>/<sessionId>/`），不留垃圾文件。由于每个 Claude Code 会话各有独立目录，这个删除是无条件的，也永远不会和同项目的并发会话相互干扰。
 
 ---
 
@@ -491,7 +491,7 @@ Chorus 注册了 3 个 `PreToolUse` Hook，分别匹配不同的工具：
 Team Lead 调用 Task 工具 spawn Sub-Agent
   │
   ├─ [PreToolUse:Task] on-pre-spawn-agent.sh
-  │    写入 .chorus/pending/<name> 文件（捕获 agent name）
+  │    写入 <sessionId>/pending/<name> 文件（捕获 agent name）
   │
   ├─ [SubagentStart] on-subagent-start.sh    ← 核心
   │    认领 pending 文件（原子 mv，处理并发）
@@ -517,12 +517,12 @@ Team Lead 调用 Task 工具 spawn Sub-Agent
        查询并展示新解除阻塞的 task
 ```
 
-### 5.2 `.chorus/` 目录：连接一切的桥梁
+### 5.2 状态目录：连接一切的桥梁
 
-前面多次提到"共享文件系统"，现在展开说。Chorus 插件在项目根目录下维护一个 `.chorus/` 目录（gitignored），它是 Team Lead、Sub-Agent、和所有 Hook 之间的信息枢纽：
+前面多次提到"共享文件系统"，现在展开说。Chorus 插件维护一个按会话隔离的状态目录，它是 Team Lead、Sub-Agent、和所有 Hook 之间的信息枢纽。它放在单一的**全局**根下——`~/.chorus/plugin/`（与 Chorus daemon 的 `~/.chorus/` 约定对齐）——再按可读的项目 slug 和 Claude Code 会话 id 分区，因此不需要在每个项目里创建或 gitignore 一个 `.chorus/` 目录：
 
 ```
-.chorus/                              # 插件运行时状态（gitignored）
+~/.chorus/plugin/<cwd-slug>/<sessionId>/   # <cwd-slug> = 项目目录，'/'→'-'（仿 ~/.claude/projects）
 ├── state.json                        # 全局状态 KV 存储
 ├── state.json.lock                   # flock 排他锁文件
 ├── sessions/                         # Sub-Agent session 元数据（供 Hook 状态查询）
@@ -534,6 +534,8 @@ Team Lead 调用 Task 工具 spawn Sub-Agent
 └── claimed/                          # SubagentStart 认领后的文件
     └── <agent-id>
 ```
+
+一个共享的 `bin/chorus-paths.sh` 模块为 `chorus-api.sh` 和所有 Hook 解析这个路径，布局只在一处定义。每个 Hook 从 stdin 事件里取出 Claude Code 的 `session_id`（整个会话内一致——子代理只靠 `agent_id` 区分）并 export，于是同一会话的所有 Hook 都解析到同一个 `<sessionId>` 目录。
 
 #### 核心：`state.json` — 跨 Hook 的状态共享
 
@@ -588,8 +590,8 @@ state_set() {
 
 ```
 时间线：
-  T1  PreToolUse:Task 触发 → 写 .chorus/pending/frontend-worker
-  T2  PreToolUse:Task 触发 → 写 .chorus/pending/backend-worker
+  T1  PreToolUse:Task 触发 → 写 <sessionId>/pending/frontend-worker
+  T2  PreToolUse:Task 触发 → 写 <sessionId>/pending/backend-worker
   T3  SubagentStart(agent_id=a0e) 触发 → mv pending/frontend-worker → claimed/a0e ✓
   T4  SubagentStart(agent_id=b1f) 触发 → mv pending/backend-worker → claimed/b1f ✓
   T4' SubagentStart(agent_id=c2g) 触发 → mv pending/frontend-worker → 失败（已被 a0e 认领）
@@ -606,17 +608,17 @@ Session 文件现在只包含最小元数据（sessionUuid、agentId、agentName
 #### 生命周期：创建到清理
 
 ```
-SessionStart  → mkdir -p .chorus/（如果不存在）
-PreToolUse    → 写 .chorus/pending/<name>
+SessionStart  → 解析 ~/.chorus/plugin/<cwd-slug>/<sessionId>/（惰性创建）
+PreToolUse    → 写 <sessionId>/pending/<name>
 SubagentStart → mv pending → claimed，写 sessions/<name>.json（仅元数据），
                 通过 additionalContext 注入工作流 → Sub-Agent，更新 state.json
 TeammateIdle  → 读 state.json（查 session_uuid），无写入
 TaskCompleted → 读 state.json（查 session_uuid），无写入
 SubagentStop  → 删 sessions/<name>.json，删 claimed/<agent_id>，清 state.json 条目
-SessionEnd    → 如果 sessions/ 为空且 state.json 为空 → rm -rf .chorus/
+SessionEnd    → rm -rf 本会话目录（~/.chorus/plugin/<cwd-slug>/<sessionId>/）
 ```
 
-整个目录的生命周期和 Claude Code session 一致——开始时创建，结束时清理，不留痕迹。
+因为目录以 Claude Code 会话 id 为 key，它的生命周期和会话完全一致——开始时解析、结束时删除——而同项目的并发会话各有独立目录，所以 `SessionEnd` 删自己那份时永远不会和兄弟会话相互干扰，项目目录里也不留痕迹。
 
 ### 5.3 核心难题：Sub-Agent 的上下文注入
 
@@ -731,7 +733,7 @@ SubagentStart Hook  →  additionalContext  →  Sub-Agent 的上下文
 
 ### 模式 2：文件系统用于 Hook 间状态传递（而非 Sub-Agent 通信）
 
-共享文件系统（`.chorus/` 目录）的价值在于 **Hook 到 Hook** 的状态传递（如 `pending/` 文件从 `PreToolUse` 传递 agent 名称到 `SubagentStart`），但不应该作为 Sub-Agent 上下文注入的主要机制。上下文注入应使用 `SubagentStart` 的 `additionalContext`。
+共享文件系统（插件在 `~/.chorus/plugin/` 下按会话隔离的状态目录）的价值在于 **Hook 到 Hook** 的状态传递（如 `pending/` 文件从 `PreToolUse` 传递 agent 名称到 `SubagentStart`），但不应该作为 Sub-Agent 上下文注入的主要机制。上下文注入应使用 `SubagentStart` 的 `additionalContext`。
 
 ### 模式 3：PreToolUse 捕获 + SubagentStart 执行
 

--- a/packages/landing/src/content/blog/zh-claude-code-vs-codex-plugin-systems.md
+++ b/packages/landing/src/content/blog/zh-claude-code-vs-codex-plugin-systems.md
@@ -135,12 +135,12 @@ Claude Code 这边钩子事件很全:
 |---|---|
 | `SessionStart` | 调 `chorus_checkin`，把身份和待办注入上下文 |
 | `UserPromptSubmit` | 轻量状态提醒（不发网络请求） |
-| `PreToolUse:Task` | 捕获子代理名字，写到 `.chorus/pending/<name>` |
+| `PreToolUse:Task` | 捕获子代理名字，写到会话的 `pending/<name>`（在全局 `~/.chorus/plugin/<cwd-slug>/<sessionId>/` 下） |
 | `SubagentStart` | **核心**: 创建或复用 session、把 session UUID 和工作流指令注入子代理 |
 | `TeammateIdle` | 发 session heartbeat 保活 |
 | `TaskCompleted` | 按 task 标签自动 checkout |
 | `SubagentStop` | 关 session、查询下游解锁的任务反馈给 Team Lead |
-| `SessionEnd` | 清理 `.chorus/` 目录 |
+| `SessionEnd` | 清理本会话的状态目录 |
 
 里面最关键的是 `SubagentStart`: 在子代理真正开始工作之前，插件可以先建好 session、把 UUID 直接写进它的上下文。可观测性由 harness 保证，不用让 agent 自己记得去调 MCP 汇报。
 

--- a/public/chorus-plugin/bin/chorus-api.sh
+++ b/public/chorus-plugin/bin/chorus-api.sh
@@ -3,18 +3,32 @@
 # Used by hook scripts to communicate with Chorus backend.
 #
 # Environment variables:
-#   CHORUS_URL      — Chorus base URL (e.g., http://localhost:8637)
-#   CHORUS_API_KEY  — Agent API key (cho_xxx)
+#   CHORUS_URL         — Chorus base URL (e.g., http://localhost:8637)
+#   CHORUS_API_KEY     — Agent API key (cho_xxx)
+#   CHORUS_SESSION_ID  — Claude Code session id (exported by the calling hook);
+#                        selects the per-session state partition.
 #
-# State file: $CLAUDE_PROJECT_DIR/.chorus/state.json (gitignored)
+# State dir: ~/.chorus/plugin/<cwd-slug>/<sessionId>/  (global, gitignore-free)
+#   resolved by chorus-paths.sh. Falls back to $CLAUDE_PROJECT_DIR/.chorus only
+#   if that module can't be sourced (fail-soft — never abort).
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # ===== Configuration =====
 
 CHORUS_URL="${CHORUS_URL:-}"
 CHORUS_API_KEY="${CHORUS_API_KEY:-}"
-STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus"
+
+# Resolve the global per-session state dir via the shared path module.
+# Fail-soft: if the module is missing/unreadable, degrade to the old
+# per-project layout rather than crashing.
+# shellcheck source=chorus-paths.sh
+if [ -f "${SCRIPT_DIR}/chorus-paths.sh" ]; then
+  . "${SCRIPT_DIR}/chorus-paths.sh" 2>/dev/null || true
+fi
+STATE_DIR="${CHORUS_STATE_DIR:-${CLAUDE_PROJECT_DIR:-.}/.chorus}"
 STATE_FILE="${STATE_DIR}/state.json"
 
 # ===== Helpers =====

--- a/public/chorus-plugin/bin/chorus-paths.sh
+++ b/public/chorus-plugin/bin/chorus-paths.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# chorus-paths.sh — single source of truth for the Claude Code plugin's
+# GLOBAL local-state layout. Sourced by chorus-api.sh and every hook that
+# touches state. NOT an executable subcommand — sourcing it defines the
+# resolved path variables in the caller's shell.
+#
+# Layout (aligned with the daemon's global ~/.chorus/ convention):
+#
+#   ~/.chorus/plugin/<cwd-slug>/<sessionId>/
+#     ├── state.json           (+ state.json.lock)
+#     ├── sessions/            <agentName>.json
+#     ├── pending/             PreToolUse:Task -> SubagentStart handoff
+#     ├── claimed/             claimed pending files, keyed by agent_id
+#     └── .mcp_headers.* / .mcp_response.*   MCP handshake temp files
+#
+# Inputs (env):
+#   CHORUS_SESSION_ID          Claude Code session id (from a hook's stdin event).
+#                              When empty, state falls back to a stable
+#                              "<slug>/no-session" bucket so resolution NEVER fails.
+#   CLAUDE_PROJECT_DIR         Project dir; defaults to $PWD.
+#   CHORUS_PLUGIN_STATE_ROOT   Optional override of the global root (used by tests
+#                              to point at a throwaway directory).
+#
+# Outputs (vars set in the caller's shell):
+#   CHORUS_PLUGIN_ROOT         The global root (default ~/.chorus/plugin).
+#   CHORUS_CWD_SLUG            Readable slug for the project dir.
+#   CHORUS_STATE_DIR           The resolved per-session state directory.
+#
+# Design constraints:
+#   - Pure variable assignment + function definitions. Runs no external command
+#     that can make the *sourcing* shell exit non-zero (the slug helper is only
+#     invoked to compute CHORUS_CWD_SLUG, and `sed` on a here-string cannot fail
+#     the caller under `set -e` in the way a pipeline might — we keep it simple).
+#   - Bash 3.2 compatible (macOS /bin/bash): no ${var//search/replace} global
+#     substitution, no associative arrays, no `realpath`, no `readarray`.
+#   - The resolved CHORUS_STATE_DIR is NEVER empty.
+
+# --- 1. Global root (honor test override) --------------------------------
+CHORUS_PLUGIN_ROOT="${CHORUS_PLUGIN_STATE_ROOT:-${HOME:-/tmp}/.chorus/plugin}"
+
+# --- 2. cwd -> readable slug ---------------------------------------------
+# Mirrors Claude Code's own ~/.claude/projects/<-abs-path> encoding:
+# make the path absolute, strip trailing slashes, then replace every
+# non-alphanumeric character with '-'. "/home/ubuntu/dev/ai-pm" becomes
+# "-home-ubuntu-dev-ai-pm". This is a legible directory name, not a hash.
+chorus_slug_for_dir() {
+  local _csd_dir="${1:-$PWD}"
+  # Make absolute without depending on realpath.
+  case "$_csd_dir" in
+    /*) : ;;
+    *)  _csd_dir="$PWD/$_csd_dir" ;;
+  esac
+  printf '%s' "$_csd_dir" | sed -e 's#/*$##' -e 's#[^A-Za-z0-9]#-#g'
+}
+
+CHORUS_CWD_SLUG="$(chorus_slug_for_dir "${CLAUDE_PROJECT_DIR:-$PWD}")"
+
+# --- 3. Per-session partition --------------------------------------------
+# Every Claude Code hook event carries the same top-level session_id (sub-agents
+# are distinguished by a separate agent_id), so all hooks in one session resolve
+# to the same <sessionId> dir. When no session id is available (e.g. a hook with
+# no stdin, or a manual invocation) fall back to a stable shared bucket so the
+# path is always valid and non-empty.
+_chorus_sid="${CHORUS_SESSION_ID:-}"
+if [ -z "$_chorus_sid" ]; then
+  _chorus_sid="no-session"
+fi
+
+CHORUS_STATE_DIR="${CHORUS_PLUGIN_ROOT}/${CHORUS_CWD_SLUG}/${_chorus_sid}"

--- a/public/chorus-plugin/bin/on-post-verify-task.sh
+++ b/public/chorus-plugin/bin/on-post-verify-task.sh
@@ -62,6 +62,11 @@ if [ -z "$EVENT" ]; then
   exit 0
 fi
 
+# Export the CC session id so chorus-api.sh's mcp-tool calls write their handshake
+# temp files under this session's global state partition (not a no-session bucket).
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
 # Extract taskUuid from .tool_input
 TASK_UUID=$(printf '%s' "$EVENT" | jq -r '.tool_input.taskUuid // empty' 2>/dev/null) || true
 

--- a/public/chorus-plugin/bin/on-pre-spawn-agent.sh
+++ b/public/chorus-plugin/bin/on-pre-spawn-agent.sh
@@ -23,6 +23,11 @@ if [ ! -t 0 ]; then
   EVENT=$(cat)
 fi
 
+# Export the CC session id so the pending dir lands in this session's partition —
+# the SubagentStart hook resolves the same <sessionId> and claims from there.
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
 # Try to extract subagent_type and name from the tool input
 AGENT_TYPE=""
 AGENT_NAME=""
@@ -48,8 +53,11 @@ esac
 #
 # CC may internally spawn cleanup agents that bypass PreToolUse:Task —
 # SubagentStart skips those if no pending file matches.
-PENDING_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus/pending"
-mkdir -p "$PENDING_DIR"
+# Resolve the global per-session state dir (fail-soft to old layout).
+# shellcheck source=chorus-paths.sh
+[ -f "${SCRIPT_DIR}/chorus-paths.sh" ] && { . "${SCRIPT_DIR}/chorus-paths.sh" 2>/dev/null || true; }
+PENDING_DIR="${CHORUS_STATE_DIR:-${CLAUDE_PROJECT_DIR:-.}/.chorus}/pending"
+mkdir -p "$PENDING_DIR" 2>/dev/null || true
 
 # Use agent name as filename; fall back to timestamp-based unique name
 PENDING_NAME="${AGENT_NAME:-unknown-$(date +%s%N)}"

--- a/public/chorus-plugin/bin/on-session-end.sh
+++ b/public/chorus-plugin/bin/on-session-end.sh
@@ -1,39 +1,52 @@
 #!/usr/bin/env bash
 # on-session-end.sh — SessionEnd hook
 # Fires when Claude Code session ends.
-# Cleans up the .chorus/ directory if all sessions are closed and state is empty.
+# Removes THIS session's global state directory
+# (~/.chorus/plugin/<cwd-slug>/<sessionId>/). Because state is now partitioned
+# per session, we can delete our own directory unconditionally without racing
+# sibling concurrent sessions of the same project.
 
 set -euo pipefail
 
-STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Read event JSON from stdin to lift the session id.
+EVENT=""
+if [ ! -t 0 ]; then
+  EVENT=$(cat)
+fi
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
+# Resolve this session's global state dir (fail-soft to old per-project layout).
+# shellcheck source=chorus-paths.sh
+if [ -f "${SCRIPT_DIR}/chorus-paths.sh" ]; then
+  . "${SCRIPT_DIR}/chorus-paths.sh" 2>/dev/null || true
+fi
+STATE_DIR="${CHORUS_STATE_DIR:-${CLAUDE_PROJECT_DIR:-.}/.chorus}"
 
 # Nothing to clean up
 if [ ! -d "$STATE_DIR" ]; then
   exit 0
 fi
 
-# Safety check: don't delete if there are still active session files
-SESSIONS_DIR="${STATE_DIR}/sessions"
-if [ -d "$SESSIONS_DIR" ]; then
-  REMAINING=0
-  for f in "$SESSIONS_DIR"/*.json; do
-    [ -f "$f" ] || continue
-    REMAINING=$((REMAINING + 1))
-  done
-  if [ "$REMAINING" -gt 0 ]; then
+# Guard: never delete the shared "no-session" fallback bucket — a degenerate
+# session (no session id on stdin) must not wipe state that a concurrent,
+# properly-identified session might also be using. Only self-delete when we
+# resolved a real per-session directory.
+case "${CHORUS_SESSION_ID:-}" in
+  ""|no-session)
     exit 0
-  fi
+    ;;
+esac
+
+# Remove only this session's directory. Session-scoped, so no sibling guard needed.
+rm -rf "$STATE_DIR" 2>/dev/null || true
+
+# Best-effort: remove the now-possibly-empty <cwd-slug>/ parent. Fails (and is
+# ignored) if other concurrent sessions of this project still have directories.
+if [ -n "${CHORUS_PLUGIN_ROOT:-}" ] && [ -n "${CHORUS_CWD_SLUG:-}" ]; then
+  rmdir "${CHORUS_PLUGIN_ROOT}/${CHORUS_CWD_SLUG}" 2>/dev/null || true
 fi
 
-# Safety check: don't delete if state.json has meaningful content
-if [ -f "${STATE_DIR}/state.json" ]; then
-  if command -v jq &>/dev/null; then
-    KEY_COUNT=$(jq 'length' "${STATE_DIR}/state.json" 2>/dev/null) || KEY_COUNT=0
-    if [ "$KEY_COUNT" -gt 0 ]; then
-      exit 0
-    fi
-  fi
-fi
-
-# All clear — remove .chorus/ directory
-rm -rf "$STATE_DIR"
+exit 0

--- a/public/chorus-plugin/bin/on-session-start.sh
+++ b/public/chorus-plugin/bin/on-session-start.sh
@@ -17,6 +17,12 @@ if [ ! -t 0 ]; then
   EVENT=$(cat)
 fi
 
+# Extract the Claude Code session id from the event and export it so chorus-api.sh
+# (and any sub-path we build) resolves to this session's global state partition.
+# Fail-soft: an absent id just falls back to the shared "no-session" bucket.
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
 # Check if Chorus environment is configured
 if [ -z "${CHORUS_URL:-}" ] || [ -z "${CHORUS_API_KEY:-}" ]; then
   "$API" hook-output \

--- a/public/chorus-plugin/bin/on-subagent-start.sh
+++ b/public/chorus-plugin/bin/on-subagent-start.sh
@@ -35,6 +35,16 @@ if [ -z "$EVENT" ]; then
   exit 0
 fi
 
+# Export the CC session id (same for every hook in this session) so state and
+# the pending/claimed/sessions dirs resolve to this session's global partition.
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
+# Resolve the global per-session state dir once (fail-soft to the old layout).
+# shellcheck source=chorus-paths.sh
+[ -f "${SCRIPT_DIR}/chorus-paths.sh" ] && { . "${SCRIPT_DIR}/chorus-paths.sh" 2>/dev/null || true; }
+CHORUS_STATE_DIR="${CHORUS_STATE_DIR:-${CLAUDE_PROJECT_DIR:-.}/.chorus}"
+
 # Extract agent info from event
 # Note: SubagentStart only provides agent_id and agent_type — NOT the name
 # from the Task tool call. The name is captured by on-pre-spawn-agent.sh
@@ -63,9 +73,9 @@ fi
 #
 # If no pending file exists, this is an internal/cleanup agent → skip.
 AGENT_NAME=""
-PENDING_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus/pending"
-CLAIMED_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus/claimed"
-mkdir -p "$CLAIMED_DIR"
+PENDING_DIR="${CHORUS_STATE_DIR}/pending"
+CLAIMED_DIR="${CHORUS_STATE_DIR}/claimed"
+mkdir -p "$CLAIMED_DIR" 2>/dev/null || true
 
 CLAIMED_FILE=""
 
@@ -178,8 +188,8 @@ fi
 "$API" state-set "name_for_agent_${AGENT_ID}" "$SESSION_NAME"
 
 # === Session file: minimal metadata for other hooks (TeammateIdle, SubagentStop) ===
-SESSIONS_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus/sessions"
-mkdir -p "$SESSIONS_DIR"
+SESSIONS_DIR="${CHORUS_STATE_DIR}/sessions"
+mkdir -p "$SESSIONS_DIR" 2>/dev/null || true
 
 cat > "${SESSIONS_DIR}/${SESSION_NAME}.json" <<SESSIONEOF
 {

--- a/public/chorus-plugin/bin/on-subagent-stop.sh
+++ b/public/chorus-plugin/bin/on-subagent-stop.sh
@@ -29,6 +29,14 @@ if [ -z "$EVENT" ]; then
   exit 0
 fi
 
+# Export the CC session id so state-get / sessions / claimed resolve to the same
+# global partition that on-subagent-start wrote to (cross-hook lookup must match).
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+# shellcheck source=chorus-paths.sh
+[ -f "${SCRIPT_DIR}/chorus-paths.sh" ] && { . "${SCRIPT_DIR}/chorus-paths.sh" 2>/dev/null || true; }
+CHORUS_STATE_DIR="${CHORUS_STATE_DIR:-${CLAUDE_PROJECT_DIR:-.}/.chorus}"
+
 # Extract agent ID from event
 # Note: SubagentStop only provides agent_id and agent_type — NOT the name.
 # We look up the name from state (stored by SubagentStart).
@@ -84,13 +92,13 @@ if [ -n "$AGENT_NAME" ]; then
 fi
 
 # Clean up session file
-SESSIONS_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus/sessions"
+SESSIONS_DIR="${CHORUS_STATE_DIR}/sessions"
 if [ -n "$AGENT_NAME" ] && [ -f "${SESSIONS_DIR}/${AGENT_NAME}.json" ]; then
   rm -f "${SESSIONS_DIR}/${AGENT_NAME}.json"
 fi
 
 # Clean up claimed file (written by SubagentStart)
-CLAIMED_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus/claimed"
+CLAIMED_DIR="${CHORUS_STATE_DIR}/claimed"
 if [ -n "$AGENT_ID" ] && [ -f "${CLAIMED_DIR}/${AGENT_ID}" ]; then
   rm -f "${CLAIMED_DIR}/${AGENT_ID}"
 fi

--- a/public/chorus-plugin/bin/on-task-completed.sh
+++ b/public/chorus-plugin/bin/on-task-completed.sh
@@ -26,6 +26,12 @@ if [ -z "$EVENT" ]; then
   exit 0
 fi
 
+# Export the CC session id so chorus-api.sh's state-get resolves to the SAME
+# <sessionId> partition on-subagent-start wrote the session_<agentId> mapping to.
+# Without this the lookup would miss and TaskCompleted auto-checkout would stop.
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
 # Extract task info
 TASK_DESCRIPTION=$(echo "$EVENT" | jq -r '.task_description // .taskDescription // .description // empty' 2>/dev/null) || true
 TASK_SUBJECT=$(echo "$EVENT" | jq -r '.task_subject // .taskSubject // .subject // empty' 2>/dev/null) || true

--- a/public/chorus-plugin/bin/on-teammate-idle.sh
+++ b/public/chorus-plugin/bin/on-teammate-idle.sh
@@ -25,6 +25,12 @@ if [ -z "$EVENT" ]; then
   exit 0
 fi
 
+# Export the CC session id so chorus-api.sh's state-get resolves to the SAME
+# <sessionId> partition on-subagent-start wrote the session_<name> mapping to.
+# Without this the lookup would miss and teammate heartbeats would silently stop.
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
 # Extract teammate info from event
 # TeammateIdle provides teammate_name (unlike SubagentStart/Stop which don't)
 TEAMMATE_NAME=$(echo "$EVENT" | jq -r '.teammate_name // .teammateName // empty' 2>/dev/null) || true

--- a/public/chorus-plugin/bin/on-user-prompt.sh
+++ b/public/chorus-plugin/bin/on-user-prompt.sh
@@ -9,13 +9,25 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.chorus"
-SESSIONS_DIR="${STATE_DIR}/sessions"
 
 # Skip entirely if Chorus is not configured
 if [ -z "${CHORUS_URL:-}" ] || [ -z "${CHORUS_API_KEY:-}" ]; then
   exit 0
 fi
+
+# Read stdin only to lift the session id (no MCP, no network — stays fast).
+EVENT=""
+if [ ! -t 0 ]; then
+  EVENT=$(cat)
+fi
+CHORUS_SESSION_ID=$(printf '%s' "$EVENT" | jq -r '.session_id // .sessionId // empty' 2>/dev/null) || true
+export CHORUS_SESSION_ID
+
+# Resolve this session's global state dir (fail-soft to the old layout).
+# shellcheck source=chorus-paths.sh
+[ -f "${SCRIPT_DIR}/chorus-paths.sh" ] && { . "${SCRIPT_DIR}/chorus-paths.sh" 2>/dev/null || true; }
+STATE_DIR="${CHORUS_STATE_DIR:-${CLAUDE_PROJECT_DIR:-.}/.chorus}"
+SESSIONS_DIR="${STATE_DIR}/sessions"
 
 # Count active session files (fast local check)
 SESSION_COUNT=0

--- a/public/chorus-plugin/bin/test-syntax.sh
+++ b/public/chorus-plugin/bin/test-syntax.sh
@@ -25,7 +25,11 @@ export CHORUS_API_KEY="cho_test"
 export CLAUDE_PROJECT_DIR="/tmp/chorus-test-$$"
 mkdir -p "$CLAUDE_PROJECT_DIR"
 
-cleanup() { rm -rf "$CLAUDE_PROJECT_DIR"; }
+# Point the plugin's GLOBAL state root at a throwaway dir so this test never
+# writes into the real ~/.chorus. chorus-paths.sh honors this override.
+export CHORUS_PLUGIN_STATE_ROOT="/tmp/chorus-test-$$/global"
+
+cleanup() { rm -rf "$CLAUDE_PROJECT_DIR" "/tmp/chorus-test-$$"; }
 trap cleanup EXIT
 
 # Mock event payloads for each hook type
@@ -80,6 +84,66 @@ run_test "on-session-end.sh"     '{}'
 
 # --- User prompt hook ---
 run_test "on-user-prompt.sh"     '{}'
+
+# ============================================================================
+# Global-state-layout assertions (chorus-paths.sh)
+# ============================================================================
+echo ""
+echo "Global state layout:"
+
+assert_eq() {
+  # assert_eq <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    printf "  PASS  %s\n" "$1"
+    PASS=$((PASS + 1))
+  else
+    printf "  FAIL  %s (expected '%s', got '%s')\n" "$1" "$2" "$3"
+    FAIL=$((FAIL + 1))
+    FAILED="$FAILED assert:$1"
+  fi
+}
+
+assert_true() {
+  # assert_true <label> <condition-cmd...>
+  local _label="$1"; shift
+  if "$@"; then
+    printf "  PASS  %s\n" "$_label"
+    PASS=$((PASS + 1))
+  else
+    printf "  FAIL  %s\n" "$_label"
+    FAIL=$((FAIL + 1))
+    FAILED="$FAILED assert:$_label"
+  fi
+}
+
+# 1. chorus_slug_for_dir encodes an absolute path to a readable slug (not a hash).
+SLUG_OUT="$( . "$DIR/chorus-paths.sh" 2>/dev/null; chorus_slug_for_dir "/home/ubuntu/dev/ai-pm" )"
+assert_eq "slug encoding /home/ubuntu/dev/ai-pm" "-home-ubuntu-dev-ai-pm" "$SLUG_OUT"
+
+# 2. With a session id, CHORUS_STATE_DIR resolves under the (overridden) global
+#    root at <root>/<slug>/<sessionId> — NOT under $CLAUDE_PROJECT_DIR/.chorus.
+STATE_WITH_SID="$( export CHORUS_SESSION_ID="sess-xyz"; . "$DIR/chorus-paths.sh" 2>/dev/null; printf '%s' "$CHORUS_STATE_DIR" )"
+EXPECT_SLUG="$( . "$DIR/chorus-paths.sh" 2>/dev/null; chorus_slug_for_dir "$CLAUDE_PROJECT_DIR" )"
+assert_eq "state dir under global root/<slug>/<sessionId>" \
+  "${CHORUS_PLUGIN_STATE_ROOT}/${EXPECT_SLUG}/sess-xyz" "$STATE_WITH_SID"
+case "$STATE_WITH_SID" in
+  *"/.chorus"*) assert_true "state dir is NOT the per-project .chorus" false ;;
+  *)            assert_true "state dir is NOT the per-project .chorus" true ;;
+esac
+
+# 3. Missing session id falls back to <slug>/no-session (never empty).
+STATE_NO_SID="$( unset CHORUS_SESSION_ID; . "$DIR/chorus-paths.sh" 2>/dev/null; printf '%s' "$CHORUS_STATE_DIR" )"
+assert_eq "no session id -> <slug>/no-session" \
+  "${CHORUS_PLUGIN_STATE_ROOT}/${EXPECT_SLUG}/no-session" "$STATE_NO_SID"
+
+# 4. A hook that writes state (on-pre-spawn-agent) lands its pending file under
+#    the global root, and does NOT create a .chorus/ in the project dir.
+printf '%s' '{"session_id":"sess-place","tool_input":{"subagent_type":"general-purpose","name":"placer"}}' \
+  | "$BASH" "$DIR/on-pre-spawn-agent.sh" >/dev/null 2>&1 || true
+assert_true "pending file written under global root" \
+  test -f "${CHORUS_PLUGIN_STATE_ROOT}/${EXPECT_SLUG}/sess-place/pending/placer"
+assert_true "no .chorus/ created in project dir" \
+  test ! -d "${CLAUDE_PROJECT_DIR}/.chorus"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- Moves the Claude Code plugin's hook coordination state from a per-project `${CLAUDE_PROJECT_DIR}/.chorus/` folder to the global `~/.chorus/plugin/<cwd-slug>/<sessionId>/` layout, aligning with the daemon's `~/.chorus/` convention — no more per-project `.chorus/` to create or gitignore.
- That folder only ever held hook-to-hook scratchpad (session mappings, cached owner/permissions, pending/claimed/sessions handoff, MCP temp files) — **not** credentials, **not** a project↔dir binding (project scoping is server-side via `X-Chorus-Project` / explicit `projectUuid`). So this is a pure relocation with no association logic lost.
- New shared `bin/chorus-paths.sh` is the single source of truth: readable cwd slug (`/`→`-`, mirrors `~/.claude/projects/`, **not** a hash), per-session partition, `no-session` fallback, `CHORUS_PLUGIN_STATE_ROOT` test override.
- All **8** STATE_DIR-touching hooks source it and thread the CC `session_id` via `CHORUS_SESSION_ID`. `on-session-end.sh` now removes only its own session dir. Everything is **fail-soft** — no path/session-id/mkdir failure can abort a hook or block development (owner's hard constraint).
- Only the Claude Code plugin is affected; Codex/OpenClaw/Kiro write nothing to disk.

## Changed files
| File | Change |
|------|--------|
| `public/chorus-plugin/bin/chorus-paths.sh` | **NEW** — single source of truth for the global layout |
| `public/chorus-plugin/bin/chorus-api.sh` | Resolve STATE_DIR/STATE_FILE/SESSIONS_DIR/MCP-temp from chorus-paths.sh; fail-soft fallback |
| `bin/on-session-start.sh`, `on-user-prompt.sh`, `on-pre-spawn-agent.sh`, `on-subagent-start.sh`, `on-subagent-stop.sh` | Export `CHORUS_SESSION_ID`; build pending/claimed/sessions off `$CHORUS_STATE_DIR` |
| `bin/on-teammate-idle.sh`, `on-task-completed.sh`, `on-post-verify-task.sh` | Export `CHORUS_SESSION_ID` — cross-hook `state-get`/MCP-temp writers (the review blocker) |
| `bin/on-session-end.sh` | Session-scoped `rm -rf` with `no-session` guard |
| `bin/test-syntax.sh` | +6 global-layout assertions (21 pass / 0 fail) |
| `docs/chorus-plugin.md`, `docs/blogs/...`, 4× `packages/landing/.../blog/*.md` | Doc/blog copy updated to global layout |
| `openspec/changes/archive/2026-07-30-move-plugin-state-to-global-chorus/`, `openspec/specs/plugin-local-state/` | OpenSpec change (archived) + long-term spec |

## Test plan
- [x] `test-syntax.sh` — 21 passed / 0 failed (`BASH=/bin/bash`); Bash 3.2 compatible, no bash-4 constructs
- [x] Proposal review (2 rounds: caught + fixed the 3 omitted cross-hook hooks), task reviews, and ship-time code-review — all PASS
- [x] **Live end-to-end validation** in a fresh session: real Agent Team sub-agent spawn exercised SubagentStart→session-create→checkin→checkout→SubagentStop→cleanup, all correctly partitioned under `~/.chorus/plugin/<cwd-slug>/<sessionId>/`; daemon's `~/.chorus/` top-level untouched; no new project `.chorus/` created
- [ ] Verify on macOS system Bash 3.2 (env here is 5.2)

## Notes
- Pre-existing, not introduced here: `grep -oP` (GNU-only PCRE) in `on-subagent-start.sh` + `on-task-completed.sh` technically violates the macOS/BSD constraint — candidate for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)