### PR TITLE
feat(mcp): bound collection responses

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -380,14 +380,14 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 
 ### chorus_get_activity
 
-**Description**: Get the activity stream for a project
+**Description**: Get the paginated activity stream for a project. There is no single-activity get tool, so each row retains the full activity payload, including `value` and session context.
 
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | projectUuid | string | Yes | Project UUID |
 | page | number | No | Page number |
-| pageSize | number | No | Items per page (default 50) |
+| pageSize | number | No | Items per page (default 20, maximum 100) |
 
 **Output**: Activity list JSON
 
@@ -713,7 +713,7 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 
 ### chorus_get_comments
 
-**Description**: Get the list of comments for an Idea/Proposal/Task/Document
+**Description**: Get paginated comments for an Idea/Proposal/Task/Document, newest first. There is no single-comment get tool, so each row includes the full `content` and resolved `author`.
 
 **Input**:
 | Parameter | Type | Required | Description |
@@ -721,7 +721,7 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 | targetType | enum | Yes | Target type: idea, proposal, task, document |
 | targetUuid | string | Yes | Target UUID |
 | page | number | No | Page number |
-| pageSize | number | No | Items per page |
+| pageSize | number | No | Items per page (default 20, maximum 100) |
 
 **Output**: Comment list JSON
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -389,7 +389,7 @@ Each idea entry carries the stored single-parent lineage edge as `parentUuid` (o
 | page | number | No | Page number |
 | pageSize | number | No | Items per page (default 20, maximum 100) |
 
-**Output**: Activity list JSON
+**Output**: Activity list JSON. All page-mode collection responses include `returned`, `page`, `pageSize`, and the full matching `total`. Bounded discovery tools may instead report `total` as the returned candidate-set size when the backing query does not expose a full count.
 
 ### chorus_get_my_assignments
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -571,12 +571,12 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 
 ### chorus_search
 
-**Description**: Search across tasks, ideas, proposals, documents, projects, and project groups. Supports scoping to project groups or specific projects.
+**Description**: Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups. A canonical UUID query performs tenant-scoped exact lookup first; text search is the fallback. Prefer search for discovery, use paginated list tools only for browsing, and call the entity's single-resource `get` tool for full details.
 
 **Input**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| query | string | Yes | Search query (matches title, description, content) |
+| query | string | Yes | Canonical entity UUID for exact lookup, or text matching title, description, and content |
 | scope | enum | No | Search scope: global, group, project (default: global) |
 | scopeUuid | string | No | Project group UUID (scope=group) or project UUID (scope=project) |
 | entityTypes | string[] | No | Entity types to search: task, idea, proposal, document, project, project_group (default: all) |
@@ -608,10 +608,16 @@ Each task in the response includes the full TaskResponse format (with dependsOn,
 ```
 
 **Usage examples**:
+- Exact UUID lookup: `{ query: "123e4567-e89b-42d3-a456-426614174000" }`
 - Global search: `{ query: "authentication" }`
 - Search in a project group: `{ query: "authentication", scope: "group", scopeUuid: "group-uuid" }`
 - Search in a specific project: `{ query: "authentication", scope: "project", scopeUuid: "project-uuid" }`
 - Search only tasks and ideas: `{ query: "authentication", entityTypes: ["task", "idea"] }`
+
+**Discovery workflow**:
+1. Use `chorus_search` with a known UUID or a filtered text query.
+2. Use paginated `chorus_list_*` / plural `chorus_get_*` tools only when browsing a collection.
+3. Pass the selected UUID to the matching single-resource `get` tool for full detail.
 
 ---
 

--- a/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/README.md
+++ b/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/README.md
@@ -1,0 +1,3 @@
+# bound-mcp-list-responses
+
+统一限制 Chorus MCP 列表响应体积，并强化 UUID 搜索路径

--- a/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/design.md
+++ b/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/design.md
@@ -1,0 +1,106 @@
+## Context
+
+Several public MCP tools already accept `page` and `pageSize`, commonly defaulting to 1 and 20, but the convention is duplicated in handlers, some defaults differ, no common maximum is enforced, and service methods often return full records or nested relations. As a result, a nominally bounded list can still produce a large serialized response. Agents also use collection scans to rediscover known resources because `chorus_search` does not guarantee exact UUID lookup.
+
+The owner confirmed that the first release covers all MCP collection interfaces, uses page-number pagination, defaults to 20 rows, keeps existing parameters compatible, makes list rows primarily UUID/title summaries, and treats a hard per-call response bound as the primary success criterion.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make every MCP collection response predictably bounded without requiring callers to add parameters.
+- Standardize pagination metadata while preserving each tool's existing collection key.
+- Minimize list-row payloads and direct agents to single-resource tools for details.
+- Make exact UUID lookup available through `chorus_search`.
+- Prevent future collection tools from bypassing the contract.
+
+**Non-Goals:**
+
+- Cursor pagination or snapshot-consistent traversal during concurrent writes.
+- Arbitrary caller-selected fields.
+- Replacing single-resource `get` tools or changing their detailed response shapes.
+- Changing REST pagination contracts or the dashboard UI except where shared service projections require isolation.
+- Bounding detailed single-resource `get` responses, which intentionally preserve full user-authored content.
+
+## Decisions
+
+### 1. Shared collection contract
+
+Introduce MCP-only helpers/constants for `DEFAULT_PAGE = 1`, `DEFAULT_PAGE_SIZE = 20`, `MAX_PAGE_SIZE = 100`, and `MAX_COLLECTION_JSON_BYTES = 65_536`. Input schemas accept existing `page` and `pageSize` fields, validate positive integers, and cap or reject values above the documented maximum consistently. Responses retain the current resource key, such as `ideas` or `tasks`, and add:
+
+```json
+{
+  "ideas": [],
+  "returned": 0,
+  "page": 1,
+  "pageSize": 20,
+  "total": 0
+}
+```
+
+`returned` is the actual row count. Keeping the current collection key and existing metadata is less disruptive than introducing a universal `items` envelope. The alternative, versioning every tool, would create unnecessary migration work for an additive metadata change.
+
+Before wrapping the JSON in MCP text content, the handler measures `Buffer.byteLength(JSON.stringify(payload), "utf8")`. A collection payload MUST be at most 65,536 bytes. If a requested page still exceeds this ceiling after summary projection and field truncation, the shared helper removes rows from the end until it fits and sets `returned` to the emitted row count. `pageSize` continues to report the requested/applied database page size, while `returned` makes byte-cap shortening explicit. If even the metadata plus one fully truncated row cannot fit, the tool returns a structured error rather than emitting an oversized payload.
+
+### 2. Explicit summary projections
+
+Each collection tool defines a typed summary projection rather than serializing full service records and deleting fields afterward. Every row includes `uuid` plus `title` or `name`. It may include compact routing fields such as `status`, `priority`, `type`, `updatedAt`, parent/proposal UUIDs, or small counts when the tool description promises them. It MUST exclude long content, descriptions, comments, document bodies, acceptance criteria, reports, reference bodies, and nested entity graphs.
+
+All user-authored string fields in collection rows are bounded before serialization. Titles, names, labels, and status-like display strings are limited to 256 Unicode code points. Search snippets and any explicitly retained preview text are limited to 512 Unicode code points. Truncation appends `...` within the limit and does not mutate stored data; full values remain available from the detailed `get` tool. UUIDs, timestamps, enums, and machine identifiers are not truncated.
+
+Database-level `select` projections are preferred so heavy columns and relations never enter memory. Where a service method is shared by REST/UI consumers, add an MCP-specific summary method or projection option instead of silently shrinking non-MCP responses.
+
+### 3. Inventory all collection-returning tools
+
+Create a checked inventory of registered MCP tools whose successful response contains zero or more homogeneous resources, including tools named `list`, plural `get`, available/unblocked assignment queries, comments, activities, notifications, references, mentionables, and search. For each tool, record one of:
+
+- adopts the shared page contract and summary projection;
+- is inherently capped by a stricter existing limit and is adapted to the same metadata;
+- is a bounded aggregate/check-in response with a documented exemption and dedicated size test.
+
+A contract test fails when a newly registered collection tool is absent from this inventory. This makes "all list interfaces" enforceable rather than dependent on naming conventions.
+
+### 4. Exact UUID search before text search
+
+`chorus_search` first recognizes a canonical UUID query. For each requested/supported entity type it performs a tenant-scoped exact UUID lookup and returns the normal compact search result when found. If no exact match exists, normal text search runs unchanged. Entity type and project filters still apply, and the response remains capped by the search limit.
+
+This central discovery path is preferable to adding UUID filters independently to every list tool. Existing direct `get` tools remain the fastest path when the entity type is already known.
+
+### 5. Agent guidance is part of the contract
+
+Tool descriptions for collection calls state that responses are summaries and direct callers to the corresponding `get` tool. `chorus_search` advertises exact UUID support. Chorus skills and MCP documentation use search for discovery and list pagination only for browsing. All maintained plugin copies are updated together to prevent host-specific behavior drift.
+
+### 6. Verification
+
+Tests use oversized fixtures and assert:
+
+- omitted pagination returns at most 20 rows;
+- configured page boundaries and metadata are correct;
+- the maximum page-size policy cannot be bypassed;
+- serialized inner JSON is at most 65,536 UTF-8 bytes, including fixtures with extremely long multibyte titles and snippets;
+- summary display strings obey the 256/512-code-point limits and indicate truncation;
+- serialized rows omit known heavy fields and nested relations;
+- exact UUID search is tenant- and filter-scoped;
+- every registered collection tool is covered by the inventory.
+
+## Risks / Trade-offs
+
+- **Compatibility risk from smaller row shapes** -> Retain collection keys and essential routing fields, document the summary contract, and ensure every summarized entity has a detailed `get` path.
+- **Byte-cap row reduction can return fewer rows than pageSize** -> Report the actual `returned` count and document that callers should use search for discovery; deterministic ordering still lets callers request subsequent pages.
+- **Shared service changes could regress UI/API consumers** -> Use explicit MCP projections or separate summary methods and test REST behavior where services are shared.
+- **Inventory can become stale** -> Make it executable through a contract test tied to registered tool names.
+- **Exact UUID detection could change ordinary text search** -> Only take the direct path for canonical UUID syntax; fall back to existing search when no exact match is found.
+
+## Migration Plan
+
+1. Add shared pagination/summary helpers and the collection-tool inventory with tests.
+2. Migrate collection handlers and service projections in coherent groups, preserving response keys.
+3. Add exact UUID search and update tool descriptions, docs, and skill copies.
+4. Run MCP and service test suites plus OpenSpec validation.
+
+Rollback is code-only: revert summary projections and helper adoption. No persisted data changes are involved.
+
+## Open Questions
+
+- The implementation task will confirm the final `MAX_PAGE_SIZE`; 100 matches the existing REST ceiling and is the proposed default.
+- The inventory audit will determine which bounded aggregate tools merit an explicit exemption rather than page-number pagination.

--- a/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/proposal.md
+++ b/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Chorus projects can accumulate enough Ideas, Tasks, Proposals, Documents, comments, activities, and other resources that MCP collection calls consume excessive model context even when the agent only needs an identifier. Existing pagination is inconsistent and list rows often contain detail that belongs in single-resource `get` tools.
+
+## What Changes
+
+- Establish one bounded page-number contract for every MCP tool that returns a resource collection: default page 1, default page size 20, an enforced maximum page size, a 64 KiB UTF-8 ceiling for the serialized inner JSON payload, and explicit `returned`, `page`, `pageSize`, and `total` metadata.
+- Replace heavy list rows with resource-specific summaries centered on UUID and title/name, plus only the status or routing fields needed to select the next resource.
+- Preserve existing list parameters and top-level collection keys while making omitted pagination bounded; retain detailed data in existing single-resource `get` tools.
+- Extend `chorus_search` so an exact UUID can locate a supported entity directly, while preserving text search.
+- Update agent-facing tool descriptions and Chorus skill guidance to prefer search or exact UUID lookup over scanning pages.
+- Add contract tests that inventory collection-returning MCP tools and enforce row and byte bounds, variable-field truncation, pagination metadata, summary projections, and UUID search behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `bounded-mcp-collections`: A uniform, compact, backward-compatible response contract for MCP collection tools and an exact-UUID discovery path.
+
+### Modified Capabilities
+
+<!-- None. This cross-cutting MCP response contract is introduced as a new capability. -->
+
+## Impact
+
+- MCP registration and handlers under `src/mcp/tools/`, especially public list and search tools.
+- Resource service list projections under `src/services/`.
+- MCP contract and regression tests under `src/mcp/__tests__/` and service tests for UUID search.
+- Agent-facing MCP documentation and Chorus skill copies across supported plugin ports.
+- No database migration or new runtime dependency is required.

--- a/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/specs/bounded-mcp-collections/spec.md
+++ b/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/specs/bounded-mcp-collections/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Bounded collection pagination
+Every MCP tool that returns a resource collection SHALL apply an explicit bounded collection policy. Page-number collection tools MUST default to page 1 and page size 20 when pagination inputs are omitted, MUST enforce a documented maximum page size, and MUST return the collection together with `returned`, `page`, `pageSize`, and `total` metadata.
+
+#### Scenario: Caller omits pagination
+- **WHEN** an agent invokes a page-number MCP collection tool without `page` or `pageSize`
+- **THEN** the tool returns the first page with no more than 20 rows and reports `returned`, `page`, `pageSize`, and `total`
+
+#### Scenario: Caller requests a later page
+- **WHEN** an agent supplies a valid page and page size
+- **THEN** the tool returns the corresponding bounded slice and metadata matching the applied values
+
+#### Scenario: Caller exceeds the maximum
+- **WHEN** an agent requests a page size above the documented maximum
+- **THEN** the tool rejects or caps the request according to the shared policy and cannot emit more than the maximum number of rows
+
+### Requirement: Serialized collection byte ceiling
+The UTF-8 byte length of the inner JSON payload emitted by any MCP collection or search tool MUST NOT exceed 65,536 bytes. Collection helpers MUST measure the final serialized payload and remove trailing rows until it fits; `returned` MUST equal the number of emitted rows. If metadata plus one fully truncated row cannot fit, the tool MUST return a structured error instead of an oversized payload.
+
+#### Scenario: Long multibyte fields overflow a nominal page
+- **WHEN** a requested page would serialize above 65,536 UTF-8 bytes after summary projection and field truncation
+- **THEN** the tool removes rows from the end, emits a payload no larger than 65,536 bytes, and reports the reduced actual `returned` count
+
+#### Scenario: Irreducible row exceeds the ceiling
+- **WHEN** metadata plus one fully truncated summary row cannot fit within 65,536 UTF-8 bytes
+- **THEN** the tool emits a structured error and does not emit the oversized collection payload
+
+### Requirement: Compact list summaries
+MCP collection rows SHALL include the resource UUID and its title or name when those fields exist, MAY include compact status and routing fields needed to choose a resource, and MUST omit long-form content and nested detail available through a single-resource tool.
+
+#### Scenario: Agent lists resources
+- **WHEN** an agent invokes an MCP collection tool for entities with detailed content
+- **THEN** each row is a compact summary without descriptions, document bodies, comments, acceptance criteria, reports, or nested entity graphs
+
+#### Scenario: Agent needs full detail
+- **WHEN** an agent selects a UUID from a compact collection row
+- **THEN** the corresponding single-resource `get` tool returns the entity's detailed representation
+
+### Requirement: Bounded summary strings
+Collection summary titles, names, labels, and display-status strings MUST be limited to 256 Unicode code points. Search snippets and retained preview strings MUST be limited to 512 Unicode code points. Truncated values MUST end with `...` within the applicable limit, and truncation MUST NOT alter persisted data or detailed `get` responses.
+
+#### Scenario: Summary title exceeds its limit
+- **WHEN** a resource title contains more than 256 Unicode code points
+- **THEN** its collection summary ends with `...`, contains no more than 256 code points, and the detailed `get` response retains the full title
+
+#### Scenario: Search snippet exceeds its limit
+- **WHEN** a generated search snippet contains more than 512 Unicode code points
+- **THEN** the emitted snippet ends with `...` and contains no more than 512 code points
+
+### Requirement: Backward-compatible collection envelopes
+Migrated MCP collection tools MUST preserve their existing input filters and top-level collection key while adding or normalizing pagination metadata.
+
+#### Scenario: Existing filtered caller migrates implicitly
+- **WHEN** an existing caller supplies a supported status, priority, project, proposal, type, or other list filter
+- **THEN** the filter retains its prior meaning and the bounded response uses the tool's existing collection key
+
+### Requirement: Exact UUID discovery
+`chorus_search` SHALL support tenant-scoped exact lookup of canonical UUID queries for every entity type supported by search, while respecting requested entity-type and project filters and preserving bounded text-search behavior.
+
+#### Scenario: UUID identifies a permitted entity
+- **WHEN** an agent searches for a canonical UUID within matching entity-type and project filters
+- **THEN** `chorus_search` returns the compact matching entity without requiring a collection scan
+
+#### Scenario: UUID is outside tenant or filters
+- **WHEN** a UUID belongs to another tenant or does not satisfy the requested entity-type or project filters
+- **THEN** the entity is not returned
+
+#### Scenario: Query is not a matching UUID
+- **WHEN** a query is not a canonical UUID or has no exact match
+- **THEN** the existing bounded text-search behavior runs
+
+### Requirement: Collection contract inventory
+The MCP test suite MUST maintain an executable inventory of every registered tool that can return a resource collection and MUST require each entry to adopt the shared bounded contract or declare a justified, tested bounded-aggregate exemption.
+
+#### Scenario: New collection tool lacks a policy
+- **WHEN** a newly registered MCP tool returns a resource collection but is absent from the contract inventory
+- **THEN** the collection contract test fails
+
+#### Scenario: Bounded aggregate is exempted
+- **WHEN** a collection-bearing aggregate cannot use page-number pagination
+- **THEN** its inventory entry documents the stricter bound and a test verifies that bound
+
+### Requirement: Agent-facing discovery guidance
+MCP tool descriptions, MCP documentation, and maintained Chorus skill copies SHALL describe list results as summaries, direct agents to single-resource tools for detail, and recommend exact UUID search or filtered search before page traversal.
+
+#### Scenario: Agent reads tool guidance
+- **WHEN** an agent inspects collection or search tool descriptions and Chorus workflow guidance
+- **THEN** it can determine how to discover a resource without requesting an unbounded or detail-heavy collection

--- a/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/tasks.md
+++ b/openspec/changes/archive/2026-07-30-bound-mcp-list-responses/tasks.md
@@ -1,0 +1,18 @@
+## 1. Shared MCP Collection Contract
+
+- [x] 1.1 Add shared page validation, default/max constants, 64 KiB final-serialization guard, 256/512-code-point truncation helpers, pagination metadata helpers, and an executable inventory covering every collection-returning MCP tool.
+- [x] 1.2 Add contract tests for default page size 20, maximum enforcement, 64 KiB UTF-8 payload enforcement with long multibyte fixtures, truncation behavior, pagination metadata, preserved collection keys, and bounded-aggregate exemptions.
+
+## 2. Compact Collection Migration
+
+- [x] 2.1 Migrate public project, idea, document, proposal, task, activity, comment, reference, notification, mentionable, and assignment collection handlers to the shared contract with explicit summary projections.
+- [x] 2.2 Audit and migrate PM/admin collection handlers and any remaining collection tools; isolate MCP projections from shared REST/UI service behavior and add oversized-fixture regression tests.
+
+## 3. Search And Agent Guidance
+
+- [x] 3.1 Add tenant- and filter-scoped exact UUID lookup to `chorus_search`, preserving bounded text-search fallback, with service and MCP tests.
+- [x] 3.2 Update MCP tool descriptions, `docs/MCP_TOOLS.md`, and all maintained Chorus skill/plugin copies to prefer UUID/search discovery and single-resource `get` calls over page scanning.
+
+## 4. Integration Verification
+
+- [x] 4.1 Run the MCP/service test suites and OpenSpec validation, then verify the collection inventory covers all registered collection tools and representative serialized inner JSON responses never exceed 65,536 UTF-8 bytes.

--- a/openspec/specs/bounded-mcp-collections/spec.md
+++ b/openspec/specs/bounded-mcp-collections/spec.md
@@ -1,0 +1,92 @@
+# bounded-mcp-collections Specification
+
+## Purpose
+TBD - created by archiving change bound-mcp-list-responses. Update Purpose after archive.
+## Requirements
+### Requirement: Bounded collection pagination
+Every MCP tool that returns a resource collection SHALL apply an explicit bounded collection policy. Page-number collection tools MUST default to page 1 and page size 20 when pagination inputs are omitted, MUST enforce a documented maximum page size, and MUST return the collection together with `returned`, `page`, `pageSize`, and `total` metadata.
+
+#### Scenario: Caller omits pagination
+- **WHEN** an agent invokes a page-number MCP collection tool without `page` or `pageSize`
+- **THEN** the tool returns the first page with no more than 20 rows and reports `returned`, `page`, `pageSize`, and `total`
+
+#### Scenario: Caller requests a later page
+- **WHEN** an agent supplies a valid page and page size
+- **THEN** the tool returns the corresponding bounded slice and metadata matching the applied values
+
+#### Scenario: Caller exceeds the maximum
+- **WHEN** an agent requests a page size above the documented maximum
+- **THEN** the tool rejects or caps the request according to the shared policy and cannot emit more than the maximum number of rows
+
+### Requirement: Serialized collection byte ceiling
+The UTF-8 byte length of the inner JSON payload emitted by any MCP collection or search tool MUST NOT exceed 65,536 bytes. Collection helpers MUST measure the final serialized payload and remove trailing rows until it fits; `returned` MUST equal the number of emitted rows. If metadata plus one fully truncated row cannot fit, the tool MUST return a structured error instead of an oversized payload.
+
+#### Scenario: Long multibyte fields overflow a nominal page
+- **WHEN** a requested page would serialize above 65,536 UTF-8 bytes after summary projection and field truncation
+- **THEN** the tool removes rows from the end, emits a payload no larger than 65,536 bytes, and reports the reduced actual `returned` count
+
+#### Scenario: Irreducible row exceeds the ceiling
+- **WHEN** metadata plus one fully truncated summary row cannot fit within 65,536 UTF-8 bytes
+- **THEN** the tool emits a structured error and does not emit the oversized collection payload
+
+### Requirement: Compact list summaries
+MCP collection rows SHALL include the resource UUID and its title or name when those fields exist, MAY include compact status and routing fields needed to choose a resource, and MUST omit long-form content and nested detail available through a single-resource tool.
+
+#### Scenario: Agent lists resources
+- **WHEN** an agent invokes an MCP collection tool for entities with detailed content
+- **THEN** each row is a compact summary without descriptions, document bodies, comments, acceptance criteria, reports, or nested entity graphs
+
+#### Scenario: Agent needs full detail
+- **WHEN** an agent selects a UUID from a compact collection row
+- **THEN** the corresponding single-resource `get` tool returns the entity's detailed representation
+
+### Requirement: Bounded summary strings
+Collection summary titles, names, labels, and display-status strings MUST be limited to 256 Unicode code points. Search snippets and retained preview strings MUST be limited to 512 Unicode code points. Truncated values MUST end with `...` within the applicable limit, and truncation MUST NOT alter persisted data or detailed `get` responses.
+
+#### Scenario: Summary title exceeds its limit
+- **WHEN** a resource title contains more than 256 Unicode code points
+- **THEN** its collection summary ends with `...`, contains no more than 256 code points, and the detailed `get` response retains the full title
+
+#### Scenario: Search snippet exceeds its limit
+- **WHEN** a generated search snippet contains more than 512 Unicode code points
+- **THEN** the emitted snippet ends with `...` and contains no more than 512 code points
+
+### Requirement: Backward-compatible collection envelopes
+Migrated MCP collection tools MUST preserve their existing input filters and top-level collection key while adding or normalizing pagination metadata.
+
+#### Scenario: Existing filtered caller migrates implicitly
+- **WHEN** an existing caller supplies a supported status, priority, project, proposal, type, or other list filter
+- **THEN** the filter retains its prior meaning and the bounded response uses the tool's existing collection key
+
+### Requirement: Exact UUID discovery
+`chorus_search` SHALL support tenant-scoped exact lookup of canonical UUID queries for every entity type supported by search, while respecting requested entity-type and project filters and preserving bounded text-search behavior.
+
+#### Scenario: UUID identifies a permitted entity
+- **WHEN** an agent searches for a canonical UUID within matching entity-type and project filters
+- **THEN** `chorus_search` returns the compact matching entity without requiring a collection scan
+
+#### Scenario: UUID is outside tenant or filters
+- **WHEN** a UUID belongs to another tenant or does not satisfy the requested entity-type or project filters
+- **THEN** the entity is not returned
+
+#### Scenario: Query is not a matching UUID
+- **WHEN** a query is not a canonical UUID or has no exact match
+- **THEN** the existing bounded text-search behavior runs
+
+### Requirement: Collection contract inventory
+The MCP test suite MUST maintain an executable inventory of every registered tool that can return a resource collection and MUST require each entry to adopt the shared bounded contract or declare a justified, tested bounded-aggregate exemption.
+
+#### Scenario: New collection tool lacks a policy
+- **WHEN** a newly registered MCP tool returns a resource collection but is absent from the contract inventory
+- **THEN** the collection contract test fails
+
+#### Scenario: Bounded aggregate is exempted
+- **WHEN** a collection-bearing aggregate cannot use page-number pagination
+- **THEN** its inventory entry documents the stricter bound and a test verifies that bound
+
+### Requirement: Agent-facing discovery guidance
+MCP tool descriptions, MCP documentation, and maintained Chorus skill copies SHALL describe list results as summaries, direct agents to single-resource tools for detail, and recommend exact UUID search or filtered search before page traversal.
+
+#### Scenario: Agent reads tool guidance
+- **WHEN** an agent inspects collection or search tool descriptions and Chorus workflow guidance
+- **THEN** it can determine how to discover a resource without requesting an unbounded or detail-heavy collection

--- a/packages/chorus-pi/skills/chorus/SKILL.md
+++ b/packages/chorus-pi/skills/chorus/SKILL.md
@@ -225,13 +225,15 @@ Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_search` | Search across tasks, ideas, proposals, documents, projects, and project groups |
+| `chorus_search` | Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups; canonical UUIDs use exact lookup |
 
 **Parameters:**
 - `query`: Search query string
 - `scope`: `"global"` (default) / `"group"` / `"project"`
 - `scopeUuid`: Project group UUID (when scope=group) or project UUID (when scope=project)
 - `entityTypes`: Array of entity types to search (default: all types)
+
+Prefer `chorus_search` for discovery, including exact UUID lookup. Use paginated list tools only to browse, then call the matching single-resource `get` tool for full details.
 
 ### Notifications
 

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -204,13 +204,15 @@ Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_search` | Search across tasks, ideas, proposals, documents, projects, and project groups |
+| `chorus_search` | Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups; canonical UUIDs use exact lookup |
 
 **Parameters:**
 - `query`: Search query string
 - `scope`: `"global"` (default) / `"group"` / `"project"`
 - `scopeUuid`: Project group UUID (when scope=group) or project UUID (when scope=project)
 - `entityTypes`: Array of entity types to search (default: all types)
+
+Prefer `chorus__chorus_search` for discovery, including exact UUID lookup. Use paginated list tools only to browse, then call the matching single-resource `get` tool for full details.
 
 ### Notifications
 

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -216,13 +216,15 @@ Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_search` | Search across tasks, ideas, proposals, documents, projects, and project groups |
+| `chorus_search` | Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups; canonical UUIDs use exact lookup |
 
 **Parameters:**
 - `query`: Search query string
 - `scope`: `"global"` (default) / `"group"` / `"project"`
 - `scopeUuid`: Project group UUID (when scope=group) or project UUID (when scope=project)
 - `entityTypes`: Array of entity types to search (default: all types)
+
+Prefer `chorus_search` for discovery, including exact UUID lookup. Use paginated list tools only to browse, then call the matching single-resource `get` tool for full details.
 
 ### Notifications
 

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -223,13 +223,15 @@ Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_search` | Search across tasks, ideas, proposals, documents, projects, and project groups |
+| `chorus_search` | Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups; canonical UUIDs use exact lookup |
 
 **Parameters:**
 - `query`: Search query string
 - `scope`: `"global"` (default) / `"group"` / `"project"`
 - `scopeUuid`: Project group UUID (when scope=group) or project UUID (when scope=project)
 - `entityTypes`: Array of entity types to search (default: all types)
+
+Prefer `chorus_search` for discovery, including exact UUID lookup. Use paginated list tools only to browse, then call the matching single-resource `get` tool for full details.
 
 ### Notifications
 

--- a/public/kiro-plugin/.kiro/steering/chorus.md
+++ b/public/kiro-plugin/.kiro/steering/chorus.md
@@ -217,13 +217,15 @@ Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_search` | Search across tasks, ideas, proposals, documents, projects, and project groups |
+| `chorus_search` | Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups; canonical UUIDs use exact lookup |
 
 **Parameters:**
 - `query`: Search query string
 - `scope`: `"global"` (default) / `"group"` / `"project"`
 - `scopeUuid`: Project group UUID (when scope=group) or project UUID (when scope=project)
 - `entityTypes`: Array of entity types to search (default: all types)
+
+Prefer `chorus_search` for discovery, including exact UUID lookup. Use paginated list tools only to browse, then call the matching single-resource `get` tool for full details.
 
 ### Notifications
 

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -270,13 +270,15 @@ Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName
 
 | Tool | Purpose |
 |------|---------|
-| `chorus_search` | Search across tasks, ideas, proposals, documents, projects, and project groups |
+| `chorus_search` | Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups; canonical UUIDs use exact lookup |
 
 **Parameters:**
 - `query`: Search query string
 - `scope`: `"global"` (default) / `"group"` / `"project"`
 - `scopeUuid`: Project group UUID (when scope=group) or project UUID (when scope=project)
 - `entityTypes`: Array of entity types to search (default: all types)
+
+Prefer `chorus_search` for discovery, including exact UUID lookup. Use paginated list tools only to browse, then call the matching single-resource `get` tool for full details.
 
 ### Notifications
 

--- a/src/mcp/__tests__/collection-contract.test.ts
+++ b/src/mcp/__tests__/collection-contract.test.ts
@@ -163,4 +163,17 @@ describe("MCP collection contract", () => {
       expect(entry.reason.trim().length).toBeGreaterThan(10);
     }
   });
+
+  it("marks every authoritative list that has no single-resource get", () => {
+    const authoritativeTools = Object.entries(COLLECTION_TOOL_INVENTORY)
+      .filter(([, entry]) => entry.detailSource === "list-authoritative")
+      .map(([name]) => name)
+      .sort();
+
+    expect(authoritativeTools).toEqual([
+      "chorus_get_activity",
+      "chorus_get_comments",
+      "chorus_get_notifications",
+    ]);
+  });
 });

--- a/src/mcp/__tests__/collection-contract.test.ts
+++ b/src/mcp/__tests__/collection-contract.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import {
+  COLLECTION_TOOL_INVENTORY,
+  CollectionPayloadTooLargeError,
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  MAX_COLLECTION_JSON_BYTES,
+  MAX_PAGE_SIZE,
+  PREVIEW_TEXT_CODE_POINTS,
+  SUMMARY_TEXT_CODE_POINTS,
+  assertCollectionToolsInventoried,
+  buildBoundedCollectionPayload,
+  collectionPageSchema,
+  collectionPageSizeSchema,
+  serializeBoundedCollection,
+  serializeBoundedAggregate,
+  truncatePreviewText,
+  truncateSummaryText,
+} from "@/mcp/tools/collection-contract";
+
+describe("MCP collection contract", () => {
+  it("applies shared defaults and validates positive bounded integers", () => {
+    expect(collectionPageSchema.parse(undefined)).toBe(DEFAULT_PAGE);
+    expect(collectionPageSizeSchema.parse(undefined)).toBe(DEFAULT_PAGE_SIZE);
+    expect(collectionPageSchema.parse(3)).toBe(3);
+    expect(collectionPageSizeSchema.parse(MAX_PAGE_SIZE)).toBe(MAX_PAGE_SIZE);
+
+    for (const invalid of [0, -1, 1.5]) {
+      expect(() => collectionPageSchema.parse(invalid)).toThrow();
+      expect(() => collectionPageSizeSchema.parse(invalid)).toThrow();
+    }
+    expect(() => collectionPageSizeSchema.parse(MAX_PAGE_SIZE + 1)).toThrow();
+  });
+
+  it("preserves the collection key and emits complete pagination metadata", () => {
+    const payload = buildBoundedCollectionPayload({
+      collectionKey: "ideas",
+      rows: [{ uuid: "one" }, { uuid: "two" }],
+      total: 9,
+      page: 2,
+      pageSize: 2,
+    });
+
+    expect(payload).toEqual({
+      ideas: [{ uuid: "one" }, { uuid: "two" }],
+      returned: 2,
+      page: 2,
+      pageSize: 2,
+      total: 9,
+    });
+  });
+
+  it("removes trailing rows until final UTF-8 JSON fits the byte ceiling", () => {
+    const multibyte = "界".repeat(8_000);
+    const text = serializeBoundedCollection({
+      collectionKey: "results",
+      rows: Array.from({ length: 5 }, (_, index) => ({
+        uuid: String(index),
+        snippet: multibyte,
+      })),
+      total: 5,
+      page: 1,
+      pageSize: 5,
+    });
+    const payload = JSON.parse(text) as {
+      results: unknown[];
+      returned: number;
+      page: number;
+      pageSize: number;
+      total: number;
+    };
+
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+      MAX_COLLECTION_JSON_BYTES,
+    );
+    expect(payload.returned).toBe(payload.results.length);
+    expect(payload.returned).toBeGreaterThan(0);
+    expect(payload.returned).toBeLessThan(5);
+    expect(payload).toMatchObject({ page: 1, pageSize: 5, total: 5 });
+  });
+
+  it("returns a structured error when one row cannot fit", () => {
+    expect.assertions(3);
+    try {
+      buildBoundedCollectionPayload({
+        collectionKey: "documents",
+        rows: [{ content: "界".repeat(30_000) }],
+        total: 1,
+        page: 1,
+        pageSize: 20,
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(CollectionPayloadTooLargeError);
+      expect(JSON.stringify(error)).toContain("MCP_COLLECTION_ROW_TOO_LARGE");
+      expect(JSON.stringify(error)).toContain("65536");
+    }
+  });
+
+  it("trims nested aggregate collection tails to the UTF-8 byte ceiling", () => {
+    const payload = {
+      agent: {
+        uuid: "agent-1",
+        name: "Agent",
+        permissions: ["idea:read", "task:read"],
+      },
+      ideaTracker: {
+        project: {
+          name: "Project",
+          ideas: Array.from({ length: 100 }, (_, index) => ({
+            uuid: `idea-${index}`,
+            title: "界".repeat(256),
+          })),
+        },
+      },
+      notifications: Array.from({ length: 5 }, (_, index) => ({
+        uuid: `notification-${index}`,
+        title: "界".repeat(512),
+      })),
+    };
+
+    const text = serializeBoundedAggregate(payload);
+    const result = JSON.parse(text);
+
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+      MAX_COLLECTION_JSON_BYTES,
+    );
+    expect(result.agent).toEqual(payload.agent);
+    expect(result.ideaTracker.project.ideas.length).toBeLessThan(100);
+    expect(result.notifications.length).toBeLessThanOrEqual(5);
+  });
+
+  it("truncates by Unicode code point and keeps the ellipsis inside the limit", () => {
+    const summarySource = "😀".repeat(SUMMARY_TEXT_CODE_POINTS + 10);
+    const previewSource = "界".repeat(PREVIEW_TEXT_CODE_POINTS + 10);
+    const summary = truncateSummaryText(summarySource);
+    const preview = truncatePreviewText(previewSource);
+
+    expect(Array.from(summary)).toHaveLength(SUMMARY_TEXT_CODE_POINTS);
+    expect(summary.endsWith("...")).toBe(true);
+    expect(Array.from(preview)).toHaveLength(PREVIEW_TEXT_CODE_POINTS);
+    expect(preview.endsWith("...")).toBe(true);
+    expect(summarySource).toHaveLength((SUMMARY_TEXT_CODE_POINTS + 10) * 2);
+    expect(previewSource).toBe("界".repeat(PREVIEW_TEXT_CODE_POINTS + 10));
+  });
+
+  it("rejects a discovered collection tool missing from the inventory", () => {
+    expect(() =>
+      assertCollectionToolsInventoried([
+        "chorus_new_unbounded_list",
+      ]),
+    ).toThrow(/chorus_new_unbounded_list/);
+  });
+
+  it("documents and tests a finite limit for every non-page exemption", () => {
+    const exemptions = Object.values(COLLECTION_TOOL_INVENTORY).filter(
+      (entry) => entry.mode !== "page",
+    );
+
+    expect(exemptions.length).toBeGreaterThan(0);
+    for (const entry of exemptions) {
+      expect(entry.maximumRows).toBeGreaterThan(0);
+      expect(entry.maximumRows).toBeLessThanOrEqual(MAX_PAGE_SIZE);
+      expect(entry.reason.trim().length).toBeGreaterThan(10);
+    }
+  });
+});

--- a/src/mcp/__tests__/collection-contract.test.ts
+++ b/src/mcp/__tests__/collection-contract.test.ts
@@ -129,6 +129,24 @@ describe("MCP collection contract", () => {
     expect(result.notifications.length).toBeLessThanOrEqual(5);
   });
 
+  it("bounds long checkin instruction scalars before trimming collections", () => {
+    const text = serializeBoundedAggregate({
+      agent: {
+        uuid: "agent-1",
+        persona: "p".repeat(100_000),
+        systemPrompt: "s".repeat(100_000),
+      },
+      notifications: [],
+    });
+    const result = JSON.parse(text);
+
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+      MAX_COLLECTION_JSON_BYTES,
+    );
+    expect(result.agent.persona).toHaveLength(4_096);
+    expect(result.agent.systemPrompt).toHaveLength(4_096);
+  });
+
   it("truncates by Unicode code point and keeps the ellipsis inside the limit", () => {
     const summarySource = "😀".repeat(SUMMARY_TEXT_CODE_POINTS + 10);
     const previewSource = "界".repeat(PREVIEW_TEXT_CODE_POINTS + 10);

--- a/src/mcp/__tests__/collection-migration.test.ts
+++ b/src/mcp/__tests__/collection-migration.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { z } from "zod";
+
+const services = vi.hoisted(() => ({
+  project: {
+    getProjectByUuid: vi.fn(),
+    listProjects: vi.fn(),
+    projectExists: vi.fn(),
+  },
+  idea: { listIdeas: vi.fn() },
+  document: { listDocuments: vi.fn() },
+  proposal: { listProposals: vi.fn() },
+  task: { listTasks: vi.fn(), getUnblockedTasks: vi.fn() },
+  activity: { listActivities: vi.fn() },
+  comment: { listComments: vi.fn() },
+  assignment: { getAvailableItems: vi.fn(), getMyAssignments: vi.fn() },
+  notification: { list: vi.fn(), markRead: vi.fn() },
+  session: { listAgentSessions: vi.fn() },
+  search: { search: vi.fn() },
+  checkin: { buildCheckinResponse: vi.fn() },
+  projectGroup: { getGroupDashboard: vi.fn() },
+}));
+
+vi.mock("@/services/project.service", () => services.project);
+vi.mock("@/services/idea.service", () => services.idea);
+vi.mock("@/services/document.service", () => services.document);
+vi.mock("@/services/proposal.service", () => services.proposal);
+vi.mock("@/services/task.service", () => services.task);
+vi.mock("@/services/activity.service", () => services.activity);
+vi.mock("@/services/comment.service", () => services.comment);
+vi.mock("@/services/assignment.service", () => services.assignment);
+vi.mock("@/services/notification.service", () => services.notification);
+vi.mock("@/services/session.service", () => services.session);
+vi.mock("@/services/reference-artifact.service", () => ({
+  REFERENCE_TYPES: ["docs", "repo", "issue_pr", "paper_blog"],
+}));
+vi.mock("@/services/elaboration.service", () => ({}));
+vi.mock("@/services/project-group.service", () => services.projectGroup);
+vi.mock("@/services/mention.service", () => ({}));
+vi.mock("@/services/search.service", () => services.search);
+vi.mock("@/services/checkin.service", () => services.checkin);
+
+import { registerPublicTools } from "@/mcp/tools/public";
+import { registerSessionTools } from "@/mcp/tools/session";
+import type { AgentAuthContext } from "@/types/auth";
+
+type Handler = (params: Record<string, unknown>) => Promise<{
+  content: Array<{ text: string }>;
+}>;
+
+const handlers: Record<string, Handler> = {};
+const schemas: Record<string, z.ZodType> = {};
+const server = {
+  registerTool: (
+    name: string,
+    config: { inputSchema: z.ZodType },
+    handler: Handler,
+  ) => {
+    schemas[name] = config.inputSchema;
+    handlers[name] = handler;
+  },
+};
+const auth: AgentAuthContext = {
+  type: "agent",
+  companyUuid: "company-1",
+  actorUuid: "agent-1",
+  ownerUuid: "owner-1",
+  roles: ["admin_agent"],
+  permissions: [],
+  agentName: "Agent",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.keys(handlers).forEach((key) => delete handlers[key]);
+  Object.keys(schemas).forEach((key) => delete schemas[key]);
+  registerPublicTools(server as never, auth);
+  registerSessionTools(server as never, auth);
+  services.project.getProjectByUuid.mockResolvedValue({ uuid: "project-1" });
+});
+
+describe("MCP collection migration", () => {
+  it.each([
+    ["chorus_checkin", () => {
+      services.checkin.buildCheckinResponse.mockResolvedValue({
+        agent: { uuid: "agent-1", name: "Agent" },
+        ideaTracker: {
+          project: {
+            name: "Project",
+            ideas: Array.from({ length: 100 }, (_, index) => ({
+              uuid: `idea-${index}`,
+              title: "界".repeat(256),
+            })),
+          },
+        },
+        notifications: [],
+      });
+    }],
+    ["chorus_get_my_assignments", () => {
+      services.assignment.getMyAssignments.mockResolvedValue({
+        ideaTracker: {
+          project: {
+            name: "Project",
+            ideas: Array.from({ length: 100 }, (_, index) => ({
+              uuid: `idea-${index}`,
+              title: "界".repeat(256),
+            })),
+          },
+        },
+        taskTracker: {
+          project: {
+            name: "Project",
+            tasks: Array.from({ length: 100 }, (_, index) => ({
+              uuid: `task-${index}`,
+              title: "界".repeat(256),
+            })),
+          },
+        },
+      });
+    }],
+    ["chorus_get_group_dashboard", () => {
+      services.projectGroup.getGroupDashboard.mockResolvedValue({
+        group: { uuid: "group-1", name: "Group" },
+        recentActivities: Array.from({ length: 20 }, (_, index) => ({
+          uuid: `activity-${index}`,
+          content: "界".repeat(2_000),
+        })),
+      });
+    }],
+  ])("guards the final %s aggregate JSON", async (tool, arrange) => {
+    arrange();
+    const response = await handlers[tool](
+      tool === "chorus_get_group_dashboard" ? { groupUuid: "group-1" } : {},
+    );
+
+    expect(Buffer.byteLength(response.content[0].text, "utf8")).toBeLessThanOrEqual(
+      65_536,
+    );
+  });
+
+  it("uses shared defaults and maximum validation for every page collection", () => {
+    const tools = [
+      "chorus_list_projects",
+      "chorus_get_ideas",
+      "chorus_get_documents",
+      "chorus_get_proposals",
+      "chorus_list_tasks",
+      "chorus_get_activity",
+      "chorus_get_comments",
+      "chorus_list_sessions",
+    ];
+
+    for (const tool of tools) {
+      const base = tool === "chorus_list_projects" || tool === "chorus_list_sessions"
+        ? {}
+        : tool === "chorus_get_comments"
+          ? { targetType: "task", targetUuid: "task-1" }
+          : { projectUuid: "project-1" };
+      const parsed = schemas[tool].parse(base) as { page: number; pageSize: number };
+      expect(parsed.page, tool).toBe(1);
+      expect(parsed.pageSize, tool).toBe(20);
+      expect(schemas[tool].safeParse({ ...base, pageSize: 101 }).success, tool)
+        .toBe(false);
+    }
+  });
+
+  it("keeps task filters but emits compact rows under the byte ceiling", async () => {
+    const long = "界".repeat(20_000);
+    services.task.listTasks.mockResolvedValue({
+      tasks: Array.from({ length: 20 }, (_, index) => ({
+        uuid: `task-${index}`,
+        title: long,
+        description: long,
+        acceptanceCriteria: long,
+        comments: [{ content: long }],
+        status: "open",
+        priority: "high",
+        proposalUuid: "proposal-1",
+      })),
+      total: 500,
+    });
+
+    const response = await handlers.chorus_list_tasks({
+      projectUuid: "project-1",
+      status: "open",
+      priority: "high",
+      proposalUuids: ["proposal-1"],
+      page: 2,
+      pageSize: 20,
+    });
+    const text = response.content[0].text;
+    const payload = JSON.parse(text);
+
+    expect(services.task.listTasks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "open",
+        priority: "high",
+        proposalUuids: ["proposal-1"],
+        skip: 20,
+        take: 20,
+      }),
+    );
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(65_536);
+    expect(payload).toMatchObject({
+      returned: 20,
+      page: 2,
+      pageSize: 20,
+      total: 500,
+    });
+    expect(payload.tasks[0].title).toHaveLength(256);
+    expect(payload.tasks[0]).not.toHaveProperty("description");
+    expect(payload.tasks[0]).not.toHaveProperty("acceptanceCriteria");
+    expect(payload.tasks[0]).not.toHaveProperty("comments");
+  });
+
+  it("traverses every task page exactly once without mutating service rows", async () => {
+    const serviceRows = Array.from({ length: 37 }, (_, index) => ({
+      uuid: `task-${index}`,
+      title: `Task ${index}`,
+      description: `Full REST detail ${index}`,
+      acceptanceCriteria: `Criterion ${index}`,
+      status: "open",
+      priority: "high",
+      proposalUuid: "proposal-1",
+    }));
+    services.task.listTasks.mockImplementation(
+      async ({ skip, take }: { skip: number; take: number }) => ({
+        tasks: serviceRows.slice(skip, skip + take),
+        total: serviceRows.length,
+      }),
+    );
+
+    const seen: string[] = [];
+    for (const page of [1, 2]) {
+      const response = await handlers.chorus_list_tasks({
+        projectUuid: "project-1",
+        page,
+        pageSize: 20,
+      });
+      const payload = JSON.parse(response.content[0].text);
+
+      expect(payload).toMatchObject({
+        returned: page === 1 ? 20 : 17,
+        page,
+        pageSize: 20,
+        total: 37,
+      });
+      expect(payload.tasks).toHaveLength(payload.returned);
+      expect(payload.tasks.every(
+        (task: Record<string, unknown>) => !("description" in task),
+      )).toBe(true);
+      seen.push(...payload.tasks.map((task: { uuid: string }) => task.uuid));
+    }
+
+    expect(seen).toEqual(serviceRows.map((task) => task.uuid));
+    expect(new Set(seen)).toHaveLength(serviceRows.length);
+    expect(serviceRows[0]).toMatchObject({
+      description: "Full REST detail 0",
+      acceptanceCriteria: "Criterion 0",
+    });
+  });
+
+  it("passes UUID search filters through and emits a compact bounded result", async () => {
+    const uuid = "123e4567-e89b-42d3-a456-426614174000";
+    services.search.search.mockResolvedValue({
+      results: [{
+        entityType: "task",
+        uuid,
+        title: "Exact task",
+        snippet: "",
+        status: "open",
+        projectUuid: "project-1",
+        projectName: "Project A",
+        updatedAt: "2026-07-30T00:00:00.000Z",
+        description: "must not escape",
+      }],
+      counts: {
+        tasks: 1,
+        ideas: 0,
+        proposals: 0,
+        documents: 0,
+        projects: 0,
+        projectGroups: 0,
+      },
+    });
+
+    const response = await handlers.chorus_search({
+      query: uuid,
+      scope: "project",
+      scopeUuid: "project-1",
+      entityTypes: ["task"],
+    });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(services.search.search).toHaveBeenCalledWith({
+      companyUuid: "company-1",
+      query: uuid,
+      scope: "project",
+      scopeUuid: "project-1",
+      entityTypes: ["task"],
+    });
+    expect(payload.results).toEqual([{
+      entityType: "task",
+      uuid,
+      title: "Exact task",
+      snippet: "",
+      status: "open",
+      projectUuid: "project-1",
+      projectName: "Project A",
+      updatedAt: "2026-07-30T00:00:00.000Z",
+    }]);
+    expect(payload).toMatchObject({
+      returned: 1,
+      page: 1,
+      pageSize: 50,
+      total: 1,
+    });
+  });
+
+  it("paginates compact sessions without changing the service call", async () => {
+    services.session.listAgentSessions.mockResolvedValue(
+      Array.from({ length: 25 }, (_, index) => ({
+        uuid: `session-${index}`,
+        name: `Session ${index}`,
+        description: "detail".repeat(1_000),
+        status: "active",
+        agentUuid: "agent-1",
+      })),
+    );
+
+    const response = await handlers.chorus_list_sessions({
+      status: "active",
+      page: 2,
+      pageSize: 20,
+    });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(services.session.listAgentSessions).toHaveBeenCalledWith(
+      "company-1",
+      "agent-1",
+      "active",
+    );
+    expect(payload).toMatchObject({
+      returned: 5,
+      page: 2,
+      pageSize: 20,
+      total: 25,
+    });
+    expect(payload.sessions[0]).not.toHaveProperty("description");
+  });
+});

--- a/src/mcp/__tests__/collection-migration.test.ts
+++ b/src/mcp/__tests__/collection-migration.test.ts
@@ -213,6 +213,111 @@ describe("MCP collection migration", () => {
     expect(payload.tasks[0]).not.toHaveProperty("comments");
   });
 
+  it("preserves authoritative fields for list-only resources", async () => {
+    services.activity.listActivities.mockResolvedValue({
+      activities: [{
+        uuid: "activity-1",
+        action: "updated",
+        targetType: "task",
+        targetUuid: "task-1",
+        actorType: "agent",
+        actorUuid: "agent-1",
+        value: { status: "done" },
+        sessionUuid: "session-1",
+        sessionName: "Worker",
+        createdAt: "2026-07-30T12:00:00.000Z",
+      }],
+      total: 1,
+    });
+    services.comment.listComments.mockResolvedValue({
+      comments: [{
+        uuid: "comment-1",
+        targetType: "task",
+        targetUuid: "task-1",
+        content: "full comment body",
+        author: { type: "user", uuid: "user-1", name: "Owner" },
+        createdAt: "2026-07-30T12:00:00.000Z",
+        updatedAt: "2026-07-30T12:00:00.000Z",
+      }],
+      total: 1,
+    });
+    services.notification.list.mockResolvedValue({
+      notifications: [{
+        uuid: "notification-1",
+        projectUuid: "project-1",
+        projectName: "Project",
+        recipientType: "agent",
+        recipientUuid: "agent-1",
+        entityType: "idea",
+        entityUuid: "idea-1",
+        entityTitle: "Idea",
+        action: "human_instruction",
+        message: "Resume work",
+        actorType: "user",
+        actorUuid: "user-1",
+        actorName: "Owner",
+        readAt: null,
+        archivedAt: null,
+        createdAt: "2026-07-30T12:00:00.000Z",
+        instructionText: "Deploy after completion",
+      }],
+      total: 1,
+      unreadCount: 1,
+    });
+
+    const activity = JSON.parse((await handlers.chorus_get_activity({
+      projectUuid: "project-1",
+      page: 1,
+      pageSize: 20,
+    })).content[0].text);
+    const comments = JSON.parse((await handlers.chorus_get_comments({
+      targetType: "task",
+      targetUuid: "task-1",
+      page: 1,
+      pageSize: 20,
+    })).content[0].text);
+    const notifications = JSON.parse((await handlers.chorus_get_notifications({
+      status: "all",
+      limit: 20,
+      offset: 0,
+      autoMarkRead: false,
+    })).content[0].text);
+
+    expect(activity.activities[0]).toMatchObject({
+      value: { status: "done" },
+      sessionUuid: "session-1",
+      sessionName: "Worker",
+    });
+    expect(comments.comments[0]).toMatchObject({
+      content: "full comment body",
+      author: { type: "user", uuid: "user-1", name: "Owner" },
+    });
+    expect(notifications.notifications[0]).toMatchObject({
+      message: "Resume work",
+      actorName: "Owner",
+      instructionText: "Deploy after completion",
+    });
+  });
+
+  it("requests comment pages in newest-first offset order", async () => {
+    services.comment.listComments.mockResolvedValue({ comments: [], total: 0 });
+
+    await handlers.chorus_get_comments({
+      targetType: "idea",
+      targetUuid: "idea-1",
+      page: 3,
+      pageSize: 10,
+    });
+
+    expect(services.comment.listComments).toHaveBeenCalledWith({
+      companyUuid: "company-1",
+      targetType: "idea",
+      targetUuid: "idea-1",
+      skip: 20,
+      take: 10,
+    });
+  });
+
   it("traverses every task page exactly once without mutating service rows", async () => {
     const serviceRows = Array.from({ length: 37 }, (_, index) => ({
       uuid: `task-${index}`,

--- a/src/mcp/__tests__/collection-migration.test.ts
+++ b/src/mcp/__tests__/collection-migration.test.ts
@@ -147,11 +147,15 @@ describe("MCP collection migration", () => {
       "chorus_list_tasks",
       "chorus_get_activity",
       "chorus_get_comments",
+      "chorus_get_unblocked_tasks",
+      "chorus_get_project_groups",
       "chorus_list_sessions",
     ];
 
     for (const tool of tools) {
-      const base = tool === "chorus_list_projects" || tool === "chorus_list_sessions"
+      const base = tool === "chorus_list_projects" ||
+          tool === "chorus_list_sessions" ||
+          tool === "chorus_get_project_groups"
         ? {}
         : tool === "chorus_get_comments"
           ? { targetType: "task", targetUuid: "task-1" }
@@ -403,6 +407,7 @@ describe("MCP collection migration", () => {
       scope: "project",
       scopeUuid: "project-1",
       entityTypes: ["task"],
+      limit: 50,
     });
     expect(payload.results).toEqual([{
       entityType: "task",

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -33,7 +33,14 @@ import { registerPmTools } from "@/mcp/tools/pm";
 import { registerDeveloperTools } from "@/mcp/tools/developer";
 import { registerAdminTools } from "@/mcp/tools/admin";
 import { registerPublicTools } from "@/mcp/tools/public";
+import { registerSessionTools } from "@/mcp/tools/session";
 import { TOOL_PERMISSIONS } from "@/mcp/tools/permission-map";
+import {
+  assertCollectionToolsInventoried,
+  enforceToolClassification,
+  isCollectionToolConfig,
+  TOOL_COLLECTION_CLASSIFICATION,
+} from "@/mcp/tools/collection-contract";
 
 // Minimal McpServer stand-in: records every tool name that gets registered.
 function makeCapturingServer() {
@@ -44,6 +51,30 @@ function makeCapturingServer() {
     },
   };
   return { server, names };
+}
+
+function registeredTools(): Array<{ name: string; collection: boolean }> {
+  const tools: Array<{ name: string; collection: boolean }> = [];
+  const server = {
+    registerTool: (name: string, config: unknown) => {
+      tools.push({ name, collection: isCollectionToolConfig(config) });
+    },
+  };
+  const auth = makeAuth([...ROLE_PRESETS.admin_agent]);
+
+  // Exercise the same production registration modules as createMcpServer.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerPublicTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerSessionTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerPmTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerDeveloperTools(server as any, auth);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerAdminTools(server as any, auth);
+
+  return tools;
 }
 
 function makeAuth(permissions: Permission[]): AgentAuthContext {
@@ -77,6 +108,51 @@ function registeredFor(permissions: Permission[]): Set<string> {
   const gated = new Set(Object.keys(TOOL_PERMISSIONS));
   return new Set(names.filter((n) => gated.has(n)));
 }
+
+describe("collection tool inventory", () => {
+  it("covers every collection-returning tool discovered from production registration", () => {
+    const registered = registeredTools()
+      .filter(({ collection }) => collection)
+      .map(({ name }) => name);
+
+    expect(registered.length).toBeGreaterThan(0);
+    expect(() => assertCollectionToolsInventoried(registered)).not.toThrow();
+  });
+
+  it("requires review of every real production registration without trusting metadata", () => {
+    const names = registeredTools().map(({ name }) => name).sort();
+
+    expect(names).toEqual(Object.keys(TOOL_COLLECTION_CLASSIFICATION).sort());
+  });
+
+  it("rejects adding a production registration without a classification entry", () => {
+    const registerTool = vi.fn();
+    const server = enforceToolClassification({ registerTool });
+
+    expect(() =>
+      server.registerTool("chorus_synthetic_collection", {}, vi.fn())
+    ).toThrow(
+      "MCP tool missing explicit collection classification: chorus_synthetic_collection",
+    );
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+
+  it("rejects explicitly classifying a registration as collection without inventory", () => {
+    const registerTool = vi.fn();
+    expect(() =>
+      enforceToolClassification(
+        { registerTool },
+        {
+          ...TOOL_COLLECTION_CLASSIFICATION,
+          chorus_synthetic_collection: "collection",
+        },
+      )
+    ).toThrow(
+      "MCP collection tools missing from COLLECTION_TOOL_INVENTORY: chorus_synthetic_collection",
+    );
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});
 
 // 0.6.x tool lists captured from pm.ts / developer.ts / admin.ts before this
 // refactor. Used for strict-equality / superset assertions.

--- a/src/mcp/tools/admin.ts
+++ b/src/mcp/tools/admin.ts
@@ -15,8 +15,10 @@ import * as activityService from "@/services/activity.service";
 import * as projectGroupService from "@/services/project-group.service";
 import { zArray } from "./schema-utils";
 import { registerPermissionedTool } from "./register-helpers";
+import { enforceToolClassification } from "./collection-contract";
 
 export function registerAdminTools(server: McpServer, auth: AgentAuthContext) {
+  server = enforceToolClassification(server);
   // chorus_admin_create_project - Create a new project
   registerPermissionedTool(
     server,

--- a/src/mcp/tools/collection-contract.ts
+++ b/src/mcp/tools/collection-contract.ts
@@ -247,18 +247,21 @@ export type CollectionContractEntry =
   | {
       mode: "page";
       collectionKey: string;
+      detailSource: "single-get" | "list-authoritative";
     }
   | {
       mode: "bounded";
       collectionKey: string;
       maximumRows: number;
       reason: string;
+      detailSource: "single-get" | "discovery";
     }
   | {
       mode: "aggregate";
       collectionKey: string;
       maximumRows: number;
       reason: string;
+      detailSource: "aggregate";
     };
 
 /**
@@ -266,68 +269,77 @@ export type CollectionContractEntry =
  * contain a resource collection. Migration tests consume this registry.
  */
 export const COLLECTION_TOOL_INVENTORY = {
-  chorus_list_projects: { mode: "page", collectionKey: "projects" },
-  chorus_get_ideas: { mode: "page", collectionKey: "ideas" },
-  chorus_get_documents: { mode: "page", collectionKey: "documents" },
-  chorus_get_proposals: { mode: "page", collectionKey: "proposals" },
-  chorus_list_tasks: { mode: "page", collectionKey: "tasks" },
-  chorus_get_activity: { mode: "page", collectionKey: "activities" },
-  chorus_get_comments: { mode: "page", collectionKey: "comments" },
-  chorus_get_notifications: { mode: "page", collectionKey: "notifications" },
-  chorus_list_sessions: { mode: "page", collectionKey: "sessions" },
+  chorus_list_projects: { mode: "page", collectionKey: "projects", detailSource: "single-get" },
+  chorus_get_ideas: { mode: "page", collectionKey: "ideas", detailSource: "single-get" },
+  chorus_get_documents: { mode: "page", collectionKey: "documents", detailSource: "single-get" },
+  chorus_get_proposals: { mode: "page", collectionKey: "proposals", detailSource: "single-get" },
+  chorus_list_tasks: { mode: "page", collectionKey: "tasks", detailSource: "single-get" },
+  chorus_get_activity: { mode: "page", collectionKey: "activities", detailSource: "list-authoritative" },
+  chorus_get_comments: { mode: "page", collectionKey: "comments", detailSource: "list-authoritative" },
+  chorus_get_notifications: { mode: "page", collectionKey: "notifications", detailSource: "list-authoritative" },
+  chorus_list_sessions: { mode: "page", collectionKey: "sessions", detailSource: "single-get" },
   chorus_search: {
     mode: "bounded",
     collectionKey: "results",
     maximumRows: 50,
     reason: "Search service enforces a cross-entity result limit.",
+    detailSource: "discovery",
   },
   chorus_search_mentionables: {
     mode: "bounded",
     collectionKey: "results",
     maximumRows: 100,
     reason: "Typeahead results use a validated hard limit.",
+    detailSource: "discovery",
   },
   chorus_get_available_ideas: {
     mode: "bounded",
     collectionKey: "ideas",
     maximumRows: 100,
     reason: "Assignment discovery is capped before serialization.",
+    detailSource: "single-get",
   },
   chorus_get_available_tasks: {
     mode: "bounded",
     collectionKey: "tasks",
     maximumRows: 100,
     reason: "Assignment discovery is capped before serialization.",
+    detailSource: "single-get",
   },
   chorus_get_unblocked_tasks: {
     mode: "bounded",
     collectionKey: "tasks",
     maximumRows: 100,
     reason: "Dependency-ready task discovery is capped before serialization.",
+    detailSource: "single-get",
   },
   chorus_get_project_groups: {
     mode: "bounded",
     collectionKey: "groups",
     maximumRows: 100,
     reason: "Project-group navigation is tenant-scoped and hard-capped.",
+    detailSource: "single-get",
   },
   chorus_checkin: {
     mode: "aggregate",
     collectionKey: "notifications",
     maximumRows: 5,
     reason: "Check-in is a bounded status aggregate with at most five notifications.",
+    detailSource: "aggregate",
   },
   chorus_get_my_assignments: {
     mode: "aggregate",
     collectionKey: "taskTracker",
     maximumRows: 100,
     reason: "The tracker is a bounded workflow aggregate, not a browsable collection.",
+    detailSource: "aggregate",
   },
   chorus_get_group_dashboard: {
     mode: "aggregate",
     collectionKey: "recentActivities",
     maximumRows: 20,
     reason: "Dashboard activity is a fixed-size supporting aggregate.",
+    detailSource: "aggregate",
   },
 } as const satisfies Record<string, CollectionContractEntry>;
 

--- a/src/mcp/tools/collection-contract.ts
+++ b/src/mcp/tools/collection-contract.ts
@@ -1,0 +1,514 @@
+import { z } from "zod";
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 20;
+export const MAX_PAGE_SIZE = 100;
+export const MAX_COLLECTION_JSON_BYTES = 65_536;
+export const SUMMARY_TEXT_CODE_POINTS = 256;
+export const PREVIEW_TEXT_CODE_POINTS = 512;
+const JSON_INDENT = 2;
+
+export const collectionPageSchema = z
+  .number()
+  .int()
+  .positive()
+  .default(DEFAULT_PAGE)
+  .describe("Page number");
+
+export const collectionPageSizeSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(MAX_PAGE_SIZE)
+  .default(DEFAULT_PAGE_SIZE)
+  .describe(`Items per page (maximum ${MAX_PAGE_SIZE})`);
+
+export interface CollectionPage {
+  page: number;
+  pageSize: number;
+}
+
+export interface CollectionMetadata extends CollectionPage {
+  returned: number;
+  total: number;
+}
+
+export type BoundedCollectionPayload<
+  Key extends string,
+  Row,
+  Extra extends Record<string, unknown> = Record<never, never>,
+> = Record<Key, Row[]> & CollectionMetadata & Extra;
+
+export class CollectionPayloadTooLargeError extends Error {
+  readonly code = "MCP_COLLECTION_ROW_TOO_LARGE";
+  readonly maxBytes = MAX_COLLECTION_JSON_BYTES;
+
+  constructor(readonly collectionKey: string) {
+    super(
+      `A single ${collectionKey} summary cannot fit within the ${MAX_COLLECTION_JSON_BYTES}-byte MCP collection limit`,
+    );
+    this.name = "CollectionPayloadTooLargeError";
+  }
+
+  toJSON() {
+    return {
+      error: {
+        code: this.code,
+        message: this.message,
+        collectionKey: this.collectionKey,
+        maxBytes: this.maxBytes,
+      },
+    };
+  }
+}
+
+export function truncateCodePoints(
+  value: string,
+  limit: number = SUMMARY_TEXT_CODE_POINTS,
+): string {
+  if (!Number.isInteger(limit) || limit < 3) {
+    throw new RangeError("Truncation limit must be an integer of at least 3");
+  }
+
+  const codePoints = Array.from(value);
+  if (codePoints.length <= limit) return value;
+  return `${codePoints.slice(0, limit - 3).join("")}...`;
+}
+
+export function truncateSummaryText(value: string): string {
+  return truncateCodePoints(value, SUMMARY_TEXT_CODE_POINTS);
+}
+
+export function truncatePreviewText(value: string): string {
+  return truncateCodePoints(value, PREVIEW_TEXT_CODE_POINTS);
+}
+
+export function compactCollectionRow<
+  const Keys extends readonly string[],
+>(
+  value: unknown,
+  keys: Keys,
+  textKeys: readonly string[] = ["title", "name", "label"],
+): Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return {};
+  const source = value as Record<string, unknown>;
+  const row: Record<string, unknown> = {};
+
+  for (const key of keys) {
+    const field = source[key];
+    if (field === undefined) continue;
+    row[key] =
+      typeof field === "string" && textKeys.includes(key)
+        ? truncateSummaryText(field)
+        : field;
+  }
+
+  return row;
+}
+
+export function collectionMetadata(
+  returned: number,
+  total: number,
+  page: number = DEFAULT_PAGE,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): CollectionMetadata {
+  return { returned, page, pageSize, total };
+}
+
+interface BuildCollectionOptions<
+  Key extends string,
+  Row,
+  Extra extends Record<string, unknown>,
+> extends CollectionPage {
+  collectionKey: Key;
+  rows: readonly Row[];
+  total: number;
+  extra?: Extra;
+  maxBytes?: number;
+}
+
+/**
+ * Builds and measures the exact inner JSON emitted by an MCP collection tool.
+ * Rows are removed from the tail until the serialized payload fits.
+ */
+export function buildBoundedCollectionPayload<
+  Key extends string,
+  Row,
+  Extra extends Record<string, unknown> = Record<never, never>,
+>({
+  collectionKey,
+  rows,
+  total,
+  page,
+  pageSize,
+  extra,
+  maxBytes = MAX_COLLECTION_JSON_BYTES,
+}: BuildCollectionOptions<Key, Row, Extra>): BoundedCollectionPayload<Key, Row, Extra> {
+  const emittedRows = [...rows];
+
+  const build = () =>
+    ({
+      [collectionKey]: emittedRows,
+      ...collectionMetadata(emittedRows.length, total, page, pageSize),
+      ...(extra ?? ({} as Extra)),
+    }) as BoundedCollectionPayload<Key, Row, Extra>;
+
+  let payload = build();
+  while (
+    emittedRows.length > 0 &&
+    Buffer.byteLength(JSON.stringify(payload, null, JSON_INDENT), "utf8") > maxBytes
+  ) {
+    emittedRows.pop();
+    payload = build();
+  }
+
+  if (rows.length > 0 && emittedRows.length === 0) {
+    throw new CollectionPayloadTooLargeError(collectionKey);
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(payload, null, JSON_INDENT), "utf8") >
+    maxBytes
+  ) {
+    throw new CollectionPayloadTooLargeError(collectionKey);
+  }
+
+  return payload;
+}
+
+export function serializeBoundedCollection<
+  Key extends string,
+  Row,
+  Extra extends Record<string, unknown> = Record<never, never>,
+>(options: BuildCollectionOptions<Key, Row, Extra>): string {
+  return JSON.stringify(
+    buildBoundedCollectionPayload(options),
+    null,
+    JSON_INDENT,
+  );
+}
+
+interface AggregateArray {
+  rows: unknown[];
+}
+
+const AGGREGATE_COLLECTION_KEYS = new Set([
+  "ideas",
+  "tasks",
+  "notifications",
+  "recentActivities",
+]);
+
+function collectAggregateArrays(
+  value: unknown,
+  arrays: AggregateArray[],
+  parentKey?: string,
+): void {
+  if (Array.isArray(value)) {
+    if (parentKey && AGGREGATE_COLLECTION_KEYS.has(parentKey)) {
+      arrays.push({ rows: value });
+    }
+    for (const item of value) collectAggregateArrays(item, arrays);
+    return;
+  }
+  if (typeof value !== "object" || value === null) return;
+  for (const [key, child] of Object.entries(value)) {
+    collectAggregateArrays(child, arrays, key);
+  }
+}
+
+/**
+ * Applies the collection byte ceiling to status/dashboard aggregates while
+ * preserving their established object shape. Deep collection tails are
+ * removed round-robin until the exact emitted JSON fits.
+ */
+export function serializeBoundedAggregate(
+  value: unknown,
+  maxBytes: number = MAX_COLLECTION_JSON_BYTES,
+): string {
+  const copy = structuredClone(value);
+  const arrays: AggregateArray[] = [];
+  collectAggregateArrays(copy, arrays);
+
+  let text = JSON.stringify(copy, null, JSON_INDENT);
+  while (Buffer.byteLength(text, "utf8") > maxBytes) {
+    const largest = arrays
+      .filter(({ rows }) => rows.length > 0)
+      .sort((left, right) => right.rows.length - left.rows.length)[0];
+    if (!largest) {
+      throw new CollectionPayloadTooLargeError("aggregate");
+    }
+    largest.rows.pop();
+    text = JSON.stringify(copy, null, JSON_INDENT);
+  }
+  return text;
+}
+
+export type CollectionContractEntry =
+  | {
+      mode: "page";
+      collectionKey: string;
+    }
+  | {
+      mode: "bounded";
+      collectionKey: string;
+      maximumRows: number;
+      reason: string;
+    }
+  | {
+      mode: "aggregate";
+      collectionKey: string;
+      maximumRows: number;
+      reason: string;
+    };
+
+/**
+ * Executable registry for every current MCP tool whose successful response can
+ * contain a resource collection. Migration tests consume this registry.
+ */
+export const COLLECTION_TOOL_INVENTORY = {
+  chorus_list_projects: { mode: "page", collectionKey: "projects" },
+  chorus_get_ideas: { mode: "page", collectionKey: "ideas" },
+  chorus_get_documents: { mode: "page", collectionKey: "documents" },
+  chorus_get_proposals: { mode: "page", collectionKey: "proposals" },
+  chorus_list_tasks: { mode: "page", collectionKey: "tasks" },
+  chorus_get_activity: { mode: "page", collectionKey: "activities" },
+  chorus_get_comments: { mode: "page", collectionKey: "comments" },
+  chorus_get_notifications: { mode: "page", collectionKey: "notifications" },
+  chorus_list_sessions: { mode: "page", collectionKey: "sessions" },
+  chorus_search: {
+    mode: "bounded",
+    collectionKey: "results",
+    maximumRows: 50,
+    reason: "Search service enforces a cross-entity result limit.",
+  },
+  chorus_search_mentionables: {
+    mode: "bounded",
+    collectionKey: "results",
+    maximumRows: 100,
+    reason: "Typeahead results use a validated hard limit.",
+  },
+  chorus_get_available_ideas: {
+    mode: "bounded",
+    collectionKey: "ideas",
+    maximumRows: 100,
+    reason: "Assignment discovery is capped before serialization.",
+  },
+  chorus_get_available_tasks: {
+    mode: "bounded",
+    collectionKey: "tasks",
+    maximumRows: 100,
+    reason: "Assignment discovery is capped before serialization.",
+  },
+  chorus_get_unblocked_tasks: {
+    mode: "bounded",
+    collectionKey: "tasks",
+    maximumRows: 100,
+    reason: "Dependency-ready task discovery is capped before serialization.",
+  },
+  chorus_get_project_groups: {
+    mode: "bounded",
+    collectionKey: "groups",
+    maximumRows: 100,
+    reason: "Project-group navigation is tenant-scoped and hard-capped.",
+  },
+  chorus_checkin: {
+    mode: "aggregate",
+    collectionKey: "notifications",
+    maximumRows: 5,
+    reason: "Check-in is a bounded status aggregate with at most five notifications.",
+  },
+  chorus_get_my_assignments: {
+    mode: "aggregate",
+    collectionKey: "taskTracker",
+    maximumRows: 100,
+    reason: "The tracker is a bounded workflow aggregate, not a browsable collection.",
+  },
+  chorus_get_group_dashboard: {
+    mode: "aggregate",
+    collectionKey: "recentActivities",
+    maximumRows: 20,
+    reason: "Dashboard activity is a fixed-size supporting aggregate.",
+  },
+} as const satisfies Record<string, CollectionContractEntry>;
+
+export type CollectionToolName = keyof typeof COLLECTION_TOOL_INVENTORY;
+
+export const COLLECTION_TOOL_META_KEY = "chorus/collection";
+export type ToolCollectionClassification = "collection" | "non-collection";
+
+/**
+ * Explicit review gate for the complete production tool surface. Do not derive
+ * this policy from registration names or inventory membership: every new tool
+ * requires a deliberate collection/non-collection decision.
+ */
+export const TOOL_COLLECTION_CLASSIFICATION = {
+  chorus_add_comment: "non-collection",
+  chorus_add_reference: "non-collection",
+  chorus_admin_approve_proposal: "non-collection",
+  chorus_admin_close_proposal: "non-collection",
+  chorus_admin_close_task: "non-collection",
+  chorus_admin_create_project: "non-collection",
+  chorus_admin_create_project_group: "non-collection",
+  chorus_admin_delete_document: "non-collection",
+  chorus_admin_delete_idea: "non-collection",
+  chorus_admin_delete_project_group: "non-collection",
+  chorus_admin_delete_task: "non-collection",
+  chorus_admin_move_project_to_group: "non-collection",
+  chorus_admin_reopen_task: "non-collection",
+  chorus_admin_update_project_group: "non-collection",
+  chorus_admin_verify_task: "non-collection",
+  chorus_answer_elaboration: "non-collection",
+  chorus_checkin: "collection",
+  chorus_claim_idea: "non-collection",
+  chorus_claim_task: "non-collection",
+  chorus_close_session: "non-collection",
+  chorus_create_report: "non-collection",
+  chorus_create_session: "non-collection",
+  chorus_create_tasks: "non-collection",
+  chorus_edit_idea: "non-collection",
+  chorus_get_activity: "collection",
+  chorus_get_available_ideas: "collection",
+  chorus_get_available_tasks: "collection",
+  chorus_get_comments: "collection",
+  chorus_get_document: "non-collection",
+  chorus_get_documents: "collection",
+  chorus_get_elaboration: "non-collection",
+  chorus_get_group_dashboard: "collection",
+  chorus_get_idea: "non-collection",
+  chorus_get_ideas: "collection",
+  chorus_get_my_assignments: "collection",
+  chorus_get_notifications: "collection",
+  chorus_get_project: "non-collection",
+  chorus_get_project_group: "non-collection",
+  chorus_get_project_groups: "collection",
+  chorus_get_proposal: "non-collection",
+  chorus_get_proposals: "collection",
+  chorus_get_session: "non-collection",
+  chorus_get_task: "non-collection",
+  chorus_get_unblocked_tasks: "collection",
+  chorus_list_projects: "collection",
+  chorus_list_sessions: "collection",
+  chorus_list_tasks: "collection",
+  chorus_mark_acceptance_criteria: "non-collection",
+  chorus_mark_notification_read: "non-collection",
+  chorus_move_idea: "non-collection",
+  chorus_pm_add_document_draft: "non-collection",
+  chorus_pm_add_task_draft: "non-collection",
+  chorus_pm_assign_task: "non-collection",
+  chorus_pm_create_document: "non-collection",
+  chorus_pm_create_idea: "non-collection",
+  chorus_pm_create_proposal: "non-collection",
+  chorus_pm_reject_proposal: "non-collection",
+  chorus_pm_remove_document_draft: "non-collection",
+  chorus_pm_remove_task_draft: "non-collection",
+  chorus_pm_revoke_proposal: "non-collection",
+  chorus_pm_skip_elaboration: "non-collection",
+  chorus_pm_start_elaboration: "non-collection",
+  chorus_pm_submit_proposal: "non-collection",
+  chorus_pm_update_document: "non-collection",
+  chorus_pm_update_document_draft: "non-collection",
+  chorus_pm_update_task_draft: "non-collection",
+  chorus_pm_validate_elaboration: "non-collection",
+  chorus_pm_validate_proposal: "non-collection",
+  chorus_release_idea: "non-collection",
+  chorus_release_task: "non-collection",
+  chorus_remove_reference: "non-collection",
+  chorus_reopen_session: "non-collection",
+  chorus_report_criteria_self_check: "non-collection",
+  chorus_report_work: "non-collection",
+  chorus_search: "collection",
+  chorus_search_mentionables: "collection",
+  chorus_session_checkin_task: "non-collection",
+  chorus_session_checkout_task: "non-collection",
+  chorus_session_heartbeat: "non-collection",
+  chorus_submit_for_verify: "non-collection",
+  chorus_update_reference: "non-collection",
+  chorus_update_task: "non-collection",
+} as const satisfies Record<string, ToolCollectionClassification>;
+
+export function assertToolClassificationPolicy(
+  classifications: Readonly<Record<string, ToolCollectionClassification>>,
+): void {
+  const missing = Object.entries(classifications)
+    .filter(([name, classification]) =>
+      classification === "collection" && !(name in COLLECTION_TOOL_INVENTORY)
+    )
+    .map(([name]) => name);
+  if (missing.length > 0) {
+    throw new Error(
+      `MCP collection tools missing from COLLECTION_TOOL_INVENTORY: ${missing.sort().join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Enforces explicit collection classification on the real registerTool path.
+ * A new tool cannot be registered until its classification is reviewed.
+ */
+export function enforceToolClassification<T extends object>(
+  server: T,
+  classifications: Readonly<Record<string, ToolCollectionClassification>> =
+    TOOL_COLLECTION_CLASSIFICATION,
+): T {
+  assertToolClassificationPolicy(classifications);
+  return new Proxy(server, {
+    get(target, property, receiver) {
+      if (property !== "registerTool") {
+        return Reflect.get(target, property, receiver);
+      }
+      return (name: string, ...args: unknown[]) => {
+        if (!(name in classifications)) {
+          throw new Error(
+            `MCP tool missing explicit collection classification: ${name}`,
+          );
+        }
+        const registerTool = Reflect.get(target, property, receiver);
+        if (typeof registerTool !== "function") {
+          throw new TypeError("MCP server registerTool must be a function");
+        }
+        return Reflect.apply(registerTool, target, [name, ...args]);
+      };
+    },
+  });
+}
+
+export function collectionToolConfig<T extends object>(
+  config: T,
+): T & { _meta: Record<string, unknown> } {
+  const existingMeta =
+    "_meta" in config &&
+    typeof config._meta === "object" &&
+    config._meta !== null
+      ? (config._meta as Record<string, unknown>)
+      : {};
+  return {
+    ...config,
+    _meta: {
+      ...existingMeta,
+      [COLLECTION_TOOL_META_KEY]: true,
+    },
+  };
+}
+
+export function isCollectionToolConfig(config: unknown): boolean {
+  if (typeof config !== "object" || config === null) return false;
+  const meta = (config as { _meta?: unknown })._meta;
+  return (
+    typeof meta === "object" &&
+    meta !== null &&
+    (meta as Record<string, unknown>)[COLLECTION_TOOL_META_KEY] === true
+  );
+}
+
+export function assertCollectionToolsInventoried(
+  registeredCollectionTools: Iterable<string>,
+): void {
+  const missing = [...registeredCollectionTools].filter(
+    (name) => !(name in COLLECTION_TOOL_INVENTORY),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `MCP collection tools missing from COLLECTION_TOOL_INVENTORY: ${missing.sort().join(", ")}`,
+    );
+  }
+}

--- a/src/mcp/tools/collection-contract.ts
+++ b/src/mcp/tools/collection-contract.ts
@@ -6,6 +6,7 @@ export const MAX_PAGE_SIZE = 100;
 export const MAX_COLLECTION_JSON_BYTES = 65_536;
 export const SUMMARY_TEXT_CODE_POINTS = 256;
 export const PREVIEW_TEXT_CODE_POINTS = 512;
+const AGGREGATE_LONG_TEXT_CODE_POINTS = 4_096;
 const JSON_INDENT = 2;
 
 export const collectionPageSchema = z
@@ -226,6 +227,20 @@ export function serializeBoundedAggregate(
   maxBytes: number = MAX_COLLECTION_JSON_BYTES,
 ): string {
   const copy = structuredClone(value);
+  if (typeof copy === "object" && copy !== null && "agent" in copy) {
+    const agent = (copy as { agent?: unknown }).agent;
+    if (typeof agent === "object" && agent !== null) {
+      for (const key of ["persona", "systemPrompt"] as const) {
+        const field = (agent as Record<string, unknown>)[key];
+        if (typeof field === "string") {
+          (agent as Record<string, unknown>)[key] = truncateCodePoints(
+            field,
+            AGGREGATE_LONG_TEXT_CODE_POINTS,
+          );
+        }
+      }
+    }
+  }
   const arrays: AggregateArray[] = [];
   collectAggregateArrays(copy, arrays);
 
@@ -295,31 +310,19 @@ export const COLLECTION_TOOL_INVENTORY = {
   chorus_get_available_ideas: {
     mode: "bounded",
     collectionKey: "ideas",
-    maximumRows: 100,
-    reason: "Assignment discovery is capped before serialization.",
+    maximumRows: 50,
+    reason: "Assignment discovery deliberately returns at most 50 claim candidates.",
     detailSource: "single-get",
   },
   chorus_get_available_tasks: {
     mode: "bounded",
     collectionKey: "tasks",
-    maximumRows: 100,
-    reason: "Assignment discovery is capped before serialization.",
+    maximumRows: 50,
+    reason: "Assignment discovery deliberately returns at most 50 claim candidates.",
     detailSource: "single-get",
   },
-  chorus_get_unblocked_tasks: {
-    mode: "bounded",
-    collectionKey: "tasks",
-    maximumRows: 100,
-    reason: "Dependency-ready task discovery is capped before serialization.",
-    detailSource: "single-get",
-  },
-  chorus_get_project_groups: {
-    mode: "bounded",
-    collectionKey: "groups",
-    maximumRows: 100,
-    reason: "Project-group navigation is tenant-scoped and hard-capped.",
-    detailSource: "single-get",
-  },
+  chorus_get_unblocked_tasks: { mode: "page", collectionKey: "tasks", detailSource: "single-get" },
+  chorus_get_project_groups: { mode: "page", collectionKey: "groups", detailSource: "single-get" },
   chorus_checkin: {
     mode: "aggregate",
     collectionKey: "notifications",

--- a/src/mcp/tools/developer.ts
+++ b/src/mcp/tools/developer.ts
@@ -13,8 +13,10 @@ import { AlreadyClaimedError, NotClaimedError } from "@/lib/errors";
 import { isAssignmentOwnedByActor } from "@/lib/uuid-resolver";
 import { zArray } from "./schema-utils";
 import { registerPermissionedTool } from "./register-helpers";
+import { enforceToolClassification } from "./collection-contract";
 
 export function registerDeveloperTools(server: McpServer, auth: AgentAuthContext) {
+  server = enforceToolClassification(server);
   // chorus_claim_task - Claim a Task
   registerPermissionedTool(
     server,

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -24,8 +24,10 @@ import { zArray } from "./schema-utils";
 import { registerPermissionedTool } from "./register-helpers";
 import { hasPermission } from "@/lib/auth";
 import { computeEffectivePermissions } from "@/lib/authz/permissions";
+import { enforceToolClassification } from "./collection-contract";
 
 export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
+  server = enforceToolClassification(server);
   // Zod enums derived from the service's allowed sets so the tool schema and the
   // service validation never drift. z.enum needs a non-empty tuple. Declared at
   // the top of the function (not beside the reference write tools) so the create

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -63,6 +63,23 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       extra,
     });
 
+  const serializeAuthoritativePage = (
+    collectionKey: string,
+    rows: unknown[],
+    total: number,
+    page: number,
+    pageSize: number,
+    extra?: Record<string, unknown>,
+  ) =>
+    serializeBoundedCollection({
+      collectionKey,
+      rows,
+      total,
+      page,
+      pageSize,
+      extra,
+    });
+
   const compactTracker = (
     tracker: Record<string, { name: string; ideas?: unknown[]; tasks?: unknown[] }>,
     itemKey: "ideas" | "tasks",
@@ -382,7 +399,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_activity",
     collectionToolConfig({
-      description: "Get compact activity summaries for a project.",
+      description: "Get the paginated activity stream for a project. Activities have no separate single-resource get tool, so rows include their full workflow data.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         page: collectionPageSchema,
@@ -407,13 +424,12 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       return {
         content: [{
           type: "text",
-          text: serializePage(
+          text: serializeAuthoritativePage(
             "activities",
             activities,
             total,
             page,
             pageSize,
-            ["uuid", "action", "targetType", "targetUuid", "actorType", "actorUuid", "projectUuid", "createdAt"],
           ),
         }],
       };
@@ -701,7 +717,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_comments",
     collectionToolConfig({
-      description: "Get compact comment summaries. Full comment content remains available on detailed entity views.",
+      description: "Get paginated comments, newest first. Comments have no separate single-resource get tool, so rows include content and author details.",
       inputSchema: z.object({
         targetType: z.enum(["idea", "proposal", "task", "document"]).describe("Target type"),
         targetUuid: z.string().describe("Target UUID"),
@@ -722,13 +738,12 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       return {
         content: [{
           type: "text",
-          text: serializePage(
+          text: serializeAuthoritativePage(
             "comments",
             comments,
             total,
             page,
             pageSize,
-            ["uuid", "targetType", "targetUuid", "authorType", "authorUuid", "createdAt", "updatedAt"],
           ),
         }],
       };
@@ -777,14 +792,12 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       return {
         content: [{
           type: "text" as const,
-          text: serializePage(
+          text: serializeAuthoritativePage(
             "notifications",
             result.notifications,
             result.total,
             Math.floor(offset / limit) + 1,
             limit,
-            ["uuid", "action", "entityType", "entityUuid", "entityTitle", "projectUuid", "readAt", "createdAt"],
-            undefined,
             { unreadCount: result.unreadCount },
           ),
         }],

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -89,7 +89,6 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     let remaining = maximumRows;
     const compact: Record<string, { name: string; [key: string]: unknown }> = {};
     for (const [projectUuid, project] of Object.entries(tracker)) {
-      if (remaining === 0) break;
       const items = project[itemKey] ?? [];
       const rows = items
         .slice(0, remaining)
@@ -534,7 +533,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_available_ideas",
     collectionToolConfig({
-      description: "Get compact Idea summaries available to claim in a project (status=open).",
+      description: "Get up to 50 compact Idea summaries available to claim in a project (status=open). This is a bounded discovery result, so total equals the returned candidate count.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
       }),
@@ -573,7 +572,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   server.registerTool(
     "chorus_get_available_tasks",
     collectionToolConfig({
-      description: "Get compact Task summaries available to claim in a project (status=open).",
+      description: "Get up to 50 compact Task summaries available to claim in a project (status=open). This is a bounded discovery result, so total equals the returned candidate count.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         proposalUuids: zArray(z.string()).optional().describe("Filter tasks by proposal UUIDs"),
@@ -682,9 +681,11 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         proposalUuids: zArray(z.string()).optional().describe("Filter tasks by proposal UUIDs"),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
     }),
-    async ({ projectUuid, proposalUuids }) => {
+    async ({ projectUuid, proposalUuids, page = 1, pageSize = 20 }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
       if (!project) {
@@ -695,6 +696,8 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         companyUuid: auth.companyUuid,
         projectUuid,
         proposalUuids,
+        skip: (page - 1) * pageSize,
+        take: pageSize,
       });
 
       return {
@@ -702,10 +705,10 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
           type: "text",
           text: serializePage(
             "tasks",
-            tasks.slice(0, 100),
+            tasks,
             total,
-            1,
-            100,
+            page,
+            pageSize,
             ["uuid", "title", "status", "priority", "projectUuid", "proposalUuid", "storyPoints", "createdAt", "updatedAt"],
           ),
         }],
@@ -903,19 +906,23 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
     "chorus_get_project_groups",
     collectionToolConfig({
       description: "List compact project-group summaries.",
-      inputSchema: z.object({}),
+      inputSchema: z.object({
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
+      }),
     }),
-    async () => {
+    async ({ page = 1, pageSize = 20 }) => {
       const result = await projectGroupService.listProjectGroups(auth.companyUuid);
+      const skip = (page - 1) * pageSize;
       return {
         content: [{
           type: "text",
           text: serializePage(
             "groups",
-            result.groups.slice(0, 100),
+            result.groups.slice(skip, skip + pageSize),
             result.total,
-            1,
-            100,
+            page,
+            pageSize,
             ["uuid", "name", "projectCount", "createdAt", "updatedAt"],
             undefined,
             { ungroupedCount: result.ungroupedCount },
@@ -1019,6 +1026,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         scope,
         scopeUuid,
         entityTypes,
+        limit: 50,
       });
       const rows = result.results.map((row) => ({
         ...compactCollectionRow(
@@ -1034,7 +1042,7 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
           text: serializeBoundedCollection({
             collectionKey: "results",
             rows,
-            total: rows.length,
+            total: Object.values(result.counts).reduce((sum, count) => sum + count, 0),
             page: 1,
             pageSize: 50,
             extra: { counts: result.counts },

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -4,6 +4,16 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import {
+  collectionPageSchema,
+  collectionPageSizeSchema,
+  collectionToolConfig,
+  compactCollectionRow,
+  enforceToolClassification,
+  serializeBoundedAggregate,
+  serializeBoundedCollection,
+  truncatePreviewText,
+} from "./collection-contract";
 import type { AgentAuthContext } from "@/types/auth";
 import * as projectService from "@/services/project.service";
 import { projectExists } from "@/services/project.service";
@@ -33,6 +43,49 @@ import {
 } from "@/lib/acceptance-criteria";
 
 export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
+  server = enforceToolClassification(server);
+  const serializePage = (
+    collectionKey: string,
+    rows: unknown[],
+    total: number,
+    page: number,
+    pageSize: number,
+    keys: readonly string[],
+    textKeys?: readonly string[],
+    extra?: Record<string, unknown>,
+  ) =>
+    serializeBoundedCollection({
+      collectionKey,
+      rows: rows.map((row) => compactCollectionRow(row, keys, textKeys)),
+      total,
+      page,
+      pageSize,
+      extra,
+    });
+
+  const compactTracker = (
+    tracker: Record<string, { name: string; ideas?: unknown[]; tasks?: unknown[] }>,
+    itemKey: "ideas" | "tasks",
+    keys: readonly string[],
+    maximumRows = 100,
+  ) => {
+    let remaining = maximumRows;
+    const compact: Record<string, { name: string; [key: string]: unknown }> = {};
+    for (const [projectUuid, project] of Object.entries(tracker)) {
+      if (remaining === 0) break;
+      const items = project[itemKey] ?? [];
+      const rows = items
+        .slice(0, remaining)
+        .map((row) => compactCollectionRow(row, keys));
+      remaining -= rows.length;
+      compact[projectUuid] = {
+        name: project.name,
+        [itemKey]: rows,
+      };
+    }
+    return compact;
+  };
+
   // Inline reference item shape (Thread C) for the per-task references[] on
   // chorus_create_tasks. Enum derived from the service's allowed set so the
   // schema and service validation never drift; matches the createReferences
@@ -67,22 +120,32 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_list_projects - List all projects
   server.registerTool(
     "chorus_list_projects",
-    {
-      description: "List all projects for the current company. Returns projects with counts of ideas, documents, tasks, and proposals.",
+    collectionToolConfig({
+      description: "List compact project summaries. Use chorus_get_project for full details.",
       inputSchema: z.object({
-        page: z.number().default(1).describe("Page number"),
-        pageSize: z.number().default(20).describe("Items per page"),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
+    }),
     async ({ page, pageSize }) => {
       const skip = (page - 1) * pageSize;
-      const result = await projectService.listProjects({
+      const { projects, total } = await projectService.listProjects({
         companyUuid: auth.companyUuid,
         skip,
         take: pageSize,
       });
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "projects",
+            projects,
+            total,
+            page,
+            pageSize,
+            ["uuid", "name", "status", "groupUuid", "_count", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -90,15 +153,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_ideas - Get Ideas list
   server.registerTool(
     "chorus_get_ideas",
-    {
-      description: "Get the list of Ideas for a project. Each row includes `reportCount` — number of completion reports for the idea.",
+    collectionToolConfig({
+      description: "Get compact Idea summaries for a project. Use chorus_get_idea for full details.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         status: z.enum(["open", "elaborating", "elaborated"]).optional().describe("Filter by status"),
-        page: z.number().optional().default(1).describe("Page number"),
-        pageSize: z.number().optional().default(20).describe("Items per page"),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
+    }),
     async ({ projectUuid, status, page = 1, pageSize = 20 }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
@@ -116,7 +179,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       });
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ ideas, total, page, pageSize }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "ideas",
+            ideas,
+            total,
+            page,
+            pageSize,
+            ["uuid", "title", "status", "derivedStatus", "projectUuid", "parentUuid", "reportCount", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -124,15 +197,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_documents - Get Documents list
   server.registerTool(
     "chorus_get_documents",
-    {
-      description: "Get the list of Documents for a project",
+    collectionToolConfig({
+      description: "Get compact Document summaries for a project. Use chorus_get_document for full content.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         type: z.enum(["prd", "tech_design", "adr", "spec", "guide", "report"]).optional().describe("Filter by type"),
-        page: z.number().optional().default(1),
-        pageSize: z.number().optional().default(20),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
+    }),
     async ({ projectUuid, type, page = 1, pageSize = 20 }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
@@ -150,7 +223,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       });
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ documents, total, page, pageSize }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "documents",
+            documents,
+            total,
+            page,
+            pageSize,
+            ["uuid", "title", "type", "projectUuid", "proposalUuid", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -178,15 +261,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_proposals - Get Proposals list
   server.registerTool(
     "chorus_get_proposals",
-    {
-      description: "Get the list of Proposals and their statuses for a project",
+    collectionToolConfig({
+      description: "Get compact Proposal summaries and statuses. Use chorus_get_proposal for details.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         status: z.enum(["draft", "pending", "approved", "closed"]).optional().describe("Filter by status"),
-        page: z.number().optional().default(1),
-        pageSize: z.number().optional().default(20),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
+    }),
     async ({ projectUuid, status, page = 1, pageSize = 20 }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
@@ -204,7 +287,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       });
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ proposals, total, page, pageSize }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "proposals",
+            proposals,
+            total,
+            page,
+            pageSize,
+            ["uuid", "title", "status", "projectUuid", "ideaUuid", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -240,17 +333,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_list_tasks - List Tasks
   server.registerTool(
     "chorus_list_tasks",
-    {
-      description: "List Tasks for a project",
+    collectionToolConfig({
+      description: "List compact Task summaries for a project. Use chorus_get_task for full details.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         status: z.enum(["open", "assigned", "in_progress", "to_verify", "done", "closed"]).optional().describe("Filter by status"),
         priority: z.enum(["low", "medium", "high"]).optional().describe("Filter by priority"),
         proposalUuids: zArray(z.string()).optional().describe("Filter tasks by proposal UUIDs"),
-        page: z.number().optional().default(1),
-        pageSize: z.number().optional().default(20),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
+    }),
     async ({ projectUuid, status, priority, proposalUuids, page = 1, pageSize = 20 }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
@@ -270,7 +363,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       });
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ tasks, total, page, pageSize }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "tasks",
+            tasks,
+            total,
+            page,
+            pageSize,
+            ["uuid", "title", "status", "priority", "projectUuid", "proposalUuid", "assigneeUuid", "storyPoints", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -278,15 +381,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_activity - Get project activity stream
   server.registerTool(
     "chorus_get_activity",
-    {
-      description: "Get the activity stream for a project",
+    collectionToolConfig({
+      description: "Get compact activity summaries for a project.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
-        page: z.number().optional().default(1),
-        pageSize: z.number().optional().default(50),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
-    async ({ projectUuid, page = 1, pageSize = 50 }) => {
+    }),
+    async ({ projectUuid, page = 1, pageSize = 20 }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
       if (!project) {
@@ -302,7 +405,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       });
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ activities, total, page, pageSize }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "activities",
+            activities,
+            total,
+            page,
+            pageSize,
+            ["uuid", "action", "targetType", "targetUuid", "actorType", "actorUuid", "projectUuid", "createdAt"],
+          ),
+        }],
       };
     }
   );
@@ -358,15 +471,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_checkin - Agent heartbeat check-in
   server.registerTool(
     "chorus_checkin",
-    {
+    collectionToolConfig({
       description:
         "Agent check-in. Returns agent identity (owner, roles, persona), a project-grouped idea tracker with derived statuses and proposal/task counts, and up to 5 recent unread notifications (auto-marked read). Recommended at session start.",
       inputSchema: z.object({}),
-    },
+    }),
     async () => {
       const result = await checkinService.buildCheckinResponse(auth);
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text", text: serializeBoundedAggregate(result) }],
       };
     }
   );
@@ -374,16 +487,29 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_my_assignments - Get own claimed Ideas + Tasks
   server.registerTool(
     "chorus_get_my_assignments",
-    {
+    collectionToolConfig({
       description:
         "Get the agent's idea/task tracker, grouped by project — same shape as checkin.ideaTracker. Returns { ideaTracker, taskTracker } where ideaTracker carries derivedStatus + proposal/task counts and taskTracker carries acceptance criteria progress.",
       inputSchema: z.object({}),
-    },
+    }),
     async () => {
       const result = await assignmentService.getMyAssignments(auth, auth.projectUuids);
+      const ideaTracker = compactTracker(
+        result.ideaTracker,
+        "ideas",
+        ["uuid", "title", "status", "parentUuid", "proposals", "tasks"],
+      );
+      const taskTracker = compactTracker(
+        result.taskTracker,
+        "tasks",
+        ["uuid", "title", "status", "priority", "proposalUuid", "acceptanceSummary"],
+      );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializeBoundedAggregate({ ideaTracker, taskTracker }),
+        }],
       };
     }
   );
@@ -391,12 +517,12 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_available_ideas - Get claimable Ideas
   server.registerTool(
     "chorus_get_available_ideas",
-    {
-      description: "Get Ideas available to claim in a project (status=open)",
+    collectionToolConfig({
+      description: "Get compact Idea summaries available to claim in a project (status=open).",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
       }),
-    },
+    }),
     async ({ projectUuid }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
@@ -412,7 +538,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ ideas }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "ideas",
+            ideas.slice(0, 100),
+            ideas.length,
+            1,
+            100,
+            ["uuid", "title", "status", "projectUuid", "parentUuid", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -420,13 +556,13 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_available_tasks - Get claimable Tasks
   server.registerTool(
     "chorus_get_available_tasks",
-    {
-      description: "Get Tasks available to claim in a project (status=open)",
+    collectionToolConfig({
+      description: "Get compact Task summaries available to claim in a project (status=open).",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         proposalUuids: zArray(z.string()).optional().describe("Filter tasks by proposal UUIDs"),
       }),
-    },
+    }),
     async ({ projectUuid, proposalUuids }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
@@ -443,7 +579,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ tasks }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "tasks",
+            tasks.slice(0, 100),
+            tasks.length,
+            1,
+            100,
+            ["uuid", "title", "status", "priority", "projectUuid", "proposalUuid", "storyPoints", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -515,13 +661,13 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_unblocked_tasks - Get unblocked tasks (all dependencies resolved)
   server.registerTool(
     "chorus_get_unblocked_tasks",
-    {
-      description: "Get tasks that are ready to start — status is open/assigned and all dependencies are resolved (done/to_verify). Useful for discovering what work can begin next after a task completes.",
+    collectionToolConfig({
+      description: "Get compact Task summaries that are ready to start. Use chorus_get_task for full details.",
       inputSchema: z.object({
         projectUuid: z.string().describe("Project UUID"),
         proposalUuids: zArray(z.string()).optional().describe("Filter tasks by proposal UUIDs"),
       }),
-    },
+    }),
     async ({ projectUuid, proposalUuids }) => {
       // Verify project exists
       const project = await projectService.getProjectByUuid(auth.companyUuid, projectUuid);
@@ -536,7 +682,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       });
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ tasks, total }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "tasks",
+            tasks.slice(0, 100),
+            total,
+            1,
+            100,
+            ["uuid", "title", "status", "priority", "projectUuid", "proposalUuid", "storyPoints", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -544,15 +700,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_comments - Get comments list
   server.registerTool(
     "chorus_get_comments",
-    {
-      description: "Get the list of comments for an Idea/Proposal/Task/Document",
+    collectionToolConfig({
+      description: "Get compact comment summaries. Full comment content remains available on detailed entity views.",
       inputSchema: z.object({
         targetType: z.enum(["idea", "proposal", "task", "document"]).describe("Target type"),
         targetUuid: z.string().describe("Target UUID"),
-        page: z.number().optional().default(1).describe("Page number"),
-        pageSize: z.number().optional().default(20).describe("Items per page"),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
+    }),
     async ({ targetType, targetUuid, page = 1, pageSize = 20 }) => {
       const skip = (page - 1) * pageSize;
       const { comments, total } = await commentService.listComments({
@@ -564,7 +720,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
       });
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ comments, total, page, pageSize }, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "comments",
+            comments,
+            total,
+            page,
+            pageSize,
+            ["uuid", "targetType", "targetUuid", "authorType", "authorUuid", "createdAt", "updatedAt"],
+          ),
+        }],
       };
     }
   );
@@ -572,15 +738,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_notifications - Get notifications for the current Agent
   server.registerTool(
     "chorus_get_notifications",
-    {
+    collectionToolConfig({
       description: "Get the list of notifications for the current Agent. By default, fetching unread notifications automatically marks them as read. Set autoMarkRead=false to keep them unread.",
       inputSchema: z.object({
         status: z.enum(["unread", "read", "all"]).default("unread").optional().describe("Filter by status"),
-        limit: z.number().default(20).optional().describe("Items per page"),
-        offset: z.number().default(0).optional().describe("Offset"),
+        limit: collectionPageSizeSchema.optional().describe("Items per page"),
+        offset: z.number().int().nonnegative().default(0).optional().describe("Offset"),
         autoMarkRead: z.boolean().default(true).optional().describe("Automatically mark fetched unread notifications as read (default: true)"),
       }),
-    },
+    }),
     async (params) => {
       const statusValue = params.status ?? "unread";
       const result = await notificationService.list({
@@ -606,7 +772,23 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         }
       }
 
-      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+      const limit = params.limit ?? 20;
+      const offset = params.offset ?? 0;
+      return {
+        content: [{
+          type: "text" as const,
+          text: serializePage(
+            "notifications",
+            result.notifications,
+            result.total,
+            Math.floor(offset / limit) + 1,
+            limit,
+            ["uuid", "action", "entityType", "entityUuid", "entityTitle", "projectUuid", "readAt", "createdAt"],
+            undefined,
+            { unreadCount: result.unreadCount },
+          ),
+        }],
+      };
     }
   );
 
@@ -706,14 +888,26 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_project_groups - List all project groups
   server.registerTool(
     "chorus_get_project_groups",
-    {
-      description: "List all project groups for the current company. Returns groups with project counts.",
+    collectionToolConfig({
+      description: "List compact project-group summaries.",
       inputSchema: z.object({}),
-    },
+    }),
     async () => {
       const result = await projectGroupService.listProjectGroups(auth.companyUuid);
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "groups",
+            result.groups.slice(0, 100),
+            result.total,
+            1,
+            100,
+            ["uuid", "name", "projectCount", "createdAt", "updatedAt"],
+            undefined,
+            { ungroupedCount: result.ungroupedCount },
+          ),
+        }],
       };
     }
   );
@@ -741,19 +935,19 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_get_group_dashboard - Get aggregated dashboard stats for a project group
   server.registerTool(
     "chorus_get_group_dashboard",
-    {
+    collectionToolConfig({
       description: "Get aggregated dashboard stats for a project group (project count, tasks, completion rate, ideas, proposals, activity stream).",
       inputSchema: z.object({
         groupUuid: z.string().describe("Project Group UUID"),
       }),
-    },
+    }),
     async ({ groupUuid }) => {
       const dashboard = await projectGroupService.getGroupDashboard(auth.companyUuid, groupUuid);
       if (!dashboard) {
         return { content: [{ type: "text", text: "Project group not found" }], isError: true };
       }
       return {
-        content: [{ type: "text", text: JSON.stringify(dashboard, null, 2) }],
+        content: [{ type: "text", text: serializeBoundedAggregate(dashboard) }],
       };
     }
   );
@@ -761,13 +955,13 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_search_mentionables - Search for @mentionable users and agents
   server.registerTool(
     "chorus_search_mentionables",
-    {
+    collectionToolConfig({
       description: "Search for users and agents that can be @mentioned. Returns name, type, and UUID. Use the UUID to write mentions as @[Name](type:uuid) in comment/description text. For results of type \"agent\" the entry also carries `online` (boolean: true iff the agent currently has a live daemon connection) and `activeCount` (number of tasks/resources its daemon is running or has queued; 0 when offline). User results do not carry these fields.",
       inputSchema: z.object({
         query: z.string().describe("Name or keyword to search"),
-        limit: z.number().optional().default(10).describe("Max results to return (default 10)"),
+        limit: z.number().int().positive().max(100).optional().default(10).describe("Max results to return (default 10, maximum 100)"),
       }),
-    },
+    }),
     async ({ query, limit }) => {
       const results = await mentionService.searchMentionables({
         companyUuid: auth.companyUuid,
@@ -778,7 +972,17 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         limit,
       });
       return {
-        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializePage(
+            "results",
+            results.slice(0, limit),
+            results.length,
+            1,
+            limit,
+            ["uuid", "name", "type", "online", "activeCount"],
+          ),
+        }],
       };
     }
   );
@@ -786,15 +990,15 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
   // chorus_search - Search across all entity types
   server.registerTool(
     "chorus_search",
-    {
-      description: "Search across tasks, ideas, proposals, documents, projects, and project groups. Supports scoping to project groups or specific projects.",
+    collectionToolConfig({
+      description: "Search compact summaries across tasks, ideas, proposals, documents, projects, and project groups. A canonical UUID query performs tenant-scoped exact lookup first; text search is the fallback. Prefer this tool for discovery, use paginated list tools only for browsing, and call the entity's single-resource get tool for full details.",
       inputSchema: z.object({
-        query: z.string().describe("Search query (matches title, description, content)"),
+        query: z.string().describe("Canonical entity UUID for exact lookup, or text matching title, description, and content"),
         scope: z.enum(["global", "group", "project"]).optional().default("global").describe("Search scope"),
         scopeUuid: z.string().optional().describe("Project group UUID (scope=group) or project UUID (scope=project)"),
         entityTypes: zArray(z.enum(["task", "idea", "proposal", "document", "project", "project_group"])).optional().describe("Entity types to search (default: all). Example: [\"task\", \"idea\"]"),
       }),
-    },
+    }),
     async ({ query, scope, scopeUuid, entityTypes }) => {
       const result = await searchService.search({
         companyUuid: auth.companyUuid,
@@ -803,8 +1007,26 @@ export function registerPublicTools(server: McpServer, auth: AgentAuthContext) {
         scopeUuid,
         entityTypes,
       });
+      const rows = result.results.map((row) => ({
+        ...compactCollectionRow(
+          row,
+          ["entityType", "uuid", "title", "status", "projectUuid", "projectName", "updatedAt"],
+          ["title", "projectName"],
+        ),
+        snippet: truncatePreviewText(row.snippet),
+      }));
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializeBoundedCollection({
+            collectionKey: "results",
+            rows,
+            total: rows.length,
+            page: 1,
+            pageSize: 50,
+            extra: { counts: result.counts },
+          }),
+        }],
       };
     }
   );

--- a/src/mcp/tools/session.ts
+++ b/src/mcp/tools/session.ts
@@ -4,28 +4,62 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import {
+  collectionPageSchema,
+  collectionPageSizeSchema,
+  collectionToolConfig,
+  compactCollectionRow,
+  enforceToolClassification,
+  serializeBoundedCollection,
+} from "./collection-contract";
 import type { AgentAuthContext } from "@/types/auth";
 import * as sessionService from "@/services/session.service";
 
 export function registerSessionTools(server: McpServer, auth: AgentAuthContext) {
+  server = enforceToolClassification(server);
   // chorus_list_sessions - List current agent's sessions
   server.registerTool(
     "chorus_list_sessions",
-    {
-      description: "List all Sessions for the current Agent",
+    collectionToolConfig({
+      description: "List compact Session summaries for the current Agent. Use chorus_get_session for details.",
       inputSchema: z.object({
         status: z.enum(["active", "closed"]).optional().describe("Filter by status"),
+        page: collectionPageSchema,
+        pageSize: collectionPageSizeSchema,
       }),
-    },
-    async ({ status }) => {
+    }),
+    async ({ status, page, pageSize }) => {
       const sessions = await sessionService.listAgentSessions(
         auth.companyUuid,
         auth.actorUuid,
         status
       );
+      const start = (page - 1) * pageSize;
+      const rows = sessions
+        .slice(start, start + pageSize)
+        .map((session) =>
+          compactCollectionRow(session, [
+            "uuid",
+            "name",
+            "status",
+            "agentUuid",
+            "createdAt",
+            "lastActiveAt",
+            "closedAt",
+          ]),
+        );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(sessions, null, 2) }],
+        content: [{
+          type: "text",
+          text: serializeBoundedCollection({
+            collectionKey: "sessions",
+            rows,
+            total: sessions.length,
+            page,
+            pageSize,
+          }),
+        }],
       };
     }
   );

--- a/src/services/__tests__/comment.service.test.ts
+++ b/src/services/__tests__/comment.service.test.ts
@@ -606,7 +606,7 @@ describe("listComments", () => {
     expect(result.comments[0].author.name).toBe("Unknown");
   });
 
-  it("offset mode is unchanged: oldest-first orderBy, {comments,total} shape, no cursor fields", async () => {
+  it("offset mode defaults to newest-first and keeps the {comments,total} shape", async () => {
     mockPrisma.comment.findMany.mockResolvedValue([makeCommentRecord()]);
     mockPrisma.comment.count.mockResolvedValue(1);
 
@@ -625,7 +625,11 @@ describe("listComments", () => {
     expect(result).not.toHaveProperty("nextCursor");
     expect(result).not.toHaveProperty("hasMore");
     expect(mockPrisma.comment.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ orderBy: { createdAt: "asc" }, skip: 0, take: 20 })
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        skip: 0,
+        take: 20,
+      })
     );
     // Offset mode must not issue a cursor-resolution lookup.
     expect(mockPrisma.comment.findFirst).not.toHaveBeenCalled();

--- a/src/services/__tests__/search.service.test.ts
+++ b/src/services/__tests__/search.service.test.ts
@@ -4,26 +4,32 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 
 const mockPrisma = vi.hoisted(() => ({
   task: {
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     count: vi.fn(),
   },
   idea: {
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     count: vi.fn(),
   },
   proposal: {
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     count: vi.fn(),
   },
   document: {
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     count: vi.fn(),
   },
   project: {
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     count: vi.fn(),
   },
   projectGroup: {
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     count: vi.fn(),
   },
@@ -40,6 +46,117 @@ import { search } from "@/services/search.service";
 describe("search.service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    for (const model of Object.values(mockPrisma)) {
+      model.findFirst.mockResolvedValue(null);
+    }
+  });
+
+  describe("canonical UUID search", () => {
+    const uuid = "123e4567-e89b-42d3-a456-426614174000";
+
+    it("returns an exact compact result with tenant isolation", async () => {
+      const now = new Date();
+      mockPrisma.task.findFirst.mockResolvedValue({
+        uuid,
+        title: "Exact task",
+        status: "open",
+        projectUuid: "project-1",
+        updatedAt: now,
+        project: { name: "Project A" },
+      });
+
+      const result = await search({
+        query: uuid.toUpperCase(),
+        companyUuid: "company-1",
+        entityTypes: ["task"],
+      });
+
+      expect(mockPrisma.task.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+        where: { uuid, companyUuid: "company-1" },
+      }));
+      expect(result).toEqual({
+        results: [{
+          entityType: "task",
+          uuid,
+          title: "Exact task",
+          snippet: "",
+          status: "open",
+          projectUuid: "project-1",
+          projectName: "Project A",
+          updatedAt: now.toISOString(),
+        }],
+        counts: {
+          tasks: 1,
+          ideas: 0,
+          proposals: 0,
+          documents: 0,
+          projects: 0,
+          projectGroups: 0,
+        },
+      });
+      expect(mockPrisma.task.findMany).not.toHaveBeenCalled();
+    });
+
+    it("honors entity and project filters", async () => {
+      mockPrisma.idea.findMany.mockResolvedValue([]);
+      mockPrisma.idea.count.mockResolvedValue(0);
+      mockPrisma.projectGroup.findMany.mockResolvedValue([]);
+      mockPrisma.projectGroup.count.mockResolvedValue(0);
+
+      await search({
+        query: uuid,
+        companyUuid: "company-1",
+        scope: "project",
+        scopeUuid: "project-1",
+        entityTypes: ["idea", "project_group"],
+      });
+
+      expect(mockPrisma.idea.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+        where: {
+          uuid,
+          companyUuid: "company-1",
+          projectUuid: { in: ["project-1"] },
+        },
+      }));
+      expect(mockPrisma.task.findFirst).not.toHaveBeenCalled();
+      expect(mockPrisma.projectGroup.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("falls back to text search when no exact UUID match survives filters", async () => {
+      mockPrisma.task.findMany.mockResolvedValue([]);
+      mockPrisma.task.count.mockResolvedValue(0);
+
+      const result = await search({
+        query: uuid,
+        companyUuid: "company-1",
+        scope: "project",
+        scopeUuid: "project-1",
+        entityTypes: ["task"],
+      });
+
+      expect(mockPrisma.task.findFirst).toHaveBeenCalled();
+      expect(mockPrisma.task.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          companyUuid: "company-1",
+          projectUuid: { in: ["project-1"] },
+        }),
+      }));
+      expect(result.results).toEqual([]);
+    });
+
+    it("does not attempt exact lookup for non-canonical UUID text", async () => {
+      mockPrisma.task.findMany.mockResolvedValue([]);
+      mockPrisma.task.count.mockResolvedValue(0);
+
+      await search({
+        query: "123e4567-e89b-42d3-a456",
+        companyUuid: "company-1",
+        entityTypes: ["task"],
+      });
+
+      expect(mockPrisma.task.findFirst).not.toHaveBeenCalled();
+      expect(mockPrisma.task.findMany).toHaveBeenCalled();
+    });
   });
 
   describe("global search", () => {

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -17,8 +17,8 @@ export interface CommentListParams {
   companyUuid: string;
   targetType: TargetType;
   targetUuid: string;
-  // Offset mode (existing — used by the MCP `chorus_get_comments` tool and the
-  // offset REST path): both present, oldest-first.
+  // Offset mode (used by the MCP `chorus_get_comments` tool and the offset REST
+  // path): both present, newest-first.
   skip?: number;
   take?: number;
   // Cursor mode (additive): selected by the presence of `limit`. `cursor` is a
@@ -110,9 +110,9 @@ export interface CommentResponse {
 // List comments.
 //
 // Two retrieval modes, selected by the presence of `limit`:
-//   - Offset mode (skip/take): oldest-first (`createdAt asc`), returns
+//   - Offset mode (skip/take): newest-first (`createdAt desc, id desc`), returns
 //     `{ comments, total }`. Used by the MCP `chorus_get_comments` tool and the
-//     offset REST path — its behavior and ordering MUST stay unchanged.
+//     offset REST path.
 //   - Cursor mode (limit, optional cursor): newest-first (`createdAt desc, id desc`),
 //     returns `{ comments, total, nextCursor, hasMore }`. The page is strictly older
 //     than the `cursor` comment (a comment uuid); an unresolvable cursor degrades to
@@ -142,7 +142,7 @@ export async function listComments(
       where,
       skip,
       take,
-      orderBy: { createdAt: "asc" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       select: COMMENT_SELECT,
     }),
     prisma.comment.count({ where }),

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -45,6 +45,20 @@ export interface SearchResponse {
 
 // ===== Helper Functions =====
 
+const CANONICAL_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function emptyCounts(): SearchCounts {
+  return {
+    tasks: 0,
+    ideas: 0,
+    proposals: 0,
+    documents: 0,
+    projects: 0,
+    projectGroups: 0,
+  };
+}
+
 // Generate snippet: extract ~100 chars around the first match position
 function generateSnippet(text: string, query: string, maxLength = 100): string {
   if (!text) return "";
@@ -86,6 +100,167 @@ async function resolveGroupProjects(companyUuid: string, groupUuid: string): Pro
     select: { uuid: true },
   });
   return projects.map(p => p.uuid);
+}
+
+async function searchExactUuid(
+  companyUuid: string,
+  uuid: string,
+  typesToSearch: EntityType[],
+  scope: SearchScope,
+  projectUuids: string[] | null,
+  groupUuid: string | null,
+): Promise<SearchResponse | null> {
+  const lookups = typesToSearch.map(async (type): Promise<SearchResult | null> => {
+    const projectFilter = projectUuids ? { in: projectUuids } : undefined;
+
+    switch (type) {
+      case "task": {
+        const task = await prisma.task.findFirst({
+          where: { uuid, companyUuid, ...(projectFilter && { projectUuid: projectFilter }) },
+          select: {
+            uuid: true,
+            title: true,
+            status: true,
+            projectUuid: true,
+            updatedAt: true,
+            project: { select: { name: true } },
+          },
+        });
+        return task && {
+          entityType: "task",
+          uuid: task.uuid,
+          title: task.title,
+          snippet: "",
+          status: task.status,
+          projectUuid: task.projectUuid,
+          projectName: task.project.name,
+          updatedAt: task.updatedAt.toISOString(),
+        };
+      }
+      case "idea": {
+        const idea = await prisma.idea.findFirst({
+          where: { uuid, companyUuid, ...(projectFilter && { projectUuid: projectFilter }) },
+          select: {
+            uuid: true,
+            title: true,
+            status: true,
+            projectUuid: true,
+            updatedAt: true,
+            project: { select: { name: true } },
+          },
+        });
+        return idea && {
+          entityType: "idea",
+          uuid: idea.uuid,
+          title: idea.title,
+          snippet: "",
+          status: idea.status,
+          projectUuid: idea.projectUuid,
+          projectName: idea.project.name,
+          updatedAt: idea.updatedAt.toISOString(),
+        };
+      }
+      case "proposal": {
+        const proposal = await prisma.proposal.findFirst({
+          where: { uuid, companyUuid, ...(projectFilter && { projectUuid: projectFilter }) },
+          select: {
+            uuid: true,
+            title: true,
+            status: true,
+            projectUuid: true,
+            updatedAt: true,
+            project: { select: { name: true } },
+          },
+        });
+        return proposal && {
+          entityType: "proposal",
+          uuid: proposal.uuid,
+          title: proposal.title,
+          snippet: "",
+          status: proposal.status,
+          projectUuid: proposal.projectUuid,
+          projectName: proposal.project.name,
+          updatedAt: proposal.updatedAt.toISOString(),
+        };
+      }
+      case "document": {
+        const document = await prisma.document.findFirst({
+          where: { uuid, companyUuid, ...(projectFilter && { projectUuid: projectFilter }) },
+          select: {
+            uuid: true,
+            title: true,
+            type: true,
+            projectUuid: true,
+            updatedAt: true,
+            project: { select: { name: true } },
+          },
+        });
+        return document && {
+          entityType: "document",
+          uuid: document.uuid,
+          title: document.title,
+          snippet: "",
+          status: document.type,
+          projectUuid: document.projectUuid,
+          projectName: document.project.name,
+          updatedAt: document.updatedAt.toISOString(),
+        };
+      }
+      case "project": {
+        if (projectUuids && !projectUuids.includes(uuid)) return null;
+        const project = await prisma.project.findFirst({
+          where: { uuid, companyUuid },
+          select: { uuid: true, name: true, updatedAt: true },
+        });
+        return project && {
+          entityType: "project",
+          uuid: project.uuid,
+          title: project.name,
+          snippet: "",
+          status: "active",
+          projectUuid: null,
+          projectName: null,
+          updatedAt: project.updatedAt.toISOString(),
+        };
+      }
+      case "project_group": {
+        if (scope === "project") return null;
+        if (groupUuid && uuid !== groupUuid) return null;
+        const projectGroup = await prisma.projectGroup.findFirst({
+          where: { uuid, companyUuid },
+          select: { uuid: true, name: true, updatedAt: true },
+        });
+        return projectGroup && {
+          entityType: "project_group",
+          uuid: projectGroup.uuid,
+          title: projectGroup.name,
+          snippet: "",
+          status: "active",
+          projectUuid: null,
+          projectName: null,
+          updatedAt: projectGroup.updatedAt.toISOString(),
+        };
+      }
+    }
+  });
+
+  const results = (await Promise.all(lookups)).filter(
+    (result): result is SearchResult => result !== null,
+  );
+  if (results.length === 0) return null;
+
+  const counts = emptyCounts();
+  for (const result of results) {
+    switch (result.entityType) {
+      case "task": counts.tasks += 1; break;
+      case "idea": counts.ideas += 1; break;
+      case "proposal": counts.proposals += 1; break;
+      case "document": counts.documents += 1; break;
+      case "project": counts.projects += 1; break;
+      case "project_group": counts.projectGroups += 1; break;
+    }
+  }
+  return { results, counts };
 }
 
 // ===== Entity Search Functions =====
@@ -447,6 +622,18 @@ export async function search(params: SearchParams): Promise<SearchResponse> {
     groupUuid = scopeUuid;
   }
 
+  if (CANONICAL_UUID_PATTERN.test(query)) {
+    const exactResult = await searchExactUuid(
+      companyUuid,
+      query.toLowerCase(),
+      typesToSearch,
+      scope,
+      projectUuids,
+      groupUuid,
+    );
+    if (exactResult) return exactResult;
+  }
+
   // Execute searches in parallel
   const searchPromises: Promise<{ results: SearchResult[]; count: number }>[] = [];
   const typeOrder: EntityType[] = [];
@@ -480,14 +667,7 @@ export async function search(params: SearchParams): Promise<SearchResponse> {
 
   // Combine results and build counts
   const allResults: SearchResult[] = [];
-  const counts: SearchCounts = {
-    tasks: 0,
-    ideas: 0,
-    proposals: 0,
-    documents: 0,
-    projects: 0,
-    projectGroups: 0,
-  };
+  const counts = emptyCounts();
 
   searchResults.forEach((result, index) => {
     allResults.push(...result.results);

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -1248,10 +1248,14 @@ export async function getUnblockedTasks({
   companyUuid,
   projectUuid,
   proposalUuids,
+  skip,
+  take,
 }: {
   companyUuid: string;
   projectUuid: string;
   proposalUuids?: string[];
+  skip?: number;
+  take?: number;
 }): Promise<{ tasks: TaskResponse[]; total: number }> {
   const where = {
     projectUuid,
@@ -1273,6 +1277,8 @@ export async function getUnblockedTasks({
   const [rawTasks, total] = await Promise.all([
     prisma.task.findMany({
       where,
+      skip,
+      take,
       orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
       select: {
         uuid: true,


### PR DESCRIPTION
## Summary
- standardize bounded pagination and compact projections for MCP collection tools
- enforce a 65,536-byte serialized response ceiling for collections and aggregates
- add exact UUID search plus exhaustive collection-tool classification and inventory checks
- synchronize MCP usage guidance across maintained plugin surfaces

## Verification
- [x] 1,981 MCP/service tests passed
- [x] TypeScript and production build passed
- [x] Deployed with `./default_deploy.sh`
- [x] Production Streamable HTTP MCP E2E: 18/18 collection and aggregate tools, 33 calls
- [x] Default/max pagination, metadata, compact projection, UUID search/get all passed
- [x] Largest production response: 37,594 bytes; zero mutations and no data residue

## OpenSpec
- archived change: `bound-mcp-list-responses`
- cumulative spec: `openspec/specs/bounded-mcp-collections/spec.md`