### PR TITLE
feat: add project Agent cwd discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ With no `--cwd`, the daemon serves the single directory it was launched from.
 | `apiKey` | string | Agent API key (`cho_…`) | `--api-key` flag → `CHORUS_API_KEY` → file |
 | `agentUuid` / `agentName` | string | Authenticated identity (recorded at login) | written by `chorus login` |
 | `cwds` | string[] | Working directories the daemon serves (multi-path) | `--cwd` flag(s) → `CHORUS_DAEMON_CWDS` → file → launch dir |
+| `browseRoots` | string[] | Roots allowed for project and temporary directory browsing | `--browse-root` flag(s) → `CHORUS_DAEMON_BROWSE_ROOTS` → file → user home |
 | `agent` | string | Local agent backend to wake (`claude-code` / `codex` / `kiro`) | `--agent` flag → `CHORUS_AGENT` → file → `claude-code` |
 | `sigintTimeoutMs` | number | Grace window (ms) after SIGINT before a forceful kill (default `10000`) | `--sigint-timeout` flag → `CHORUS_DAEMON_SIGINT_TIMEOUT` → file → `10000` |
 | `yoloAckAt` | string | Internal — timestamp of a TTY yolo confirmation (managed automatically) | — |

--- a/cli/__tests__/client-args.test.mjs
+++ b/cli/__tests__/client-args.test.mjs
@@ -36,6 +36,11 @@ describe("parseClientFlags — new daemon flags", () => {
     expect(parseClientFlags(["--agent=codex"]).agent).toBe("codex");
   });
 
+  it("collects repeatable --browse-root values independently from --cwd", () => {
+    expect(parseClientFlags(["--browse-root", "/srv", "--browse-root=/home/u", "--cwd", "/repo"]))
+      .toMatchObject({ browseRoot: ["/srv", "/home/u"], cwd: ["/repo"] });
+  });
+
   it("parses boolean --chorus-only / --verbose / -d / --detach / --force", () => {
     expect(parseClientFlags(["--chorus-only"]).chorusOnly).toBe(true);
     expect(parseClientFlags(["--verbose"]).verbose).toBe(true);

--- a/cli/__tests__/control-handler.test.mjs
+++ b/cli/__tests__/control-handler.test.mjs
@@ -337,3 +337,51 @@ describe("control-handler deliver_turn (子2 — origin-only live delivery)", ()
     expect(() => onControl(deliverEvent())).not.toThrow();
   });
 });
+
+describe("control-handler browse_directory", () => {
+  it("correlates a successful request after checking the target connection", async () => {
+    const handleDirectoryRequest = vi.fn(async () => ({ items: [{ name: "repo", path: "/repo" }] }));
+    const reportDirectoryRequest = vi.fn(async () => {});
+    const onControl = createControlHandler({
+      waker: makeWaker([]),
+      getConnectionUuid: () => CONN,
+      handleDirectoryRequest,
+      reportDirectoryRequest,
+      logger: silent,
+    });
+    onControl({
+      type: "control", command: "browse_directory", targetConnectionUuid: CONN,
+      requestUuid: "req-1", operation: "list", prefix: "/r",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(reportDirectoryRequest).toHaveBeenCalledWith({
+      requestUuid: "req-1", status: "succeeded", items: [{ name: "repo", path: "/repo" }],
+    });
+  });
+
+  it("reports stable failures and ignores stale targets", async () => {
+    const error = Object.assign(new Error("outside"), { code: "OUTSIDE_ROOT" });
+    const handleDirectoryRequest = vi.fn(async () => { throw error; });
+    const reportDirectoryRequest = vi.fn(async () => {});
+    const onControl = createControlHandler({
+      waker: makeWaker([]),
+      getConnectionUuid: () => CONN,
+      handleDirectoryRequest,
+      reportDirectoryRequest,
+      logger: silent,
+    });
+    onControl({
+      type: "control", command: "browse_directory", targetConnectionUuid: CONN,
+      requestUuid: "req-2", operation: "list", prefix: "/outside",
+    });
+    onControl({
+      type: "control", command: "browse_directory", targetConnectionUuid: "stale",
+      requestUuid: "req-3", operation: "list", prefix: "/r",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(reportDirectoryRequest).toHaveBeenCalledTimes(1);
+    expect(reportDirectoryRequest).toHaveBeenCalledWith({
+      requestUuid: "req-2", status: "failed", errorCode: "OUTSIDE_ROOT",
+    });
+  });
+});

--- a/cli/__tests__/daemon-banner.test.mjs
+++ b/cli/__tests__/daemon-banner.test.mjs
@@ -135,7 +135,10 @@ describe("bannerRows", () => {
 
 describe("resolveAgentType", () => {
   it("defaults to claude-code", () => {
-    expect(resolveAgentType({}, {})).toEqual({ ok: true, agent: "claude-code" });
+    expect(resolveAgentType({}, {}, { readJson: () => null })).toEqual({
+      ok: true,
+      agent: "claude-code",
+    });
     expect(DEFAULT_AGENT).toBe("claude-code");
     expect(KNOWN_AGENTS).toContain("claude-code");
   });

--- a/cli/__tests__/daemon-claude-notfound-warning.test.mjs
+++ b/cli/__tests__/daemon-claude-notfound-warning.test.mjs
@@ -26,7 +26,7 @@ describe("runDaemon — claude CLI NOT FOUND warning", () => {
     const errs = [];
     const build = vi.fn(() => ({ async start() {}, async stop() {} }));
     const code = await runDaemon(
-      { chorusOnly: true }, // restricted → no yolo warning to disambiguate from
+      { chorusOnly: true, agent: "claude-code" }, // explicit backend isolates host daemon config
       baseDeps({ build, errLog: (m) => errs.push(m), resolveClaudePath: () => null })
     );
     expect(code).toBe(0);
@@ -43,7 +43,7 @@ describe("runDaemon — claude CLI NOT FOUND warning", () => {
     const errs = [];
     const build = vi.fn(() => ({ async start() {}, async stop() {} }));
     const code = await runDaemon(
-      { chorusOnly: true },
+      { chorusOnly: true, agent: "claude-code" },
       baseDeps({ build, errLog: (m) => errs.push(m), resolveClaudePath: () => "/usr/bin/claude" })
     );
     expect(code).toBe(0);

--- a/cli/__tests__/daemon-config.test.mjs
+++ b/cli/__tests__/daemon-config.test.mjs
@@ -7,6 +7,7 @@ import {
   resolveSigintTimeoutMs,
   DEFAULT_SIGINT_TIMEOUT_MS,
   resolveDaemonCwds,
+  resolveBrowseRoots,
 } from "../daemon-config.mjs";
 
 describe("resolveSigintTimeoutMs layered precedence", () => {
@@ -61,6 +62,33 @@ describe("resolveSigintTimeoutMs layered precedence", () => {
   it("a malformed daemon.json (readJson returns null) falls through to the default", () => {
     const ms = resolveSigintTimeoutMs({}, { env: {}, readJson: () => null });
     expect(ms).toBe(10_000);
+  });
+});
+
+describe("resolveBrowseRoots layered precedence", () => {
+  const deps = { home: "/home/u", readJson: () => ({ browseRoots: ["/file"] }) };
+
+  it("uses home by default and never returns the cwd sentinel", () => {
+    expect(resolveBrowseRoots({}, { env: {}, readJson: () => null, home: "/home/u" }))
+      .toEqual(["/home/u"]);
+  });
+
+  it("resolves flag > env > file", () => {
+    expect(resolveBrowseRoots({ browseRoot: ["/flag"] }, {
+      ...deps, env: { CHORUS_DAEMON_BROWSE_ROOTS: "/env" },
+    })).toEqual(["/flag"]);
+    expect(resolveBrowseRoots({}, {
+      ...deps, env: { CHORUS_DAEMON_BROWSE_ROOTS: "/env-a,/env-b" },
+    })).toEqual(["/env-a", "/env-b"]);
+    expect(resolveBrowseRoots({}, { ...deps, env: {} })).toEqual(["/file"]);
+  });
+
+  it("is independent from startup cwds", () => {
+    const file = { cwds: ["/served"], browseRoots: ["/discoverable"] };
+    expect(resolveDaemonCwds({}, { env: {}, readJson: () => file, home: "/home/u" }))
+      .toEqual(["/served"]);
+    expect(resolveBrowseRoots({}, { env: {}, readJson: () => file, home: "/home/u" }))
+      .toEqual(["/discoverable"]);
   });
 });
 

--- a/cli/__tests__/daemon-install-config.test.mjs
+++ b/cli/__tests__/daemon-install-config.test.mjs
@@ -10,6 +10,7 @@ import {
   resolveInstallCredentials,
   resolveInstallCwds,
   resolveInstallAgent,
+  resolveInstallBrowseRoots,
 } from "../daemon-install-config.mjs";
 
 // ---- resolveInstallCredentials ------------------------------------------
@@ -88,6 +89,31 @@ describe("resolveInstallCredentials", () => {
     expect(r.ok).toBe(false);
     expect(d.validate).toHaveBeenCalledOnce();
     expect(d.writeConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveInstallBrowseRoots", () => {
+  it("normalizes, deduplicates, and field-merges explicit roots", async () => {
+    const writeConfig = vi.fn();
+    const result = await resolveInstallBrowseRoots(
+      { browseRoot: ["~/src", "/opt", "~/src"] },
+      { home: "/home/u", readJson: () => ({ cwds: ["/served"] }), writeConfig },
+    );
+    expect(result.browseRoots).toEqual(["/home/u/src", "/opt"]);
+    expect(writeConfig).toHaveBeenCalledWith({ browseRoots: ["/home/u/src", "/opt"] });
+  });
+
+  it("preserves stored roots and defaults to OS home when absent", async () => {
+    const writeConfig = vi.fn();
+    expect(await resolveInstallBrowseRoots({}, {
+      home: "/home/u", readJson: () => ({ browseRoots: ["/stored"] }), writeConfig,
+    })).toEqual({ browseRoots: ["/stored"] });
+    expect(writeConfig).not.toHaveBeenCalled();
+
+    expect(await resolveInstallBrowseRoots({}, {
+      home: "/home/u", readJson: () => null, writeConfig,
+    })).toEqual({ browseRoots: ["/home/u"] });
+    expect(writeConfig).toHaveBeenCalledWith({ browseRoots: ["/home/u"] });
   });
 });
 

--- a/cli/__tests__/daemon-integration.test.mjs
+++ b/cli/__tests__/daemon-integration.test.mjs
@@ -1144,6 +1144,15 @@ describe("daemon graceful shutdown (fix-daemon-exit-orphan-running-turn)", () =>
     };
     const turnReports = [];
     const mcp = mockMcp();
+    const killer = vi.fn(async () => {
+      order.push("killed");
+      releaseChild();
+      return { killed: true };
+    });
+    const advanceTurn = async (params) => {
+      turnReports.push(params);
+      order.push(`turn:${params.status}`);
+    };
     const daemon = buildDaemon(
       { url: "https://chorus.example", apiKey: "cho_x" },
       {
@@ -1154,19 +1163,10 @@ describe("daemon graceful shutdown (fix-daemon-exit-orphan-running-turn)", () =>
         cwd: "/nonexistent/chorus-daemon-shutdown-itest",
         makeSseListener: (o) => new MockSse(o),
         sigintTimeoutMs: 200,
+        killer,
+        advanceTurn,
       }
     );
-    // Spy on the primary waker's injected killer + turn reporter AFTER build. The
-    // killer releases the "child" (simulating the kill landing).
-    daemon.waker.killer = vi.fn(async () => {
-      order.push("killed");
-      releaseChild();
-      return { killed: true };
-    });
-    daemon.waker.advanceTurn = async (params) => {
-      turnReports.push(params);
-      order.push(`turn:${params.status}`);
-    };
 
     await daemon.start();
     daemon.sseListener.opts.onEvent({ type: "new_notification", notificationUuid: "notif-1" });
@@ -1203,9 +1203,9 @@ describe("daemon graceful shutdown (fix-daemon-exit-orphan-running-turn)", () =>
         cwd: "/nonexistent/chorus-daemon-shutdown-itest2",
         makeSseListener: (o) => new MockSse(o),
         sigintTimeoutMs: 50, // drain bound = 50ms + 5s cap
+        killer: vi.fn(async () => ({ killed: false })),
       }
     );
-    daemon.waker.killer = vi.fn(async () => ({ killed: false }));
 
     await daemon.start();
     daemon.sseListener.opts.onEvent({ type: "new_notification", notificationUuid: "notif-1" });

--- a/cli/__tests__/daemon-integration.test.mjs
+++ b/cli/__tests__/daemon-integration.test.mjs
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { EventEmitter } from "node:events";
 import { buildDaemon, runDaemon } from "../daemon.mjs";
 import { transcriptPath } from "../claude-spawner.mjs";
 
@@ -189,7 +190,7 @@ describe("daemon integration: notification → spawn", () => {
 describe("daemon integration: reverse control channel (子3)", () => {
   it("a control event interrupts the running child, never enqueues a wake, and reports interrupted(user)", async () => {
     const CONN = "conn-itest";
-    const FAKE_CHILD = { pid: 24680 };
+    const FAKE_CHILD = Object.assign(new EventEmitter(), { pid: 24680 });
     const reportInterrupt = vi.fn(async () => {});
 
     // A controllable spawner: it registers the child via onChild, then HANGS until
@@ -201,7 +202,10 @@ describe("daemon integration: reverse control channel (子3)", () => {
           new Promise((resolve) => {
             params.onChild?.(FAKE_CHILD);
             params.onMessage?.({ type: "system", session_id: params.sessionId });
-            resolveWake = () => resolve({ sessionId: params.sessionId, exitCode: 0, isNew: params.isNew });
+            resolveWake = () => {
+              FAKE_CHILD.emit("exit", 0, null);
+              resolve({ sessionId: params.sessionId, exitCode: 0, isNew: params.isNew });
+            };
           })
       ),
     };

--- a/cli/__tests__/daemon-rest-client.test.mjs
+++ b/cli/__tests__/daemon-rest-client.test.mjs
@@ -225,6 +225,39 @@ describe("createDaemonRestClient — payload shapes (single source of truth)", (
     });
   });
 
+  it("reports correlated directory success and typed failure", async () => {
+    const fetchImpl = okFetch();
+    const client = makeClient({ fetchImpl });
+    await client.reportDirectoryRequest({
+      requestUuid: "req-1",
+      status: "succeeded",
+      items: [{ name: "repo", path: "/home/u/repo" }],
+      nextCursor: null,
+    });
+    await client.reportDirectoryRequest({
+      requestUuid: "req-2",
+      status: "failed",
+      errorCode: "OUTSIDE_ROOT",
+    });
+    expect(fetchImpl.mock.calls.map(([url]) => url)).toEqual([
+      "https://chorus.example.com/api/daemon/directory-request/report",
+      "https://chorus.example.com/api/daemon/directory-request/report",
+    ]);
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual({
+      requestUuid: "req-1",
+      connectionUuid: "conn-1",
+      status: "succeeded",
+      items: [{ name: "repo", path: "/home/u/repo" }],
+      nextCursor: null,
+    });
+    expect(JSON.parse(fetchImpl.mock.calls[1][1].body)).toEqual({
+      requestUuid: "req-2",
+      connectionUuid: "conn-1",
+      status: "failed",
+      errorCode: "OUTSIDE_ROOT",
+    });
+  });
+
   it("readPendingTurns GETs ?connectionUuid=… (encoded) and returns the parsed turns", async () => {
     const turns = [
       { turnUuid: "t-1", sessionId: "idea-1", directIdeaUuid: "idea-1", trigger: "human_instruction", promptText: "do it" },

--- a/cli/__tests__/daemon-runtime-cwd.test.mjs
+++ b/cli/__tests__/daemon-runtime-cwd.test.mjs
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildDaemon } from "../daemon.mjs";
+import { Waker } from "../waker.mjs";
+
+const silent = { info() {}, warn() {}, error() {} };
+const creds = { url: "http://chorus.test", apiKey: "cho_test" };
+
+describe("directed runtime cwd isolation", () => {
+  it("creates one isolated Waker context per runtime cwd without adding connections", () => {
+    const daemon = buildDaemon(creds, {
+      cwd: "/startup",
+      browseRoots: ["/work"],
+      logger: silent,
+      mcpClient: {},
+      lineage: { resolve: vi.fn() },
+      spawner: {},
+      sseListener: {},
+    });
+    const connection = daemon.connections[0];
+
+    connection.waker.markQueued(
+      { entityType: "task", entityUuid: "task-a", runtimeCwd: "/work/a" },
+      "idea:a",
+      {},
+    );
+    connection.waker.markQueued(
+      { entityType: "task", entityUuid: "task-b", runtimeCwd: "/work/b" },
+      "idea:b",
+      {},
+    );
+
+    expect(connection.runtimeWakers.size).toBe(3);
+    expect(daemon.connections).toHaveLength(1);
+    expect(connection.runtimeWakers.get("/work/a")).not.toBe(
+      connection.runtimeWakers.get("/work/b"),
+    );
+  });
+
+  it("revalidates immediately before probe and spawn and uses the normalized cwd for both", async () => {
+    const calls = [];
+    const waker = new Waker({
+      creds,
+      cwd: "/startup",
+      logger: silent,
+      lineage: { resolve: async () => ({ rootIdeaUuid: null, directIdeaUuid: null }) },
+      validateRuntimeCwd: async (cwd) => {
+        calls.push(["validate", cwd]);
+        return { normalizedPath: "/work/normalized" };
+      },
+      isNewSessionFn: (sessionId, cwd) => {
+        calls.push(["probe", cwd]);
+        return true;
+      },
+      writeMcpConfigFn: () => ({ path: "/tmp/mcp.json", cleanup() {} }),
+      spawner: {
+        wake: async ({ cwd }) => {
+          calls.push(["spawn", cwd]);
+          return { sessionId: "11111111-1111-4111-8111-111111111111", exitCode: 0, isNew: true };
+        },
+      },
+    });
+
+    await waker.wake(
+      {
+        action: "task_assigned",
+        entityType: "task",
+        entityUuid: "11111111-1111-4111-8111-111111111111",
+        runtimeCwd: "/work/raw",
+      },
+      "entity:task:11111111-1111-4111-8111-111111111111",
+      {},
+    );
+
+    expect(calls.slice(0, 3)).toEqual([
+      ["validate", "/work/raw"],
+      ["probe", "/work/normalized"],
+      ["spawn", "/work/normalized"],
+    ]);
+  });
+
+  it("reports an invalid directed cwd as an explicit terminal turn state", async () => {
+    const advanceTurn = vi.fn(async () => ({ ok: true }));
+    const error = Object.assign(new Error("outside configured roots"), {
+      code: "OUTSIDE_ROOT",
+    });
+    const waker = new Waker({
+      creds,
+      cwd: "/startup",
+      logger: silent,
+      lineage: { resolve: async () => ({ rootIdeaUuid: null, directIdeaUuid: null }) },
+      validateRuntimeCwd: async () => {
+        throw error;
+      },
+      advanceTurn,
+      spawner: { wake: vi.fn() },
+    });
+
+    await waker.wake(
+      {
+        action: "task_assigned",
+        entityType: "task",
+        entityUuid: "11111111-1111-4111-8111-111111111111",
+        runtimeCwd: "/outside",
+      },
+      "entity:task:11111111-1111-4111-8111-111111111111",
+      {},
+    );
+
+    expect(advanceTurn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ status: "running" }),
+    );
+    expect(advanceTurn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        status: "interrupted",
+        interruptedReason: "invalid_path",
+        transcriptRelayError: "OUTSIDE_ROOT: outside configured roots",
+      }),
+    );
+  });
+});

--- a/cli/__tests__/directory-discovery.test.mjs
+++ b/cli/__tests__/directory-discovery.test.mjs
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, symlink, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  DirectoryDiscoveryError,
+  discoverDirectories,
+  isPathWithin,
+  validateDirectory,
+} from "../directory-discovery.mjs";
+
+const cleanup = [];
+afterEach(async () => Promise.all(cleanup.splice(0).map((p) => rm(p, { recursive: true, force: true }))));
+
+async function fixture() {
+  const root = await mkdtemp(path.join(tmpdir(), "chorus-discovery-"));
+  cleanup.push(root);
+  await Promise.all([
+    mkdir(path.join(root, "project-a")),
+    mkdir(path.join(root, "Project-b")),
+    mkdir(path.join(root, "other")),
+    mkdir(path.join(root, ".hidden")),
+    writeFile(path.join(root, "project-file"), "x"),
+  ]);
+  await symlink(path.join(root, "project-a"), path.join(root, "project-link"));
+  return root;
+}
+
+describe("directory discovery", () => {
+  it("returns matching direct directories only, without metadata", async () => {
+    const root = await fixture();
+    const result = await discoverDirectories({ prefix: path.join(root, "pro"), browseRoots: [root] });
+    expect(result.items.map((x) => x.name)).toEqual(["project-a"]);
+    expect(result.items.every((x) => Object.keys(x).sort().join(",") === "name,path")).toBe(true);
+    expect(result.items.some((x) => x.name === "project-link")).toBe(false);
+  });
+
+  it("distinguishes an empty success from an error", async () => {
+    const root = await fixture();
+    expect((await discoverDirectories({ prefix: path.join(root, "zzz"), browseRoots: [root] })).items)
+      .toEqual([]);
+    await expect(discoverDirectories({ prefix: path.join(root, "..", "secret"), browseRoots: [root] }))
+      .rejects.toMatchObject({ code: "OUTSIDE_ROOT" });
+  });
+
+  it("provides stable pagination and rejects excessive limits", async () => {
+    const root = await fixture();
+    const first = await discoverDirectories({ prefix: `${root}${path.sep}`, browseRoots: [root], limit: 2 });
+    const second = await discoverDirectories({
+      prefix: `${root}${path.sep}`, browseRoots: [root], limit: 2, cursor: first.nextCursor,
+    });
+    expect(first.items.map((x) => x.name)).toEqual(["other", "project-a"]);
+    expect(second.items.map((x) => x.name)).toEqual(["Project-b"]);
+    await expect(discoverDirectories({ prefix: root, browseRoots: [root], limit: 101 }))
+      .rejects.toMatchObject({ code: "LIMIT_EXCEEDED" });
+  });
+
+  it("validates an existing directory under a root", async () => {
+    const root = await fixture();
+    await expect(validateDirectory({ cwd: path.join(root, "project-a"), browseRoots: [root] }))
+      .resolves.toMatchObject({ valid: true, normalizedPath: path.join(root, "project-a") });
+  });
+
+  it("rejects discovery and validation through an intermediate symlink", async () => {
+    const root = await fixture();
+    const outside = await mkdtemp(path.join(tmpdir(), "chorus-outside-"));
+    cleanup.push(outside);
+    await mkdir(path.join(outside, "escaped"));
+    await symlink(outside, path.join(root, "intermediate-link"));
+
+    await expect(discoverDirectories({
+      prefix: path.join(root, "intermediate-link", "esc"),
+      browseRoots: [root],
+    })).rejects.toMatchObject({ code: "OUTSIDE_ROOT" });
+    await expect(validateDirectory({
+      cwd: path.join(root, "intermediate-link", "escaped"),
+      browseRoots: [root],
+    })).rejects.toMatchObject({ code: "OUTSIDE_ROOT" });
+  });
+
+  it("uses component-aware POSIX and Windows containment", () => {
+    expect(isPathWithin("/home/u", "/home/u/repo", path.posix)).toBe(true);
+    expect(isPathWithin("/home/u", "/home/user2", path.posix)).toBe(false);
+    expect(isPathWithin("C:\\Users\\u", "C:\\Users\\u\\repo", path.win32)).toBe(true);
+    expect(isPathWithin("C:\\Users\\u", "C:\\Users\\user2", path.win32)).toBe(false);
+  });
+
+  it("maps a hard timeout to TIMEOUT", async () => {
+    const fsApi = {
+      realpath: async (value) => value,
+      lstat: () => new Promise(() => {}),
+      access: async () => {},
+      readdir: async () => [],
+    };
+    await expect(discoverDirectories({
+      prefix: "/root/a", browseRoots: ["/root"], fsApi, timeoutMs: 5,
+    })).rejects.toEqual(expect.objectContaining({ code: "TIMEOUT" }));
+  });
+});

--- a/cli/__tests__/turn-reporter.test.mjs
+++ b/cli/__tests__/turn-reporter.test.mjs
@@ -188,7 +188,12 @@ describe("createTurnReporter", () => {
   });
 
   it("TURN_INTERRUPT_REASONS is the daemon-reportable subset (no offline)", () => {
-    expect([...TURN_INTERRUPT_REASONS].sort()).toEqual(["crash", "shutdown", "user"]);
+    expect([...TURN_INTERRUPT_REASONS].sort()).toEqual([
+      "crash",
+      "invalid_path",
+      "shutdown",
+      "user",
+    ]);
   });
 
   it("sends interruptedReason alongside status=interrupted", async () => {

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -60,6 +60,10 @@ export function parseClientFlags(argv) {
       const value = a === "--cwd" ? argv[i + 1] : a.slice("--cwd=".length);
       if (typeof value === "string") (out.cwd ??= []).push(value);
     }
+    else if (a === "--browse-root" || a.startsWith("--browse-root=")) {
+      const value = a === "--browse-root" ? argv[i + 1] : a.slice("--browse-root=".length);
+      if (typeof value === "string") (out.browseRoot ??= []).push(value);
+    }
     else if (a === "--chorus-only") out.chorusOnly = true;
     else if (a === "--verbose") out.verbose = true;
     else if (a === "-d" || a === "--detach") out.detach = true;
@@ -133,6 +137,10 @@ OPTIONS
                            connection for that path, so one daemon can serve several
                            local paths at once. Default: the directory it was launched
                            from. (Also configurable as "cwds":[…] in ~/.chorus/daemon.json.)
+  --browse-root <path>     A directory root exposed to remote cwd discovery.
+                           Repeatable; independent from --cwd and does not create
+                           Agent connections. (env: CHORUS_DAEMON_BROWSE_ROOTS;
+                           config: "browseRoots":[…]; default: OS user home.)
   -d, --detach             Run detached in the background (pidfile + logfile)
   -y, --yes                Non-interactive install: skip all 'chorus daemon
                            install' prompts (credentials, served cwds, and agent

--- a/cli/control-handler.mjs
+++ b/cli/control-handler.mjs
@@ -66,6 +66,8 @@ export function createControlHandler(deps) {
   const sigintTimeoutMs = deps.sigintTimeoutMs;
   const redispatchResume = deps.redispatchResume;
   const deliverTurn = deps.deliverTurn;
+  const handleDirectoryRequest = deps.handleDirectoryRequest;
+  const reportDirectoryRequest = deps.reportDirectoryRequest;
   const logger = deps.logger ?? NOOP_LOGGER;
 
   /** Registry key for a resource — MUST match waker.#execKey. */
@@ -89,7 +91,8 @@ export function createControlHandler(deps) {
       if (
         event.command !== "interrupt" &&
         event.command !== "resume" &&
-        event.command !== "deliver_turn"
+        event.command !== "deliver_turn" &&
+        event.command !== "browse_directory"
       ) {
         // Forward-compatible: the wire enum may grow.
         logger.warn(`[Chorus] control command "${event.command}" not supported; ignoring`);
@@ -106,6 +109,28 @@ export function createControlHandler(deps) {
           `[Chorus] control: ignoring ${command} for connection ${targetConnectionUuid} ` +
             `(this daemon is ${myConnectionUuid ?? "<unregistered>"})`
         );
+        return;
+      }
+
+      if (command === "browse_directory") {
+        const requestUuid = event.requestUuid;
+        if (typeof requestUuid !== "string" || !requestUuid) {
+          logger.warn("[Chorus] control: browse_directory missing requestUuid; ignoring");
+          return;
+        }
+        Promise.resolve()
+          .then(() => handleDirectoryRequest?.(event))
+          .then((result) => reportDirectoryRequest?.({
+            requestUuid,
+            status: "succeeded",
+            ...result,
+          }))
+          .catch((err) => reportDirectoryRequest?.({
+            requestUuid,
+            status: "failed",
+            errorCode: err?.code ?? "INTERNAL_ERROR",
+          }))
+          .catch((err) => logger.warn(`[Chorus] control: directory report failed: ${err}`));
         return;
       }
 
@@ -155,7 +180,11 @@ export function createControlHandler(deps) {
             `)`
         );
         try {
-          redispatchResume?.(entityType, entityUuid, resumeReason);
+          if (typeof event.runtimeCwd === "string" && event.runtimeCwd) {
+            redispatchResume?.(entityType, entityUuid, resumeReason, event.runtimeCwd);
+          } else {
+            redispatchResume?.(entityType, entityUuid, resumeReason);
+          }
         } catch (err) {
           logger.warn(`[Chorus] control: resume re-dispatch failed for ${entityType}:${entityUuid}: ${err}`);
         }

--- a/cli/daemon-config.mjs
+++ b/cli/daemon-config.mjs
@@ -200,3 +200,38 @@ export function resolveDaemonCwds(flags = {}, deps = {}) {
   //    for (HARD-1 / single-path — exactly today's behavior).
   return [undefined];
 }
+
+/**
+ * Resolve the host-local directory discovery allowlist. Unlike `cwds`, these
+ * roots never create connections. The whole list comes from the first
+ * non-empty source: flag > env > daemon.json > OS home.
+ */
+export function resolveBrowseRoots(flags = {}, deps = {}) {
+  const env = deps.env ?? process.env;
+  const readJson = deps.readJson ?? readJsonSafe;
+  const loginPath = deps.loginPath ?? loginFilePath();
+  const home = deps.home ?? homedir();
+  const flagList = Array.isArray(flags.browseRoot)
+    ? flags.browseRoot
+    : typeof flags.browseRoot === "string"
+      ? [flags.browseRoot]
+      : [];
+  const fromFlags = cleanCwdList(flagList, home);
+  if (fromFlags.length) return fromFlags;
+
+  const envRaw = env.CHORUS_DAEMON_BROWSE_ROOTS;
+  if (typeof envRaw === "string" && envRaw.trim()) {
+    const separator = deps.delimiter ?? (process.platform === "win32" ? ";" : ":");
+    const fromEnv = cleanCwdList(
+      envRaw.split(envRaw.includes(",") ? "," : separator),
+      home,
+    );
+    if (fromEnv.length) return fromEnv;
+  }
+
+  const file = readJson(loginPath);
+  const fromFile = file && Array.isArray(file.browseRoots)
+    ? cleanCwdList(file.browseRoots, home)
+    : [];
+  return fromFile.length ? fromFile : [normalizeCwd(home, home)];
+}

--- a/cli/daemon-install-config.mjs
+++ b/cli/daemon-install-config.mjs
@@ -217,6 +217,32 @@ export async function resolveInstallCwds(flags = {}, opts = {}) {
   return { cwds: finalCwds };
 }
 
+/** Persist explicit install-time browse roots without coupling them to `cwds`. */
+export async function resolveInstallBrowseRoots(flags = {}, opts = {}) {
+  const readJson = opts.readJson ?? readJsonSafe;
+  const loginPath = opts.loginPath ?? loginFilePath();
+  const writeConfig = opts.writeConfig ?? updateDaemonConfig;
+  const home = opts.home ?? homedir();
+  const flagList = Array.isArray(flags.browseRoot)
+    ? flags.browseRoot
+    : typeof flags.browseRoot === "string"
+      ? [flags.browseRoot]
+      : [];
+  const explicit = cleanCwdList(flagList, home);
+  if (explicit.length) {
+    writeConfig({ browseRoots: explicit });
+    return { browseRoots: explicit };
+  }
+  const file = readJson(loginPath);
+  const stored = file && Array.isArray(file.browseRoots)
+    ? cleanCwdList(file.browseRoots, home)
+    : [];
+  if (stored.length) return { browseRoots: stored };
+  const browseRoots = [normalizeCwd(home, home)];
+  writeConfig({ browseRoots });
+  return { browseRoots };
+}
+
 /**
  * The interactive agent-backend menu. Order mirrors KNOWN_AGENTS with claude-code
  * first (it is the default). Kept beside the resolver so the numbered prompt and

--- a/cli/daemon-rest-client.mjs
+++ b/cli/daemon-rest-client.mjs
@@ -75,6 +75,7 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
  *   executionState: (p: { executions: Array<Record<string, unknown>> }) => Promise<DaemonRestResult>,
  *   reportInterrupt: (p: { entityType: string, entityUuid: string, reason: string }) => Promise<DaemonRestResult>,
  *   heartbeat: (p: { connectionUuid: string, connectedAt: string }) => Promise<DaemonRestResult>,
+ *   reportDirectoryRequest: (p: { requestUuid: string, status: "succeeded"|"failed", items?: Array<{name:string,path:string}>, nextCursor?: string|null, normalizedPath?: string, errorCode?: string }) => Promise<DaemonRestResult>,
  *   readPendingTurns: () => Promise<DaemonRestResult>,
  * }}
  */
@@ -252,6 +253,28 @@ export function createDaemonRestClient(opts) {
         "connection-heartbeat",
         "/api/daemon/connection-heartbeat",
         { connectionUuid, connectedAt },
+      );
+    },
+
+    async reportDirectoryRequest({ requestUuid, status, items, nextCursor, normalizedPath, errorCode }) {
+      const connectionUuid = getConnectionUuid();
+      if (!connectionUuid) {
+        const error = `cannot report directory request ${requestUuid} — no connection uuid yet`;
+        logger.warn(`[Chorus] ${error}`);
+        return { ok: false, status: null, error, skipped: true };
+      }
+      const body = { requestUuid, connectionUuid, status };
+      if (status === "succeeded") {
+        if (items !== undefined) body.items = items;
+        if (nextCursor !== undefined) body.nextCursor = nextCursor;
+        if (normalizedPath !== undefined) body.normalizedPath = normalizedPath;
+      } else {
+        body.errorCode = errorCode ?? "INTERNAL_ERROR";
+      }
+      return post(
+        "directory-request report",
+        "/api/daemon/directory-request/report",
+        body,
       );
     },
 

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -17,6 +17,7 @@ import { prompt, writeLoginFile, updateDaemonConfig } from "./login.mjs";
 import {
   resolveInstallCredentials,
   resolveInstallCwds,
+  resolveInstallBrowseRoots,
   resolveInstallAgent,
 } from "./daemon-install-config.mjs";
 import {
@@ -46,7 +47,8 @@ import { createInterruptReporter } from "./interrupt-reporter.mjs";
 import { createTurnReporter } from "./turn-reporter.mjs";
 import { createDaemonRestClient } from "./daemon-rest-client.mjs";
 import { createControlHandler } from "./control-handler.mjs";
-import { resolveSigintTimeoutMs, resolveDaemonCwds } from "./daemon-config.mjs";
+import { resolveSigintTimeoutMs, resolveDaemonCwds, resolveBrowseRoots } from "./daemon-config.mjs";
+import { discoverDirectories, validateDirectory } from "./directory-discovery.mjs";
 import {
   startBackground,
   stopDaemon,
@@ -124,6 +126,7 @@ export function buildDaemon(creds, deps = {}) {
   // the layered resolver; falls back to the resolver's default here when not given,
   // so a daemon built directly (integration tests) still gets a sane value.
   const sigintTimeoutMs = deps.sigintTimeoutMs ?? resolveSigintTimeoutMs();
+  const browseRoots = deps.browseRoots ?? resolveBrowseRoots();
   // ===== Shared deps (one set per daemon process) =====
   // These are process-wide — independent of how many paths (cwds) the daemon serves.
   const mcpClient =
@@ -245,7 +248,8 @@ export function buildDaemon(creds, deps = {}) {
         fetchImpl: deps.fetchImpl,
       });
 
-    /** @type {Waker|undefined} */
+    /** @type {Map<string, Waker>} */
+    const runtimeWakers = new Map();
     let waker;
 
     // Execution + transcript upload hooks (子1), merged. Bound to THIS connection's
@@ -257,7 +261,8 @@ export function buildDaemon(creds, deps = {}) {
           url: creds.url,
           apiKey: creds.apiKey,
           getConnectionUuid: () => connectionState.connectionUuid,
-          getSnapshot: () => waker?.buildExecutionSnapshot() ?? [],
+          getSnapshot: () =>
+            [...runtimeWakers.values()].flatMap((candidate) => candidate.buildExecutionSnapshot()),
           logger,
           fetchImpl: deps.fetchImpl,
         }),
@@ -277,20 +282,69 @@ export function buildDaemon(creds, deps = {}) {
     // transcript (new-vs-resume) and to spawn, so they never diverge (Module Contract
     // 1 — resolveCwd is the single source). `cwd` is `undefined` for the single-path /
     // old-daemon default, which the Waker degrades to process.cwd() (HARD-1).
-    waker = new Waker({
-      creds,
-      lineage,
-      spawner,
-      cwd,
-      hooks,
-      logger,
-      reportInterrupt,
-      advanceTurn,
-      verbose,
-      // Graceful-shutdown kill escalation (fix-daemon-exit-orphan-running-turn):
-      // interruptAll() reuses the SAME window the interrupt control handler uses.
-      sigintTimeoutMs,
-    });
+    const makeWaker = (boundCwd) =>
+      new Waker({
+        creds,
+        lineage,
+        spawner,
+        cwd: boundCwd,
+        hooks,
+        logger,
+        reportInterrupt,
+        advanceTurn,
+        verbose,
+        validateRuntimeCwd: (runtimeCwd) => validateDirectory({ cwd: runtimeCwd, browseRoots }),
+        killer: deps.killer,
+        sigintTimeoutMs,
+      });
+    const startupKey = cwd ?? process.cwd();
+    runtimeWakers.set(startupKey, makeWaker(cwd));
+    const selectWaker = (notification) => {
+      const runtimeCwd =
+        typeof notification?.runtimeCwd === "string" && notification.runtimeCwd
+          ? notification.runtimeCwd
+          : startupKey;
+      let selected = runtimeWakers.get(runtimeCwd);
+      if (!selected) {
+        selected = makeWaker(runtimeCwd);
+        runtimeWakers.set(runtimeCwd, selected);
+      }
+      return selected;
+    };
+    const startupWaker = runtimeWakers.get(startupKey);
+    waker = {
+      get executions() {
+        const merged = new Map();
+        for (const candidate of runtimeWakers.values()) {
+          for (const [key, value] of candidate.executions) merged.set(key, value);
+        }
+        return merged;
+      },
+      get interrupting() {
+        return {
+          has: (key) =>
+            [...runtimeWakers.values()].some((candidate) => candidate.interrupting.has(key)),
+        };
+      },
+      keyFor: (notification) => startupWaker.keyFor(notification),
+      resolveCwd: () => startupWaker.resolveCwd(),
+      markQueued: (notification, key, attribution) =>
+        selectWaker(notification).markQueued(notification, key, attribution),
+      wake: (notification, key, attribution) =>
+        selectWaker(notification).wake(notification, key, attribution),
+      markInterrupting(entityType, entityUuid) {
+        for (const candidate of runtimeWakers.values()) {
+          if (candidate.executions.has(`${entityType}:${entityUuid}`)) {
+            candidate.markInterrupting(entityType, entityUuid);
+          }
+        }
+      },
+      interruptAll() {
+        for (const candidate of runtimeWakers.values()) candidate.interruptAll();
+      },
+      buildExecutionSnapshot: () =>
+        [...runtimeWakers.values()].flatMap((candidate) => candidate.buildExecutionSnapshot()),
+    };
     // The router reads THIS connection's own uuid lazily (same source the control handler
     // uses) to suppress a DIRECTED (pinned) wake stamped for a different connection
     // (fix-pinned-wake-directed-delivery, T2). Null until the SSE handshake assigns it — a
@@ -310,8 +364,8 @@ export function buildDaemon(creds, deps = {}) {
     // all scoped to THIS connection's uuid/router/backfill (see the original wiring
     // comments retained on the shared helpers). The control handler verifies a control
     // event against this connection's own connectionUuid before acting.
-    const redispatchResume = (entityType, entityUuid, resumeReason) => {
-      router.dispatchResume?.({ entityType, entityUuid, resumeReason });
+    const redispatchResume = (entityType, entityUuid, resumeReason, runtimeCwd) => {
+      router.dispatchResume?.({ entityType, entityUuid, resumeReason, runtimeCwd });
     };
     const deliverTurn = (turnUuid) => backfill?.pendingTurnsOnly?.(turnUuid);
     const onControl = createControlHandler({
@@ -320,6 +374,18 @@ export function buildDaemon(creds, deps = {}) {
       sigintTimeoutMs,
       redispatchResume,
       deliverTurn,
+      handleDirectoryRequest: async (event) => {
+        if (event.operation === "validate") {
+          return validateDirectory({ cwd: event.cwd, browseRoots });
+        }
+        return discoverDirectories({
+          prefix: event.prefix,
+          cursor: event.cursor,
+          limit: event.limit,
+          browseRoots,
+        });
+      },
+      reportDirectoryRequest: (result) => daemonRestClient.reportDirectoryRequest(result),
       logger,
     });
 
@@ -403,7 +469,17 @@ export function buildDaemon(creds, deps = {}) {
         logger,
       });
 
-    return { cwd, connectionState, waker, router, backfill, sseListener, hooks, outcome };
+    return {
+      cwd,
+      connectionState,
+      waker,
+      runtimeWakers,
+      router,
+      backfill,
+      sseListener,
+      hooks,
+      outcome,
+    };
   }
 
   // Build one connection per declared cwd. The order is the declaration order; the
@@ -569,6 +645,7 @@ export async function runDaemon(flags = {}, deps = {}) {
   // is exactly today's single-path behavior. JUST a list of paths — no project
   // binding (DEC-5: cwd ⟂ project). The daemon process's own cwd never changes.
   const cwds = resolveDaemonCwds({ cwd: flags.cwd }, { env });
+  const browseRoots = resolveBrowseRoots({ browseRoot: flags.browseRoot }, { env });
 
   // Foreground preflight: resolve/complete credentials + resolve the permission
   // posture (confirming yolo on a TTY). Reuses the same pfDeps bundle the detach
@@ -634,6 +711,7 @@ export async function runDaemon(flags = {}, deps = {}) {
   } else {
     log(`[Chorus] serving path: ${servedPaths[0]}`);
   }
+  log(`[Chorus] browse roots: ${browseRoots.join(", ")} (discovery only; no connections created)`);
 
   const daemon = build(creds, {
     logger: { info: log, warn: errLog, error: errLog },
@@ -642,6 +720,7 @@ export async function runDaemon(flags = {}, deps = {}) {
     verbose,
     sigintTimeoutMs,
     cwds,
+    browseRoots,
   });
 
   // Graceful shutdown on signals.
@@ -778,6 +857,7 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
     const installCfg = svc.installConfig ?? {
       resolveInstallCredentials,
       resolveInstallCwds,
+      resolveInstallBrowseRoots,
       resolveInstallAgent,
     };
 
@@ -811,6 +891,13 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
       prompt: pfDeps?.askPrompt,
       log,
     });
+    if (installCfg.resolveInstallBrowseRoots) {
+      await installCfg.resolveInstallBrowseRoots(flags, {
+        writeConfig: pfDeps?.writeConfig ?? updateDaemonConfig,
+        readJson: pfDeps?.readJson,
+        loginPath: pfDeps?.loginPath,
+      });
+    }
 
     // Configure + persist the agent backend to daemon.json `agent` (single source
     // of truth; the unit carries no --agent, exactly like --cwd). Prompts an

--- a/cli/directory-discovery.mjs
+++ b/cli/directory-discovery.mjs
@@ -1,0 +1,184 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export const DIRECTORY_ERROR_CODES = Object.freeze([
+  "HOST_OFFLINE",
+  "TIMEOUT",
+  "INVALID_PATH",
+  "OUTSIDE_ROOT",
+  "NOT_DIRECTORY",
+  "ACCESS_DENIED",
+  "STALE_TARGET",
+  "LIMIT_EXCEEDED",
+  "INTERNAL_ERROR",
+]);
+
+export class DirectoryDiscoveryError extends Error {
+  constructor(code, message = code) {
+    super(message);
+    this.name = "DirectoryDiscoveryError";
+    this.code = code;
+  }
+}
+
+function expandHome(value, home, pathApi) {
+  if (value === "~") return home;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return pathApi.join(home, value.slice(2));
+  }
+  return value;
+}
+
+export function isPathWithin(root, candidate, pathApi = path) {
+  const relative = pathApi.relative(pathApi.resolve(root), pathApi.resolve(candidate));
+  return relative === "" || (!relative.startsWith("..") && !pathApi.isAbsolute(relative));
+}
+
+function cursorIndex(cursor) {
+  if (cursor == null || cursor === "") return 0;
+  try {
+    const parsed = Number(Buffer.from(cursor, "base64url").toString("utf8"));
+    if (Number.isSafeInteger(parsed) && parsed >= 0) return parsed;
+  } catch {}
+  throw new DirectoryDiscoveryError("INVALID_PATH", "Invalid directory cursor");
+}
+
+function fsError(err) {
+  if (err?.code === "EACCES" || err?.code === "EPERM") return "ACCESS_DENIED";
+  if (err?.code === "ENOTDIR") return "NOT_DIRECTORY";
+  if (err?.code === "ENOENT") return "INVALID_PATH";
+  return "INTERNAL_ERROR";
+}
+
+async function resolveRoots(roots, fsApi, pathApi) {
+  try {
+    return await Promise.all(roots.map(async (root) => ({
+      lexical: root,
+      real: await fsApi.realpath(root),
+    })));
+  } catch (err) {
+    throw new DirectoryDiscoveryError(fsError(err));
+  }
+}
+
+async function assertCanonicalWithin(candidate, roots, fsApi, pathApi) {
+  const lexicalRoot = roots.find((root) =>
+    isPathWithin(root.lexical, candidate, pathApi));
+  if (!lexicalRoot) throw new DirectoryDiscoveryError("OUTSIDE_ROOT");
+
+  let realCandidate;
+  try {
+    realCandidate = await fsApi.realpath(candidate);
+  } catch (err) {
+    throw new DirectoryDiscoveryError(fsError(err));
+  }
+  const relative = pathApi.relative(lexicalRoot.lexical, pathApi.resolve(candidate));
+  const expected = pathApi.resolve(lexicalRoot.real, relative);
+  if (realCandidate !== expected || !isPathWithin(lexicalRoot.real, realCandidate, pathApi)) {
+    throw new DirectoryDiscoveryError("OUTSIDE_ROOT");
+  }
+  return realCandidate;
+}
+
+/**
+ * Complete one path segment. Results intentionally contain only `{name,path}`.
+ */
+export async function discoverDirectories(options) {
+  const pathApi = options.pathApi ?? path;
+  const fsApi = options.fsApi ?? fs;
+  const home = options.home ?? homedir();
+  const maxScan = options.maxScan ?? 10_000;
+  const maxResults = options.maxResults ?? 1_000;
+  const maxLimit = options.maxLimit ?? 100;
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  const limit = options.limit ?? 50;
+  if (!Number.isInteger(limit) || limit < 1 || limit > maxLimit) {
+    throw new DirectoryDiscoveryError("LIMIT_EXCEEDED");
+  }
+  if (typeof options.prefix !== "string" || !options.prefix.trim()) {
+    throw new DirectoryDiscoveryError("INVALID_PATH");
+  }
+  const expanded = expandHome(options.prefix.trim(), home, pathApi);
+  if (!pathApi.isAbsolute(expanded)) throw new DirectoryDiscoveryError("INVALID_PATH");
+  const normalized = pathApi.normalize(expanded);
+  const parent = normalized.endsWith(pathApi.sep)
+    ? normalized
+    : pathApi.dirname(normalized);
+  const namePrefix = normalized.endsWith(pathApi.sep) ? "" : pathApi.basename(normalized);
+  const lexicalRoots = (options.browseRoots ?? []).map((root) => pathApi.resolve(root));
+  if (!lexicalRoots.some((root) => isPathWithin(root, parent, pathApi))) {
+    throw new DirectoryDiscoveryError("OUTSIDE_ROOT");
+  }
+
+  const scan = async () => {
+    const roots = await resolveRoots(lexicalRoots, fsApi, pathApi);
+    let parentStat;
+    try {
+      parentStat = await fsApi.lstat(parent);
+      await fsApi.access(parent);
+    } catch (err) {
+      throw new DirectoryDiscoveryError(fsError(err));
+    }
+    if (parentStat.isSymbolicLink()) throw new DirectoryDiscoveryError("OUTSIDE_ROOT");
+    if (!parentStat.isDirectory()) throw new DirectoryDiscoveryError("NOT_DIRECTORY");
+    await assertCanonicalWithin(parent, roots, fsApi, pathApi);
+
+    let entries;
+    try {
+      entries = await fsApi.readdir(parent, { withFileTypes: true });
+    } catch (err) {
+      throw new DirectoryDiscoveryError(fsError(err));
+    }
+    if (entries.length > maxScan) throw new DirectoryDiscoveryError("LIMIT_EXCEEDED");
+    const matches = [];
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") || !entry.name.startsWith(namePrefix)) continue;
+      const candidate = pathApi.resolve(parent, entry.name);
+      if (!roots.some((root) => isPathWithin(root.lexical, candidate, pathApi))) continue;
+      try {
+        const stat = await fsApi.lstat(candidate);
+        if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+        await fsApi.access(candidate);
+        await assertCanonicalWithin(candidate, roots, fsApi, pathApi);
+      } catch {
+        continue;
+      }
+      matches.push({ name: entry.name, path: candidate });
+      if (matches.length > maxResults) throw new DirectoryDiscoveryError("LIMIT_EXCEEDED");
+    }
+    matches.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) || a.name.localeCompare(b.name));
+    const start = cursorIndex(options.cursor);
+    const items = matches.slice(start, start + limit);
+    const next = start + items.length;
+    return {
+      items,
+      nextCursor: next < matches.length
+        ? Buffer.from(String(next), "utf8").toString("base64url")
+        : null,
+    };
+  };
+
+  let timer;
+  try {
+    return await Promise.race([
+      scan(),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new DirectoryDiscoveryError("TIMEOUT")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function validateDirectory(options) {
+  const result = await discoverDirectories({
+    ...options,
+    prefix: options.cwd.endsWith(options.pathApi?.sep ?? path.sep)
+      ? options.cwd
+      : `${options.cwd}${options.pathApi?.sep ?? path.sep}`,
+    limit: 1,
+  });
+  return { valid: true, normalizedPath: (options.pathApi ?? path).normalize(options.cwd), ...result };
+}

--- a/cli/event-router.mjs
+++ b/cli/event-router.mjs
@@ -105,7 +105,8 @@ export class EventRouter {
     const targetConnectionUuid =
       typeof event.targetConnectionUuid === "string" ? event.targetConnectionUuid : null;
     const suppressWake = event.suppressWake === true;
-    this.#fetchAndRoute(event.notificationUuid, { targetConnectionUuid, suppressWake }).catch(
+    const runtimeCwd = typeof event.runtimeCwd === "string" ? event.runtimeCwd : null;
+    this.#fetchAndRoute(event.notificationUuid, { targetConnectionUuid, suppressWake, runtimeCwd }).catch(
       (err) => {
         this.logger.error(`[Chorus] failed to route notification ${event.notificationUuid}: ${err}`);
       }
@@ -209,7 +210,8 @@ export class EventRouter {
       );
     }
 
-    await this.#resolveAndEnqueue(n, notificationUuid);
+    const routed = transport.runtimeCwd ? { ...n, runtimeCwd: transport.runtimeCwd } : n;
+    await this.#resolveAndEnqueue(routed, notificationUuid);
   }
 
   /**
@@ -244,6 +246,7 @@ export class EventRouter {
       entityType,
       entityUuid,
       ...(resumedFrom ? { resumedFrom } : {}),
+      ...(typeof target?.runtimeCwd === "string" ? { runtimeCwd: target.runtimeCwd } : {}),
     };
     this.#resolveAndEnqueue(n, `resume:${entityType}:${entityUuid}`).catch((err) => {
       this.logger.error(`[Chorus] failed to dispatch resume for ${entityType}:${entityUuid}: ${err}`);
@@ -319,6 +322,7 @@ export class EventRouter {
         sessionId,
         directIdeaUuid,
         trigger: pending.trigger,
+        runtimeCwd: typeof pending.runtimeCwd === "string" ? pending.runtimeCwd : null,
       }).catch((err) => {
         this.logger.error(
           `[Chorus] failed to re-dispatch autonomous pending turn ${turnUuid}: ${err}`
@@ -367,6 +371,7 @@ export class EventRouter {
       entityType: directIdeaUuid ? "idea" : "daemon_session",
       entityUuid: directIdeaUuid ? directIdeaUuid : sessionId,
       instructionText: instruction,
+      ...(typeof pending.runtimeCwd === "string" ? { runtimeCwd: pending.runtimeCwd } : {}),
     };
     const key = directIdeaUuid ? `idea:${directIdeaUuid}` : `entity:daemon_session:${sessionId}`;
     const attribution = { key, rootIdeaUuid: directIdeaUuid, directIdeaUuid };
@@ -407,7 +412,7 @@ export class EventRouter {
    * @param {{ turnUuid: string, sessionId: string, directIdeaUuid: string|null, trigger: string }} pending
    */
   async #redispatchAutonomousTurn(pending) {
-    const { turnUuid, sessionId, directIdeaUuid, trigger } = pending;
+    const { turnUuid, sessionId, directIdeaUuid, trigger, runtimeCwd } = pending;
     let result;
     try {
       result = await this.mcp.callTool("chorus_get_notifications", {
@@ -488,7 +493,10 @@ export class EventRouter {
     this.logger.info(
       `[Chorus] autonomous pending turn ${turnUuid} (${trigger}): waking from re-read notification ${match.uuid}`
     );
-    await this.#resolveAndEnqueue(match, match.uuid);
+    await this.#resolveAndEnqueue(
+      runtimeCwd ? { ...match, runtimeCwd } : match,
+      match.uuid,
+    );
   }
 
   /**

--- a/cli/turn-reporter.mjs
+++ b/cli/turn-reporter.mjs
@@ -4,7 +4,8 @@
 // persistent conversation; the server creates that turn (status `pending`) at the
 // notification chokepoint, and the daemon advances it:
 //   • on spawn      → pending → running
-//   • on subprocess exit → running → ended (clean) | interrupted (user/crash/shutdown)
+//   • on subprocess exit/validation → running → ended (clean) |
+//     interrupted (user/crash/shutdown/invalid_path)
 //
 // The daemon does NOT know the server-side turn uuid. It identifies the turn the SAME
 // way the transcript ingest does — by the session BUSINESS KEY (`sessionId` = the
@@ -30,7 +31,12 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 export const TURN_STATUSES = new Set(["pending", "running", "ended", "interrupted"]);
 
 /** Interrupt reasons a DAEMON may report (`offline` is server-reconcile-only). */
-export const TURN_INTERRUPT_REASONS = new Set(["user", "crash", "shutdown"]);
+export const TURN_INTERRUPT_REASONS = new Set([
+  "user",
+  "crash",
+  "shutdown",
+  "invalid_path",
+]);
 
 /**
  * Build an `advanceTurn(params)` function the waker invokes on a wake's spawn (→
@@ -46,7 +52,7 @@ export const TURN_INTERRUPT_REASONS = new Set(["user", "crash", "shutdown"]);
  *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
  *   fetchImpl?: typeof fetch,             Injectable for tests.
  * }} opts
- * @returns {(params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown"|null, transcriptRelayError?: string|null, usage?: import("./upload-hooks.mjs").TokenUsage|null }) => Promise<void>}
+ * @returns {(params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown"|"invalid_path"|null, transcriptRelayError?: string|null, usage?: import("./upload-hooks.mjs").TokenUsage|null }) => Promise<void>}
  */
 export function createTurnReporter(opts) {
   const logger = opts.logger ?? NOOP_LOGGER;

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -30,6 +30,7 @@ export class Waker {
    *   lineage: { resolve: (event: any) => Promise<{ rootIdeaUuid: string|null, directIdeaUuid: string|null }> },
    *   spawner: { wake: (params: any) => Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }> },
    *   cwd?: string,  The connection/session-bound working directory this Waker serves; resolveCwd() is the single source the probe + spawn + resume use. `undefined` ⇒ the process default cwd (HARD-1 / single-path).
+   *   validateRuntimeCwd?: (cwd: string) => Promise<{normalizedPath?: string}>,
    *   hooks?: import("./upload-hooks.mjs").UploadHooks,
    *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
    *   writeMcpConfigFn?: typeof writeMcpConfig,
@@ -67,6 +68,7 @@ export class Waker {
     // so resolveCwd() is the SINGLE place the process-default fallback is applied
     // (Module Contract 1 — one cwd source of truth, no scattered process.cwd()).
     this.cwd = opts.cwd;
+    this.validateRuntimeCwd = opts.validateRuntimeCwd;
     this.hooks = opts.hooks;
     this.logger = opts.logger ?? NOOP_LOGGER;
     this.writeMcpConfigFn = opts.writeMcpConfigFn ?? writeMcpConfig;
@@ -145,8 +147,8 @@ export class Waker {
    * wake path reads `process.cwd()`.
    * @returns {string}
    */
-  resolveCwd() {
-    return this.cwd ?? process.cwd();
+  resolveCwd(runtimeCwd) {
+    return runtimeCwd ?? this.cwd ?? process.cwd();
   }
 
   /**
@@ -340,6 +342,11 @@ export class Waker {
     // duration. `Date.now()` is fine here (runtime metric, not a resume seed).
     const startMs = Date.now();
     const target = entity ? `${entity.entityType}:${entity.entityUuid}` : key;
+    const sessionId = directIdeaUuid ?? notification.entityUuid ?? null;
+    const requestedRuntimeCwd =
+      typeof notification?.runtimeCwd === "string" && notification.runtimeCwd
+        ? notification.runtimeCwd
+        : null;
     try {
       const prompt = buildPrompt(notification);
       if (!prompt) {
@@ -377,12 +384,21 @@ export class Waker {
       // Decide new-vs-resume by probing the on-disk transcript in the SAME cwd we
       // spawn in. The spawner re-validates the id is a lowercase UUID before
       // spawning, so a garbage id surfaces visibly rather than misanchoring.
-      const sessionId = directIdeaUuid ?? notification.entityUuid ?? null;
       // Resolve the connection/session-bound cwd ONCE for this wake (Module Contract
       // 1). The transcript probe and the spawn below BOTH use this same value, so a
       // session's repeated wakes/probes always land the same cwd (NFR-3) — and a
       // multi-path daemon's other Wakers (other cwds) never bleed in.
-      const cwd = this.resolveCwd();
+      let cwd = this.resolveCwd(requestedRuntimeCwd);
+      if (requestedRuntimeCwd) {
+        if (!this.validateRuntimeCwd) {
+          throw new Error("Directed runtime cwd cannot be validated by this daemon");
+        }
+        const validation = await this.validateRuntimeCwd(requestedRuntimeCwd);
+        if (!validation?.normalizedPath) {
+          throw new Error("Directed runtime cwd validation returned no normalized path");
+        }
+        cwd = validation.normalizedPath;
+      }
       const isNew = sessionId ? this.isNewSessionFn(sessionId, cwd) : true;
 
       // Spawners declare whether the shared transcript probe is authoritative
@@ -566,6 +582,16 @@ export class Waker {
       }
     } catch (err) {
       this.logger.warn(`[Chorus] wake failed for ${key}: ${err}`);
+      if (sessionId && requestedRuntimeCwd && typeof err?.code === "string") {
+        await this.#advanceTurn(sessionId, "running", entity);
+        await this.#advanceTurn(
+          sessionId,
+          "interrupted",
+          entity,
+          "invalid_path",
+          `${err.code}: ${err.message ?? "Runtime cwd validation failed"}`,
+        );
+      }
     } finally {
       // Wake finished (cleanly or not): the resource leaves the active set. Drop
       // it and emit a fresh snapshot so the server ends its running/queued row.

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -179,8 +179,22 @@ chorus daemon stop --force  # force-clean the pidfile when a stuck/unverifiable
 chorus daemon install --cwd ~/proj          # generate the systemd --user unit,
                                              # daemon-reload, enable --now
 chorus daemon install --cwd ~/a --cwd ~/b    # serve several paths at boot
+chorus daemon install --browse-root ~/work   # allow project directory browsing
 chorus daemon uninstall                      # disable + remove the unit
 ```
+
+`cwds` are registered as daemon instances at startup. `browseRoots` are a
+separate allowlist for remote directory discovery and directed runtime
+execution; they do not create startup connections. Repeat `--browse-root` for
+multiple roots. Precedence is command line, `CHORUS_DAEMON_BROWSE_ROOTS`,
+`daemon.json`, then the daemon user's home directory. File changes require
+`chorus daemon restart`.
+
+Project settings can fix one host and cwd independently for each Agent. A fixed
+cwd stays authoritative for that user and project until replaced or cleared.
+Without one, operation pickers can use a registered directory or browse an
+allowed directory for that operation only. Temporary choices do not modify
+`daemon.json`, register an instance, or persist a project preference.
 
 `install` generates a correct `systemd --user` unit and starts it — you never
 hand-write the file. It captures the `--chorus-only` flag you pass, plus absolute

--- a/messages/en.json
+++ b/messages/en.json
@@ -974,6 +974,7 @@
     "offlineHint": "Agent offline — enables on reconnect",
     "errorAgentOffline": "The assigned agent is offline. Start development after it reconnects.",
     "errorInstanceOffline": "The idea is pinned to a daemon instance that is offline. Start development after that instance reconnects.",
+    "errorFixedCwdHostOffline": "The host for this project's fixed working directory is offline. Start development after that host reconnects.",
     "errorNoApprovedProposal": "This idea has no approved proposal yet",
     "errorNoUnfinishedTasks": "All tasks are already finished",
     "errorAssigneeNotAgent": "The idea's assignee is not an agent",
@@ -990,6 +991,7 @@
     "offlineHint": "Agent offline — enables on reconnect",
     "errorAgentOffline": "The assigned agent is offline. Run Yolo after it reconnects.",
     "errorInstanceOffline": "The idea is pinned to a daemon instance that is offline. Run Yolo after that instance reconnects.",
+    "errorFixedCwdHostOffline": "The host for this project's fixed working directory is offline. Run Yolo after that host reconnects.",
     "errorAssigneeNotAgent": "The idea's assignee is not an agent",
     "errorGeneric": "Failed to start Yolo"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -306,7 +306,14 @@
     "saveFailed": "Failed to update project",
     "dangerZone": "Danger zone",
     "deleteTitle": "Delete this project",
-    "deleteDescription": "Permanently remove this project and all its data. This action cannot be undone."
+    "deleteDescription": "Permanently remove this project and all its data. This action cannot be undone.",
+    "agentCwds": {
+      "title": "Agent working directories", "description": "Fix a host and directory for each Agent in this project.",
+      "loading": "Loading working directories...", "loadFailed": "Working directories could not be loaded.", "empty": "No Agents are available.",
+      "notConfigured": "Uses a temporary directory for each operation", "configure": "Configure working directory", "replace": "Replace working directory",
+      "clear": "Clear fixed working directory", "save": "Save fixed directory",
+      "status": { "valid": "Available", "offline": "Host offline", "invalid": "Directory unavailable" }
+    }
   },
   "projects": {
     "title": "Projects",
@@ -1682,7 +1689,16 @@
     "title": "Pick a working directory to run in",
     "subtitle": "{name} is online in {count, plural, one {# instance} other {# instances}} across {hosts, plural, one {# host} other {# hosts}}. Choose which one to pin and wake.",
     "confirm": "Pin & continue",
-    "cancel": "Cancel"
+    "cancel": "Cancel", "browseAnother": "Browse another directory", "registeredDirectories": "Registered directories", "useOnce": "Use for this operation"
+  },
+  "directoryBrowser": {
+    "chooseHost": "Choose a host", "unknownHost": "Unknown host", "pathPrefix": "Directory path prefix", "pathPlaceholder": "/home/user/project",
+    "browse": "Browse directories", "noHosts": "No online host is available for this Agent.", "empty": "No matching directories.", "selection": "Selected directory",
+    "errors": {
+      "HOST_OFFLINE": "The selected host is offline. Choose another host.", "TIMEOUT": "The host did not respond. Try again.", "INVALID_PATH": "Enter a valid absolute path.",
+      "OUTSIDE_ROOT": "That path is outside the host's allowed browse roots.", "NOT_DIRECTORY": "The selected path is not a directory.", "ACCESS_DENIED": "The daemon cannot access that directory.",
+      "STALE_TARGET": "The selection is stale. Browse and select it again.", "LIMIT_EXCEEDED": "Too many entries matched. Enter a more specific prefix.", "INTERNAL_ERROR": "The directory could not be loaded. Try again."
+    }
   },
   "graph": {
     "title": "Graph",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -306,7 +306,14 @@
     "saveFailed": "プロジェクトの更新に失敗しました",
     "dangerZone": "危険な操作",
     "deleteTitle": "このプロジェクトを削除",
-    "deleteDescription": "このプロジェクトとすべてのデータを完全に削除します。この操作は取り消せません。"
+    "deleteDescription": "このプロジェクトとすべてのデータを完全に削除します。この操作は取り消せません。",
+    "agentCwds": {
+      "title": "Agent の作業ディレクトリ", "description": "このプロジェクトの Agent ごとにホストとディレクトリを固定します。",
+      "loading": "作業ディレクトリを読み込んでいます...", "loadFailed": "作業ディレクトリを読み込めませんでした。", "empty": "利用できる Agent がありません。",
+      "notConfigured": "操作ごとに一時ディレクトリを使用", "configure": "作業ディレクトリを設定", "replace": "作業ディレクトリを変更",
+      "clear": "固定作業ディレクトリを解除", "save": "固定ディレクトリを保存",
+      "status": { "valid": "利用可能", "offline": "ホストはオフライン", "invalid": "ディレクトリを利用できません" }
+    }
   },
   "projects": {
     "title": "プロジェクト",
@@ -1682,7 +1689,16 @@
     "title": "実行する作業ディレクトリを選択してください",
     "subtitle": "{name} は {hosts} 台のホストの {count} 件のインスタンスでオンラインです。ピン留めして起動するインスタンスを選択してください。",
     "confirm": "ピン留めして続行",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル", "browseAnother": "別のディレクトリを参照", "registeredDirectories": "登録済みディレクトリ", "useOnce": "この操作のみで使用"
+  },
+  "directoryBrowser": {
+    "chooseHost": "ホストを選択", "unknownHost": "不明なホスト", "pathPrefix": "ディレクトリパスの接頭辞", "pathPlaceholder": "/home/user/project",
+    "browse": "ディレクトリを参照", "noHosts": "この Agent にオンラインのホストがありません。", "empty": "一致するディレクトリがありません。", "selection": "選択したディレクトリ",
+    "errors": {
+      "HOST_OFFLINE": "選択したホストはオフラインです。別のホストを選択してください。", "TIMEOUT": "ホストが応答しませんでした。再試行してください。", "INVALID_PATH": "有効な絶対パスを入力してください。",
+      "OUTSIDE_ROOT": "このパスはホストで許可された参照ルートの外にあります。", "NOT_DIRECTORY": "選択したパスはディレクトリではありません。", "ACCESS_DENIED": "Daemon はこのディレクトリにアクセスできません。",
+      "STALE_TARGET": "選択が古くなりました。もう一度参照して選択してください。", "LIMIT_EXCEEDED": "一致する項目が多すぎます。より具体的な接頭辞を入力してください。", "INTERNAL_ERROR": "ディレクトリを読み込めませんでした。再試行してください。"
+    }
   },
   "graph": {
     "title": "グラフ",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -974,6 +974,7 @@
     "offlineHint": "エージェントオフライン — 再接続で有効化",
     "errorAgentOffline": "割り当てられたエージェントはオフラインです。再接続後に開発を開始してください。",
     "errorInstanceOffline": "この着想はオフラインのデーモンインスタンスに固定されています。そのインスタンスの再接続後に開発を開始してください。",
+    "errorFixedCwdHostOffline": "このプロジェクトの固定作業ディレクトリのホストはオフラインです。ホストの再接続後に開発を開始してください。",
     "errorNoApprovedProposal": "この着想にはまだ承認済みの提案がありません",
     "errorNoUnfinishedTasks": "すべての課題はすでに完了しています",
     "errorAssigneeNotAgent": "この着想の担当者はエージェントではありません",
@@ -990,6 +991,7 @@
     "offlineHint": "エージェントオフライン — 再接続で有効化",
     "errorAgentOffline": "割り当てられたエージェントはオフラインです。再接続後に Yolo を実行してください。",
     "errorInstanceOffline": "この着想はオフラインのデーモンインスタンスに固定されています。そのインスタンスの再接続後に Yolo を実行してください。",
+    "errorFixedCwdHostOffline": "このプロジェクトの固定作業ディレクトリのホストはオフラインです。ホストの再接続後に Yolo を実行してください。",
     "errorAssigneeNotAgent": "この着想の担当者はエージェントではありません",
     "errorGeneric": "Yolo の開始に失敗しました"
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -974,6 +974,7 @@
     "offlineHint": "에이전트 오프라인 — 재연결 시 사용 가능",
     "errorAgentOffline": "배정된 에이전트가 오프라인입니다. 다시 연결된 후 개발을 시작하세요.",
     "errorInstanceOffline": "이 아이디어는 오프라인 상태인 데몬 인스턴스에 고정되어 있습니다. 해당 인스턴스가 다시 연결된 후 개발을 시작하세요.",
+    "errorFixedCwdHostOffline": "이 프로젝트의 고정 작업 디렉터리 호스트가 오프라인입니다. 해당 호스트가 다시 연결된 후 개발을 시작하세요.",
     "errorNoApprovedProposal": "이 아이디어에는 승인된 제안이 아직 없습니다",
     "errorNoUnfinishedTasks": "모든 작업이 이미 완료되었습니다",
     "errorAssigneeNotAgent": "이 아이디어의 담당자는 에이전트가 아닙니다",
@@ -990,6 +991,7 @@
     "offlineHint": "에이전트 오프라인 — 재연결 시 사용 가능",
     "errorAgentOffline": "배정된 에이전트가 오프라인입니다. 다시 연결된 후 Yolo를 실행하세요.",
     "errorInstanceOffline": "이 아이디어는 오프라인 상태인 데몬 인스턴스에 고정되어 있습니다. 해당 인스턴스가 다시 연결된 후 Yolo를 실행하세요.",
+    "errorFixedCwdHostOffline": "이 프로젝트의 고정 작업 디렉터리 호스트가 오프라인입니다. 해당 호스트가 다시 연결된 후 Yolo를 실행하세요.",
     "errorAssigneeNotAgent": "이 아이디어의 담당자는 에이전트가 아닙니다",
     "errorGeneric": "Yolo를 시작하지 못했습니다"
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -306,7 +306,14 @@
     "saveFailed": "프로젝트를 수정하지 못했습니다",
     "dangerZone": "위험 구역",
     "deleteTitle": "이 프로젝트 삭제",
-    "deleteDescription": "이 프로젝트와 모든 데이터를 영구적으로 제거합니다. 이 작업은 되돌릴 수 없습니다."
+    "deleteDescription": "이 프로젝트와 모든 데이터를 영구적으로 제거합니다. 이 작업은 되돌릴 수 없습니다.",
+    "agentCwds": {
+      "title": "Agent 작업 디렉터리", "description": "이 프로젝트의 Agent마다 호스트와 디렉터리를 고정합니다.",
+      "loading": "작업 디렉터리를 불러오는 중...", "loadFailed": "작업 디렉터리를 불러올 수 없습니다.", "empty": "사용 가능한 Agent가 없습니다.",
+      "notConfigured": "작업마다 임시 디렉터리 사용", "configure": "작업 디렉터리 설정", "replace": "작업 디렉터리 변경",
+      "clear": "고정 작업 디렉터리 해제", "save": "고정 디렉터리 저장",
+      "status": { "valid": "사용 가능", "offline": "호스트 오프라인", "invalid": "디렉터리 사용 불가" }
+    }
   },
   "projects": {
     "title": "프로젝트",
@@ -1682,7 +1689,16 @@
     "title": "실행할 작업 디렉터리를 선택하세요",
     "subtitle": "{name}은(는) 호스트 {hosts}대에서 인스턴스 {count}개로 온라인 상태입니다. 고정하고 깨울 인스턴스를 선택하세요.",
     "confirm": "고정하고 계속",
-    "cancel": "취소"
+    "cancel": "취소", "browseAnother": "다른 디렉터리 찾아보기", "registeredDirectories": "등록된 디렉터리", "useOnce": "이 작업에만 사용"
+  },
+  "directoryBrowser": {
+    "chooseHost": "호스트 선택", "unknownHost": "알 수 없는 호스트", "pathPrefix": "디렉터리 경로 접두사", "pathPlaceholder": "/home/user/project",
+    "browse": "디렉터리 찾아보기", "noHosts": "이 Agent에 온라인 호스트가 없습니다.", "empty": "일치하는 디렉터리가 없습니다.", "selection": "선택한 디렉터리",
+    "errors": {
+      "HOST_OFFLINE": "선택한 호스트가 오프라인입니다. 다른 호스트를 선택하세요.", "TIMEOUT": "호스트가 응답하지 않았습니다. 다시 시도하세요.", "INVALID_PATH": "유효한 절대 경로를 입력하세요.",
+      "OUTSIDE_ROOT": "이 경로는 호스트에서 허용한 탐색 루트 밖에 있습니다.", "NOT_DIRECTORY": "선택한 경로가 디렉터리가 아닙니다.", "ACCESS_DENIED": "Daemon이 이 디렉터리에 접근할 수 없습니다.",
+      "STALE_TARGET": "선택이 만료되었습니다. 다시 찾아 선택하세요.", "LIMIT_EXCEEDED": "일치 항목이 너무 많습니다. 더 구체적인 접두사를 입력하세요.", "INTERNAL_ERROR": "디렉터리를 불러올 수 없습니다. 다시 시도하세요."
+    }
   },
   "graph": {
     "title": "그래프",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -974,6 +974,7 @@
     "offlineHint": "Agent 离线，重连后可用",
     "errorAgentOffline": "该 agent 当前离线，请等它重新连接后再开始开发。",
     "errorInstanceOffline": "该 idea 已固定到一个离线的 daemon 实例，请等该实例重新连接后再开始开发。",
+    "errorFixedCwdHostOffline": "该项目固定工作目录所在的主机当前离线，请等该主机重新连接后再开始开发。",
     "errorNoApprovedProposal": "该 idea 还没有已批准的 proposal",
     "errorNoUnfinishedTasks": "所有任务都已完成",
     "errorAssigneeNotAgent": "该 idea 的负责人不是 agent",
@@ -990,6 +991,7 @@
     "offlineHint": "Agent 离线，重连后可用",
     "errorAgentOffline": "该 agent 当前离线，请等它重新连接后再执行 Yolo。",
     "errorInstanceOffline": "该 idea 已固定到一个离线的 daemon 实例，请等该实例重新连接后再执行 Yolo。",
+    "errorFixedCwdHostOffline": "该项目固定工作目录所在的主机当前离线，请等该主机重新连接后再执行 Yolo。",
     "errorAssigneeNotAgent": "该 idea 的负责人不是 agent",
     "errorGeneric": "启动 Yolo 失败"
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -306,7 +306,14 @@
     "saveFailed": "更新项目失败",
     "dangerZone": "危险区域",
     "deleteTitle": "删除此项目",
-    "deleteDescription": "永久删除此项目及其所有数据，此操作无法撤销。"
+    "deleteDescription": "永久删除此项目及其所有数据，此操作无法撤销。",
+    "agentCwds": {
+      "title": "Agent 工作目录", "description": "为此项目中的每个 Agent 固定主机和目录。",
+      "loading": "正在加载工作目录...", "loadFailed": "无法加载工作目录。", "empty": "暂无可用 Agent。",
+      "notConfigured": "每次操作临时选择目录", "configure": "配置工作目录", "replace": "替换工作目录",
+      "clear": "清除固定工作目录", "save": "保存固定目录",
+      "status": { "valid": "可用", "offline": "主机离线", "invalid": "目录不可用" }
+    }
   },
   "projects": {
     "title": "项目",
@@ -1682,7 +1689,16 @@
     "title": "选择要运行的工作目录",
     "subtitle": "{name} 在 {hosts, plural, other {# 台主机}}上有 {count, plural, other {# 个在线实例}}。请选择要固定并唤醒的实例。",
     "confirm": "固定并继续",
-    "cancel": "取消"
+    "cancel": "取消", "browseAnother": "浏览其他目录", "registeredDirectories": "已注册目录", "useOnce": "仅用于本次操作"
+  },
+  "directoryBrowser": {
+    "chooseHost": "选择主机", "unknownHost": "未知主机", "pathPrefix": "目录路径前缀", "pathPlaceholder": "/home/user/project",
+    "browse": "浏览目录", "noHosts": "此 Agent 暂无在线主机。", "empty": "没有匹配的目录。", "selection": "已选目录",
+    "errors": {
+      "HOST_OFFLINE": "所选主机已离线，请选择其他主机。", "TIMEOUT": "主机未响应，请重试。", "INVALID_PATH": "请输入有效的绝对路径。",
+      "OUTSIDE_ROOT": "该路径不在主机允许浏览的根目录内。", "NOT_DIRECTORY": "所选路径不是目录。", "ACCESS_DENIED": "Daemon 无法访问该目录。",
+      "STALE_TARGET": "选择已失效，请重新浏览并选择。", "LIMIT_EXCEEDED": "匹配项过多，请输入更具体的前缀。", "INTERNAL_ERROR": "无法加载目录，请重试。"
+    }
   },
   "graph": {
     "title": "图谱",

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/README.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/README.md
@@ -1,0 +1,3 @@
+# add-project-agent-cwd-discovery
+
+Add daemon host directory discovery and project-level per-Agent cwd defaults

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/design.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/design.md
@@ -1,0 +1,109 @@
+## Context
+
+Today each daemon startup cwd owns an SSE connection, `AgentInstance`, `Waker`, transcript namespace, and session origin. Wake preview and assignment persist an `agent_instance` only after choosing an already-online `(host, cwd)`. Project settings have no Agent cwd configuration, and the reverse control channel is server-to-daemon fire-and-forward with no correlated response.
+
+The requested flow must discover directories that are not startup connections, pin a project default for several Agents independently, and run in the selected cwd. A path is host-local: storing only a string is ambiguous across hosts, while storing only `AgentInstance.uuid` cannot represent an unregistered path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let a host operator bound discovery independently from startup `cwds`.
+- Browse one directory level at a time without leaking hidden, inaccessible, symlinked, or out-of-root paths.
+- Persist a fixed cwd per user, project, and Agent, including its host identity.
+- Make a fixed cwd authoritative until explicitly cleared.
+- Preserve transcript/session cwd consistency when running in a discovered path.
+- Expose deterministic pending/success/error states to project settings.
+
+**Non-Goals:**
+
+- A general remote filesystem browser or file API.
+- Server-side expansion of a daemon's browse allowlist.
+- Symlink traversal, hidden-directory browsing, stale-result caching, or cross-host path inference.
+- Persisting project-to-cwd bindings in `daemon.json`.
+
+## Decisions
+
+### Separate served cwds, browse roots, and project pins
+
+`cwds` remains the daemon's startup connection set. `browseRoots` is a host-local maximum disclosure boundary. Project pins are server-side user preferences keyed by `(userUuid, projectUuid, agentUuid)` and store `host`, normalized `cwd`, and the validating Agent instance used as the host anchor.
+
+This preserves ownership: the host controls exposure, while each user controls project defaults. One project can have independent pins for multiple Agents.
+
+### Resolve browse roots once at daemon startup
+
+Resolution is `--browse-root` > `CHORUS_DAEMON_BROWSE_ROOTS` > `daemon.json.browseRoots` > OS user home. `chorus daemon install --browse-root` persists the normalized list using the existing field-merge writer. Direct file edits require restart. Service units do not embed roots.
+
+### Use a correlated persisted control request
+
+The server creates a short-lived `DaemonDirectoryRequest` row with a request UUID, target connection, prefix, limit, and deadline, then dispatches `browse_directory` over the existing per-connection control channel. The daemon validates and scans locally, then reports success or a typed error through the authenticated daemon REST client. The UI polls the request endpoint until terminal state.
+
+A persisted row works across multiple web processes, survives an SSE reconnect long enough to report a clear timeout, and avoids holding HTTP requests open across the event bus.
+
+### Normalize and authorize before and after filesystem access
+
+The daemon expands `~`, requires an absolute normalized prefix, derives parent and basename, and uses `lstat`/directory access checks. It rejects symlinks and verifies the parent and every returned candidate remain under a configured root using path-component-aware containment. Hidden entries and inaccessible entries are omitted. Results contain direct child directories only, sorted by normalized name, with an opaque cursor and hard result/time limits.
+
+The server authorizes the caller against the target Agent owner/company before dispatch and never accepts a client-selected connection outside that Agent.
+
+### Represent a project pin as host plus cwd, not a startup instance
+
+`ProjectAgentCwdPreference` stores the owning user, project, Agent, host, normalized cwd, and the anchor instance UUID used to verify that host. The durable semantic identity is `(agentUuid, host, cwd)`; the anchor instance is transport metadata and may change.
+
+Saving performs a fresh daemon validation request. Clearing deletes the preference. Invalid/offline pins remain visible with a typed status rather than silently falling back.
+
+### Add directed runtime cwd to the daemon execution contract
+
+When a fixed or temporary discovered path is selected, the server targets any online connection for the same Agent and host and includes `runtimeCwd` in a directed wake/control payload. The daemon owns a per-runtime-cwd Waker/session context cache and passes that exact cwd to transcript probing and spawn. `DaemonSession` records `runtimeCwd`; later turns and resume use the same value and origin connection.
+
+The daemon validates `runtimeCwd` against current browse roots again immediately before execution. It does not add the path to startup `cwds` or mutate `daemon.json`.
+
+Alternative considered: dynamically register every selected path as a normal SSE connection. Rejected because a project preference would mutate daemon process topology, create unbounded connections, and still need restart recovery.
+
+### Fixed pins are sticky
+
+Resolution order is:
+
+1. A valid project-Agent fixed preference.
+2. A temporary cwd explicitly selected for the current operation when no fixed preference exists.
+3. Existing instance selection/auto-pin behavior.
+
+Once fixed, workflows do not prompt and cannot override it inline. The user must clear or replace the pin in project settings. This supersedes the earlier single-operation override answer.
+
+When no fixed preference exists, the existing instance picker retains its registered-cwd choices and adds a "Browse another directory" action. That action selects an online Agent host, invokes the same prefix-discovery flow, validates the final path, and passes `runtimeCwd` only to the current operation. It does not create a preference or mutate the Idea/Task assignee into a fabricated `AgentInstance`.
+
+## Data Model
+
+- `ProjectAgentCwdPreference`: unique `(userUuid, projectUuid, agentUuid)`; `host`, `cwd`, optional `anchorAgentInstanceUuid`, timestamps.
+- `DaemonDirectoryRequest`: request UUID, company/caller/agent/connection identifiers, operation (`list` or `validate`), prefix/cwd, cursor/limit, status, result JSON, error code, deadline, timestamps.
+- `DaemonSession.runtimeCwd`: nullable for backward compatibility; set for directed runtime-cwd sessions.
+
+Project deletion cascades preferences. Agent/user deletion removes preferences. Request rows are short-lived and periodically pruned.
+
+## API and Module Contracts
+
+- Project cwd preference API: list Agents and preference states; upsert after daemon validation; clear.
+- Directory request API: create authorized list/validate request and read its terminal state.
+- Daemon report API: authenticated completion by request UUID, accepted only from the targeted connection/Agent.
+- Typed errors: `HOST_OFFLINE`, `TIMEOUT`, `INVALID_PATH`, `OUTSIDE_ROOT`, `NOT_DIRECTORY`, `ACCESS_DENIED`, `STALE_TARGET`, `LIMIT_EXCEEDED`, `INTERNAL_ERROR`.
+- Result entries: `{ name, path }`; no filesystem metadata beyond what the picker needs.
+- Every runtime wake resolves one effective cwd and records it before dispatch; probe, spawn, resume, and subsequent turns use that same value.
+
+## Risks / Trade-offs
+
+- [Anchor connection disconnects mid-request] -> deadline plus `HOST_OFFLINE`/`TIMEOUT`; no stale cache.
+- [TOCTOU path changes] -> validate at browse time, save time, and immediately before spawn.
+- [Large directories consume resources] -> hard scan/time/result limits, stable cursor, one-level scans only.
+- [Runtime cwd diverges from session origin] -> persist `DaemonSession.runtimeCwd` and make it the sole cwd source for directed sessions.
+- [Sticky pin points to an offline host] -> surface the pin as offline and block the wake; never reroute to another host or cwd.
+- [Cross-platform paths] -> daemon performs platform-native normalization; server treats normalized paths as opaque host-local strings.
+
+## Migration Plan
+
+1. Add nullable schema and request/preference tables.
+2. Ship daemon config and discovery handlers with backward-compatible control enums.
+3. Ship server APIs and runtime-cwd routing.
+4. Add project settings and workflow consumption.
+5. Existing users have no preferences, so existing wake behavior remains unchanged.
+
+Rollback disables the new UI and directed runtime-cwd dispatch; nullable session data and preference rows may remain without affecting legacy routing.

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/proposal.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Chorus can currently route work only to working directories already registered as live daemon connections. Users with several repositories on one host must preconfigure every cwd at daemon startup and repeatedly choose an instance in project workflows. This prevents project settings from establishing a durable per-Agent cwd and cannot discover an unregistered directory safely.
+
+## What Changes
+
+- Add a daemon-local `browseRoots` allowlist and a bounded, prefix-based directory discovery protocol addressed to an online Agent instance.
+- Add a user-scoped project-Agent cwd preference that can pin one cwd for each Agent in a project or leave the Agent in temporary-selection mode.
+- Extend project settings with Agent working-directory controls that select a host first, browse allowed directories, explicitly save or clear a fixed cwd, and show invalid/offline states.
+- Make a fixed project-Agent cwd sticky across project workflows and Agent instances until cleared; when no fixed cwd exists, existing temporary cwd selection remains available.
+- Let workflows without a fixed cwd expand the temporary picker to browse an allowed unregistered directory for that operation without persisting a project preference.
+- Route work to a discovered cwd through the selected daemon host without requiring that directory to have been registered as a startup `cwd`.
+- Return stable typed errors for offline hosts, timeouts, invalid or out-of-root paths, inaccessible directories, and stale selections.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-directory-discovery`: Host-controlled browse roots, remote prefix completion, request/response transport, normalization, limits, and typed failures.
+- `project-agent-cwd`: User × project × Agent fixed cwd persistence, resolution priority, project-settings workflow, and wake routing to discovered paths.
+
+### Modified Capabilities
+
+- `daemon-cwd-instance-addressing`: Permit a selected online daemon host to execute a wake in an allowed discovered cwd even when no startup connection was registered for that path.
+- `daemon-background-lifecycle`: Configure and persist daemon browse roots independently from served startup cwds.
+
+## Impact
+
+The change affects daemon CLI configuration, reverse control transport, daemon filesystem access, connection and wake-target services, Prisma data, project settings, assignment/stage-advance cwd selection, localization, and focused unit/integration/browser tests. Existing projects and daemons retain current behavior when no project-Agent cwd has been fixed.

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/daemon-background-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/daemon-background-lifecycle/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Install SHALL persist browse roots separately from served cwds
+`chorus daemon install` SHALL accept repeatable `--browse-root` values, normalize and de-duplicate them, and persist them as `browseRoots` in `~/.chorus/daemon.json` through the existing owner-only field-merge writer. It MUST preserve credentials, `cwds`, Agent selection, and other daemon fields. The generated service unit MUST NOT embed browse-root arguments.
+
+#### Scenario: Install receives browse roots
+- **WHEN** an operator runs `chorus daemon install --browse-root ~/work --browse-root /srv/repos`
+- **THEN** the normalized roots MUST be stored in `daemon.json` independently from `cwds`
+- **AND** the installed service MUST read them from that file at startup
+
+#### Scenario: Install runs without browse-root flags
+- **WHEN** `daemon.json` already contains `browseRoots`
+- **THEN** reinstall MUST preserve and reuse them without prompting or replacing them

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/daemon-cwd-instance-addressing/spec.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/daemon-cwd-instance-addressing/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: A wake SHALL have one immutable runtime working directory
+Every daemon wake SHALL resolve exactly one runtime working directory before transcript probing or process spawn. For a startup-connection wake, that directory SHALL remain the connection-bound cwd. For a directed discovered-cwd wake, it SHALL be the validated `runtimeCwd` persisted on the daemon session. Transcript probing, spawn, resume, and subsequent turns MUST all consume that same value. A directed runtime cwd MUST NOT mutate the daemon's process cwd, startup `cwds`, or another concurrent wake's directory.
+
+#### Scenario: Startup connection wake
+- **WHEN** a wake is delivered through an existing cwd-bound connection without a directed runtime cwd
+- **THEN** probing and spawn MUST use that connection's cwd exactly as before
+
+#### Scenario: Directed discovered-cwd wake
+- **WHEN** an authorized wake targets an allowed runtime cwd on the connection's host
+- **THEN** the daemon MUST create or reuse an isolated runtime context bound to that cwd
+- **AND** probing and spawn MUST use the runtime cwd
+
+#### Scenario: Concurrent runtime directories
+- **WHEN** one daemon runs wakes for two different runtime cwd values concurrently
+- **THEN** each wake MUST retain its own cwd, transcript namespace, execution state, and session continuation without cross-talk

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/daemon-directory-discovery/spec.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/daemon-directory-discovery/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Daemon browse-root configuration
+The daemon SHALL resolve a host-local directory-discovery allowlist independently from startup `cwds`, using `--browse-root` over `CHORUS_DAEMON_BROWSE_ROOTS` over `~/.chorus/daemon.json` `browseRoots` over the daemon OS user's home directory. `chorus daemon install --browse-root` SHALL persist normalized roots through the existing owner-only field-merge configuration writer, and changes SHALL take effect after daemon restart.
+
+#### Scenario: No browse roots are configured
+- **WHEN** a daemon starts without a browse-root flag, environment value, or stored value
+- **THEN** its effective browse root MUST be the daemon OS user's home directory
+
+#### Scenario: Browse roots do not become startup connections
+- **WHEN** a path is configured only as a browse root
+- **THEN** the daemon MUST NOT register that path as a startup cwd or create an online Agent instance for it
+
+### Requirement: Correlated remote directory requests
+The server SHALL authorize and persist each list or validate request, dispatch it to the selected online Agent instance over the connection-specific control channel, and expose pending and terminal request states. The daemon SHALL report the correlated result through an authenticated endpoint before the deadline.
+
+#### Scenario: Target instance is offline
+- **WHEN** the selected Agent instance has no effective online connection
+- **THEN** request creation MUST return `HOST_OFFLINE` without dispatching to another host
+
+#### Scenario: Daemon does not answer before deadline
+- **WHEN** a dispatched request remains incomplete at its deadline
+- **THEN** the read API MUST return terminal `TIMEOUT` and MUST NOT return cached candidates
+
+### Requirement: Safe one-level prefix completion
+The daemon SHALL accept an absolute path prefix, derive its parent and basename prefix, and return only matching direct child directories under an effective browse root. It MUST normalize paths, enforce component-aware root containment, exclude symlinks and hidden entries, omit inaccessible entries, sort deterministically, and enforce scan, time, page, and result limits.
+
+#### Scenario: Prefix resolves inside a browse root
+- **WHEN** an authorized request supplies `/home/user/proj` and accessible direct child directories match that prefix
+- **THEN** the response MUST contain only normalized matching direct-child `{name, path}` entries in stable order
+
+#### Scenario: Prefix escapes a root
+- **WHEN** normalization or traversal would place the parent or candidate outside every browse root
+- **THEN** the request MUST fail with `OUTSIDE_ROOT` without revealing whether the target exists
+
+#### Scenario: Entry is hidden, inaccessible, or a symlink
+- **WHEN** a scanned child is hidden, cannot be safely traversed by the daemon identity, or is a symbolic link
+- **THEN** that entry MUST be omitted from results
+
+### Requirement: Stable discovery failures
+Directory discovery SHALL expose stable error codes for offline host, timeout, invalid path, outside root, non-directory, access denied, stale target, limit exceeded, and internal failure. An error MUST NOT be represented as an empty successful result.
+
+#### Scenario: Empty directory versus failed request
+- **WHEN** an accessible directory has no matching children
+- **THEN** the request MUST succeed with an empty items array
+- **AND** when the scan fails it MUST instead return the corresponding typed error

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/project-agent-cwd/spec.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/specs/project-agent-cwd/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Per-user project-Agent cwd preferences
+Chorus SHALL let each user persist at most one fixed cwd for each `(project, Agent)` pair, including the target host and normalized path. One project MAY hold independent fixed cwd preferences for multiple Agents, and one user's preferences MUST NOT affect another user.
+
+#### Scenario: User fixes cwd for two Agents
+- **WHEN** a user saves different valid paths for Agent A and Agent B in one project
+- **THEN** both preferences MUST coexist and resolve independently
+
+#### Scenario: Another user opens the same project
+- **WHEN** a second user has no preference for the same project and Agent
+- **THEN** the second user MUST retain the unconfigured behavior
+
+### Requirement: Project settings is the management surface
+Project settings SHALL include an Agent working-directory section that shows each Agent's fixed path, host, and validity state and supports selecting, explicitly saving, replacing, and clearing the preference. Selection SHALL choose an online Agent instance/host before browsing that daemon's allowed directories.
+
+#### Scenario: User saves a discovered cwd
+- **WHEN** the user chooses an online host, browses to an allowed directory, and confirms Save
+- **THEN** Chorus MUST freshly validate the directory on that daemon and persist the preference only after validation succeeds
+
+#### Scenario: Fixed cwd becomes unavailable
+- **WHEN** the stored host is offline or the directory no longer validates
+- **THEN** project settings MUST show a distinguishable invalid/offline state and offer replace or clear actions
+
+### Requirement: Fixed cwd is sticky until cleared
+A valid fixed project-Agent cwd SHALL be the authoritative cwd for that user's project workflows across all instances of that Agent. Those workflows MUST NOT prompt for or accept an inline temporary override while the preference exists. Clearing the preference SHALL restore temporary or existing instance selection.
+
+#### Scenario: Fixed Agent is selected in a project workflow
+- **WHEN** a project operation selects an Agent with a valid fixed cwd
+- **THEN** the operation MUST use that host and cwd without asking the user to select an instance
+
+#### Scenario: User wants another cwd
+- **WHEN** a fixed preference exists and the user needs a different cwd
+- **THEN** the user MUST clear or replace the preference in project settings before choosing a temporary cwd
+
+#### Scenario: No fixed preference exists
+- **WHEN** a project operation selects an Agent without a fixed cwd
+- **THEN** existing temporary instance selection and auto-selection behavior MUST remain available
+- **AND** the picker MUST offer browsing another allowed directory on an online host for this operation
+
+#### Scenario: User chooses a temporary discovered cwd
+- **WHEN** no fixed preference exists and the user browses to an allowed unregistered directory from an operation's temporary picker
+- **THEN** Chorus MUST freshly validate and use that runtime cwd for only the current operation
+- **AND** it MUST NOT persist a project preference or fabricate a registered Agent instance
+
+### Requirement: Directed execution in a discovered cwd
+Chorus SHALL execute work in a valid fixed or temporary discovered cwd through an online connection for the selected Agent and host without requiring that path to be a startup connection. The daemon MUST validate the runtime cwd immediately before spawn, and transcript probe, spawn, resume, and subsequent session turns MUST use the same persisted runtime cwd.
+
+#### Scenario: Discovered path is not a startup cwd
+- **WHEN** a valid project preference names an allowed directory with no registered startup connection
+- **THEN** the selected host daemon MUST run the work in that directory without adding it to `daemon.json` or startup `cwds`
+
+#### Scenario: Host is offline at wake time
+- **WHEN** the fixed cwd's host has no online connection when work is triggered
+- **THEN** the operation MUST fail with a distinguishable offline state and MUST NOT reroute to another host or cwd
+
+#### Scenario: Session continues after initial wake
+- **WHEN** a directed runtime-cwd session receives another turn or resumes
+- **THEN** it MUST use the same persisted runtime cwd and origin connection as the initial execution
+
+### Requirement: Backward-compatible cwd resolution
+Projects without a fixed preference and sessions without a runtime cwd SHALL preserve existing Agent-instance assignment, wake preview, auto-pin, transcript, and spawn behavior.
+
+#### Scenario: Existing project has no preferences
+- **WHEN** the feature is deployed for an existing project
+- **THEN** its wake and assignment behavior MUST remain unchanged until a user saves a preference

--- a/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/tasks.md
+++ b/openspec/changes/archive/2026-08-02-add-project-agent-cwd-discovery/tasks.md
@@ -1,0 +1,17 @@
+## 1. Daemon discovery foundation
+
+- [ ] 1.1 Add layered `browseRoots` resolution, install persistence, CLI help, startup diagnostics, and focused configuration tests.
+- [ ] 1.2 Add safe one-level directory scanning with normalization, containment, symlink/hidden/access filtering, stable pagination, limits, typed errors, and cross-platform unit tests.
+- [ ] 1.3 Extend daemon control and REST reporting with correlated list/validate requests and test offline, timeout, stale-target, and reconnect behavior.
+
+## 2. Project cwd model and routing
+
+- [ ] 2.1 Add Prisma models/migration and services/APIs for user × project × Agent cwd preferences and short-lived directory requests, including tenant/owner authorization and cleanup.
+- [ ] 2.2 Add directed runtime-cwd dispatch, daemon runtime Waker contexts, `DaemonSession.runtimeCwd`, and immutable probe/spawn/resume/turn routing with concurrency tests.
+- [ ] 2.3 Integrate sticky fixed-cwd resolution into assignment and stage-advance workflows while preserving existing behavior when no preference exists.
+
+## 3. Product workflow and integration
+
+- [ ] 3.1 Add the project-settings Agent working-directory UI with host-first remote browsing, explicit save/replace/clear, typed states, responsive behavior, and localization; when no fixed value exists, extend operation cwd pickers with a non-persisting "browse another directory" flow.
+- [ ] 3.2 Add end-to-end integration coverage from browse-root configuration through discovery, fixed preference, directed wake, continued session, clear-to-temporary fallback, temporary unregistered-directory execution without persistence, offline/error states, and regression suites.
+- [ ] 3.3 Update daemon and project configuration documentation and manually verify the project-settings workflow in desktop and mobile browsers.

--- a/openspec/specs/daemon-background-lifecycle/spec.md
+++ b/openspec/specs/daemon-background-lifecycle/spec.md
@@ -258,3 +258,15 @@ The CLI SHALL accept a `--yes` / `-y` flag on `chorus daemon install` that suppr
 - **WHEN** `chorus daemon install --yes` (or a non-TTY install) cannot resolve credentials from any source
 - **THEN** install emits the multi-source actionable error, writes no unit, and exits non-zero instead of prompting
 
+### Requirement: Install SHALL persist browse roots separately from served cwds
+`chorus daemon install` SHALL accept repeatable `--browse-root` values, normalize and de-duplicate them, and persist them as `browseRoots` in `~/.chorus/daemon.json` through the existing owner-only field-merge writer. It MUST preserve credentials, `cwds`, Agent selection, and other daemon fields. The generated service unit MUST NOT embed browse-root arguments.
+
+#### Scenario: Install receives browse roots
+- **WHEN** an operator runs `chorus daemon install --browse-root ~/work --browse-root /srv/repos`
+- **THEN** the normalized roots MUST be stored in `daemon.json` independently from `cwds`
+- **AND** the installed service MUST read them from that file at startup
+
+#### Scenario: Install runs without browse-root flags
+- **WHEN** `daemon.json` already contains `browseRoots`
+- **THEN** reinstall MUST preserve and reuse them without prompting or replacing them
+

--- a/openspec/specs/daemon-cwd-instance-addressing/spec.md
+++ b/openspec/specs/daemon-cwd-instance-addressing/spec.md
@@ -323,3 +323,19 @@ reach it.
 - **THEN** the dialog renders the full list with the title and footer visible and introduces
   no internal scrolling beyond what the content needs
 
+### Requirement: A wake SHALL have one immutable runtime working directory
+Every daemon wake SHALL resolve exactly one runtime working directory before transcript probing or process spawn. For a startup-connection wake, that directory SHALL remain the connection-bound cwd. For a directed discovered-cwd wake, it SHALL be the validated `runtimeCwd` persisted on the daemon session. Transcript probing, spawn, resume, and subsequent turns MUST all consume that same value. A directed runtime cwd MUST NOT mutate the daemon's process cwd, startup `cwds`, or another concurrent wake's directory.
+
+#### Scenario: Startup connection wake
+- **WHEN** a wake is delivered through an existing cwd-bound connection without a directed runtime cwd
+- **THEN** probing and spawn MUST use that connection's cwd exactly as before
+
+#### Scenario: Directed discovered-cwd wake
+- **WHEN** an authorized wake targets an allowed runtime cwd on the connection's host
+- **THEN** the daemon MUST create or reuse an isolated runtime context bound to that cwd
+- **AND** probing and spawn MUST use the runtime cwd
+
+#### Scenario: Concurrent runtime directories
+- **WHEN** one daemon runs wakes for two different runtime cwd values concurrently
+- **THEN** each wake MUST retain its own cwd, transcript namespace, execution state, and session continuation without cross-talk
+

--- a/openspec/specs/daemon-directory-discovery/spec.md
+++ b/openspec/specs/daemon-directory-discovery/spec.md
@@ -1,0 +1,49 @@
+# daemon-directory-discovery Specification
+
+## Purpose
+TBD - created by archiving change add-project-agent-cwd-discovery. Update Purpose after archive.
+## Requirements
+### Requirement: Daemon browse-root configuration
+The daemon SHALL resolve a host-local directory-discovery allowlist independently from startup `cwds`, using `--browse-root` over `CHORUS_DAEMON_BROWSE_ROOTS` over `~/.chorus/daemon.json` `browseRoots` over the daemon OS user's home directory. `chorus daemon install --browse-root` SHALL persist normalized roots through the existing owner-only field-merge configuration writer, and changes SHALL take effect after daemon restart.
+
+#### Scenario: No browse roots are configured
+- **WHEN** a daemon starts without a browse-root flag, environment value, or stored value
+- **THEN** its effective browse root MUST be the daemon OS user's home directory
+
+#### Scenario: Browse roots do not become startup connections
+- **WHEN** a path is configured only as a browse root
+- **THEN** the daemon MUST NOT register that path as a startup cwd or create an online Agent instance for it
+
+### Requirement: Correlated remote directory requests
+The server SHALL authorize and persist each list or validate request, dispatch it to the selected online Agent instance over the connection-specific control channel, and expose pending and terminal request states. The daemon SHALL report the correlated result through an authenticated endpoint before the deadline.
+
+#### Scenario: Target instance is offline
+- **WHEN** the selected Agent instance has no effective online connection
+- **THEN** request creation MUST return `HOST_OFFLINE` without dispatching to another host
+
+#### Scenario: Daemon does not answer before deadline
+- **WHEN** a dispatched request remains incomplete at its deadline
+- **THEN** the read API MUST return terminal `TIMEOUT` and MUST NOT return cached candidates
+
+### Requirement: Safe one-level prefix completion
+The daemon SHALL accept an absolute path prefix, derive its parent and basename prefix, and return only matching direct child directories under an effective browse root. It MUST normalize paths, enforce component-aware root containment, exclude symlinks and hidden entries, omit inaccessible entries, sort deterministically, and enforce scan, time, page, and result limits.
+
+#### Scenario: Prefix resolves inside a browse root
+- **WHEN** an authorized request supplies `/home/user/proj` and accessible direct child directories match that prefix
+- **THEN** the response MUST contain only normalized matching direct-child `{name, path}` entries in stable order
+
+#### Scenario: Prefix escapes a root
+- **WHEN** normalization or traversal would place the parent or candidate outside every browse root
+- **THEN** the request MUST fail with `OUTSIDE_ROOT` without revealing whether the target exists
+
+#### Scenario: Entry is hidden, inaccessible, or a symlink
+- **WHEN** a scanned child is hidden, cannot be safely traversed by the daemon identity, or is a symbolic link
+- **THEN** that entry MUST be omitted from results
+
+### Requirement: Stable discovery failures
+Directory discovery SHALL expose stable error codes for offline host, timeout, invalid path, outside root, non-directory, access denied, stale target, limit exceeded, and internal failure. An error MUST NOT be represented as an empty successful result.
+
+#### Scenario: Empty directory versus failed request
+- **WHEN** an accessible directory has no matching children
+- **THEN** the request MUST succeed with an empty items array
+- **AND** when the scan fails it MUST instead return the corresponding typed error

--- a/openspec/specs/project-agent-cwd/spec.md
+++ b/openspec/specs/project-agent-cwd/spec.md
@@ -1,0 +1,69 @@
+# project-agent-cwd Specification
+
+## Purpose
+TBD - created by archiving change add-project-agent-cwd-discovery. Update Purpose after archive.
+## Requirements
+### Requirement: Per-user project-Agent cwd preferences
+Chorus SHALL let each user persist at most one fixed cwd for each `(project, Agent)` pair, including the target host and normalized path. One project MAY hold independent fixed cwd preferences for multiple Agents, and one user's preferences MUST NOT affect another user.
+
+#### Scenario: User fixes cwd for two Agents
+- **WHEN** a user saves different valid paths for Agent A and Agent B in one project
+- **THEN** both preferences MUST coexist and resolve independently
+
+#### Scenario: Another user opens the same project
+- **WHEN** a second user has no preference for the same project and Agent
+- **THEN** the second user MUST retain the unconfigured behavior
+
+### Requirement: Project settings is the management surface
+Project settings SHALL include an Agent working-directory section that shows each Agent's fixed path, host, and validity state and supports selecting, explicitly saving, replacing, and clearing the preference. Selection SHALL choose an online Agent instance/host before browsing that daemon's allowed directories.
+
+#### Scenario: User saves a discovered cwd
+- **WHEN** the user chooses an online host, browses to an allowed directory, and confirms Save
+- **THEN** Chorus MUST freshly validate the directory on that daemon and persist the preference only after validation succeeds
+
+#### Scenario: Fixed cwd becomes unavailable
+- **WHEN** the stored host is offline or the directory no longer validates
+- **THEN** project settings MUST show a distinguishable invalid/offline state and offer replace or clear actions
+
+### Requirement: Fixed cwd is sticky until cleared
+A valid fixed project-Agent cwd SHALL be the authoritative cwd for that user's project workflows across all instances of that Agent. Those workflows MUST NOT prompt for or accept an inline temporary override while the preference exists. Clearing the preference SHALL restore temporary or existing instance selection.
+
+#### Scenario: Fixed Agent is selected in a project workflow
+- **WHEN** a project operation selects an Agent with a valid fixed cwd
+- **THEN** the operation MUST use that host and cwd without asking the user to select an instance
+
+#### Scenario: User wants another cwd
+- **WHEN** a fixed preference exists and the user needs a different cwd
+- **THEN** the user MUST clear or replace the preference in project settings before choosing a temporary cwd
+
+#### Scenario: No fixed preference exists
+- **WHEN** a project operation selects an Agent without a fixed cwd
+- **THEN** existing temporary instance selection and auto-selection behavior MUST remain available
+- **AND** the picker MUST offer browsing another allowed directory on an online host for this operation
+
+#### Scenario: User chooses a temporary discovered cwd
+- **WHEN** no fixed preference exists and the user browses to an allowed unregistered directory from an operation's temporary picker
+- **THEN** Chorus MUST freshly validate and use that runtime cwd for only the current operation
+- **AND** it MUST NOT persist a project preference or fabricate a registered Agent instance
+
+### Requirement: Directed execution in a discovered cwd
+Chorus SHALL execute work in a valid fixed or temporary discovered cwd through an online connection for the selected Agent and host without requiring that path to be a startup connection. The daemon MUST validate the runtime cwd immediately before spawn, and transcript probe, spawn, resume, and subsequent session turns MUST use the same persisted runtime cwd.
+
+#### Scenario: Discovered path is not a startup cwd
+- **WHEN** a valid project preference names an allowed directory with no registered startup connection
+- **THEN** the selected host daemon MUST run the work in that directory without adding it to `daemon.json` or startup `cwds`
+
+#### Scenario: Host is offline at wake time
+- **WHEN** the fixed cwd's host has no online connection when work is triggered
+- **THEN** the operation MUST fail with a distinguishable offline state and MUST NOT reroute to another host or cwd
+
+#### Scenario: Session continues after initial wake
+- **WHEN** a directed runtime-cwd session receives another turn or resumes
+- **THEN** it MUST use the same persisted runtime cwd and origin connection as the initial execution
+
+### Requirement: Backward-compatible cwd resolution
+Projects without a fixed preference and sessions without a runtime cwd SHALL preserve existing Agent-instance assignment, wake preview, auto-pin, transcript, and spawn behavior.
+
+#### Scenario: Existing project has no preferences
+- **WHEN** the feature is deployed for an existing project
+- **THEN** its wake and assignment behavior MUST remain unchanged until a user saves a preference

--- a/prisma/migrations/20260801113000_add_project_agent_cwd_discovery/migration.sql
+++ b/prisma/migrations/20260801113000_add_project_agent_cwd_discovery/migration.sql
@@ -1,0 +1,50 @@
+CREATE TABLE "ProjectAgentCwdPreference" (
+  "id" SERIAL NOT NULL,
+  "uuid" TEXT NOT NULL,
+  "companyUuid" TEXT NOT NULL,
+  "userUuid" TEXT NOT NULL,
+  "projectUuid" TEXT NOT NULL,
+  "agentUuid" TEXT NOT NULL,
+  "host" TEXT NOT NULL,
+  "cwd" TEXT NOT NULL,
+  "anchorAgentInstanceUuid" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "ProjectAgentCwdPreference_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "DaemonDirectoryRequest" (
+  "id" SERIAL NOT NULL,
+  "uuid" TEXT NOT NULL,
+  "companyUuid" TEXT NOT NULL,
+  "callerUserUuid" TEXT NOT NULL,
+  "agentUuid" TEXT NOT NULL,
+  "targetConnectionUuid" TEXT NOT NULL,
+  "operation" TEXT NOT NULL,
+  "prefix" TEXT,
+  "cwd" TEXT,
+  "cursor" TEXT,
+  "limit" INTEGER NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "result" JSONB,
+  "errorCode" TEXT,
+  "deadlineAt" TIMESTAMP(3) NOT NULL,
+  "completedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "DaemonDirectoryRequest_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProjectAgentCwdPreference_uuid_key" ON "ProjectAgentCwdPreference"("uuid");
+CREATE UNIQUE INDEX "ProjectAgentCwdPreference_userUuid_projectUuid_agentUuid_key" ON "ProjectAgentCwdPreference"("userUuid", "projectUuid", "agentUuid");
+CREATE INDEX "ProjectAgentCwdPreference_companyUuid_projectUuid_idx" ON "ProjectAgentCwdPreference"("companyUuid", "projectUuid");
+CREATE INDEX "ProjectAgentCwdPreference_projectUuid_idx" ON "ProjectAgentCwdPreference"("projectUuid");
+CREATE INDEX "ProjectAgentCwdPreference_agentUuid_idx" ON "ProjectAgentCwdPreference"("agentUuid");
+CREATE INDEX "ProjectAgentCwdPreference_anchorAgentInstanceUuid_idx" ON "ProjectAgentCwdPreference"("anchorAgentInstanceUuid");
+CREATE UNIQUE INDEX "DaemonDirectoryRequest_uuid_key" ON "DaemonDirectoryRequest"("uuid");
+CREATE INDEX "DaemonDirectoryRequest_companyUuid_callerUserUuid_createdAt_idx" ON "DaemonDirectoryRequest"("companyUuid", "callerUserUuid", "createdAt");
+CREATE INDEX "DaemonDirectoryRequest_callerUserUuid_idx" ON "DaemonDirectoryRequest"("callerUserUuid");
+CREATE INDEX "DaemonDirectoryRequest_agentUuid_idx" ON "DaemonDirectoryRequest"("agentUuid");
+CREATE INDEX "DaemonDirectoryRequest_targetConnectionUuid_status_idx" ON "DaemonDirectoryRequest"("targetConnectionUuid", "status");
+CREATE INDEX "DaemonDirectoryRequest_deadlineAt_idx" ON "DaemonDirectoryRequest"("deadlineAt");
+ALTER TABLE "DaemonSession" ADD COLUMN "runtimeCwd" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,20 +24,22 @@ model Company {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  users             User[]
-  agents            Agent[]
-  apiKeys           ApiKey[]
-  projects          Project[]
-  ideas             Idea[]
-  documents         Document[]
-  tasks             Task[]
-  proposals         Proposal[]
-  activities        Activity[]
-  comments          Comment[]
-  sessions          AgentSession[]
-  daemonConnections DaemonConnection[]
-  agentInstances    AgentInstance[]
-  referenceArtifacts ReferenceArtifact[]
+  users                      User[]
+  agents                     Agent[]
+  apiKeys                    ApiKey[]
+  projects                   Project[]
+  ideas                      Idea[]
+  documents                  Document[]
+  tasks                      Task[]
+  proposals                  Proposal[]
+  activities                 Activity[]
+  comments                   Comment[]
+  sessions                   AgentSession[]
+  daemonConnections          DaemonConnection[]
+  agentInstances             AgentInstance[]
+  referenceArtifacts         ReferenceArtifact[]
+  projectAgentCwdPreferences ProjectAgentCwdPreference[]
+  daemonDirectoryRequests    DaemonDirectoryRequest[]
 }
 
 // User (human, OIDC login)
@@ -52,7 +54,9 @@ model User {
   avatarUrl   String?
   createdAt   DateTime @default(now())
 
-  ownedAgents Agent[]
+  ownedAgents                Agent[]
+  projectAgentCwdPreferences ProjectAgentCwdPreference[]
+  daemonDirectoryRequests    DaemonDirectoryRequest[]
 
   @@unique([companyUuid, oidcSub])
   @@index([companyUuid])
@@ -75,12 +79,14 @@ model Agent {
   lastActiveAt DateTime?
   createdAt    DateTime  @default(now())
 
-  apiKeys           ApiKey[]
-  sessions          AgentSession[]
-  daemonConnections DaemonConnection[]
-  daemonExecutions  DaemonExecution[]
-  daemonSessions    DaemonSession[]
-  agentInstances    AgentInstance[]
+  apiKeys                    ApiKey[]
+  sessions                   AgentSession[]
+  daemonConnections          DaemonConnection[]
+  daemonExecutions           DaemonExecution[]
+  daemonSessions             DaemonSession[]
+  agentInstances             AgentInstance[]
+  projectAgentCwdPreferences ProjectAgentCwdPreference[]
+  daemonDirectoryRequests    DaemonDirectoryRequest[]
 
   @@index([companyUuid])
   @@index([ownerUuid])
@@ -110,7 +116,8 @@ model AgentInstance {
 
   // Connections that have served this instance (current + historical). Liveness is
   // derived from these, never duplicated onto the instance row.
-  connections DaemonConnection[]
+  connections    DaemonConnection[]
+  cwdPreferences ProjectAgentCwdPreference[]
 
   @@unique([companyUuid, agentUuid, host, cwd])
   @@index([companyUuid])
@@ -162,11 +169,12 @@ model Project {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  ideas      Idea[]
-  documents  Document[]
-  tasks      Task[]
-  proposals  Proposal[]
-  activities Activity[]
+  ideas               Idea[]
+  documents           Document[]
+  tasks               Task[]
+  proposals           Proposal[]
+  activities          Activity[]
+  agentCwdPreferences ProjectAgentCwdPreference[]
 
   @@index([companyUuid])
   @@index([groupUuid])
@@ -517,6 +525,61 @@ model DaemonConnection {
   @@index([agentInstanceUuid])
 }
 
+model ProjectAgentCwdPreference {
+  id                      Int            @id @default(autoincrement())
+  uuid                    String         @unique @default(uuid())
+  companyUuid             String
+  company                 Company        @relation(fields: [companyUuid], references: [uuid], onDelete: Cascade)
+  userUuid                String
+  user                    User           @relation(fields: [userUuid], references: [uuid], onDelete: Cascade)
+  projectUuid             String
+  project                 Project        @relation(fields: [projectUuid], references: [uuid], onDelete: Cascade)
+  agentUuid               String
+  agent                   Agent          @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  host                    String
+  cwd                     String
+  anchorAgentInstanceUuid String?
+  anchorAgentInstance     AgentInstance? @relation(fields: [anchorAgentInstanceUuid], references: [uuid], onDelete: SetNull)
+  createdAt               DateTime       @default(now())
+  updatedAt               DateTime       @updatedAt
+
+  @@unique([userUuid, projectUuid, agentUuid])
+  @@index([companyUuid, projectUuid])
+  @@index([projectUuid])
+  @@index([agentUuid])
+  @@index([anchorAgentInstanceUuid])
+}
+
+model DaemonDirectoryRequest {
+  id                   Int       @id @default(autoincrement())
+  uuid                 String    @unique @default(uuid())
+  companyUuid          String
+  company              Company   @relation(fields: [companyUuid], references: [uuid], onDelete: Cascade)
+  callerUserUuid       String
+  callerUser           User      @relation(fields: [callerUserUuid], references: [uuid], onDelete: Cascade)
+  agentUuid            String
+  agent                Agent     @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  targetConnectionUuid String
+  operation            String
+  prefix               String?
+  cwd                  String?
+  cursor               String?
+  limit                Int
+  status               String    @default("pending")
+  result               Json?
+  errorCode            String?
+  deadlineAt           DateTime
+  completedAt          DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@index([companyUuid, callerUserUuid, createdAt])
+  @@index([callerUserUuid])
+  @@index([agentUuid])
+  @@index([targetConnectionUuid, status])
+  @@index([deadlineAt])
+}
+
 // Daemon execution state — one row per (connection, resource) the daemon is
 // running or has queued. The "resource" is whatever entity the wake-triggering
 // notification pointed at: a task, an idea (e.g. an @-mention or elaboration
@@ -592,40 +655,43 @@ model DaemonExecution {
 // Only the `agent` relation is modeled with a DB-level back-relation so the
 // cascade convention matches DaemonConnection/DaemonExecution/ApiKey.
 model DaemonSession {
-  id                   Int                 @id @default(autoincrement())
-  uuid                 String              @unique @default(uuid())
-  companyUuid          String
-  agentUuid            String
-  agent                Agent               @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
+  id                       Int                 @id @default(autoincrement())
+  uuid                     String              @unique @default(uuid())
+  companyUuid              String
+  agentUuid                String
+  agent                    Agent               @relation(fields: [agentUuid], references: [uuid], onDelete: Cascade)
   // Stable business key: the directIdeaUuid for an idea-anchored session, or a
   // server-generated uuid for an ad-hoc session. Unique per agent.
-  sessionId            String
+  sessionId                String
   // Backend-owned resume identity, distinct from Chorus's routing key above.
-  backendSessionId     String?
-  directIdeaUuid       String? // null ⇒ ad-hoc (no idea lineage)
+  backendSessionId         String?
+  directIdeaUuid           String? // null ⇒ ad-hoc (no idea lineage)
   // → DaemonConnection.uuid (weak ref, no DB FK). The connection/cwd that owns
   //   the on-disk Claude transcript. Fixed at creation; continuation is only ever
   //   routed here, because `claude --resume <sessionId>` is cwd/machine-bound.
-  originConnectionUuid String
-  status               String              @default("active") // active | ended
-  title                String?
-  lastTurnAt           DateTime            @default(now())
+  originConnectionUuid     String
+  // Directed discovered cwd. Null keeps the legacy connection-bound cwd behavior.
+  // Once set, every continuation uses this value rather than the anchor connection cwd.
+  runtimeCwd               String?
+  status                   String              @default("active") // active | ended
+  title                    String?
+  lastTurnAt               DateTime            @default(now())
   // Running conversation token rollup (daemon-token-usage): headline input+output totals
   // across all turns that reported usage. SCALAR Int (not JSON) on purpose — maintained
   // with Prisma's atomic `increment` on the terminal edge, which cannot operate inside a
   // Json column. Cache totals are NOT rolled up here (the header derives its conditional
   // cache line from the per-turn `usage` of loaded turns). Default 0 so an existing session
   // reads a valid zero total with no backfill.
-  totalInputTokens     Int                 @default(0)
-  totalOutputTokens    Int                 @default(0)
+  totalInputTokens         Int                 @default(0)
+  totalOutputTokens        Int                 @default(0)
   // Whole-session cache rollup (daemon-token-usage): so the header badge's tooltip can show
   // cache read/write at the SAME whole-session scope as its in+out face (not loaded-turns
   // scope). Scalar Int for the same atomic-increment reason as the in/out rollup.
-  totalCacheReadTokens     Int             @default(0)
-  totalCacheCreationTokens Int             @default(0)
-  createdAt            DateTime            @default(now())
-  updatedAt            DateTime            @updatedAt
-  turns                DaemonSessionTurn[]
+  totalCacheReadTokens     Int                 @default(0)
+  totalCacheCreationTokens Int                 @default(0)
+  createdAt                DateTime            @default(now())
+  updatedAt                DateTime            @updatedAt
+  turns                    DaemonSessionTurn[]
 
   @@unique([agentUuid, sessionId])
   @@index([companyUuid, agentUuid])
@@ -637,14 +703,14 @@ model DaemonSession {
 // turn, distinguished only by `trigger`. Turn creation + status transitions are
 // the SSE chokepoint for the conversation's live updates.
 model DaemonSessionTurn {
-  id            Int                       @id @default(autoincrement())
-  uuid          String                    @unique @default(uuid())
-  sessionUuid   String
-  session       DaemonSession             @relation(fields: [sessionUuid], references: [uuid], onDelete: Cascade)
-  seq           Int // monotonic per session
-  trigger       String // task_assigned | mentioned | elaboration | elaboration_verified | start_development | yolo_requested | resume | human_instruction
-  promptText    String? // free-text body for human_instruction; null otherwise (canonical source)
-  status        String                    @default("pending") // pending | running | ended | interrupted
+  id                Int                       @id @default(autoincrement())
+  uuid              String                    @unique @default(uuid())
+  sessionUuid       String
+  session           DaemonSession             @relation(fields: [sessionUuid], references: [uuid], onDelete: Cascade)
+  seq               Int // monotonic per session
+  trigger           String // task_assigned | mentioned | elaboration | elaboration_verified | start_development | yolo_requested | resume | human_instruction
+  promptText        String? // free-text body for human_instruction; null otherwise (canonical source)
+  status            String                    @default("pending") // pending | running | ended | interrupted
   // Discriminator for the `interrupted` status: `user` = user-requested interrupt,
   // `crash` = subprocess exited dirty, `shutdown` = daemon graceful shutdown killed
   // the wake, `offline` = server-side reconcile of a turn whose origin connection
@@ -658,21 +724,21 @@ model DaemonSessionTurn {
   // Chorus. Orthogonal to `status`: the turn is still a clean `ended`; this only records
   // WHY its transcript is missing so the UI can say "reply couldn't be uploaded (reason)"
   // instead of the misleading "no reply received". Null on a successful/skipped upload.
-  relayError    String?
+  relayError        String?
   // Per-turn token usage (daemon-token-usage) — the whole normalized TokenUsage object
   // ({ inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, model, source },
   // all nullable except source) stored as ONE JSON blob (human instruction: one JSON, not a
   // field per number). Null when the backend reported none (pre-feature turns, silent turns,
   // or backends that can't report). Written on the terminal edge only, verbatim from the
   // authoritative Claude Code `result` envelope. Cost is intentionally NOT included this slice.
-  usage         Json?
+  usage             Json?
   // Weak ref to the live DaemonExecution row this turn corresponds to (no DB FK;
   // execution rows are reconciled/transient).
-  executionUuid String?
-  startedAt     DateTime?
-  endedAt       DateTime?
-  createdAt     DateTime                  @default(now())
-  messages      DaemonTranscriptMessage[]
+  executionUuid     String?
+  startedAt         DateTime?
+  endedAt           DateTime?
+  createdAt         DateTime                  @default(now())
+  messages          DaemonTranscriptMessage[]
 
   @@unique([sessionUuid, seq])
   @@index([sessionUuid, status])

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/project-settings-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/project-settings-modal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "@/hooks/use-progress-router";
 import { useTranslations } from "next-intl";
-import { Settings, Loader2 } from "lucide-react";
+import { Settings, Loader2, FolderCog, RotateCcw, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -28,6 +28,21 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { updateProjectAction, deleteProjectAction } from "../actions";
+import {
+  DirectoryBrowser,
+  type ValidatedDirectory,
+} from "@/components/agent-presence/directory-browser";
+import type { InstanceCandidate } from "@/components/agent-presence/instance-picker";
+
+interface AgentCwdItem {
+  agent: { uuid: string; name: string };
+  onlineInstances: InstanceCandidate[];
+  preference: {
+    host: string;
+    cwd: string;
+    status: "valid" | "offline" | "invalid";
+  } | null;
+}
 
 interface ProjectSettingsModalProps {
   projectUuid: string;
@@ -47,6 +62,65 @@ export function ProjectSettingsModal({
   const [description, setDescription] = useState(projectDescription || "");
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [cwdItems, setCwdItems] = useState<AgentCwdItem[]>([]);
+  const [cwdLoading, setCwdLoading] = useState(false);
+  const [editingAgent, setEditingAgent] = useState<string | null>(null);
+  const [cwdError, setCwdError] = useState(false);
+
+  const loadCwds = async () => {
+    setCwdLoading(true);
+    setCwdError(false);
+    try {
+      const response = await fetch(
+        `/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`,
+      );
+      const body = await response.json();
+      if (!response.ok || !body.success) throw new Error("load failed");
+      setCwdItems(body.data.agents);
+    } catch {
+      setCwdError(true);
+    } finally {
+      setCwdLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) void loadCwds();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, projectUuid]);
+
+  const saveCwd = async (selection: ValidatedDirectory) => {
+    const response = await fetch(
+      `/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentUuid: selection.agentUuid,
+          validationRequestUuid: selection.validationRequestUuid,
+        }),
+      },
+    );
+    if (!response.ok) throw new Error("save failed");
+    setEditingAgent(null);
+    await loadCwds();
+  };
+
+  const clearCwd = async (agentUuid: string) => {
+    const response = await fetch(
+      `/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentUuid }),
+      },
+    );
+    if (!response.ok) {
+      setCwdError(true);
+      return;
+    }
+    await loadCwds();
+  };
 
   const handleSave = async () => {
     setSaving(true);
@@ -81,7 +155,7 @@ export function ProjectSettingsModal({
           {t("dashboard.settings")}
         </Button>
       </DialogTrigger>
-      <DialogContent className="gap-0 overflow-hidden rounded-2xl border-0 p-0 sm:max-w-[520px]">
+      <DialogContent className="flex max-h-[90svh] flex-col gap-0 overflow-hidden rounded-2xl border-0 p-0 sm:max-w-[620px]">
         <DialogHeader className="px-7 py-6">
           <DialogTitle className="text-[20px] font-semibold tracking-tight text-foreground">
             {t("projectSettings.title")}
@@ -90,7 +164,8 @@ export function ProjectSettingsModal({
 
         <Separator className="bg-[#E5E2DC] dark:bg-[#26241f]" />
 
-        <div className="flex flex-col gap-7 p-7">
+        <div className="min-h-0 overflow-y-auto">
+        <div className="flex flex-col gap-7 p-5 sm:p-7">
           {/* Basic Information */}
           <div className="flex flex-col gap-5">
             <h3 className="text-[14px] font-semibold text-foreground">
@@ -134,6 +209,127 @@ export function ProjectSettingsModal({
                 t("projectSettings.saveChanges")
               )}
             </Button>
+          </div>
+
+          <Separator className="bg-[#E5E2DC] dark:bg-[#26241f]" />
+
+          <div className="flex min-w-0 flex-col gap-4">
+            <div>
+              <h3 className="text-[14px] font-semibold text-foreground">
+                {t("projectSettings.agentCwds.title")}
+              </h3>
+              <p className="mt-1 text-[12px] text-muted-foreground">
+                {t("projectSettings.agentCwds.description")}
+              </p>
+            </div>
+
+            {cwdLoading && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                {t("projectSettings.agentCwds.loading")}
+              </div>
+            )}
+            {cwdError && (
+              <div className="flex items-center justify-between gap-3" role="alert">
+                <span className="text-xs text-destructive">
+                  {t("projectSettings.agentCwds.loadFailed")}
+                </span>
+                <Button type="button" size="sm" variant="outline" onClick={loadCwds}>
+                  <RotateCcw className="mr-2 size-3.5" />
+                  {t("common.retry")}
+                </Button>
+              </div>
+            )}
+            {!cwdLoading && !cwdError && cwdItems.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                {t("projectSettings.agentCwds.empty")}
+              </p>
+            )}
+
+            {cwdItems.map((item) => (
+              <div
+                key={item.agent.uuid}
+                className="min-w-0 rounded-xl border border-[#E5E2DC] p-4 dark:border-[#2a2a2e]"
+              >
+                <div className="flex min-w-0 items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-[13px] font-semibold">{item.agent.name}</p>
+                    {item.preference ? (
+                      <>
+                        <p className="mt-1 break-all font-mono text-[11px]">
+                          {item.preference.cwd}
+                        </p>
+                        <p className="mt-1 truncate text-[11px] text-muted-foreground">
+                          {item.preference.host}
+                        </p>
+                        <p
+                          className={
+                            item.preference.status === "valid"
+                              ? "mt-1 text-[11px] text-emerald-700 dark:text-emerald-400"
+                              : "mt-1 text-[11px] text-destructive"
+                          }
+                        >
+                          {t(
+                            `projectSettings.agentCwds.status.${item.preference.status}`,
+                          )}
+                        </p>
+                      </>
+                    ) : (
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        {t("projectSettings.agentCwds.notConfigured")}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 gap-1">
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      title={t(
+                        item.preference
+                          ? "projectSettings.agentCwds.replace"
+                          : "projectSettings.agentCwds.configure",
+                      )}
+                      aria-label={t(
+                        item.preference
+                          ? "projectSettings.agentCwds.replace"
+                          : "projectSettings.agentCwds.configure",
+                      )}
+                      onClick={() =>
+                        setEditingAgent(
+                          editingAgent === item.agent.uuid ? null : item.agent.uuid,
+                        )
+                      }
+                    >
+                      <FolderCog className="size-4" />
+                    </Button>
+                    {item.preference && (
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="text-destructive"
+                        title={t("projectSettings.agentCwds.clear")}
+                        aria-label={t("projectSettings.agentCwds.clear")}
+                        onClick={() => void clearCwd(item.agent.uuid)}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                {editingAgent === item.agent.uuid && (
+                  <div className="mt-4 border-t border-border pt-4">
+                    <DirectoryBrowser
+                      agentUuid={item.agent.uuid}
+                      instances={item.onlineInstances}
+                      confirmLabel={t("projectSettings.agentCwds.save")}
+                      onValidated={saveCwd}
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
 
           <Separator className="bg-[#E5E2DC] dark:bg-[#26241f]" />
@@ -199,6 +395,7 @@ export function ProjectSettingsModal({
               </div>
             </div>
           </div>
+        </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/stage-advance-actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/stage-advance-actions.ts
@@ -25,6 +25,7 @@ export type StartDevelopmentErrorCode =
   | "no_unfinished_tasks"
   | "agent_offline"
   | "instance_offline"
+  | "fixed_cwd_host_offline"
   | "unknown";
 
 function toErrorCode(error: unknown): StartDevelopmentErrorCode {
@@ -40,6 +41,8 @@ function toErrorCode(error: unknown): StartDevelopmentErrorCode {
         return "agent_offline";
       case "INSTANCE_OFFLINE":
         return "instance_offline";
+      case "FIXED_CWD_HOST_OFFLINE":
+        return "fixed_cwd_host_offline";
       case "PRECONDITION_FAILED":
         if (error.reason === START_DEVELOPMENT_REASONS.NO_APPROVED_PROPOSAL)
           return "no_approved_proposal";
@@ -120,6 +123,7 @@ export type YoloRequestedErrorCode =
   | "assignee_not_agent"
   | "agent_offline"
   | "instance_offline"
+  | "fixed_cwd_host_offline"
   | "unknown";
 
 function toYoloErrorCode(error: unknown): YoloRequestedErrorCode {
@@ -135,6 +139,8 @@ function toYoloErrorCode(error: unknown): YoloRequestedErrorCode {
         return "agent_offline";
       case "INSTANCE_OFFLINE":
         return "instance_offline";
+      case "FIXED_CWD_HOST_OFFLINE":
+        return "fixed_cwd_host_offline";
       // PRECONDITION_FAILED cannot occur for yolo_requested (the precondition
       // only throws ASSIGNEE_NOT_AGENT), but keep the exhaustive fallthrough.
       case "PRECONDITION_FAILED":

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/stage-advance-actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/stage-advance-actions.ts
@@ -10,6 +10,9 @@ import { requestYolo } from "@/services/yolo-request.service";
 import { StageAdvanceError } from "@/services/stage-advance.service";
 import { prisma } from "@/lib/prisma";
 import logger from "@/lib/logger";
+import { resolveTemporaryRuntimeCwd } from "@/services/project-agent-cwd.service";
+
+type TemporaryCwdInput = { agentUuid: string; validationRequestUuid: string };
 
 // Machine-readable failure codes surfaced to the client so each maps to a
 // distinct i18n message (the raw error prose is never shown to users).
@@ -49,7 +52,8 @@ function toErrorCode(error: unknown): StartDevelopmentErrorCode {
 }
 
 export async function startDevelopmentAction(
-  ideaUuid: string
+  ideaUuid: string,
+  temporary?: TemporaryCwdInput,
 ): Promise<{ success: boolean; errorCode?: StartDevelopmentErrorCode }> {
   const auth = await getServerAuthContext();
   if (!auth) {
@@ -63,11 +67,19 @@ export async function startDevelopmentAction(
   }
 
   try {
+    const temporaryCwd = temporary
+      ? await resolveTemporaryRuntimeCwd({
+          companyUuid: auth.companyUuid,
+          userUuid: auth.actorUuid,
+          ...temporary,
+        })
+      : null;
     await startDevelopment({
       companyUuid: auth.companyUuid,
       ideaUuid,
       actorUuid: auth.actorUuid,
       actorType: auth.type,
+      temporaryCwd,
     });
 
     // Revalidate the ideas page so the panel refreshes
@@ -133,7 +145,8 @@ function toYoloErrorCode(error: unknown): YoloRequestedErrorCode {
 }
 
 export async function yoloRequestedAction(
-  ideaUuid: string
+  ideaUuid: string,
+  temporary?: TemporaryCwdInput,
 ): Promise<{ success: boolean; errorCode?: YoloRequestedErrorCode }> {
   const auth = await getServerAuthContext();
   if (!auth) {
@@ -147,11 +160,19 @@ export async function yoloRequestedAction(
   }
 
   try {
+    const temporaryCwd = temporary
+      ? await resolveTemporaryRuntimeCwd({
+          companyUuid: auth.companyUuid,
+          userUuid: auth.actorUuid,
+          ...temporary,
+        })
+      : null;
     await requestYolo({
       companyUuid: auth.companyUuid,
       ideaUuid,
       actorUuid: auth.actorUuid,
       actorType: auth.type,
+      temporaryCwd,
     });
 
     // Revalidate the ideas page so the panel refreshes

--- a/src/app/api/daemon-directory-requests/[uuid]/route.ts
+++ b/src/app/api/daemon-directory-requests/[uuid]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import {
+  CwdServiceError,
+  getDirectoryRequest,
+} from "@/services/project-agent-cwd.service";
+
+type RouteContext = { params: Promise<{ uuid: string }> };
+
+export const GET = withErrorHandler(async (request: NextRequest, context: RouteContext) => {
+  const auth = await getAuthContext(request);
+  if (!auth) return errors.unauthorized();
+  if (auth.type !== "user") return errors.forbidden("User session required");
+  const { uuid } = await context.params;
+  try {
+    return success({ request: await getDirectoryRequest(auth.companyUuid, auth.actorUuid, uuid) });
+  } catch (error) {
+    if (!(error instanceof CwdServiceError)) throw error;
+    return NextResponse.json(
+      { success: false, error: { code: error.code, message: error.message } },
+      { status: error.code === "NOT_FOUND" ? 404 : 409 },
+    );
+  }
+});

--- a/src/app/api/daemon-directory-requests/__tests__/route.test.ts
+++ b/src/app/api/daemon-directory-requests/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { getAuthContext, createDirectoryRequest } = vi.hoisted(() => ({
+  getAuthContext: vi.fn(),
+  createDirectoryRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ getAuthContext }));
+vi.mock("@/services/project-agent-cwd.service", () => {
+  class CwdServiceError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+    }
+  }
+  return { CwdServiceError, createDirectoryRequest };
+});
+
+import { POST } from "@/app/api/daemon-directory-requests/route";
+import { CwdServiceError } from "@/services/project-agent-cwd.service";
+
+function request(body: unknown) {
+  return new NextRequest("http://localhost/api/daemon-directory-requests", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const valid = {
+  operation: "validate",
+  agentUuid: "agent-1",
+  targetConnectionUuid: "conn-1",
+  cwd: "/work/repo",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAuthContext.mockResolvedValue({
+    type: "user",
+    companyUuid: "company-1",
+    actorUuid: "user-1",
+  });
+});
+
+describe("POST /api/daemon-directory-requests", () => {
+  it("requires authentication and a human user", async () => {
+    getAuthContext.mockResolvedValue(null);
+    expect((await POST(request(valid), { params: Promise.resolve({}) })).status).toBe(401);
+
+    getAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid: "company-1",
+      actorUuid: "agent-1",
+    });
+    expect((await POST(request(valid), { params: Promise.resolve({}) })).status).toBe(403);
+    expect(createDirectoryRequest).not.toHaveBeenCalled();
+  });
+
+  it("passes only authenticated tenant/user identity to the service", async () => {
+    createDirectoryRequest.mockResolvedValue({ uuid: "request-1", status: "pending" });
+    const response = await POST(request(valid), { params: Promise.resolve({}) });
+    expect(response.status).toBe(200);
+    expect(createDirectoryRequest).toHaveBeenCalledWith({
+      companyUuid: "company-1",
+      userUuid: "user-1",
+      ...valid,
+    });
+  });
+
+  it("returns stable typed failures and rejects malformed operations", async () => {
+    createDirectoryRequest.mockRejectedValue(
+      new CwdServiceError("HOST_OFFLINE", "Target host is offline"),
+    );
+    const offline = await POST(request(valid), { params: Promise.resolve({}) });
+    expect(offline.status).toBe(409);
+    expect((await offline.json()).error.code).toBe("HOST_OFFLINE");
+
+    const invalid = await POST(
+      request({ ...valid, operation: "unknown" }),
+      { params: Promise.resolve({}) },
+    );
+    expect(invalid.status).toBe(422);
+  });
+});

--- a/src/app/api/daemon-directory-requests/route.ts
+++ b/src/app/api/daemon-directory-requests/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import {
+  CwdServiceError,
+  createDirectoryRequest,
+} from "@/services/project-agent-cwd.service";
+
+const schema = z.discriminatedUnion("operation", [
+  z.object({
+    operation: z.literal("list"),
+    agentUuid: z.string().min(1),
+    targetConnectionUuid: z.string().min(1),
+    prefix: z.string().min(1),
+    cursor: z.string().optional(),
+    limit: z.number().int().positive().max(100).optional(),
+  }),
+  z.object({
+    operation: z.literal("validate"),
+    agentUuid: z.string().min(1),
+    targetConnectionUuid: z.string().min(1),
+    cwd: z.string().min(1),
+  }),
+]);
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) return errors.unauthorized();
+  if (auth.type !== "user") return errors.forbidden("User session required");
+  const parsed = schema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return errors.validationError(parsed.error.flatten());
+  try {
+    const directoryRequest = await createDirectoryRequest({
+      companyUuid: auth.companyUuid,
+      userUuid: auth.actorUuid,
+      ...parsed.data,
+    });
+    return success({ request: directoryRequest });
+  } catch (error) {
+    if (!(error instanceof CwdServiceError)) throw error;
+    const status = error.code === "NOT_FOUND" ? 404 : error.code === "VALIDATION_ERROR" ? 422 : 409;
+    return NextResponse.json(
+      { success: false, error: { code: error.code, message: error.message } },
+      { status },
+    );
+  }
+});

--- a/src/app/api/daemon/directory-request/report/route.ts
+++ b/src/app/api/daemon/directory-request/report/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext } from "@/lib/auth";
+import {
+  CwdServiceError,
+  DIRECTORY_ERROR_CODES,
+  completeDirectoryRequest,
+} from "@/services/project-agent-cwd.service";
+
+const schema = z.discriminatedUnion("status", [
+  z.object({
+    requestUuid: z.string().min(1),
+    connectionUuid: z.string().min(1),
+    status: z.literal("succeeded"),
+    items: z.array(z.object({ name: z.string(), path: z.string() })).optional(),
+    nextCursor: z.string().nullable().optional(),
+    normalizedPath: z.string().optional(),
+  }),
+  z.object({
+    requestUuid: z.string().min(1),
+    connectionUuid: z.string().min(1),
+    status: z.literal("failed"),
+    errorCode: z.enum(DIRECTORY_ERROR_CODES),
+  }),
+]);
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) return errors.unauthorized();
+  if (auth.type !== "agent") return errors.forbidden("Agent API key required");
+  const parsed = schema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return errors.validationError(parsed.error.flatten());
+
+  const body = parsed.data;
+  try {
+    const directoryRequest = await completeDirectoryRequest({
+      companyUuid: auth.companyUuid,
+      agentUuid: auth.actorUuid,
+      connectionUuid: body.connectionUuid,
+      requestUuid: body.requestUuid,
+      ...(body.status === "succeeded"
+        ? {
+            status: "success" as const,
+            result: {
+              items: body.items ?? [],
+              nextCursor: body.nextCursor ?? null,
+              normalizedPath: body.normalizedPath,
+            },
+          }
+        : { status: "error" as const, errorCode: body.errorCode }),
+    });
+    return success({ request: directoryRequest });
+  } catch (error) {
+    if (!(error instanceof CwdServiceError)) throw error;
+    return NextResponse.json(
+      { success: false, error: { code: error.code, message: error.message } },
+      { status: error.code === "NOT_FOUND" ? 404 : error.code === "VALIDATION_ERROR" ? 422 : 409 },
+    );
+  }
+});

--- a/src/app/api/daemon/resume/route.ts
+++ b/src/app/api/daemon/resume/route.ts
@@ -35,6 +35,7 @@ import {
   publishExecutionChange,
   isConnectionLive,
 } from "@/services/daemon-execution.service";
+import { prisma } from "@/lib/prisma";
 
 const bodySchema = z.object({
   connectionUuid: z.string().min(1),
@@ -98,6 +99,18 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       `Execution is not resumable (status=${result.status}, reason=${result.interruptedReason ?? "none"})`,
     );
   }
+  const execution = await prisma.daemonExecution?.findFirst({
+    where: { companyUuid: auth.companyUuid, connectionUuid, entityType, entityUuid },
+    select: { directIdeaUuid: true },
+  });
+  const resumedSession = await prisma.daemonSession?.findFirst({
+    where: {
+      companyUuid: auth.companyUuid,
+      agentUuid: authz.target.agentUuid,
+      sessionId: execution?.directIdeaUuid ?? entityUuid,
+    },
+    select: { runtimeCwd: true },
+  });
 
   // Tell the daemon to re-spawn and continue the session, then push the updated
   // active set so the UI reflects the resumed row immediately. `resumeReason` is the
@@ -109,6 +122,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     entityType,
     entityUuid,
     resumeReason: result.resumedFrom,
+    ...(resumedSession?.runtimeCwd ? { runtimeCwd: resumedSession.runtimeCwd } : {}),
   });
   await publishExecutionChange(auth.companyUuid, connectionUuid);
 

--- a/src/app/api/daemon/turn-advance/__tests__/route.test.ts
+++ b/src/app/api/daemon/turn-advance/__tests__/route.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/services/daemon-execution.service", () => ({
 // subset, re-exported for the route's zod enums.
 vi.mock("@/services/daemon-session.service", () => ({
   TURN_STATUSES: ["pending", "running", "ended", "interrupted"],
-  DAEMON_REPORTABLE_INTERRUPT_REASONS: ["user", "crash", "shutdown"],
+  DAEMON_REPORTABLE_INTERRUPT_REASONS: ["user", "crash", "shutdown", "invalid_path"],
   advanceTurnForWake: (...args: unknown[]) => mockAdvanceTurnForWake(...args),
 }));
 

--- a/src/app/api/ideas/[uuid]/wake-preview/__tests__/route.test.ts
+++ b/src/app/api/ideas/[uuid]/wake-preview/__tests__/route.test.ts
@@ -78,7 +78,7 @@ describe("GET /api/ideas/[uuid]/wake-preview", () => {
 
     expect(res.status).toBe(200);
     expect(mockPreviewIdeaWakeTarget).toHaveBeenCalledTimes(1);
-    expect(mockPreviewIdeaWakeTarget).toHaveBeenCalledWith(companyUuid, ideaUuid);
+    expect(mockPreviewIdeaWakeTarget).toHaveBeenCalledWith(companyUuid, ideaUuid, actorUuid);
     expect(body).toEqual({ success: true, data: samplePreview, meta: undefined });
   });
 
@@ -89,7 +89,7 @@ describe("GET /api/ideas/[uuid]/wake-preview", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(mockPreviewIdeaWakeTarget).toHaveBeenCalledWith(companyUuid, ideaUuid);
+    expect(mockPreviewIdeaWakeTarget).toHaveBeenCalledWith(companyUuid, ideaUuid, actorUuid);
     expect(body.data.outcome).toBe("pick");
   });
 
@@ -101,6 +101,6 @@ describe("GET /api/ideas/[uuid]/wake-preview", () => {
 
     expect(res.status).toBe(404);
     // The scoped lookup ran; the null result is what maps to 404.
-    expect(mockPreviewIdeaWakeTarget).toHaveBeenCalledWith(companyUuid, ideaUuid);
+    expect(mockPreviewIdeaWakeTarget).toHaveBeenCalledWith(companyUuid, ideaUuid, actorUuid);
   });
 });

--- a/src/app/api/ideas/[uuid]/wake-preview/route.ts
+++ b/src/app/api/ideas/[uuid]/wake-preview/route.ts
@@ -36,7 +36,7 @@ export const GET = withErrorHandler<{ uuid: string }>(
 
     const { uuid } = await context.params;
 
-    const preview = await previewIdeaWakeTarget(auth.companyUuid, uuid);
+    const preview = await previewIdeaWakeTarget(auth.companyUuid, uuid, auth.actorUuid);
     // null → the idea does not exist in this company (or a foreign-company idea) → 404.
     if (!preview) {
       return errors.notFound("Idea");

--- a/src/app/api/projects/[uuid]/agent-cwds/route.ts
+++ b/src/app/api/projects/[uuid]/agent-cwds/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext, isUser } from "@/lib/auth";
+import type { UserAuthContext } from "@/types/auth";
+import {
+  CwdServiceError,
+  clearProjectAgentCwdPreference,
+  listProjectAgentCwdPreferences,
+  saveProjectAgentCwdPreference,
+} from "@/services/project-agent-cwd.service";
+
+type RouteContext = { params: Promise<{ uuid: string }> };
+
+function serviceError(error: unknown): NextResponse {
+  if (!(error instanceof CwdServiceError)) {
+    throw error;
+  }
+  if (error.code === "NOT_FOUND") return errors.notFound();
+  const status = error.code === "VALIDATION_ERROR" ? 422 : error.code === "FORBIDDEN" ? 403 : 409;
+  return NextResponse.json(
+    { success: false, error: { code: error.code, message: error.message } },
+    { status },
+  );
+}
+
+async function requireUser(
+  request: NextRequest,
+): Promise<{ auth: UserAuthContext } | { error: NextResponse }> {
+  const auth = await getAuthContext(request);
+  if (!auth) return { error: errors.unauthorized() };
+  if (!isUser(auth)) return { error: errors.forbidden("User session required") };
+  return { auth };
+}
+
+export const GET = withErrorHandler(async (request: NextRequest, context: RouteContext) => {
+  const authorized = await requireUser(request);
+  if ("error" in authorized) return authorized.error;
+  const { uuid } = await context.params;
+  try {
+    return success({
+      agents: await listProjectAgentCwdPreferences(
+        authorized.auth.companyUuid,
+        authorized.auth.actorUuid,
+        uuid,
+      ),
+    });
+  } catch (error) {
+    return serviceError(error);
+  }
+});
+
+const saveSchema = z.object({
+  agentUuid: z.string().min(1),
+  validationRequestUuid: z.string().min(1),
+});
+
+export const PUT = withErrorHandler(async (request: NextRequest, context: RouteContext) => {
+  const authorized = await requireUser(request);
+  if ("error" in authorized) return authorized.error;
+  const parsed = saveSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return errors.validationError(parsed.error.flatten());
+  const { uuid } = await context.params;
+  try {
+    const preference = await saveProjectAgentCwdPreference({
+      companyUuid: authorized.auth.companyUuid,
+      userUuid: authorized.auth.actorUuid,
+      projectUuid: uuid,
+      ...parsed.data,
+    });
+    return success({ preference });
+  } catch (error) {
+    return serviceError(error);
+  }
+});
+
+const clearSchema = z.object({ agentUuid: z.string().min(1) });
+
+export const DELETE = withErrorHandler(async (request: NextRequest, context: RouteContext) => {
+  const authorized = await requireUser(request);
+  if ("error" in authorized) return authorized.error;
+  const parsed = clearSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return errors.validationError(parsed.error.flatten());
+  const { uuid } = await context.params;
+  try {
+    await clearProjectAgentCwdPreference({
+      companyUuid: authorized.auth.companyUuid,
+      userUuid: authorized.auth.actorUuid,
+      projectUuid: uuid,
+      agentUuid: parsed.data.agentUuid,
+    });
+    return success({ cleared: true });
+  } catch (error) {
+    return serviceError(error);
+  }
+});

--- a/src/components/agent-presence/__tests__/directory-browser.test.tsx
+++ b/src/components/agent-presence/__tests__/directory-browser.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import { DirectoryBrowser } from "@/components/agent-presence/directory-browser";
+
+const instance = {
+  connectionUuid: "connection-1",
+  agentInstanceUuid: "instance-1",
+  host: "build-host",
+  cwd: "/workspace",
+  effectiveStatus: "online" as const,
+};
+
+describe("DirectoryBrowser", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not browse when Enter confirms an active IME composition", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <DirectoryBrowser
+        agentUuid="agent-1"
+        instances={[instance]}
+        onValidated={vi.fn()}
+        confirmLabel="Confirm"
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/workspace/pro" } });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes unknown server error codes before translation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ success: false, error: { code: "FORBIDDEN" } }),
+      }),
+    );
+    render(
+      <DirectoryBrowser
+        agentUuid="agent-1"
+        instances={[instance]}
+        onValidated={vi.fn()}
+        confirmLabel="Confirm"
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/workspace/pro" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toBe(
+        "errors.INTERNAL_ERROR",
+      );
+    });
+  });
+});

--- a/src/components/agent-presence/directory-browser.tsx
+++ b/src/components/agent-presence/directory-browser.tsx
@@ -5,9 +5,26 @@ import { useTranslations } from "next-intl";
 import { Folder, Loader2, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { isImeComposing } from "@/lib/ime";
 import type { InstanceCandidate } from "./instance-picker";
 
 type DirectoryItem = { name: string; path: string };
+const DIRECTORY_ERROR_CODES = new Set([
+  "HOST_OFFLINE",
+  "TIMEOUT",
+  "INVALID_PATH",
+  "OUTSIDE_ROOT",
+  "NOT_DIRECTORY",
+  "ACCESS_DENIED",
+  "STALE_TARGET",
+  "LIMIT_EXCEEDED",
+  "INTERNAL_ERROR",
+]);
+
+function normalizeDirectoryError(error: unknown): string {
+  const code = error instanceof Error ? error.message : "INTERNAL_ERROR";
+  return DIRECTORY_ERROR_CODES.has(code) ? code : "INTERNAL_ERROR";
+}
 
 export interface ValidatedDirectory {
   agentUuid: string;
@@ -86,7 +103,7 @@ export function DirectoryBrowser({
       setItems(result?.items ?? []);
     } catch (error) {
       setItems([]);
-      setErrorCode(error instanceof Error ? error.message : "INTERNAL_ERROR");
+      setErrorCode(normalizeDirectoryError(error));
     } finally {
       setPending(null);
     }
@@ -115,7 +132,7 @@ export function DirectoryBrowser({
         validationRequestUuid: request.uuid,
       });
     } catch (error) {
-      setErrorCode(error instanceof Error ? error.message : "INTERNAL_ERROR");
+      setErrorCode(normalizeDirectoryError(error));
     } finally {
       setPending(null);
     }
@@ -155,10 +172,9 @@ export function DirectoryBrowser({
               value={prefix}
               onChange={(event) => setPrefix(event.target.value)}
               onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  void browse();
-                }
+                if (event.key !== "Enter" || isImeComposing(event)) return;
+                event.preventDefault();
+                void browse();
               }}
               placeholder={t("pathPlaceholder")}
               className="min-w-0 font-mono text-xs"
@@ -183,10 +199,12 @@ export function DirectoryBrowser({
           {items.length > 0 && (
             <div className="max-h-40 overflow-y-auto rounded-lg border border-border p-1">
               {items.map((item) => (
-                <button
+                <Button
                   key={item.path}
                   type="button"
-                  className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  variant="ghost"
+                  size="sm"
+                  className="flex h-auto w-full min-w-0 justify-start px-2 py-2 text-left text-xs"
                   onClick={() => {
                     setSelectedPath(item.path);
                     setPrefix(`${item.path}/`);
@@ -196,7 +214,7 @@ export function DirectoryBrowser({
                   <span className="truncate font-mono" title={item.path}>
                     {item.path}
                   </span>
-                </button>
+                </Button>
               ))}
             </div>
           )}

--- a/src/components/agent-presence/directory-browser.tsx
+++ b/src/components/agent-presence/directory-browser.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Folder, Loader2, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { InstanceCandidate } from "./instance-picker";
+
+type DirectoryItem = { name: string; path: string };
+
+export interface ValidatedDirectory {
+  agentUuid: string;
+  connectionUuid: string;
+  host: string;
+  cwd: string;
+  validationRequestUuid: string;
+}
+
+interface DirectoryBrowserProps {
+  agentUuid: string;
+  instances: InstanceCandidate[];
+  onValidated: (selection: ValidatedDirectory) => void | Promise<void>;
+  confirmLabel: string;
+}
+
+async function requestDirectory(payload: Record<string, unknown>) {
+  const response = await fetch("/api/daemon-directory-requests", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await response.json();
+  if (!response.ok || !body.success) {
+    throw new Error(body.error?.code ?? "INTERNAL_ERROR");
+  }
+  let request = body.data.request;
+  while (request.status === "pending") {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const poll = await fetch(
+      `/api/daemon-directory-requests/${encodeURIComponent(request.uuid)}`,
+    );
+    const pollBody = await poll.json();
+    if (!poll.ok || !pollBody.success) {
+      throw new Error(pollBody.error?.code ?? "INTERNAL_ERROR");
+    }
+    request = pollBody.data.request;
+  }
+  if (request.status !== "success") {
+    throw new Error(request.errorCode ?? "INTERNAL_ERROR");
+  }
+  return request;
+}
+
+export function DirectoryBrowser({
+  agentUuid,
+  instances,
+  onValidated,
+  confirmLabel,
+}: DirectoryBrowserProps) {
+  const t = useTranslations("directoryBrowser");
+  const hosts = Array.from(
+    new Map(instances.map((instance) => [instance.host, instance])).values(),
+  );
+  const [anchor, setAnchor] = useState<InstanceCandidate | null>(
+    hosts.length === 1 ? hosts[0] : null,
+  );
+  const [prefix, setPrefix] = useState("");
+  const [selectedPath, setSelectedPath] = useState("");
+  const [items, setItems] = useState<DirectoryItem[]>([]);
+  const [pending, setPending] = useState<"browse" | "validate" | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+
+  const browse = async () => {
+    if (!anchor || !prefix.trim()) return;
+    setPending("browse");
+    setErrorCode(null);
+    try {
+      const request = await requestDirectory({
+        operation: "list",
+        agentUuid,
+        targetConnectionUuid: anchor.connectionUuid,
+        prefix: prefix.trim(),
+      });
+      const result = request.result as { items?: DirectoryItem[] } | null;
+      setItems(result?.items ?? []);
+    } catch (error) {
+      setItems([]);
+      setErrorCode(error instanceof Error ? error.message : "INTERNAL_ERROR");
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const validate = async () => {
+    if (!anchor || !selectedPath) return;
+    setPending("validate");
+    setErrorCode(null);
+    try {
+      const request = await requestDirectory({
+        operation: "validate",
+        agentUuid,
+        targetConnectionUuid: anchor.connectionUuid,
+        cwd: selectedPath,
+      });
+      const normalizedPath =
+        typeof request.result?.normalizedPath === "string"
+          ? request.result.normalizedPath
+          : selectedPath;
+      await onValidated({
+        agentUuid,
+        connectionUuid: anchor.connectionUuid,
+        host: anchor.host,
+        cwd: normalizedPath,
+        validationRequestUuid: request.uuid,
+      });
+    } catch (error) {
+      setErrorCode(error instanceof Error ? error.message : "INTERNAL_ERROR");
+    } finally {
+      setPending(null);
+    }
+  };
+
+  if (hosts.length === 0) {
+    return <p className="text-xs text-muted-foreground">{t("noHosts")}</p>;
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex flex-wrap gap-2" aria-label={t("chooseHost")}>
+        {hosts.map((host) => (
+          <Button
+            key={host.connectionUuid}
+            type="button"
+            size="sm"
+            variant={anchor?.connectionUuid === host.connectionUuid ? "default" : "outline"}
+            className="max-w-full"
+            onClick={() => {
+              setAnchor(host);
+              setItems([]);
+              setSelectedPath("");
+              setErrorCode(null);
+            }}
+          >
+            <span className="truncate">{host.host || t("unknownHost")}</span>
+          </Button>
+        ))}
+      </div>
+
+      {anchor && (
+        <>
+          <div className="flex min-w-0 gap-2">
+            <Input
+              aria-label={t("pathPrefix")}
+              value={prefix}
+              onChange={(event) => setPrefix(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  void browse();
+                }
+              }}
+              placeholder={t("pathPlaceholder")}
+              className="min-w-0 font-mono text-xs"
+            />
+            <Button
+              type="button"
+              size="icon"
+              variant="outline"
+              disabled={!prefix.trim() || pending !== null}
+              onClick={() => void browse()}
+              aria-label={t("browse")}
+              title={t("browse")}
+            >
+              {pending === "browse" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Search className="size-4" />
+              )}
+            </Button>
+          </div>
+
+          {items.length > 0 && (
+            <div className="max-h-40 overflow-y-auto rounded-lg border border-border p-1">
+              {items.map((item) => (
+                <button
+                  key={item.path}
+                  type="button"
+                  className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  onClick={() => {
+                    setSelectedPath(item.path);
+                    setPrefix(`${item.path}/`);
+                  }}
+                >
+                  <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate font-mono" title={item.path}>
+                    {item.path}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {items.length === 0 && prefix && pending === null && !errorCode && (
+            <p className="text-xs text-muted-foreground">{t("empty")}</p>
+          )}
+
+          {selectedPath && (
+            <div className="min-w-0 rounded-lg border border-border bg-muted/30 p-3">
+              <p className="text-[11px] font-medium text-muted-foreground">
+                {t("selection")}
+              </p>
+              <p className="mt-1 break-all font-mono text-xs">{selectedPath}</p>
+              <p className="mt-1 truncate text-[11px] text-muted-foreground">
+                {anchor.host}
+              </p>
+            </div>
+          )}
+
+          {errorCode && (
+            <p role="alert" className="text-xs text-destructive">
+              {t(`errors.${errorCode}`)}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            size="sm"
+            className="w-fit"
+            disabled={!selectedPath || pending !== null}
+            onClick={() => void validate()}
+          >
+            {pending === "validate" && <Loader2 className="mr-2 size-4 animate-spin" />}
+            {confirmLabel}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/agent-presence/wake-cwd-picker-dialog.tsx
+++ b/src/components/agent-presence/wake-cwd-picker-dialog.tsx
@@ -32,6 +32,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { InstancePicker, type InstanceCandidate } from "./instance-picker";
+import {
+  DirectoryBrowser,
+  type ValidatedDirectory,
+} from "./directory-browser";
 
 export interface WakeCwdPickerDialogProps {
   /** Controlled open state — the caller mounts once and toggles this. */
@@ -46,6 +50,11 @@ export interface WakeCwdPickerDialogProps {
    * connectionUuid) via the non-waking reassign, then fire the wake.
    */
   onConfirm: (instance: InstanceCandidate) => void;
+  agentUuid?: string;
+  onTemporaryConfirm?: (selection: {
+    agentUuid: string;
+    validationRequestUuid: string;
+  }) => void;
   /** Fires when the human dismisses the dialog (Cancel / overlay / Esc). */
   onCancel: () => void;
 }
@@ -60,17 +69,23 @@ export function WakeCwdPickerDialog({
   agentName,
   instances,
   onConfirm,
+  agentUuid,
+  onTemporaryConfirm,
   onCancel,
 }: WakeCwdPickerDialogProps) {
   const t = useTranslations("wakeCwdPicker");
   const [selected, setSelected] = useState<InstanceCandidate | null>(null);
+  const [browsing, setBrowsing] = useState(false);
 
   // Default-select the FIRST instance whenever a new pick opens the dialog so
   // Confirm is reachable immediately (no click) and Radix RadioGroup's roving
   // focus lands on a concrete row. The dialog only opens for >=2 instances (the
   // `pick` outcome), so there is always something to default to.
   useEffect(() => {
-    if (open) setSelected(instances[0] ?? null);
+    if (open) {
+      setSelected(instances[0] ?? null);
+      setBrowsing(false);
+    }
   }, [open, instances]);
 
   // Enter confirms the current selection — the keyboard counterpart to clicking
@@ -115,25 +130,46 @@ export function WakeCwdPickerDialog({
           className="min-h-0 flex-1 overflow-y-auto py-3"
           onKeyDown={handleListKeyDown}
         >
-          <InstancePicker
-            instances={instances}
-            selectedConnectionUuid={selected?.connectionUuid ?? null}
-            onSelect={setSelected}
-            ariaLabel={t("title")}
-          />
+          {browsing && agentUuid && onTemporaryConfirm ? (
+            <DirectoryBrowser
+              agentUuid={agentUuid}
+              instances={instances}
+              confirmLabel={t("useOnce")}
+              onValidated={(selection: ValidatedDirectory) =>
+                onTemporaryConfirm({
+                  agentUuid: selection.agentUuid,
+                  validationRequestUuid: selection.validationRequestUuid,
+                })
+              }
+            />
+          ) : (
+            <InstancePicker
+              instances={instances}
+              selectedConnectionUuid={selected?.connectionUuid ?? null}
+              onSelect={setSelected}
+              ariaLabel={t("title")}
+            />
+          )}
         </div>
         <DialogFooter className="shrink-0">
           <Button variant="ghost" onClick={onCancel}>
             {t("cancel")}
           </Button>
-          <Button
-            disabled={!selected}
-            onClick={() => {
-              if (selected) onConfirm(selected);
-            }}
-          >
-            {t("confirm")}
-          </Button>
+          {agentUuid && onTemporaryConfirm && (
+            <Button variant="outline" onClick={() => setBrowsing((value) => !value)}>
+              {browsing ? t("registeredDirectories") : t("browseAnother")}
+            </Button>
+          )}
+          {!browsing && (
+            <Button
+              disabled={!selected}
+              onClick={() => {
+                if (selected) onConfirm(selected);
+              }}
+            >
+              {t("confirm")}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/start-development-button.tsx
+++ b/src/components/start-development-button.tsx
@@ -57,6 +57,7 @@ const ERROR_CODE_I18N_KEY: Record<StartDevelopmentErrorCode, string> = {
   no_unfinished_tasks: "errorNoUnfinishedTasks",
   agent_offline: "errorAgentOffline",
   instance_offline: "errorInstanceOffline",
+  fixed_cwd_host_offline: "errorFixedCwdHostOffline",
   unknown: "errorGeneric",
 };
 

--- a/src/components/start-development-button.tsx
+++ b/src/components/start-development-button.tsx
@@ -84,6 +84,7 @@ export function StartDevelopmentButton({
     start: startPinThenWake,
     pickerState,
     confirmPick,
+    confirmTemporary,
     cancelPick,
     isResolving,
   } = usePinThenWake({ reassignNoWake: reassignIdeaInstanceNoWakeAction });
@@ -129,9 +130,14 @@ export function StartDevelopmentButton({
   // The actual wake — fired directly on `direct`/`auto_pin`, or after the human
   // picks a cwd on `pick`. The server re-validates every precondition (incl. the
   // HARD instance-offline check → instance_offline error code).
-  const runWake = async () => {
+  const runWake = async (temporary?: {
+    agentUuid: string;
+    validationRequestUuid: string;
+  }) => {
     setIsStarting(true);
-    const result = await startDevelopmentAction(ideaUuid);
+    const result = temporary
+      ? await startDevelopmentAction(ideaUuid, temporary)
+      : await startDevelopmentAction(ideaUuid);
     setIsStarting(false);
 
     if (result.success) {
@@ -199,7 +205,9 @@ export function StartDevelopmentButton({
         open={pickerState !== null}
         agentName={assigneeName ?? ""}
         instances={pickerState?.instances ?? []}
+        agentUuid={pickerState?.agentUuid}
         onConfirm={confirmPick}
+        onTemporaryConfirm={confirmTemporary}
         onCancel={cancelPick}
       />
     </>

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -101,6 +101,7 @@ export function YoloButton({
     start: startPinThenWake,
     pickerState,
     confirmPick,
+    confirmTemporary,
     cancelPick,
     isResolving,
   } = usePinThenWake({ reassignNoWake: reassignIdeaInstanceNoWakeAction });
@@ -142,9 +143,14 @@ export function YoloButton({
   // The actual wake — fired directly on `direct`/`auto_pin`, or after the human
   // picks a cwd on `pick`. The server re-validates every precondition (incl. the
   // HARD instance-offline check → instance_offline error code).
-  const runWake = async () => {
+  const runWake = async (temporary?: {
+    agentUuid: string;
+    validationRequestUuid: string;
+  }) => {
     setIsStarting(true);
-    const result = await yoloRequestedAction(ideaUuid);
+    const result = temporary
+      ? await yoloRequestedAction(ideaUuid, temporary)
+      : await yoloRequestedAction(ideaUuid);
     setIsStarting(false);
 
     if (result.success) {
@@ -244,7 +250,9 @@ export function YoloButton({
         open={pickerState !== null}
         agentName={assigneeName ?? ""}
         instances={pickerState?.instances ?? []}
+        agentUuid={pickerState?.agentUuid}
         onConfirm={confirmPick}
+        onTemporaryConfirm={confirmTemporary}
         onCancel={cancelPick}
       />
     </>

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -69,6 +69,7 @@ const ERROR_CODE_I18N_KEY: Record<YoloRequestedErrorCode, string> = {
   assignee_not_agent: "errorAssigneeNotAgent",
   agent_offline: "errorAgentOffline",
   instance_offline: "errorInstanceOffline",
+  fixed_cwd_host_offline: "errorFixedCwdHostOffline",
   unknown: "errorGeneric",
 };
 

--- a/src/hooks/__tests__/use-pin-then-wake.test.tsx
+++ b/src/hooks/__tests__/use-pin-then-wake.test.tsx
@@ -53,9 +53,12 @@ function Harness({
     agentUuid: string,
     instanceUuid: string,
   ) => Promise<{ success: boolean; error?: string }>;
-  wake: () => void | Promise<void>;
+  wake: (temporary?: {
+    agentUuid: string;
+    validationRequestUuid: string;
+  }) => void | Promise<void>;
 }) {
-  const { start, pickerState, confirmPick, cancelPick } = usePinThenWake({
+  const { start, pickerState, confirmPick, confirmTemporary, cancelPick } = usePinThenWake({
     fetchPreview: async () => preview,
     reassignNoWake,
   });
@@ -76,6 +79,17 @@ function Harness({
           ))}
           <button data-testid="cancel" onClick={cancelPick}>
             cancel
+          </button>
+          <button
+            data-testid="temporary"
+            onClick={() =>
+              confirmTemporary({
+                agentUuid: AGENT,
+                validationRequestUuid: "request-1",
+              })
+            }
+          >
+            temporary
           </button>
         </div>
       )}
@@ -188,6 +202,33 @@ describe("usePinThenWake", () => {
     expect(reassign).not.toHaveBeenCalled();
     expect(wake).not.toHaveBeenCalled();
     expect(screen.queryByTestId("picker")).toBeNull();
+  });
+
+  it("pick → temporary directory wakes with validation metadata without reassigning", async () => {
+    const reassign = vi.fn().mockResolvedValue({ success: true });
+    const wake = vi.fn().mockResolvedValue(undefined);
+    render(
+      <Harness
+        preview={{
+          outcome: "pick",
+          assigneeAgentUuid: AGENT,
+          onlineInstances: [candidate(), candidate({ connectionUuid: "conn-2" })],
+        }}
+        reassignNoWake={reassign}
+        wake={wake}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("go"));
+    await userEvent.click(await screen.findByTestId("temporary"));
+
+    await waitFor(() =>
+      expect(wake).toHaveBeenCalledWith({
+        agentUuid: AGENT,
+        validationRequestUuid: "request-1",
+      }),
+    );
+    expect(reassign).not.toHaveBeenCalled();
   });
 
   it("preview miss (null) → wakes directly", async () => {

--- a/src/hooks/use-pin-then-wake.ts
+++ b/src/hooks/use-pin-then-wake.ts
@@ -88,7 +88,12 @@ export interface StartPinThenWakeArgs {
    * action (e.g. startDevelopmentAction). The hook does not interpret its
    * result — the caller handles success/error toasts as it does today.
    */
-  wake: () => void | Promise<void>;
+  wake: (temporary?: TemporaryCwdSelection) => void | Promise<void>;
+}
+
+export interface TemporaryCwdSelection {
+  agentUuid: string;
+  validationRequestUuid: string;
 }
 
 /** Default preview fetch against the real REST endpoint. */
@@ -131,7 +136,9 @@ export function usePinThenWake({
   const [isResolving, setIsResolving] = useState(false);
   // The wake bound to the currently-open picker, captured at `start` time so
   // `confirmPick` fires the exact wake the user initiated.
-  const [pendingWake, setPendingWake] = useState<{ run: () => void | Promise<void> } | null>(
+  const [pendingWake, setPendingWake] = useState<{
+    run: (temporary?: TemporaryCwdSelection) => void | Promise<void>;
+  } | null>(
     null,
   );
 
@@ -229,5 +236,22 @@ export function usePinThenWake({
     setPendingWake(null);
   }, []);
 
-  return { start, pickerState, confirmPick, cancelPick, isResolving };
+  const confirmTemporary = useCallback(
+    async (selection: TemporaryCwdSelection) => {
+      const wake = pendingWake;
+      setPickerState(null);
+      setPendingWake(null);
+      if (wake) await wake.run(selection);
+    },
+    [pendingWake],
+  );
+
+  return {
+    start,
+    pickerState,
+    confirmPick,
+    confirmTemporary,
+    cancelPick,
+    isResolving,
+  };
 }

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -73,6 +73,7 @@ export interface ControlEvent {
   entityType?: "task" | "idea" | "proposal" | "document" | "daemon_session";
   entityUuid?: string;
   turnUuid?: string;
+  runtimeCwd?: string;
   // Present ONLY on a `resume`: the row's PRIOR interruptedReason, so the daemon can
   // inject a crash-specific continue instruction into the resumed wake
   // (add-crash-execution-resume). Older daemons ignore it.

--- a/src/services/__tests__/daemon-directory-request.integration.test.ts
+++ b/src/services/__tests__/daemon-directory-request.integration.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { prismaMock, emitted, getAuthContext } = vi.hoisted(() => ({
+  emitted: [] as Array<[string, Record<string, unknown>]>,
+  getAuthContext: vi.fn(),
+  prismaMock: {
+    agent: { findFirst: vi.fn() },
+    daemonConnection: { findFirst: vi.fn() },
+    daemonDirectoryRequest: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/auth", () => ({ getAuthContext }));
+vi.mock("@/lib/event-bus", () => ({
+  eventBus: {
+    emit: (channel: string, event: Record<string, unknown>) => emitted.push([channel, event]),
+  },
+  controlEventName: (uuid: string) => `control:${uuid}`,
+}));
+
+import { createDirectoryRequest } from "@/services/project-agent-cwd.service";
+import { POST as reportResult } from "@/app/api/daemon/directory-request/report/route";
+import { createControlHandler } from "../../../cli/control-handler.mjs";
+import { createDaemonRestClient } from "../../../cli/daemon-rest-client.mjs";
+
+describe("directory request server-daemon boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emitted.length = 0;
+    getAuthContext.mockResolvedValue({
+      type: "agent",
+      companyUuid: "company-1",
+      actorUuid: "agent-1",
+    });
+    prismaMock.agent.findFirst.mockResolvedValue({ uuid: "agent-1" });
+    prismaMock.daemonDirectoryRequest.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.daemonConnection.findFirst.mockResolvedValue({
+      uuid: "conn-1",
+      host: "host-1",
+      agentInstanceUuid: "instance-1",
+    });
+  });
+
+  it("creates, delivers, reports, and completes a correlated successful request", async () => {
+    const deadlineAt = new Date(Date.now() + 15_000);
+    prismaMock.daemonDirectoryRequest.create.mockResolvedValue({
+      uuid: "request-1",
+      limit: 50,
+      deadlineAt,
+      status: "pending",
+    });
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      uuid: "request-1",
+      companyUuid: "company-1",
+      agentUuid: "agent-1",
+      targetConnectionUuid: "conn-1",
+      status: "pending",
+      deadlineAt,
+    });
+    prismaMock.daemonDirectoryRequest.update.mockResolvedValue({
+      uuid: "request-1",
+      status: "success",
+      result: { items: [{ name: "repo", path: "/work/repo" }], nextCursor: null },
+    });
+
+    await createDirectoryRequest({
+      companyUuid: "company-1",
+      userUuid: "user-1",
+      agentUuid: "agent-1",
+      targetConnectionUuid: "conn-1",
+      operation: "list",
+      prefix: "/work/re",
+    });
+
+    expect(emitted).toHaveLength(1);
+    const [channel, controlEvent] = emitted[0];
+    expect(channel).toBe("control:conn-1");
+    expect(controlEvent).toMatchObject({
+      command: "browse_directory",
+      requestUuid: "request-1",
+      targetConnectionUuid: "conn-1",
+      operation: "list",
+      prefix: "/work/re",
+    });
+
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe("https://chorus.test/api/daemon/directory-request/report");
+      const request = new NextRequest(String(url), {
+        method: init?.method,
+        headers: init?.headers,
+        body: init?.body,
+      });
+      return reportResult(request, { params: Promise.resolve({}) });
+    });
+    const restClient = createDaemonRestClient({
+      url: "https://chorus.test",
+      apiKey: "cho_test",
+      getConnectionUuid: () => "conn-1",
+      fetchImpl,
+    });
+    const handler = createControlHandler({
+      waker: { executions: new Map() },
+      getConnectionUuid: () => "conn-1",
+      handleDirectoryRequest: vi.fn(async () => ({
+        items: [{ name: "repo", path: "/work/repo" }],
+        nextCursor: null,
+      })),
+      reportDirectoryRequest: restClient.reportDirectoryRequest,
+    });
+
+    handler(controlEvent);
+    await vi.waitFor(() => expect(prismaMock.daemonDirectoryRequest.update).toHaveBeenCalled());
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toEqual({
+      requestUuid: "request-1",
+      connectionUuid: "conn-1",
+      status: "succeeded",
+      items: [{ name: "repo", path: "/work/repo" }],
+      nextCursor: null,
+    });
+    expect(prismaMock.daemonDirectoryRequest.update).toHaveBeenCalledWith({
+      where: { uuid: "request-1" },
+      data: {
+        status: "success",
+        result: {
+          items: [{ name: "repo", path: "/work/repo" }],
+          nextCursor: null,
+          normalizedPath: undefined,
+        },
+        errorCode: null,
+        completedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("preserves a typed daemon failure instead of turning it into empty success", async () => {
+    const deadlineAt = new Date(Date.now() + 15_000);
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      uuid: "request-2",
+      status: "pending",
+      deadlineAt,
+    });
+    prismaMock.daemonDirectoryRequest.update.mockResolvedValue({
+      uuid: "request-2",
+      status: "error",
+      errorCode: "OUTSIDE_ROOT",
+    });
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) =>
+      reportResult(
+        new NextRequest(String(url), {
+          method: init?.method,
+          headers: init?.headers,
+          body: init?.body,
+        }),
+        { params: Promise.resolve({}) },
+      ),
+    );
+    const restClient = createDaemonRestClient({
+      url: "https://chorus.test",
+      apiKey: "cho_test",
+      getConnectionUuid: () => "conn-1",
+      fetchImpl,
+    });
+    const handler = createControlHandler({
+      waker: { executions: new Map() },
+      getConnectionUuid: () => "conn-1",
+      handleDirectoryRequest: vi.fn(async () => {
+        throw Object.assign(new Error("outside"), { code: "OUTSIDE_ROOT" });
+      }),
+      reportDirectoryRequest: restClient.reportDirectoryRequest,
+    });
+
+    handler({
+      type: "control",
+      command: "browse_directory",
+      targetConnectionUuid: "conn-1",
+      requestUuid: "request-2",
+      operation: "list",
+      prefix: "/outside",
+    });
+    await vi.waitFor(() => expect(prismaMock.daemonDirectoryRequest.update).toHaveBeenCalled());
+
+    expect(prismaMock.daemonDirectoryRequest.update).toHaveBeenCalledWith({
+      where: { uuid: "request-2" },
+      data: {
+        status: "error",
+        result: undefined,
+        errorCode: "OUTSIDE_ROOT",
+        completedAt: expect.any(Date),
+      },
+    });
+  });
+});

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -40,12 +40,14 @@ const mockDaemonSessionFindFirst = vi.hoisted(() => vi.fn());
 // idea's canonical session (prisma.daemonSession.update) instead of forking a per-instance
 // `${idea}::${conn}` thread. Mock update so we can assert the re-point without a DB.
 const mockDaemonSessionUpdate = vi.hoisted(() => vi.fn());
+const mockPreferenceFindFirst = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     task: { findFirst: mockTaskFindFirst },
     idea: { findFirst: mockIdeaFindFirst },
     agentInstance: { findFirst: mockAgentInstanceFindFirst },
     daemonSession: { findFirst: mockDaemonSessionFindFirst, update: mockDaemonSessionUpdate },
+    projectAgentCwdPreference: { findFirst: mockPreferenceFindFirst },
   },
 }));
 
@@ -240,6 +242,91 @@ beforeEach(() => {
   // Default: the canonical-session re-point update resolves (no-op body) unless a case
   // asserts on its args.
   mockDaemonSessionUpdate.mockResolvedValue({});
+  mockPreferenceFindFirst.mockResolvedValue(null);
+});
+
+describe("project-Agent fixed cwd resolution", () => {
+  it("routes a temporary runtime cwd through its selected host without persisting an instance", async () => {
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "temporary-anchor", host: "host-a", cwd: "/startup" }),
+      onlineConn({ uuid: "other-anchor", host: "host-b", cwd: "/other" }),
+    ]);
+
+    const result = await createTurnAndResolveTarget(
+      ctx({
+        actorType: "user",
+        actorUuid: "user-1",
+        temporaryHost: "host-a",
+        temporaryRuntimeCwd: "/work/temporary",
+      }),
+    );
+
+    expect(result.targetConnectionUuid).toBe("temporary-anchor");
+    expect(result.runtimeCwd).toBe("/work/temporary");
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originConnectionUuid: "temporary-anchor",
+        runtimeCwd: "/work/temporary",
+      }),
+    );
+  });
+
+  it("uses the fixed host/runtime cwd ahead of an inline mention pin", async () => {
+    mockPreferenceFindFirst.mockResolvedValue({
+      host: "fixed-host",
+      cwd: "/work/fixed",
+    });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "fixed-anchor", host: "fixed-host", cwd: "/startup" }),
+      onlineConn({ uuid: "inline-target", host: "inline-host", cwd: "/inline" }),
+    ]);
+
+    const result = await createTurnAndResolveTarget(
+      ctx({
+        action: "mentioned",
+        projectUuid: "project-1",
+        actorType: "user",
+        actorUuid: "user-1",
+        pinnedHost: "inline-host",
+        pinnedCwd: "/inline",
+      }),
+    );
+
+    expect(result.targetConnectionUuid).toBe("fixed-anchor");
+    expect(result.runtimeCwd).toBe("/work/fixed");
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originConnectionUuid: "fixed-anchor",
+        runtimeCwd: "/work/fixed",
+      }),
+    );
+  });
+
+  it("blocks on an offline fixed host without rerouting to another online host", async () => {
+    mockPreferenceFindFirst.mockResolvedValue({
+      host: "offline-fixed-host",
+      cwd: "/work/fixed",
+    });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "other-host", host: "online-elsewhere", cwd: "/repo" }),
+    ]);
+
+    const result = await createTurnAndResolveTarget(
+      ctx({
+        projectUuid: "project-1",
+        actorType: "user",
+        actorUuid: "user-1",
+      }),
+    );
+
+    expect(result).toEqual({
+      turn: null,
+      targetConnectionUuid: null,
+      runtimeCwd: "/work/fixed",
+      suppressWake: true,
+    });
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+  });
 });
 
 // ===== Action → trigger mapping =====

--- a/src/services/__tests__/project-agent-cwd.service.test.ts
+++ b/src/services/__tests__/project-agent-cwd.service.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { emit, prismaMock } = vi.hoisted(() => ({
+  emit: vi.fn(),
+  prismaMock: {
+    agent: { findFirst: vi.fn(), findMany: vi.fn() },
+    project: { findFirst: vi.fn() },
+    daemonConnection: { findFirst: vi.fn(), findMany: vi.fn() },
+    daemonDirectoryRequest: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    projectAgentCwdPreference: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/event-bus", () => ({
+  eventBus: { emit: (...args: unknown[]) => emit(...args) },
+  controlEventName: (uuid: string) => `control:${uuid}`,
+}));
+
+import {
+  CwdServiceError,
+  clearProjectAgentCwdPreference,
+  cleanupDirectoryRequests,
+  completeDirectoryRequest,
+  createDirectoryRequest,
+  getDirectoryRequest,
+  resolveTemporaryRuntimeCwd,
+  saveProjectAgentCwdPreference,
+} from "@/services/project-agent-cwd.service";
+
+const base = {
+  companyUuid: "company-1",
+  userUuid: "user-1",
+  agentUuid: "agent-1",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.agent.findFirst.mockResolvedValue({ uuid: "agent-1" });
+  prismaMock.project.findFirst.mockResolvedValue({ uuid: "project-1" });
+});
+
+describe("project-agent cwd request service", () => {
+  it("returns non-disclosing NOT_FOUND when the agent is not owned in the tenant", async () => {
+    prismaMock.agent.findFirst.mockResolvedValue(null);
+    await expect(
+      createDirectoryRequest({
+        ...base,
+        targetConnectionUuid: "conn-1",
+        operation: "list",
+        prefix: "/work/a",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(prismaMock.daemonConnection.findFirst).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("requires an online connection belonging to the same company and agent", async () => {
+    prismaMock.daemonConnection.findFirst.mockResolvedValue(null);
+    await expect(
+      createDirectoryRequest({
+        ...base,
+        targetConnectionUuid: "foreign-conn",
+        operation: "validate",
+        cwd: "/work/a",
+      }),
+    ).rejects.toMatchObject({ code: "HOST_OFFLINE" });
+    expect(prismaMock.daemonConnection.findFirst).toHaveBeenCalledWith({
+      where: {
+        uuid: "foreign-conn",
+        companyUuid: "company-1",
+        agentUuid: "agent-1",
+        status: "online",
+      },
+      select: { uuid: true, host: true, agentInstanceUuid: true },
+    });
+  });
+
+  it("persists then dispatches a bounded correlated request", async () => {
+    prismaMock.daemonDirectoryRequest.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.daemonConnection.findFirst.mockResolvedValue({
+      uuid: "conn-1",
+      host: "host-1",
+      agentInstanceUuid: "instance-1",
+    });
+    const created = {
+      uuid: "request-1",
+      limit: 100,
+      deadlineAt: new Date(Date.now() + 15_000),
+    };
+    prismaMock.daemonDirectoryRequest.create.mockResolvedValue(created);
+
+    await createDirectoryRequest({
+      ...base,
+      targetConnectionUuid: "conn-1",
+      operation: "list",
+      prefix: "/work/a",
+      limit: 999,
+    });
+
+    expect(prismaMock.daemonDirectoryRequest.deleteMany).toHaveBeenCalledOnce();
+    expect(prismaMock.daemonDirectoryRequest.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        companyUuid: "company-1",
+        callerUserUuid: "user-1",
+        agentUuid: "agent-1",
+        targetConnectionUuid: "conn-1",
+        operation: "list",
+        prefix: "/work/a",
+        limit: 100,
+      }),
+    });
+    expect(emit).toHaveBeenCalledWith(
+      "control:conn-1",
+      expect.objectContaining({
+        command: "browse_directory",
+        requestUuid: "request-1",
+        limit: 100,
+      }),
+    );
+  });
+
+  it("turns an overdue pending request into a terminal TIMEOUT", async () => {
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      uuid: "request-1",
+      status: "pending",
+      deadlineAt: new Date(0),
+    });
+    prismaMock.daemonDirectoryRequest.update.mockResolvedValue({
+      uuid: "request-1",
+      status: "error",
+      errorCode: "TIMEOUT",
+    });
+
+    const result = await getDirectoryRequest("company-1", "user-1", "request-1");
+    expect(result).toMatchObject({ status: "error", errorCode: "TIMEOUT" });
+    expect(prismaMock.daemonDirectoryRequest.findFirst).toHaveBeenCalledWith({
+      where: { uuid: "request-1", companyUuid: "company-1", callerUserUuid: "user-1" },
+    });
+  });
+
+  it("accepts completion only from the targeted agent connection", async () => {
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue(null);
+    await expect(
+      completeDirectoryRequest({
+        companyUuid: "company-1",
+        agentUuid: "agent-1",
+        connectionUuid: "wrong-conn",
+        requestUuid: "request-1",
+        status: "success",
+        result: { items: [] },
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(prismaMock.daemonDirectoryRequest.findFirst).toHaveBeenCalledWith({
+      where: {
+        uuid: "request-1",
+        companyUuid: "company-1",
+        agentUuid: "agent-1",
+        targetConnectionUuid: "wrong-conn",
+        status: "pending",
+      },
+    });
+  });
+});
+
+describe("project-agent cwd preference service", () => {
+  it("isolates multiple users and Agents across fixed save, clear, and temporary fallback", async () => {
+    const validations = new Map([
+      ["validation-user-1-agent-a", { cwd: "/raw/a", normalizedPath: "/work/a", connection: "conn-a" }],
+      ["validation-user-1-agent-b", { cwd: "/raw/b", normalizedPath: "/work/b", connection: "conn-b" }],
+      ["validation-user-2-agent-a", { cwd: "/raw/u2", normalizedPath: "/work/u2", connection: "conn-u2" }],
+    ]);
+    prismaMock.daemonDirectoryRequest.findFirst.mockImplementation(async ({ where }) => {
+      const row = validations.get(where.uuid);
+      return row
+        ? {
+            uuid: where.uuid,
+            cwd: row.cwd,
+            result: { normalizedPath: row.normalizedPath },
+            targetConnectionUuid: row.connection,
+          }
+        : null;
+    });
+    prismaMock.daemonConnection.findFirst.mockImplementation(async ({ where }) => ({
+      host: `host-${where.uuid}`,
+      agentInstanceUuid: `instance-${where.uuid}`,
+    }));
+    prismaMock.projectAgentCwdPreference.upsert.mockResolvedValue({ uuid: "preference" });
+    prismaMock.projectAgentCwdPreference.deleteMany.mockResolvedValue({ count: 1 });
+
+    for (const input of [
+      { userUuid: "user-1", agentUuid: "agent-a", validationRequestUuid: "validation-user-1-agent-a" },
+      { userUuid: "user-1", agentUuid: "agent-b", validationRequestUuid: "validation-user-1-agent-b" },
+      { userUuid: "user-2", agentUuid: "agent-a", validationRequestUuid: "validation-user-2-agent-a" },
+    ]) {
+      await saveProjectAgentCwdPreference({
+        companyUuid: "company-1",
+        projectUuid: "project-1",
+        ...input,
+      });
+    }
+
+    expect(
+      prismaMock.projectAgentCwdPreference.upsert.mock.calls.map(([call]) => ({
+        key: call.where.userUuid_projectUuid_agentUuid,
+        cwd: call.create.cwd,
+      })),
+    ).toEqual([
+      {
+        key: { userUuid: "user-1", projectUuid: "project-1", agentUuid: "agent-a" },
+        cwd: "/work/a",
+      },
+      {
+        key: { userUuid: "user-1", projectUuid: "project-1", agentUuid: "agent-b" },
+        cwd: "/work/b",
+      },
+      {
+        key: { userUuid: "user-2", projectUuid: "project-1", agentUuid: "agent-a" },
+        cwd: "/work/u2",
+      },
+    ]);
+
+    await clearProjectAgentCwdPreference({
+      companyUuid: "company-1",
+      userUuid: "user-1",
+      projectUuid: "project-1",
+      agentUuid: "agent-a",
+    });
+    expect(prismaMock.projectAgentCwdPreference.deleteMany).toHaveBeenCalledWith({
+      where: {
+        companyUuid: "company-1",
+        userUuid: "user-1",
+        projectUuid: "project-1",
+        agentUuid: "agent-a",
+      },
+    });
+    // Clearing only this scoped row leaves the operation free to use a temporary
+    // registered or discovered runtime cwd without writing another preference.
+    expect(prismaMock.projectAgentCwdPreference.upsert).toHaveBeenCalledTimes(3);
+  });
+
+  it("resolves a fresh temporary cwd without writing a project preference", async () => {
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      targetConnectionUuid: "conn-1",
+      result: { normalizedPath: "/work/temporary" },
+    });
+    prismaMock.daemonConnection.findFirst.mockResolvedValue({ host: "host-1" });
+
+    await expect(
+      resolveTemporaryRuntimeCwd({
+        ...base,
+        validationRequestUuid: "validation-1",
+      }),
+    ).resolves.toEqual({ host: "host-1", cwd: "/work/temporary" });
+    expect(prismaMock.projectAgentCwdPreference.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.projectAgentCwdPreference.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("upserts only from a fresh successful validate request and replaces the same user/project/agent row", async () => {
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      uuid: "validation-1",
+      cwd: "/work/../work/repo",
+      result: { normalizedPath: "/work/repo" },
+      targetConnectionUuid: "conn-1",
+    });
+    prismaMock.daemonConnection.findFirst.mockResolvedValue({
+      host: "host-1",
+      agentInstanceUuid: "instance-1",
+    });
+    prismaMock.projectAgentCwdPreference.upsert.mockResolvedValue({ uuid: "preference-1" });
+
+    await saveProjectAgentCwdPreference({
+      ...base,
+      projectUuid: "project-1",
+      validationRequestUuid: "validation-1",
+    });
+
+    expect(prismaMock.daemonDirectoryRequest.findFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        uuid: "validation-1",
+        companyUuid: "company-1",
+        callerUserUuid: "user-1",
+        agentUuid: "agent-1",
+        operation: "validate",
+        status: "success",
+        completedAt: { gte: expect.any(Date) },
+      }),
+    });
+    expect(prismaMock.projectAgentCwdPreference.upsert).toHaveBeenCalledWith({
+      where: {
+        userUuid_projectUuid_agentUuid: {
+          userUuid: "user-1",
+          projectUuid: "project-1",
+          agentUuid: "agent-1",
+        },
+      },
+      create: expect.objectContaining({ host: "host-1", cwd: "/work/repo" }),
+      update: {
+        host: "host-1",
+        cwd: "/work/repo",
+        anchorAgentInstanceUuid: "instance-1",
+      },
+    });
+  });
+
+  it("rejects stale or unsuccessful validation and prunes expired request history", async () => {
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue(null);
+    await expect(
+      saveProjectAgentCwdPreference({
+        ...base,
+        projectUuid: "project-1",
+        validationRequestUuid: "stale",
+      }),
+    ).rejects.toMatchObject({ code: "STALE_TARGET" });
+    expect(prismaMock.projectAgentCwdPreference.upsert).not.toHaveBeenCalled();
+
+    prismaMock.daemonDirectoryRequest.deleteMany.mockResolvedValue({ count: 2 });
+    await cleanupDirectoryRequests(new Date("2026-08-01T12:00:00Z"));
+    expect(prismaMock.daemonDirectoryRequest.deleteMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { deadlineAt: { lt: new Date("2026-08-01T11:00:00Z") } },
+          { completedAt: { lt: new Date("2026-08-01T11:00:00Z") } },
+        ],
+      },
+    });
+  });
+});

--- a/src/services/__tests__/stage-advance.service.test.ts
+++ b/src/services/__tests__/stage-advance.service.test.ts
@@ -248,6 +248,36 @@ describe("executeStageAdvance — offline policy", () => {
     expect(mockCreateActivity).not.toHaveBeenCalled();
   });
 
+  it("checks a fixed cwd before an online AgentInstance assignment", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(
+      makeIdea({ assigneeType: "agent_instance", assigneeUuid: INSTANCE_UUID }),
+    );
+    mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
+      host: "fixed-host",
+    });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+
+    await expect(
+      executeStageAdvance(
+        makeDefinition({ offlinePolicy: "require_online" }),
+        HUMAN_PARAMS,
+      ),
+    ).rejects.toMatchObject({ code: "FIXED_CWD_HOST_OFFLINE" });
+
+    expect(mockPrisma.agentInstance.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { uuid: INSTANCE_UUID, companyUuid: COMPANY_UUID },
+        select: { agentUuid: true },
+      }),
+    );
+    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ host: "fixed-host" }),
+      }),
+    );
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
   it("require_online on an agent_instance assignee checks the PINNED INSTANCE's own connection (host+cwd), not just the agent", async () => {
     // HARD-pin split: an instance-pinned idea's require_online check must target the exact
     // (host, cwd) place of the pinned instance — a wake there is notify-only when offline, so

--- a/src/services/__tests__/stage-advance.service.test.ts
+++ b/src/services/__tests__/stage-advance.service.test.ts
@@ -13,6 +13,9 @@ const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
     daemonConnection: {
       findFirst: vi.fn(),
     },
+    projectAgentCwdPreference: {
+      findFirst: vi.fn(),
+    },
   },
   mockEventBus: { emitChange: vi.fn() },
   mockCreateActivity: vi.fn().mockResolvedValue(undefined),
@@ -75,6 +78,7 @@ beforeEach(() => {
   mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
   mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-1" });
   mockPrisma.agentInstance.findFirst.mockResolvedValue({ agentUuid: AGENT_UUID });
+  mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
 });
 
 describe("executeStageAdvance — actor gate", () => {
@@ -209,6 +213,37 @@ describe("executeStageAdvance — offline policy", () => {
       )
     ).rejects.toMatchObject({ code: "AGENT_OFFLINE" });
 
+    expect(transition).not.toHaveBeenCalled();
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
+  it("rejects an offline fixed cwd host without rerouting to another online host", async () => {
+    const transition = vi.fn();
+    mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
+      host: "fixed-host",
+    });
+    mockPrisma.daemonConnection.findFirst.mockImplementation(
+      async ({ where }: { where: { host?: string } }) =>
+        where.host === "fixed-host" ? null : { uuid: "conn-other-host" },
+    );
+
+    await expect(
+      executeStageAdvance(
+        makeDefinition({ offlinePolicy: "require_online", transition }),
+        HUMAN_PARAMS,
+      ),
+    ).rejects.toMatchObject({ code: "FIXED_CWD_HOST_OFFLINE" });
+
+    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          agentUuid: AGENT_UUID,
+          host: "fixed-host",
+          status: "online",
+        }),
+      }),
+    );
+    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
     expect(transition).not.toHaveBeenCalled();
     expect(mockCreateActivity).not.toHaveBeenCalled();
   });

--- a/src/services/__tests__/start-development.service.test.ts
+++ b/src/services/__tests__/start-development.service.test.ts
@@ -19,6 +19,9 @@ const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
     daemonConnection: {
       findFirst: vi.fn(),
     },
+    projectAgentCwdPreference: {
+      findFirst: vi.fn(),
+    },
   },
   mockEventBus: { emitChange: vi.fn() },
   mockCreateActivity: vi.fn().mockResolvedValue(undefined),
@@ -71,6 +74,7 @@ beforeEach(() => {
   mockPrisma.task.count.mockResolvedValue(3);
   mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-1" });
   mockPrisma.agentInstance.findFirst.mockResolvedValue({ agentUuid: AGENT_UUID });
+  mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
 });
 
 describe("startDevelopment — success", () => {
@@ -234,6 +238,18 @@ describe("startDevelopment — precondition failures (each emits nothing)", () =
 
     await expect(startDevelopment(PARAMS)).rejects.toMatchObject({
       code: "INSTANCE_OFFLINE",
+    });
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
+  it("rejects with FIXED_CWD_HOST_OFFLINE when another Agent host is online", async () => {
+    mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
+      host: "fixed-host",
+    });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+
+    await expect(startDevelopment(PARAMS)).rejects.toMatchObject({
+      code: "FIXED_CWD_HOST_OFFLINE",
     });
     expect(mockCreateActivity).not.toHaveBeenCalled();
   });

--- a/src/services/__tests__/wake-preview.service.test.ts
+++ b/src/services/__tests__/wake-preview.service.test.ts
@@ -13,9 +13,11 @@ const mockIdeaFindFirst = vi.hoisted(() => vi.fn());
 const mockIdeaUpdate = vi.hoisted(() => vi.fn());
 const mockActivityCreate = vi.hoisted(() => vi.fn());
 const mockNotificationCreate = vi.hoisted(() => vi.fn());
+const mockPreferenceFindFirst = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     idea: { findFirst: mockIdeaFindFirst, update: mockIdeaUpdate },
+    projectAgentCwdPreference: { findFirst: mockPreferenceFindFirst },
     activity: { create: mockActivityCreate },
     notification: { create: mockNotificationCreate },
   },
@@ -101,6 +103,7 @@ beforeEach(() => {
   });
   mockResolveAssigneeAgentUuid.mockResolvedValue(agentUuid);
   mockListConnectionsForAgent.mockResolvedValue([]);
+  mockPreferenceFindFirst.mockResolvedValue(null);
 });
 
 describe("previewIdeaWakeTarget — outcome classification", () => {
@@ -141,6 +144,29 @@ describe("previewIdeaWakeTarget — outcome classification", () => {
     expect(preview!.outcome).toBe("auto_pin");
     expect(preview!.onlineInstances).toHaveLength(1);
     expectNoSideEffects();
+  });
+
+  it("direct: a fixed project-Agent cwd suppresses picker and auto-pin semantics", async () => {
+    mockIdeaFindFirst.mockImplementation(async ({ select }) =>
+      "projectUuid" in select
+        ? { projectUuid: "project-1" }
+        : { assigneeType: "agent", assigneeUuid: agentUuid },
+    );
+    mockPreferenceFindFirst.mockResolvedValue({ uuid: "preference-1" });
+    mockListConnectionsForAgent.mockResolvedValue([makeConnection(), makeConnection()]);
+
+    const preview = await previewIdeaWakeTarget(companyUuid, ideaUuid, "user-1");
+
+    expect(preview!.outcome).toBe("direct");
+    expect(mockPreferenceFindFirst).toHaveBeenCalledWith({
+      where: {
+        companyUuid,
+        userUuid: "user-1",
+        projectUuid: "project-1",
+        agentUuid,
+      },
+      select: { uuid: true },
+    });
   });
 
   it("direct (sub-case: already agent_instance): assignee is instance-pinned", async () => {

--- a/src/services/__tests__/yolo-request.service.test.ts
+++ b/src/services/__tests__/yolo-request.service.test.ts
@@ -19,6 +19,9 @@ const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
     daemonConnection: {
       findFirst: vi.fn(),
     },
+    projectAgentCwdPreference: {
+      findFirst: vi.fn(),
+    },
   },
   mockEventBus: { emitChange: vi.fn() },
   mockCreateActivity: vi.fn().mockResolvedValue(undefined),
@@ -69,6 +72,7 @@ beforeEach(() => {
   mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
   mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-1" });
   mockPrisma.agentInstance.findFirst.mockResolvedValue({ agentUuid: AGENT_UUID });
+  mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
 });
 
 describe("requestYolo — success", () => {
@@ -188,6 +192,18 @@ describe("requestYolo — precondition failures (each emits nothing)", () => {
 
     await expect(requestYolo(PARAMS)).rejects.toMatchObject({
       code: "INSTANCE_OFFLINE",
+    });
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
+  it("rejects with FIXED_CWD_HOST_OFFLINE when another Agent host is online", async () => {
+    mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
+      host: "fixed-host",
+    });
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+
+    await expect(requestYolo(PARAMS)).rejects.toMatchObject({
+      code: "FIXED_CWD_HOST_OFFLINE",
     });
     expect(mockCreateActivity).not.toHaveBeenCalled();
   });

--- a/src/services/daemon-control.service.ts
+++ b/src/services/daemon-control.service.ts
@@ -194,12 +194,14 @@ export type DispatchControlParams =
       entityType: ControlEntityType;
       entityUuid: string;
       resumeReason?: "user" | "crash";
+      runtimeCwd?: string | null;
     }
   | {
       companyUuid: string;
       targetConnectionUuid: string;
       command: "deliver_turn";
       turnUuid: string;
+      runtimeCwd?: string | null;
     };
 
 export function dispatchControl(params: DispatchControlParams): void {
@@ -213,6 +215,7 @@ export function dispatchControl(params: DispatchControlParams): void {
           command: "deliver_turn",
           targetConnectionUuid: params.targetConnectionUuid,
           turnUuid: params.turnUuid,
+          ...(params.runtimeCwd ? { runtimeCwd: params.runtimeCwd } : {}),
         }
       : {
           type: "control",
@@ -220,6 +223,7 @@ export function dispatchControl(params: DispatchControlParams): void {
           targetConnectionUuid: params.targetConnectionUuid,
           entityType: params.entityType,
           entityUuid: params.entityUuid,
+          ...(params.runtimeCwd ? { runtimeCwd: params.runtimeCwd } : {}),
           // Only a resume carries a reason; spread-if-present keeps the interrupt
           // wire shape byte-identical to before.
           ...(params.resumeReason ? { resumeReason: params.resumeReason } : {}),

--- a/src/services/daemon-instruction.service.ts
+++ b/src/services/daemon-instruction.service.ts
@@ -336,6 +336,7 @@ export function deliverTurnPing(params: {
   companyUuid: string;
   originConnectionUuid: string;
   turnUuid: string;
+  runtimeCwd?: string | null;
 }): void {
   try {
     dispatchControl({
@@ -343,6 +344,7 @@ export function deliverTurnPing(params: {
       targetConnectionUuid: params.originConnectionUuid,
       command: "deliver_turn",
       turnUuid: params.turnUuid,
+      ...(params.runtimeCwd ? { runtimeCwd: params.runtimeCwd } : {}),
     });
   } catch (err) {
     // Non-fatal: the persisted turn + reconnect-backfill guarantee durability. Log loudly.
@@ -833,6 +835,7 @@ export async function createConversationalIdeaSession(
     backendSessionId: sessionRow.backendSessionId,
     directIdeaUuid: sessionRow.directIdeaUuid,
     originConnectionUuid: sessionRow.originConnectionUuid,
+    runtimeCwd: sessionRow.runtimeCwd,
     status: sessionRow.status,
     title: sessionRow.title,
     lastTurnAt: sessionRow.lastTurnAt.toISOString(),
@@ -1028,6 +1031,7 @@ export async function repointSessionOriginAndSend(
     backendSessionId: updated.backendSessionId,
     directIdeaUuid: updated.directIdeaUuid,
     originConnectionUuid: updated.originConnectionUuid,
+    runtimeCwd: updated.runtimeCwd,
     status: updated.status,
     title: updated.title,
     lastTurnAt: updated.lastTurnAt.toISOString(),

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -71,10 +71,21 @@ export type TurnStatus = (typeof TURN_STATUSES)[number];
 // daemon-reported outcomes; `offline` is reserved to SERVER-side reconcile of a turn
 // whose origin connection went stale — the turn-advance route rejects a daemon
 // claiming it (the daemon being alive to report contradicts the verdict).
-export const TURN_INTERRUPT_REASONS = ["user", "crash", "shutdown", "offline"] as const;
+export const TURN_INTERRUPT_REASONS = [
+  "user",
+  "crash",
+  "shutdown",
+  "offline",
+  "invalid_path",
+] as const;
 export type TurnInterruptReason = (typeof TURN_INTERRUPT_REASONS)[number];
 // The subset a daemon may self-report over `/api/daemon/turn-advance`.
-export const DAEMON_REPORTABLE_INTERRUPT_REASONS = ["user", "crash", "shutdown"] as const;
+export const DAEMON_REPORTABLE_INTERRUPT_REASONS = [
+  "user",
+  "crash",
+  "shutdown",
+  "invalid_path",
+] as const;
 
 // The two session lifecycle states. A session is `active` until explicitly ended;
 // it stays readable (its turns/transcript) regardless of state — `ended` is history,
@@ -137,6 +148,7 @@ export interface SessionView {
   backendSessionId: string | null;
   directIdeaUuid: string | null;
   originConnectionUuid: string;
+  runtimeCwd?: string | null;
   status: string; // active | ended
   title: string | null;
   lastTurnAt: string; // ISO-8601
@@ -219,6 +231,7 @@ interface DaemonSessionRow {
   backendSessionId: string | null;
   directIdeaUuid: string | null;
   originConnectionUuid: string;
+  runtimeCwd: string | null;
   status: string;
   title: string | null;
   lastTurnAt: Date;
@@ -280,6 +293,7 @@ function toSessionView(row: DaemonSessionRow): SessionView {
     backendSessionId: row.backendSessionId,
     directIdeaUuid: row.directIdeaUuid,
     originConnectionUuid: row.originConnectionUuid,
+    runtimeCwd: row.runtimeCwd ?? null,
     status: row.status,
     title: row.title,
     lastTurnAt: row.lastTurnAt.toISOString(),
@@ -391,6 +405,7 @@ export async function resolveOrCreateSession(params: {
   sessionId: string;
   directIdeaUuid?: string | null;
   originConnectionUuid: string;
+  runtimeCwd?: string | null;
 }): Promise<SessionView> {
   const row = await prisma.daemonSession.upsert({
     where: {
@@ -405,12 +420,14 @@ export async function resolveOrCreateSession(params: {
       sessionId: params.sessionId,
       directIdeaUuid: params.directIdeaUuid ?? null,
       originConnectionUuid: params.originConnectionUuid,
+      runtimeCwd: params.runtimeCwd ?? null,
       status: "active",
     },
     update: {
       // Re-affirm companyUuid from the authenticated context. originConnectionUuid
       // and directIdeaUuid are write-once — intentionally NOT updated here.
       companyUuid: params.companyUuid,
+      ...(params.runtimeCwd !== undefined ? { runtimeCwd: params.runtimeCwd } : {}),
     },
   });
   return toSessionView(row);
@@ -1807,6 +1824,7 @@ export interface PendingTurnView {
   sessionUuid: string;
   sessionId: string;
   directIdeaUuid: string | null;
+  runtimeCwd: string | null;
   seq: number;
   trigger: string;
   promptText: string | null;
@@ -1847,7 +1865,7 @@ export async function getPendingTurnsForConnection(params: {
       seq: true,
       trigger: true,
       promptText: true,
-      session: { select: { sessionId: true, directIdeaUuid: true } },
+      session: { select: { sessionId: true, directIdeaUuid: true, runtimeCwd: true } },
     },
   });
 
@@ -1856,6 +1874,7 @@ export async function getPendingTurnsForConnection(params: {
     sessionUuid: r.sessionUuid,
     sessionId: r.session.sessionId,
     directIdeaUuid: r.session.directIdeaUuid,
+    runtimeCwd: r.session.runtimeCwd,
     seq: r.seq,
     trigger: r.trigger,
     promptText: r.promptText,

--- a/src/services/notification-listener.ts
+++ b/src/services/notification-listener.ts
@@ -640,7 +640,12 @@ export async function handleActivity(event: ActivityEvent): Promise<void> {
     const message = buildMessage(notificationType, actorName, entityTitle, event.value);
 
     const notifications: NotificationCreateParams[] = eligibleRecipients.map(
-      (recipient) => ({
+      (recipient) => {
+        const value =
+          event.value && typeof event.value === "object"
+            ? (event.value as Record<string, unknown>)
+            : {};
+        return {
         companyUuid: event.companyUuid,
         projectUuid: event.projectUuid,
         recipientType: recipient.type,
@@ -654,7 +659,14 @@ export async function handleActivity(event: ActivityEvent): Promise<void> {
         actorType: event.actorType,
         actorUuid: event.actorUuid,
         actorName,
-      })
+        temporaryHost:
+          typeof value.temporaryHost === "string" ? value.temporaryHost : undefined,
+        temporaryRuntimeCwd:
+          typeof value.temporaryRuntimeCwd === "string"
+            ? value.temporaryRuntimeCwd
+            : undefined,
+      };
+      }
     );
 
     await notificationService.createBatch(notifications);

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -210,6 +210,9 @@ export interface WakeNotificationContext {
   // lives on the created turn's `promptText`; the notification row carries the
   // denormalized copy. Null/undefined for autonomous wakes.
   instructionText?: string | null;
+  projectUuid?: string | null;
+  actorType?: string | null;
+  actorUuid?: string | null;
   // Pinned target daemon instance carried by a `mentioned` wake (cwd-addressable
   // instances): the owner-chosen `(host, cwd)` parsed from the mention markup and
   // threaded here by mention.service. The wake resolves it to a matching ONLINE
@@ -222,6 +225,8 @@ export interface WakeNotificationContext {
   // `pinnedCwd` null = unknown-path instance.
   pinnedHost?: string | null;
   pinnedCwd?: string | null;
+  temporaryHost?: string | null;
+  temporaryRuntimeCwd?: string | null;
 }
 
 /**
@@ -250,6 +255,7 @@ interface PinnedTarget {
   host: string;
   cwd: string | null;
   soft: boolean;
+  runtimeCwd?: string | null;
 }
 
 /**
@@ -328,6 +334,38 @@ async function resolvePinnedTarget(
   ctx: WakeNotificationContext,
   trigger: TurnTrigger,
 ): Promise<PinnedTarget | null> {
+  // A project preference is authoritative across every instance and inline selection
+  // for this user. Its cwd need not be a registered connection; any online connection
+  // for the same Agent + host is an anchor for directed runtime execution.
+  if (ctx.projectUuid && ctx.actorType === "user" && ctx.actorUuid) {
+    const preference = await prisma.projectAgentCwdPreference?.findFirst({
+      where: {
+        companyUuid: ctx.companyUuid,
+        userUuid: ctx.actorUuid,
+        projectUuid: ctx.projectUuid,
+        agentUuid: ctx.recipientUuid,
+      },
+      select: { host: true, cwd: true },
+    });
+    if (preference) {
+      return {
+        host: preference.host,
+        cwd: null,
+        runtimeCwd: preference.cwd,
+        soft: false,
+      };
+    }
+  }
+
+  if (ctx.temporaryHost && ctx.temporaryRuntimeCwd) {
+    return {
+      host: ctx.temporaryHost,
+      cwd: null,
+      runtimeCwd: ctx.temporaryRuntimeCwd,
+      soft: false,
+    };
+  }
+
   // (1) Mention pin — HARD. A human typed an exact place; offline stays notify-only.
   if (trigger === "mentioned") {
     return makePinnedTarget(ctx.pinnedHost, ctx.pinnedCwd, false);
@@ -484,7 +522,7 @@ function selectOriginConnection(
     const matched = connections.find(
       (c) =>
         c.host === pin.host &&
-        c.cwd === pin.cwd &&
+        (pin.runtimeCwd ? true : c.cwd === pin.cwd) &&
         c.effectiveStatus === "online",
     );
     if (matched) return { kind: "directed", connection: matched };
@@ -584,6 +622,7 @@ export async function resolveIdeaSessionOriginTarget(
 export interface WakeTurnResult {
   turn: TurnView | null;
   targetConnectionUuid: string | null;
+  runtimeCwd: string | null;
   suppressWake: boolean;
 }
 
@@ -636,6 +675,7 @@ export async function createTurnAndResolveTarget(
   const empty: WakeTurnResult = {
     turn: null,
     targetConnectionUuid: null,
+    runtimeCwd: null,
     suppressWake: false,
   };
 
@@ -717,7 +757,7 @@ export async function createTurnAndResolveTarget(
     // and a momentarily-no-online UN-PINNED wake must remain byte-identical to before (no new
     // suppression behavior). So only `offline_pin` suppresses agent-wide.
     if (selection.kind === "offline_pin") {
-      return { turn: null, targetConnectionUuid: null, suppressWake: true };
+      return { turn: null, targetConnectionUuid: null, runtimeCwd: pin?.runtimeCwd ?? null, suppressWake: true };
     }
     if (selection.kind === "none") {
       return empty;
@@ -725,6 +765,7 @@ export async function createTurnAndResolveTarget(
 
     const origin = selection.connection;
     const directed = selection.kind === "directed";
+    const runtimeCwd = pin?.runtimeCwd ?? null;
 
     // (5) Session business key — ONE conversation per idea per agent (fix idea 2ddd1d11:
     // "switching daemon cwd / agent splits the chat into two threads → can't interrupt").
@@ -769,7 +810,10 @@ export async function createTurnAndResolveTarget(
         // ownership is proven by the same-agent connection resolution above.
         await prisma.daemonSession.update({
           where: { uuid: existing.uuid, companyUuid: ctx.companyUuid },
-          data: { originConnectionUuid: origin.uuid },
+          data: {
+            originConnectionUuid: origin.uuid,
+            ...(runtimeCwd ? { runtimeCwd } : {}),
+          },
         });
       }
     }
@@ -784,7 +828,9 @@ export async function createTurnAndResolveTarget(
       sessionId,
       directIdeaUuid: sessionDirectIdeaUuid,
       originConnectionUuid: origin.uuid,
+      ...(runtimeCwd ? { runtimeCwd } : {}),
     });
+    const effectiveRuntimeCwd = runtimeCwd ?? session.runtimeCwd ?? null;
 
     const promptText =
       trigger === "human_instruction" ? ctx.instructionText ?? null : null;
@@ -819,11 +865,17 @@ export async function createTurnAndResolveTarget(
         companyUuid: ctx.companyUuid,
         originConnectionUuid: origin.uuid,
         turnUuid: turn.uuid,
+        ...(effectiveRuntimeCwd ? { runtimeCwd: effectiveRuntimeCwd } : {}),
       });
-      return { turn, targetConnectionUuid: origin.uuid, suppressWake: false };
+      return {
+        turn,
+        targetConnectionUuid: origin.uuid,
+        runtimeCwd: effectiveRuntimeCwd,
+        suppressWake: false,
+      };
     }
 
-    return { turn, targetConnectionUuid: null, suppressWake: false };
+    return { turn, targetConnectionUuid: null, runtimeCwd: null, suppressWake: false };
   } catch (error) {
     // VISIBLE failure (repo "no silent errors"): log with full context but DO NOT
     // rethrow — the notification was already created and must not be aborted by a

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -41,6 +41,8 @@ export interface NotificationCreateParams {
   // `pinnedHost` "" = unknown-host instance; `pinnedCwd` null = unknown-path instance.
   pinnedHost?: string | null;
   pinnedCwd?: string | null;
+  temporaryHost?: string | null;
+  temporaryRuntimeCwd?: string | null;
 }
 
 export interface NotificationListParams {
@@ -211,7 +213,7 @@ export async function createReturningTurn(
   // target. It runs BEFORE the SSE emit so the `new_notification` event can stamp the
   // resolved `targetConnectionUuid` (the bridge reads only `params`, not the created row,
   // so this reorder is behavior-preserving for the notification row itself).
-  const { turn, targetConnectionUuid, suppressWake } =
+  const { turn, targetConnectionUuid, runtimeCwd, suppressWake } =
     await createTurnAndResolveTarget(params);
 
   // Emit SSE event for real-time notification delivery (includes details for toast).
@@ -249,6 +251,7 @@ export async function createReturningTurn(
     projectUuid: params.projectUuid,
     // Transport-only directed-delivery target (null for un-pinned / notify-only wakes).
     targetConnectionUuid,
+    runtimeCwd,
     // Transport-only offline-pin marker: true ONLY for an offline-pin wake (suppress on
     // EVERY connection), false otherwise.
     suppressWake,
@@ -311,12 +314,12 @@ export async function createBatch(
   // notification params (referential identity) so the per-recipient emit below can read it.
   const targetByParams = new Map<
     NotificationCreateParams,
-    { targetConnectionUuid: string | null; suppressWake: boolean }
+    { targetConnectionUuid: string | null; runtimeCwd: string | null; suppressWake: boolean }
   >();
   for (const params of notifications) {
-    const { targetConnectionUuid, suppressWake } =
+    const { targetConnectionUuid, runtimeCwd, suppressWake } =
       await createTurnAndResolveTarget(params);
-    targetByParams.set(params, { targetConnectionUuid, suppressWake });
+    targetByParams.set(params, { targetConnectionUuid, runtimeCwd, suppressWake });
   }
 
   // Deduplicate recipients and emit one event per recipient
@@ -351,6 +354,9 @@ export async function createBatch(
       // un-pinned / notify-only). Resolved above by the wake-turn chokepoint.
       targetConnectionUuid: matchParams
         ? targetByParams.get(matchParams)?.targetConnectionUuid ?? null
+        : null,
+      runtimeCwd: matchParams
+        ? targetByParams.get(matchParams)?.runtimeCwd ?? null
         : null,
       // Transport-only offline-pin marker: true ONLY for an offline-pin wake — tells every
       // daemon to suppress (Q2 notify-only), distinguishing it from an un-pinned wake.

--- a/src/services/project-agent-cwd.service.ts
+++ b/src/services/project-agent-cwd.service.ts
@@ -1,0 +1,356 @@
+import { prisma } from "@/lib/prisma";
+import { eventBus, controlEventName } from "@/lib/event-bus";
+
+export const DIRECTORY_ERROR_CODES = [
+  "HOST_OFFLINE",
+  "TIMEOUT",
+  "INVALID_PATH",
+  "OUTSIDE_ROOT",
+  "NOT_DIRECTORY",
+  "ACCESS_DENIED",
+  "STALE_TARGET",
+  "LIMIT_EXCEEDED",
+  "INTERNAL_ERROR",
+] as const;
+
+export type DirectoryErrorCode = (typeof DIRECTORY_ERROR_CODES)[number];
+export type DirectoryOperation = "list" | "validate";
+
+export class CwdServiceError extends Error {
+  constructor(
+    public readonly code: DirectoryErrorCode | "NOT_FOUND" | "FORBIDDEN" | "VALIDATION_ERROR",
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const REQUEST_TTL_MS = 15_000;
+const VALIDATION_FRESH_MS = 60_000;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+async function requireOwnedAgent(companyUuid: string, userUuid: string, agentUuid: string) {
+  const agent = await prisma.agent.findFirst({
+    where: { uuid: agentUuid, companyUuid, ownerUuid: userUuid },
+    select: { uuid: true },
+  });
+  if (!agent) throw new CwdServiceError("NOT_FOUND", "Agent not found");
+}
+
+async function requireProject(companyUuid: string, projectUuid: string) {
+  const project = await prisma.project.findFirst({
+    where: { uuid: projectUuid, companyUuid },
+    select: { uuid: true },
+  });
+  if (!project) throw new CwdServiceError("NOT_FOUND", "Project not found");
+}
+
+export async function listProjectAgentCwdPreferences(
+  companyUuid: string,
+  userUuid: string,
+  projectUuid: string,
+) {
+  await requireProject(companyUuid, projectUuid);
+  const [agents, preferences] = await Promise.all([
+    prisma.agent.findMany({
+      where: { companyUuid, ownerUuid: userUuid },
+      select: { uuid: true, name: true },
+      orderBy: [{ name: "asc" }, { uuid: "asc" }],
+    }),
+    prisma.projectAgentCwdPreference.findMany({
+      where: { companyUuid, userUuid, projectUuid },
+    }),
+  ]);
+  const connections = await prisma.daemonConnection.findMany({
+    where: { companyUuid, agentUuid: { in: agents.map((agent) => agent.uuid) }, status: "online" },
+    select: {
+      uuid: true,
+      agentUuid: true,
+      agentInstanceUuid: true,
+      host: true,
+      cwd: true,
+      lastSeenAt: true,
+    },
+  });
+  const onlineHosts = new Set(connections.map((connection) => `${connection.agentUuid}\0${connection.host}`));
+  const byAgent = new Map(preferences.map((preference) => [preference.agentUuid, preference]));
+  return agents.map((agent) => {
+    const preference = byAgent.get(agent.uuid);
+    return {
+      agent,
+      onlineInstances: connections
+        .filter((connection) => connection.agentUuid === agent.uuid)
+        .map((connection) => ({
+          connectionUuid: connection.uuid,
+          agentInstanceUuid: connection.agentInstanceUuid,
+          host: connection.host,
+          cwd: connection.cwd,
+          effectiveStatus: "online" as const,
+        })),
+      preference: preference
+        ? {
+            uuid: preference.uuid,
+            host: preference.host,
+            cwd: preference.cwd,
+            anchorAgentInstanceUuid: preference.anchorAgentInstanceUuid,
+            status: onlineHosts.has(`${agent.uuid}\0${preference.host}`) ? "valid" : "offline",
+            updatedAt: preference.updatedAt,
+          }
+        : null,
+    };
+  });
+}
+
+export async function resolveTemporaryRuntimeCwd(params: {
+  companyUuid: string;
+  userUuid: string;
+  agentUuid: string;
+  validationRequestUuid: string;
+}) {
+  await requireOwnedAgent(params.companyUuid, params.userUuid, params.agentUuid);
+  const validation = await prisma.daemonDirectoryRequest.findFirst({
+    where: {
+      uuid: params.validationRequestUuid,
+      companyUuid: params.companyUuid,
+      callerUserUuid: params.userUuid,
+      agentUuid: params.agentUuid,
+      operation: "validate",
+      status: "success",
+      completedAt: { gte: new Date(Date.now() - VALIDATION_FRESH_MS) },
+    },
+  });
+  const normalizedPath =
+    validation?.result &&
+    typeof validation.result === "object" &&
+    !Array.isArray(validation.result) &&
+    typeof (validation.result as { normalizedPath?: unknown }).normalizedPath === "string"
+      ? (validation.result as { normalizedPath: string }).normalizedPath
+      : null;
+  if (!validation || !normalizedPath) {
+    throw new CwdServiceError("STALE_TARGET", "Fresh successful validation required");
+  }
+  const connection = await prisma.daemonConnection.findFirst({
+    where: {
+      uuid: validation.targetConnectionUuid,
+      companyUuid: params.companyUuid,
+      agentUuid: params.agentUuid,
+      status: "online",
+    },
+    select: { host: true },
+  });
+  if (!connection) throw new CwdServiceError("HOST_OFFLINE", "Target host is offline");
+  return { host: connection.host, cwd: normalizedPath };
+}
+
+export async function createDirectoryRequest(params: {
+  companyUuid: string;
+  userUuid: string;
+  agentUuid: string;
+  targetConnectionUuid: string;
+  operation: DirectoryOperation;
+  prefix?: string;
+  cwd?: string;
+  cursor?: string;
+  limit?: number;
+}) {
+  await cleanupDirectoryRequests();
+  await requireOwnedAgent(params.companyUuid, params.userUuid, params.agentUuid);
+  if (params.operation === "list" && !params.prefix) {
+    throw new CwdServiceError("VALIDATION_ERROR", "prefix is required");
+  }
+  if (params.operation === "validate" && !params.cwd) {
+    throw new CwdServiceError("VALIDATION_ERROR", "cwd is required");
+  }
+  const connection = await prisma.daemonConnection.findFirst({
+    where: {
+      uuid: params.targetConnectionUuid,
+      companyUuid: params.companyUuid,
+      agentUuid: params.agentUuid,
+      status: "online",
+    },
+    select: { uuid: true, host: true, agentInstanceUuid: true },
+  });
+  if (!connection) throw new CwdServiceError("HOST_OFFLINE", "Target host is offline");
+
+  const now = new Date();
+  const request = await prisma.daemonDirectoryRequest.create({
+    data: {
+      companyUuid: params.companyUuid,
+      callerUserUuid: params.userUuid,
+      agentUuid: params.agentUuid,
+      targetConnectionUuid: connection.uuid,
+      operation: params.operation,
+      prefix: params.prefix ?? null,
+      cwd: params.cwd ?? null,
+      cursor: params.cursor ?? null,
+      limit: Math.max(1, Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT)),
+      deadlineAt: new Date(now.getTime() + REQUEST_TTL_MS),
+    },
+  });
+  eventBus.emit(controlEventName(connection.uuid), {
+    type: "control",
+    command: "browse_directory",
+    targetConnectionUuid: connection.uuid,
+    requestUuid: request.uuid,
+    operation: params.operation,
+    prefix: params.prefix,
+    cwd: params.cwd,
+    cursor: params.cursor,
+    limit: request.limit,
+    deadlineAt: request.deadlineAt.toISOString(),
+  });
+  return request;
+}
+
+export async function getDirectoryRequest(companyUuid: string, userUuid: string, uuid: string) {
+  const request = await prisma.daemonDirectoryRequest.findFirst({
+    where: { uuid, companyUuid, callerUserUuid: userUuid },
+  });
+  if (!request) throw new CwdServiceError("NOT_FOUND", "Directory request not found");
+  if (request.status === "pending" && request.deadlineAt <= new Date()) {
+    return prisma.daemonDirectoryRequest.update({
+      where: { uuid: request.uuid },
+      data: { status: "error", errorCode: "TIMEOUT", completedAt: new Date() },
+    });
+  }
+  return request;
+}
+
+export async function completeDirectoryRequest(params: {
+  companyUuid: string;
+  agentUuid: string;
+  connectionUuid: string;
+  requestUuid: string;
+  status: "success" | "error";
+  result?: unknown;
+  errorCode?: DirectoryErrorCode;
+}) {
+  const request = await prisma.daemonDirectoryRequest.findFirst({
+    where: {
+      uuid: params.requestUuid,
+      companyUuid: params.companyUuid,
+      agentUuid: params.agentUuid,
+      targetConnectionUuid: params.connectionUuid,
+      status: "pending",
+    },
+  });
+  if (!request) throw new CwdServiceError("NOT_FOUND", "Directory request not found");
+  if (request.deadlineAt <= new Date()) {
+    await prisma.daemonDirectoryRequest.update({
+      where: { uuid: request.uuid },
+      data: { status: "error", errorCode: "TIMEOUT", completedAt: new Date() },
+    });
+    throw new CwdServiceError("TIMEOUT", "Directory request timed out");
+  }
+  if (params.status === "error" && !params.errorCode) {
+    throw new CwdServiceError("VALIDATION_ERROR", "errorCode is required");
+  }
+  return prisma.daemonDirectoryRequest.update({
+    where: { uuid: request.uuid },
+    data: {
+      status: params.status,
+      result: params.status === "success" ? (params.result as object) : undefined,
+      errorCode: params.status === "error" ? params.errorCode : null,
+      completedAt: new Date(),
+    },
+  });
+}
+
+export async function saveProjectAgentCwdPreference(params: {
+  companyUuid: string;
+  userUuid: string;
+  projectUuid: string;
+  agentUuid: string;
+  validationRequestUuid: string;
+}) {
+  await Promise.all([
+    requireProject(params.companyUuid, params.projectUuid),
+    requireOwnedAgent(params.companyUuid, params.userUuid, params.agentUuid),
+  ]);
+  const freshAfter = new Date(Date.now() - VALIDATION_FRESH_MS);
+  const validation = await prisma.daemonDirectoryRequest.findFirst({
+    where: {
+      uuid: params.validationRequestUuid,
+      companyUuid: params.companyUuid,
+      callerUserUuid: params.userUuid,
+      agentUuid: params.agentUuid,
+      operation: "validate",
+      status: "success",
+      completedAt: { gte: freshAfter },
+    },
+  });
+  if (!validation?.cwd) {
+    throw new CwdServiceError("STALE_TARGET", "Fresh successful validation required");
+  }
+  const normalizedCwd =
+    validation.result &&
+    typeof validation.result === "object" &&
+    !Array.isArray(validation.result) &&
+    typeof (validation.result as { normalizedPath?: unknown }).normalizedPath === "string"
+      ? (validation.result as { normalizedPath: string }).normalizedPath
+      : null;
+  if (!normalizedCwd) {
+    throw new CwdServiceError("STALE_TARGET", "Validation result is missing normalized path");
+  }
+  const connection = await prisma.daemonConnection.findFirst({
+    where: {
+      uuid: validation.targetConnectionUuid,
+      companyUuid: params.companyUuid,
+      agentUuid: params.agentUuid,
+    },
+    select: { host: true, agentInstanceUuid: true },
+  });
+  if (!connection) throw new CwdServiceError("STALE_TARGET", "Validation target is stale");
+  return prisma.projectAgentCwdPreference.upsert({
+    where: {
+      userUuid_projectUuid_agentUuid: {
+        userUuid: params.userUuid,
+        projectUuid: params.projectUuid,
+        agentUuid: params.agentUuid,
+      },
+    },
+    create: {
+      companyUuid: params.companyUuid,
+      userUuid: params.userUuid,
+      projectUuid: params.projectUuid,
+      agentUuid: params.agentUuid,
+      host: connection.host,
+      cwd: normalizedCwd,
+      anchorAgentInstanceUuid: connection.agentInstanceUuid,
+    },
+    update: {
+      host: connection.host,
+      cwd: normalizedCwd,
+      anchorAgentInstanceUuid: connection.agentInstanceUuid,
+    },
+  });
+}
+
+export async function clearProjectAgentCwdPreference(params: {
+  companyUuid: string;
+  userUuid: string;
+  projectUuid: string;
+  agentUuid: string;
+}) {
+  await requireProject(params.companyUuid, params.projectUuid);
+  await prisma.projectAgentCwdPreference.deleteMany({
+    where: {
+      companyUuid: params.companyUuid,
+      userUuid: params.userUuid,
+      projectUuid: params.projectUuid,
+      agentUuid: params.agentUuid,
+    },
+  });
+}
+
+export async function cleanupDirectoryRequests(now = new Date()) {
+  return prisma.daemonDirectoryRequest.deleteMany({
+    where: {
+      OR: [
+        { deadlineAt: { lt: new Date(now.getTime() - 60 * 60 * 1000) } },
+        { completedAt: { lt: new Date(now.getTime() - 60 * 60 * 1000) } },
+      ],
+    },
+  });
+}

--- a/src/services/stage-advance.service.ts
+++ b/src/services/stage-advance.service.ts
@@ -166,11 +166,13 @@ export async function executeStageAdvance(
     ideaUuid,
     actorUuid,
     actorType,
+    temporaryCwd,
   }: {
     companyUuid: string;
     ideaUuid: string;
     actorUuid: string;
     actorType: string;
+    temporaryCwd?: { host: string; cwd: string } | null;
   }
 ): Promise<void> {
   // 1. Stage-advance is a human affordance. Agents keep their own paths (e.g.
@@ -206,7 +208,15 @@ export async function executeStageAdvance(
   };
 
   // 3. Per-stage precondition. Its return value becomes the activity payload.
-  const activityValue = await definition.precondition(ctx);
+  const activityValue = {
+    ...(await definition.precondition(ctx)),
+    ...(temporaryCwd
+      ? {
+          temporaryHost: temporaryCwd.host,
+          temporaryRuntimeCwd: temporaryCwd.cwd,
+        }
+      : {}),
+  };
 
   // 4. Offline policy. "queue" never blocks on liveness; "require_online"
   // resolves the assignee and demands a live connection. The check SPLITS on the

--- a/src/services/stage-advance.service.ts
+++ b/src/services/stage-advance.service.ts
@@ -253,7 +253,45 @@ export async function executeStageAdvance(
   //   - bare `agent`: the wake goes online-first, so ANY online connection of the agent
   //     suffices → AGENT_OFFLINE when none.
   if (definition.offlinePolicy === "require_online") {
-    if (ctx.idea.assigneeType === "agent_instance" && ctx.idea.assigneeUuid) {
+    const agentUuid = await resolveAssigneeAgentUuid(
+      companyUuid,
+      ctx.idea.assigneeType,
+      ctx.idea.assigneeUuid
+    );
+    if (!agentUuid) {
+      if (ctx.idea.assigneeType === "agent_instance") {
+        throw new StageAdvanceError(
+          "INSTANCE_OFFLINE",
+          "The Idea is pinned to a daemon instance that no longer exists"
+        );
+      }
+      throw new StageAdvanceError(
+        "ASSIGNEE_NOT_AGENT",
+        "The Idea's assignee is not an agent — there is no daemon to wake"
+      );
+    }
+
+    // Project fixed cwd is the highest-priority wake pin, including when the Idea
+    // itself is assigned to an AgentInstance. Match notification-turn's routing
+    // order so this gate checks the place the wake will actually target.
+    const fixedHostOnline = await hasEffectivelyOnlineFixedCwdHost(
+      companyUuid,
+      actorUuid,
+      ctx.idea.projectUuid,
+      agentUuid,
+    );
+    if (fixedHostOnline === false) {
+      throw new StageAdvanceError(
+        "FIXED_CWD_HOST_OFFLINE",
+        "The project's fixed cwd host has no online daemon connection"
+      );
+    }
+
+    if (
+      fixedHostOnline === null &&
+      ctx.idea.assigneeType === "agent_instance" &&
+      ctx.idea.assigneeUuid
+    ) {
       if (
         !(await hasEffectivelyOnlineInstance(companyUuid, ctx.idea.assigneeUuid))
       ) {
@@ -262,36 +300,14 @@ export async function executeStageAdvance(
           "The Idea is pinned to a daemon instance that has no online connection"
         );
       }
-    } else {
-      const agentUuid = await resolveAssigneeAgentUuid(
-        companyUuid,
-        ctx.idea.assigneeType,
-        ctx.idea.assigneeUuid
+    } else if (
+      fixedHostOnline === null &&
+      !(await hasEffectivelyOnlineConnection(agentUuid))
+    ) {
+      throw new StageAdvanceError(
+        "AGENT_OFFLINE",
+        "The assigned agent has no online daemon connection"
       );
-      if (!agentUuid) {
-        throw new StageAdvanceError(
-          "ASSIGNEE_NOT_AGENT",
-          "The Idea's assignee is not an agent — there is no daemon to wake"
-        );
-      }
-      const fixedHostOnline = await hasEffectivelyOnlineFixedCwdHost(
-        companyUuid,
-        actorUuid,
-        ctx.idea.projectUuid,
-        agentUuid,
-      );
-      if (fixedHostOnline === false) {
-        throw new StageAdvanceError(
-          "FIXED_CWD_HOST_OFFLINE",
-          "The project's fixed cwd host has no online daemon connection"
-        );
-      }
-      if (fixedHostOnline === null && !(await hasEffectivelyOnlineConnection(agentUuid))) {
-        throw new StageAdvanceError(
-          "AGENT_OFFLINE",
-          "The assigned agent has no online daemon connection"
-        );
-      }
     }
   }
 

--- a/src/services/stage-advance.service.ts
+++ b/src/services/stage-advance.service.ts
@@ -41,6 +41,7 @@ export type StageAdvanceErrorCode =
   | "PRECONDITION_FAILED"
   | "AGENT_OFFLINE"
   | "INSTANCE_OFFLINE"
+  | "FIXED_CWD_HOST_OFFLINE"
   | "ASSIGNEE_NOT_AGENT";
 
 export class StageAdvanceError extends Error {
@@ -106,6 +107,31 @@ async function hasEffectivelyOnlineConnection(agentUuid: string): Promise<boolea
   const online = await prisma.daemonConnection.findFirst({
     where: {
       agentUuid,
+      status: "online",
+      lastSeenAt: { gte: staleFloor },
+    },
+    select: { uuid: true },
+  });
+  return online !== null;
+}
+
+async function hasEffectivelyOnlineFixedCwdHost(
+  companyUuid: string,
+  userUuid: string,
+  projectUuid: string,
+  agentUuid: string,
+): Promise<boolean | null> {
+  const preference = await prisma.projectAgentCwdPreference.findFirst({
+    where: { companyUuid, userUuid, projectUuid, agentUuid },
+    select: { host: true },
+  });
+  if (!preference) return null;
+
+  const staleFloor = new Date(Date.now() - STALE_THRESHOLD_MS);
+  const online = await prisma.daemonConnection.findFirst({
+    where: {
+      agentUuid,
+      host: preference.host,
       status: "online",
       lastSeenAt: { gte: staleFloor },
     },
@@ -248,7 +274,19 @@ export async function executeStageAdvance(
           "The Idea's assignee is not an agent — there is no daemon to wake"
         );
       }
-      if (!(await hasEffectivelyOnlineConnection(agentUuid))) {
+      const fixedHostOnline = await hasEffectivelyOnlineFixedCwdHost(
+        companyUuid,
+        actorUuid,
+        ctx.idea.projectUuid,
+        agentUuid,
+      );
+      if (fixedHostOnline === false) {
+        throw new StageAdvanceError(
+          "FIXED_CWD_HOST_OFFLINE",
+          "The project's fixed cwd host has no online daemon connection"
+        );
+      }
+      if (fixedHostOnline === null && !(await hasEffectivelyOnlineConnection(agentUuid))) {
         throw new StageAdvanceError(
           "AGENT_OFFLINE",
           "The assigned agent has no online daemon connection"

--- a/src/services/start-development.service.ts
+++ b/src/services/start-development.service.ts
@@ -89,16 +89,19 @@ export async function startDevelopment({
   ideaUuid,
   actorUuid,
   actorType,
+  temporaryCwd,
 }: {
   companyUuid: string;
   ideaUuid: string;
   actorUuid: string;
   actorType: string;
+  temporaryCwd?: { host: string; cwd: string } | null;
 }): Promise<void> {
   await executeStageAdvance(START_DEVELOPMENT_STAGE, {
     companyUuid,
     ideaUuid,
     actorUuid,
     actorType,
+    temporaryCwd,
   });
 }

--- a/src/services/wake-preview.service.ts
+++ b/src/services/wake-preview.service.ts
@@ -108,6 +108,7 @@ function toInstanceCandidate(c: ConnectionView): InstanceCandidate {
 export async function previewIdeaWakeTarget(
   companyUuid: string,
   ideaUuid: string,
+  userUuid?: string,
 ): Promise<WakeTargetPreview | null> {
   // (1) The idea's assignee — company-scoped. A miss is a not-found (route → 404), NOT a
   // cross-company read: an idea in another tenant simply is not returned.
@@ -134,6 +135,25 @@ export async function previewIdeaWakeTarget(
   // Resolved BEFORE the connection read matters, but we still surface the agent's online
   // instances for completeness (the client ignores them on `direct`).
   const alreadyPinned = idea.assigneeType === "agent_instance";
+  const project =
+    userUuid && prisma.projectAgentCwdPreference
+      ? await prisma.idea.findFirst({
+          where: { uuid: ideaUuid, companyUuid },
+          select: { projectUuid: true },
+        })
+      : null;
+  const fixedPreference =
+    userUuid && project && prisma.projectAgentCwdPreference
+      ? await prisma.projectAgentCwdPreference.findFirst({
+          where: {
+            companyUuid,
+            userUuid,
+            projectUuid: project.projectUuid,
+            agentUuid: assigneeAgentUuid,
+          },
+          select: { uuid: true },
+        })
+      : null;
 
   // (2) The agent's live registry (online-first sorted; carries effectiveStatus + the
   // durable agentInstanceUuid). Take the ONLINE subset as the picker candidates —
@@ -145,7 +165,7 @@ export async function previewIdeaWakeTarget(
   const onlineInstances = onlineConnections.map(toInstanceCandidate);
 
   // (3) The three-way decision tree (Tech Design D1), in exact priority order.
-  if (alreadyPinned) {
+  if (fixedPreference || alreadyPinned) {
     // Already pinned to a specific instance → wake as-is.
     return { outcome: "direct", assigneeAgentUuid, onlineInstances };
   }

--- a/src/services/yolo-request.service.ts
+++ b/src/services/yolo-request.service.ts
@@ -53,16 +53,19 @@ export async function requestYolo({
   ideaUuid,
   actorUuid,
   actorType,
+  temporaryCwd,
 }: {
   companyUuid: string;
   ideaUuid: string;
   actorUuid: string;
   actorType: string;
+  temporaryCwd?: { host: string; cwd: string } | null;
 }): Promise<void> {
   await executeStageAdvance(YOLO_REQUESTED_STAGE, {
     companyUuid,
     ideaUuid,
     actorUuid,
     actorType,
+    temporaryCwd,
   });
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     reporters: process.env.GITHUB_ACTIONS === 'true' ? ['default', 'github-actions'] : ['default'],
     globals: true,
     environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/__tests__/**/*.test.{ts,tsx}', 'cli/**/__tests__/**/*.test.mjs'],
     exclude: ['node_modules', '.next', 'packages'],
     coverage: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,14 @@
+import { beforeAll } from "vitest";
+
+const nativeProcessKill = process.kill.bind(process);
+
+beforeAll(() => {
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    if (signal === 0) {
+      return nativeProcessKill(pid, signal);
+    }
+    throw new Error(
+      `Tests must inject a process-kill mock instead of sending ${String(signal)} to pid ${pid}`,
+    );
+  }) as typeof process.kill;
+});


### PR DESCRIPTION
## Summary
- add daemon-scoped safe directory discovery with browse roots, typed terminal errors, limits, and correlated request handling
- add per-user, per-project, per-Agent fixed cwd preferences plus Project Settings management
- route temporary and fixed runtime cwd consistently through wake, spawn, resume, and continuation
- add API, migration, i18n, documentation, OpenSpec archive, unit/integration tests, and browser verification

## Test plan
- [x] Production Next.js build and TypeScript checks pass
- [x] Aggregate reviewer suite passes (194 tests)
- [x] Focused daemon, service, API, routing, and UI tests pass
- [x] Production OIDC browser verification covers discovery, save, availability, and clear
- [x] Playwright verifies temporary "Browse another directory" and mobile no-overflow
- [x] OpenSpec cumulative documents pass byte-for-byte round-trip verification

## Deployment
- Deployed and health-checked at `https://chorus.yfeichen.people.amazon.dev`

Generated with OpenAI Codex