### PR TITLE
feat: add daemon directory autocomplete

### DIFF
--- a/cli/__tests__/control-handler.test.mjs
+++ b/cli/__tests__/control-handler.test.mjs
@@ -359,6 +359,26 @@ describe("control-handler browse_directory", () => {
     });
   });
 
+  it("reports effective roots from the targeted connection", async () => {
+    const handleDirectoryRequest = vi.fn(async () => ({ roots: ["/work", "/opt"] }));
+    const reportDirectoryRequest = vi.fn(async () => {});
+    const onControl = createControlHandler({
+      waker: makeWaker([]),
+      getConnectionUuid: () => CONN,
+      handleDirectoryRequest,
+      reportDirectoryRequest,
+      logger: silent,
+    });
+    onControl({
+      type: "control", command: "browse_directory", targetConnectionUuid: CONN,
+      requestUuid: "roots-1", operation: "roots",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(reportDirectoryRequest).toHaveBeenCalledWith({
+      requestUuid: "roots-1", status: "succeeded", roots: ["/work", "/opt"],
+    });
+  });
+
   it("reports stable failures and ignores stale targets", async () => {
     const error = Object.assign(new Error("outside"), { code: "OUTSIDE_ROOT" });
     const handleDirectoryRequest = vi.fn(async () => { throw error; });

--- a/cli/daemon-rest-client.mjs
+++ b/cli/daemon-rest-client.mjs
@@ -75,7 +75,7 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
  *   executionState: (p: { executions: Array<Record<string, unknown>> }) => Promise<DaemonRestResult>,
  *   reportInterrupt: (p: { entityType: string, entityUuid: string, reason: string }) => Promise<DaemonRestResult>,
  *   heartbeat: (p: { connectionUuid: string, connectedAt: string }) => Promise<DaemonRestResult>,
- *   reportDirectoryRequest: (p: { requestUuid: string, status: "succeeded"|"failed", items?: Array<{name:string,path:string}>, nextCursor?: string|null, normalizedPath?: string, errorCode?: string }) => Promise<DaemonRestResult>,
+ *   reportDirectoryRequest: (p: { requestUuid: string, status: "succeeded"|"failed", roots?: string[], items?: Array<{name:string,path:string}>, nextCursor?: string|null, normalizedPath?: string, errorCode?: string }) => Promise<DaemonRestResult>,
  *   readPendingTurns: () => Promise<DaemonRestResult>,
  * }}
  */
@@ -256,7 +256,7 @@ export function createDaemonRestClient(opts) {
       );
     },
 
-    async reportDirectoryRequest({ requestUuid, status, items, nextCursor, normalizedPath, errorCode }) {
+    async reportDirectoryRequest({ requestUuid, status, roots, items, nextCursor, normalizedPath, errorCode }) {
       const connectionUuid = getConnectionUuid();
       if (!connectionUuid) {
         const error = `cannot report directory request ${requestUuid} — no connection uuid yet`;
@@ -265,6 +265,7 @@ export function createDaemonRestClient(opts) {
       }
       const body = { requestUuid, connectionUuid, status };
       if (status === "succeeded") {
+        if (roots !== undefined) body.roots = roots;
         if (items !== undefined) body.items = items;
         if (nextCursor !== undefined) body.nextCursor = nextCursor;
         if (normalizedPath !== undefined) body.normalizedPath = normalizedPath;

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -375,6 +375,9 @@ export function buildDaemon(creds, deps = {}) {
       redispatchResume,
       deliverTurn,
       handleDirectoryRequest: async (event) => {
+        if (event.operation === "roots") {
+          return { roots: [...browseRoots] };
+        }
         if (event.operation === "validate") {
           return validateDirectory({ cwd: event.cwd, browseRoots });
         }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1695,6 +1695,7 @@
   },
   "directoryBrowser": {
     "chooseHost": "Choose a host", "unknownHost": "Unknown host", "pathPrefix": "Directory path prefix", "pathPlaceholder": "/home/user/project",
+    "browseRoot": "Browse root", "loadingRoots": "Loading allowed roots…", "loadingCandidates": "Loading directory suggestions", "parent": "Go to parent directory",
     "browse": "Browse directories", "noHosts": "No online host is available for this Agent.", "empty": "No matching directories.", "selection": "Selected directory",
     "errors": {
       "HOST_OFFLINE": "The selected host is offline. Choose another host.", "TIMEOUT": "The host did not respond. Try again.", "INVALID_PATH": "Enter a valid absolute path.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1695,6 +1695,7 @@
   },
   "directoryBrowser": {
     "chooseHost": "ホストを選択", "unknownHost": "不明なホスト", "pathPrefix": "ディレクトリパスの接頭辞", "pathPlaceholder": "/home/user/project",
+    "browseRoot": "参照ルート", "loadingRoots": "許可されたルートを読み込み中…", "loadingCandidates": "ディレクトリ候補を読み込み中", "parent": "親ディレクトリへ移動",
     "browse": "ディレクトリを参照", "noHosts": "この Agent にオンラインのホストがありません。", "empty": "一致するディレクトリがありません。", "selection": "選択したディレクトリ",
     "errors": {
       "HOST_OFFLINE": "選択したホストはオフラインです。別のホストを選択してください。", "TIMEOUT": "ホストが応答しませんでした。再試行してください。", "INVALID_PATH": "有効な絶対パスを入力してください。",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1695,6 +1695,7 @@
   },
   "directoryBrowser": {
     "chooseHost": "호스트 선택", "unknownHost": "알 수 없는 호스트", "pathPrefix": "디렉터리 경로 접두사", "pathPlaceholder": "/home/user/project",
+    "browseRoot": "탐색 루트", "loadingRoots": "허용된 루트를 불러오는 중…", "loadingCandidates": "디렉터리 제안을 불러오는 중", "parent": "상위 디렉터리로 이동",
     "browse": "디렉터리 찾아보기", "noHosts": "이 Agent에 온라인 호스트가 없습니다.", "empty": "일치하는 디렉터리가 없습니다.", "selection": "선택한 디렉터리",
     "errors": {
       "HOST_OFFLINE": "선택한 호스트가 오프라인입니다. 다른 호스트를 선택하세요.", "TIMEOUT": "호스트가 응답하지 않았습니다. 다시 시도하세요.", "INVALID_PATH": "유효한 절대 경로를 입력하세요.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1695,6 +1695,7 @@
   },
   "directoryBrowser": {
     "chooseHost": "选择主机", "unknownHost": "未知主机", "pathPrefix": "目录路径前缀", "pathPlaceholder": "/home/user/project",
+    "browseRoot": "浏览根目录", "loadingRoots": "正在加载允许的根目录…", "loadingCandidates": "正在加载目录建议", "parent": "返回上一级目录",
     "browse": "浏览目录", "noHosts": "此 Agent 暂无在线主机。", "empty": "没有匹配的目录。", "selection": "已选目录",
     "errors": {
       "HOST_OFFLINE": "所选主机已离线，请选择其他主机。", "TIMEOUT": "主机未响应，请重试。", "INVALID_PATH": "请输入有效的绝对路径。",

--- a/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/README.md
+++ b/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/README.md
@@ -1,0 +1,3 @@
+# improve-daemon-directory-autocomplete
+
+Prefill daemon browse roots and provide race-safe path-prefix autocomplete in fixed and temporary cwd pickers

--- a/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/design.md
+++ b/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/design.md
@@ -1,0 +1,125 @@
+# Design: daemon root prefill and path-prefix autocomplete
+
+## Context
+
+`DirectoryBrowser` is already shared by project settings and the temporary wake
+cwd picker. It currently derives hosts from online instances, starts with an
+empty path, and sends `list` only after Enter or a search-button click. The
+server persists and correlates `list` and `validate` requests, while the daemon
+alone knows the effective `browseRoots` that bound discovery.
+
+The root list must therefore come from the live daemon, not from startup cwd
+instances, client inference, or a server-configured fallback.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Make the valid starting roots discoverable without weakening daemon ownership.
+- Make completion responsive under fast typing and out-of-order responses.
+- Keep fixed and temporary cwd flows behaviorally identical.
+- Preserve bounded one-level results and fresh validation before use.
+- Support keyboard, IME, and narrow mobile viewports.
+
+### Non-Goals
+
+- Persisting a user's last selected root.
+- Returning an unbounded directory listing.
+- Adding fuzzy search, file discovery, hidden paths, symlink traversal, or
+  server-side browse-root configuration.
+- Replacing the persisted directory-request transport.
+
+## Architecture
+
+### Correlated effective-root request
+
+Extend `DirectoryOperation` and the directory request API with `roots`. A roots
+request carries the same user, Agent, target connection, deadline, and report
+authentication as `list` and `validate`, but no client path. The daemon returns
+only its normalized effective roots in configured order.
+
+The server does not cache or merge root lists. Switching host creates a new
+request. Offline, timeout, stale-target, and internal failures use the existing
+typed terminal states. This keeps the displayed roots aligned with the daemon
+that will later list and validate the path.
+
+### Shared autocomplete state machine
+
+Keep one `DirectoryBrowser` for both callers. Its state is keyed by selected
+connection:
+
+- `loadingRoots`, `ready`, `loadingCandidates`, `validating`, or `error`
+- effective roots and selected root
+- editable full path and the current basename prefix
+- candidate page and highlighted candidate index
+- monotonically increasing query generation
+
+Selecting a host invalidates all prior generations, clears candidates and
+selection, requests roots, and initializes the path from the first root.
+Changing roots performs the same invalidation without querying candidates.
+
+Candidate requests start only when the path is inside the selected root and the
+current basename has at least one character. Input changes wait 250 ms. Each
+effect cleanup aborts its fetch/poll loop where supported and increments the
+generation. A completion updates visible state only when connection, root,
+prefix, and generation still match.
+
+The request uses the backend's bounded default limit and does not auto-fetch
+additional pages. Users narrow the prefix to refine results.
+
+### Combobox interaction
+
+The path input owns an ARIA combobox and controls a listbox. The first returned
+candidate is highlighted by default. Arrow keys move the highlight, `Tab`
+accepts the highlighted candidate, `Enter` selects it, and `Escape` closes the
+list. IME composition suppresses completion commands.
+
+Selecting a candidate writes its full path plus the platform separator and
+prepares the next level. Because an empty basename does not query, the user
+types the next first character before another request. A parent-directory
+control clamps navigation to the selected root. Mobile users tap candidates and
+the same parent control; path text wraps or scrolls without widening dialogs.
+
+### Validation and errors
+
+Candidate selection is not sufficient to save or run. The existing `validate`
+operation remains the final gate and returns the normalized path. Loading roots,
+loading candidates, empty candidates, offline, timeout, invalid, outside-root,
+access-denied, stale-target, limit, and internal states remain distinguishable.
+Errors from an obsolete generation are discarded rather than replacing current
+results.
+
+## API and Module Contracts
+
+- `DirectoryOperation = "roots" | "list" | "validate"`.
+- `roots` success result: `{ roots: string[] }`, in daemon effective order.
+- A successful roots result MUST contain at least one normalized root; malformed
+  success payloads map to `INTERNAL_ERROR`.
+- `list` retains `{ items, nextCursor? }` and the existing server-side limit.
+- `DirectoryBrowser` receives online instances and emits only a freshly
+  validated `ValidatedDirectory`; callers do not implement root or completion
+  state themselves.
+- Both entry points retain their existing final action: project settings saves
+  a preference, while the wake picker passes a one-operation validation UUID.
+
+## Implementation Plan
+
+1. Extend daemon and server request contracts with `roots`, including
+   authorization, correlation, timeout, and protocol tests.
+2. Refactor `DirectoryBrowser` around a cancellable query generation and
+   accessible combobox state machine.
+3. Update both consumers, translations, focused component tests, and browser
+   coverage across desktop and mobile.
+
+## Risks and Mitigations
+
+- **Root disclosure expands accidentally:** return only the live daemon's
+  effective allowlist through the already authorized target connection.
+- **Old polling loops overwrite new input:** guard every transition by
+  connection, prefix, and generation in addition to aborting work.
+- **`Tab` breaks normal focus traversal:** prevent default only when a visible
+  highlighted candidate is accepted; otherwise preserve native focus behavior.
+- **Path separators vary by host:** treat daemon-normalized roots and candidate
+  paths as opaque and derive navigation from returned paths, not local OS APIs.
+- **Large roots produce noisy results:** retain the bounded server limit and
+  require one basename character before listing.

--- a/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/proposal.md
+++ b/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/proposal.md
@@ -1,0 +1,46 @@
+# Improve daemon directory autocomplete
+
+## Why
+
+The shipped daemon directory picker requires users to guess an allowed absolute
+root, type a prefix, and explicitly submit each browse request. This exposes the
+backend capability but makes both project cwd configuration and temporary cwd
+selection slow and error-prone. The UI also has no race policy for overlapping
+requests, so converting the current button flow directly to input-driven
+requests would allow stale results and request storms.
+
+## What Changes
+
+- Add an authorized, correlated directory request operation that returns the
+  selected daemon's currently effective `browseRoots`.
+- Prefill the only root automatically; for multiple roots, select the first
+  daemon-provided root by default and expose an explicit root selector.
+- Replace manual browse submission with bounded path-prefix autocomplete after
+  the first basename character.
+- Debounce input by 250 ms, cancel client work where possible, correlate each
+  request with its prefix, and ignore every stale response.
+- Provide standard combobox keyboard behavior, including an initially
+  highlighted first result and `Tab` acceptance, plus mobile-safe selection and
+  navigation to the parent directory.
+- Reuse one directory browser component and state contract in project fixed-cwd
+  settings and one-operation temporary cwd selection.
+- Preserve the daemon's existing normalization, containment, omission, result
+  limit, typed error, and fresh validation guarantees.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `daemon-directory-discovery`: expose effective roots through the existing
+  correlated control path and define bounded, race-safe prefix-completion
+  consumption.
+- `project-agent-cwd`: use the same root-aware autocomplete interaction in the
+  fixed and temporary cwd entry points.
+
+## Impact
+
+The change affects the daemon directory control command, directory-request API
+and service types, the shared `DirectoryBrowser`, project settings, the
+temporary wake cwd picker, localization, and focused service/component/browser
+tests. It does not change `browseRoots` ownership, create startup connections,
+expand filesystem visibility, or alter runtime-cwd routing.

--- a/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/specs/daemon-directory-discovery/spec.md
+++ b/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/specs/daemon-directory-discovery/spec.md
@@ -1,18 +1,4 @@
-# daemon-directory-discovery Specification
-
-## Purpose
-TBD - created by archiving change add-project-agent-cwd-discovery. Update Purpose after archive.
-## Requirements
-### Requirement: Daemon browse-root configuration
-The daemon SHALL resolve a host-local directory-discovery allowlist independently from startup `cwds`, using `--browse-root` over `CHORUS_DAEMON_BROWSE_ROOTS` over `~/.chorus/daemon.json` `browseRoots` over the daemon OS user's home directory. `chorus daemon install --browse-root` SHALL persist normalized roots through the existing owner-only field-merge configuration writer, and changes SHALL take effect after daemon restart.
-
-#### Scenario: No browse roots are configured
-- **WHEN** a daemon starts without a browse-root flag, environment value, or stored value
-- **THEN** its effective browse root MUST be the daemon OS user's home directory
-
-#### Scenario: Browse roots do not become startup connections
-- **WHEN** a path is configured only as a browse root
-- **THEN** the daemon MUST NOT register that path as a startup cwd or create an online Agent instance for it
+## MODIFIED Requirements
 
 ### Requirement: Correlated remote directory requests
 The server SHALL authorize and persist each roots, list, or validate request,
@@ -60,11 +46,3 @@ basename character before automatically issuing a list request.
 - **WHEN** a user types the first basename character under a selected browse root
 - **THEN** the client MUST request only the bounded first result page
 - **AND** further characters MUST refine the prefix instead of causing unbounded enumeration
-
-### Requirement: Stable discovery failures
-Directory discovery SHALL expose stable error codes for offline host, timeout, invalid path, outside root, non-directory, access denied, stale target, limit exceeded, and internal failure. An error MUST NOT be represented as an empty successful result.
-
-#### Scenario: Empty directory versus failed request
-- **WHEN** an accessible directory has no matching children
-- **THEN** the request MUST succeed with an empty items array
-- **AND** when the scan fails it MUST instead return the corresponding typed error

--- a/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/specs/project-agent-cwd/spec.md
+++ b/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/specs/project-agent-cwd/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Project settings is the management surface
+Project settings SHALL include an Agent working-directory section that shows
+each Agent's fixed path, host, and validity state and supports selecting,
+explicitly saving, replacing, and clearing the preference. Selection SHALL
+choose an online Agent instance or host before requesting that daemon's
+effective browse roots. A single root SHALL be prefilled; when multiple roots
+exist, the first daemon-provided root SHALL be selected by default and the user
+MUST be able to switch roots.
+
+#### Scenario: User saves a discovered cwd
+- **WHEN** the user chooses an online host, completes an allowed directory path, and confirms Save
+- **THEN** Chorus MUST freshly validate the directory on that daemon and persist the preference only after validation succeeds
+
+#### Scenario: Host exposes one browse root
+- **WHEN** the selected daemon returns exactly one effective browse root
+- **THEN** project settings MUST prefill that root without requiring the user to guess or type it
+
+#### Scenario: Host exposes multiple browse roots
+- **WHEN** the selected daemon returns multiple effective browse roots
+- **THEN** project settings MUST select the first returned root by default
+- **AND** it MUST provide an explicit control for switching to another returned root
+
+#### Scenario: Fixed cwd becomes unavailable
+- **WHEN** the stored host is offline or the directory no longer validates
+- **THEN** project settings MUST show a distinguishable invalid or offline state and offer replace or clear actions
+
+## ADDED Requirements
+
+### Requirement: Shared cwd path autocomplete
+Project fixed-cwd settings and one-operation temporary cwd selection SHALL use
+one shared root-aware path autocomplete behavior. After the user types the first
+basename character, the client MUST debounce list requests by 250 ms, cancel
+obsolete client work where supported, and discard any response whose
+connection, root, prefix, or request generation is no longer current. Loading,
+empty, offline, timeout, invalid, outside-root, access-denied, stale-target,
+limit, and internal states MUST remain distinguishable.
+
+#### Scenario: User types and deletes quickly
+- **WHEN** multiple prefixes are produced before earlier requests finish
+- **THEN** only the newest prefix result or error MUST be rendered
+- **AND** obsolete results MUST NOT flash back into the candidate list
+
+#### Scenario: Candidates become available
+- **WHEN** a bounded candidate page is returned for the current prefix
+- **THEN** the first candidate MUST be highlighted by default
+- **AND** arrow keys MUST move the highlight, `Tab` MUST accept the highlighted candidate, `Enter` MUST select it, and `Escape` MUST close the list
+
+#### Scenario: No candidate is highlighted
+- **WHEN** the candidate list is closed or empty
+- **THEN** `Tab` MUST preserve normal focus navigation
+
+#### Scenario: User selects a candidate
+- **WHEN** a user selects the highlighted or tapped candidate
+- **THEN** the full path MUST update to that directory
+- **AND** the user MUST be able to type the next basename character or navigate back to the parent without leaving the selected root
+
+#### Scenario: User composes text with an IME
+- **WHEN** a keyboard event occurs during active IME composition
+- **THEN** the event MUST NOT accidentally accept or validate a directory
+
+#### Scenario: Temporary cwd picker consumes autocomplete
+- **WHEN** a user browses another directory for one operation
+- **THEN** the temporary picker MUST expose the same root, candidate, keyboard, mobile, loading, empty, error, and race behavior as project settings
+- **AND** only the final action MUST differ by using the validation for one operation instead of saving a preference

--- a/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/tasks.md
+++ b/openspec/changes/archive/2026-08-02-improve-daemon-directory-autocomplete/tasks.md
@@ -1,0 +1,17 @@
+## 1. Effective browse-root protocol
+
+- [ ] Extend directory operations with a correlated roots request.
+- [ ] Return only the selected daemon's effective normalized roots.
+- [ ] Cover authorization, offline, timeout, malformed result, and no-cache behavior.
+
+## 2. Shared path autocomplete
+
+- [ ] Refactor `DirectoryBrowser` to load roots and prefill the default root.
+- [ ] Add 250 ms debounce, abort/generation guards, bounded candidates, and stale-result rejection.
+- [ ] Implement accessible keyboard, IME, parent-navigation, and mobile behavior.
+
+## 3. Consumer integration and verification
+
+- [ ] Keep project fixed-cwd and temporary cwd consumers on the shared component.
+- [ ] Add localized loading, empty, root, and typed-error states.
+- [ ] Verify single/multiple roots, races, keyboard, mobile, validation, and both final actions.

--- a/openspec/specs/project-agent-cwd/spec.md
+++ b/openspec/specs/project-agent-cwd/spec.md
@@ -29,12 +29,18 @@ MUST be able to switch roots.
 
 #### Scenario: Host exposes one browse root
 - **WHEN** the selected daemon returns exactly one effective browse root
-- **THEN** project settings MUST prefill that root without requiring the user to guess or type it
+- **THEN** project settings MUST prefill that root with its trailing platform separator without requiring the user to guess or type it
 
 #### Scenario: Host exposes multiple browse roots
 - **WHEN** the selected daemon returns multiple effective browse roots
 - **THEN** project settings MUST select the first returned root by default
 - **AND** it MUST provide an explicit control for switching to another returned root
+- **AND** the path input MUST include the selected root's trailing platform separator
+
+#### Scenario: Browse roots are unavailable
+- **WHEN** the roots request fails, returns no usable roots, or targets an older daemon without roots support
+- **THEN** the directory picker MUST fall back to an editable manual path
+- **AND** the user MUST still be able to validate and confirm that path without autocomplete
 
 #### Scenario: Fixed cwd becomes unavailable
 - **WHEN** the stored host is offline or the directory no longer validates
@@ -101,6 +107,7 @@ limit, and internal states MUST remain distinguishable.
 - **WHEN** a bounded candidate page is returned for the current prefix
 - **THEN** the first candidate MUST be highlighted by default
 - **AND** arrow keys MUST move the highlight, `Tab` MUST accept the highlighted candidate, `Enter` MUST select it, and `Escape` MUST close the list
+- **AND** keyboard navigation MUST scroll the highlighted candidate into the listbox viewport
 
 #### Scenario: No candidate is highlighted
 - **WHEN** the candidate list is closed or empty

--- a/openspec/specs/project-agent-cwd/spec.md
+++ b/openspec/specs/project-agent-cwd/spec.md
@@ -15,15 +15,30 @@ Chorus SHALL let each user persist at most one fixed cwd for each `(project, Age
 - **THEN** the second user MUST retain the unconfigured behavior
 
 ### Requirement: Project settings is the management surface
-Project settings SHALL include an Agent working-directory section that shows each Agent's fixed path, host, and validity state and supports selecting, explicitly saving, replacing, and clearing the preference. Selection SHALL choose an online Agent instance/host before browsing that daemon's allowed directories.
+Project settings SHALL include an Agent working-directory section that shows
+each Agent's fixed path, host, and validity state and supports selecting,
+explicitly saving, replacing, and clearing the preference. Selection SHALL
+choose an online Agent instance or host before requesting that daemon's
+effective browse roots. A single root SHALL be prefilled; when multiple roots
+exist, the first daemon-provided root SHALL be selected by default and the user
+MUST be able to switch roots.
 
 #### Scenario: User saves a discovered cwd
-- **WHEN** the user chooses an online host, browses to an allowed directory, and confirms Save
+- **WHEN** the user chooses an online host, completes an allowed directory path, and confirms Save
 - **THEN** Chorus MUST freshly validate the directory on that daemon and persist the preference only after validation succeeds
+
+#### Scenario: Host exposes one browse root
+- **WHEN** the selected daemon returns exactly one effective browse root
+- **THEN** project settings MUST prefill that root without requiring the user to guess or type it
+
+#### Scenario: Host exposes multiple browse roots
+- **WHEN** the selected daemon returns multiple effective browse roots
+- **THEN** project settings MUST select the first returned root by default
+- **AND** it MUST provide an explicit control for switching to another returned root
 
 #### Scenario: Fixed cwd becomes unavailable
 - **WHEN** the stored host is offline or the directory no longer validates
-- **THEN** project settings MUST show a distinguishable invalid/offline state and offer replace or clear actions
+- **THEN** project settings MUST show a distinguishable invalid or offline state and offer replace or clear actions
 
 ### Requirement: Fixed cwd is sticky until cleared
 A valid fixed project-Agent cwd SHALL be the authoritative cwd for that user's project workflows across all instances of that Agent. Those workflows MUST NOT prompt for or accept an inline temporary override while the preference exists. Clearing the preference SHALL restore temporary or existing instance selection.
@@ -67,3 +82,40 @@ Projects without a fixed preference and sessions without a runtime cwd SHALL pre
 #### Scenario: Existing project has no preferences
 - **WHEN** the feature is deployed for an existing project
 - **THEN** its wake and assignment behavior MUST remain unchanged until a user saves a preference
+
+### Requirement: Shared cwd path autocomplete
+Project fixed-cwd settings and one-operation temporary cwd selection SHALL use
+one shared root-aware path autocomplete behavior. After the user types the first
+basename character, the client MUST debounce list requests by 250 ms, cancel
+obsolete client work where supported, and discard any response whose
+connection, root, prefix, or request generation is no longer current. Loading,
+empty, offline, timeout, invalid, outside-root, access-denied, stale-target,
+limit, and internal states MUST remain distinguishable.
+
+#### Scenario: User types and deletes quickly
+- **WHEN** multiple prefixes are produced before earlier requests finish
+- **THEN** only the newest prefix result or error MUST be rendered
+- **AND** obsolete results MUST NOT flash back into the candidate list
+
+#### Scenario: Candidates become available
+- **WHEN** a bounded candidate page is returned for the current prefix
+- **THEN** the first candidate MUST be highlighted by default
+- **AND** arrow keys MUST move the highlight, `Tab` MUST accept the highlighted candidate, `Enter` MUST select it, and `Escape` MUST close the list
+
+#### Scenario: No candidate is highlighted
+- **WHEN** the candidate list is closed or empty
+- **THEN** `Tab` MUST preserve normal focus navigation
+
+#### Scenario: User selects a candidate
+- **WHEN** a user selects the highlighted or tapped candidate
+- **THEN** the full path MUST update to that directory
+- **AND** the user MUST be able to type the next basename character or navigate back to the parent without leaving the selected root
+
+#### Scenario: User composes text with an IME
+- **WHEN** a keyboard event occurs during active IME composition
+- **THEN** the event MUST NOT accidentally accept or validate a directory
+
+#### Scenario: Temporary cwd picker consumes autocomplete
+- **WHEN** a user browses another directory for one operation
+- **THEN** the temporary picker MUST expose the same root, candidate, keyboard, mobile, loading, empty, error, and race behavior as project settings
+- **AND** only the final action MUST differ by using the validation for one operation instead of saving a preference

--- a/src/app/api/daemon-directory-requests/__tests__/route.test.ts
+++ b/src/app/api/daemon-directory-requests/__tests__/route.test.ts
@@ -68,6 +68,24 @@ describe("POST /api/daemon-directory-requests", () => {
     });
   });
 
+  it("accepts roots without forwarding a client-provided path", async () => {
+    createDirectoryRequest.mockResolvedValue({ uuid: "roots-1", status: "pending" });
+    const roots = {
+      operation: "roots",
+      agentUuid: "agent-1",
+      targetConnectionUuid: "conn-1",
+    };
+    const response = await POST(request({ ...roots, prefix: "/client-root" }), {
+      params: Promise.resolve({}),
+    });
+    expect(response.status).toBe(200);
+    expect(createDirectoryRequest).toHaveBeenCalledWith({
+      companyUuid: "company-1",
+      userUuid: "user-1",
+      ...roots,
+    });
+  });
+
   it("returns stable typed failures and rejects malformed operations", async () => {
     createDirectoryRequest.mockRejectedValue(
       new CwdServiceError("HOST_OFFLINE", "Target host is offline"),

--- a/src/app/api/daemon-directory-requests/route.ts
+++ b/src/app/api/daemon-directory-requests/route.ts
@@ -10,6 +10,11 @@ import {
 
 const schema = z.discriminatedUnion("operation", [
   z.object({
+    operation: z.literal("roots"),
+    agentUuid: z.string().min(1),
+    targetConnectionUuid: z.string().min(1),
+  }),
+  z.object({
     operation: z.literal("list"),
     agentUuid: z.string().min(1),
     targetConnectionUuid: z.string().min(1),

--- a/src/app/api/daemon/directory-request/report/route.ts
+++ b/src/app/api/daemon/directory-request/report/route.ts
@@ -14,6 +14,7 @@ const schema = z.discriminatedUnion("status", [
     requestUuid: z.string().min(1),
     connectionUuid: z.string().min(1),
     status: z.literal("succeeded"),
+    roots: z.unknown().optional(),
     items: z.array(z.object({ name: z.string(), path: z.string() })).optional(),
     nextCursor: z.string().nullable().optional(),
     normalizedPath: z.string().optional(),
@@ -44,6 +45,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
         ? {
             status: "success" as const,
             result: {
+              ...(body.roots !== undefined ? { roots: body.roots } : {}),
               items: body.items ?? [],
               nextCursor: body.nextCursor ?? null,
               normalizedPath: body.normalizedPath,

--- a/src/components/agent-presence/__tests__/directory-browser.test.tsx
+++ b/src/components/agent-presence/__tests__/directory-browser.test.tsx
@@ -52,7 +52,7 @@ async function loadRoot(fetchMock: ReturnType<typeof vi.fn>, roots = ["/work"]) 
   renderBrowser();
   await waitFor(() => {
     expect((screen.getByRole("combobox", { name: "pathPrefix" }) as HTMLInputElement).value)
-      .toBe(roots[0]);
+      .toBe(`${roots[0]}/`);
   });
 }
 
@@ -62,6 +62,7 @@ describe("DirectoryBrowser", () => {
   });
 
   afterEach(() => {
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView;
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -96,12 +97,56 @@ describe("DirectoryBrowser", () => {
     const root = await screen.findByRole("combobox", { name: "browseRoot" });
     expect((root as HTMLSelectElement).value).toBe("/work");
     expect((screen.getByRole("combobox", { name: "pathPrefix" }) as HTMLInputElement).value)
-      .toBe("/work");
+      .toBe("/work/");
 
     fireEvent.change(root, { target: { value: "/opt" } });
     expect((screen.getByRole("combobox", { name: "pathPrefix" }) as HTMLInputElement).value)
-      .toBe("/opt");
+      .toBe("/opt/");
     expect(document.getElementById("directory-candidates")).toBeNull();
+  });
+
+  it("uses the root platform separator when prefilling the path", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockImplementationOnce(() => success({ roots: ["C:\\work"] }));
+    renderBrowser();
+
+    await waitFor(() => {
+      expect((screen.getByRole("combobox", { name: "pathPrefix" }) as HTMLInputElement).value)
+        .toBe("C:\\work\\");
+    });
+  });
+
+  it("falls back to manual path validation when roots are unavailable", async () => {
+    const fetchMock = vi.fn();
+    const onValidated = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockImplementationOnce(() => Promise.resolve({
+      ok: false,
+      json: async () => ({ success: false, error: { code: "INTERNAL_ERROR" } }),
+    }));
+    renderBrowser([instance], onValidated);
+
+    const input = await screen.findByRole("combobox", { name: "pathPrefix" });
+    expect(input.getAttribute("aria-autocomplete")).toBe("none");
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    fireEvent.change(input, { target: { value: "/legacy/project" } });
+    fetchMock.mockImplementationOnce(() =>
+      success({ normalizedPath: "/legacy/project" }, "validation-legacy"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(onValidated).toHaveBeenCalledWith(expect.objectContaining({
+        cwd: "/legacy/project",
+        validationRequestUuid: "validation-legacy",
+      }));
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+      operation: "validate",
+      cwd: "/legacy/project",
+    });
   });
 
   it("discards stale success and stale error responses", async () => {
@@ -170,6 +215,40 @@ describe("DirectoryBrowser", () => {
     fireEvent.keyDown(input, { key: "Tab" });
     expect((input as HTMLInputElement).value).toBe("/work/repo/");
     expect(screen.getByText("/work/repo")).not.toBeNull();
+  });
+
+  it("scrolls the keyboard-highlighted candidate into view", async () => {
+    const fetchMock = vi.fn();
+    const scrollIntoView = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    await loadRoot(fetchMock);
+    fetchMock.mockImplementationOnce(() =>
+      success({
+        items: Array.from({ length: 12 }, (_, index) => ({
+          name: `repo-${index}`,
+          path: `/work/repo-${index}`,
+        })),
+      }),
+    );
+    const input = screen.getByRole("combobox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/work/r" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    await screen.findAllByRole("option");
+    scrollIntoView.mockClear();
+
+    for (let index = 0; index < 6; index += 1) {
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+    }
+
+    await waitFor(() => {
+      expect(document.getElementById("directory-candidate-6")?.getAttribute("aria-selected"))
+        .toBe("true");
+      expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest" });
+    });
   });
 
   it("preserves Tab and ignores completion keys during IME composition", async () => {

--- a/src/components/agent-presence/__tests__/directory-browser.test.tsx
+++ b/src/components/agent-presence/__tests__/directory-browser.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -16,55 +16,249 @@ const instance = {
   effectiveStatus: "online" as const,
 };
 
+function success(result: Record<string, unknown>, uuid = "request-1") {
+  return Promise.resolve({
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: { request: { uuid, status: "success", result } },
+    }),
+  });
+}
+
+function deferredResponse() {
+  let resolve!: (value: Awaited<ReturnType<typeof success>>) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<Awaited<ReturnType<typeof success>>>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function renderBrowser(instances = [instance], onValidated = vi.fn()) {
+  return render(
+    <DirectoryBrowser
+      agentUuid="agent-1"
+      instances={instances}
+      onValidated={onValidated}
+      confirmLabel="Confirm"
+    />,
+  );
+}
+
+async function loadRoot(fetchMock: ReturnType<typeof vi.fn>, roots = ["/work"]) {
+  fetchMock.mockImplementationOnce(() => success({ roots }));
+  renderBrowser();
+  await waitFor(() => {
+    expect((screen.getByRole("combobox", { name: "pathPrefix" }) as HTMLInputElement).value)
+      .toBe(roots[0]);
+  });
+}
+
 describe("DirectoryBrowser", () => {
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("does not browse when Enter confirms an active IME composition", () => {
+  it("prefills one root and debounces the bounded first-page query", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
-    render(
-      <DirectoryBrowser
-        agentUuid="agent-1"
-        instances={[instance]}
-        onValidated={vi.fn()}
-        confirmLabel="Confirm"
-      />,
+    await loadRoot(fetchMock);
+    fetchMock.mockImplementationOnce(() =>
+      success({ items: [{ name: "repo", path: "/work/repo" }], nextCursor: null }),
     );
 
-    const input = screen.getByRole("textbox", { name: "pathPrefix" });
-    fireEvent.change(input, { target: { value: "/workspace/pro" } });
-    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+    fireEvent.change(screen.getByRole("combobox", { name: "pathPrefix" }), {
+      target: { value: "/work/r" },
+    });
+    await act(() => vi.advanceTimersByTimeAsync(249));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await act(() => vi.advanceTimersByTimeAsync(1));
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByRole("option").textContent).toContain("/work/repo"));
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+      operation: "list",
+      prefix: "/work/r",
+    });
   });
 
-  it("normalizes unknown server error codes before translation", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        json: async () => ({ success: false, error: { code: "FORBIDDEN" } }),
-      }),
-    );
-    render(
-      <DirectoryBrowser
-        agentUuid="agent-1"
-        instances={[instance]}
-        onValidated={vi.fn()}
-        confirmLabel="Confirm"
-      />,
-    );
+  it("defaults to the first of multiple roots and clears candidates when switching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockImplementationOnce(() => success({ roots: ["/work", "/opt"] }));
+    renderBrowser();
+    const root = await screen.findByRole("combobox", { name: "browseRoot" });
+    expect((root as HTMLSelectElement).value).toBe("/work");
+    expect((screen.getByRole("combobox", { name: "pathPrefix" }) as HTMLInputElement).value)
+      .toBe("/work");
 
-    const input = screen.getByRole("textbox", { name: "pathPrefix" });
-    fireEvent.change(input, { target: { value: "/workspace/pro" } });
-    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.change(root, { target: { value: "/opt" } });
+    expect((screen.getByRole("combobox", { name: "pathPrefix" }) as HTMLInputElement).value)
+      .toBe("/opt");
+    expect(document.getElementById("directory-candidates")).toBeNull();
+  });
 
-    await waitFor(() => {
-      expect(screen.getByRole("alert").textContent).toBe(
-        "errors.INTERNAL_ERROR",
-      );
+  it("discards stale success and stale error responses", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await loadRoot(fetchMock);
+    const stale = deferredResponse();
+    fetchMock.mockImplementationOnce(() => stale.promise);
+    const input = screen.getByRole("combobox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/work/a" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+
+    fetchMock.mockImplementationOnce(() =>
+      success({ items: [{ name: "about", path: "/work/about" }] }, "new"),
+    );
+    fireEvent.change(input, { target: { value: "/work/ab" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    await waitFor(() => expect(screen.getByRole("option").textContent).toContain("/work/about"));
+
+    stale.resolve(await success({ items: [{ name: "archive", path: "/work/archive" }] }, "old"));
+    await act(async () => {});
+    expect(screen.getByRole("option").textContent).toContain("/work/about");
+    expect(screen.queryByText("/work/archive")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not replace current candidates with an obsolete error", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await loadRoot(fetchMock);
+    const stale = deferredResponse();
+    fetchMock.mockImplementationOnce(() => stale.promise);
+    const input = screen.getByRole("combobox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/work/a" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+
+    fetchMock.mockImplementationOnce(() =>
+      success({ items: [{ name: "about", path: "/work/about" }] }, "new"),
+    );
+    fireEvent.change(input, { target: { value: "/work/ab" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    await screen.findByRole("option");
+
+    stale.reject(new Error("TIMEOUT"));
+    await act(async () => {});
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByRole("option").textContent).toContain("/work/about");
+  });
+
+  it("highlights the first candidate and accepts it with Tab", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await loadRoot(fetchMock);
+    fetchMock.mockImplementationOnce(() =>
+      success({ items: [
+        { name: "repo", path: "/work/repo" },
+        { name: "runtime", path: "/work/runtime" },
+      ] }),
+    );
+    const input = screen.getByRole("combobox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/work/r" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    const options = await screen.findAllByRole("option");
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect((input as HTMLInputElement).value).toBe("/work/repo/");
+    expect(screen.getByText("/work/repo")).not.toBeNull();
+  });
+
+  it("preserves Tab and ignores completion keys during IME composition", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await loadRoot(fetchMock);
+    fetchMock.mockImplementationOnce(() =>
+      success({ items: [{ name: "repo", path: "/work/repo" }] }),
+    );
+    const input = screen.getByRole("combobox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/work/r" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    await screen.findByRole("option");
+
+    const ime = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
     });
+    input.dispatchEvent(ime);
+    expect((input as HTMLInputElement).value).toBe("/work/r");
+
+    fireEvent.keyDown(input, { key: "Escape" });
+    const tab = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+    input.dispatchEvent(tab);
+    expect(tab.defaultPrevented).toBe(false);
+  });
+
+  it("shows stable typed errors for the current prefix", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await loadRoot(fetchMock);
+    fetchMock.mockImplementationOnce(() => Promise.resolve({
+      ok: false,
+      json: async () => ({ success: false, error: { code: "OUTSIDE_ROOT" } }),
+    }));
+    fireEvent.change(screen.getByRole("combobox", { name: "pathPrefix" }), {
+      target: { value: "/work/x" },
+    });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("errors.OUTSIDE_ROOT");
+    });
+  });
+
+  it("navigates to a parent but never above the selected root", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await loadRoot(fetchMock);
+    const input = screen.getByRole("combobox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/work/repo/src" } });
+    fireEvent.click(screen.getByRole("button", { name: "parent" }));
+    expect((input as HTMLInputElement).value).toBe("/work/repo/");
+    fireEvent.click(screen.getByRole("button", { name: "parent" }));
+    expect((input as HTMLInputElement).value).toBe("/work/");
+    fireEvent.click(screen.getByRole("button", { name: "parent" }));
+    expect((input as HTMLInputElement).value).toBe("/work/");
+  });
+
+  it("cancels and fences validation when the root changes", async () => {
+    const fetchMock = vi.fn();
+    const onValidated = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockImplementationOnce(() => success({ roots: ["/work", "/opt"] }));
+    renderBrowser([instance], onValidated);
+    await screen.findByRole("combobox", { name: "browseRoot" });
+
+    fetchMock.mockImplementationOnce(() =>
+      success({ items: [{ name: "repo", path: "/work/repo" }] }),
+    );
+    const input = screen.getByRole("combobox", { name: "pathPrefix" });
+    fireEvent.change(input, { target: { value: "/work/r" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    await waitFor(() => expect(document.getElementById("directory-candidate-0")).not.toBeNull());
+    fireEvent.click(document.getElementById("directory-candidate-0")!);
+
+    const validation = deferredResponse();
+    fetchMock.mockImplementationOnce(() => validation.promise);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    const validationSignal = fetchMock.mock.calls.at(-1)?.[1]?.signal as AbortSignal;
+
+    fireEvent.change(screen.getByRole("combobox", { name: "browseRoot" }), {
+      target: { value: "/opt" },
+    });
+    expect(validationSignal.aborted).toBe(true);
+
+    validation.resolve(await success({ normalizedPath: "/work/repo" }, "validation"));
+    await act(async () => {});
+    expect(onValidated).not.toHaveBeenCalled();
   });
 });

--- a/src/components/agent-presence/__tests__/wake-cwd-picker-dialog.test.tsx
+++ b/src/components/agent-presence/__tests__/wake-cwd-picker-dialog.test.tsx
@@ -229,7 +229,7 @@ describe("WakeCwdPickerDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Browse another directory" }));
     await waitFor(() => {
       expect((screen.getByRole("combobox", { name: "Directory path prefix" }) as HTMLInputElement).value)
-        .toBe("/workspace");
+        .toBe("/workspace/");
     });
     const input = screen.getByRole("combobox", { name: "Directory path prefix" });
     fireEvent.change(input, { target: { value: "/workspace/r" } });

--- a/src/components/agent-presence/__tests__/wake-cwd-picker-dialog.test.tsx
+++ b/src/components/agent-presence/__tests__/wake-cwd-picker-dialog.test.tsx
@@ -9,7 +9,7 @@
 // behavior specific to the wake-cwd copy.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
+import { act, render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react";
 
 vi.mock("next-intl", async () => {
   const en = (await import("../../../../messages/en.json")).default as Record<
@@ -186,5 +186,64 @@ describe("WakeCwdPickerDialog", () => {
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ connectionUuid: instances[0].connectionUuid }),
     );
+  });
+
+  it("uses a freshly validated temporary cwd without confirming a registered instance", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onConfirm = vi.fn();
+    const onTemporaryConfirm = vi.fn();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { operation: string; cwd?: string };
+      const result = body.operation === "roots"
+        ? { roots: ["/workspace"] }
+        : body.operation === "list"
+          ? { items: [{ name: "repo", path: "/workspace/repo" }] }
+          : { normalizedPath: body.cwd };
+      return {
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: {
+            request: {
+              uuid: `request-${body.operation}`,
+              status: "success",
+              result,
+            },
+          },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <WakeCwdPickerDialog
+        open
+        agentName="Test Agent"
+        instances={makeInstances(2)}
+        agentUuid="agent-1"
+        onConfirm={onConfirm}
+        onTemporaryConfirm={onTemporaryConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse another directory" }));
+    await waitFor(() => {
+      expect((screen.getByRole("combobox", { name: "Directory path prefix" }) as HTMLInputElement).value)
+        .toBe("/workspace");
+    });
+    const input = screen.getByRole("combobox", { name: "Directory path prefix" });
+    fireEvent.change(input, { target: { value: "/workspace/r" } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
+    fireEvent.click(await screen.findByRole("option"));
+    fireEvent.click(screen.getByRole("button", { name: "Use for this operation" }));
+
+    await waitFor(() => {
+      expect(onTemporaryConfirm).toHaveBeenCalledWith({
+        agentUuid: "agent-1",
+        validationRequestUuid: "request-validate",
+      });
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/src/components/agent-presence/directory-browser.tsx
+++ b/src/components/agent-presence/directory-browser.tsx
@@ -137,6 +137,7 @@ export function DirectoryBrowser({
   );
   const [roots, setRoots] = useState<string[]>([]);
   const [selectedRoot, setSelectedRoot] = useState("");
+  const [manualMode, setManualMode] = useState(false);
   const [prefix, setPrefix] = useState("");
   const [selectedPath, setSelectedPath] = useState("");
   const [items, setItems] = useState<DirectoryItem[]>([]);
@@ -151,6 +152,13 @@ export function DirectoryBrowser({
   const rootsController = useRef<AbortController | null>(null);
   const browseController = useRef<AbortController | null>(null);
   const validationController = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!listOpen || highlightedIndex < 0) return;
+    document
+      .getElementById(`directory-candidate-${highlightedIndex}`)
+      ?.scrollIntoView?.({ block: "nearest" });
+  }, [highlightedIndex, listOpen]);
 
   const clearCandidates = () => {
     browseGeneration.current += 1;
@@ -174,6 +182,7 @@ export function DirectoryBrowser({
     clearCandidates();
     setRoots([]);
     setSelectedRoot("");
+    setManualMode(false);
     setPrefix("");
     setSelectedPath("");
     setErrorCode(null);
@@ -202,11 +211,13 @@ export function DirectoryBrowser({
       }
       setRoots(nextRoots);
       setSelectedRoot(nextRoots[0]);
-      setPrefix(nextRoots[0]);
+      setManualMode(false);
+      setPrefix(withTrailingSeparator(nextRoots[0]));
     }).catch((error) => {
       const code = normalizeDirectoryError(error);
       if (code !== "ABORTED" && generation === rootsGeneration.current) {
-        setErrorCode(code);
+        setManualMode(true);
+        setErrorCode(null);
       }
     }).finally(() => {
       if (generation === rootsGeneration.current) setPending(null);
@@ -369,7 +380,7 @@ export function DirectoryBrowser({
                   cancelValidation();
                   clearCandidates();
                   setSelectedRoot(event.target.value);
-                  setPrefix(event.target.value);
+                  setPrefix(withTrailingSeparator(event.target.value));
                   setSelectedPath("");
                   setErrorCode(null);
                 }}
@@ -379,15 +390,15 @@ export function DirectoryBrowser({
             </label>
           )}
 
-          {selectedRoot && (
+          {(selectedRoot || manualMode) && (
             <div className="flex min-w-0 gap-2">
               <div className="relative min-w-0 flex-1">
                 <Input
                   role="combobox"
                   aria-label={t("pathPrefix")}
-                  aria-autocomplete="list"
+                  aria-autocomplete={manualMode ? "none" : "list"}
                   aria-expanded={listOpen}
-                  aria-controls="directory-candidates"
+                  aria-controls={manualMode ? undefined : "directory-candidates"}
                   aria-activedescendant={
                     listOpen && highlightedIndex >= 0
                       ? `directory-candidate-${highlightedIndex}`
@@ -397,7 +408,7 @@ export function DirectoryBrowser({
                   onChange={(event) => {
                     cancelValidation();
                     setPrefix(event.target.value);
-                    setSelectedPath("");
+                    setSelectedPath(manualMode ? event.target.value.trim() : "");
                     setErrorCode(null);
                   }}
                   onKeyDown={(event) => {
@@ -433,25 +444,27 @@ export function DirectoryBrowser({
                   />
                 )}
               </div>
-              <Button
-                type="button"
-                size="icon"
-                variant="outline"
-                className="size-11 sm:size-9"
-                disabled={prefix === selectedRoot}
-                onClick={() => {
-                  cancelValidation();
-                  const parent = parentWithinRoot(prefix, selectedRoot);
-                  clearCandidates();
-                  setPrefix(withTrailingSeparator(parent));
-                  setSelectedPath(parent);
-                  setErrorCode(null);
-                }}
-                aria-label={t("parent")}
-                title={t("parent")}
-              >
-                <ChevronUp className="size-4" />
-              </Button>
+              {!manualMode && (
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  className="size-11 sm:size-9"
+                  disabled={prefix === selectedRoot}
+                  onClick={() => {
+                    cancelValidation();
+                    const parent = parentWithinRoot(prefix, selectedRoot);
+                    clearCandidates();
+                    setPrefix(withTrailingSeparator(parent));
+                    setSelectedPath(parent);
+                    setErrorCode(null);
+                  }}
+                  aria-label={t("parent")}
+                  title={t("parent")}
+                >
+                  <ChevronUp className="size-4" />
+                </Button>
+              )}
             </div>
           )}
 

--- a/src/components/agent-presence/directory-browser.tsx
+++ b/src/components/agent-presence/directory-browser.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Folder, Loader2, Search } from "lucide-react";
+import { ChevronUp, Folder, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { isImeComposing } from "@/lib/ime";
@@ -20,10 +20,45 @@ const DIRECTORY_ERROR_CODES = new Set([
   "LIMIT_EXCEEDED",
   "INTERNAL_ERROR",
 ]);
+const AUTOCOMPLETE_DELAY_MS = 250;
 
 function normalizeDirectoryError(error: unknown): string {
+  if (error instanceof DOMException && error.name === "AbortError") return "ABORTED";
   const code = error instanceof Error ? error.message : "INTERNAL_ERROR";
   return DIRECTORY_ERROR_CODES.has(code) ? code : "INTERNAL_ERROR";
+}
+
+function separatorFor(path: string) {
+  return path.includes("\\") && !path.includes("/") ? "\\" : "/";
+}
+
+function withTrailingSeparator(path: string) {
+  const separator = separatorFor(path);
+  return path.endsWith(separator) ? path : `${path}${separator}`;
+}
+
+function basenameAfterRoot(path: string, root: string) {
+  const separator = separatorFor(root);
+  const rootWithSeparator = withTrailingSeparator(root);
+  if (path === root || path === rootWithSeparator) return "";
+  if (!path.startsWith(rootWithSeparator)) return null;
+  const tail = path.slice(rootWithSeparator.length);
+  return tail.endsWith(separator) ? "" : tail.split(separator).at(-1) ?? "";
+}
+
+function parentWithinRoot(path: string, root: string) {
+  const separator = separatorFor(root);
+  const rootWithoutSeparator = root.endsWith(separator) && root.length > 1
+    ? root.slice(0, -1)
+    : root;
+  const withoutTrailing = path.endsWith(separator) && path.length > rootWithoutSeparator.length
+    ? path.slice(0, -1)
+    : path;
+  const parent = withoutTrailing.slice(0, withoutTrailing.lastIndexOf(separator));
+  if (!parent || parent.length < rootWithoutSeparator.length) return rootWithoutSeparator;
+  return parent.startsWith(withTrailingSeparator(rootWithoutSeparator))
+    ? parent
+    : rootWithoutSeparator;
 }
 
 export interface ValidatedDirectory {
@@ -41,11 +76,25 @@ interface DirectoryBrowserProps {
   confirmLabel: string;
 }
 
-async function requestDirectory(payload: Record<string, unknown>) {
+function abortableDelay(signal: AbortSignal, delay: number) {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, delay);
+    signal.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    }, { once: true });
+  });
+}
+
+async function requestDirectory(
+  payload: Record<string, unknown>,
+  signal: AbortSignal,
+) {
   const response = await fetch("/api/daemon-directory-requests", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
+    signal,
   });
   const body = await response.json();
   if (!response.ok || !body.success) {
@@ -53,9 +102,10 @@ async function requestDirectory(payload: Record<string, unknown>) {
   }
   let request = body.data.request;
   while (request.status === "pending") {
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await abortableDelay(signal, 300);
     const poll = await fetch(
       `/api/daemon-directory-requests/${encodeURIComponent(request.uuid)}`,
+      { signal },
     );
     const pollBody = await poll.json();
     if (!poll.ok || !pollBody.success) {
@@ -76,41 +126,174 @@ export function DirectoryBrowser({
   confirmLabel,
 }: DirectoryBrowserProps) {
   const t = useTranslations("directoryBrowser");
-  const hosts = Array.from(
-    new Map(instances.map((instance) => [instance.host, instance])).values(),
+  const hosts = useMemo(
+    () => Array.from(
+      new Map(instances.map((instance) => [instance.host, instance])).values(),
+    ),
+    [instances],
   );
   const [anchor, setAnchor] = useState<InstanceCandidate | null>(
     hosts.length === 1 ? hosts[0] : null,
   );
+  const [roots, setRoots] = useState<string[]>([]);
+  const [selectedRoot, setSelectedRoot] = useState("");
   const [prefix, setPrefix] = useState("");
   const [selectedPath, setSelectedPath] = useState("");
   const [items, setItems] = useState<DirectoryItem[]>([]);
-  const [pending, setPending] = useState<"browse" | "validate" | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [listOpen, setListOpen] = useState(false);
+  const [completedPrefix, setCompletedPrefix] = useState("");
+  const [pending, setPending] = useState<"roots" | "browse" | "validate" | null>(null);
   const [errorCode, setErrorCode] = useState<string | null>(null);
+  const rootsGeneration = useRef(0);
+  const browseGeneration = useRef(0);
+  const validationGeneration = useRef(0);
+  const rootsController = useRef<AbortController | null>(null);
+  const browseController = useRef<AbortController | null>(null);
+  const validationController = useRef<AbortController | null>(null);
 
-  const browse = async () => {
-    if (!anchor || !prefix.trim()) return;
-    setPending("browse");
+  const clearCandidates = () => {
+    browseGeneration.current += 1;
+    browseController.current?.abort();
+    setItems([]);
+    setHighlightedIndex(-1);
+    setListOpen(false);
+    setCompletedPrefix("");
+  };
+
+  const cancelValidation = () => {
+    validationGeneration.current += 1;
+    validationController.current?.abort();
+    setPending((current) => current === "validate" ? null : current);
+  };
+
+  useEffect(() => {
+    rootsGeneration.current += 1;
+    rootsController.current?.abort();
+    cancelValidation();
+    clearCandidates();
+    setRoots([]);
+    setSelectedRoot("");
+    setPrefix("");
+    setSelectedPath("");
     setErrorCode(null);
-    try {
-      const request = await requestDirectory({
+    if (!anchor) {
+      setPending(null);
+      return;
+    }
+
+    const generation = rootsGeneration.current;
+    const connectionUuid = anchor.connectionUuid;
+    const controller = new AbortController();
+    rootsController.current = controller;
+    setPending("roots");
+    void requestDirectory({
+      operation: "roots",
+      agentUuid,
+      targetConnectionUuid: connectionUuid,
+    }, controller.signal).then((request) => {
+      if (
+        generation !== rootsGeneration.current ||
+        connectionUuid !== anchor.connectionUuid
+      ) return;
+      const nextRoots = request.result?.roots;
+      if (!Array.isArray(nextRoots) || nextRoots.length === 0) {
+        throw new Error("INTERNAL_ERROR");
+      }
+      setRoots(nextRoots);
+      setSelectedRoot(nextRoots[0]);
+      setPrefix(nextRoots[0]);
+    }).catch((error) => {
+      const code = normalizeDirectoryError(error);
+      if (code !== "ABORTED" && generation === rootsGeneration.current) {
+        setErrorCode(code);
+      }
+    }).finally(() => {
+      if (generation === rootsGeneration.current) setPending(null);
+    });
+
+    return () => controller.abort();
+  }, [agentUuid, anchor]);
+
+  const basename = selectedRoot ? basenameAfterRoot(prefix, selectedRoot) : null;
+  useEffect(() => {
+    browseGeneration.current += 1;
+    browseController.current?.abort();
+    const generation = browseGeneration.current;
+    setItems([]);
+    setHighlightedIndex(-1);
+    setListOpen(false);
+    setCompletedPrefix("");
+    if (!anchor || !selectedRoot || basename === null || basename.length === 0) {
+      setPending((current) => current === "browse" ? null : current);
+      return;
+    }
+
+    const connectionUuid = anchor.connectionUuid;
+    const root = selectedRoot;
+    const queryPrefix = prefix;
+    const controller = new AbortController();
+    browseController.current = controller;
+    const timer = setTimeout(() => {
+      setPending("browse");
+      setErrorCode(null);
+      void requestDirectory({
         operation: "list",
         agentUuid,
-        targetConnectionUuid: anchor.connectionUuid,
-        prefix: prefix.trim(),
+        targetConnectionUuid: connectionUuid,
+        prefix: queryPrefix,
+      }, controller.signal).then((request) => {
+        if (
+          generation !== browseGeneration.current ||
+          connectionUuid !== anchor.connectionUuid ||
+          root !== selectedRoot ||
+          queryPrefix !== prefix
+        ) return;
+        const nextItems = Array.isArray(request.result?.items)
+          ? request.result.items as DirectoryItem[]
+          : [];
+        setItems(nextItems);
+        setHighlightedIndex(nextItems.length > 0 ? 0 : -1);
+        setListOpen(nextItems.length > 0);
+        setCompletedPrefix(queryPrefix);
+      }).catch((error) => {
+        const code = normalizeDirectoryError(error);
+        if (code !== "ABORTED" && generation === browseGeneration.current) {
+          setErrorCode(code);
+          setCompletedPrefix(queryPrefix);
+        }
+      }).finally(() => {
+        if (generation === browseGeneration.current) setPending(null);
       });
-      const result = request.result as { items?: DirectoryItem[] } | null;
-      setItems(result?.items ?? []);
-    } catch (error) {
-      setItems([]);
-      setErrorCode(normalizeDirectoryError(error));
-    } finally {
-      setPending(null);
-    }
+    }, AUTOCOMPLETE_DELAY_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [agentUuid, anchor, basename, prefix, selectedRoot]);
+
+  useEffect(() => () => {
+    rootsController.current?.abort();
+    browseController.current?.abort();
+    validationController.current?.abort();
+  }, []);
+
+  const chooseCandidate = (item: DirectoryItem) => {
+    cancelValidation();
+    clearCandidates();
+    setSelectedPath(item.path);
+    setPrefix(withTrailingSeparator(item.path));
+    setErrorCode(null);
   };
 
   const validate = async () => {
     if (!anchor || !selectedPath) return;
+    validationGeneration.current += 1;
+    validationController.current?.abort();
+    const generation = validationGeneration.current;
+    const controller = new AbortController();
+    validationController.current = controller;
     setPending("validate");
     setErrorCode(null);
     try {
@@ -119,11 +302,12 @@ export function DirectoryBrowser({
         agentUuid,
         targetConnectionUuid: anchor.connectionUuid,
         cwd: selectedPath,
-      });
+      }, controller.signal);
       const normalizedPath =
         typeof request.result?.normalizedPath === "string"
           ? request.result.normalizedPath
           : selectedPath;
+      if (generation !== validationGeneration.current) return;
       await onValidated({
         agentUuid,
         connectionUuid: anchor.connectionUuid,
@@ -132,9 +316,12 @@ export function DirectoryBrowser({
         validationRequestUuid: request.uuid,
       });
     } catch (error) {
-      setErrorCode(normalizeDirectoryError(error));
+      const code = normalizeDirectoryError(error);
+      if (code !== "ABORTED" && generation === validationGeneration.current) {
+        setErrorCode(code);
+      }
     } finally {
-      setPending(null);
+      if (generation === validationGeneration.current) setPending(null);
     }
   };
 
@@ -151,12 +338,10 @@ export function DirectoryBrowser({
             type="button"
             size="sm"
             variant={anchor?.connectionUuid === host.connectionUuid ? "default" : "outline"}
-            className="max-w-full"
+            className="h-11 max-w-full sm:h-8"
             onClick={() => {
+              cancelValidation();
               setAnchor(host);
-              setItems([]);
-              setSelectedPath("");
-              setErrorCode(null);
             }}
           >
             <span className="truncate">{host.host || t("unknownHost")}</span>
@@ -166,65 +351,143 @@ export function DirectoryBrowser({
 
       {anchor && (
         <>
-          <div className="flex min-w-0 gap-2">
-            <Input
-              aria-label={t("pathPrefix")}
-              value={prefix}
-              onChange={(event) => setPrefix(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter" || isImeComposing(event)) return;
-                event.preventDefault();
-                void browse();
-              }}
-              placeholder={t("pathPlaceholder")}
-              className="min-w-0 font-mono text-xs"
-            />
-            <Button
-              type="button"
-              size="icon"
-              variant="outline"
-              disabled={!prefix.trim() || pending !== null}
-              onClick={() => void browse()}
-              aria-label={t("browse")}
-              title={t("browse")}
-            >
-              {pending === "browse" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Search className="size-4" />
-              )}
-            </Button>
-          </div>
+          {pending === "roots" && (
+            <p role="status" className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" />
+              {t("loadingRoots")}
+            </p>
+          )}
 
-          {items.length > 0 && (
-            <div className="max-h-40 overflow-y-auto rounded-lg border border-border p-1">
-              {items.map((item) => (
-                <Button
+          {roots.length > 1 && (
+            <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
+              {t("browseRoot")}
+              <select
+                aria-label={t("browseRoot")}
+                value={selectedRoot}
+                className="h-11 min-w-0 rounded-md border border-input bg-background px-3 font-mono text-xs sm:h-9"
+                onChange={(event) => {
+                  cancelValidation();
+                  clearCandidates();
+                  setSelectedRoot(event.target.value);
+                  setPrefix(event.target.value);
+                  setSelectedPath("");
+                  setErrorCode(null);
+                }}
+              >
+                {roots.map((root) => <option key={root} value={root}>{root}</option>)}
+              </select>
+            </label>
+          )}
+
+          {selectedRoot && (
+            <div className="flex min-w-0 gap-2">
+              <div className="relative min-w-0 flex-1">
+                <Input
+                  role="combobox"
+                  aria-label={t("pathPrefix")}
+                  aria-autocomplete="list"
+                  aria-expanded={listOpen}
+                  aria-controls="directory-candidates"
+                  aria-activedescendant={
+                    listOpen && highlightedIndex >= 0
+                      ? `directory-candidate-${highlightedIndex}`
+                      : undefined
+                  }
+                  value={prefix}
+                  onChange={(event) => {
+                    cancelValidation();
+                    setPrefix(event.target.value);
+                    setSelectedPath("");
+                    setErrorCode(null);
+                  }}
+                  onKeyDown={(event) => {
+                    if (isImeComposing(event)) return;
+                    if (event.key === "Escape" && listOpen) {
+                      event.preventDefault();
+                      setListOpen(false);
+                      return;
+                    }
+                    if (items.length === 0 || !listOpen) return;
+                    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                      event.preventDefault();
+                      const direction = event.key === "ArrowDown" ? 1 : -1;
+                      setHighlightedIndex((current) =>
+                        (current + direction + items.length) % items.length);
+                      return;
+                    }
+                    if (
+                      (event.key === "Tab" || event.key === "Enter") &&
+                      highlightedIndex >= 0
+                    ) {
+                      event.preventDefault();
+                      chooseCandidate(items[highlightedIndex]);
+                    }
+                  }}
+                  placeholder={t("pathPlaceholder")}
+                  className="h-11 min-w-0 pr-9 font-mono text-xs sm:h-9"
+                />
+                {pending === "browse" && (
+                  <Loader2
+                    aria-label={t("loadingCandidates")}
+                    className="absolute right-3 top-2.5 size-4 animate-spin text-muted-foreground"
+                  />
+                )}
+              </div>
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                className="size-11 sm:size-9"
+                disabled={prefix === selectedRoot}
+                onClick={() => {
+                  cancelValidation();
+                  const parent = parentWithinRoot(prefix, selectedRoot);
+                  clearCandidates();
+                  setPrefix(withTrailingSeparator(parent));
+                  setSelectedPath(parent);
+                  setErrorCode(null);
+                }}
+                aria-label={t("parent")}
+                title={t("parent")}
+              >
+                <ChevronUp className="size-4" />
+              </Button>
+            </div>
+          )}
+
+          {listOpen && items.length > 0 && (
+            <div
+              id="directory-candidates"
+              role="listbox"
+              className="max-h-40 overflow-y-auto rounded-md border border-border p-1"
+            >
+              {items.map((item, index) => (
+                <button
+                  id={`directory-candidate-${index}`}
                   key={item.path}
                   type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="flex h-auto w-full min-w-0 justify-start px-2 py-2 text-left text-xs"
-                  onClick={() => {
-                    setSelectedPath(item.path);
-                    setPrefix(`${item.path}/`);
-                  }}
+                  role="option"
+                  aria-selected={index === highlightedIndex}
+                  className="flex min-h-11 w-full min-w-0 items-center gap-2 rounded px-2 py-2 text-left text-xs hover:bg-muted aria-selected:bg-muted"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => chooseCandidate(item)}
                 >
                   <Folder className="size-3.5 shrink-0 text-muted-foreground" />
-                  <span className="truncate font-mono" title={item.path}>
-                    {item.path}
-                  </span>
-                </Button>
+                  <span className="min-w-0 break-all font-mono">{item.path}</span>
+                </button>
               ))}
             </div>
           )}
 
-          {items.length === 0 && prefix && pending === null && !errorCode && (
-            <p className="text-xs text-muted-foreground">{t("empty")}</p>
-          )}
+          {completedPrefix === prefix &&
+            items.length === 0 &&
+            pending === null &&
+            !errorCode && (
+              <p className="text-xs text-muted-foreground">{t("empty")}</p>
+            )}
 
           {selectedPath && (
-            <div className="min-w-0 rounded-lg border border-border bg-muted/30 p-3">
+            <div className="min-w-0 rounded-md border border-border bg-muted/30 p-3">
               <p className="text-[11px] font-medium text-muted-foreground">
                 {t("selection")}
               </p>
@@ -244,7 +507,7 @@ export function DirectoryBrowser({
           <Button
             type="button"
             size="sm"
-            className="w-fit"
+            className="h-11 w-fit sm:h-8"
             disabled={!selectedPath || pending !== null}
             onClick={() => void validate()}
           >

--- a/src/components/agent-presence/wake-cwd-picker-dialog.tsx
+++ b/src/components/agent-presence/wake-cwd-picker-dialog.tsx
@@ -93,7 +93,7 @@ export function WakeCwdPickerDialog({
   // CJK/JP/KR user pressing Enter to CONFIRM an IME candidate must not
   // accidentally pin+wake.
   const handleListKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== "Enter" || isImeComposing(e)) return;
+    if (browsing || e.key !== "Enter" || isImeComposing(e)) return;
     if (!selected) return;
     e.preventDefault();
     onConfirm(selected);

--- a/src/services/__tests__/daemon-directory-request.integration.test.ts
+++ b/src/services/__tests__/daemon-directory-request.integration.test.ts
@@ -198,4 +198,44 @@ describe("directory request server-daemon boundary", () => {
       },
     });
   });
+
+  it("terminalizes a malformed roots report instead of leaving it pending", async () => {
+    const deadlineAt = new Date(Date.now() + 15_000);
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      uuid: "roots-1",
+      operation: "roots",
+      status: "pending",
+      deadlineAt,
+    });
+    prismaMock.daemonDirectoryRequest.update.mockResolvedValue({
+      uuid: "roots-1",
+      status: "error",
+      errorCode: "INTERNAL_ERROR",
+    });
+
+    const response = await reportResult(
+      new NextRequest("https://chorus.test/api/daemon/directory-request/report", {
+        method: "POST",
+        body: JSON.stringify({
+          requestUuid: "roots-1",
+          connectionUuid: "conn-1",
+          status: "succeeded",
+          roots: [],
+        }),
+        headers: { "content-type": "application/json" },
+      }),
+      { params: Promise.resolve({}) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.daemonDirectoryRequest.update).toHaveBeenCalledWith({
+      where: { uuid: "roots-1" },
+      data: {
+        status: "error",
+        result: undefined,
+        errorCode: "INTERNAL_ERROR",
+        completedAt: expect.any(Date),
+      },
+    });
+  });
 });

--- a/src/services/__tests__/project-agent-cwd.service.test.ts
+++ b/src/services/__tests__/project-agent-cwd.service.test.ts
@@ -129,6 +129,42 @@ describe("project-agent cwd request service", () => {
     );
   });
 
+  it("dispatches a roots request without accepting a client path", async () => {
+    prismaMock.daemonDirectoryRequest.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.daemonConnection.findFirst.mockResolvedValue({
+      uuid: "conn-1",
+      host: "host-1",
+      agentInstanceUuid: "instance-1",
+    });
+    prismaMock.daemonDirectoryRequest.create.mockResolvedValue({
+      uuid: "roots-1",
+      limit: 50,
+      deadlineAt: new Date(Date.now() + 15_000),
+    });
+
+    await createDirectoryRequest({
+      ...base,
+      targetConnectionUuid: "conn-1",
+      operation: "roots",
+    });
+
+    expect(prismaMock.daemonDirectoryRequest.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        operation: "roots",
+        prefix: null,
+        cwd: null,
+      }),
+    });
+    expect(emit).toHaveBeenCalledWith(
+      "control:conn-1",
+      expect.objectContaining({
+        operation: "roots",
+        prefix: undefined,
+        cwd: undefined,
+      }),
+    );
+  });
+
   it("turns an overdue pending request into a terminal TIMEOUT", async () => {
     prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
       uuid: "request-1",
@@ -167,6 +203,41 @@ describe("project-agent cwd request service", () => {
         agentUuid: "agent-1",
         targetConnectionUuid: "wrong-conn",
         status: "pending",
+      },
+    });
+  });
+
+  it("terminalizes a malformed successful roots report as INTERNAL_ERROR", async () => {
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      uuid: "roots-1",
+      operation: "roots",
+      status: "pending",
+      deadlineAt: new Date(Date.now() + 15_000),
+    });
+
+    prismaMock.daemonDirectoryRequest.update.mockResolvedValue({
+      uuid: "roots-1",
+      status: "error",
+      errorCode: "INTERNAL_ERROR",
+    });
+
+    const result = await completeDirectoryRequest({
+      companyUuid: "company-1",
+      agentUuid: "agent-1",
+      connectionUuid: "conn-1",
+      requestUuid: "roots-1",
+      status: "success",
+      result: { roots: [] },
+    });
+
+    expect(result).toMatchObject({ status: "error", errorCode: "INTERNAL_ERROR" });
+    expect(prismaMock.daemonDirectoryRequest.update).toHaveBeenCalledWith({
+      where: { uuid: "roots-1" },
+      data: {
+        status: "error",
+        result: undefined,
+        errorCode: "INTERNAL_ERROR",
+        completedAt: expect.any(Date),
       },
     });
   });

--- a/src/services/project-agent-cwd.service.ts
+++ b/src/services/project-agent-cwd.service.ts
@@ -14,7 +14,7 @@ export const DIRECTORY_ERROR_CODES = [
 ] as const;
 
 export type DirectoryErrorCode = (typeof DIRECTORY_ERROR_CODES)[number];
-export type DirectoryOperation = "list" | "validate";
+export type DirectoryOperation = "roots" | "list" | "validate";
 
 export class CwdServiceError extends Error {
   constructor(
@@ -245,6 +245,30 @@ export async function completeDirectoryRequest(params: {
   }
   if (params.status === "error" && !params.errorCode) {
     throw new CwdServiceError("VALIDATION_ERROR", "errorCode is required");
+  }
+  if (params.status === "success") {
+    const result = params.result;
+    if (
+      request.operation === "roots" &&
+      (!result ||
+        typeof result !== "object" ||
+        Array.isArray(result) ||
+        !Array.isArray((result as { roots?: unknown }).roots) ||
+        (result as { roots: unknown[] }).roots.length === 0 ||
+        !(result as { roots: unknown[] }).roots.every(
+          (root) => typeof root === "string" && root.length > 0,
+        ))
+    ) {
+      return prisma.daemonDirectoryRequest.update({
+        where: { uuid: request.uuid },
+        data: {
+          status: "error",
+          result: undefined,
+          errorCode: "INTERNAL_ERROR",
+          completedAt: new Date(),
+        },
+      });
+    }
   }
   return prisma.daemonDirectoryRequest.update({
     where: { uuid: request.uuid },


### PR DESCRIPTION
## Summary
- expose effective daemon browse roots through the correlated directory-request protocol
- add a shared root-aware, debounced, race-safe directory autocomplete for fixed and temporary cwd flows
- keep keyboard-highlighted candidates visible in long scrollable lists
- prefill selected roots with the platform-correct trailing separator
- fall back to manual path validation when roots fail or an older daemon lacks roots support
- cover keyboard/IME, typed errors, responsive behavior, persistence boundaries, compatibility fallback, and OpenSpec artifacts

## Test plan
- [x] Full Vitest suite: 298 files, 4697 tests passed (16 skipped)
- [x] TypeScript typecheck
- [x] Focused ESLint and Impeccable detector
- [x] GitHub Test & Coverage CI
- [x] Independent follow-up task review: PASS
- [x] Aggregate Chorus code review: PASS WITH NOTES, 0 blockers
- [x] AWS CDK production redeploy and health check

## Notes
- Browser acceptance is manual and screenshot-backed; the exhaustive interaction/error matrix is covered by component and integration tests.
- Existing unrelated OpenSpec validation failure remains in `daemon-session-conversation`; both specs touched by this PR validate successfully.

Generated with Codex