### PR TITLE
feat: make project cwd authoritative for agent anchoring

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -315,6 +315,19 @@
       "status": { "valid": "Available", "offline": "Host offline", "invalid": "Directory unavailable" }
     }
   },
+  "fixedCwdAnchor": {
+    "title": "Fixed working directory",
+    "host": "Host",
+    "cwd": "Directory",
+    "status": "Status",
+    "unknown": "Unknown",
+    "manage": "Manage in project settings",
+    "availability": {
+      "ready": "Available",
+      "offline": "Host offline",
+      "invalid": "Directory unavailable"
+    }
+  },
   "projects": {
     "title": "Projects",
     "subtitle": "Manage your projects and track progress",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1707,7 +1707,7 @@
     "cancel": "Cancel", "browseAnother": "Browse another directory", "registeredDirectories": "Registered directories", "useOnce": "Use for this operation"
   },
   "directoryBrowser": {
-    "chooseHost": "Choose a host", "unknownHost": "Unknown host", "chooseDirectorySource": "Choose a working directory source", "daemonCwd": "Daemon working directory", "customCwd": "Another directory on this host", "pathPrefix": "Directory path prefix", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "Choose a host", "unknownHost": "Unknown host", "chooseDirectorySource": "Choose a working directory source", "daemonCwd": "Daemon working directory", "configuredCwd": "Configured daemon directory", "customCwd": "Another directory on this host", "pathPrefix": "Directory path prefix", "pathPlaceholder": "/home/user/project",
     "browseRoot": "Browse root", "loadingRoots": "Loading allowed roots…", "loadingCandidates": "Loading directory suggestions", "parent": "Go to parent directory",
     "browse": "Browse directories", "noHosts": "No online host is available for this Agent.", "empty": "No matching directories.", "selection": "Selected directory",
     "errors": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -309,9 +309,9 @@
     "deleteDescription": "Permanently remove this project and all its data. This action cannot be undone.",
     "agentCwds": {
       "title": "Agent working directories", "description": "Fix a host and directory for each Agent in this project.",
-      "loading": "Loading working directories...", "loadFailed": "Working directories could not be loaded.", "empty": "No Agents are available.",
+      "loading": "Loading working directories...", "loadFailed": "Working directories could not be loaded.", "empty": "No Agents are available.", "emptyOnline": "No Agents are online.",
       "notConfigured": "Uses a temporary directory for each operation", "configure": "Configure working directory", "replace": "Replace working directory",
-      "clear": "Clear fixed working directory", "save": "Save fixed directory",
+      "clear": "Clear fixed working directory", "save": "Save fixed directory", "createFailed": "The project was not created because its Agent working directory could not be saved.",
       "status": { "valid": "Available", "offline": "Host offline", "invalid": "Directory unavailable" }
     }
   },
@@ -1707,7 +1707,7 @@
     "cancel": "Cancel", "browseAnother": "Browse another directory", "registeredDirectories": "Registered directories", "useOnce": "Use for this operation"
   },
   "directoryBrowser": {
-    "chooseHost": "Choose a host", "unknownHost": "Unknown host", "pathPrefix": "Directory path prefix", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "Choose a host", "unknownHost": "Unknown host", "chooseDirectorySource": "Choose a working directory source", "daemonCwd": "Daemon working directory", "customCwd": "Another directory on this host", "pathPrefix": "Directory path prefix", "pathPlaceholder": "/home/user/project",
     "browseRoot": "Browse root", "loadingRoots": "Loading allowed roots…", "loadingCandidates": "Loading directory suggestions", "parent": "Go to parent directory",
     "browse": "Browse directories", "noHosts": "No online host is available for this Agent.", "empty": "No matching directories.", "selection": "Selected directory",
     "errors": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -309,9 +309,9 @@
     "deleteDescription": "このプロジェクトとすべてのデータを完全に削除します。この操作は取り消せません。",
     "agentCwds": {
       "title": "Agent の作業ディレクトリ", "description": "このプロジェクトの Agent ごとにホストとディレクトリを固定します。",
-      "loading": "作業ディレクトリを読み込んでいます...", "loadFailed": "作業ディレクトリを読み込めませんでした。", "empty": "利用できる Agent がありません。",
+      "loading": "作業ディレクトリを読み込んでいます...", "loadFailed": "作業ディレクトリを読み込めませんでした。", "empty": "利用できる Agent がありません。", "emptyOnline": "オンラインの Agent がありません。",
       "notConfigured": "操作ごとに一時ディレクトリを使用", "configure": "作業ディレクトリを設定", "replace": "作業ディレクトリを変更",
-      "clear": "固定作業ディレクトリを解除", "save": "固定ディレクトリを保存",
+      "clear": "固定作業ディレクトリを解除", "save": "固定ディレクトリを保存", "createFailed": "Agent の作業ディレクトリを保存できなかったため、プロジェクトは作成されませんでした。",
       "status": { "valid": "利用可能", "offline": "ホストはオフライン", "invalid": "ディレクトリを利用できません" }
     }
   },
@@ -1707,7 +1707,7 @@
     "cancel": "キャンセル", "browseAnother": "別のディレクトリを参照", "registeredDirectories": "登録済みディレクトリ", "useOnce": "この操作のみで使用"
   },
   "directoryBrowser": {
-    "chooseHost": "ホストを選択", "unknownHost": "不明なホスト", "pathPrefix": "ディレクトリパスの接頭辞", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "ホストを選択", "unknownHost": "不明なホスト", "chooseDirectorySource": "作業ディレクトリのソースを選択", "daemonCwd": "Daemon の作業ディレクトリ", "customCwd": "このホスト上の別のディレクトリ", "pathPrefix": "ディレクトリパスの接頭辞", "pathPlaceholder": "/home/user/project",
     "browseRoot": "参照ルート", "loadingRoots": "許可されたルートを読み込み中…", "loadingCandidates": "ディレクトリ候補を読み込み中", "parent": "親ディレクトリへ移動",
     "browse": "ディレクトリを参照", "noHosts": "この Agent にオンラインのホストがありません。", "empty": "一致するディレクトリがありません。", "selection": "選択したディレクトリ",
     "errors": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1707,7 +1707,7 @@
     "cancel": "キャンセル", "browseAnother": "別のディレクトリを参照", "registeredDirectories": "登録済みディレクトリ", "useOnce": "この操作のみで使用"
   },
   "directoryBrowser": {
-    "chooseHost": "ホストを選択", "unknownHost": "不明なホスト", "chooseDirectorySource": "作業ディレクトリのソースを選択", "daemonCwd": "Daemon の作業ディレクトリ", "customCwd": "このホスト上の別のディレクトリ", "pathPrefix": "ディレクトリパスの接頭辞", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "ホストを選択", "unknownHost": "不明なホスト", "chooseDirectorySource": "作業ディレクトリのソースを選択", "daemonCwd": "Daemon の作業ディレクトリ", "configuredCwd": "Daemon 設定ディレクトリ", "customCwd": "このホスト上の別のディレクトリ", "pathPrefix": "ディレクトリパスの接頭辞", "pathPlaceholder": "/home/user/project",
     "browseRoot": "参照ルート", "loadingRoots": "許可されたルートを読み込み中…", "loadingCandidates": "ディレクトリ候補を読み込み中", "parent": "親ディレクトリへ移動",
     "browse": "ディレクトリを参照", "noHosts": "この Agent にオンラインのホストがありません。", "empty": "一致するディレクトリがありません。", "selection": "選択したディレクトリ",
     "errors": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -315,6 +315,19 @@
       "status": { "valid": "利用可能", "offline": "ホストはオフライン", "invalid": "ディレクトリを利用できません" }
     }
   },
+  "fixedCwdAnchor": {
+    "title": "固定作業ディレクトリ",
+    "host": "ホスト",
+    "cwd": "ディレクトリ",
+    "status": "状態",
+    "unknown": "不明",
+    "manage": "プロジェクト設定で管理",
+    "availability": {
+      "ready": "利用可能",
+      "offline": "ホストはオフライン",
+      "invalid": "ディレクトリを利用できません"
+    }
+  },
   "projects": {
     "title": "プロジェクト",
     "subtitle": "プロジェクトを管理し、進捗を追跡します",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -309,9 +309,9 @@
     "deleteDescription": "이 프로젝트와 모든 데이터를 영구적으로 제거합니다. 이 작업은 되돌릴 수 없습니다.",
     "agentCwds": {
       "title": "Agent 작업 디렉터리", "description": "이 프로젝트의 Agent마다 호스트와 디렉터리를 고정합니다.",
-      "loading": "작업 디렉터리를 불러오는 중...", "loadFailed": "작업 디렉터리를 불러올 수 없습니다.", "empty": "사용 가능한 Agent가 없습니다.",
+      "loading": "작업 디렉터리를 불러오는 중...", "loadFailed": "작업 디렉터리를 불러올 수 없습니다.", "empty": "사용 가능한 Agent가 없습니다.", "emptyOnline": "온라인 Agent가 없습니다.",
       "notConfigured": "작업마다 임시 디렉터리 사용", "configure": "작업 디렉터리 설정", "replace": "작업 디렉터리 변경",
-      "clear": "고정 작업 디렉터리 해제", "save": "고정 디렉터리 저장",
+      "clear": "고정 작업 디렉터리 해제", "save": "고정 디렉터리 저장", "createFailed": "Agent 작업 디렉터리를 저장할 수 없어 프로젝트가 생성되지 않았습니다.",
       "status": { "valid": "사용 가능", "offline": "호스트 오프라인", "invalid": "디렉터리 사용 불가" }
     }
   },
@@ -1707,7 +1707,7 @@
     "cancel": "취소", "browseAnother": "다른 디렉터리 찾아보기", "registeredDirectories": "등록된 디렉터리", "useOnce": "이 작업에만 사용"
   },
   "directoryBrowser": {
-    "chooseHost": "호스트 선택", "unknownHost": "알 수 없는 호스트", "pathPrefix": "디렉터리 경로 접두사", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "호스트 선택", "unknownHost": "알 수 없는 호스트", "chooseDirectorySource": "작업 디렉터리 소스 선택", "daemonCwd": "Daemon 작업 디렉터리", "customCwd": "이 호스트의 다른 디렉터리", "pathPrefix": "디렉터리 경로 접두사", "pathPlaceholder": "/home/user/project",
     "browseRoot": "탐색 루트", "loadingRoots": "허용된 루트를 불러오는 중…", "loadingCandidates": "디렉터리 제안을 불러오는 중", "parent": "상위 디렉터리로 이동",
     "browse": "디렉터리 찾아보기", "noHosts": "이 Agent에 온라인 호스트가 없습니다.", "empty": "일치하는 디렉터리가 없습니다.", "selection": "선택한 디렉터리",
     "errors": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -315,6 +315,19 @@
       "status": { "valid": "사용 가능", "offline": "호스트 오프라인", "invalid": "디렉터리 사용 불가" }
     }
   },
+  "fixedCwdAnchor": {
+    "title": "고정 작업 디렉터리",
+    "host": "호스트",
+    "cwd": "디렉터리",
+    "status": "상태",
+    "unknown": "알 수 없음",
+    "manage": "프로젝트 설정에서 관리",
+    "availability": {
+      "ready": "사용 가능",
+      "offline": "호스트 오프라인",
+      "invalid": "디렉터리를 사용할 수 없음"
+    }
+  },
   "projects": {
     "title": "프로젝트",
     "subtitle": "프로젝트를 관리하고 진행 상황을 추적하세요",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1707,7 +1707,7 @@
     "cancel": "취소", "browseAnother": "다른 디렉터리 찾아보기", "registeredDirectories": "등록된 디렉터리", "useOnce": "이 작업에만 사용"
   },
   "directoryBrowser": {
-    "chooseHost": "호스트 선택", "unknownHost": "알 수 없는 호스트", "chooseDirectorySource": "작업 디렉터리 소스 선택", "daemonCwd": "Daemon 작업 디렉터리", "customCwd": "이 호스트의 다른 디렉터리", "pathPrefix": "디렉터리 경로 접두사", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "호스트 선택", "unknownHost": "알 수 없는 호스트", "chooseDirectorySource": "작업 디렉터리 소스 선택", "daemonCwd": "Daemon 작업 디렉터리", "configuredCwd": "Daemon 구성 디렉터리", "customCwd": "이 호스트의 다른 디렉터리", "pathPrefix": "디렉터리 경로 접두사", "pathPlaceholder": "/home/user/project",
     "browseRoot": "탐색 루트", "loadingRoots": "허용된 루트를 불러오는 중…", "loadingCandidates": "디렉터리 제안을 불러오는 중", "parent": "상위 디렉터리로 이동",
     "browse": "디렉터리 찾아보기", "noHosts": "이 Agent에 온라인 호스트가 없습니다.", "empty": "일치하는 디렉터리가 없습니다.", "selection": "선택한 디렉터리",
     "errors": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -309,9 +309,9 @@
     "deleteDescription": "永久删除此项目及其所有数据，此操作无法撤销。",
     "agentCwds": {
       "title": "Agent 工作目录", "description": "为此项目中的每个 Agent 固定主机和目录。",
-      "loading": "正在加载工作目录...", "loadFailed": "无法加载工作目录。", "empty": "暂无可用 Agent。",
+      "loading": "正在加载工作目录...", "loadFailed": "无法加载工作目录。", "empty": "暂无可用 Agent。", "emptyOnline": "暂无在线 Agent。",
       "notConfigured": "每次操作临时选择目录", "configure": "配置工作目录", "replace": "替换工作目录",
-      "clear": "清除固定工作目录", "save": "保存固定目录",
+      "clear": "清除固定工作目录", "save": "保存固定目录", "createFailed": "Agent 工作目录保存失败，项目未创建。",
       "status": { "valid": "可用", "offline": "主机离线", "invalid": "目录不可用" }
     }
   },
@@ -1707,7 +1707,7 @@
     "cancel": "取消", "browseAnother": "浏览其他目录", "registeredDirectories": "已注册目录", "useOnce": "仅用于本次操作"
   },
   "directoryBrowser": {
-    "chooseHost": "选择主机", "unknownHost": "未知主机", "pathPrefix": "目录路径前缀", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "选择主机", "unknownHost": "未知主机", "chooseDirectorySource": "选择工作目录来源", "daemonCwd": "Daemon 当前工作目录", "customCwd": "此主机上的其他目录", "pathPrefix": "目录路径前缀", "pathPlaceholder": "/home/user/project",
     "browseRoot": "浏览根目录", "loadingRoots": "正在加载允许的根目录…", "loadingCandidates": "正在加载目录建议", "parent": "返回上一级目录",
     "browse": "浏览目录", "noHosts": "此 Agent 暂无在线主机。", "empty": "没有匹配的目录。", "selection": "已选目录",
     "errors": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -315,6 +315,19 @@
       "status": { "valid": "可用", "offline": "主机离线", "invalid": "目录不可用" }
     }
   },
+  "fixedCwdAnchor": {
+    "title": "固定工作目录",
+    "host": "主机",
+    "cwd": "目录",
+    "status": "状态",
+    "unknown": "未知",
+    "manage": "在项目设置中管理",
+    "availability": {
+      "ready": "可用",
+      "offline": "主机离线",
+      "invalid": "目录不可用"
+    }
+  },
   "projects": {
     "title": "项目",
     "subtitle": "管理您的项目并跟踪进度",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1707,7 +1707,7 @@
     "cancel": "取消", "browseAnother": "浏览其他目录", "registeredDirectories": "已注册目录", "useOnce": "仅用于本次操作"
   },
   "directoryBrowser": {
-    "chooseHost": "选择主机", "unknownHost": "未知主机", "chooseDirectorySource": "选择工作目录来源", "daemonCwd": "Daemon 当前工作目录", "customCwd": "此主机上的其他目录", "pathPrefix": "目录路径前缀", "pathPlaceholder": "/home/user/project",
+    "chooseHost": "选择主机", "unknownHost": "未知主机", "chooseDirectorySource": "选择工作目录来源", "daemonCwd": "Daemon 当前工作目录", "configuredCwd": "Daemon 配置目录", "customCwd": "此主机上的其他目录", "pathPrefix": "目录路径前缀", "pathPlaceholder": "/home/user/project",
     "browseRoot": "浏览根目录", "loadingRoots": "正在加载允许的根目录…", "loadingCandidates": "正在加载目录建议", "parent": "返回上一级目录",
     "browse": "浏览目录", "noHosts": "此 Agent 暂无在线主机。", "empty": "没有匹配的目录。", "selection": "已选目录",
     "errors": {

--- a/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/README.md
+++ b/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/README.md
@@ -1,0 +1,3 @@
+# unify-project-agent-cwd-anchoring
+
+Make project Agent cwd preferences authoritative across assignment, stage advance, wake, and session anchoring flows

--- a/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/design.md
+++ b/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/design.md
@@ -1,0 +1,123 @@
+## Context
+
+The predecessor change added per-user `(project, Agent)` fixed cwd preferences and directed
+execution for paths that are not daemon startup cwds. Consumption is currently fragmented:
+`wake-preview`, `notification-turn`, and `stage-advance` each query preferences separately,
+while assignment modals only understand registered `AgentInstance` rows. A discovered fixed
+cwd therefore cannot consistently become the root Idea anchor that existing proposal/task
+inheritance expects.
+
+The existing wake chain already defines the safety model we need: a Task instance override
+wins, then the root Idea hard pin, then online-first fallback. A hard pin that is offline is
+notify-only for recoverable wakes and causes a distinct failure for `require_online`
+operations. `DaemonSession.runtimeCwd` and the origin connection already keep an active
+conversation in one directory.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Resolve fixed, temporary, registered-instance, and fallback targets through one service.
+- Make a fixed preference authoritative at every new project workflow entry.
+- Materialize or reuse a durable Agent instance identity for a fixed `(agent, host, cwd)` so
+  the root Idea can use the existing hard-pin inheritance model.
+- Keep active sessions immutable when preferences change.
+- Return typed unavailable states without silently selecting another directory.
+- Keep Agent A and Agent B preferences independent in the same project.
+
+**Non-Goals:**
+
+- Moving an active session to a new cwd.
+- Making a user's preference project-shared.
+- Changing daemon browse-root security or directory discovery.
+- Allowing inline overrides while a fixed preference exists.
+
+## Decisions
+
+### Use one resolved-target contract
+
+Add a project cwd anchoring service that accepts company, actor, project, Agent, and optional
+operation-local target. It returns a discriminated result containing:
+
+- `source`: `project_fixed`, `temporary`, `registered_instance`, or `unconfigured`
+- `agentUuid`, `host`, `cwd`, and optional connection/instance identifiers
+- `actorUserUuid`, identifying the user whose project preference authorized the anchor
+- `status`: `ready`, `offline`, or `invalid`
+- whether the caller must prompt
+
+Callers consume this result instead of querying `ProjectAgentCwdPreference` directly.
+Preference resolution precedes temporary and registered-instance choices. A stored
+preference never degrades to `unconfigured`.
+
+The workflow entry resolves exactly once and passes the complete result through all
+subsequent stages of that operation. Later stages do not re-resolve against a changed actor,
+preference, or connection registry. When the operation creates a durable Idea/Task anchor
+or daemon session, that persisted target becomes the source for later independent
+operations.
+
+Alternative: keep a common helper that returns only the preference row. Rejected because
+callers would still duplicate online-host lookup, hard-pin construction, and error policy.
+
+### Anchor fixed targets through durable AgentInstance identity
+
+When a fixed target is ready, resolve or materialize the durable
+`AgentInstance(agentUuid, host, cwd)` identity even if the cwd is not a startup connection.
+Assignment persists that instance on the root Idea or Task. Dispatch still chooses an online
+connection on the same Agent and host and carries `runtimeCwd` for an unregistered path.
+
+This lets all existing proposal/task inheritance and hard-pin rules work without adding a
+second cwd reference to Idea or Task. It also means unattended flows use the Idea's persisted
+target rather than guessing which user's preference to load later.
+
+Alternative: store a new preference UUID on every Idea. Rejected because it couples an
+immutable execution anchor to a mutable/deletable user preference and duplicates the
+polymorphic assignment model.
+
+### Preference changes affect only future anchors
+
+Replacing or clearing a preference changes later assignment and stage-entry resolution. It
+does not rewrite existing Idea/Task assignees and never mutates `DaemonSession.runtimeCwd` or
+origin connection. Resume, continuation, and delivered turns remain attached to the session
+that created them.
+
+### Preserve hard-pin offline policy
+
+A fixed target with no online connection on its host returns `offline`; an invalid path
+returns `invalid`. Interactive surfaces show the fixed host/cwd and a project-settings link.
+Recoverable wake paths keep the hard target and remain notify-only for reconnect backfill.
+`Start Development`, `Yolo`, and other `require_online` actions fail with a typed target
+error. No branch falls through to online-first.
+
+### Suppress pickers but keep the anchor visible
+
+Assignment and stage-entry surfaces do not render instance/cwd pickers when the resolver
+returns `project_fixed`. They render a compact read-only host/cwd summary and a settings
+action. Clearing the preference restores the existing auto-pin/picker/temporary browse flow.
+
+## Risks / Trade-offs
+
+- [A discovered cwd has no startup AgentInstance] -> Upsert only the durable identity; do not
+  create a fake online connection, and continue dispatching with host plus `runtimeCwd`.
+- [Preference is cleared after an Idea is anchored] -> Existing Idea remains intentionally
+  pinned; only a new assignment can establish a new anchor.
+- [Callers bypass the resolver] -> Add focused tests and repository searches covering every
+  project workflow entry; keep direct preference reads confined to the resolver/settings.
+- [Host is online but path became invalid] -> Validate at dispatch and return the typed
+  invalid state; never reroute.
+
+## Migration Plan
+
+1. Introduce the resolver and durable fixed-target anchoring with compatibility tests.
+2. Migrate assignment, wake-preview, and stage-entry callers to resolve once, propagate the
+   actor-bearing result, and reuse it through each operation.
+3. Add UI fixed-anchor states and remove picker rendering for fixed targets.
+4. Run integration and browser acceptance across fixed, cleared, multi-Agent, offline, and
+   session-continuity cases.
+
+Rollback restores the old callers. Existing preference, instance, and session rows remain
+compatible and require no cleanup.
+
+## Open Questions
+
+None. Round 1 established root-Idea anchoring, immutable active sessions, visible read-only
+anchors, and alignment with current hard-pin offline behavior.

--- a/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/proposal.md
+++ b/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Project-level Agent cwd preferences exist, but each assignment, stage-advance, and wake
+surface still decides independently whether to show an instance picker or how to resolve a
+runtime cwd. This duplication lets a saved fixed cwd be bypassed and risks starting work in
+the wrong repository.
+
+## What Changes
+
+- Add one shared project-Agent cwd target resolver with an explicit resolution source,
+  liveness state, and immutable host/cwd result.
+- Make new Idea and Task assignment flows consume a valid fixed cwd directly and suppress
+  instance/cwd pickers while the fixed preference exists.
+- Anchor a root Idea once, then let same-Agent proposal, task, stage-advance, and wake flows
+  inherit that target through the existing hard-pin chain.
+- Preserve active session cwd and origin-host stickiness when a project preference is later
+  replaced or cleared.
+- Apply the existing hard-pin offline policy to fixed targets: recoverable wakes remain
+  notify-only, require-online actions fail distinctly, and no flow silently reroutes.
+- Restore existing instance auto-selection, picker, and temporary discovered-cwd behavior
+  only after the preference is explicitly cleared.
+
+## Capabilities
+
+### New Capabilities
+
+- `project-cwd-anchoring`: Authoritative project-Agent cwd resolution, root-Idea anchoring,
+  picker suppression, hard-pin failures, Agent isolation, and session continuity.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects project cwd preference services, Idea and Task assignment actions and
+modals, wake preview, stage-advance services, notification target resolution, shared picker
+orchestration, and focused unit/integration/browser coverage. It reuses the existing
+`ProjectAgentCwdPreference`, `AgentInstance`, directed `runtimeCwd`, and daemon session
+models without a data migration.

--- a/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/specs/project-cwd-anchoring/spec.md
+++ b/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/specs/project-cwd-anchoring/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Fixed project-Agent cwd is the authoritative new-work anchor
+
+For the current user, Chorus SHALL resolve a saved fixed cwd before any temporary cwd,
+registered instance, auto-selection, or picker behavior whenever new project work targets
+that Agent. The resolved target MUST include the actor user, Agent, host, cwd, source, and
+availability state, and callers MUST NOT independently reinterpret the preference.
+
+#### Scenario: Idea is assigned to an Agent with a fixed cwd
+- **WHEN** a user assigns a new or existing Idea to an Agent with a ready fixed cwd
+- **THEN** Chorus MUST persist that host and cwd as the Idea's hard execution anchor
+- **AND** it MUST NOT display an instance or cwd picker
+
+#### Scenario: Task targets another Agent
+- **WHEN** a Task is assigned to Agent B while its root Idea is anchored to Agent A
+- **THEN** Chorus MUST resolve Agent B's own project preference independently
+- **AND** it MUST NOT inherit Agent A's cwd
+
+#### Scenario: Fixed preference is cleared
+- **WHEN** the user clears the Agent's fixed cwd and starts a later assignment
+- **THEN** Chorus MUST restore the existing online-instance auto-selection or picker behavior
+- **AND** temporary discovered-cwd selection MUST again be available for that operation
+
+#### Scenario: One operation spans multiple stages
+- **WHEN** an assignment or stage-entry operation resolves its project-Agent cwd target
+- **THEN** every later stage of that operation MUST reuse the same actor-bearing resolved target
+- **AND** it MUST NOT re-resolve against a changed preference, actor, or connection registry
+
+### Requirement: Root Idea anchor governs same-Agent downstream flows
+
+Once a root Idea has a hard cwd anchor, Chorus MUST make same-Agent proposal, task,
+stage-advance, Yolo, wake, and continuation entry points inherit that immutable target
+through the shared resolution chain. They MUST NOT reopen an instance/cwd picker or re-read
+a mutable project preference to replace the established anchor.
+
+#### Scenario: Start Development inherits the root anchor
+- **WHEN** Start Development is invoked for an Idea anchored to a fixed host and cwd
+- **THEN** Chorus MUST use that exact target without another picker
+
+#### Scenario: Proposal stage advance inherits the root anchor
+- **WHEN** an approval or elaboration transition wakes the same Agent under an anchored Idea
+- **THEN** the wake MUST target the root Idea's host and cwd
+
+#### Scenario: Preference changes after anchoring
+- **WHEN** a user replaces or clears the project preference after an Idea was anchored
+- **THEN** the existing Idea and its active sessions MUST keep their original target
+- **AND** the new preference MUST apply only to later anchors
+
+### Requirement: Fixed anchors preserve hard-pin failure behavior
+
+A fixed project cwd SHALL remain a hard target when its host is offline or its path is
+invalid. Chorus MUST expose a typed state and MUST NOT silently fall back to another
+connection, cwd, or Agent instance.
+
+#### Scenario: Recoverable wake targets an offline fixed host
+- **WHEN** a recoverable wake resolves to a fixed target whose host is offline
+- **THEN** delivery MUST remain notify-only for that target
+- **AND** reconnect backfill MAY deliver it only to the original host and cwd
+
+#### Scenario: Require-online action targets an unavailable fixed cwd
+- **WHEN** Start Development, Yolo, or another require-online action resolves an offline or invalid fixed target
+- **THEN** the action MUST fail with a distinguishable typed error
+- **AND** no other cwd of the Agent may be woken
+
+#### Scenario: UI encounters an unavailable fixed cwd
+- **WHEN** an assignment or stage-entry surface resolves an offline or invalid fixed target
+- **THEN** it MUST show the fixed host, cwd, and state with a project-settings replace or clear action
+- **AND** it MUST NOT show an alternate cwd picker
+
+### Requirement: Active session cwd remains sticky
+
+Every directed session SHALL persist its runtime cwd and origin connection, and resume,
+continuation, and delivered instruction turns MUST reuse those values regardless of later
+project preference changes.
+
+#### Scenario: Preference changes during an active session
+- **WHEN** the user replaces or clears the fixed cwd after a directed session starts
+- **THEN** the next resume or continuation MUST use the session's original runtime cwd and origin connection
+
+#### Scenario: Origin host is unavailable during resume
+- **WHEN** an active session's origin host is offline
+- **THEN** Chorus MUST report the existing resume failure state
+- **AND** it MUST NOT start a replacement session in the current project preference
+
+### Requirement: Fixed-anchor UI suppresses cwd selection
+
+Every project workflow surface that would otherwise ask for an Agent instance or cwd SHALL
+hide that picker when a fixed target exists. The surface MUST display a read-only anchor
+summary and a route to manage the preference in project settings.
+
+#### Scenario: Fixed target is ready
+- **WHEN** a fixed Agent target is available on an assignment or stage-entry surface
+- **THEN** the surface MUST display the resolved host and cwd
+- **AND** no selectable instance or temporary-directory control may be rendered
+
+#### Scenario: Multiple Agents have fixed targets
+- **WHEN** a project has independent fixed cwd preferences for Agent A and Agent B
+- **THEN** selecting either Agent MUST display only that Agent's anchor
+- **AND** changing one preference MUST NOT alter the other Agent's UI or resolution

--- a/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/tasks.md
+++ b/openspec/changes/archive/2026-08-02-unify-project-agent-cwd-anchoring/tasks.md
@@ -1,0 +1,14 @@
+## 1. Shared Resolution
+
+- [x] 1.1 Implement the authoritative actor-bearing project-Agent cwd resolved-target service, including durable fixed-target AgentInstance identity and typed ready/offline/invalid states.
+- [x] 1.2 Migrate wake preview, stage advance, and notification target resolution to the shared service while preserving hard-pin and active-session precedence.
+
+## 2. Assignment And Entry Surfaces
+
+- [x] 2.1 Integrate fixed cwd anchoring into Idea and Task assignment actions and suppress instance/cwd pickers in favor of a read-only anchor with a project-settings action.
+- [x] 2.2 Reuse the fixed-anchor state in Start Development, Yolo, proposal actions, and all other cwd-confirming project entry points.
+
+## 3. Verification
+
+- [x] 3.1 Add unit and integration coverage for fixed/clear transitions, actor capture, immutable reuse across one operation, multiple Agent isolation, hard-pin offline/invalid behavior, root inheritance, and sticky resume/continuation.
+- [x] 3.2 Add browser acceptance coverage proving that fixed targets never render cwd pickers and cleared targets restore existing selection behavior.

--- a/openspec/specs/project-cwd-anchoring/spec.md
+++ b/openspec/specs/project-cwd-anchoring/spec.md
@@ -1,0 +1,103 @@
+# project-cwd-anchoring Specification
+
+## Purpose
+TBD - created by archiving change unify-project-agent-cwd-anchoring. Update Purpose after archive.
+## Requirements
+### Requirement: Fixed project-Agent cwd is the authoritative new-work anchor
+
+For the current user, Chorus SHALL resolve a saved fixed cwd before any temporary cwd,
+registered instance, auto-selection, or picker behavior whenever new project work targets
+that Agent. The resolved target MUST include the actor user, Agent, host, cwd, source, and
+availability state, and callers MUST NOT independently reinterpret the preference.
+
+#### Scenario: Idea is assigned to an Agent with a fixed cwd
+- **WHEN** a user assigns a new or existing Idea to an Agent with a ready fixed cwd
+- **THEN** Chorus MUST persist that host and cwd as the Idea's hard execution anchor
+- **AND** it MUST NOT display an instance or cwd picker
+
+#### Scenario: Task targets another Agent
+- **WHEN** a Task is assigned to Agent B while its root Idea is anchored to Agent A
+- **THEN** Chorus MUST resolve Agent B's own project preference independently
+- **AND** it MUST NOT inherit Agent A's cwd
+
+#### Scenario: Fixed preference is cleared
+- **WHEN** the user clears the Agent's fixed cwd and starts a later assignment
+- **THEN** Chorus MUST restore the existing online-instance auto-selection or picker behavior
+- **AND** temporary discovered-cwd selection MUST again be available for that operation
+
+#### Scenario: One operation spans multiple stages
+- **WHEN** an assignment or stage-entry operation resolves its project-Agent cwd target
+- **THEN** every later stage of that operation MUST reuse the same actor-bearing resolved target
+- **AND** it MUST NOT re-resolve against a changed preference, actor, or connection registry
+
+### Requirement: Root Idea anchor governs same-Agent downstream flows
+
+Once a root Idea has a hard cwd anchor, Chorus MUST make same-Agent proposal, task,
+stage-advance, Yolo, wake, and continuation entry points inherit that immutable target
+through the shared resolution chain. They MUST NOT reopen an instance/cwd picker or re-read
+a mutable project preference to replace the established anchor.
+
+#### Scenario: Start Development inherits the root anchor
+- **WHEN** Start Development is invoked for an Idea anchored to a fixed host and cwd
+- **THEN** Chorus MUST use that exact target without another picker
+
+#### Scenario: Proposal stage advance inherits the root anchor
+- **WHEN** an approval or elaboration transition wakes the same Agent under an anchored Idea
+- **THEN** the wake MUST target the root Idea's host and cwd
+
+#### Scenario: Preference changes after anchoring
+- **WHEN** a user replaces or clears the project preference after an Idea was anchored
+- **THEN** the existing Idea and its active sessions MUST keep their original target
+- **AND** the new preference MUST apply only to later anchors
+
+### Requirement: Fixed anchors preserve hard-pin failure behavior
+
+A fixed project cwd SHALL remain a hard target when its host is offline or its path is
+invalid. Chorus MUST expose a typed state and MUST NOT silently fall back to another
+connection, cwd, or Agent instance.
+
+#### Scenario: Recoverable wake targets an offline fixed host
+- **WHEN** a recoverable wake resolves to a fixed target whose host is offline
+- **THEN** delivery MUST remain notify-only for that target
+- **AND** reconnect backfill MAY deliver it only to the original host and cwd
+
+#### Scenario: Require-online action targets an unavailable fixed cwd
+- **WHEN** Start Development, Yolo, or another require-online action resolves an offline or invalid fixed target
+- **THEN** the action MUST fail with a distinguishable typed error
+- **AND** no other cwd of the Agent may be woken
+
+#### Scenario: UI encounters an unavailable fixed cwd
+- **WHEN** an assignment or stage-entry surface resolves an offline or invalid fixed target
+- **THEN** it MUST show the fixed host, cwd, and state with a project-settings replace or clear action
+- **AND** it MUST NOT show an alternate cwd picker
+
+### Requirement: Active session cwd remains sticky
+
+Every directed session SHALL persist its runtime cwd and origin connection, and resume,
+continuation, and delivered instruction turns MUST reuse those values regardless of later
+project preference changes.
+
+#### Scenario: Preference changes during an active session
+- **WHEN** the user replaces or clears the fixed cwd after a directed session starts
+- **THEN** the next resume or continuation MUST use the session's original runtime cwd and origin connection
+
+#### Scenario: Origin host is unavailable during resume
+- **WHEN** an active session's origin host is offline
+- **THEN** Chorus MUST report the existing resume failure state
+- **AND** it MUST NOT start a replacement session in the current project preference
+
+### Requirement: Fixed-anchor UI suppresses cwd selection
+
+Every project workflow surface that would otherwise ask for an Agent instance or cwd SHALL
+hide that picker when a fixed target exists. The surface MUST display a read-only anchor
+summary and a route to manage the preference in project settings.
+
+#### Scenario: Fixed target is ready
+- **WHEN** a fixed Agent target is available on an assignment or stage-entry surface
+- **THEN** the surface MUST display the resolved host and cwd
+- **AND** no selectable instance or temporary-directory control may be rendered
+
+#### Scenario: Multiple Agents have fixed targets
+- **WHEN** a project has independent fixed cwd preferences for Agent A and Agent B
+- **THEN** selecting either Agent MUST display only that Agent's anchor
+- **AND** changing one preference MUST NOT alter the other Agent's UI or resolution

--- a/prisma/migrations/20260802140000_add_assignment_runtime_cwd_snapshot/migration.sql
+++ b/prisma/migrations/20260802140000_add_assignment_runtime_cwd_snapshot/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "Idea" ADD COLUMN "cwdSource" TEXT;
+ALTER TABLE "Idea" ADD COLUMN "cwdHost" TEXT;
+ALTER TABLE "Idea" ADD COLUMN "runtimeCwd" TEXT;
+
+ALTER TABLE "Task" ADD COLUMN "cwdSource" TEXT;
+ALTER TABLE "Task" ADD COLUMN "cwdHost" TEXT;
+ALTER TABLE "Task" ADD COLUMN "runtimeCwd" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,6 +195,9 @@ model Idea {
   status            String    @default("open") // open | elaborating | elaborated (3-state model; post-elaboration status derived from Proposal+Task)
   assigneeType      String? // user | agent
   assigneeUuid      String? // User or Agent UUID (polymorphic)
+  cwdSource         String? // project_fixed when this anchor originated from a fixed preference
+  cwdHost           String? // Host anchor for a discovered runtime cwd assignment
+  runtimeCwd        String? // Runtime cwd executed through any online connection on cwdHost
   assignedAt        DateTime? // Assignment timestamp
   assignedByUuid    String? // User UUID (human assignment)
   // Elaboration (AI-DLC Stage 3 — structured requirements clarification)
@@ -262,6 +265,9 @@ model Task {
   // root idea's instance (notification-turn.ts resolvePinnedTarget).
   assigneeType            String? // user | agent | agent_instance
   assigneeUuid            String? // User / Agent / AgentInstance UUID (polymorphic)
+  cwdSource               String? // project_fixed when this anchor originated from a fixed preference
+  cwdHost                 String? // Host anchor for a discovered runtime cwd assignment
+  runtimeCwd              String? // Runtime cwd executed through any online connection on cwdHost
   assignedAt              DateTime? // Assignment timestamp
   assignedByUuid          String? // User UUID (human assignment)
   proposalUuid            String? // Source Proposal UUID (traceable, optional)

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/new-idea-dialog.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/new-idea-dialog.test.tsx
@@ -117,6 +117,10 @@ function renderDialog(over: Partial<Parameters<typeof NewIdeaDialog>[0]> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockAuthFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, data: { agents: [] } }),
+  });
 });
 
 describe("NewIdeaDialog — mode gating", () => {
@@ -156,8 +160,11 @@ describe("NewIdeaDialog — mode gating", () => {
       userText: "my idea",
     });
     expect(returned).toEqual(session);
-    expect(mockAuthFetch).toHaveBeenCalledTimes(1);
-    const [url, init] = mockAuthFetch.mock.calls[0];
+    const ideaCalls = mockAuthFetch.mock.calls.filter(
+      ([url]) => url === "/api/ideas/conversational",
+    );
+    expect(ideaCalls).toHaveLength(1);
+    const [url, init] = ideaCalls[0];
     expect(url).toBe("/api/ideas/conversational");
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({
       projectUuid: "proj-1",
@@ -190,7 +197,9 @@ describe("NewIdeaDialog — mode gating", () => {
       connectionUuid: "c1",
       userText: "big feature to split",
     });
-    const [url, init] = mockAuthFetch.mock.calls[0];
+    const [url, init] = mockAuthFetch.mock.calls.find(
+      ([calledUrl]) => calledUrl === "/api/ideas/conversational",
+    )!;
     expect(url).toBe("/api/ideas/conversational");
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({
       projectUuid: "proj-1",
@@ -256,6 +265,25 @@ describe("NewIdeaDialog — mode gating", () => {
     expect(screen.getByText("daemon-connect-cta")).toBeTruthy();
     // Form still fully usable.
     expect(screen.getByLabelText("Title")).toBeTruthy();
+  });
+
+  it("offline fixed target keeps the conversational tab enabled", async () => {
+    setPresence(false);
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          agents: [{ agent: { uuid: "agent-1" }, preference: { status: "offline" } }],
+        },
+      }),
+    });
+    renderDialog();
+
+    const tab = (await screen.findByRole("tab", {
+      name: "Describe to an agent",
+    })) as HTMLButtonElement;
+    expect(tab.disabled).toBe(false);
   });
 
   it("derive-child mode renders no tabs at all (form only)", () => {

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/project-cwd-summary.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/project-cwd-summary.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) =>
+    key === "title" ? "Project fixed directory" : key,
+}));
+
+const mockAuthFetch = vi.fn();
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
+import { ProjectCwdSummary } from "../project-cwd-summary";
+
+describe("ProjectCwdSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders configured Agent cwd values beside the project title", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          agents: [
+            {
+              agent: { uuid: "agent-1", name: "Claude" },
+              preference: { cwd: "/work/dynamic-project" },
+            },
+            {
+              agent: { uuid: "agent-2", name: "Codex" },
+              preference: null,
+            },
+          ],
+        },
+      }),
+    });
+
+    render(<ProjectCwdSummary projectUuid="project-1" />);
+
+    const summary = await screen.findByLabelText("Project fixed directory");
+    expect(summary.textContent).toContain("/work/dynamic-project");
+    expect(summary.getAttribute("class")).toContain("flex-wrap");
+    expect(screen.queryByText("Codex")).toBeNull();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/dashboard-content.tsx
@@ -6,6 +6,7 @@ import { getDashboardData } from "./dashboard-data";
 import { ProjectSettingsModal } from "./project-settings-modal";
 import { IdeaTracker } from "./idea-tracker";
 import { CollapsibleMarkdown } from "@/components/collapsible-markdown";
+import { ProjectCwdSummary } from "./project-cwd-summary";
 
 interface DashboardContentProps {
   projectUuid: string;
@@ -21,7 +22,12 @@ export async function DashboardContent({ projectUuid, initialSelectedIdeaUuid }:
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">{t("ideaTracker.overview")}</p>
-          <h1 className="mt-1 truncate text-2xl font-semibold tracking-tight text-foreground">{project.name}</h1>
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+            <h1 className="min-w-0 truncate text-2xl font-semibold tracking-tight text-foreground">
+              {project.name}
+            </h1>
+            <ProjectCwdSummary projectUuid={projectUuid} />
+          </div>
           {project.description?.trim() ? (
             <CollapsibleMarkdown
               content={project.description}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/new-idea-dialog.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/new-idea-dialog.tsx
@@ -20,7 +20,7 @@
 //   - Derive-child mode (parentUuid set) is form-only: the template contract
 //     does not cover lineage, so the tabs are not rendered at all.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -88,6 +88,29 @@ export function NewIdeaDialog({
   // agent to propose child ideas as an elaboration round. Rides the existing
   // conversational wake — no new action type.
   const [decompose, setDecompose] = useState(false);
+  const [hasProjectFixedTarget, setHasProjectFixedTarget] = useState(false);
+  useEffect(() => {
+    if (!open || isDerive) return;
+    let cancelled = false;
+    authFetch(`/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`)
+      .then(async (response) => {
+        if (!response.ok) return;
+        const json = await response.json();
+        if (!cancelled) {
+          setHasProjectFixedTarget(
+            (json?.data?.agents ?? []).some(
+              (item: { preference?: unknown }) => item.preference,
+            ),
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setHasProjectFixedTarget(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isDerive, open, projectUuid]);
 
   // Conversational mode plumbing. The presence spine is optional so the dialog
   // stays mountable outside the dashboard shell (treated as "no daemon online").
@@ -298,6 +321,7 @@ export function NewIdeaDialog({
         </div>
       </div>
       <ConversationalEntry
+        projectUuid={projectUuid}
         dispatch={conversationalDispatch}
         onStarted={(session) => {
           onOpenChange(false);
@@ -330,7 +354,10 @@ export function NewIdeaDialog({
                 {/* Visible-but-disabled when no daemon is online (q6=b) — the
                     affordance advertises the conversational path; the hint
                     below explains why and how to enable it. */}
-                <TabsTrigger value="conversation" disabled={!daemonOnline}>
+                <TabsTrigger
+                  value="conversation"
+                  disabled={!daemonOnline && !hasProjectFixedTarget}
+                >
                   {t("newIdea.modeConversation")}
                 </TabsTrigger>
               </TabsList>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -47,6 +47,7 @@ import { YoloButton } from "@/components/yolo-button";
 import { ReferencesSection } from "@/components/references-section";
 import { usePinThenWake } from "@/hooks/use-pin-then-wake";
 import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
+import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
 import { reassignIdeaInstanceNoWakeAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions";
 import { clientLogger } from "@/lib/logger-client";
 import { formatDateTime } from "@/lib/format-date";
@@ -211,7 +212,11 @@ export function IdeaDetailPanel({
     confirmPick: confirmVerifyPick,
     cancelPick: cancelVerifyPick,
     isResolving: isResolvingVerify,
-  } = usePinThenWake({ reassignNoWake: reassignIdeaInstanceNoWakeAction });
+    fixedTarget,
+  } = usePinThenWake({
+    reassignNoWake: reassignIdeaInstanceNoWakeAction,
+    previewIdeaUuid: idea?.uuid,
+  });
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -1055,66 +1060,67 @@ export function IdeaDetailPanel({
                       / Yolo are suppressed. "Derive child idea" (header GitFork
                       button) is the primary progression path instead. */}
                   {!isContainer && (
-                  <>
-                  {/* Verify Elaborate — human "elaboration confirmed, agent
-                      writes the proposal" action, gated by the shared
-                      predicate. No manual create-proposal fallback here. */}
-                  {canVerify && !verified && (
-                    <Button
-                      className="bg-primary hover:bg-[#B56A42] text-white"
-                      onClick={handleVerify}
-                      disabled={isVerifying || isResolvingVerify}
-                    >
-                      {isVerifying ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          {t("elaboration.verifying")}
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle2 className="mr-2 h-4 w-4" />
-                          {t("elaboration.verifyButton")}
-                        </>
+                    <>
+                      {fixedTarget && <FixedCwdAnchor target={fixedTarget} />}
+                      {/* Verify Elaborate — human "elaboration confirmed, agent
+                          writes the proposal" action, gated by the shared
+                          predicate. No manual create-proposal fallback here. */}
+                      {canVerify && !verified && (
+                        <Button
+                          className="bg-primary hover:bg-[#B56A42] text-white"
+                          onClick={handleVerify}
+                          disabled={isVerifying || isResolvingVerify}
+                        >
+                          {isVerifying ? (
+                            <>
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              {t("elaboration.verifying")}
+                            </>
+                          ) : (
+                            <>
+                              <CheckCircle2 className="mr-2 h-4 w-4" />
+                              {t("elaboration.verifyButton")}
+                            </>
+                          )}
+                        </Button>
                       )}
-                    </Button>
-                  )}
-                  {verified && (
-                    <span className="text-[11px] text-[#00796B] dark:text-[#4FD1C0]">
-                      {t("elaboration.verifiedQueuedHint")}
-                    </span>
-                  )}
-                  {verifyError && (
-                    <span className="text-[11px] text-destructive">{verifyError}</span>
-                  )}
-                  {/* Start Development — human "the plan is approved, go build
-                      it" action (add-stage-advance-start-development). Same
-                      shared-predicate contract as Verify Elaborate; presence
-                      gating + per-error-code toasts live in the component. */}
-                  <StartDevelopmentButton
-                    ideaUuid={idea.uuid}
-                    assignee={idea.assignee}
-                    assigneeName={idea.assignee?.name}
-                    proposals={proposals}
-                    tasks={tasks}
-                    onStarted={() => {
-                      fetchIdea();
-                    }}
-                  />
-                  {/* Yolo — human "drive this whole idea to done via the yolo
-                      skill" action (add-stage-advance-yolo). Shows at any
-                      incomplete stage (relaxed predicate), so it can coexist
-                      with Start Development on a building-stage idea. */}
-                  <YoloButton
-                    ideaUuid={idea.uuid}
-                    assignee={idea.assignee}
-                    assigneeName={idea.assignee?.name}
-                    proposals={proposals}
-                    tasks={tasks}
-                    onStarted={() => {
-                      fetchIdea();
-                    }}
-                  />
-                  </>
+                      {verified && (
+                        <span className="text-[11px] text-[#00796B] dark:text-[#4FD1C0]">
+                          {t("elaboration.verifiedQueuedHint")}
+                        </span>
+                      )}
+                      {verifyError && (
+                        <span className="text-[11px] text-destructive">{verifyError}</span>
+                      )}
+                      {/* Start Development — human "the plan is approved, go build
+                          it" action (add-stage-advance-start-development). Same
+                          shared-predicate contract as Verify Elaborate; presence
+                          gating + per-error-code toasts live in the component. */}
+                      <StartDevelopmentButton
+                        ideaUuid={idea.uuid}
+                        assignee={idea.assignee}
+                        assigneeName={idea.assignee?.name}
+                        proposals={proposals}
+                        tasks={tasks}
+                        onStarted={() => {
+                          fetchIdea();
+                        }}
+                      />
+                      {/* Yolo — human "drive this whole idea to done via the yolo
+                          skill" action (add-stage-advance-yolo). Shows at any
+                          incomplete stage (relaxed predicate), so it can coexist
+                          with Start Development on a building-stage idea. */}
+                      <YoloButton
+                        ideaUuid={idea.uuid}
+                        assignee={idea.assignee}
+                        assigneeName={idea.assignee?.name}
+                        proposals={proposals}
+                        tasks={tasks}
+                        onStarted={() => {
+                          fetchIdea();
+                        }}
+                      />
+                    </>
                   )}
                   {/* Container hint — replaces the proposal CTAs so the footer
                       is never empty and the "derive instead" affordance reads. */}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -47,7 +47,6 @@ import { YoloButton } from "@/components/yolo-button";
 import { ReferencesSection } from "@/components/references-section";
 import { usePinThenWake } from "@/hooks/use-pin-then-wake";
 import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
-import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
 import { reassignIdeaInstanceNoWakeAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions";
 import { clientLogger } from "@/lib/logger-client";
 import { formatDateTime } from "@/lib/format-date";
@@ -212,7 +211,6 @@ export function IdeaDetailPanel({
     confirmPick: confirmVerifyPick,
     cancelPick: cancelVerifyPick,
     isResolving: isResolvingVerify,
-    fixedTarget,
   } = usePinThenWake({
     reassignNoWake: reassignIdeaInstanceNoWakeAction,
     previewIdeaUuid: idea?.uuid,
@@ -1061,7 +1059,6 @@ export function IdeaDetailPanel({
                       button) is the primary progression path instead. */}
                   {!isContainer && (
                     <>
-                      {fixedTarget && <FixedCwdAnchor target={fixedTarget} />}
                       {/* Verify Elaborate — human "elaboration confirmed, agent
                           writes the proposal" action, gated by the shared
                           predicate. No manual create-proposal fallback here. */}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/project-cwd-summary.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/project-cwd-summary.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FolderLock } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { authFetch } from "@/lib/auth-client";
+
+interface FixedCwdPreference {
+  agent: { uuid: string; name: string };
+  preference: {
+    cwd: string;
+  } | null;
+}
+
+export function ProjectCwdSummary({ projectUuid }: { projectUuid: string }) {
+  const t = useTranslations("fixedCwdAnchor");
+  const [preferences, setPreferences] = useState<FixedCwdPreference[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    authFetch(`/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`)
+      .then(async (response) => {
+        if (!response.ok) return;
+        const json = await response.json();
+        if (!cancelled) {
+          setPreferences(
+            (json?.data?.agents ?? []).filter(
+              (item: FixedCwdPreference) => item.preference?.cwd,
+            ),
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setPreferences([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectUuid]);
+
+  if (preferences.length === 0) return null;
+
+  return (
+    <div
+      className="flex min-w-0 flex-wrap items-center gap-1.5"
+      aria-label={t("title")}
+    >
+      {preferences.map(({ agent, preference }) => (
+        <span
+          key={agent.uuid}
+          className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[11px] text-muted-foreground"
+          title={`${agent.name}: ${preference!.cwd}`}
+        >
+          <FolderLock className="size-3.5 shrink-0 text-primary" aria-hidden />
+          <span className="max-w-[min(18rem,65vw)] truncate font-mono">
+            {preference!.cwd}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/project-settings-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/project-settings-modal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "@/hooks/use-progress-router";
 import { useTranslations } from "next-intl";
-import { Settings, Loader2, FolderCog, RotateCcw, Trash2 } from "lucide-react";
+import { Settings, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,21 +29,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { updateProjectAction, deleteProjectAction } from "../actions";
-import {
-  DirectoryBrowser,
-  type ValidatedDirectory,
-} from "@/components/agent-presence/directory-browser";
-import type { InstanceCandidate } from "@/components/agent-presence/instance-picker";
-
-interface AgentCwdItem {
-  agent: { uuid: string; name: string };
-  onlineInstances: InstanceCandidate[];
-  preference: {
-    host: string;
-    cwd: string;
-    status: "valid" | "offline" | "invalid";
-  } | null;
-}
+import { ProjectAgentCwdSettings } from "@/components/project-agent-cwd-settings";
 
 interface ProjectSettingsModalProps {
   projectUuid: string;
@@ -64,66 +50,6 @@ export function ProjectSettingsModal({
   const [description, setDescription] = useState(projectDescription || "");
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [cwdItems, setCwdItems] = useState<AgentCwdItem[]>([]);
-  const [cwdLoading, setCwdLoading] = useState(false);
-  const [editingAgent, setEditingAgent] = useState<string | null>(null);
-  const [cwdError, setCwdError] = useState(false);
-
-  const loadCwds = async () => {
-    setCwdLoading(true);
-    setCwdError(false);
-    try {
-      const response = await fetch(
-        `/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`,
-      );
-      const body = await response.json();
-      if (!response.ok || !body.success) throw new Error("load failed");
-      setCwdItems(body.data.agents);
-    } catch {
-      setCwdError(true);
-    } finally {
-      setCwdLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (open) void loadCwds();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, projectUuid]);
-
-  const saveCwd = async (selection: ValidatedDirectory) => {
-    const response = await fetch(
-      `/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`,
-      {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          agentUuid: selection.agentUuid,
-          validationRequestUuid: selection.validationRequestUuid,
-        }),
-      },
-    );
-    if (!response.ok) throw new Error("save failed");
-    setEditingAgent(null);
-    await loadCwds();
-  };
-
-  const clearCwd = async (agentUuid: string) => {
-    const response = await fetch(
-      `/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`,
-      {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ agentUuid }),
-      },
-    );
-    if (!response.ok) {
-      setCwdError(true);
-      return;
-    }
-    await loadCwds();
-  };
-
   const handleSave = async () => {
     setSaving(true);
     const result = await updateProjectAction(projectUuid, {
@@ -215,124 +141,7 @@ export function ProjectSettingsModal({
 
           <Separator className="bg-[#E5E2DC] dark:bg-[#26241f]" />
 
-          <div className="flex min-w-0 flex-col gap-4">
-            <div>
-              <h3 className="text-[14px] font-semibold text-foreground">
-                {t("projectSettings.agentCwds.title")}
-              </h3>
-              <p className="mt-1 text-[12px] text-muted-foreground">
-                {t("projectSettings.agentCwds.description")}
-              </p>
-            </div>
-
-            {cwdLoading && (
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Loader2 className="size-4 animate-spin" />
-                {t("projectSettings.agentCwds.loading")}
-              </div>
-            )}
-            {cwdError && (
-              <div className="flex items-center justify-between gap-3" role="alert">
-                <span className="text-xs text-destructive">
-                  {t("projectSettings.agentCwds.loadFailed")}
-                </span>
-                <Button type="button" size="sm" variant="outline" onClick={loadCwds}>
-                  <RotateCcw className="mr-2 size-3.5" />
-                  {t("common.retry")}
-                </Button>
-              </div>
-            )}
-            {!cwdLoading && !cwdError && cwdItems.length === 0 && (
-              <p className="text-xs text-muted-foreground">
-                {t("projectSettings.agentCwds.empty")}
-              </p>
-            )}
-
-            {cwdItems.map((item) => (
-              <div
-                key={item.agent.uuid}
-                className="min-w-0 rounded-xl border border-[#E5E2DC] p-4 dark:border-[#2a2a2e]"
-              >
-                <div className="flex min-w-0 items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="truncate text-[13px] font-semibold">{item.agent.name}</p>
-                    {item.preference ? (
-                      <>
-                        <p className="mt-1 break-all font-mono text-[11px]">
-                          {item.preference.cwd}
-                        </p>
-                        <p className="mt-1 truncate text-[11px] text-muted-foreground">
-                          {item.preference.host}
-                        </p>
-                        <p
-                          className={
-                            item.preference.status === "valid"
-                              ? "mt-1 text-[11px] text-emerald-700 dark:text-emerald-400"
-                              : "mt-1 text-[11px] text-destructive"
-                          }
-                        >
-                          {t(
-                            `projectSettings.agentCwds.status.${item.preference.status}`,
-                          )}
-                        </p>
-                      </>
-                    ) : (
-                      <p className="mt-1 text-[11px] text-muted-foreground">
-                        {t("projectSettings.agentCwds.notConfigured")}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex shrink-0 gap-1">
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="ghost"
-                      title={t(
-                        item.preference
-                          ? "projectSettings.agentCwds.replace"
-                          : "projectSettings.agentCwds.configure",
-                      )}
-                      aria-label={t(
-                        item.preference
-                          ? "projectSettings.agentCwds.replace"
-                          : "projectSettings.agentCwds.configure",
-                      )}
-                      onClick={() =>
-                        setEditingAgent(
-                          editingAgent === item.agent.uuid ? null : item.agent.uuid,
-                        )
-                      }
-                    >
-                      <FolderCog className="size-4" />
-                    </Button>
-                    {item.preference && (
-                      <Button
-                        type="button"
-                        size="icon"
-                        variant="ghost"
-                        className="text-destructive"
-                        title={t("projectSettings.agentCwds.clear")}
-                        aria-label={t("projectSettings.agentCwds.clear")}
-                        onClick={() => void clearCwd(item.agent.uuid)}
-                      >
-                        <Trash2 className="size-4" />
-                      </Button>
-                    )}
-                  </div>
-                </div>
-                {editingAgent === item.agent.uuid && (
-                  <div className="mt-4 border-t border-border pt-4">
-                    <DirectoryBrowser
-                      agentUuid={item.agent.uuid}
-                      instances={item.onlineInstances}
-                      confirmLabel={t("projectSettings.agentCwds.save")}
-                      onValidated={saveCwd}
-                    />
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+          <ProjectAgentCwdSettings projectUuid={projectUuid} />
 
           <Separator className="bg-[#E5E2DC] dark:bg-[#26241f]" />
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/project-settings-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/project-settings-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useRouter } from "@/hooks/use-progress-router";
 import { useTranslations } from "next-intl";
 import { Settings, Loader2, FolderCog, RotateCcw, Trash2 } from "lucide-react";
@@ -56,8 +57,9 @@ export function ProjectSettingsModal({
   projectDescription,
 }: ProjectSettingsModalProps) {
   const t = useTranslations();
+  const searchParams = useSearchParams();
   const router = useRouter();
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(searchParams.get("settings") === "agent-cwds");
   const [name, setName] = useState(projectName);
   const [description, setDescription] = useState(projectDescription || "");
   const [saving, setSaving] = useState(false);

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/__tests__/reassign-instance-actions.test.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/__tests__/reassign-instance-actions.test.ts
@@ -25,6 +25,11 @@ vi.mock("@/services/daemon-connection.service", () => ({
   listConnectionsForAgent: vi.fn(),
 }));
 
+const mockResolveProjectAgentCwdTarget = vi.hoisted(() => vi.fn());
+vi.mock("@/services/project-agent-cwd.service", () => ({
+  resolveProjectAgentCwdTarget: mockResolveProjectAgentCwdTarget,
+}));
+
 // createActivity is the wake trigger; the non-waking action must NEVER call it.
 const mockCreateActivity = vi.hoisted(() => vi.fn());
 vi.mock("@/services/activity.service", () => ({
@@ -47,7 +52,10 @@ vi.mock("@/lib/logger", () => {
   return { default: noopLogger };
 });
 
-import { reassignIdeaInstanceNoWakeAction } from "../actions";
+import {
+  claimIdeaToAgentAction,
+  reassignIdeaInstanceNoWakeAction,
+} from "../actions";
 
 const COMPANY_A = "company-a";
 const PROJECT_UUID = "project-1";
@@ -238,5 +246,64 @@ describe("reassignIdeaInstanceNoWakeAction", () => {
     expect(result).toEqual({ success: false, error: "Failed to reassign idea" });
     expect(mockCreateActivity).not.toHaveBeenCalled();
     expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe("claimIdeaToAgentAction fixed cwd", () => {
+  it("persists the selected Agent's fixed instance instead of a client picker value", async () => {
+    mockGetServerAuthContext.mockResolvedValue(humanAuth());
+    mockGetIdeaByUuid.mockResolvedValue(makeIdeaRow());
+    mockResolveProjectAgentCwdTarget.mockResolvedValue({
+      source: "project_fixed",
+      agentInstanceUuid: "fixed-instance",
+      host: "fixed-host",
+      cwd: "/discovered/project",
+    });
+    mockAssignIdea.mockResolvedValue(undefined);
+    mockCreateActivity.mockResolvedValue(undefined);
+
+    await claimIdeaToAgentAction(IDEA_UUID, AGENT_UUID, "stale-picker-instance");
+
+    expect(mockResolveProjectAgentCwdTarget).toHaveBeenCalledWith({
+      companyUuid: COMPANY_A,
+      actorUserUuid: "user-1",
+      projectUuid: PROJECT_UUID,
+      agentUuid: AGENT_UUID,
+    });
+    expect(mockAssignIdea).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceUuid: "fixed-instance",
+        cwdSource: "project_fixed",
+        cwdHost: "fixed-host",
+        runtimeCwd: "/discovered/project",
+      }),
+    );
+    expect(mockCreateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: expect.objectContaining({
+          instanceUuid: "fixed-instance",
+          resolvedCwdSource: "project_fixed",
+          resolvedCwdHost: "fixed-host",
+          resolvedRuntimeCwd: "/discovered/project",
+        }),
+      }),
+    );
+  });
+
+  it("restores the existing picker selection after the fixed preference is cleared", async () => {
+    mockGetServerAuthContext.mockResolvedValue(humanAuth());
+    mockGetIdeaByUuid.mockResolvedValue(makeIdeaRow());
+    mockResolveProjectAgentCwdTarget.mockResolvedValue({
+      source: "unconfigured",
+      agentInstanceUuid: null,
+      host: null,
+      cwd: null,
+    });
+
+    await claimIdeaToAgentAction(IDEA_UUID, AGENT_UUID, INSTANCE_UUID);
+
+    expect(mockAssignIdea).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceUuid: INSTANCE_UUID }),
+    );
   });
 });

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions.ts
@@ -5,6 +5,10 @@ import { getServerAuthContext } from "@/lib/auth-server";
 import { assignIdea, releaseIdea, getIdeaByUuid } from "@/services/idea.service";
 import { getAssignableAgents, getCompanyUsers } from "@/services/agent.service";
 import { listConnectionsForAgent } from "@/services/daemon-connection.service";
+import {
+  resolveProjectAgentCwdTarget,
+  type ResolvedProjectAgentCwdTarget,
+} from "@/services/project-agent-cwd.service";
 import { createActivity } from "@/services/activity.service";
 import type { InstanceCandidate } from "@/components/agent-presence/instance-picker";
 import logger from "@/lib/logger";
@@ -85,13 +89,27 @@ export async function claimIdeaToAgentAction(
       return { success: false, error: "Idea is not available for assignment" };
     }
 
+    const target = await resolveProjectAgentCwdTarget({
+      companyUuid: auth.companyUuid,
+      actorUserUuid: auth.actorUuid,
+      projectUuid: idea.projectUuid,
+      agentUuid,
+    });
+    const resolvedInstanceUuid =
+      target.source === "project_fixed"
+        ? target.agentInstanceUuid
+        : instanceUuid;
+
     await assignIdea({
       ideaUuid,
       companyUuid: auth.companyUuid,
       assigneeType: "agent",
       assigneeUuid: agentUuid,
       assignedByUuid: auth.actorUuid,
-      instanceUuid: instanceUuid ?? undefined,
+      instanceUuid: resolvedInstanceUuid ?? undefined,
+      cwdSource: target.source === "project_fixed" ? target.source : null,
+      cwdHost: target.source === "project_fixed" ? target.host : null,
+      runtimeCwd: target.source === "project_fixed" ? target.cwd : null,
     });
 
     await createActivity({
@@ -105,7 +123,14 @@ export async function claimIdeaToAgentAction(
       value: {
         assigneeType: "agent",
         assigneeUuid: agentUuid,
-        ...(instanceUuid ? { instanceUuid } : {}),
+        ...(resolvedInstanceUuid ? { instanceUuid: resolvedInstanceUuid } : {}),
+        ...(target.source === "project_fixed"
+          ? {
+              resolvedCwdSource: target.source,
+              resolvedCwdHost: target.host,
+              resolvedRuntimeCwd: target.cwd,
+            }
+          : {}),
       },
     });
 
@@ -276,14 +301,28 @@ export async function getPmAgentsAction() {
 // shows its own "no instances" empty state — never a silent throw).
 export async function getAgentInstancesAction(
   agentUuid: string,
-): Promise<{ instances: InstanceCandidate[] }> {
+  projectUuid?: string,
+): Promise<{
+  instances: InstanceCandidate[];
+  resolvedTarget: ResolvedProjectAgentCwdTarget | null;
+}> {
   const auth = await getServerAuthContext();
   if (!auth || auth.type !== "user") {
-    return { instances: [] };
+    return { instances: [], resolvedTarget: null };
   }
 
   try {
-    const connections = await listConnectionsForAgent(auth.companyUuid, agentUuid);
+    const [connections, resolvedTarget] = await Promise.all([
+      listConnectionsForAgent(auth.companyUuid, agentUuid),
+      projectUuid
+        ? resolveProjectAgentCwdTarget({
+            companyUuid: auth.companyUuid,
+            actorUserUuid: auth.actorUuid,
+            projectUuid,
+            agentUuid,
+          })
+        : null,
+    ]);
     return {
       instances: connections.map((c) => ({
         connectionUuid: c.uuid,
@@ -292,9 +331,10 @@ export async function getAgentInstancesAction(
         cwd: c.cwd,
         effectiveStatus: c.effectiveStatus,
       })),
+      resolvedTarget,
     };
   } catch (error) {
     logger.error({ err: error }, "Failed to get agent instances");
-    return { instances: [] };
+    return { instances: [], resolvedTarget: null };
   }
 }

--- a/src/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal.tsx
@@ -24,6 +24,8 @@ import {
   type InstanceCandidate,
 } from "@/components/agent-presence/instance-picker";
 import { formatCwd, formatHost } from "@/lib/daemon-instance-format";
+import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
+import type { ResolvedProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
 import {
   claimIdeaAction,
   claimIdeaToAgentAction,
@@ -91,6 +93,8 @@ export function AssignIdeaModal({
   // online; a fully-offline agent yields no picker and assigns the plain agent.
   const [instances, setInstances] = useState<InstanceCandidate[]>([]);
   const [isLoadingInstances, setIsLoadingInstances] = useState(false);
+  const [resolvedTarget, setResolvedTarget] =
+    useState<ResolvedProjectAgentCwdTarget | null>(null);
   const [pinnedConnectionUuid, setPinnedConnectionUuid] = useState<string | null>(
     null,
   );
@@ -117,17 +121,19 @@ export function AssignIdeaModal({
     if (selectedOption !== "agent" || !selectedAgentUuid) {
       setInstances([]);
       setPinnedConnectionUuid(null);
+      setResolvedTarget(null);
       return;
     }
     let cancelled = false;
     setIsLoadingInstances(true);
     setPinnedConnectionUuid(null);
-    getAgentInstancesAction(selectedAgentUuid)
+    getAgentInstancesAction(selectedAgentUuid, projectUuid)
       .then((res) => {
         if (cancelled) return;
         // Online-only: an offline instance is not a wake target, so it never
         // appears in the picker. A fully-offline agent yields [] → no picker.
         setInstances(filterOnlineInstances(res.instances));
+        setResolvedTarget(res.resolvedTarget);
       })
       .finally(() => {
         if (!cancelled) setIsLoadingInstances(false);
@@ -135,7 +141,7 @@ export function AssignIdeaModal({
     return () => {
       cancelled = true;
     };
-  }, [selectedOption, selectedAgentUuid]);
+  }, [projectUuid, selectedOption, selectedAgentUuid]);
 
   // The instance the owner pinned, resolved from the controlled connectionUuid.
   // null → "inherit / plain agent" (revert-to-plain-agent is simply no pin).
@@ -374,6 +380,8 @@ export function AssignIdeaModal({
                             <Loader2 className="h-3.5 w-3.5 animate-spin" />
                             {t("assignInstance.loadingInstances")}
                           </div>
+                        ) : resolvedTarget?.source === "project_fixed" ? (
+                          <FixedCwdAnchor target={resolvedTarget} />
                         ) : instances.length === 0 ? (
                           <p className="rounded-lg bg-background p-2.5 text-[11px] leading-relaxed text-muted-foreground">
                             {t("assignInstance.noInstances")}
@@ -388,10 +396,12 @@ export function AssignIdeaModal({
                             ariaLabel={t("assignInstance.workingDirectory")}
                           />
                         )}
-                        <div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-[#9A8C7E]">
-                          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-                          <span>{t("assignInstance.ideaPinNote")}</span>
-                        </div>
+                        {resolvedTarget?.source !== "project_fixed" && (
+                          <div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-[#9A8C7E]">
+                            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                            <span>{t("assignInstance.ideaPinNote")}</span>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
@@ -47,6 +47,7 @@ import { YoloButton } from "@/components/yolo-button";
 import { ReferencesSection } from "@/components/references-section";
 import { usePinThenWake } from "@/hooks/use-pin-then-wake";
 import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
+import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
 import { reassignIdeaInstanceNoWakeAction } from "./[ideaUuid]/actions";
 import { useRealtimeEntityTypeEvent, useRealtimeEntityEvent } from "@/contexts/realtime-context";
 import type { ElaborationResponse } from "@/types/elaboration";
@@ -248,7 +249,11 @@ export function IdeaDetailPanel({
     confirmPick: confirmVerifyPick,
     cancelPick: cancelVerifyPick,
     isResolving: isResolvingVerify,
-  } = usePinThenWake({ reassignNoWake: reassignIdeaInstanceNoWakeAction });
+    fixedTarget,
+  } = usePinThenWake({
+    reassignNoWake: reassignIdeaInstanceNoWakeAction,
+    previewIdeaUuid: idea.uuid,
+  });
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -730,6 +735,7 @@ export function IdeaDetailPanel({
                       agent should write the proposal" action. Replaces the old
                       idea-panel "Create Proposal" button. No manual
                       create-proposal fallback is offered here. */}
+                  {fixedTarget && <FixedCwdAnchor target={fixedTarget} />}
                   {canVerify && !verified && (
                     <Button
                       className="bg-primary hover:bg-[#B56A42] text-white"

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx
@@ -25,6 +25,7 @@ import { approveProposalAction, rejectProposalAction, closeProposalAction, revok
 import { reassignIdeaInstanceNoWakeAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions";
 import { usePinThenWake } from "@/hooks/use-pin-then-wake";
 import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
+import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
 
 interface MaterializedEntities {
   tasks: { uuid: string; title: string; status: string }[];
@@ -59,7 +60,11 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
     confirmPick,
     cancelPick,
     isResolving,
-  } = usePinThenWake({ reassignNoWake: reassignIdeaInstanceNoWakeAction });
+    fixedTarget,
+  } = usePinThenWake({
+    reassignNoWake: reassignIdeaInstanceNoWakeAction,
+    previewIdeaUuid: inputIdeaUuid,
+  });
   const [isPending, startTransition] = useTransition();
   const [approveDialogOpen, setApproveDialogOpen] = useState(false);
   const [approveNote, setApproveNote] = useState("");
@@ -162,6 +167,7 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
 
   return (
     <>
+      {fixedTarget && <FixedCwdAnchor target={fixedTarget} />}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/__tests__/reassign-instance-actions.test.ts
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/__tests__/reassign-instance-actions.test.ts
@@ -30,6 +30,11 @@ vi.mock("@/services/daemon-connection.service", () => ({
   listConnectionsForAgent: vi.fn(),
 }));
 
+const mockResolveProjectAgentCwdTarget = vi.hoisted(() => vi.fn());
+vi.mock("@/services/project-agent-cwd.service", () => ({
+  resolveProjectAgentCwdTarget: mockResolveProjectAgentCwdTarget,
+}));
+
 // createActivity is the wake trigger; the non-waking action must NEVER call it.
 const mockCreateActivity = vi.hoisted(() => vi.fn());
 vi.mock("@/services/activity.service", () => ({
@@ -52,7 +57,10 @@ vi.mock("@/lib/logger", () => {
   return { default: noopLogger };
 });
 
-import { reassignTaskInstanceNoWakeAction } from "../actions";
+import {
+  claimTaskToAgentAction,
+  reassignTaskInstanceNoWakeAction,
+} from "../actions";
 
 const COMPANY_A = "company-a";
 const PROJECT_UUID = "project-1";
@@ -208,5 +216,58 @@ describe("reassignTaskInstanceNoWakeAction", () => {
     });
     expect(mockClaimTask).not.toHaveBeenCalled();
     expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("claimTaskToAgentAction fixed cwd", () => {
+  it("persists the selected Agent's own fixed instance", async () => {
+    mockGetServerAuthContext.mockResolvedValue(humanAuth());
+    mockGetTaskByUuid.mockResolvedValue(makeTaskRow());
+    mockResolveProjectAgentCwdTarget.mockResolvedValue({
+      source: "project_fixed",
+      agentInstanceUuid: "agent-b-fixed-instance",
+      host: "fixed-host",
+      cwd: "/discovered/task",
+    });
+    mockClaimTask.mockResolvedValue(undefined);
+    mockCreateActivity.mockResolvedValue(undefined);
+
+    await claimTaskToAgentAction(TASK_UUID, AGENT_UUID, "agent-a-instance");
+
+    expect(mockClaimTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceUuid: "agent-b-fixed-instance",
+        cwdSource: "project_fixed",
+        cwdHost: "fixed-host",
+        runtimeCwd: "/discovered/task",
+      }),
+    );
+    expect(mockCreateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: expect.objectContaining({
+          instanceUuid: "agent-b-fixed-instance",
+          resolvedCwdSource: "project_fixed",
+          resolvedCwdHost: "fixed-host",
+          resolvedRuntimeCwd: "/discovered/task",
+        }),
+      }),
+    );
+  });
+
+  it("keeps the existing picker selection when no fixed target exists", async () => {
+    mockGetServerAuthContext.mockResolvedValue(humanAuth());
+    mockGetTaskByUuid.mockResolvedValue(makeTaskRow());
+    mockResolveProjectAgentCwdTarget.mockResolvedValue({
+      source: "unconfigured",
+      agentInstanceUuid: null,
+      host: null,
+      cwd: null,
+    });
+
+    await claimTaskToAgentAction(TASK_UUID, AGENT_UUID, INSTANCE_UUID);
+
+    expect(mockClaimTask).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceUuid: INSTANCE_UUID }),
+    );
   });
 });

--- a/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/[taskUuid]/actions.ts
@@ -5,6 +5,10 @@ import { getServerAuthContext } from "@/lib/auth-server";
 import { claimTask, getTaskByUuid, updateTask, releaseTask, createTask, deleteTask, checkAcceptanceCriteriaGate, replaceAcceptanceCriteria } from "@/services/task.service";
 import { getAssignableAgents, getCompanyUsers } from "@/services/agent.service";
 import { listConnectionsForAgent } from "@/services/daemon-connection.service";
+import {
+  resolveProjectAgentCwdTarget,
+  type ResolvedProjectAgentCwdTarget,
+} from "@/services/project-agent-cwd.service";
 import { createActivity } from "@/services/activity.service";
 import type { AcceptanceCriteriaItemInput } from "@/lib/acceptance-criteria";
 import type { InstanceCandidate } from "@/components/agent-presence/instance-picker";
@@ -84,6 +88,17 @@ export async function claimTaskToAgentAction(
       return { success: false, error: "Task is not available for claiming" };
     }
 
+    const target = await resolveProjectAgentCwdTarget({
+      companyUuid: auth.companyUuid,
+      actorUserUuid: auth.actorUuid,
+      projectUuid: task.projectUuid,
+      agentUuid,
+    });
+    const resolvedInstanceUuid =
+      target.source === "project_fixed"
+        ? target.agentInstanceUuid
+        : instanceUuid;
+
     await claimTask({
       taskUuid,
       companyUuid: auth.companyUuid,
@@ -94,7 +109,10 @@ export async function claimTaskToAgentAction(
       // the company and promotes the row to assigneeType="agent_instance"; with
       // no instanceUuid the assignment stays a plain agent (also the path that
       // reverts a prior instance pin back to the plain agent on re-assignment).
-      instanceUuid: instanceUuid ?? undefined,
+      instanceUuid: resolvedInstanceUuid ?? undefined,
+      cwdSource: target.source === "project_fixed" ? target.source : null,
+      cwdHost: target.source === "project_fixed" ? target.host : null,
+      runtimeCwd: target.source === "project_fixed" ? target.cwd : null,
     });
 
     // Record activity
@@ -111,7 +129,14 @@ export async function claimTaskToAgentAction(
         assigneeUuid: agentUuid,
         // Record the durable instance pin in the activity value so the timeline
         // reflects which place was chosen (omitted when un-pinned).
-        ...(instanceUuid ? { instanceUuid } : {}),
+        ...(resolvedInstanceUuid ? { instanceUuid: resolvedInstanceUuid } : {}),
+        ...(target.source === "project_fixed"
+          ? {
+              resolvedCwdSource: target.source,
+              resolvedCwdHost: target.host,
+              resolvedRuntimeCwd: target.cwd,
+            }
+          : {}),
       },
     });
 
@@ -496,14 +521,28 @@ export async function getDeveloperAgentsAction() {
 // (InstanceCandidate / AgentInstanceCandidate) are now the single InstanceCandidate.
 export async function getAgentInstancesAction(
   agentUuid: string,
-): Promise<{ instances: InstanceCandidate[] }> {
+  projectUuid?: string,
+): Promise<{
+  instances: InstanceCandidate[];
+  resolvedTarget: ResolvedProjectAgentCwdTarget | null;
+}> {
   const auth = await getServerAuthContext();
   if (!auth || auth.type !== "user") {
-    return { instances: [] };
+    return { instances: [], resolvedTarget: null };
   }
 
   try {
-    const connections = await listConnectionsForAgent(auth.companyUuid, agentUuid);
+    const [connections, resolvedTarget] = await Promise.all([
+      listConnectionsForAgent(auth.companyUuid, agentUuid),
+      projectUuid
+        ? resolveProjectAgentCwdTarget({
+            companyUuid: auth.companyUuid,
+            actorUserUuid: auth.actorUuid,
+            projectUuid,
+            agentUuid,
+          })
+        : null,
+    ]);
     return {
       instances: connections.map((c) => ({
         connectionUuid: c.uuid,
@@ -512,9 +551,10 @@ export async function getAgentInstancesAction(
         cwd: c.cwd,
         effectiveStatus: c.effectiveStatus,
       })),
+      resolvedTarget,
     };
   } catch (error) {
     logger.error({ err: error }, "Failed to get agent instances");
-    return { instances: [] };
+    return { instances: [], resolvedTarget: null };
   }
 }

--- a/src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/tasks/assign-task-modal.tsx
@@ -27,6 +27,8 @@ import {
   formatCwd,
   formatHost,
 } from "@/lib/daemon-instance-format";
+import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
+import type { ResolvedProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
 import {
   claimTaskAction,
   claimTaskToAgentAction,
@@ -94,6 +96,8 @@ export function AssignTaskModal({
   // just assigns plainly, inheriting the root idea's instance via wake lineage).
   const [instances, setInstances] = useState<InstanceCandidate[]>([]);
   const [isLoadingInstances, setIsLoadingInstances] = useState(false);
+  const [resolvedTarget, setResolvedTarget] =
+    useState<ResolvedProjectAgentCwdTarget | null>(null);
   const [pinnedConnectionUuid, setPinnedConnectionUuid] = useState<string | null>(
     null,
   );
@@ -121,17 +125,19 @@ export function AssignTaskModal({
     if (selectedOption !== "agent" || !selectedAgentUuid) {
       setInstances([]);
       setPinnedConnectionUuid(null);
+      setResolvedTarget(null);
       return;
     }
     let cancelled = false;
     setIsLoadingInstances(true);
     setPinnedConnectionUuid(null);
-    getAgentInstancesAction(selectedAgentUuid)
+    getAgentInstancesAction(selectedAgentUuid, projectUuid)
       .then((res) => {
         if (cancelled) return;
         // Online-only: an offline instance is not a wake target, so it never
         // appears in the picker. A fully-offline agent yields [] → no picker.
         setInstances(filterOnlineInstances(res.instances));
+        setResolvedTarget(res.resolvedTarget);
       })
       .finally(() => {
         if (!cancelled) setIsLoadingInstances(false);
@@ -139,7 +145,7 @@ export function AssignTaskModal({
     return () => {
       cancelled = true;
     };
-  }, [selectedOption, selectedAgentUuid]);
+  }, [projectUuid, selectedOption, selectedAgentUuid]);
 
   // The instance the owner pinned, resolved from the controlled connectionUuid.
   const pinnedInstance =
@@ -376,6 +382,8 @@ export function AssignTaskModal({
                             <Loader2 className="h-3.5 w-3.5 animate-spin" />
                             {t("assignInstance.loadingInstances")}
                           </div>
+                        ) : resolvedTarget?.source === "project_fixed" ? (
+                          <FixedCwdAnchor target={resolvedTarget} />
                         ) : instances.length === 0 ? (
                           <p className="rounded-lg bg-background p-2.5 text-[11px] leading-relaxed text-muted-foreground">
                             {t("assignInstance.noInstances")}
@@ -390,10 +398,12 @@ export function AssignTaskModal({
                             ariaLabel={t("assignInstance.workingDirectory")}
                           />
                         )}
-                        <div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-[#9A8C7E]">
-                          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-                          <span>{t("assignInstance.pinNote")}</span>
-                        </div>
+                        {resolvedTarget?.source !== "project_fixed" && (
+                          <div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-[#9A8C7E]">
+                            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                            <span>{t("assignInstance.pinNote")}</span>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/app/api/ideas/conversational/__tests__/route.test.ts
+++ b/src/app/api/ideas/conversational/__tests__/route.test.ts
@@ -55,6 +55,9 @@ vi.mock("@/services/daemon-instruction.service", () => {
       this.reason = reason;
     }
   }
+  class ProjectCwdTargetUnavailableError extends Error {
+    readonly code = "project_cwd_target_unavailable";
+  }
   return {
     createConversationalIdeaSession: (...args: unknown[]) =>
       mockCreateConversational(...args),
@@ -63,6 +66,7 @@ vi.mock("@/services/daemon-instruction.service", () => {
     ConnectionInstanceMissingError,
     ProjectNotVisibleError,
     InstructionTextError,
+    ProjectCwdTargetUnavailableError,
   };
 });
 

--- a/src/app/api/ideas/conversational/route.ts
+++ b/src/app/api/ideas/conversational/route.ts
@@ -29,6 +29,7 @@ import {
   ConnectionInstanceMissingError,
   ProjectNotVisibleError,
   InstructionTextError,
+  ProjectCwdTargetUnavailableError,
 } from "@/services/daemon-instruction.service";
 
 // Request body schema. `descriptionText` length is validated in the service (the
@@ -87,6 +88,9 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       return errors.conflict(err.message);
     }
     if (err instanceof ConnectionInstanceMissingError) {
+      return errors.conflict(err.message);
+    }
+    if (err instanceof ProjectCwdTargetUnavailableError) {
       return errors.conflict(err.message);
     }
     // Empty description / over-length composed instruction → 400. Nothing was created.

--- a/src/app/api/projects/agent-cwd-options/route.ts
+++ b/src/app/api/projects/agent-cwd-options/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { withErrorHandler } from "@/lib/api-handler";
+import { success, errors } from "@/lib/api-response";
+import { getAuthContext, isUser } from "@/lib/auth";
+import { listAvailableAgentCwdOptions } from "@/services/project-agent-cwd.service";
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const auth = await getAuthContext(request);
+  if (!auth) return errors.unauthorized();
+  if (!isUser(auth)) return errors.forbidden("User session required");
+  return success({
+    agents: await listAvailableAgentCwdOptions(auth.companyUuid, auth.actorUuid),
+  });
+});

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -7,6 +7,10 @@ import { prisma } from "@/lib/prisma";
 import { withErrorHandler, parseBody, parsePagination } from "@/lib/api-handler";
 import { success, paginated, errors } from "@/lib/api-response";
 import { getAuthContext, isUser, isAgent, hasPermission, checkAgentPermission } from "@/lib/auth";
+import {
+  CwdServiceError,
+  createProjectWithAgentCwds,
+} from "@/services/project-agent-cwd.service";
 
 // GET /api/projects - List Projects
 export const GET = withErrorHandler(async (request: NextRequest) => {
@@ -91,6 +95,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     name: string;
     description?: string;
     groupUuid?: string;
+    agentCwds?: Array<{ agentUuid: string; validationRequestUuid: string }>;
   }>(request);
 
   // Validate required fields
@@ -108,21 +113,37 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     }
   }
 
-  const project = await prisma.project.create({
-    data: {
+  const agentCwds = body.agentCwds ?? [];
+  if (
+    !Array.isArray(agentCwds) ||
+    agentCwds.some((draft) =>
+      !draft ||
+      typeof draft.agentUuid !== "string" ||
+      !draft.agentUuid ||
+      typeof draft.validationRequestUuid !== "string" ||
+      !draft.validationRequestUuid
+    ) ||
+    new Set(agentCwds.map((draft) => draft.agentUuid)).size !== agentCwds.length
+  ) {
+    return errors.validationError({ agentCwds: "Invalid or duplicate Agent cwd selection" });
+  }
+
+  let project;
+  try {
+    project = await createProjectWithAgentCwds({
       companyUuid: auth.companyUuid,
+      userUuid: auth.actorUuid,
       name: body.name.trim(),
       description: body.description?.trim() || null,
       groupUuid: body.groupUuid || null,
-    },
-    select: {
-      uuid: true,
-      name: true,
-      description: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  });
+      agentCwds,
+    });
+  } catch (error) {
+    if (error instanceof CwdServiceError) {
+      return errors.conflict(error.message);
+    }
+    throw error;
+  }
 
   return success({
     uuid: project.uuid,

--- a/src/components/__tests__/mention-editor-selection.test.ts
+++ b/src/components/__tests__/mention-editor-selection.test.ts
@@ -63,7 +63,7 @@ describe("resolveMentionSelection — inherit the direct idea's pin", () => {
     });
     expect(decision).toEqual({
       kind: "insert",
-      pin: { host: "fixed-host", cwd: "/fixed/project" },
+      pin: { host: "fixed-host", cwd: "/fixed/project", runtimeCwd: true },
     });
   });
 

--- a/src/components/__tests__/mention-editor-selection.test.ts
+++ b/src/components/__tests__/mention-editor-selection.test.ts
@@ -46,6 +46,27 @@ function offlineInstance(
 }
 
 describe("resolveMentionSelection — inherit the direct idea's pin", () => {
+  it("project-fixed cwd suppresses the picker even with multiple online instances", () => {
+    const decision = resolveMentionSelection({
+      type: "agent",
+      uuid: "agent-G",
+      name: "Agent G",
+      projectFixedCwd: {
+        host: "fixed-host",
+        cwd: "/fixed/project",
+        availability: "offline",
+      },
+      instances: [
+        onlineInstance("conn-a", "/cwd/a"),
+        onlineInstance("conn-b", "/cwd/b"),
+      ],
+    });
+    expect(decision).toEqual({
+      kind: "insert",
+      pin: { host: "fixed-host", cwd: "/fixed/project" },
+    });
+  });
+
   it("(a) assignee + ideaPin → insert with the inherited pin, NO picker (even when that place is offline)", () => {
     const decision = resolveMentionSelection({
       type: "agent",

--- a/src/components/__tests__/mention-editor-selection.test.ts
+++ b/src/components/__tests__/mention-editor-selection.test.ts
@@ -67,6 +67,31 @@ describe("resolveMentionSelection — inherit the direct idea's pin", () => {
     });
   });
 
+  it("project-fixed cwd overrides an inherited Idea pin and keeps runtime routing", () => {
+    const decision = resolveMentionSelection({
+      type: "agent",
+      uuid: "agent-G",
+      name: "Agent G",
+      isIdeaAssignee: true,
+      ideaPin: {
+        host: "old-host",
+        cwd: "/old/idea",
+        agentInstanceUuid: "inst-old",
+      },
+      projectFixedCwd: {
+        host: "fixed-host",
+        cwd: "/fixed/project",
+        availability: "ready",
+      },
+      instances: [onlineInstance("conn-a", "/daemon/startup", "fixed-host")],
+    });
+
+    expect(decision).toEqual({
+      kind: "insert",
+      pin: { host: "fixed-host", cwd: "/fixed/project", runtimeCwd: true },
+    });
+  });
+
   it("(a) assignee + ideaPin → insert with the inherited pin, NO picker (even when that place is offline)", () => {
     const decision = resolveMentionSelection({
       type: "agent",

--- a/src/components/__tests__/mention-renderer.test.ts
+++ b/src/components/__tests__/mention-renderer.test.ts
@@ -47,6 +47,20 @@ describe("client mention parser — pin suffix support", () => {
     expect("pinnedCwd" in refs[0]).toBe(false);
   });
 
+  it("preserves the runtime cwd marker for comment liveness", () => {
+    const refs = extractMentions(
+      `@[DevBot](agent:${AGENT}?cwd=%2Fwork%2Fdynamic&host=prod&runtime=1)`,
+    );
+    expect(refs[0]).toEqual<ParsedMentionRef>({
+      type: "agent",
+      uuid: AGENT,
+      displayName: "DevBot",
+      pinnedHost: "prod",
+      pinnedCwd: "/work/dynamic",
+      runtimeCwd: true,
+    });
+  });
+
   it("parses an unknown-path pin (cwd=&host=…) as pinnedCwd:null, pinnedHost set", () => {
     const refs = extractMentions(`@[CI](agent:${AGENT}?cwd=&host=ci-runner)`);
     expect(refs[0]).toEqual<ParsedMentionRef>({

--- a/src/components/agent-presence/__tests__/conversational-entry.test.tsx
+++ b/src/components/agent-presence/__tests__/conversational-entry.test.tsx
@@ -64,6 +64,9 @@ vi.mock("@/lib/auth-client", () => ({
 vi.mock("@/lib/logger-client", () => ({
   clientLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ uuid: "project-1" }),
+}));
 
 // Presence spine mocked at the hook seam: each test sets the value.
 const mockPresence = vi.fn();
@@ -159,6 +162,45 @@ beforeEach(() => {
 });
 
 describe("ConversationalEntry — offline gating", () => {
+  it("keeps an offline project-fixed anchor visible instead of falling back", async () => {
+    setPresence([conn({ uuid: "c1", effectiveStatus: "offline" })]);
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          agents: [
+            {
+              agent: { uuid: "agent-1", name: "Alpha" },
+              preference: {
+                host: "fixed-host",
+                cwd: "/offline/fixed",
+                status: "offline",
+                anchorAgentInstanceUuid: "fixed-instance",
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    render(
+      <ConversationalEntry
+        projectUuid="project-1"
+        dispatch={vi.fn()}
+        onStarted={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("/offline/fixed")).toBeTruthy();
+    expect(screen.getByText("Host offline")).toBeTruthy();
+    expect(screen.queryByText(DAEMON_START_COMMAND)).toBeNull();
+    expect(
+      (screen.getByRole("button", { name: /Send to agent/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
   it("renders the offline fallback with the shared daemon CTA when no connection is online", () => {
     setPresence([conn({ uuid: "c1", effectiveStatus: "offline" })]);
     render(
@@ -196,6 +238,44 @@ describe("ConversationalEntry — offline gating", () => {
 });
 
 describe("ConversationalEntry — selection", () => {
+  it("project-fixed cwd hides the instance picker and shows the read-only anchor", async () => {
+    setPresence([
+      conn({ uuid: "c1", host: "fixed-host", cwd: "/startup" }),
+      conn({ uuid: "c2", host: "other-host", cwd: "/other" }),
+    ]);
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          agents: [
+            {
+              agent: { uuid: "agent-1", name: "Alpha" },
+              preference: {
+                host: "fixed-host",
+                cwd: "/srv/project",
+                status: "valid",
+                anchorAgentInstanceUuid: "fixed-instance",
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    render(
+      <ConversationalEntry
+        projectUuid="project-1"
+        dispatch={vi.fn()}
+        onStarted={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("/srv/project")).toBeTruthy();
+    expect(screen.getByText("fixed-host")).toBeTruthy();
+    expect(screen.queryByText("other")).toBeNull();
+  });
+
   it("sole agent + sole instance: agent Select still shows the agent's NAME, instance auto-selected, Send enabled once text present", async () => {
     setPresence([conn({ uuid: "c1" })]);
     respondOk();

--- a/src/components/agent-presence/__tests__/conversational-entry.test.tsx
+++ b/src/components/agent-presence/__tests__/conversational-entry.test.tsx
@@ -238,7 +238,7 @@ describe("ConversationalEntry — offline gating", () => {
 });
 
 describe("ConversationalEntry — selection", () => {
-  it("project-fixed cwd hides the instance picker and shows the read-only anchor", async () => {
+  it("project-fixed cwd hides the instance picker without repeating the project-level summary", async () => {
     setPresence([
       conn({ uuid: "c1", host: "fixed-host", cwd: "/startup" }),
       conn({ uuid: "c2", host: "other-host", cwd: "/other" }),
@@ -271,8 +271,9 @@ describe("ConversationalEntry — selection", () => {
       />,
     );
 
-    expect(await screen.findByText("/srv/project")).toBeTruthy();
-    expect(screen.getByText("fixed-host")).toBeTruthy();
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+    expect(screen.queryByText("/srv/project")).toBeNull();
+    expect(screen.queryByText("fixed-host")).toBeNull();
     expect(screen.queryByText("other")).toBeNull();
   });
 

--- a/src/components/agent-presence/__tests__/copy-session-id-button.test.tsx
+++ b/src/components/agent-presence/__tests__/copy-session-id-button.test.tsx
@@ -263,6 +263,37 @@ describe("CopySessionIdButton — responsive label (mobile icon-only)", () => {
 });
 
 describe("CopySessionIdButton — inside the TranscriptView header", () => {
+  it("shows the session runtime cwd instead of the origin connection startup cwd", () => {
+    const session = sessionView({ runtimeCwd: "/work/dynamic-project" });
+    render(
+      <TranscriptView
+        {...transcriptProps(session)}
+        originConnection={{
+          uuid: "conn-1",
+          agentUuid: "agent-1",
+          ownerUuid: "owner-1",
+          agentName: "Alpha",
+          clientType: "claude_code",
+          clientVersion: "1.0.0",
+          host: "host-a",
+          cwd: "/work/ai-pm",
+          startedAt: NOW,
+          status: "online",
+          effectiveStatus: "online",
+          connectedAt: NOW,
+          lastSeenAt: NOW,
+          disconnectedAt: null,
+        }}
+        originOnline
+      />,
+    );
+
+    expect(
+      screen.getByLabelText("Working directory: /work/dynamic-project"),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Working directory: /work/ai-pm")).toBeNull();
+  });
+
   it("keeps the existing control and copies backendSessionId for an idea-anchored session", async () => {
     const writeText = installClipboard();
     const session = sessionView({ backendSessionId: "codex-idea-thread" });

--- a/src/components/agent-presence/__tests__/directory-browser.test.tsx
+++ b/src/components/agent-presence/__tests__/directory-browser.test.tsx
@@ -67,31 +67,42 @@ describe("DirectoryBrowser", () => {
     vi.restoreAllMocks();
   });
 
-  it("validates the daemon working directory as a fixed-cwd shortcut", async () => {
+  it("lists every daemon.json cwd and validates the exact selected connection", async () => {
     const fetchMock = vi.fn();
     const onValidated = vi.fn();
+    const secondInstance = {
+      ...instance,
+      connectionUuid: "connection-2",
+      agentInstanceUuid: "instance-2",
+      cwd: "/strands-ai-sdk",
+    };
     vi.stubGlobal("fetch", fetchMock);
     fetchMock
       .mockImplementationOnce(() => success({ roots: ["/work"] }, "roots-1"))
       .mockImplementationOnce(() =>
-        success({ normalizedPath: "/workspace" }, "validation-1"),
+        success({ normalizedPath: "/strands-ai-sdk" }, "validation-1"),
       );
-    renderBrowser([instance], onValidated);
+    renderBrowser([instance, secondInstance], onValidated);
 
     await screen.findByRole("combobox", { name: "pathPrefix" });
-    fireEvent.click(screen.getByRole("button", { name: /daemonCwd/ }));
+    expect(screen.getByRole("button", { name: /configuredCwd\/workspace/ }))
+      .toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: /configuredCwd\/strands-ai-sdk/ }),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
     await waitFor(() => expect(onValidated).toHaveBeenCalledWith({
       agentUuid: "agent-1",
-      connectionUuid: "connection-1",
+      connectionUuid: "connection-2",
       host: "build-host",
-      cwd: "/workspace",
+      cwd: "/strands-ai-sdk",
       validationRequestUuid: "validation-1",
     }));
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
       operation: "validate",
-      cwd: "/workspace",
+      targetConnectionUuid: "connection-2",
+      cwd: "/strands-ai-sdk",
     });
   });
 

--- a/src/components/agent-presence/__tests__/directory-browser.test.tsx
+++ b/src/components/agent-presence/__tests__/directory-browser.test.tsx
@@ -67,6 +67,34 @@ describe("DirectoryBrowser", () => {
     vi.restoreAllMocks();
   });
 
+  it("validates the daemon working directory as a fixed-cwd shortcut", async () => {
+    const fetchMock = vi.fn();
+    const onValidated = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock
+      .mockImplementationOnce(() => success({ roots: ["/work"] }, "roots-1"))
+      .mockImplementationOnce(() =>
+        success({ normalizedPath: "/workspace" }, "validation-1"),
+      );
+    renderBrowser([instance], onValidated);
+
+    await screen.findByRole("combobox", { name: "pathPrefix" });
+    fireEvent.click(screen.getByRole("button", { name: /daemonCwd/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(onValidated).toHaveBeenCalledWith({
+      agentUuid: "agent-1",
+      connectionUuid: "connection-1",
+      host: "build-host",
+      cwd: "/workspace",
+      validationRequestUuid: "validation-1",
+    }));
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+      operation: "validate",
+      cwd: "/workspace",
+    });
+  });
+
   it("prefills one root and debounces the bounded first-page query", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/src/components/agent-presence/__tests__/fixed-cwd-anchor.test.tsx
+++ b/src/components/agent-presence/__tests__/fixed-cwd-anchor.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ uuid: "project-1" }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("FixedCwdAnchor", () => {
+  it("renders the immutable host/cwd anchor and project settings link", () => {
+    render(
+      <FixedCwdAnchor
+        target={{
+          actorUserUuid: "user-1",
+          agentUuid: "agent-1",
+          source: "project_fixed",
+          host: "build-host",
+          cwd: "/workspace/chorus",
+          availability: "offline",
+          promptPolicy: "suppress",
+          connectionUuid: null,
+          agentInstanceUuid: "instance-1",
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("region", { name: "title" })).toBeTruthy();
+    expect(screen.getByText("build-host")).toBeTruthy();
+    expect(screen.getByText("/workspace/chorus")).toBeTruthy();
+    expect(screen.getByText("availability.offline")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "manage" }).getAttribute("href")).toBe(
+      "/projects/project-1/dashboard?settings=agent-cwds",
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/src/components/agent-presence/chat/transcript-view.tsx
+++ b/src/components/agent-presence/chat/transcript-view.tsx
@@ -274,6 +274,10 @@ export function TranscriptView({
 
   const agentName =
     originConnection?.agentName?.trim() || t("roleAgent");
+  const displayConnection =
+    originConnection && session?.runtimeCwd
+      ? { ...originConnection, cwd: session.runtimeCwd }
+      : originConnection;
 
   // Current/last turn status for the header badge — the running turn if any,
   // otherwise the newest turn's status.
@@ -358,11 +362,11 @@ export function TranscriptView({
           <h3 className="truncate text-[17px] font-semibold text-foreground min-w-0">
             {title}
           </h3>
-          {originConnection && (
+          {displayConnection && (
             <div className="shrink-0">
               <InstanceIdentity
-                cwd={originConnection.cwd}
-                host={originConnection.host}
+                cwd={displayConnection.cwd}
+                host={displayConnection.host}
                 crossHost={originCrossHost}
               />
             </div>
@@ -439,31 +443,31 @@ export function TranscriptView({
               </div>
             )}
           </div>
-          {originConnection && (
+          {displayConnection && (
             <CollapsibleContent>
               <div className="mt-3 flex flex-col gap-3 rounded-xl border border-[#EFEBE4] dark:border-[#2a2a2e] bg-[#FCFBF8] dark:bg-[#1e1d1b] p-4">
-                <IdentityBlock connection={originConnection} size="sm" />
+                <IdentityBlock connection={displayConnection} size="sm" />
                 <div className="grid grid-cols-2 gap-3">
                   {originOnline && (
                     <DetailField
                       label={t("detailUptime")}
-                      value={formatUptime(originConnection.connectedAt, nowMs)}
+                      value={formatUptime(displayConnection.connectedAt, nowMs)}
                       mono
                     />
                   )}
                   <DetailField
                     label={t("detailHost")}
                     value={
-                      originConnection.host === ""
+                      displayConnection.host === ""
                         ? t("detailsHostUnknown")
-                        : originConnection.host
+                        : displayConnection.host
                     }
                     mono
                   />
-                  {originConnection.startedAt && (
+                  {displayConnection.startedAt && (
                     <DetailField
                       label={t("detailStarted")}
-                      value={formatRelative(originConnection.startedAt, nowMs)}
+                      value={formatRelative(displayConnection.startedAt, nowMs)}
                     />
                   )}
                 </div>

--- a/src/components/agent-presence/conversational-entry.tsx
+++ b/src/components/agent-presence/conversational-entry.tsx
@@ -36,7 +36,7 @@
 // connection list immediately (`refreshConnections`) so the picker re-syncs;
 // other failures surface the server reason inline the same way.
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Loader2, SendHorizonal, TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
@@ -56,6 +56,8 @@ import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
 import type { SessionView } from "@/services/daemon-session.service";
 import { DaemonConnectCta } from "./daemon-connect-cta";
 import { InstancePicker, type InstanceCandidate } from "./instance-picker";
+import { FixedCwdAnchor } from "./fixed-cwd-anchor";
+import type { ResolvedProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
 import {
   connectionsToInstanceCandidates,
   extractInstructionError,
@@ -117,7 +119,13 @@ export interface ConversationalEntryProps {
   // Preselect this agent when it has an online connection (e.g. a future
   // idea-detail entry point that already knows the assignee).
   defaultAgentUuid?: string;
+  projectUuid?: string;
 }
+
+type FixedTargetEntry = {
+  agentName: string;
+  target: ResolvedProjectAgentCwdTarget;
+};
 
 // Group the online connections by agent for the agent Select. Insertion order
 // follows the connection list (server-deterministic ordering).
@@ -149,6 +157,7 @@ export function ConversationalEntry({
   offlineFallback,
   onStarted,
   defaultAgentUuid,
+  projectUuid,
 }: ConversationalEntryProps) {
   const t = useTranslations("conversationalEntry");
   const presence = useAgentPresenceOptional();
@@ -163,18 +172,75 @@ export function ConversationalEntry({
       ),
     [presence?.connections],
   );
-  const agentGroups = useMemo(
-    () => groupByAgent(onlineConnections),
-    [onlineConnections],
+  const [fixedTargets, setFixedTargets] = useState<Map<string, FixedTargetEntry>>(
+    new Map(),
   );
+  const agentGroups = useMemo(() => {
+    const groups = groupByAgent(onlineConnections);
+    const present = new Set(groups.map((group) => group.agentUuid));
+    for (const [agentUuid, fixed] of fixedTargets) {
+      if (present.has(agentUuid)) continue;
+      groups.push({
+        agentUuid,
+        agentName: fixed.agentName,
+        connections: [],
+      });
+    }
+    return groups;
+  }, [fixedTargets, onlineConnections]);
 
   // Agent selection: explicit pick wins while it still resolves to an online
   // group; otherwise prefer the consumer's default, then the sole/first group.
   const [pickedAgentUuid, setPickedAgentUuid] = useState<string | null>(null);
+  useEffect(() => {
+    if (!projectUuid) {
+      setFixedTargets(new Map());
+      return;
+    }
+    let cancelled = false;
+    authFetch(`/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`)
+      .then(async (response) => {
+        if (!response.ok) return;
+        const json = await response.json();
+        const next = new Map<string, FixedTargetEntry>();
+        for (const item of json?.data?.agents ?? []) {
+          if (!item.preference) continue;
+          next.set(item.agent.uuid, {
+            agentName: item.agent.name,
+            target: {
+              actorUserUuid: "",
+              source: "project_fixed",
+              agentUuid: item.agent.uuid,
+              host: item.preference.host,
+              cwd: item.preference.cwd,
+              availability:
+                item.preference.status === "valid"
+                  ? "ready"
+                  : item.preference.status === "offline"
+                    ? "offline"
+                    : "invalid",
+              promptPolicy: "suppress",
+              connectionUuid: null,
+              agentInstanceUuid: item.preference.anchorAgentInstanceUuid ?? null,
+            },
+          });
+        }
+        if (!cancelled) setFixedTargets(next);
+      })
+      .catch((error) =>
+        clientLogger.error("Failed to load project Agent cwd preferences:", error),
+      );
+    return () => {
+      cancelled = true;
+    };
+  }, [projectUuid]);
   const selectedAgent =
     agentGroups.find((g) => g.agentUuid === pickedAgentUuid) ??
     agentGroups.find((g) => g.agentUuid === defaultAgentUuid) ??
     (agentGroups.length === 1 ? agentGroups[0] : null);
+  const fixedTarget = selectedAgent
+    ? fixedTargets.get(selectedAgent.agentUuid)?.target ?? null
+    : null;
 
   // Instance selection within the picked agent. The picker auto-selects a sole
   // instance; 2+ instances require an explicit pick (send stays disabled).
@@ -188,7 +254,9 @@ export function ConversationalEntry({
   // The selection is valid only while it still points at one of the CURRENT
   // agent's online instances (agent switch / connection drop invalidates it).
   const selectedInstance =
-    instances.find((i) => i.connectionUuid === pickedConnectionUuid) ?? null;
+    (fixedTarget
+      ? instances.find((instance) => instance.host === fixedTarget.host)
+      : instances.find((i) => i.connectionUuid === pickedConnectionUuid)) ?? null;
 
   const [text, setText] = useState("");
   const [pending, setPending] = useState(false);
@@ -286,7 +354,7 @@ export function ConversationalEntry({
   };
 
   // ===== Offline fallback =====
-  if (onlineConnections.length === 0) {
+  if (onlineConnections.length === 0 && fixedTargets.size === 0) {
     return (
       <div className="flex flex-col gap-2">
         <p className="text-[12.5px] leading-relaxed text-muted-foreground">
@@ -332,7 +400,9 @@ export function ConversationalEntry({
 
       {/* Instance picker for the selected agent (online instances only; a sole
           instance auto-selects). No agent selected yet → prompt instead. */}
-      {selectedAgent ? (
+      {selectedAgent && fixedTarget ? (
+        <FixedCwdAnchor target={fixedTarget} />
+      ) : selectedAgent ? (
         <div className="flex flex-col gap-1.5">
           <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             {t("instanceLabel")}

--- a/src/components/agent-presence/conversational-entry.tsx
+++ b/src/components/agent-presence/conversational-entry.tsx
@@ -56,8 +56,8 @@ import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
 import type { SessionView } from "@/services/daemon-session.service";
 import { DaemonConnectCta } from "./daemon-connect-cta";
 import { InstancePicker, type InstanceCandidate } from "./instance-picker";
-import { FixedCwdAnchor } from "./fixed-cwd-anchor";
 import type { ResolvedProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
+import { FixedCwdAnchor } from "./fixed-cwd-anchor";
 import {
   connectionsToInstanceCandidates,
   extractInstructionError,
@@ -400,9 +400,9 @@ export function ConversationalEntry({
 
       {/* Instance picker for the selected agent (online instances only; a sole
           instance auto-selects). No agent selected yet → prompt instead. */}
-      {selectedAgent && fixedTarget ? (
+      {selectedAgent && fixedTarget && fixedTarget.availability !== "ready" ? (
         <FixedCwdAnchor target={fixedTarget} />
-      ) : selectedAgent ? (
+      ) : selectedAgent && !fixedTarget ? (
         <div className="flex flex-col gap-1.5">
           <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             {t("instanceLabel")}
@@ -414,9 +414,9 @@ export function ConversationalEntry({
             ariaLabel={t("instanceLabel")}
           />
         </div>
-      ) : (
+      ) : !selectedAgent ? (
         <p className="text-[12px] text-muted-foreground">{t("pickAgentFirst")}</p>
-      )}
+      ) : null}
 
       {/* Description input — plain Enter sends (IME-guarded), Shift+Enter newline. */}
       <div className="flex flex-col gap-1.5">

--- a/src/components/agent-presence/directory-browser.tsx
+++ b/src/components/agent-presence/directory-browser.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import { ChevronUp, Folder, Loader2 } from "lucide-react";
+import { ChevronUp, Folder, HardDrive, Loader2, TextCursorInput } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { isImeComposing } from "@/lib/ime";
@@ -137,6 +137,7 @@ export function DirectoryBrowser({
   );
   const [roots, setRoots] = useState<string[]>([]);
   const [selectedRoot, setSelectedRoot] = useState("");
+  const [pathMode, setPathMode] = useState<"daemon" | "custom">("custom");
   const [manualMode, setManualMode] = useState(false);
   const [prefix, setPrefix] = useState("");
   const [selectedPath, setSelectedPath] = useState("");
@@ -182,6 +183,7 @@ export function DirectoryBrowser({
     clearCandidates();
     setRoots([]);
     setSelectedRoot("");
+    setPathMode("custom");
     setManualMode(false);
     setPrefix("");
     setSelectedPath("");
@@ -362,6 +364,48 @@ export function DirectoryBrowser({
 
       {anchor && (
         <>
+          <div
+            className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2"
+            role="group"
+            aria-label={t("chooseDirectorySource")}
+          >
+            <Button
+              type="button"
+              variant={pathMode === "daemon" ? "default" : "outline"}
+              className="h-auto min-w-0 justify-start px-3 py-2 text-left"
+              onClick={() => {
+                cancelValidation();
+                clearCandidates();
+                setPathMode("daemon");
+                setSelectedPath(anchor.cwd ?? "");
+                setErrorCode(null);
+              }}
+            >
+              <HardDrive className="mr-2 size-4 shrink-0" />
+              <span className="min-w-0">
+                <span className="block text-xs font-medium">{t("daemonCwd")}</span>
+                <span className="block truncate font-mono text-[10px] opacity-75">
+                  {anchor.cwd ?? t("unknownHost")}
+                </span>
+              </span>
+            </Button>
+            <Button
+              type="button"
+              variant={pathMode === "custom" ? "default" : "outline"}
+              className="h-auto min-w-0 justify-start px-3 py-2 text-left"
+              onClick={() => {
+                cancelValidation();
+                setPathMode("custom");
+                setSelectedPath("");
+                setPrefix(selectedRoot ? withTrailingSeparator(selectedRoot) : "");
+                setErrorCode(null);
+              }}
+            >
+              <TextCursorInput className="mr-2 size-4 shrink-0" />
+              <span className="text-xs font-medium">{t("customCwd")}</span>
+            </Button>
+          </div>
+
           {pending === "roots" && (
             <p role="status" className="flex items-center gap-2 text-xs text-muted-foreground">
               <Loader2 className="size-3.5 animate-spin" />
@@ -369,7 +413,7 @@ export function DirectoryBrowser({
             </p>
           )}
 
-          {roots.length > 1 && (
+          {pathMode === "custom" && roots.length > 1 && (
             <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
               {t("browseRoot")}
               <select
@@ -390,7 +434,7 @@ export function DirectoryBrowser({
             </label>
           )}
 
-          {(selectedRoot || manualMode) && (
+          {pathMode === "custom" && (selectedRoot || manualMode) && (
             <div className="flex min-w-0 gap-2">
               <div className="relative min-w-0 flex-1">
                 <Input
@@ -468,7 +512,7 @@ export function DirectoryBrowser({
             </div>
           )}
 
-          {listOpen && items.length > 0 && (
+          {pathMode === "custom" && listOpen && items.length > 0 && (
             <div
               id="directory-candidates"
               role="listbox"
@@ -492,7 +536,8 @@ export function DirectoryBrowser({
             </div>
           )}
 
-          {completedPrefix === prefix &&
+          {pathMode === "custom" &&
+            completedPrefix === prefix &&
             items.length === 0 &&
             pending === null &&
             !errorCode && (

--- a/src/components/agent-presence/directory-browser.tsx
+++ b/src/components/agent-presence/directory-browser.tsx
@@ -137,7 +137,9 @@ export function DirectoryBrowser({
   );
   const [roots, setRoots] = useState<string[]>([]);
   const [selectedRoot, setSelectedRoot] = useState("");
-  const [pathMode, setPathMode] = useState<"daemon" | "custom">("custom");
+  const [pathMode, setPathMode] = useState<"configured" | "custom">("custom");
+  const [configuredSelection, setConfiguredSelection] =
+    useState<InstanceCandidate | null>(null);
   const [manualMode, setManualMode] = useState(false);
   const [prefix, setPrefix] = useState("");
   const [selectedPath, setSelectedPath] = useState("");
@@ -184,6 +186,7 @@ export function DirectoryBrowser({
     setRoots([]);
     setSelectedRoot("");
     setPathMode("custom");
+    setConfiguredSelection(null);
     setManualMode(false);
     setPrefix("");
     setSelectedPath("");
@@ -301,7 +304,8 @@ export function DirectoryBrowser({
   };
 
   const validate = async () => {
-    if (!anchor || !selectedPath) return;
+    const validationAnchor = configuredSelection ?? anchor;
+    if (!validationAnchor || !selectedPath) return;
     validationGeneration.current += 1;
     validationController.current?.abort();
     const generation = validationGeneration.current;
@@ -313,7 +317,7 @@ export function DirectoryBrowser({
       const request = await requestDirectory({
         operation: "validate",
         agentUuid,
-        targetConnectionUuid: anchor.connectionUuid,
+        targetConnectionUuid: validationAnchor.connectionUuid,
         cwd: selectedPath,
       }, controller.signal);
       const normalizedPath =
@@ -323,8 +327,8 @@ export function DirectoryBrowser({
       if (generation !== validationGeneration.current) return;
       await onValidated({
         agentUuid,
-        connectionUuid: anchor.connectionUuid,
-        host: anchor.host,
+        connectionUuid: validationAnchor.connectionUuid,
+        host: validationAnchor.host,
         cwd: normalizedPath,
         validationRequestUuid: request.uuid,
       });
@@ -354,6 +358,8 @@ export function DirectoryBrowser({
             className="h-11 max-w-full sm:h-8"
             onClick={() => {
               cancelValidation();
+              setPathMode("custom");
+              setConfiguredSelection(null);
               setAnchor(host);
             }}
           >
@@ -364,31 +370,45 @@ export function DirectoryBrowser({
 
       {anchor && (
         <>
+          {(() => {
+            const configuredCwds = instances.filter(
+              (instance) => instance.host === anchor.host && instance.cwd,
+            );
+            return (
           <div
-            className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2"
+            className="grid min-w-0 grid-cols-1 gap-2"
             role="group"
             aria-label={t("chooseDirectorySource")}
           >
-            <Button
-              type="button"
-              variant={pathMode === "daemon" ? "default" : "outline"}
-              className="h-auto min-w-0 justify-start px-3 py-2 text-left"
-              onClick={() => {
-                cancelValidation();
-                clearCandidates();
-                setPathMode("daemon");
-                setSelectedPath(anchor.cwd ?? "");
-                setErrorCode(null);
-              }}
-            >
-              <HardDrive className="mr-2 size-4 shrink-0" />
-              <span className="min-w-0">
-                <span className="block text-xs font-medium">{t("daemonCwd")}</span>
-                <span className="block truncate font-mono text-[10px] opacity-75">
-                  {anchor.cwd ?? t("unknownHost")}
+            {configuredCwds.map((instance) => (
+              <Button
+                key={instance.connectionUuid}
+                type="button"
+                variant={
+                  pathMode === "configured" &&
+                  configuredSelection?.connectionUuid === instance.connectionUuid
+                    ? "default"
+                    : "outline"
+                }
+                className="h-auto min-w-0 justify-start px-3 py-2 text-left"
+                onClick={() => {
+                  cancelValidation();
+                  clearCandidates();
+                  setPathMode("configured");
+                  setConfiguredSelection(instance);
+                  setSelectedPath(instance.cwd ?? "");
+                  setErrorCode(null);
+                }}
+              >
+                <HardDrive className="mr-2 size-4 shrink-0" />
+                <span className="min-w-0">
+                  <span className="block text-xs font-medium">{t("configuredCwd")}</span>
+                  <span className="block truncate font-mono text-[10px] opacity-75">
+                    {instance.cwd}
+                  </span>
                 </span>
-              </span>
-            </Button>
+              </Button>
+            ))}
             <Button
               type="button"
               variant={pathMode === "custom" ? "default" : "outline"}
@@ -396,6 +416,7 @@ export function DirectoryBrowser({
               onClick={() => {
                 cancelValidation();
                 setPathMode("custom");
+                setConfiguredSelection(null);
                 setSelectedPath("");
                 setPrefix(selectedRoot ? withTrailingSeparator(selectedRoot) : "");
                 setErrorCode(null);
@@ -405,6 +426,8 @@ export function DirectoryBrowser({
               <span className="text-xs font-medium">{t("customCwd")}</span>
             </Button>
           </div>
+            );
+          })()}
 
           {pending === "roots" && (
             <p role="status" className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -551,7 +574,7 @@ export function DirectoryBrowser({
               </p>
               <p className="mt-1 break-all font-mono text-xs">{selectedPath}</p>
               <p className="mt-1 truncate text-[11px] text-muted-foreground">
-                {anchor.host}
+                {(configuredSelection ?? anchor).host}
               </p>
             </div>
           )}

--- a/src/components/agent-presence/fixed-cwd-anchor.tsx
+++ b/src/components/agent-presence/fixed-cwd-anchor.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { FolderLock, Settings } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ResolvedProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
+
+interface FixedCwdAnchorProps {
+  target: ResolvedProjectAgentCwdTarget;
+}
+
+export function FixedCwdAnchor({ target }: FixedCwdAnchorProps) {
+  const t = useTranslations("fixedCwdAnchor");
+  const params = useParams<{ uuid: string }>();
+
+  return (
+    <div
+      role="region"
+      aria-label={t("title")}
+      className="space-y-2 rounded-lg border border-border bg-background p-3"
+    >
+      <div className="flex items-center gap-2 text-xs font-medium text-foreground">
+        <FolderLock className="h-4 w-4 text-primary" aria-hidden />
+        {t("title")}
+      </div>
+      <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-[11px]">
+        <dt className="text-muted-foreground">{t("host")}</dt>
+        <dd className="truncate font-mono text-foreground">{target.host ?? t("unknown")}</dd>
+        <dt className="text-muted-foreground">{t("cwd")}</dt>
+        <dd className="break-all font-mono text-foreground">{target.cwd ?? t("unknown")}</dd>
+        <dt className="text-muted-foreground">{t("status")}</dt>
+        <dd className="text-foreground">{t(`availability.${target.availability}`)}</dd>
+      </dl>
+      <Link
+        href={`/projects/${params.uuid}/dashboard?settings=agent-cwds`}
+        className="inline-flex items-center gap-1.5 text-[11px] font-medium text-primary hover:underline"
+      >
+        <Settings className="h-3.5 w-3.5" aria-hidden />
+        {t("manage")}
+      </Link>
+    </div>
+  );
+}

--- a/src/components/create-project-dialog.tsx
+++ b/src/components/create-project-dialog.tsx
@@ -17,6 +17,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { isImeComposing } from "@/lib/ime";
+import {
+  ProjectAgentCwdSettings,
+  type ProjectAgentCwdDraft,
+} from "@/components/project-agent-cwd-settings";
 
 interface CreateProjectDialogProps {
   open: boolean;
@@ -40,6 +44,7 @@ export function CreateProjectDialog({
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [cwdDrafts, setCwdDrafts] = useState<ProjectAgentCwdDraft[]>([]);
 
   const displayGroupName = groupName || t("projectGroups.ungrouped");
 
@@ -61,10 +66,33 @@ export function CreateProjectDialog({
         const data = await res.json();
 
         if (data.success) {
+          try {
+            for (const draft of cwdDrafts) {
+              const cwdResponse = await fetch(
+                `/api/projects/${encodeURIComponent(data.data.uuid)}/agent-cwds`,
+                {
+                  method: "PUT",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    agentUuid: draft.agentUuid,
+                    validationRequestUuid: draft.validationRequestUuid,
+                  }),
+                },
+              );
+              if (!cwdResponse.ok) throw new Error("cwd save failed");
+            }
+          } catch {
+            await fetch(`/api/projects/${encodeURIComponent(data.data.uuid)}`, {
+              method: "DELETE",
+            });
+            setError(t("projectSettings.agentCwds.createFailed"));
+            return;
+          }
           setSuccess(true);
           setTimeout(() => {
             setTitle("");
             setDescription("");
+            setCwdDrafts([]);
             onOpenChange(false);
             onCreated?.();
             router.refresh();
@@ -82,7 +110,7 @@ export function CreateProjectDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="sm:max-w-[480px] gap-0 p-0 rounded-[16px]"
+        className="flex max-h-[90svh] flex-col gap-0 overflow-hidden rounded-[16px] p-0 sm:max-w-[620px]"
         showCloseButton={false}
       >
         <DialogHeader className="flex flex-row items-center justify-between p-[20px_24px] border-b border-[#E5E2DC] dark:border-[#2a2a2e]">
@@ -99,7 +127,7 @@ export function CreateProjectDialog({
           {t("projectGroups.newProjectTitle")}
         </DialogDescription>
 
-        <div className="flex flex-col gap-5 p-6">
+        <div className="flex min-h-0 flex-col gap-5 overflow-y-auto p-6">
           {error && (
             <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
               {error}
@@ -132,6 +160,10 @@ export function CreateProjectDialog({
               placeholder={t("projectGroups.projectDescriptionPlaceholder")}
               className="min-h-[80px] rounded-lg border-[#E5E2DC] dark:border-[#2a2a2e]"
             />
+          </div>
+
+          <div className="border-t border-border pt-5">
+            <ProjectAgentCwdSettings onDraftChange={setCwdDrafts} />
           </div>
         </div>
 

--- a/src/components/create-project-dialog.tsx
+++ b/src/components/create-project-dialog.tsx
@@ -61,33 +61,15 @@ export function CreateProjectDialog({
             name: title.trim(),
             description: description.trim() || undefined,
             groupUuid: groupUuid || undefined,
+            agentCwds: cwdDrafts.map(({ agentUuid, validationRequestUuid }) => ({
+              agentUuid,
+              validationRequestUuid,
+            })),
           }),
         });
         const data = await res.json();
 
         if (data.success) {
-          try {
-            for (const draft of cwdDrafts) {
-              const cwdResponse = await fetch(
-                `/api/projects/${encodeURIComponent(data.data.uuid)}/agent-cwds`,
-                {
-                  method: "PUT",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
-                    agentUuid: draft.agentUuid,
-                    validationRequestUuid: draft.validationRequestUuid,
-                  }),
-                },
-              );
-              if (!cwdResponse.ok) throw new Error("cwd save failed");
-            }
-          } catch {
-            await fetch(`/api/projects/${encodeURIComponent(data.data.uuid)}`, {
-              method: "DELETE",
-            });
-            setError(t("projectSettings.agentCwds.createFailed"));
-            return;
-          }
           setSuccess(true);
           setTimeout(() => {
             setTitle("");

--- a/src/components/mention-editor.tsx
+++ b/src/components/mention-editor.tsx
@@ -115,6 +115,11 @@ interface Mentionable {
     cwd: string | null;
     agentInstanceUuid: string;
   };
+  projectFixedCwd?: {
+    host: string;
+    cwd: string;
+    availability: "ready" | "offline" | "invalid";
+  };
 }
 
 // The durable (host, cwd) "place" a mention pins to. A structural subset of both
@@ -158,6 +163,19 @@ export function resolveMentionSelection(item: Mentionable): MentionSelection {
     return {
       kind: "insert",
       pin: { host: item.ideaPin.host, cwd: item.ideaPin.cwd },
+    };
+  }
+
+  // Project-fixed cwd is authoritative for new mention work. It is encoded even
+  // while offline/invalid so the server keeps the wake notify-only instead of
+  // silently falling back to another live instance.
+  if (item.type === "agent" && item.projectFixedCwd) {
+    return {
+      kind: "insert",
+      pin: {
+        host: item.projectFixedCwd.host,
+        cwd: item.projectFixedCwd.cwd,
+      },
     };
   }
 

--- a/src/components/mention-editor.tsx
+++ b/src/components/mention-editor.tsx
@@ -79,6 +79,13 @@ const CustomMention = Mention.extend({
             ? {}
             : { "data-pinned-cwd": String(attributes.pinnedCwd) },
       },
+      runtimeCwd: {
+        default: false,
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-runtime-cwd") === "true",
+        renderHTML: (attributes: Record<string, unknown>) =>
+          attributes.runtimeCwd ? { "data-runtime-cwd": "true" } : {},
+      },
     };
   },
 });
@@ -129,6 +136,7 @@ interface Mentionable {
 export interface MentionPin {
   host: string;
   cwd: string | null;
+  runtimeCwd?: boolean;
 }
 
 // The decision the mention-selection precedence yields for a chosen candidate:
@@ -175,6 +183,7 @@ export function resolveMentionSelection(item: Mentionable): MentionSelection {
       pin: {
         host: item.projectFixedCwd.host,
         cwd: item.projectFixedCwd.cwd,
+        runtimeCwd: true,
       },
     };
   }
@@ -263,7 +272,7 @@ function editorToPlainText(editor: Editor): string {
 
   function processNode(node: Record<string, unknown>): string {
     if (node.type === "mention") {
-      const attrs = node.attrs as Record<string, string | null> | undefined;
+      const attrs = node.attrs as Record<string, string | boolean | null> | undefined;
       if (attrs) {
         // Serialize via the shared codec so the optional pinned (host, cwd)
         // suffix matches what the service parser reads. Un-pinned (both null) →
@@ -272,8 +281,9 @@ function editorToPlainText(editor: Editor): string {
           (attrs.label || attrs.id) as string,
           ((attrs.mentionType as string) || "user") as "user" | "agent",
           attrs.id as string,
-          attrs.pinnedHost ?? null,
-          attrs.pinnedCwd ?? null,
+          (attrs.pinnedHost as string | null) ?? null,
+          (attrs.pinnedCwd as string | null) ?? null,
+          attrs.runtimeCwd === true,
         );
       }
       return "";
@@ -327,7 +337,7 @@ function plainTextToEditorContent(text: string): Record<string, unknown> {
         });
       }
 
-      const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
+      const { pinnedHost, pinnedCwd, runtimeCwd } = decodePinSuffix(match[4]);
       inlineContent.push({
         type: "mention",
         attrs: {
@@ -336,6 +346,7 @@ function plainTextToEditorContent(text: string): Record<string, unknown> {
           mentionType: match[2],
           pinnedHost,
           pinnedCwd,
+          runtimeCwd: runtimeCwd === true,
         },
       });
 
@@ -790,7 +801,7 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
         item: Mentionable,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         command: (attrs: any) => void,
-        pin?: { host: string; cwd: string | null },
+        pin?: { host: string; cwd: string | null; runtimeCwd?: boolean },
       ) => {
         command({
           id: item.uuid,
@@ -800,6 +811,7 @@ export const MentionEditor = forwardRef<MentionEditorRef, MentionEditorProps>(
           // mention. host "" is preserved (unknown-host instance).
           pinnedHost: pin ? pin.host : null,
           pinnedCwd: pin ? pin.cwd : null,
+          runtimeCwd: pin?.runtimeCwd === true,
         });
       },
       [],

--- a/src/components/mention-editor.tsx
+++ b/src/components/mention-editor.tsx
@@ -166,17 +166,9 @@ export type MentionSelection =
  *     persisted to the idea.
  */
 export function resolveMentionSelection(item: Mentionable): MentionSelection {
-  // Rule 1: inherit the direct idea's pin (HARD) — not filtered by online status.
-  if (item.isIdeaAssignee && item.ideaPin) {
-    return {
-      kind: "insert",
-      pin: { host: item.ideaPin.host, cwd: item.ideaPin.cwd },
-    };
-  }
-
-  // Project-fixed cwd is authoritative for new mention work. It is encoded even
-  // while offline/invalid so the server keeps the wake notify-only instead of
-  // silently falling back to another live instance.
+  // A project-level preference takes over historical per-Idea assignments. The
+  // runtime marker is required so the server routes by host and runs in the
+  // configured cwd instead of treating the value as an exact daemon instance.
   if (item.type === "agent" && item.projectFixedCwd) {
     return {
       kind: "insert",
@@ -185,6 +177,14 @@ export function resolveMentionSelection(item: Mentionable): MentionSelection {
         cwd: item.projectFixedCwd.cwd,
         runtimeCwd: true,
       },
+    };
+  }
+
+  // Rule 1: inherit the direct idea's pin (HARD) — not filtered by online status.
+  if (item.isIdeaAssignee && item.ideaPin) {
+    return {
+      kind: "insert",
+      pin: { host: item.ideaPin.host, cwd: item.ideaPin.cwd },
     };
   }
 

--- a/src/components/mention-renderer.tsx
+++ b/src/components/mention-renderer.tsx
@@ -42,6 +42,7 @@ export interface ParsedMentionRef {
   displayName: string;
   pinnedHost?: string | null;
   pinnedCwd?: string | null;
+  runtimeCwd?: boolean;
 }
 
 interface MentionPart {
@@ -53,6 +54,7 @@ interface MentionPart {
   // (mirrors ParsedMentionRef / MentionRef — absent on un-pinned tokens).
   pinnedHost?: string | null;
   pinnedCwd?: string | null;
+  runtimeCwd?: boolean;
 }
 
 function parseMentions(text: string): MentionPart[] {
@@ -73,7 +75,7 @@ function parseMentions(text: string): MentionPart[] {
     // Decode the optional pin suffix (group 4) via the shared codec. Attach the
     // pin fields ONLY when present, keeping un-pinned parts byte-identical to the
     // legacy shape (mirrors the server parser in mention.service.ts).
-    const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
+    const { pinnedHost, pinnedCwd, runtimeCwd } = decodePinSuffix(match[4]);
     const part: MentionPart = {
       type: "mention",
       content: match[1],
@@ -83,6 +85,7 @@ function parseMentions(text: string): MentionPart[] {
     if (pinnedHost !== null || pinnedCwd !== null) {
       part.pinnedHost = pinnedHost;
       part.pinnedCwd = pinnedCwd;
+      if (runtimeCwd) part.runtimeCwd = true;
     }
     parts.push(part);
 
@@ -120,6 +123,7 @@ export function preprocessMentions(content: string): {
     uuid: string;
     pinnedHost?: string | null;
     pinnedCwd?: string | null;
+    runtimeCwd?: boolean;
   }>;
 } {
   const mentions: Array<{
@@ -128,6 +132,7 @@ export function preprocessMentions(content: string): {
     uuid: string;
     pinnedHost?: string | null;
     pinnedCwd?: string | null;
+    runtimeCwd?: boolean;
   }> = [];
   const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
 
@@ -136,17 +141,19 @@ export function preprocessMentions(content: string): {
   // placeholders stay byte-identical).
   const processed = content.replace(regex, (_match, name, type, uuid, pin) => {
     const index = mentions.length;
-    const { pinnedHost, pinnedCwd } = decodePinSuffix(pin);
+    const { pinnedHost, pinnedCwd, runtimeCwd } = decodePinSuffix(pin);
     const entry: {
       displayName: string;
       type: string;
       uuid: string;
       pinnedHost?: string | null;
       pinnedCwd?: string | null;
+      runtimeCwd?: boolean;
     } = { displayName: name, type, uuid };
     if (pinnedHost !== null || pinnedCwd !== null) {
       entry.pinnedHost = pinnedHost;
       entry.pinnedCwd = pinnedCwd;
+      if (runtimeCwd) entry.runtimeCwd = true;
     }
     mentions.push(entry);
     return `${MENTION_PLACEHOLDER_PREFIX}${index}${MENTION_PLACEHOLDER_SUFFIX}`;
@@ -203,7 +210,7 @@ export function preprocessMentionsAsTags(content: string): {
 
   const processed = content.replace(regex, (_match, name, type, uuid, pin) => {
     const index = mentions.length;
-    const { pinnedHost, pinnedCwd } = decodePinSuffix(pin);
+    const { pinnedHost, pinnedCwd, runtimeCwd } = decodePinSuffix(pin);
     const ref: ParsedMentionRef = {
       type: (type as string).toLowerCase() as "user" | "agent",
       uuid: (uuid as string).toLowerCase(),
@@ -212,6 +219,7 @@ export function preprocessMentionsAsTags(content: string): {
     if (pinnedHost !== null || pinnedCwd !== null) {
       ref.pinnedHost = pinnedHost;
       ref.pinnedCwd = pinnedCwd;
+      if (runtimeCwd) ref.runtimeCwd = true;
     }
     mentions.push(ref);
     const label = `@${name}`
@@ -487,7 +495,7 @@ export function extractMentions(text: string): ParsedMentionRef[] {
   let match;
 
   while ((match = regex.exec(text)) !== null) {
-    const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
+    const { pinnedHost, pinnedCwd, runtimeCwd } = decodePinSuffix(match[4]);
     const ref: ParsedMentionRef = {
       displayName: match[1],
       type: match[2].toLowerCase() as "user" | "agent",
@@ -496,6 +504,7 @@ export function extractMentions(text: string): ParsedMentionRef[] {
     if (pinnedHost !== null || pinnedCwd !== null) {
       ref.pinnedHost = pinnedHost;
       ref.pinnedCwd = pinnedCwd;
+      if (runtimeCwd) ref.runtimeCwd = true;
     }
     mentions.push(ref);
   }

--- a/src/components/project-agent-cwd-settings.tsx
+++ b/src/components/project-agent-cwd-settings.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { FolderCog, Loader2, RotateCcw, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DirectoryBrowser,
+  type ValidatedDirectory,
+} from "@/components/agent-presence/directory-browser";
+import type { InstanceCandidate } from "@/components/agent-presence/instance-picker";
+
+interface AgentCwdItem {
+  agent: { uuid: string; name: string };
+  onlineInstances: InstanceCandidate[];
+  preference: {
+    host: string;
+    cwd: string;
+    status: "valid" | "offline" | "invalid";
+  } | null;
+}
+
+export interface ProjectAgentCwdDraft {
+  agentUuid: string;
+  validationRequestUuid: string;
+  host: string;
+  cwd: string;
+}
+
+export function ProjectAgentCwdSettings({
+  projectUuid,
+  onDraftChange,
+}: {
+  projectUuid?: string;
+  onDraftChange?: (drafts: ProjectAgentCwdDraft[]) => void;
+}) {
+  const t = useTranslations();
+  const [items, setItems] = useState<AgentCwdItem[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, ProjectAgentCwdDraft>>({});
+  const [loading, setLoading] = useState(true);
+  const [editingAgent, setEditingAgent] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const response = await fetch(projectUuid
+        ? `/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`
+        : "/api/projects/agent-cwd-options");
+      const body = await response.json();
+      if (!response.ok || !body.success) throw new Error("load failed");
+      setItems(body.data.agents);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectUuid]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const updateDrafts = (next: Record<string, ProjectAgentCwdDraft>) => {
+    setDrafts(next);
+    onDraftChange?.(Object.values(next));
+  };
+
+  const save = async (selection: ValidatedDirectory) => {
+    if (!projectUuid) {
+      updateDrafts({
+        ...drafts,
+        [selection.agentUuid]: {
+          agentUuid: selection.agentUuid,
+          validationRequestUuid: selection.validationRequestUuid,
+          host: selection.host,
+          cwd: selection.cwd,
+        },
+      });
+      setEditingAgent(null);
+      return;
+    }
+    const response = await fetch(`/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agentUuid: selection.agentUuid,
+        validationRequestUuid: selection.validationRequestUuid,
+      }),
+    });
+    if (!response.ok) throw new Error("save failed");
+    setEditingAgent(null);
+    await load();
+  };
+
+  const clear = async (agentUuid: string) => {
+    if (!projectUuid) {
+      const next = { ...drafts };
+      delete next[agentUuid];
+      updateDrafts(next);
+      return;
+    }
+    const response = await fetch(`/api/projects/${encodeURIComponent(projectUuid)}/agent-cwds`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentUuid }),
+    });
+    if (!response.ok) {
+      setError(true);
+      return;
+    }
+    await load();
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <div>
+        <h3 className="text-[14px] font-semibold text-foreground">
+          {t("projectSettings.agentCwds.title")}
+        </h3>
+        <p className="mt-1 text-[12px] text-muted-foreground">
+          {t("projectSettings.agentCwds.description")}
+        </p>
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          {t("projectSettings.agentCwds.loading")}
+        </div>
+      )}
+      {error && (
+        <div className="flex items-center justify-between gap-3" role="alert">
+          <span className="text-xs text-destructive">
+            {t("projectSettings.agentCwds.loadFailed")}
+          </span>
+          <Button type="button" size="sm" variant="outline" onClick={() => void load()}>
+            <RotateCcw className="mr-2 size-3.5" />
+            {t("common.retry")}
+          </Button>
+        </div>
+      )}
+      {!loading && !error && items.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          {t("projectSettings.agentCwds.emptyOnline")}
+        </p>
+      )}
+
+      {items.map((item) => {
+        const draft = drafts[item.agent.uuid];
+        const preference = draft
+          ? { host: draft.host, cwd: draft.cwd, status: "valid" as const }
+          : item.preference;
+        return (
+          <div key={item.agent.uuid} className="min-w-0 rounded-lg border border-border p-4">
+            <div className="flex min-w-0 items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-[13px] font-semibold">{item.agent.name}</p>
+                {preference ? (
+                  <>
+                    <p className="mt-1 break-all font-mono text-[11px]">{preference.cwd}</p>
+                    <p className="mt-1 truncate text-[11px] text-muted-foreground">
+                      {preference.host}
+                    </p>
+                    <p className={preference.status === "valid"
+                      ? "mt-1 text-[11px] text-emerald-700 dark:text-emerald-400"
+                      : "mt-1 text-[11px] text-destructive"}>
+                      {t(`projectSettings.agentCwds.status.${preference.status}`)}
+                    </p>
+                  </>
+                ) : (
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    {t("projectSettings.agentCwds.notConfigured")}
+                  </p>
+                )}
+              </div>
+              <div className="flex shrink-0 gap-1">
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  title={t(preference
+                    ? "projectSettings.agentCwds.replace"
+                    : "projectSettings.agentCwds.configure")}
+                  aria-label={t(preference
+                    ? "projectSettings.agentCwds.replace"
+                    : "projectSettings.agentCwds.configure")}
+                  onClick={() => setEditingAgent(
+                    editingAgent === item.agent.uuid ? null : item.agent.uuid,
+                  )}
+                >
+                  <FolderCog className="size-4" />
+                </Button>
+                {preference && (
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="text-destructive"
+                    title={t("projectSettings.agentCwds.clear")}
+                    aria-label={t("projectSettings.agentCwds.clear")}
+                    onClick={() => void clear(item.agent.uuid)}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+            {editingAgent === item.agent.uuid && (
+              <div className="mt-4 border-t border-border pt-4">
+                <DirectoryBrowser
+                  agentUuid={item.agent.uuid}
+                  instances={item.onlineInstances}
+                  confirmLabel={t("projectSettings.agentCwds.save")}
+                  onValidated={save}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/start-development-button.tsx
+++ b/src/components/start-development-button.tsx
@@ -88,7 +88,10 @@ export function StartDevelopmentButton({
     confirmTemporary,
     cancelPick,
     isResolving,
-  } = usePinThenWake({ reassignNoWake: reassignIdeaInstanceNoWakeAction });
+  } = usePinThenWake({
+    reassignNoWake: reassignIdeaInstanceNoWakeAction,
+    previewIdeaUuid: ideaUuid,
+  });
 
   // The started hint is transient: it clears when the panel moves to another
   // idea, and — because a wake normally flips a task to in_progress quickly —

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -105,7 +105,10 @@ export function YoloButton({
     confirmTemporary,
     cancelPick,
     isResolving,
-  } = usePinThenWake({ reassignNoWake: reassignIdeaInstanceNoWakeAction });
+  } = usePinThenWake({
+    reassignNoWake: reassignIdeaInstanceNoWakeAction,
+    previewIdeaUuid: ideaUuid,
+  });
 
   // The started hint is transient: it clears when the panel moves to another
   // idea, and — because a wake normally flips the idea into motion quickly —

--- a/src/hooks/__tests__/use-pin-then-wake.test.tsx
+++ b/src/hooks/__tests__/use-pin-then-wake.test.tsx
@@ -46,6 +46,7 @@ function Harness({
   preview,
   reassignNoWake,
   wake,
+  previewIdeaUuid,
 }: {
   preview: WakeTargetPreview | null;
   reassignNoWake: (
@@ -57,14 +58,28 @@ function Harness({
     agentUuid: string;
     validationRequestUuid: string;
   }) => void | Promise<void>;
+  previewIdeaUuid?: string | null;
 }) {
-  const { start, pickerState, confirmPick, confirmTemporary, cancelPick } = usePinThenWake({
+  const {
+    start,
+    pickerState,
+    confirmPick,
+    confirmTemporary,
+    cancelPick,
+    fixedTarget,
+  } = usePinThenWake({
     fetchPreview: async () => preview,
     reassignNoWake,
+    previewIdeaUuid,
   });
   return (
     <div>
       <button onClick={() => start({ ideaUuid: IDEA, wake })}>go</button>
+      {fixedTarget && (
+        <span data-testid="fixed-target">
+          {fixedTarget.host}:{fixedTarget.cwd}
+        </span>
+      )}
       {pickerState && (
         <div data-testid="picker">
           <span data-testid="picker-count">{pickerState.instances.length}</span>
@@ -102,6 +117,54 @@ beforeEach(() => {
 });
 
 describe("usePinThenWake", () => {
+  it("preloads a fixed target and clears it when selection behavior is restored", async () => {
+    const reassign = vi.fn();
+    const wake = vi.fn();
+    const fixedPreview: WakeTargetPreview = {
+      outcome: "direct",
+      assigneeAgentUuid: AGENT,
+      onlineInstances: [],
+      resolvedTarget: {
+        actorUserUuid: "user-1",
+        agentUuid: AGENT,
+        source: "project_fixed",
+        host: "fixed-host",
+        cwd: "/work/fixed",
+        availability: "ready",
+        promptPolicy: "suppress",
+        connectionUuid: "connection-1",
+        agentInstanceUuid: "instance-1",
+      },
+    };
+    const { rerender } = render(
+      <Harness
+        preview={fixedPreview}
+        previewIdeaUuid={IDEA}
+        reassignNoWake={reassign}
+        wake={wake}
+      />,
+    );
+
+    expect((await screen.findByTestId("fixed-target")).textContent).toBe(
+      "fixed-host:/work/fixed",
+    );
+
+    rerender(
+      <Harness
+        preview={{
+          outcome: "pick",
+          assigneeAgentUuid: AGENT,
+          onlineInstances: [candidate(), candidate({ connectionUuid: "conn-2" })],
+        }}
+        previewIdeaUuid="idea-2"
+        reassignNoWake={reassign}
+        wake={wake}
+      />,
+    );
+
+    await waitFor(() => expect(screen.queryByTestId("fixed-target")).toBeNull());
+  });
+
   it("direct → wakes immediately, no picker, no reassign", async () => {
     const reassign = vi.fn().mockResolvedValue({ success: true });
     const wake = vi.fn().mockResolvedValue(undefined);

--- a/src/hooks/use-pin-then-wake.ts
+++ b/src/hooks/use-pin-then-wake.ts
@@ -33,12 +33,13 @@
 // falls back to its own wake-target resolution (session-origin upgrade / HARD
 // pin) — the same behavior as before this change, so no regression.
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { clientLogger } from "@/lib/logger-client";
 import {
   filterOnlineInstances,
   type InstanceCandidate,
 } from "@/components/agent-presence/instance-picker";
+import type { ResolvedProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
 
 /** The three pre-wake outcomes returned by GET /api/ideas/[uuid]/wake-preview. */
 export type WakeTargetOutcome = "pick" | "auto_pin" | "direct";
@@ -48,6 +49,7 @@ export interface WakeTargetPreview {
   outcome: WakeTargetOutcome;
   assigneeAgentUuid: string | null;
   onlineInstances: InstanceCandidate[];
+  resolvedTarget?: ResolvedProjectAgentCwdTarget;
 }
 
 /**
@@ -78,6 +80,7 @@ export interface UsePinThenWakeOptions {
   fetchPreview?: (ideaUuid: string) => Promise<WakeTargetPreview | null>;
   /** The entity-specific non-waking reassign server action. */
   reassignNoWake: ReassignNoWakeAction;
+  previewIdeaUuid?: string | null;
 }
 
 export interface StartPinThenWakeArgs {
@@ -131,9 +134,12 @@ async function defaultFetchPreview(
 export function usePinThenWake({
   fetchPreview = defaultFetchPreview,
   reassignNoWake,
+  previewIdeaUuid,
 }: UsePinThenWakeOptions) {
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
   const [isResolving, setIsResolving] = useState(false);
+  const [fixedTarget, setFixedTarget] =
+    useState<ResolvedProjectAgentCwdTarget | null>(null);
   // The wake bound to the currently-open picker, captured at `start` time so
   // `confirmPick` fires the exact wake the user initiated.
   const [pendingWake, setPendingWake] = useState<{
@@ -141,6 +147,25 @@ export function usePinThenWake({
   } | null>(
     null,
   );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!previewIdeaUuid) {
+      setFixedTarget(null);
+      return;
+    }
+    void fetchPreview(previewIdeaUuid).then((preview) => {
+      if (cancelled) return;
+      setFixedTarget(
+        preview?.resolvedTarget?.source === "project_fixed"
+          ? preview.resolvedTarget
+          : null,
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchPreview, previewIdeaUuid]);
 
   // Reassign that never throws and never blocks the wake — logs and continues.
   // Used by both the auto_pin path and the picker confirm.
@@ -170,6 +195,11 @@ export function usePinThenWake({
       let preview: WakeTargetPreview | null = null;
       try {
         preview = await fetchPreview(ideaUuid);
+        setFixedTarget(
+          preview?.resolvedTarget?.source === "project_fixed"
+            ? preview.resolvedTarget
+            : null,
+        );
       } finally {
         setIsResolving(false);
       }
@@ -253,5 +283,6 @@ export function usePinThenWake({
     confirmTemporary,
     cancelPick,
     isResolving,
+    fixedTarget,
   };
 }

--- a/src/lib/__tests__/mention-format.test.ts
+++ b/src/lib/__tests__/mention-format.test.ts
@@ -19,6 +19,17 @@ describe("encodePinSuffix", () => {
     );
   });
 
+  it("marks a host-routed runtime cwd without changing ordinary instance pins", () => {
+    expect(encodePinSuffix("prod", "/work/dynamic", true)).toBe(
+      "?cwd=%2Fwork%2Fdynamic&host=prod&runtime=1",
+    );
+    expect(decodePinSuffix("cwd=%2Fwork%2Fdynamic&host=prod&runtime=1")).toEqual({
+      pinnedHost: "prod",
+      pinnedCwd: "/work/dynamic",
+      runtimeCwd: true,
+    });
+  });
+
   it("writes an empty cwd value for a null-cwd pin (unknown-path instance)", () => {
     // host pinned but cwd unknown → cwd present-but-empty so the decoder can
     // distinguish "pinned to unknown path" from "not pinned".
@@ -91,6 +102,12 @@ describe("buildMentionMarker", () => {
     expect(
       buildMentionMarker("DevBot", "agent", UUID, "Laptop-Q3", "/home/u/dev/chorus"),
     ).toBe(`@[DevBot](agent:${UUID}?cwd=%2Fhome%2Fu%2Fdev%2Fchorus&host=Laptop-Q3)`);
+  });
+
+  it("appends runtime=1 for a project-fixed runtime cwd", () => {
+    expect(buildMentionMarker("DevBot", "agent", UUID, "prod", "/dynamic", true)).toBe(
+      `@[DevBot](agent:${UUID}?cwd=%2Fdynamic&host=prod&runtime=1)`,
+    );
   });
 
   it("round-trips a pinned marker through encode→decode", () => {

--- a/src/lib/__tests__/mention-liveness.test.ts
+++ b/src/lib/__tests__/mention-liveness.test.ts
@@ -85,6 +85,37 @@ describe("resolveMentionLiveness — pinned mention (instance-precise)", () => {
     expect(r.ownerUuid).toBe(OWNER);
   });
 
+  it("runtime cwd is online through any online connection on the fixed host", () => {
+    const runtimeRef: MentionLivenessRef = {
+      uuid: AGENT,
+      pinnedHost: "prod",
+      pinnedCwd: "/work/dynamic",
+      runtimeCwd: true,
+    };
+    const result = resolveMentionLiveness(runtimeRef, [
+      conn({ host: "prod", cwd: "/daemon/startup", effectiveStatus: "online" }),
+    ]);
+    expect(result).toMatchObject({
+      pinned: true,
+      online: true,
+      ownerUuid: OWNER,
+      host: "prod",
+      cwd: "/work/dynamic",
+    });
+  });
+
+  it("runtime cwd stays offline when only another host is online", () => {
+    const runtimeRef: MentionLivenessRef = {
+      uuid: AGENT,
+      pinnedHost: "fixed-host",
+      pinnedCwd: "/work/dynamic",
+      runtimeCwd: true,
+    };
+    expect(resolveMentionLiveness(runtimeRef, [
+      conn({ host: "other-host", cwd: "/daemon/startup", effectiveStatus: "online" }),
+    ]).online).toBe(false);
+  });
+
   it("pinned place exists but its connection is offline → offline, instance identity surfaced", () => {
     const connections = [
       conn({ host: "prod", cwd: "/work", effectiveStatus: "offline" }),

--- a/src/lib/mention-format.ts
+++ b/src/lib/mention-format.ts
@@ -21,6 +21,7 @@
 export function encodePinSuffix(
   pinnedHost: string | null | undefined,
   pinnedCwd: string | null | undefined,
+  runtimeCwd = false,
 ): string {
   // No pin at all → no suffix (un-pinned mention is unchanged).
   if (
@@ -35,6 +36,7 @@ export function encodePinSuffix(
   // cwd present-but-null → empty value (distinct from "absent" by the decoder).
   parts.push(`cwd=${pinnedCwd == null ? "" : enc(pinnedCwd)}`);
   if (pinnedHost != null) parts.push(`host=${enc(pinnedHost)}`);
+  if (runtimeCwd) parts.push("runtime=1");
   return `?${parts.join("&")}`;
 }
 
@@ -48,6 +50,7 @@ export function encodePinSuffix(
 export function decodePinSuffix(suffix: string | undefined | null): {
   pinnedHost: string | null;
   pinnedCwd: string | null;
+  runtimeCwd?: true;
 } {
   if (!suffix) return { pinnedHost: null, pinnedCwd: null };
   const params = new URLSearchParams(suffix);
@@ -56,12 +59,18 @@ export function decodePinSuffix(suffix: string | undefined | null): {
   if (!hasCwd && !hasHost) return { pinnedHost: null, pinnedCwd: null };
   const rawCwd = params.get("cwd") ?? "";
   const rawHost = params.get("host");
-  return {
+  const decoded: {
+    pinnedHost: string | null;
+    pinnedCwd: string | null;
+    runtimeCwd?: true;
+  } = {
     // Empty cwd value → unknown-path pin (null). Otherwise the decoded path.
     pinnedCwd: hasCwd && rawCwd !== "" ? rawCwd : null,
     // host present (even empty) → the host pin ("" = unknown-host). Absent → null.
     pinnedHost: hasHost ? rawHost ?? "" : null,
   };
+  if (params.get("runtime") === "1") decoded.runtimeCwd = true;
+  return decoded;
 }
 
 /**
@@ -75,6 +84,7 @@ export function buildMentionMarker(
   uuid: string,
   pinnedHost?: string | null,
   pinnedCwd?: string | null,
+  runtimeCwd = false,
 ): string {
-  return `@[${displayName}](${type}:${uuid}${encodePinSuffix(pinnedHost, pinnedCwd)})`;
+  return `@[${displayName}](${type}:${uuid}${encodePinSuffix(pinnedHost, pinnedCwd, runtimeCwd)})`;
 }

--- a/src/lib/mention-liveness.ts
+++ b/src/lib/mention-liveness.ts
@@ -28,6 +28,7 @@ export interface MentionLivenessRef {
   uuid: string;
   pinnedHost?: string | null;
   pinnedCwd?: string | null;
+  runtimeCwd?: boolean;
 }
 
 /**
@@ -88,16 +89,18 @@ export function resolveMentionLiveness(
     // The exact (host, cwd) place. host is "" for an unknown-host pin and cwd is
     // null for an unknown-path pin — strict equality handles both since the
     // connection projection uses the same sentinels (host: "", cwd: null).
-    const match = agentConnections.find(
-      (c) => c.host === pinnedHost && c.cwd === pinnedCwd,
+    const match = agentConnections.find((c) =>
+      ref.runtimeCwd
+        ? c.host === pinnedHost && c.effectiveStatus === "online"
+        : c.host === pinnedHost && c.cwd === pinnedCwd,
     );
     if (match) {
       return {
         pinned: true,
         online: match.effectiveStatus === "online",
         ownerUuid: match.ownerUuid,
-        host: match.host,
-        cwd: match.cwd,
+        host: ref.runtimeCwd ? pinnedHost : match.host,
+        cwd: ref.runtimeCwd ? pinnedCwd : match.cwd,
       };
     }
     // No connection for this exact place → offline. Echo the ref's place for

--- a/src/lib/use-mention-liveness.tsx
+++ b/src/lib/use-mention-liveness.tsx
@@ -37,12 +37,12 @@ export function useMentionLiveness(ref: MentionLivenessRef): MentionLiveness {
   // verdict stable across re-parses while satisfying exhaustive-deps. A fresh
   // MentionLivenessRef is rebuilt from these so resolveMentionLiveness sees the
   // same shape (pin keys present iff this is a pinned ref).
-  const { uuid, pinnedHost, pinnedCwd } = ref;
+  const { uuid, pinnedHost, pinnedCwd, runtimeCwd } = ref;
   const isPinned = "pinnedHost" in ref || "pinnedCwd" in ref;
   return useMemo(() => {
     const stableRef: MentionLivenessRef = isPinned
-      ? { uuid, pinnedHost, pinnedCwd }
+      ? { uuid, pinnedHost, pinnedCwd, runtimeCwd }
       : { uuid };
     return resolveMentionLiveness(stableRef, connections);
-  }, [connections, uuid, pinnedHost, pinnedCwd, isPinned]);
+  }, [connections, uuid, pinnedHost, pinnedCwd, runtimeCwd, isPinned]);
 }

--- a/src/services/__tests__/daemon-instruction.conversational.test.ts
+++ b/src/services/__tests__/daemon-instruction.conversational.test.ts
@@ -58,6 +58,12 @@ vi.mock("@/services/daemon-control.service", () => ({
   dispatchControl: (...a: unknown[]) => mockDispatchControl(...a),
 }));
 
+const mockResolveProjectAgentCwdTarget = vi.fn();
+vi.mock("@/services/project-agent-cwd.service", () => ({
+  resolveProjectAgentCwdTarget: (...args: unknown[]) =>
+    mockResolveProjectAgentCwdTarget(...args),
+}));
+
 // Deterministic server-generated ideaUuid.
 const STUB_IDEA_UUID = "idea-0000-0000-0000-00000000gen1";
 vi.mock("crypto", () => ({ randomUUID: () => STUB_IDEA_UUID }));
@@ -104,6 +110,17 @@ beforeEach(() => {
   });
   mockConnectionBelongsToAgent.mockResolvedValue(true);
   mockIsConnectionLive.mockResolvedValue(true);
+  mockResolveProjectAgentCwdTarget.mockResolvedValue({
+    actorUserUuid: ownerUuid,
+    source: "unconfigured",
+    agentUuid,
+    host: null,
+    cwd: null,
+    availability: "ready",
+    promptPolicy: "select",
+    connectionUuid,
+    agentInstanceUuid: null,
+  });
 
   // $transaction runs its callback against the tx client and returns its result.
   mockPrisma.$transaction.mockImplementation(
@@ -280,6 +297,69 @@ describe("composeConversationalIdeaInstruction", () => {
 
 // ===== createConversationalIdeaSession — happy path =====
 describe("createConversationalIdeaSession", () => {
+  it("uses the project-fixed target and snapshots it on the Idea and root session", async () => {
+    mockResolveProjectAgentCwdTarget.mockResolvedValue({
+      actorUserUuid: ownerUuid,
+      source: "project_fixed",
+      agentUuid,
+      host: "builder-host",
+      cwd: "/srv/project",
+      availability: "ready",
+      promptPolicy: "suppress",
+      connectionUuid: "fixed-connection",
+      agentInstanceUuid: "fixed-instance",
+    });
+
+    await createConversationalIdeaSession(userAuth, validParams);
+
+    expect(mockTx.idea.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          assigneeUuid: "fixed-instance",
+          cwdSource: "project_fixed",
+          cwdHost: "builder-host",
+          runtimeCwd: "/srv/project",
+        }),
+      }),
+    );
+    expect(mockTx.daemonSession.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          originConnectionUuid: "fixed-connection",
+          runtimeCwd: "/srv/project",
+        }),
+      }),
+    );
+    expect(mockDispatchControl).toHaveBeenCalledWith(
+      expect.objectContaining({ targetConnectionUuid: "fixed-connection" }),
+    );
+  });
+
+  it("rejects an offline project-fixed target without falling back or writing", async () => {
+    mockResolveProjectAgentCwdTarget.mockResolvedValue({
+      actorUserUuid: ownerUuid,
+      source: "project_fixed",
+      agentUuid,
+      host: "builder-host",
+      cwd: "/srv/project",
+      availability: "offline",
+      promptPolicy: "suppress",
+      connectionUuid: null,
+      agentInstanceUuid: "fixed-instance",
+    });
+
+    await expect(
+      createConversationalIdeaSession(userAuth, validParams),
+    ).rejects.toMatchObject({
+      name: "Error",
+      code: "project_cwd_target_unavailable",
+      availability: "offline",
+    });
+    expect(mockConnectionBelongsToAgent).not.toHaveBeenCalled();
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    expect(mockDispatchControl).not.toHaveBeenCalled();
+  });
+
   it("creates idea + idea-anchored session + first turn in one transaction", async () => {
     const { idea, session, turn } = await createConversationalIdeaSession(
       userAuth,

--- a/src/services/__tests__/elaboration.service.test.ts
+++ b/src/services/__tests__/elaboration.service.test.ts
@@ -11,6 +11,12 @@ const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
     agentInstance: {
       findFirst: vi.fn(),
     },
+    daemonConnection: {
+      findMany: vi.fn(),
+    },
+    projectAgentCwdPreference: {
+      findFirst: vi.fn(),
+    },
     elaborationRound: {
       count: vi.fn(),
       create: vi.fn(),
@@ -145,6 +151,8 @@ function makeRound(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
+  mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
 });
 
 describe("startElaboration", () => {

--- a/src/services/__tests__/idea.service.test.ts
+++ b/src/services/__tests__/idea.service.test.ts
@@ -338,6 +338,33 @@ describe("claimIdea", () => {
     );
   });
 
+  it.each([undefined, "", "   "])(
+    "stores a null cwd source when runtime cwd exists but source is %j",
+    async (cwdSource) => {
+      mockPrisma.idea.findFirst.mockResolvedValue(
+        makeIdeaRecord({ status: "open", assigneeUuid: null }),
+      );
+      mockPrisma.idea.update.mockResolvedValue(
+        makeIdeaRecord({ status: "elaborating", assigneeUuid: ACTOR_UUID }),
+      );
+
+      await claimIdea({
+        ideaUuid: IDEA_UUID,
+        companyUuid: COMPANY_UUID,
+        assigneeType: "agent",
+        assigneeUuid: ACTOR_UUID,
+        runtimeCwd: "/workspace/project",
+        cwdSource,
+      });
+
+      expect(mockPrisma.idea.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ cwdSource: null }),
+        }),
+      );
+    },
+  );
+
   it("rejects pinning to a foreign / missing company instance", async () => {
     mockPrisma.idea.findFirst.mockResolvedValue(makeIdeaRecord({ status: "open", assigneeUuid: null }));
     mockPrisma.agentInstance.findFirst.mockResolvedValue(null); // company-scoped miss
@@ -428,6 +455,29 @@ describe("assignIdea", () => {
     );
 
     expect(result.status).toBe("elaborating");
+  });
+
+  it("clears a stale cwd source when reassigning with runtime cwd but no source", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValue(
+      makeIdeaRecord({ status: "elaborating", cwdSource: "project_fixed" }),
+    );
+    mockPrisma.idea.update.mockResolvedValue(
+      makeIdeaRecord({ status: "elaborating", assigneeUuid: ACTOR_UUID }),
+    );
+
+    await assignIdea({
+      ideaUuid: IDEA_UUID,
+      companyUuid: COMPANY_UUID,
+      assigneeType: "agent",
+      assigneeUuid: ACTOR_UUID,
+      runtimeCwd: "/workspace/project",
+    });
+
+    expect(mockPrisma.idea.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ cwdSource: null }),
+      }),
+    );
   });
 
   it("should throw if idea not found", async () => {

--- a/src/services/__tests__/mention.service.entity-context.test.ts
+++ b/src/services/__tests__/mention.service.entity-context.test.ts
@@ -107,7 +107,6 @@ describe("enrichIdeaContext (pin-cwd-before-wake, Part 2a)", () => {
       host: "Laptop-Q3",
       cwd: "/home/u/dev/chorus",
     });
-
     const results: Mentionable[] = [
       { type: "agent", uuid: AGENT_G, name: "G" },
       { type: "agent", uuid: AGENT_H, name: "H" },
@@ -276,6 +275,13 @@ describe("searchMentionables — entity context threading (pin-cwd-before-wake, 
       host: "Laptop-Q3",
       cwd: "/home/u/dev/chorus",
     });
+    mockPrisma.projectAgentCwdPreference.findMany.mockResolvedValue([
+      {
+        agentUuid: AGENT_G,
+        host: "runtime-host",
+        cwd: "/runtime/project",
+      },
+    ]);
 
     const results = await searchMentionables({
       companyUuid: COMPANY_UUID,
@@ -293,6 +299,11 @@ describe("searchMentionables — entity context threading (pin-cwd-before-wake, 
       host: "Laptop-Q3",
       cwd: "/home/u/dev/chorus",
       agentInstanceUuid: INSTANCE_A,
+    });
+    expect(g.projectFixedCwd).toEqual({
+      host: "runtime-host",
+      cwd: "/runtime/project",
+      availability: "offline",
     });
     expect(h.isIdeaAssignee).toBe(false);
     expect(h.ideaPin).toBeUndefined();

--- a/src/services/__tests__/mention.service.entity-context.test.ts
+++ b/src/services/__tests__/mention.service.entity-context.test.ts
@@ -27,6 +27,8 @@ const {
     user: { findFirst: vi.fn(), findMany: vi.fn() },
     agent: { findFirst: vi.fn(), findMany: vi.fn() },
     project: { findUnique: vi.fn() },
+    task: { findFirst: vi.fn() },
+    projectAgentCwdPreference: { findMany: vi.fn() },
     comment: { findUnique: vi.fn() },
     idea: { findFirst: vi.fn() },
     daemonConnection: { findMany: vi.fn() },
@@ -84,6 +86,8 @@ beforeEach(() => {
   // path (which returns agents) never hits an undefined mock.
   mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
   mockPrisma.daemonExecution.groupBy.mockResolvedValue([]);
+  mockPrisma.task.findFirst.mockResolvedValue({ projectUuid: "project-1" });
+  mockPrisma.projectAgentCwdPreference.findMany.mockResolvedValue([]);
 });
 
 describe("enrichIdeaContext (pin-cwd-before-wake, Part 2a)", () => {

--- a/src/services/__tests__/mention.service.instances.test.ts
+++ b/src/services/__tests__/mention.service.instances.test.ts
@@ -105,6 +105,17 @@ describe("parseMentions — pinned instance suffix (T3)", () => {
     expect("pinnedCwd" in refs[0]).toBe(false);
   });
 
+  it("preserves a project-fixed runtime cwd marker", () => {
+    const refs = parseMentions(
+      `@[DevBot](agent:${AGENT_A}?cwd=%2Fwork%2Fdynamic&host=prod&runtime=1)`,
+    );
+    expect(refs[0]).toMatchObject({
+      pinnedHost: "prod",
+      pinnedCwd: "/work/dynamic",
+      runtimeCwd: true,
+    });
+  });
+
   it("decodes an unknown-path pin (empty cwd) to a null cwd", () => {
     const refs = parseMentions(`@[DevBot](agent:${AGENT_A}?cwd=&host=ci-runner)`);
     expect(refs[0].pinnedCwd).toBeNull();

--- a/src/services/__tests__/mention.service.pin-threading.test.ts
+++ b/src/services/__tests__/mention.service.pin-threading.test.ts
@@ -200,6 +200,53 @@ describe("createMentions — threads the mention pin into the wake notification 
     });
   });
 
+  it("a project runtime pin resolves the server-side preference snapshot for host-routed wake", async () => {
+    mockResolveCwd.mockResolvedValue({
+      actorUserUuid: ACTOR_UUID,
+      source: "project_fixed",
+      agentUuid: AGENT_UUID,
+      host: "fixed-host",
+      cwd: "/fixed/dynamic",
+      availability: "ready",
+      promptPolicy: "suppress",
+      connectionUuid: "startup-connection",
+      agentInstanceUuid: "fixed-instance",
+    });
+
+    await createMentions({
+      companyUuid: COMPANY_UUID,
+      sourceType: "comment",
+      sourceUuid: SOURCE_UUID,
+      content: `cc ${buildMentionMarker(
+        "DevBot",
+        "agent",
+        AGENT_UUID,
+        "fixed-host",
+        "/fixed/dynamic",
+        true,
+      )}`,
+      actorType: "user",
+      actorUuid: ACTOR_UUID,
+      projectUuid: PROJECT_UUID,
+      entityTitle: "Test Task",
+    });
+
+    expect(mockResolveCwd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserUuid: ACTOR_UUID,
+        projectUuid: PROJECT_UUID,
+        agentUuid: AGENT_UUID,
+        registeredInstanceUuid: null,
+      }),
+    );
+    expect(notifiedParams()).toMatchObject({
+      resolvedCwdSource: "project_fixed",
+      resolvedCwdHost: "fixed-host",
+      resolvedRuntimeCwd: "/fixed/dynamic",
+      resolvedCwdAvailability: "ready",
+    });
+  });
+
   it("an UN-PINNED mention threads no pin (both undefined) → wake stays agent-overall online-first", async () => {
     // The whole point of the additive design: an un-pinned token carries no pin,
     // so resolvePinnedTarget(mentioned) gets pinnedHost/pinnedCwd === undefined →

--- a/src/services/__tests__/mention.service.pin-threading.test.ts
+++ b/src/services/__tests__/mention.service.pin-threading.test.ts
@@ -17,7 +17,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Prisma is mocked via vi.hoisted(); createBatch is captured so we can assert
 // the exact pin payload that flows toward the wake-turn chokepoint.
 
-const { mockPrisma, mockGetActorName, mockGetPreferences, mockCreateBatch } =
+const { mockPrisma, mockGetActorName, mockGetPreferences, mockCreateBatch, mockResolveCwd } =
   vi.hoisted(() => ({
     mockPrisma: {
       mention: { createMany: vi.fn() },
@@ -31,6 +31,7 @@ const { mockPrisma, mockGetActorName, mockGetPreferences, mockCreateBatch } =
     mockGetActorName: vi.fn().mockResolvedValue("Test Actor"),
     mockGetPreferences: vi.fn().mockResolvedValue({ mentioned: true }),
     mockCreateBatch: vi.fn().mockResolvedValue([]),
+    mockResolveCwd: vi.fn(),
   }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
@@ -38,6 +39,15 @@ vi.mock("@/lib/uuid-resolver", () => ({ getActorName: mockGetActorName }));
 vi.mock("@/services/notification.service", () => ({
   getPreferences: (...args: unknown[]) => mockGetPreferences(...args),
   createBatch: (...args: unknown[]) => mockCreateBatch(...args),
+}));
+vi.mock("@/services/lineage.service", () => ({
+  resolveRootIdea: vi.fn().mockResolvedValue({
+    rootIdeaUuid: null,
+    directIdeaUuid: null,
+  }),
+}));
+vi.mock("@/services/project-agent-cwd.service", () => ({
+  resolveProjectAgentCwdTarget: (...args: unknown[]) => mockResolveCwd(...args),
 }));
 
 import { createMentions } from "@/services/mention.service";
@@ -63,6 +73,17 @@ beforeEach(() => {
   mockPrisma.project.findUnique.mockResolvedValue({
     uuid: PROJECT_UUID,
     name: "Test Project",
+  });
+  mockResolveCwd.mockResolvedValue({
+    actorUserUuid: ACTOR_UUID,
+    source: "unconfigured",
+    agentUuid: AGENT_UUID,
+    host: null,
+    cwd: null,
+    availability: "ready",
+    promptPolicy: "select",
+    connectionUuid: null,
+    agentInstanceUuid: null,
   });
 });
 
@@ -96,6 +117,70 @@ function notifiedParams(): Record<string, unknown> {
 }
 
 describe("createMentions — threads the mention pin into the wake notification (T6 seam)", () => {
+  it("an unpinned Agent comment uses the project-fixed cwd snapshot", async () => {
+    mockResolveCwd.mockResolvedValue({
+      actorUserUuid: ACTOR_UUID,
+      source: "project_fixed",
+      agentUuid: AGENT_UUID,
+      host: "fixed-host",
+      cwd: "/fixed/project",
+      availability: "offline",
+      promptPolicy: "suppress",
+      connectionUuid: null,
+      agentInstanceUuid: "fixed-instance",
+    });
+
+    await mentionAgentWith(undefined, undefined);
+
+    expect(notifiedParams()).toMatchObject({
+      resolvedCwdSource: "project_fixed",
+      resolvedCwdHost: "fixed-host",
+      resolvedRuntimeCwd: "/fixed/project",
+      resolvedCwdAvailability: "offline",
+    });
+  });
+
+  it("resolves an Agent-authored MCP comment through the author's owner preference", async () => {
+    const authorAgentUuid = "77777777-7777-7777-7777-777777777777";
+    const ownerUuid = "88888888-8888-8888-8888-888888888888";
+    mockPrisma.agent.findFirst.mockImplementation(async ({ where }) =>
+      where.uuid === authorAgentUuid
+        ? { uuid: authorAgentUuid, ownerUuid }
+        : { uuid: AGENT_UUID },
+    );
+    mockResolveCwd.mockResolvedValue({
+      actorUserUuid: ownerUuid,
+      source: "project_fixed",
+      agentUuid: AGENT_UUID,
+      host: "agent-owner-host",
+      cwd: "/owner/project",
+      availability: "ready",
+      promptPolicy: "suppress",
+      connectionUuid: "fixed-connection",
+      agentInstanceUuid: "fixed-instance",
+    });
+
+    await createMentions({
+      companyUuid: COMPANY_UUID,
+      sourceType: "comment",
+      sourceUuid: SOURCE_UUID,
+      content: `cc ${buildMentionMarker("DevBot", "agent", AGENT_UUID)}`,
+      actorType: "agent",
+      actorUuid: authorAgentUuid,
+      projectUuid: PROJECT_UUID,
+      entityTitle: "Test Task",
+    });
+
+    expect(mockResolveCwd).toHaveBeenCalledWith(
+      expect.objectContaining({ actorUserUuid: ownerUuid }),
+    );
+    expect(notifiedParams()).toMatchObject({
+      resolvedCwdSource: "project_fixed",
+      resolvedCwdHost: "agent-owner-host",
+      resolvedRuntimeCwd: "/owner/project",
+    });
+  });
+
   it("a PINNED mention threads (pinnedHost, pinnedCwd) onto the wake notification — the AgentInstance identity the resolver matches", async () => {
     // Spec scenario: a comment contains @[Name](agent:uuid?cwd=/work&host=prod)
     // → the mention resolves to the AgentInstance at (host="prod", cwd="/work")

--- a/src/services/__tests__/mention.service.test.ts
+++ b/src/services/__tests__/mention.service.test.ts
@@ -43,6 +43,25 @@ vi.mock("@/services/notification.service", () => ({
   getPreferences: (...args: unknown[]) => mockGetPreferences(...args),
   createBatch: (...args: unknown[]) => mockCreateBatch(...args),
 }));
+vi.mock("@/services/lineage.service", () => ({
+  resolveRootIdea: vi.fn().mockResolvedValue({
+    rootIdeaUuid: null,
+    directIdeaUuid: null,
+  }),
+}));
+vi.mock("@/services/project-agent-cwd.service", () => ({
+  resolveProjectAgentCwdTarget: vi.fn().mockResolvedValue({
+    actorUserUuid: "33333333-3333-3333-3333-333333333333",
+    source: "unconfigured",
+    agentUuid: "55555555-5555-5555-5555-555555555555",
+    host: null,
+    cwd: null,
+    availability: "ready",
+    promptPolicy: "select",
+    connectionUuid: null,
+    agentInstanceUuid: null,
+  }),
+}));
 
 import { createMentions, searchMentionables } from "@/services/mention.service";
 

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -246,6 +246,52 @@ beforeEach(() => {
 });
 
 describe("project-Agent fixed cwd resolution", () => {
+  it.each([
+    {
+      label: "replacement",
+      preference: { host: "replacement-host", cwd: "/work/replacement" },
+    },
+    { label: "clear", preference: null },
+  ])(
+    "keeps an active root session on its captured target after preference $label",
+    async ({ preference }) => {
+      const rootConnection = "root-connection";
+      mockPreferenceFindFirst.mockResolvedValue(preference);
+      mockListConnectionsForAgent.mockResolvedValue([
+        onlineConn({ uuid: rootConnection, host: "root-host", cwd: "/work/root" }),
+        onlineConn({
+          uuid: "replacement-connection",
+          host: "replacement-host",
+          cwd: "/work/replacement",
+        }),
+      ]);
+      mockDaemonSessionFindFirst.mockResolvedValue({
+        uuid: sessionUuid,
+        originConnectionUuid: rootConnection,
+      });
+
+      const result = await createTurnAndResolveTarget(
+        ctx({
+          resolvedCwdSource: "registered_instance",
+          resolvedCwdHost: "root-host",
+          resolvedRuntimeCwd: "/work/root",
+        }),
+      );
+
+      expect(result.targetConnectionUuid).toBe(rootConnection);
+      expect(result.runtimeCwd).toBe("/work/root");
+      expect(mockDaemonSessionUpdate).not.toHaveBeenCalled();
+      expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: ideaUuid,
+          originConnectionUuid: rootConnection,
+          runtimeCwd: "/work/root",
+        }),
+      );
+      expect(mockPreferenceFindFirst).not.toHaveBeenCalled();
+    },
+  );
+
   it("routes a temporary runtime cwd through its selected host without persisting an instance", async () => {
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: "temporary-anchor", host: "host-a", cwd: "/startup" }),
@@ -272,10 +318,6 @@ describe("project-Agent fixed cwd resolution", () => {
   });
 
   it("uses the fixed host/runtime cwd ahead of an inline mention pin", async () => {
-    mockPreferenceFindFirst.mockResolvedValue({
-      host: "fixed-host",
-      cwd: "/work/fixed",
-    });
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: "fixed-anchor", host: "fixed-host", cwd: "/startup" }),
       onlineConn({ uuid: "inline-target", host: "inline-host", cwd: "/inline" }),
@@ -287,6 +329,9 @@ describe("project-Agent fixed cwd resolution", () => {
         projectUuid: "project-1",
         actorType: "user",
         actorUuid: "user-1",
+        resolvedCwdSource: "project_fixed",
+        resolvedCwdHost: "fixed-host",
+        resolvedRuntimeCwd: "/work/fixed",
         pinnedHost: "inline-host",
         pinnedCwd: "/inline",
       }),
@@ -303,10 +348,6 @@ describe("project-Agent fixed cwd resolution", () => {
   });
 
   it("blocks on an offline fixed host without rerouting to another online host", async () => {
-    mockPreferenceFindFirst.mockResolvedValue({
-      host: "offline-fixed-host",
-      cwd: "/work/fixed",
-    });
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: "other-host", host: "online-elsewhere", cwd: "/repo" }),
     ]);
@@ -316,6 +357,9 @@ describe("project-Agent fixed cwd resolution", () => {
         projectUuid: "project-1",
         actorType: "user",
         actorUuid: "user-1",
+        resolvedCwdSource: "project_fixed",
+        resolvedCwdHost: "offline-fixed-host",
+        resolvedRuntimeCwd: "/work/fixed",
       }),
     );
 
@@ -1514,6 +1558,31 @@ describe("createTurnAndResolveTarget — instance-based pin lineage (T11)", () =
     expect(targetConnectionUuid).toBe(taskConnUuid);
   });
 
+  it("falls back from a blank task cwd host to the resolved instance host without rerouting", async () => {
+    mockTaskFindFirst.mockResolvedValue({
+      assigneeType: "agent_instance",
+      assigneeUuid: "task-inst",
+      cwdHost: "   ",
+      runtimeCwd: "/discovered/task",
+    });
+    mockAgentInstanceFindFirst.mockResolvedValue({
+      host: taskHost,
+      cwd: "/materialized/not-a-startup-cwd",
+      agentUuid,
+    });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "other-host", host: "elsewhere", cwd: "/startup-a" }),
+      taskInstanceConn({ cwd: "/startup-b" }),
+    ]);
+
+    const result = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned" }),
+    );
+
+    expect(result.targetConnectionUuid).toBe(taskConnUuid);
+    expect(result.runtimeCwd).toBe("/discovered/task");
+  });
+
   // ----- (3) root-idea inheritance WITH the same-agent guard -----
 
   it("inherits the root-idea instance (SAME agent) when the Task has no override → targets the idea's instance", async () => {
@@ -1538,6 +1607,41 @@ describe("createTurnAndResolveTarget — instance-based pin lineage (T11)", () =
       expect.objectContaining({ originConnectionUuid: ideaConnUuid, turnUuid: turn?.uuid }),
     );
     expect(targetConnectionUuid).toBe(ideaConnUuid);
+  });
+
+  it("inherits a discovered root runtime cwd through any online connection on its fixed host", async () => {
+    mockIdeaFindFirst.mockResolvedValue({
+      assigneeType: "agent_instance",
+      assigneeUuid: "idea-inst",
+      cwdHost: "   ",
+      runtimeCwd: "/discovered/project",
+    });
+    mockAgentInstanceFindFirst.mockResolvedValue({
+      host: ideaHost,
+      cwd: "/materialized/not-a-startup-cwd",
+      agentUuid,
+    });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "other-host", host: "elsewhere", cwd: "/startup-a" }),
+      onlineConn({
+        uuid: ideaConnUuid,
+        host: ideaHost,
+        cwd: "/startup-b",
+      }),
+    ]);
+
+    const result = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned" }),
+    );
+
+    expect(result.targetConnectionUuid).toBe(ideaConnUuid);
+    expect(result.runtimeCwd).toBe("/discovered/project");
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originConnectionUuid: ideaConnUuid,
+        runtimeCwd: "/discovered/project",
+      }),
+    );
   });
 
   // ----- (3) cross-agent → NO inherit (the same-agent guard blocks it) -----

--- a/src/services/__tests__/project-agent-cwd.service.test.ts
+++ b/src/services/__tests__/project-agent-cwd.service.test.ts
@@ -13,10 +13,13 @@ const { emit, prismaMock } = vi.hoisted(() => ({
       deleteMany: vi.fn(),
     },
     projectAgentCwdPreference: {
+      findFirst: vi.fn(),
       findMany: vi.fn(),
       upsert: vi.fn(),
+      update: vi.fn(),
       deleteMany: vi.fn(),
     },
+    agentInstance: { findFirst: vi.fn(), upsert: vi.fn() },
   },
 }));
 
@@ -33,6 +36,7 @@ import {
   completeDirectoryRequest,
   createDirectoryRequest,
   getDirectoryRequest,
+  resolveProjectAgentCwdTarget,
   resolveTemporaryRuntimeCwd,
   saveProjectAgentCwdPreference,
 } from "@/services/project-agent-cwd.service";
@@ -47,6 +51,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   prismaMock.agent.findFirst.mockResolvedValue({ uuid: "agent-1" });
   prismaMock.project.findFirst.mockResolvedValue({ uuid: "project-1" });
+  prismaMock.agentInstance.upsert.mockResolvedValue({ uuid: "instance-1" });
 });
 
 describe("project-agent cwd request service", () => {
@@ -244,6 +249,224 @@ describe("project-agent cwd request service", () => {
 });
 
 describe("project-agent cwd preference service", () => {
+  it.each([
+    {
+      label: "replacement",
+      preference: {
+        uuid: "pref-2",
+        host: "replacement-host",
+        cwd: "/work/replacement",
+        anchorAgentInstanceUuid: "replacement-instance",
+      },
+    },
+    { label: "clear", preference: null },
+  ])(
+    "keeps the persisted root instance after preference $label",
+    async ({ preference }) => {
+      prismaMock.projectAgentCwdPreference.findFirst.mockResolvedValue(preference);
+      prismaMock.agentInstance.findFirst.mockResolvedValue({
+        uuid: "root-instance",
+        host: "root-host",
+        cwd: "/work/root",
+      });
+      prismaMock.daemonConnection.findMany.mockResolvedValue([
+        {
+          uuid: "root-connection",
+          agentUuid: "agent-1",
+          agent: { name: "Agent", ownerUuid: "user-1" },
+          clientType: "claude_code",
+          clientVersion: null,
+          host: "root-host",
+          cwd: "/work/root",
+          startedAt: null,
+          status: "online",
+          connectedAt: new Date(),
+          lastSeenAt: new Date(),
+          disconnectedAt: null,
+          agentInstanceUuid: "root-instance",
+        },
+      ]);
+
+      await expect(
+        resolveProjectAgentCwdTarget({
+          companyUuid: "company-1",
+          actorUserUuid: "user-1",
+          projectUuid: "project-1",
+          agentUuid: "agent-1",
+          temporaryTarget: { host: "temporary-host", cwd: "/work/temporary" },
+          registeredInstanceUuid: "root-instance",
+        }),
+      ).resolves.toEqual({
+        actorUserUuid: "user-1",
+        source: "registered_instance",
+        agentUuid: "agent-1",
+        host: "root-host",
+        cwd: "/work/root",
+        availability: "ready",
+        promptPolicy: "none",
+        connectionUuid: "root-connection",
+        agentInstanceUuid: "root-instance",
+      });
+      expect(prismaMock.agentInstance.upsert).not.toHaveBeenCalled();
+    },
+  );
+
+  it("resolves a registered discovered path through an online connection on the same host", async () => {
+    prismaMock.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
+    prismaMock.agentInstance.findFirst.mockResolvedValue({
+      uuid: "root-instance",
+      host: "root-host",
+      cwd: "/discovered/not-a-startup-cwd",
+    });
+    prismaMock.daemonConnection.findMany.mockResolvedValue([
+      {
+        uuid: "root-connection",
+        agentUuid: "agent-1",
+        agent: { name: "Agent", ownerUuid: "user-1" },
+        clientType: "claude_code",
+        clientVersion: null,
+        host: "root-host",
+        cwd: "/daemon/startup",
+        startedAt: null,
+        status: "online",
+        connectedAt: new Date(),
+        lastSeenAt: new Date(),
+        disconnectedAt: null,
+        agentInstanceUuid: "startup-instance",
+      },
+    ]);
+
+    await expect(
+      resolveProjectAgentCwdTarget({
+        companyUuid: "company-1",
+        actorUserUuid: "user-1",
+        projectUuid: "project-1",
+        agentUuid: "agent-1",
+        registeredInstanceUuid: "root-instance",
+        registeredHost: "root-host",
+        registeredRuntimeCwd: "/discovered/not-a-startup-cwd",
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        source: "registered_instance",
+        host: "root-host",
+        cwd: "/discovered/not-a-startup-cwd",
+        availability: "ready",
+        connectionUuid: "root-connection",
+      }),
+    );
+  });
+
+  it.each([
+    { label: "replacement", preference: { uuid: "new-pref" } },
+    { label: "clear", preference: null },
+  ])(
+    "preserves fixed origin and runtime cwd after preference $label",
+    async ({ preference }) => {
+      prismaMock.projectAgentCwdPreference.findFirst.mockResolvedValue(preference);
+      prismaMock.agentInstance.findFirst.mockResolvedValue({
+        uuid: "fixed-instance",
+        host: "fixed-host",
+        cwd: "/discovered/fixed",
+      });
+      prismaMock.daemonConnection.findMany.mockResolvedValue([]);
+
+      await expect(
+        resolveProjectAgentCwdTarget({
+          companyUuid: "company-1",
+          actorUserUuid: "user-1",
+          projectUuid: "project-1",
+          agentUuid: "agent-1",
+          registeredInstanceUuid: "fixed-instance",
+          registeredSource: "project_fixed",
+          registeredHost: "fixed-host",
+          registeredRuntimeCwd: "/discovered/fixed",
+        }),
+      ).resolves.toEqual({
+        actorUserUuid: "user-1",
+        source: "project_fixed",
+        agentUuid: "agent-1",
+        host: "fixed-host",
+        cwd: "/discovered/fixed",
+        availability: "offline",
+        promptPolicy: "suppress",
+        connectionUuid: null,
+        agentInstanceUuid: "fixed-instance",
+      });
+      expect(prismaMock.agentInstance.upsert).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns an actor-bearing fixed snapshot, materializes its instance, and never degrades offline", async () => {
+    prismaMock.projectAgentCwdPreference.findFirst.mockResolvedValue({
+      uuid: "pref-1",
+      host: "fixed-host",
+      cwd: "/work/fixed",
+      anchorAgentInstanceUuid: null,
+    });
+    prismaMock.daemonConnection.findMany.mockResolvedValue([]);
+    prismaMock.agentInstance.upsert.mockResolvedValue({ uuid: "fixed-instance" });
+
+    await expect(
+      resolveProjectAgentCwdTarget({
+        companyUuid: "company-1",
+        actorUserUuid: "user-1",
+        projectUuid: "project-1",
+        agentUuid: "agent-1",
+        temporaryTarget: { host: "other-host", cwd: "/other" },
+      }),
+    ).resolves.toEqual({
+      actorUserUuid: "user-1",
+      source: "project_fixed",
+      agentUuid: "agent-1",
+      host: "fixed-host",
+      cwd: "/work/fixed",
+      availability: "offline",
+      promptPolicy: "suppress",
+      connectionUuid: null,
+      agentInstanceUuid: "fixed-instance",
+    });
+    expect(prismaMock.agentInstance.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          companyUuid_agentUuid_host_cwd: {
+            companyUuid: "company-1",
+            agentUuid: "agent-1",
+            host: "fixed-host",
+            cwd: "/work/fixed",
+          },
+        },
+      }),
+    );
+    expect(prismaMock.projectAgentCwdPreference.update).toHaveBeenCalledWith({
+      where: { uuid: "pref-1" },
+      data: { anchorAgentInstanceUuid: "fixed-instance" },
+    });
+  });
+
+  it("keeps Agent and actor preference lookup isolated", async () => {
+    prismaMock.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
+    prismaMock.daemonConnection.findMany.mockResolvedValue([]);
+
+    await resolveProjectAgentCwdTarget({
+      companyUuid: "company-1",
+      actorUserUuid: "user-2",
+      projectUuid: "project-1",
+      agentUuid: "agent-b",
+    });
+
+    expect(prismaMock.projectAgentCwdPreference.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          companyUuid: "company-1",
+          userUuid: "user-2",
+          projectUuid: "project-1",
+          agentUuid: "agent-b",
+        },
+      }),
+    );
+  });
+
   it("isolates multiple users and Agents across fixed save, clear, and temporary fallback", async () => {
     const validations = new Map([
       ["validation-user-1-agent-a", { cwd: "/raw/a", normalizedPath: "/work/a", connection: "conn-a" }],

--- a/src/services/__tests__/project-agent-cwd.service.test.ts
+++ b/src/services/__tests__/project-agent-cwd.service.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const { emit, prismaMock } = vi.hoisted(() => ({
   emit: vi.fn(),
   prismaMock: {
+    $transaction: vi.fn(),
     agent: { findFirst: vi.fn(), findMany: vi.fn() },
-    project: { findFirst: vi.fn() },
+    project: { findFirst: vi.fn(), create: vi.fn() },
     daemonConnection: { findFirst: vi.fn(), findMany: vi.fn() },
     daemonDirectoryRequest: {
       create: vi.fn(),
@@ -15,6 +16,7 @@ const { emit, prismaMock } = vi.hoisted(() => ({
     projectAgentCwdPreference: {
       findFirst: vi.fn(),
       findMany: vi.fn(),
+      create: vi.fn(),
       upsert: vi.fn(),
       update: vi.fn(),
       deleteMany: vi.fn(),
@@ -34,6 +36,7 @@ import {
   clearProjectAgentCwdPreference,
   cleanupDirectoryRequests,
   completeDirectoryRequest,
+  createProjectWithAgentCwds,
   createDirectoryRequest,
   getDirectoryRequest,
   listProjectAgentCwdPreferences,
@@ -53,9 +56,49 @@ beforeEach(() => {
   prismaMock.agent.findFirst.mockResolvedValue({ uuid: "agent-1" });
   prismaMock.project.findFirst.mockResolvedValue({ uuid: "project-1" });
   prismaMock.agentInstance.upsert.mockResolvedValue({ uuid: "instance-1" });
+  prismaMock.$transaction.mockImplementation(
+    (callback: (tx: typeof prismaMock) => unknown) => callback(prismaMock),
+  );
 });
 
 describe("project-agent cwd request service", () => {
+  it("creates a project and its fixed cwd in one transaction", async () => {
+    prismaMock.daemonDirectoryRequest.findFirst.mockResolvedValue({
+      targetConnectionUuid: "conn-1",
+      result: { normalizedPath: "/workspace" },
+    });
+    prismaMock.daemonConnection.findFirst.mockResolvedValue({ host: "host-1" });
+    prismaMock.project.create.mockResolvedValue({
+      uuid: "project-new",
+      name: "New",
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await createProjectWithAgentCwds({
+      companyUuid: "company-1",
+      userUuid: "user-1",
+      name: "New",
+      description: null,
+      groupUuid: null,
+      agentCwds: [{
+        agentUuid: "agent-1",
+        validationRequestUuid: "validation-1",
+      }],
+    });
+
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(prismaMock.projectAgentCwdPreference.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        projectUuid: "project-new",
+        agentUuid: "agent-1",
+        host: "host-1",
+        cwd: "/workspace",
+      }),
+    });
+  });
+
   it("lists online Agents plus configured offline preferences only", async () => {
     prismaMock.agent.findMany.mockResolvedValue([
       { uuid: "online", name: "Online" },

--- a/src/services/__tests__/project-agent-cwd.service.test.ts
+++ b/src/services/__tests__/project-agent-cwd.service.test.ts
@@ -36,6 +36,7 @@ import {
   completeDirectoryRequest,
   createDirectoryRequest,
   getDirectoryRequest,
+  listProjectAgentCwdPreferences,
   resolveProjectAgentCwdTarget,
   resolveTemporaryRuntimeCwd,
   saveProjectAgentCwdPreference,
@@ -55,6 +56,42 @@ beforeEach(() => {
 });
 
 describe("project-agent cwd request service", () => {
+  it("lists online Agents plus configured offline preferences only", async () => {
+    prismaMock.agent.findMany.mockResolvedValue([
+      { uuid: "online", name: "Online" },
+      { uuid: "offline-configured", name: "Configured" },
+      { uuid: "offline-empty", name: "Hidden" },
+    ]);
+    prismaMock.projectAgentCwdPreference.findMany.mockResolvedValue([{
+      uuid: "pref-1",
+      agentUuid: "offline-configured",
+      host: "old-host",
+      cwd: "/old",
+      anchorAgentInstanceUuid: "instance-old",
+      updatedAt: new Date(),
+    }]);
+    prismaMock.daemonConnection.findMany.mockResolvedValue([{
+      uuid: "conn-1",
+      agentUuid: "online",
+      agentInstanceUuid: "instance-1",
+      host: "host-1",
+      cwd: "/work",
+      lastSeenAt: new Date(),
+    }]);
+
+    const result = await listProjectAgentCwdPreferences(
+      "company-1",
+      "user-1",
+      "project-1",
+    );
+
+    expect(result.map((item) => item.agent.uuid)).toEqual([
+      "online",
+      "offline-configured",
+    ]);
+    expect(result[1].preference?.status).toBe("offline");
+  });
+
   it("returns non-disclosing NOT_FOUND when the agent is not owned in the tenant", async () => {
     prismaMock.agent.findFirst.mockResolvedValue(null);
     await expect(

--- a/src/services/__tests__/stage-advance.service.test.ts
+++ b/src/services/__tests__/stage-advance.service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ===== Mocks (hoisted so vi.mock factories can reference them) =====
 
-const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
+const { mockPrisma, mockEventBus, mockCreateActivity, mockResolveTarget } = vi.hoisted(() => ({
   mockPrisma: {
     idea: {
       findFirst: vi.fn(),
@@ -19,12 +19,16 @@ const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
   },
   mockEventBus: { emitChange: vi.fn() },
   mockCreateActivity: vi.fn().mockResolvedValue(undefined),
+  mockResolveTarget: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
 vi.mock("@/services", () => ({
   activityService: { createActivity: mockCreateActivity },
+}));
+vi.mock("@/services/project-agent-cwd.service", () => ({
+  resolveProjectAgentCwdTarget: mockResolveTarget,
 }));
 
 import {
@@ -79,6 +83,17 @@ beforeEach(() => {
   mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-1" });
   mockPrisma.agentInstance.findFirst.mockResolvedValue({ agentUuid: AGENT_UUID });
   mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
+  mockResolveTarget.mockResolvedValue({
+    actorUserUuid: USER_UUID,
+    source: "unconfigured",
+    agentUuid: AGENT_UUID,
+    host: null,
+    cwd: null,
+    availability: "ready",
+    promptPolicy: "select",
+    connectionUuid: "conn-1",
+    agentInstanceUuid: null,
+  });
 });
 
 describe("executeStageAdvance — actor gate", () => {
@@ -161,7 +176,12 @@ describe("executeStageAdvance — precondition", () => {
         targetType: "idea",
         targetUuid: IDEA_UUID,
         projectUuid: PROJECT_UUID,
-        value: { proposalUuid: "p-1", remainingTasks: 3 },
+        value: expect.objectContaining({
+          proposalUuid: "p-1",
+          remainingTasks: 3,
+          resolvedCwdActorUserUuid: USER_UUID,
+          resolvedCwdSource: "unconfigured",
+        }),
       })
     );
     expect(mockEventBus.emitChange).toHaveBeenCalledWith(
@@ -176,7 +196,7 @@ describe("executeStageAdvance — offline policy", () => {
 
     await executeStageAdvance(makeDefinition({ offlinePolicy: "queue" }), HUMAN_PARAMS);
 
-    expect(mockPrisma.daemonConnection.findFirst).not.toHaveBeenCalled();
+    expect(mockResolveTarget).toHaveBeenCalledOnce();
     expect(mockCreateActivity).toHaveBeenCalled();
   });
 
@@ -188,16 +208,12 @@ describe("executeStageAdvance — offline policy", () => {
       HUMAN_PARAMS
     );
 
-    // The liveness query filters on status="online" AND a lastSeenAt floor
-    // derived from STALE_THRESHOLD_MS.
-    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
+    expect(mockResolveTarget).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          agentUuid: AGENT_UUID,
-          status: "online",
-          lastSeenAt: expect.objectContaining({ gte: expect.any(Date) }),
-        }),
-      })
+        actorUserUuid: USER_UUID,
+        projectUuid: PROJECT_UUID,
+        agentUuid: AGENT_UUID,
+      }),
     );
     expect(mockCreateActivity).toHaveBeenCalled();
   });
@@ -205,6 +221,17 @@ describe("executeStageAdvance — offline policy", () => {
   it("require_online throws coded AGENT_OFFLINE when no live connection exists and emits nothing", async () => {
     const transition = vi.fn();
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    mockResolveTarget.mockResolvedValue({
+      actorUserUuid: USER_UUID,
+      source: "unconfigured",
+      agentUuid: AGENT_UUID,
+      host: null,
+      cwd: null,
+      availability: "offline",
+      promptPolicy: "select",
+      connectionUuid: null,
+      agentInstanceUuid: null,
+    });
 
     await expect(
       executeStageAdvance(
@@ -222,6 +249,17 @@ describe("executeStageAdvance — offline policy", () => {
     mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
       host: "fixed-host",
     });
+    mockResolveTarget.mockResolvedValue({
+      actorUserUuid: USER_UUID,
+      source: "project_fixed",
+      agentUuid: AGENT_UUID,
+      host: "fixed-host",
+      cwd: "/work/fixed",
+      availability: "offline",
+      promptPolicy: "suppress",
+      connectionUuid: null,
+      agentInstanceUuid: INSTANCE_UUID,
+    });
     mockPrisma.daemonConnection.findFirst.mockImplementation(
       async ({ where }: { where: { host?: string } }) =>
         where.host === "fixed-host" ? null : { uuid: "conn-other-host" },
@@ -234,35 +272,35 @@ describe("executeStageAdvance — offline policy", () => {
       ),
     ).rejects.toMatchObject({ code: "FIXED_CWD_HOST_OFFLINE" });
 
-    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          agentUuid: AGENT_UUID,
-          host: "fixed-host",
-          status: "online",
-        }),
-      }),
-    );
-    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledTimes(1);
+    expect(mockResolveTarget).toHaveBeenCalledOnce();
     expect(transition).not.toHaveBeenCalled();
     expect(mockCreateActivity).not.toHaveBeenCalled();
   });
 
-  it("checks a fixed cwd before an online AgentInstance assignment", async () => {
+  it("keeps an established AgentInstance assignment ahead of a replaced fixed cwd", async () => {
     mockPrisma.idea.findFirst.mockResolvedValue(
       makeIdea({ assigneeType: "agent_instance", assigneeUuid: INSTANCE_UUID }),
     );
     mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
       host: "fixed-host",
     });
-    mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-pinned" });
+    mockResolveTarget.mockResolvedValue({
+      actorUserUuid: USER_UUID,
+      source: "registered_instance",
+      agentUuid: AGENT_UUID,
+      host: "root-host",
+      cwd: "/work/root",
+      availability: "ready",
+      promptPolicy: "none",
+      connectionUuid: "conn-pinned",
+      agentInstanceUuid: INSTANCE_UUID,
+    });
 
-    await expect(
-      executeStageAdvance(
-        makeDefinition({ offlinePolicy: "require_online" }),
-        HUMAN_PARAMS,
-      ),
-    ).rejects.toMatchObject({ code: "FIXED_CWD_HOST_OFFLINE" });
+    await executeStageAdvance(
+      makeDefinition({ offlinePolicy: "require_online" }),
+      HUMAN_PARAMS,
+    );
 
     expect(mockPrisma.agentInstance.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -270,12 +308,18 @@ describe("executeStageAdvance — offline policy", () => {
         select: { agentUuid: true },
       }),
     );
-    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
+    expect(mockResolveTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ registeredInstanceUuid: INSTANCE_UUID }),
+    );
+    expect(mockCreateActivity).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ host: "fixed-host" }),
+        value: expect.objectContaining({
+          resolvedCwdSource: "registered_instance",
+          resolvedCwdHost: "root-host",
+          resolvedRuntimeCwd: "/work/root",
+        }),
       }),
     );
-    expect(mockCreateActivity).not.toHaveBeenCalled();
   });
 
   it("require_online on an agent_instance assignee checks the PINNED INSTANCE's own connection (host+cwd), not just the agent", async () => {
@@ -291,6 +335,17 @@ describe("executeStageAdvance — offline policy", () => {
       cwd: "/home/u/dev/payments",
     });
     mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-pinned" });
+    mockResolveTarget.mockResolvedValue({
+      actorUserUuid: USER_UUID,
+      source: "registered_instance",
+      agentUuid: AGENT_UUID,
+      host: "Laptop-Q3",
+      cwd: "/home/u/dev/payments",
+      availability: "ready",
+      promptPolicy: "none",
+      connectionUuid: "conn-pinned",
+      agentInstanceUuid: INSTANCE_UUID,
+    });
 
     await executeStageAdvance(
       makeDefinition({ offlinePolicy: "require_online" }),
@@ -303,16 +358,8 @@ describe("executeStageAdvance — offline policy", () => {
       })
     );
     // The liveness query is scoped to the pinned instance's exact (agent, host, cwd) place.
-    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          agentUuid: AGENT_UUID,
-          host: "Laptop-Q3",
-          cwd: "/home/u/dev/payments",
-          status: "online",
-          lastSeenAt: expect.objectContaining({ gte: expect.any(Date) }),
-        }),
-      })
+    expect(mockResolveTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ registeredInstanceUuid: INSTANCE_UUID }),
     );
     expect(mockCreateActivity).toHaveBeenCalled();
   });
@@ -331,6 +378,17 @@ describe("executeStageAdvance — offline policy", () => {
       cwd: "/home/u/dev/payments",
     });
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    mockResolveTarget.mockResolvedValue({
+      actorUserUuid: USER_UUID,
+      source: "registered_instance",
+      agentUuid: AGENT_UUID,
+      host: "Laptop-Q3",
+      cwd: "/home/u/dev/payments",
+      availability: "offline",
+      promptPolicy: "none",
+      connectionUuid: null,
+      agentInstanceUuid: INSTANCE_UUID,
+    });
 
     await expect(
       executeStageAdvance(
@@ -348,6 +406,17 @@ describe("executeStageAdvance — offline policy", () => {
       makeIdea({ assigneeType: "agent_instance", assigneeUuid: INSTANCE_UUID })
     );
     mockPrisma.agentInstance.findFirst.mockResolvedValue(null);
+    mockResolveTarget.mockResolvedValue({
+      actorUserUuid: USER_UUID,
+      source: "registered_instance",
+      agentUuid: AGENT_UUID,
+      host: null,
+      cwd: null,
+      availability: "invalid",
+      promptPolicy: "none",
+      connectionUuid: null,
+      agentInstanceUuid: INSTANCE_UUID,
+    });
 
     await expect(
       executeStageAdvance(

--- a/src/services/__tests__/start-development.service.test.ts
+++ b/src/services/__tests__/start-development.service.test.ts
@@ -15,12 +15,15 @@ const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
     },
     agentInstance: {
       findFirst: vi.fn(),
+      upsert: vi.fn(),
     },
     daemonConnection: {
       findFirst: vi.fn(),
+      findMany: vi.fn(),
     },
     projectAgentCwdPreference: {
       findFirst: vi.fn(),
+      update: vi.fn(),
     },
   },
   mockEventBus: { emitChange: vi.fn() },
@@ -73,6 +76,14 @@ beforeEach(() => {
   mockPrisma.proposal.findFirst.mockResolvedValue({ uuid: PROPOSAL_UUID });
   mockPrisma.task.count.mockResolvedValue(3);
   mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-1" });
+  mockPrisma.daemonConnection.findMany.mockResolvedValue([{
+    uuid: "conn-1", agentUuid: AGENT_UUID, clientType: "claude_code",
+    clientVersion: null, host: "Laptop-Q3", cwd: "/home/u/dev/payments",
+    startedAt: null, status: "online", connectedAt: new Date(),
+    lastSeenAt: new Date(), disconnectedAt: null, agentInstanceUuid: INSTANCE_UUID,
+    agent: { name: "Agent", ownerUuid: USER_UUID },
+  }]);
+  mockPrisma.agentInstance.upsert.mockResolvedValue({ uuid: INSTANCE_UUID });
   mockPrisma.agentInstance.findFirst.mockResolvedValue({ agentUuid: AGENT_UUID });
   mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
 });
@@ -90,7 +101,10 @@ describe("startDevelopment — success", () => {
         projectUuid: PROJECT_UUID,
         actorType: "user",
         actorUuid: USER_UUID,
-        value: { proposalUuid: PROPOSAL_UUID, remainingTasks: 3 },
+        value: expect.objectContaining({
+          proposalUuid: PROPOSAL_UUID,
+          remainingTasks: 3,
+        }),
       })
     );
     // Wake-only: the framework was given no transition, so nothing may touch
@@ -156,14 +170,9 @@ describe("startDevelopment — success", () => {
       })
     );
     // HARD pin: the liveness check targets the pinned instance's exact (host, cwd) place.
-    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
+    expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          agentUuid: AGENT_UUID,
-          host: "Laptop-Q3",
-          cwd: "/home/u/dev/payments",
-          status: "online",
-        }),
+        where: { companyUuid: COMPANY_UUID, agentUuid: AGENT_UUID },
       })
     );
     expect(mockCreateActivity).toHaveBeenCalled();
@@ -215,6 +224,7 @@ describe("startDevelopment — precondition failures (each emits nothing)", () =
 
   it("rejects with AGENT_OFFLINE when the agent has no effectively-online connection", async () => {
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
 
     await expect(startDevelopment(PARAMS)).rejects.toMatchObject({
       code: "AGENT_OFFLINE",
@@ -235,6 +245,7 @@ describe("startDevelopment — precondition failures (each emits nothing)", () =
       cwd: "/home/u/dev/payments",
     });
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
 
     await expect(startDevelopment(PARAMS)).rejects.toMatchObject({
       code: "INSTANCE_OFFLINE",
@@ -244,7 +255,10 @@ describe("startDevelopment — precondition failures (each emits nothing)", () =
 
   it("rejects with FIXED_CWD_HOST_OFFLINE when another Agent host is online", async () => {
     mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
+      uuid: "pref-1",
       host: "fixed-host",
+      cwd: "/work/fixed",
+      anchorAgentInstanceUuid: INSTANCE_UUID,
     });
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
 

--- a/src/services/__tests__/task.service.test.ts
+++ b/src/services/__tests__/task.service.test.ts
@@ -600,6 +600,32 @@ describe("claimTask", () => {
     expect(updateData.assignedByUuid).toBe("user-123");
   });
 
+  it.each([undefined, "", "   "])(
+    "stores a null cwd source when runtime cwd exists but source is %j",
+    async (cwdSource) => {
+      const claimed = {
+        ...rawTask({ status: "assigned", assigneeUuid: "a1" }),
+        project: { uuid: PROJECT_UUID, name: "Test Project" },
+      };
+      mockPrisma.task.update.mockResolvedValue(claimed);
+
+      await claimTask({
+        taskUuid: TASK_UUID,
+        companyUuid: COMPANY_UUID,
+        assigneeType: "agent",
+        assigneeUuid: "a1",
+        runtimeCwd: "/workspace/project",
+        cwdSource,
+      });
+
+      expect(mockPrisma.task.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ cwdSource: null }),
+        }),
+      );
+    },
+  );
+
   // add-agent-instance-addressing: an optional instance override persists the
   // pin as the TASK ROW's own agent_instance assignment (assigneeType=
   // "agent_instance", assigneeUuid=<instance uuid>), overriding the passed-in

--- a/src/services/__tests__/wake-preview.service.test.ts
+++ b/src/services/__tests__/wake-preview.service.test.ts
@@ -14,10 +14,17 @@ const mockIdeaUpdate = vi.hoisted(() => vi.fn());
 const mockActivityCreate = vi.hoisted(() => vi.fn());
 const mockNotificationCreate = vi.hoisted(() => vi.fn());
 const mockPreferenceFindFirst = vi.hoisted(() => vi.fn());
+const mockPreferenceUpdate = vi.hoisted(() => vi.fn());
+const mockAgentInstanceUpsert = vi.hoisted(() => vi.fn());
+const mockAgentInstanceFindFirst = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     idea: { findFirst: mockIdeaFindFirst, update: mockIdeaUpdate },
-    projectAgentCwdPreference: { findFirst: mockPreferenceFindFirst },
+    projectAgentCwdPreference: { findFirst: mockPreferenceFindFirst, update: mockPreferenceUpdate },
+    agentInstance: {
+      upsert: mockAgentInstanceUpsert,
+      findFirst: mockAgentInstanceFindFirst,
+    },
     activity: { create: mockActivityCreate },
     notification: { create: mockNotificationCreate },
   },
@@ -100,10 +107,16 @@ beforeEach(() => {
   mockIdeaFindFirst.mockResolvedValue({
     assigneeType: "agent",
     assigneeUuid: agentUuid,
+    projectUuid: "project-1",
+    cwdSource: null,
+    cwdHost: null,
+    runtimeCwd: null,
   });
   mockResolveAssigneeAgentUuid.mockResolvedValue(agentUuid);
   mockListConnectionsForAgent.mockResolvedValue([]);
   mockPreferenceFindFirst.mockResolvedValue(null);
+  mockAgentInstanceUpsert.mockResolvedValue({ uuid: "fixed-instance" });
+  mockAgentInstanceFindFirst.mockResolvedValue(null);
 });
 
 describe("previewIdeaWakeTarget — outcome classification", () => {
@@ -165,7 +178,12 @@ describe("previewIdeaWakeTarget — outcome classification", () => {
         projectUuid: "project-1",
         agentUuid,
       },
-      select: { uuid: true },
+      select: {
+        uuid: true,
+        host: true,
+        cwd: true,
+        anchorAgentInstanceUuid: true,
+      },
     });
   });
 
@@ -185,6 +203,68 @@ describe("previewIdeaWakeTarget — outcome classification", () => {
     expect(preview!.outcome).toBe("direct");
     expect(preview!.assigneeAgentUuid).toBe(agentUuid);
     expectNoSideEffects();
+  });
+
+  it("direct: a persisted fixed assignment retains fixed origin and discovered runtime cwd", async () => {
+    mockIdeaFindFirst.mockResolvedValue({
+      assigneeType: "agent_instance",
+      assigneeUuid: "fixed-instance",
+      projectUuid: "project-1",
+      cwdSource: "project_fixed",
+      cwdHost: "fixed-host",
+      runtimeCwd: "/discovered/fixed",
+    });
+    mockAgentInstanceFindFirst.mockResolvedValue({
+      uuid: "fixed-instance",
+      host: "fixed-host",
+      cwd: "/discovered/fixed",
+    });
+
+    const preview = await previewIdeaWakeTarget(
+      companyUuid,
+      ideaUuid,
+      "user-1",
+    );
+
+    expect(preview).toMatchObject({
+      outcome: "direct",
+      resolvedTarget: {
+        source: "project_fixed",
+        host: "fixed-host",
+        cwd: "/discovered/fixed",
+        availability: "offline",
+        promptPolicy: "suppress",
+      },
+    });
+  });
+
+  it("direct: an ordinary instance pin is not mislabeled as project fixed", async () => {
+    mockIdeaFindFirst.mockResolvedValue({
+      assigneeType: "agent_instance",
+      assigneeUuid: "ordinary-instance",
+      projectUuid: "project-1",
+      cwdSource: null,
+      cwdHost: null,
+      runtimeCwd: null,
+    });
+    mockAgentInstanceFindFirst.mockResolvedValue({
+      uuid: "ordinary-instance",
+      host: "ordinary-host",
+      cwd: "/ordinary",
+    });
+
+    const preview = await previewIdeaWakeTarget(
+      companyUuid,
+      ideaUuid,
+      "user-1",
+    );
+
+    expect(preview?.resolvedTarget).toMatchObject({
+      source: "registered_instance",
+      host: "ordinary-host",
+      cwd: "/ordinary",
+      promptPolicy: "none",
+    });
   });
 
   it("direct (sub-case: zero online): the agent has connections but none online", async () => {
@@ -285,7 +365,14 @@ describe("previewIdeaWakeTarget — candidate shape & scoping", () => {
     // Company-scoped lookup: the miss came from the scoped where clause.
     expect(mockIdeaFindFirst).toHaveBeenCalledWith({
       where: { uuid: ideaUuid, companyUuid },
-      select: { assigneeType: true, assigneeUuid: true },
+      select: {
+        assigneeType: true,
+        assigneeUuid: true,
+        projectUuid: true,
+        cwdSource: true,
+        cwdHost: true,
+        runtimeCwd: true,
+      },
     });
     // Never resolves an assignee / touches the registry / wakes for a missing idea.
     expect(mockResolveAssigneeAgentUuid).not.toHaveBeenCalled();

--- a/src/services/__tests__/yolo-request.service.test.ts
+++ b/src/services/__tests__/yolo-request.service.test.ts
@@ -15,12 +15,15 @@ const { mockPrisma, mockEventBus, mockCreateActivity } = vi.hoisted(() => ({
     },
     agentInstance: {
       findFirst: vi.fn(),
+      upsert: vi.fn(),
     },
     daemonConnection: {
       findFirst: vi.fn(),
+      findMany: vi.fn(),
     },
     projectAgentCwdPreference: {
       findFirst: vi.fn(),
+      update: vi.fn(),
     },
   },
   mockEventBus: { emitChange: vi.fn() },
@@ -71,6 +74,14 @@ beforeEach(() => {
   // incomplete stage), so the proposal/task mocks are intentionally left unset.
   mockPrisma.idea.findFirst.mockResolvedValue(makeIdea());
   mockPrisma.daemonConnection.findFirst.mockResolvedValue({ uuid: "conn-1" });
+  mockPrisma.daemonConnection.findMany.mockResolvedValue([{
+    uuid: "conn-1", agentUuid: AGENT_UUID, clientType: "claude_code",
+    clientVersion: null, host: "Laptop-Q3", cwd: "/home/u/dev/payments",
+    startedAt: null, status: "online", connectedAt: new Date(),
+    lastSeenAt: new Date(), disconnectedAt: null, agentInstanceUuid: INSTANCE_UUID,
+    agent: { name: "Agent", ownerUuid: USER_UUID },
+  }]);
+  mockPrisma.agentInstance.upsert.mockResolvedValue({ uuid: INSTANCE_UUID });
   mockPrisma.agentInstance.findFirst.mockResolvedValue({ agentUuid: AGENT_UUID });
   mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue(null);
 });
@@ -130,14 +141,9 @@ describe("requestYolo — success", () => {
       })
     );
     // HARD pin: the liveness check targets the pinned instance's exact (host, cwd) place.
-    expect(mockPrisma.daemonConnection.findFirst).toHaveBeenCalledWith(
+    expect(mockPrisma.daemonConnection.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          agentUuid: AGENT_UUID,
-          host: "Laptop-Q3",
-          cwd: "/home/u/dev/payments",
-          status: "online",
-        }),
+        where: { companyUuid: COMPANY_UUID, agentUuid: AGENT_UUID },
       })
     );
     expect(mockCreateActivity).toHaveBeenCalled();
@@ -169,6 +175,7 @@ describe("requestYolo — precondition failures (each emits nothing)", () => {
 
   it("rejects with AGENT_OFFLINE (distinguishable from ASSIGNEE_NOT_AGENT) when no online connection", async () => {
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
 
     await expect(requestYolo(PARAMS)).rejects.toMatchObject({
       code: "AGENT_OFFLINE",
@@ -189,6 +196,7 @@ describe("requestYolo — precondition failures (each emits nothing)", () => {
       cwd: "/home/u/dev/payments",
     });
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
 
     await expect(requestYolo(PARAMS)).rejects.toMatchObject({
       code: "INSTANCE_OFFLINE",
@@ -198,7 +206,10 @@ describe("requestYolo — precondition failures (each emits nothing)", () => {
 
   it("rejects with FIXED_CWD_HOST_OFFLINE when another Agent host is online", async () => {
     mockPrisma.projectAgentCwdPreference.findFirst.mockResolvedValue({
+      uuid: "pref-1",
       host: "fixed-host",
+      cwd: "/work/fixed",
+      anchorAgentInstanceUuid: INSTANCE_UUID,
     });
     mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
 

--- a/src/services/daemon-instruction.service.ts
+++ b/src/services/daemon-instruction.service.ts
@@ -56,6 +56,7 @@ import {
   connectionBelongsToAgent,
   isConnectionLive,
 } from "@/services/daemon-execution.service";
+import { resolveProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
 
 // ===== Constants =====
 
@@ -535,6 +536,13 @@ export class ConnectionInstanceMissingError extends Error {
   }
 }
 
+export class ProjectCwdTargetUnavailableError extends Error {
+  readonly code = "project_cwd_target_unavailable";
+  constructor(readonly availability: "offline" | "invalid") {
+    super(`Project fixed working directory is ${availability}`);
+  }
+}
+
 /** Max length of the server-derived placeholder title for a pre-created idea. */
 export const PLACEHOLDER_TITLE_MAX = 60;
 
@@ -714,18 +722,7 @@ export async function createConversationalIdeaSession(
   // (1) Visibility + ownership fence, identical posture to the ad-hoc path: either miss
   // collapses to ONE 404 non-disclosure verdict.
   const ownsAgent = await callerOwnsAgent(auth, params.agentUuid);
-  const connectionOfAgent = await connectionBelongsToAgent(
-    auth.companyUuid,
-    params.agentUuid,
-    params.connectionUuid,
-  );
-  if (!ownsAgent || !connectionOfAgent) {
-    throw new ConnectionNotVisibleError();
-  }
-  const online = await isConnectionLive(auth.companyUuid, params.connectionUuid);
-  if (!online) {
-    throw new ConnectionOfflineError(params.connectionUuid);
-  }
+  if (!ownsAgent) throw new ConnectionNotVisibleError();
 
   // (2) Project visibility (company-scoped) + the template's display name.
   const project = await prisma.project.findFirst({
@@ -736,16 +733,62 @@ export async function createConversationalIdeaSession(
     throw new ProjectNotVisibleError();
   }
 
-  // (3) The durable instance behind the chosen connection — the idea's pin target. A
-  // live connection normally always has one (linked at handshake); never bind to null.
-  const connection = await prisma.daemonConnection.findFirst({
-    where: { uuid: params.connectionUuid, companyUuid: auth.companyUuid },
-    select: { agentInstanceUuid: true },
+  // (3) A project-fixed cwd is authoritative for new work. Resolve it server-side so a
+  // stale or crafted client connection cannot bypass the saved target. Without a fixed
+  // preference, preserve the explicitly selected online instance.
+  const actorUserUuid =
+    auth.type === "user"
+      ? auth.actorUuid
+      : (
+          await prisma.agent.findFirst({
+            where: { uuid: auth.actorUuid, companyUuid: auth.companyUuid },
+            select: { ownerUuid: true },
+          })
+        )?.ownerUuid;
+  if (!actorUserUuid) throw new ConnectionNotVisibleError();
+
+  const projectTarget = await resolveProjectAgentCwdTarget({
+    companyUuid: auth.companyUuid,
+    actorUserUuid,
+    projectUuid: project.uuid,
+    agentUuid: params.agentUuid,
   });
-  if (!connection?.agentInstanceUuid) {
-    throw new ConnectionInstanceMissingError(params.connectionUuid);
+
+  let originConnectionUuid = params.connectionUuid;
+  let instanceUuid: string | null = null;
+  let cwdSource: string | null = null;
+  let cwdHost: string | null = null;
+  let runtimeCwd: string | null = null;
+
+  if (projectTarget.source === "project_fixed") {
+    if (projectTarget.availability !== "ready" || !projectTarget.connectionUuid || !projectTarget.agentInstanceUuid) {
+      throw new ProjectCwdTargetUnavailableError(
+        projectTarget.availability === "offline" ? "offline" : "invalid",
+      );
+    }
+    originConnectionUuid = projectTarget.connectionUuid;
+    instanceUuid = projectTarget.agentInstanceUuid;
+    cwdSource = "project_fixed";
+    cwdHost = projectTarget.host;
+    runtimeCwd = projectTarget.cwd;
+  } else {
+    const connectionOfAgent = await connectionBelongsToAgent(
+      auth.companyUuid,
+      params.agentUuid,
+      params.connectionUuid,
+    );
+    if (!connectionOfAgent) throw new ConnectionNotVisibleError();
+    const online = await isConnectionLive(auth.companyUuid, params.connectionUuid);
+    if (!online) throw new ConnectionOfflineError(params.connectionUuid);
+    const connection = await prisma.daemonConnection.findFirst({
+      where: { uuid: params.connectionUuid, companyUuid: auth.companyUuid },
+      select: { agentInstanceUuid: true },
+    });
+    if (!connection?.agentInstanceUuid) {
+      throw new ConnectionInstanceMissingError(params.connectionUuid);
+    }
+    instanceUuid = connection.agentInstanceUuid;
   }
-  const instanceUuid = connection.agentInstanceUuid;
 
   // (4) Server-generated ideaUuid FIRST, so the composed instruction can embed it while
   // the idea write stays inside the transaction. Reject empty descriptions before
@@ -785,6 +828,9 @@ export async function createConversationalIdeaSession(
         status: "elaborating",
         assigneeType: "agent_instance",
         assigneeUuid: instanceUuid,
+        cwdSource,
+        cwdHost,
+        runtimeCwd,
         assignedAt: new Date(),
         assignedByUuid: auth.actorUuid,
         createdByUuid: auth.actorUuid,
@@ -808,7 +854,8 @@ export async function createConversationalIdeaSession(
         agentUuid: params.agentUuid,
         sessionId: ideaUuid,
         directIdeaUuid: ideaUuid,
-        originConnectionUuid: params.connectionUuid,
+        originConnectionUuid,
+        runtimeCwd,
         status: "active",
       },
     });
@@ -892,7 +939,7 @@ export async function createConversationalIdeaSession(
   });
   deliverTurnPing({
     companyUuid: auth.companyUuid,
-    originConnectionUuid: params.connectionUuid,
+    originConnectionUuid,
     turnUuid: turn.uuid,
   });
 

--- a/src/services/idea.service.ts
+++ b/src/services/idea.service.ts
@@ -73,6 +73,9 @@ export interface IdeaClaimParams {
   // omitted/null, the assignment behaves exactly as before this change
   // (assigneeType="agent" → un-pinned, online-first at wake time).
   instanceUuid?: string | null;
+  cwdSource?: string | null;
+  cwdHost?: string | null;
+  runtimeCwd?: string | null;
   // Allow a SAME-owning-agent cwd re-pin on an ALREADY-elaborated idea
   // (pin-cwd-before-wake). An elaborated idea normally rejects every assignment
   // (its elaboration lifecycle is done), but pinning the (host, cwd) of the
@@ -762,6 +765,9 @@ export async function claimIdea({
   assigneeUuid,
   assignedByUuid,
   instanceUuid,
+  cwdSource,
+  cwdHost,
+  runtimeCwd,
 }: IdeaClaimParams): Promise<IdeaResponse> {
   const existing = await prisma.idea.findFirst({
     where: { uuid: ideaUuid, companyUuid },
@@ -785,6 +791,9 @@ export async function claimIdea({
       status: "elaborating",
       assigneeType: resolved.assigneeType,
       assigneeUuid: resolved.assigneeUuid,
+      cwdSource: runtimeCwd && cwdSource?.trim() ? cwdSource : null,
+      cwdHost: runtimeCwd ? cwdHost : null,
+      runtimeCwd: runtimeCwd ?? null,
       assignedAt: new Date(),
       assignedByUuid,
     },
@@ -832,6 +841,9 @@ export async function assignIdea({
   assigneeUuid,
   assignedByUuid,
   instanceUuid,
+  cwdSource,
+  cwdHost,
+  runtimeCwd,
   allowElaboratedInstanceRepin = false,
 }: IdeaClaimParams): Promise<IdeaResponse> {
   const existing = await prisma.idea.findFirst({
@@ -870,6 +882,9 @@ export async function assignIdea({
       status: newStatus,
       assigneeType: resolved.assigneeType,
       assigneeUuid: resolved.assigneeUuid,
+      cwdSource: runtimeCwd && cwdSource?.trim() ? cwdSource : null,
+      cwdHost: runtimeCwd ? cwdHost : null,
+      runtimeCwd: runtimeCwd ?? null,
       assignedAt: new Date(),
       assignedByUuid,
     },
@@ -898,6 +913,9 @@ export async function releaseIdea(uuid: string): Promise<IdeaResponse> {
       status: "open",
       assigneeType: null,
       assigneeUuid: null,
+      cwdSource: null,
+      cwdHost: null,
+      runtimeCwd: null,
       assignedAt: null,
       assignedByUuid: null,
       elaborationDepth: null,

--- a/src/services/mention.service.ts
+++ b/src/services/mention.service.ts
@@ -33,6 +33,10 @@ import {
   listConnectionsForAgent,
 } from "@/services/daemon-connection.service";
 import { ACTIVE_EXECUTION_STATUSES } from "@/services/daemon-execution.service";
+import {
+  resolveProjectAgentCwdTarget,
+  type ResolvedProjectAgentCwdTarget,
+} from "@/services/project-agent-cwd.service";
 
 // ===== Constants =====
 
@@ -154,6 +158,133 @@ export interface Mentionable {
     cwd: string | null;
     agentInstanceUuid: string;
   };
+  projectFixedCwd?: {
+    host: string;
+    cwd: string;
+    availability: "ready" | "offline" | "invalid";
+  };
+}
+
+async function resolveActorUserUuid(
+  companyUuid: string,
+  actorType: string,
+  actorUuid: string,
+): Promise<string | null> {
+  if (actorType === "user") return actorUuid;
+  const agent = await prisma.agent.findFirst({
+    where: { uuid: actorUuid, companyUuid },
+    select: { ownerUuid: true },
+  });
+  return agent?.ownerUuid ?? null;
+}
+
+async function resolveEntityProjectUuid(
+  companyUuid: string,
+  entityType: LineageEntityType,
+  entityUuid: string,
+): Promise<string | null> {
+  if (entityType === "idea") {
+    return (
+      await prisma.idea.findFirst({
+        where: { uuid: entityUuid, companyUuid },
+        select: { projectUuid: true },
+      })
+    )?.projectUuid ?? null;
+  }
+  if (entityType === "task") {
+    return (
+      await prisma.task.findFirst({
+        where: { uuid: entityUuid, companyUuid },
+        select: { projectUuid: true },
+      })
+    )?.projectUuid ?? null;
+  }
+  if (entityType === "proposal") {
+    return (
+      await prisma.proposal.findFirst({
+        where: { uuid: entityUuid, companyUuid },
+        select: { projectUuid: true },
+      })
+    )?.projectUuid ?? null;
+  }
+  return (
+    await prisma.document.findFirst({
+      where: { uuid: entityUuid, companyUuid },
+      select: { projectUuid: true },
+    })
+  )?.projectUuid ?? null;
+}
+
+async function resolveMentionTarget(params: {
+  companyUuid: string;
+  actorType: string;
+  actorUuid: string;
+  projectUuid: string;
+  agentUuid: string;
+  entityType?: LineageEntityType;
+  entityUuid?: string;
+}): Promise<ResolvedProjectAgentCwdTarget | null> {
+  const actorUserUuid = await resolveActorUserUuid(
+    params.companyUuid,
+    params.actorType,
+    params.actorUuid,
+  );
+  if (!actorUserUuid) return null;
+
+  let registeredInstanceUuid: string | null = null;
+  let registeredSource: "project_fixed" | "registered_instance" | null = null;
+  let registeredHost: string | null = null;
+  let registeredRuntimeCwd: string | null = null;
+
+  if (params.entityType && params.entityUuid) {
+    const { resolveRootIdea } = await import("@/services/lineage.service");
+    const { directIdeaUuid } = await resolveRootIdea(
+      params.companyUuid,
+      params.entityType,
+      params.entityUuid,
+    );
+    if (directIdeaUuid) {
+      const idea = await prisma.idea.findFirst({
+        where: { uuid: directIdeaUuid, companyUuid: params.companyUuid },
+        select: {
+          assigneeType: true,
+          assigneeUuid: true,
+          cwdSource: true,
+          cwdHost: true,
+          runtimeCwd: true,
+        },
+      });
+      const assigneeAgentUuid = idea
+        ? await resolveAssigneeAgentUuid(
+            params.companyUuid,
+            idea.assigneeType,
+            idea.assigneeUuid,
+          )
+        : null;
+      if (
+        idea?.assigneeType === "agent_instance" &&
+        idea.assigneeUuid &&
+        assigneeAgentUuid === params.agentUuid
+      ) {
+        registeredInstanceUuid = idea.assigneeUuid;
+        registeredSource =
+          idea.cwdSource === "project_fixed" ? "project_fixed" : "registered_instance";
+        registeredHost = idea.cwdHost;
+        registeredRuntimeCwd = idea.runtimeCwd;
+      }
+    }
+  }
+
+  return resolveProjectAgentCwdTarget({
+    companyUuid: params.companyUuid,
+    actorUserUuid,
+    projectUuid: params.projectUuid,
+    agentUuid: params.agentUuid,
+    registeredInstanceUuid,
+    registeredSource,
+    registeredHost,
+    registeredRuntimeCwd,
+  });
 }
 
 export interface CreateMentionsParams {
@@ -336,6 +467,24 @@ export async function createMentions(params: CreateMentionsParams): Promise<void
     if (!prefs.mentioned) continue;
 
     const message = `${actorName} mentioned you: "${snippet}"`;
+    const hasExplicitPin =
+      mention.pinnedHost !== undefined || mention.pinnedCwd !== undefined;
+    const resolvedTarget =
+      mention.type === "agent" && !hasExplicitPin
+        ? await resolveMentionTarget({
+            companyUuid,
+            actorType,
+            actorUuid,
+            projectUuid,
+            agentUuid: mention.uuid,
+            entityType: (
+              ["idea", "task", "proposal", "document"] as string[]
+            ).includes(notifEntityType)
+              ? (notifEntityType as LineageEntityType)
+              : undefined,
+            entityUuid: notifEntityUuid,
+          })
+        : null;
 
     notifications.push({
       companyUuid,
@@ -359,6 +508,19 @@ export async function createMentions(params: CreateMentionsParams): Promise<void
       // pin is transport-only here — it is NOT persisted on the Notification row.
       pinnedHost: mention.pinnedHost,
       pinnedCwd: mention.pinnedCwd,
+      ...(resolvedTarget?.source === "project_fixed"
+        ? {
+            resolvedCwdSource: resolvedTarget.source,
+            resolvedCwdHost: resolvedTarget.host,
+            resolvedRuntimeCwd: resolvedTarget.cwd,
+            resolvedCwdAvailability: resolvedTarget.availability,
+          }
+        : resolvedTarget?.source === "registered_instance"
+          ? {
+              pinnedHost: resolvedTarget.host,
+              pinnedCwd: resolvedTarget.cwd,
+            }
+          : {}),
     });
   }
 
@@ -632,6 +794,57 @@ export async function enrichIdeaContext(
   }
 }
 
+async function enrichProjectFixedCwds(params: {
+  companyUuid: string;
+  actorType: string;
+  actorUuid: string;
+  ownerUuid?: string;
+  results: Mentionable[];
+  entityType: LineageEntityType;
+  entityUuid: string;
+}): Promise<void> {
+  const agentResults = params.results.filter(
+    (result): result is Mentionable & { type: "agent" } => result.type === "agent",
+  );
+  if (agentResults.length === 0) return;
+  const actorUserUuid =
+    params.actorType === "user" ? params.actorUuid : params.ownerUuid;
+  if (!actorUserUuid) return;
+  const projectUuid = await resolveEntityProjectUuid(
+    params.companyUuid,
+    params.entityType,
+    params.entityUuid,
+  );
+  if (!projectUuid) return;
+
+  const preferences = await prisma.projectAgentCwdPreference.findMany({
+    where: {
+      companyUuid: params.companyUuid,
+      userUuid: actorUserUuid,
+      projectUuid,
+      agentUuid: { in: agentResults.map((result) => result.uuid) },
+    },
+    select: { agentUuid: true, host: true, cwd: true },
+  });
+  const byAgent = new Map(preferences.map((preference) => [preference.agentUuid, preference]));
+  for (const result of agentResults) {
+    // An existing direct-Idea assignment is immutable and takes precedence.
+    if (result.ideaPin) continue;
+    const preference = byAgent.get(result.uuid);
+    if (!preference) continue;
+    const ready = (result.instances ?? []).some(
+      (instance) =>
+        instance.host === preference.host && instance.effectiveStatus === "online",
+    );
+    result.projectFixedCwd = {
+      host: preference.host,
+      cwd: preference.cwd,
+      availability:
+        !preference.host || !preference.cwd ? "invalid" : ready ? "ready" : "offline",
+    };
+  }
+}
+
 /**
  * Search for mentionable users and agents within a company.
  * Permission scoping:
@@ -698,7 +911,18 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
     if (withInstances) await enrichAgentInstances(companyUuid, sliced);
     // Annotate root-idea assignment context AFTER the slice too (pin-cwd-before-wake,
     // Part 2a) — the resolve is bounded (single root-idea resolve, no per-candidate query).
-    if (hasEntityContext) await enrichIdeaContext(companyUuid, sliced, entityType!, entityUuid!);
+    if (hasEntityContext) {
+      await enrichIdeaContext(companyUuid, sliced, entityType!, entityUuid!);
+      await enrichProjectFixedCwds({
+        companyUuid,
+        actorType,
+        actorUuid,
+        ownerUuid,
+        results: sliced,
+        entityType: entityType!,
+        entityUuid: entityUuid!,
+      });
+    }
     return sliced;
   }
   // Search users (all company users are mentionable)
@@ -778,7 +1002,18 @@ export async function searchMentionables(params: SearchMentionablesParams): Prom
   if (withInstances) await enrichAgentInstances(companyUuid, sliced);
   // Annotate root-idea assignment context AFTER the slice too (pin-cwd-before-wake,
   // Part 2a) — the resolve is bounded (single root-idea resolve, no per-candidate query).
-  if (hasEntityContext) await enrichIdeaContext(companyUuid, sliced, entityType!, entityUuid!);
+  if (hasEntityContext) {
+    await enrichIdeaContext(companyUuid, sliced, entityType!, entityUuid!);
+    await enrichProjectFixedCwds({
+      companyUuid,
+      actorType,
+      actorUuid,
+      ownerUuid,
+      results: sliced,
+      entityType: entityType!,
+      entityUuid: entityUuid!,
+    });
+  }
   return sliced;
 }
 

--- a/src/services/mention.service.ts
+++ b/src/services/mention.service.ts
@@ -842,8 +842,6 @@ async function enrichProjectFixedCwds(params: {
   });
   const byAgent = new Map(preferences.map((preference) => [preference.agentUuid, preference]));
   for (const result of agentResults) {
-    // An existing direct-Idea assignment is immutable and takes precedence.
-    if (result.ideaPin) continue;
     const preference = byAgent.get(result.uuid);
     if (!preference) continue;
     const ready = (result.instances ?? []).some(

--- a/src/services/mention.service.ts
+++ b/src/services/mention.service.ts
@@ -471,20 +471,32 @@ export async function createMentions(params: CreateMentionsParams): Promise<void
     const message = `${actorName} mentioned you: "${snippet}"`;
     const hasExplicitPin =
       mention.pinnedHost !== undefined || mention.pinnedCwd !== undefined;
+    // A runtime-cwd token is emitted only for a project-fixed preference. Resolve
+    // it again server-side (without lineage assignment inheritance) so the stored
+    // marker cannot authorize an arbitrary runtime directory and the wake receives
+    // an immutable host/runtime snapshot. Ordinary instance pins remain exact and
+    // deliberately skip the project resolver.
+    const shouldResolveProjectTarget =
+      mention.type === "agent" && (!hasExplicitPin || mention.runtimeCwd === true);
     const resolvedTarget =
-      mention.type === "agent" && !hasExplicitPin
+      shouldResolveProjectTarget
         ? await resolveMentionTarget({
             companyUuid,
             actorType,
             actorUuid,
             projectUuid,
             agentUuid: mention.uuid,
-            entityType: (
-              ["idea", "task", "proposal", "document"] as string[]
-            ).includes(notifEntityType)
-              ? (notifEntityType as LineageEntityType)
-              : undefined,
-            entityUuid: notifEntityUuid,
+            // Runtime markers represent the current project preference, not an
+            // existing root Idea's sticky assignment.
+            entityType:
+              mention.runtimeCwd === true
+                ? undefined
+                : (
+                    ["idea", "task", "proposal", "document"] as string[]
+                  ).includes(notifEntityType)
+                  ? (notifEntityType as LineageEntityType)
+                  : undefined,
+            entityUuid: mention.runtimeCwd === true ? undefined : notifEntityUuid,
           })
         : null;
 

--- a/src/services/mention.service.ts
+++ b/src/services/mention.service.ts
@@ -84,6 +84,7 @@ export interface MentionRef {
   // to the stored token and no migration of existing comment tokens.
   pinnedHost?: string | null;
   pinnedCwd?: string | null;
+  runtimeCwd?: boolean;
 }
 
 /**
@@ -350,7 +351,7 @@ export function parseMentions(content: string): MentionRef[] {
     const displayName = match[1];
     const type = match[2].toLowerCase() as "user" | "agent";
     const uuid = match[3].toLowerCase();
-    const { pinnedHost, pinnedCwd } = decodePinSuffix(match[4]);
+    const { pinnedHost, pinnedCwd, runtimeCwd } = decodePinSuffix(match[4]);
     const key = `${type}:${uuid}`;
 
     if (!seen.has(key)) {
@@ -361,6 +362,7 @@ export function parseMentions(content: string): MentionRef[] {
       if (pinnedHost !== null || pinnedCwd !== null) {
         ref.pinnedHost = pinnedHost;
         ref.pinnedCwd = pinnedCwd;
+        if (runtimeCwd) ref.runtimeCwd = true;
       }
       mentions.push(ref);
     }

--- a/src/services/notification-listener.ts
+++ b/src/services/notification-listener.ts
@@ -665,6 +665,18 @@ export async function handleActivity(event: ActivityEvent): Promise<void> {
           typeof value.temporaryRuntimeCwd === "string"
             ? value.temporaryRuntimeCwd
             : undefined,
+        resolvedCwdSource:
+          typeof value.resolvedCwdSource === "string"
+            ? value.resolvedCwdSource
+            : undefined,
+        resolvedCwdHost:
+          typeof value.resolvedCwdHost === "string"
+            ? value.resolvedCwdHost
+            : undefined,
+        resolvedRuntimeCwd:
+          typeof value.resolvedRuntimeCwd === "string"
+            ? value.resolvedRuntimeCwd
+            : undefined,
       };
       }
     );

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -227,6 +227,9 @@ export interface WakeNotificationContext {
   pinnedCwd?: string | null;
   temporaryHost?: string | null;
   temporaryRuntimeCwd?: string | null;
+  resolvedCwdSource?: string | null;
+  resolvedCwdHost?: string | null;
+  resolvedRuntimeCwd?: string | null;
 }
 
 /**
@@ -334,27 +337,21 @@ async function resolvePinnedTarget(
   ctx: WakeNotificationContext,
   trigger: TurnTrigger,
 ): Promise<PinnedTarget | null> {
-  // A project preference is authoritative across every instance and inline selection
-  // for this user. Its cwd need not be a registered connection; any online connection
-  // for the same Agent + host is an anchor for directed runtime execution.
-  if (ctx.projectUuid && ctx.actorType === "user" && ctx.actorUuid) {
-    const preference = await prisma.projectAgentCwdPreference?.findFirst({
-      where: {
-        companyUuid: ctx.companyUuid,
-        userUuid: ctx.actorUuid,
-        projectUuid: ctx.projectUuid,
-        agentUuid: ctx.recipientUuid,
-      },
-      select: { host: true, cwd: true },
-    });
-    if (preference) {
-      return {
-        host: preference.host,
-        cwd: null,
-        runtimeCwd: preference.cwd,
-        soft: false,
-      };
-    }
+  // Stage-entry operations carry their actor-bearing target snapshot in the
+  // activity. Consume it verbatim so preference/actor/registry changes cannot
+  // alter the target between the stage action and notification delivery.
+  if (
+    ctx.resolvedCwdSource &&
+    ctx.resolvedCwdSource !== "unconfigured" &&
+    ctx.resolvedCwdHost &&
+    ctx.resolvedRuntimeCwd
+  ) {
+    return {
+      host: ctx.resolvedCwdHost,
+      cwd: null,
+      runtimeCwd: ctx.resolvedRuntimeCwd,
+      soft: false,
+    };
   }
 
   if (ctx.temporaryHost && ctx.temporaryRuntimeCwd) {
@@ -383,14 +380,26 @@ async function resolvePinnedTarget(
   if (ctx.entityType === "task") {
     const task = await prisma.task.findFirst({
       where: { uuid: ctx.entityUuid, companyUuid: ctx.companyUuid },
-      select: { assigneeType: true, assigneeUuid: true },
+      select: {
+        assigneeType: true,
+        assigneeUuid: true,
+        cwdHost: true,
+        runtimeCwd: true,
+      },
     });
     if (task?.assigneeType === "agent_instance" && task.assigneeUuid) {
       const place = await resolveInstancePlace(ctx.companyUuid, task.assigneeUuid);
       if (place) {
         // HARD (owner choice B): an assignment pin is never re-routed. An offline
         // task-override pin is notify-only, identical to a mention pin.
-        const pin = makePinnedTarget(place.host, place.cwd, false);
+        const pin = task.runtimeCwd
+          ? {
+              host: task.cwdHost?.trim() ? task.cwdHost : place.host,
+              cwd: null,
+              runtimeCwd: task.runtimeCwd,
+              soft: false,
+            }
+          : makePinnedTarget(place.host, place.cwd, false);
         if (pin) return pin;
       }
     }
@@ -434,7 +443,12 @@ async function resolveIdeaInstancePin(
   if (!ideaUuid) return null;
   const idea = await prisma.idea.findFirst({
     where: { uuid: ideaUuid, companyUuid: ctx.companyUuid },
-    select: { assigneeType: true, assigneeUuid: true },
+    select: {
+      assigneeType: true,
+      assigneeUuid: true,
+      cwdHost: true,
+      runtimeCwd: true,
+    },
   });
   if (idea?.assigneeType === "agent_instance" && idea.assigneeUuid) {
     const place = await resolveInstancePlace(ctx.companyUuid, idea.assigneeUuid);
@@ -442,7 +456,14 @@ async function resolveIdeaInstancePin(
     if (place && place.agentUuid === ctx.recipientUuid) {
       // HARD (owner choice B): an inherited idea-instance pin is never re-routed. An
       // offline pin is notify-only, identical to a mention pin.
-      return makePinnedTarget(place.host, place.cwd, false);
+      return idea.runtimeCwd
+        ? {
+            host: idea.cwdHost?.trim() ? idea.cwdHost : place.host,
+            cwd: null,
+            runtimeCwd: idea.runtimeCwd,
+            soft: false,
+          }
+        : makePinnedTarget(place.host, place.cwd, false);
     }
   }
   return null;

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -230,6 +230,7 @@ export interface WakeNotificationContext {
   resolvedCwdSource?: string | null;
   resolvedCwdHost?: string | null;
   resolvedRuntimeCwd?: string | null;
+  resolvedCwdAvailability?: "ready" | "offline" | "invalid" | null;
 }
 
 /**
@@ -340,14 +341,14 @@ async function resolvePinnedTarget(
   // Stage-entry operations carry their actor-bearing target snapshot in the
   // activity. Consume it verbatim so preference/actor/registry changes cannot
   // alter the target between the stage action and notification delivery.
-  if (
-    ctx.resolvedCwdSource &&
-    ctx.resolvedCwdSource !== "unconfigured" &&
-    ctx.resolvedCwdHost &&
-    ctx.resolvedRuntimeCwd
-  ) {
+  if (ctx.resolvedCwdSource && ctx.resolvedCwdSource !== "unconfigured") {
     return {
-      host: ctx.resolvedCwdHost,
+      // An invalid fixed target is still a hard pin. The sentinel cannot match a
+      // daemon host, producing the same notify-only behavior as an offline target.
+      host:
+        ctx.resolvedCwdAvailability === "invalid"
+          ? "\u0000invalid-project-cwd"
+          : (ctx.resolvedCwdHost ?? ""),
       cwd: null,
       runtimeCwd: ctx.resolvedRuntimeCwd,
       soft: false,

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -43,6 +43,9 @@ export interface NotificationCreateParams {
   pinnedCwd?: string | null;
   temporaryHost?: string | null;
   temporaryRuntimeCwd?: string | null;
+  resolvedCwdSource?: string | null;
+  resolvedCwdHost?: string | null;
+  resolvedRuntimeCwd?: string | null;
 }
 
 export interface NotificationListParams {

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -46,6 +46,7 @@ export interface NotificationCreateParams {
   resolvedCwdSource?: string | null;
   resolvedCwdHost?: string | null;
   resolvedRuntimeCwd?: string | null;
+  resolvedCwdAvailability?: "ready" | "offline" | "invalid" | null;
 }
 
 export interface NotificationListParams {

--- a/src/services/project-agent-cwd.service.ts
+++ b/src/services/project-agent-cwd.service.ts
@@ -276,15 +276,32 @@ export async function listProjectAgentCwdPreferences(
   projectUuid: string,
 ) {
   await requireProject(companyUuid, projectUuid);
+  return listAgentCwdOptions(companyUuid, userUuid, projectUuid);
+}
+
+export async function listAvailableAgentCwdOptions(
+  companyUuid: string,
+  userUuid: string,
+) {
+  return listAgentCwdOptions(companyUuid, userUuid, null);
+}
+
+async function listAgentCwdOptions(
+  companyUuid: string,
+  userUuid: string,
+  projectUuid: string | null,
+) {
   const [agents, preferences] = await Promise.all([
     prisma.agent.findMany({
       where: { companyUuid, ownerUuid: userUuid },
       select: { uuid: true, name: true },
       orderBy: [{ name: "asc" }, { uuid: "asc" }],
     }),
-    prisma.projectAgentCwdPreference.findMany({
-      where: { companyUuid, userUuid, projectUuid },
-    }),
+    projectUuid
+      ? prisma.projectAgentCwdPreference.findMany({
+          where: { companyUuid, userUuid, projectUuid },
+        })
+      : Promise.resolve([]),
   ]);
   const connections = await prisma.daemonConnection.findMany({
     where: { companyUuid, agentUuid: { in: agents.map((agent) => agent.uuid) }, status: "online" },
@@ -299,19 +316,23 @@ export async function listProjectAgentCwdPreferences(
   });
   const onlineHosts = new Set(connections.map((connection) => `${connection.agentUuid}\0${connection.host}`));
   const byAgent = new Map(preferences.map((preference) => [preference.agentUuid, preference]));
-  return agents.map((agent) => {
+  return agents.flatMap((agent) => {
     const preference = byAgent.get(agent.uuid);
-    return {
+    const onlineInstances = connections
+      .filter((connection) => connection.agentUuid === agent.uuid)
+      .map((connection) => ({
+        connectionUuid: connection.uuid,
+        agentInstanceUuid: connection.agentInstanceUuid,
+        host: connection.host,
+        cwd: connection.cwd,
+        effectiveStatus: "online" as const,
+      }));
+    // Unconfigured offline Agents cannot provide a usable cwd choice. Keep an
+    // existing offline preference visible so the user can replace or clear it.
+    if (onlineInstances.length === 0 && !preference) return [];
+    return [{
       agent,
-      onlineInstances: connections
-        .filter((connection) => connection.agentUuid === agent.uuid)
-        .map((connection) => ({
-          connectionUuid: connection.uuid,
-          agentInstanceUuid: connection.agentInstanceUuid,
-          host: connection.host,
-          cwd: connection.cwd,
-          effectiveStatus: "online" as const,
-        })),
+      onlineInstances,
       preference: preference
         ? {
             uuid: preference.uuid,
@@ -322,7 +343,7 @@ export async function listProjectAgentCwdPreferences(
             updatedAt: preference.updatedAt,
           }
         : null,
-    };
+    }];
   });
 }
 

--- a/src/services/project-agent-cwd.service.ts
+++ b/src/services/project-agent-cwd.service.ts
@@ -1,5 +1,34 @@
 import { prisma } from "@/lib/prisma";
 import { eventBus, controlEventName } from "@/lib/event-bus";
+import {
+  listConnectionsForAgent,
+  type ConnectionView,
+} from "@/services/daemon-connection.service";
+
+export type ProjectAgentCwdSource =
+  | "project_fixed"
+  | "temporary"
+  | "registered_instance"
+  | "unconfigured";
+export type ProjectAgentCwdAvailability = "ready" | "offline" | "invalid";
+export type ProjectAgentCwdPromptPolicy = "suppress" | "none" | "select";
+
+export interface ResolvedProjectAgentCwdTarget {
+  actorUserUuid: string;
+  source: ProjectAgentCwdSource;
+  agentUuid: string;
+  host: string | null;
+  cwd: string | null;
+  availability: ProjectAgentCwdAvailability;
+  promptPolicy: ProjectAgentCwdPromptPolicy;
+  connectionUuid: string | null;
+  agentInstanceUuid: string | null;
+}
+
+export interface ProjectAgentCwdOperationTarget {
+  host: string;
+  cwd: string;
+}
 
 export const DIRECTORY_ERROR_CODES = [
   "HOST_OFFLINE",
@@ -44,6 +73,201 @@ async function requireProject(companyUuid: string, projectUuid: string) {
     select: { uuid: true },
   });
   if (!project) throw new CwdServiceError("NOT_FOUND", "Project not found");
+}
+
+function onlineConnectionForHost(
+  connections: ConnectionView[],
+  host: string,
+): ConnectionView | null {
+  return (
+    connections.find(
+      (connection) =>
+        connection.host === host && connection.effectiveStatus === "online",
+    ) ?? null
+  );
+}
+
+async function materializeAgentInstance(
+  companyUuid: string,
+  agentUuid: string,
+  host: string,
+  cwd: string,
+): Promise<string> {
+  const row = await prisma.agentInstance.upsert({
+    where: {
+      companyUuid_agentUuid_host_cwd: { companyUuid, agentUuid, host, cwd },
+    },
+    create: { companyUuid, agentUuid, host, cwd },
+    update: { updatedAt: new Date() },
+    select: { uuid: true },
+  });
+  return row.uuid;
+}
+
+/**
+ * Resolve one immutable, actor-bearing target snapshot for a project operation.
+ * Callers pass this object through the operation rather than re-reading mutable
+ * preferences or connection state.
+ */
+export async function resolveProjectAgentCwdTarget(params: {
+  companyUuid: string;
+  actorUserUuid: string;
+  projectUuid: string;
+  agentUuid: string;
+  temporaryTarget?: ProjectAgentCwdOperationTarget | null;
+  registeredInstanceUuid?: string | null;
+  registeredSource?: ProjectAgentCwdSource | null;
+  registeredHost?: string | null;
+  registeredRuntimeCwd?: string | null;
+}): Promise<ResolvedProjectAgentCwdTarget> {
+  const [preference, connections] = await Promise.all([
+    prisma.projectAgentCwdPreference.findFirst({
+      where: {
+        companyUuid: params.companyUuid,
+        userUuid: params.actorUserUuid,
+        projectUuid: params.projectUuid,
+        agentUuid: params.agentUuid,
+      },
+      select: {
+        uuid: true,
+        host: true,
+        cwd: true,
+        anchorAgentInstanceUuid: true,
+      },
+    }),
+    listConnectionsForAgent(params.companyUuid, params.agentUuid),
+  ]);
+
+  // A registered instance supplied by the caller is an established assignment/root
+  // anchor. Once work is anchored, a later preference replacement or clear must not
+  // move that Idea/session to a different cwd.
+  if (params.registeredInstanceUuid) {
+    const instance = await prisma.agentInstance.findFirst({
+      where: {
+        uuid: params.registeredInstanceUuid,
+        companyUuid: params.companyUuid,
+        agentUuid: params.agentUuid,
+      },
+      select: { uuid: true, host: true, cwd: true },
+    });
+    if (instance) {
+      const host = params.registeredRuntimeCwd
+        ? params.registeredHost ?? instance.host
+        : instance.host;
+      const cwd = params.registeredRuntimeCwd ?? instance.cwd;
+      const connection = params.registeredRuntimeCwd
+        ? onlineConnectionForHost(connections, host)
+        : connections.find(
+            (candidate) =>
+              candidate.host === host &&
+              candidate.cwd === cwd &&
+              candidate.effectiveStatus === "online",
+          );
+      return {
+        actorUserUuid: params.actorUserUuid,
+        source:
+          params.registeredSource === "project_fixed"
+            ? "project_fixed"
+            : "registered_instance",
+        agentUuid: params.agentUuid,
+        host,
+        cwd,
+        availability: connection ? "ready" : "offline",
+        promptPolicy:
+          params.registeredSource === "project_fixed" ? "suppress" : "none",
+        connectionUuid: connection?.uuid ?? null,
+        agentInstanceUuid: instance.uuid,
+      };
+    }
+    return {
+      actorUserUuid: params.actorUserUuid,
+      source:
+        params.registeredSource === "project_fixed"
+          ? "project_fixed"
+          : "registered_instance",
+      agentUuid: params.agentUuid,
+      host: null,
+      cwd: null,
+      availability: "invalid",
+      promptPolicy:
+        params.registeredSource === "project_fixed" ? "suppress" : "none",
+      connectionUuid: null,
+      agentInstanceUuid: params.registeredInstanceUuid,
+    };
+  }
+
+  if (preference) {
+    if (!preference.host || !preference.cwd) {
+      return {
+        actorUserUuid: params.actorUserUuid,
+        source: "project_fixed",
+        agentUuid: params.agentUuid,
+        host: preference.host || null,
+        cwd: preference.cwd || null,
+        availability: "invalid",
+        promptPolicy: "suppress",
+        connectionUuid: null,
+        agentInstanceUuid: preference.anchorAgentInstanceUuid,
+      };
+    }
+    const agentInstanceUuid = await materializeAgentInstance(
+      params.companyUuid,
+      params.agentUuid,
+      preference.host,
+      preference.cwd,
+    );
+    if (preference.anchorAgentInstanceUuid !== agentInstanceUuid) {
+      await prisma.projectAgentCwdPreference.update({
+        where: { uuid: preference.uuid },
+        data: { anchorAgentInstanceUuid: agentInstanceUuid },
+      });
+    }
+    const connection = onlineConnectionForHost(connections, preference.host);
+    return {
+      actorUserUuid: params.actorUserUuid,
+      source: "project_fixed",
+      agentUuid: params.agentUuid,
+      host: preference.host,
+      cwd: preference.cwd,
+      availability: connection ? "ready" : "offline",
+      promptPolicy: "suppress",
+      connectionUuid: connection?.uuid ?? null,
+      agentInstanceUuid,
+    };
+  }
+
+  if (params.temporaryTarget) {
+    const connection = onlineConnectionForHost(
+      connections,
+      params.temporaryTarget.host,
+    );
+    return {
+      actorUserUuid: params.actorUserUuid,
+      source: "temporary",
+      agentUuid: params.agentUuid,
+      host: params.temporaryTarget.host,
+      cwd: params.temporaryTarget.cwd,
+      availability: connection ? "ready" : "offline",
+      promptPolicy: "none",
+      connectionUuid: connection?.uuid ?? null,
+      agentInstanceUuid: null,
+    };
+  }
+
+  const onlineFirst =
+    connections.find((connection) => connection.effectiveStatus === "online") ??
+    null;
+  return {
+    actorUserUuid: params.actorUserUuid,
+    source: "unconfigured",
+    agentUuid: params.agentUuid,
+    host: null,
+    cwd: null,
+    availability: onlineFirst ? "ready" : "offline",
+    promptPolicy: "select",
+    connectionUuid: onlineFirst?.uuid ?? null,
+    agentInstanceUuid: null,
+  };
 }
 
 export async function listProjectAgentCwdPreferences(
@@ -323,9 +547,15 @@ export async function saveProjectAgentCwdPreference(params: {
       companyUuid: params.companyUuid,
       agentUuid: params.agentUuid,
     },
-    select: { host: true, agentInstanceUuid: true },
+    select: { host: true },
   });
   if (!connection) throw new CwdServiceError("STALE_TARGET", "Validation target is stale");
+  const anchorAgentInstanceUuid = await materializeAgentInstance(
+    params.companyUuid,
+    params.agentUuid,
+    connection.host,
+    normalizedCwd,
+  );
   return prisma.projectAgentCwdPreference.upsert({
     where: {
       userUuid_projectUuid_agentUuid: {
@@ -341,12 +571,12 @@ export async function saveProjectAgentCwdPreference(params: {
       agentUuid: params.agentUuid,
       host: connection.host,
       cwd: normalizedCwd,
-      anchorAgentInstanceUuid: connection.agentInstanceUuid,
+      anchorAgentInstanceUuid,
     },
     update: {
       host: connection.host,
       cwd: normalizedCwd,
-      anchorAgentInstanceUuid: connection.agentInstanceUuid,
+      anchorAgentInstanceUuid,
     },
   });
 }

--- a/src/services/project-agent-cwd.service.ts
+++ b/src/services/project-agent-cwd.service.ts
@@ -59,6 +59,11 @@ const VALIDATION_FRESH_MS = 60_000;
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
+export interface ProjectAgentCwdDraftInput {
+  agentUuid: string;
+  validationRequestUuid: string;
+}
+
 async function requireOwnedAgent(companyUuid: string, userUuid: string, agentUuid: string) {
   const agent = await prisma.agent.findFirst({
     where: { uuid: agentUuid, companyUuid, ownerUuid: userUuid },
@@ -102,6 +107,112 @@ async function materializeAgentInstance(
     select: { uuid: true },
   });
   return row.uuid;
+}
+
+async function resolveValidatedPreference(params: {
+  companyUuid: string;
+  userUuid: string;
+  agentUuid: string;
+  validationRequestUuid: string;
+}) {
+  await requireOwnedAgent(params.companyUuid, params.userUuid, params.agentUuid);
+  const validation = await prisma.daemonDirectoryRequest.findFirst({
+    where: {
+      uuid: params.validationRequestUuid,
+      companyUuid: params.companyUuid,
+      callerUserUuid: params.userUuid,
+      agentUuid: params.agentUuid,
+      operation: "validate",
+      status: "success",
+      completedAt: { gte: new Date(Date.now() - VALIDATION_FRESH_MS) },
+    },
+  });
+  const cwd =
+    validation?.result &&
+    typeof validation.result === "object" &&
+    !Array.isArray(validation.result) &&
+    typeof (validation.result as { normalizedPath?: unknown }).normalizedPath === "string"
+      ? (validation.result as { normalizedPath: string }).normalizedPath
+      : null;
+  if (!validation || !cwd) {
+    throw new CwdServiceError("STALE_TARGET", "Fresh successful validation required");
+  }
+  const connection = await prisma.daemonConnection.findFirst({
+    where: {
+      uuid: validation.targetConnectionUuid,
+      companyUuid: params.companyUuid,
+      agentUuid: params.agentUuid,
+    },
+    select: { host: true },
+  });
+  if (!connection) throw new CwdServiceError("STALE_TARGET", "Validation target is stale");
+  return { agentUuid: params.agentUuid, host: connection.host, cwd };
+}
+
+export async function createProjectWithAgentCwds(params: {
+  companyUuid: string;
+  userUuid: string;
+  name: string;
+  description: string | null;
+  groupUuid: string | null;
+  agentCwds: ProjectAgentCwdDraftInput[];
+}) {
+  const targets = await Promise.all(
+    params.agentCwds.map((draft) => resolveValidatedPreference({
+      companyUuid: params.companyUuid,
+      userUuid: params.userUuid,
+      ...draft,
+    })),
+  );
+  return prisma.$transaction(async (tx) => {
+    const project = await tx.project.create({
+      data: {
+        companyUuid: params.companyUuid,
+        name: params.name,
+        description: params.description,
+        groupUuid: params.groupUuid,
+      },
+      select: {
+        uuid: true,
+        name: true,
+        description: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    for (const target of targets) {
+      const instance = await tx.agentInstance.upsert({
+        where: {
+          companyUuid_agentUuid_host_cwd: {
+            companyUuid: params.companyUuid,
+            agentUuid: target.agentUuid,
+            host: target.host,
+            cwd: target.cwd,
+          },
+        },
+        create: {
+          companyUuid: params.companyUuid,
+          agentUuid: target.agentUuid,
+          host: target.host,
+          cwd: target.cwd,
+        },
+        update: { updatedAt: new Date() },
+        select: { uuid: true },
+      });
+      await tx.projectAgentCwdPreference.create({
+        data: {
+          companyUuid: params.companyUuid,
+          userUuid: params.userUuid,
+          projectUuid: project.uuid,
+          agentUuid: target.agentUuid,
+          host: target.host,
+          cwd: target.cwd,
+          anchorAgentInstanceUuid: instance.uuid,
+        },
+      });
+    }
+    return project;
+  });
 }
 
 /**

--- a/src/services/stage-advance.service.ts
+++ b/src/services/stage-advance.service.ts
@@ -22,7 +22,10 @@ import { prisma } from "@/lib/prisma";
 import { eventBus } from "@/lib/event-bus";
 import { activityService } from "@/services";
 import { resolveAssigneeAgentUuid } from "@/lib/uuid-resolver";
-import { STALE_THRESHOLD_MS } from "@/services/daemon-connection.service";
+import {
+  resolveProjectAgentCwdTarget,
+  type ResolvedProjectAgentCwdTarget,
+} from "@/services/project-agent-cwd.service";
 
 // Machine-readable failure codes so callers (server actions) can map each
 // failure to a distinct i18n message instead of parsing error prose.
@@ -69,6 +72,9 @@ export interface StageAdvanceIdea {
   elaborationStatus: string | null;
   assigneeType: string | null;
   assigneeUuid: string | null;
+  cwdSource: string | null;
+  cwdHost: string | null;
+  runtimeCwd: string | null;
 }
 
 export interface StageAdvanceContext {
@@ -102,78 +108,6 @@ export interface StageAdvanceDefinition {
  * connection of the owning agent qualifies: a bare-agent wake goes online-first, so the
  * wake chokepoint's session-origin upgrade picks the right cwd, not this gate.
  */
-async function hasEffectivelyOnlineConnection(agentUuid: string): Promise<boolean> {
-  const staleFloor = new Date(Date.now() - STALE_THRESHOLD_MS);
-  const online = await prisma.daemonConnection.findFirst({
-    where: {
-      agentUuid,
-      status: "online",
-      lastSeenAt: { gte: staleFloor },
-    },
-    select: { uuid: true },
-  });
-  return online !== null;
-}
-
-async function hasEffectivelyOnlineFixedCwdHost(
-  companyUuid: string,
-  userUuid: string,
-  projectUuid: string,
-  agentUuid: string,
-): Promise<boolean | null> {
-  const preference = await prisma.projectAgentCwdPreference.findFirst({
-    where: { companyUuid, userUuid, projectUuid, agentUuid },
-    select: { host: true },
-  });
-  if (!preference) return null;
-
-  const staleFloor = new Date(Date.now() - STALE_THRESHOLD_MS);
-  const online = await prisma.daemonConnection.findFirst({
-    where: {
-      agentUuid,
-      host: preference.host,
-      status: "online",
-      lastSeenAt: { gte: staleFloor },
-    },
-    select: { uuid: true },
-  });
-  return online !== null;
-}
-
-/**
- * Effectively-online check for the `require_online` policy on an `agent_instance`-pinned
- * assignee — the HARD-pin case (pin-cwd-before-wake, owner choice B). The wake targets the
- * pinned instance's EXACT `(host, cwd)` and is notify-only (never re-routed) when that
- * place has no online connection, so require_online must verify THAT instance's own
- * connection — not merely that the agent has some online connection elsewhere. Resolves the
- * `AgentInstance.uuid` to its `(host, cwd)` place (company-scoped), then applies the same
- * liveness rule to a connection at that exact place. A stale/missing instance row → false
- * (treated as offline: the wake would find no place to land). The connection match uses the
- * registry's sentinels (host defaults to "", cwd nullable) exactly as the wake path does.
- */
-async function hasEffectivelyOnlineInstance(
-  companyUuid: string,
-  instanceUuid: string,
-): Promise<boolean> {
-  const instance = await prisma.agentInstance.findFirst({
-    where: { uuid: instanceUuid, companyUuid },
-    select: { agentUuid: true, host: true, cwd: true },
-  });
-  if (!instance) return false;
-  const staleFloor = new Date(Date.now() - STALE_THRESHOLD_MS);
-  const online = await prisma.daemonConnection.findFirst({
-    where: {
-      agentUuid: instance.agentUuid,
-      host: instance.host,
-      cwd: instance.cwd,
-      status: "online",
-      lastSeenAt: { gte: staleFloor },
-    },
-    select: { uuid: true },
-  });
-  return online !== null;
-}
-
 /**
  * Execute a stage-advance event. Ordered pipeline; a failure at any step emits
  * nothing (no transition, no activity):
@@ -230,16 +164,49 @@ export async function executeStageAdvance(
       elaborationStatus: idea.elaborationStatus,
       assigneeType: idea.assigneeType,
       assigneeUuid: idea.assigneeUuid,
+      cwdSource: idea.cwdSource,
+      cwdHost: idea.cwdHost,
+      runtimeCwd: idea.runtimeCwd,
     },
   };
 
   // 3. Per-stage precondition. Its return value becomes the activity payload.
+  const preconditionValue = await definition.precondition(ctx);
+
+  const agentUuid = await resolveAssigneeAgentUuid(
+    companyUuid,
+    ctx.idea.assigneeType,
+    ctx.idea.assigneeUuid,
+  );
+  let resolvedTarget: ResolvedProjectAgentCwdTarget | null = null;
+  if (agentUuid) {
+    resolvedTarget = await resolveProjectAgentCwdTarget({
+      companyUuid,
+      actorUserUuid: actorUuid,
+      projectUuid: ctx.idea.projectUuid,
+      agentUuid,
+      temporaryTarget: temporaryCwd,
+      registeredInstanceUuid:
+        ctx.idea.assigneeType === "agent_instance"
+          ? ctx.idea.assigneeUuid
+          : null,
+      registeredSource:
+        ctx.idea.cwdSource === "project_fixed" ? "project_fixed" : null,
+      registeredHost: ctx.idea.cwdHost,
+      registeredRuntimeCwd: ctx.idea.runtimeCwd,
+    });
+  }
   const activityValue = {
-    ...(await definition.precondition(ctx)),
-    ...(temporaryCwd
+    ...preconditionValue,
+    ...(resolvedTarget
       ? {
-          temporaryHost: temporaryCwd.host,
-          temporaryRuntimeCwd: temporaryCwd.cwd,
+          resolvedCwdActorUserUuid: resolvedTarget.actorUserUuid,
+          resolvedCwdSource: resolvedTarget.source,
+          resolvedCwdHost: resolvedTarget.host,
+          resolvedRuntimeCwd: resolvedTarget.cwd,
+          resolvedCwdAvailability: resolvedTarget.availability,
+          resolvedCwdPromptPolicy: resolvedTarget.promptPolicy,
+          resolvedCwdAgentInstanceUuid: resolvedTarget.agentInstanceUuid,
         }
       : {}),
   };
@@ -253,11 +220,6 @@ export async function executeStageAdvance(
   //   - bare `agent`: the wake goes online-first, so ANY online connection of the agent
   //     suffices → AGENT_OFFLINE when none.
   if (definition.offlinePolicy === "require_online") {
-    const agentUuid = await resolveAssigneeAgentUuid(
-      companyUuid,
-      ctx.idea.assigneeType,
-      ctx.idea.assigneeUuid
-    );
     if (!agentUuid) {
       if (ctx.idea.assigneeType === "agent_instance") {
         throw new StageAdvanceError(
@@ -271,38 +233,27 @@ export async function executeStageAdvance(
       );
     }
 
-    // Project fixed cwd is the highest-priority wake pin, including when the Idea
-    // itself is assigned to an AgentInstance. Match notification-turn's routing
-    // order so this gate checks the place the wake will actually target.
-    const fixedHostOnline = await hasEffectivelyOnlineFixedCwdHost(
-      companyUuid,
-      actorUuid,
-      ctx.idea.projectUuid,
-      agentUuid,
-    );
-    if (fixedHostOnline === false) {
+    if (
+      resolvedTarget?.source === "project_fixed" &&
+      resolvedTarget.availability !== "ready"
+    ) {
       throw new StageAdvanceError(
         "FIXED_CWD_HOST_OFFLINE",
-        "The project's fixed cwd host has no online daemon connection"
+        "The project's fixed cwd target is unavailable",
       );
     }
-
     if (
-      fixedHostOnline === null &&
-      ctx.idea.assigneeType === "agent_instance" &&
-      ctx.idea.assigneeUuid
+      resolvedTarget?.source === "registered_instance" &&
+      resolvedTarget.availability !== "ready"
     ) {
-      if (
-        !(await hasEffectivelyOnlineInstance(companyUuid, ctx.idea.assigneeUuid))
-      ) {
-        throw new StageAdvanceError(
-          "INSTANCE_OFFLINE",
-          "The Idea is pinned to a daemon instance that has no online connection"
-        );
-      }
-    } else if (
-      fixedHostOnline === null &&
-      !(await hasEffectivelyOnlineConnection(agentUuid))
+      throw new StageAdvanceError(
+        "INSTANCE_OFFLINE",
+        "The Idea is pinned to a daemon instance that has no online connection",
+      );
+    }
+    if (
+      resolvedTarget?.source === "unconfigured" &&
+      !resolvedTarget.connectionUuid
     ) {
       throw new StageAdvanceError(
         "AGENT_OFFLINE",

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -55,6 +55,9 @@ export interface TaskClaimParams {
   // task has no override (assigneeType="agent") and its wake-time instance is
   // inherited from the root idea by the wake path (T6) — not resolved here.
   instanceUuid?: string | null;
+  cwdSource?: string | null;
+  cwdHost?: string | null;
+  runtimeCwd?: string | null;
 }
 
 export interface TaskUpdateParams {
@@ -654,6 +657,9 @@ export async function claimTask({
   assigneeUuid,
   assignedByUuid,
   instanceUuid,
+  cwdSource,
+  cwdHost,
+  runtimeCwd,
 }: TaskClaimParams): Promise<TaskResponse> {
   try {
     // Apply an optional durable instance override pin (validates company
@@ -668,6 +674,9 @@ export async function claimTask({
         status: "assigned",
         assigneeType: resolved.assigneeType,
         assigneeUuid: resolved.assigneeUuid,
+        cwdSource: runtimeCwd && cwdSource?.trim() ? cwdSource : null,
+        cwdHost: runtimeCwd ? cwdHost : null,
+        runtimeCwd: runtimeCwd ?? null,
         assignedAt: new Date(),
         assignedByUuid,
       },
@@ -696,6 +705,9 @@ export async function releaseTask(uuid: string): Promise<TaskResponse> {
         status: "open",
         assigneeType: null,
         assigneeUuid: null,
+        cwdSource: null,
+        cwdHost: null,
+        runtimeCwd: null,
         assignedAt: null,
         assignedByUuid: null,
       },

--- a/src/services/wake-preview.service.ts
+++ b/src/services/wake-preview.service.ts
@@ -43,6 +43,7 @@ import {
   listConnectionsForAgent,
   type ConnectionView,
 } from "@/services/daemon-connection.service";
+import { resolveProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
 // Type-only import (erased at compile) of the ONE canonical selectable-instance shape,
 // so the preview's `onlineInstances` are byte-compatible with what the InstancePicker
 // consumes and what a subsequent non-waking reassign persists (via `agentInstanceUuid`).
@@ -77,6 +78,7 @@ export interface WakeTargetPreview {
   outcome: WakeTargetOutcome;
   assigneeAgentUuid: string | null;
   onlineInstances: InstanceCandidate[];
+  resolvedTarget?: Awaited<ReturnType<typeof resolveProjectAgentCwdTarget>>;
 }
 
 /**
@@ -114,7 +116,14 @@ export async function previewIdeaWakeTarget(
   // cross-company read: an idea in another tenant simply is not returned.
   const idea = await prisma.idea.findFirst({
     where: { uuid: ideaUuid, companyUuid },
-    select: { assigneeType: true, assigneeUuid: true },
+    select: {
+      assigneeType: true,
+      assigneeUuid: true,
+      projectUuid: true,
+      cwdSource: true,
+      cwdHost: true,
+      runtimeCwd: true,
+    },
   });
   if (!idea) return null;
 
@@ -135,25 +144,20 @@ export async function previewIdeaWakeTarget(
   // Resolved BEFORE the connection read matters, but we still surface the agent's online
   // instances for completeness (the client ignores them on `direct`).
   const alreadyPinned = idea.assigneeType === "agent_instance";
-  const project =
-    userUuid && prisma.projectAgentCwdPreference
-      ? await prisma.idea.findFirst({
-          where: { uuid: ideaUuid, companyUuid },
-          select: { projectUuid: true },
-        })
-      : null;
-  const fixedPreference =
-    userUuid && project && prisma.projectAgentCwdPreference
-      ? await prisma.projectAgentCwdPreference.findFirst({
-          where: {
-            companyUuid,
-            userUuid,
-            projectUuid: project.projectUuid,
-            agentUuid: assigneeAgentUuid,
-          },
-          select: { uuid: true },
-        })
-      : null;
+  const resolvedTarget = userUuid
+    ? await resolveProjectAgentCwdTarget({
+        companyUuid,
+        actorUserUuid: userUuid,
+        projectUuid: idea.projectUuid,
+        agentUuid: assigneeAgentUuid,
+        registeredInstanceUuid:
+          idea.assigneeType === "agent_instance" ? idea.assigneeUuid : null,
+        registeredSource:
+          idea.cwdSource === "project_fixed" ? "project_fixed" : null,
+        registeredHost: idea.cwdHost,
+        registeredRuntimeCwd: idea.runtimeCwd,
+      })
+    : null;
 
   // (2) The agent's live registry (online-first sorted; carries effectiveStatus + the
   // durable agentInstanceUuid). Take the ONLINE subset as the picker candidates —
@@ -165,9 +169,14 @@ export async function previewIdeaWakeTarget(
   const onlineInstances = onlineConnections.map(toInstanceCandidate);
 
   // (3) The three-way decision tree (Tech Design D1), in exact priority order.
-  if (fixedPreference || alreadyPinned) {
+  if (resolvedTarget?.source === "project_fixed" || alreadyPinned) {
     // Already pinned to a specific instance → wake as-is.
-    return { outcome: "direct", assigneeAgentUuid, onlineInstances };
+    return {
+      outcome: "direct",
+      assigneeAgentUuid,
+      onlineInstances,
+      ...(resolvedTarget ? { resolvedTarget } : {}),
+    };
   }
   if (onlineConnections.length === 0) {
     // Nothing online to pick; the server handles the offline case at wake time.


### PR DESCRIPTION
## Summary
- centralize actor-bearing project Agent cwd resolution and persist immutable Idea/Task anchor snapshots
- route discovered non-startup cwd through an online same-host connection with `runtimeCwd`, preserving hard-pin and session stickiness
- suppress cwd pickers for fixed targets and show an accessible read-only host/cwd anchor across assignment and stage-entry surfaces
- add nullable assignment snapshot migration, OpenSpec contract, translations, and broad service/UI regression coverage

## Review and verification
- Claude Code headless review: PASS after two Quick Dev correction rounds
- Chorus aggregate code review: PASS (Round 2)
- full suite: 4,723 passed, 16 skipped
- TypeScript: passed
- focused ESLint and `git diff --check`: passed
- Playwright fixed/clear browser acceptance: passed
- AWS CDK deployment: complete
- production health: `status=ok`, database connected

## Deployment
- deployed to https://chorus.yfeichen.people.amazon.dev
- additive nullable migration applied through the production container entrypoint

## Chorus
- Idea: `5eb76ad5-769d-4c65-8e38-1e663272e1a2`
- Proposal: `dd6a1973-176a-4186-b383-6479f61adc11`

Generated with [Claude Code](https://claude.com/claude-code)