### PR TITLE
feat: allow idea reassignment across lifecycle

### DIFF
--- a/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/README.md
+++ b/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/README.md
@@ -1,0 +1,3 @@
+# reassign-idea-across-lifecycle
+
+Allow Idea assignees to be changed from the tracker at every lifecycle stage, including completed ideas.

--- a/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/design.md
+++ b/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/design.md
@@ -1,0 +1,89 @@
+## Context
+
+Idea assignment is gated independently in three places:
+
+1. `AssigneeSection` is passed `editable={idea.status !== "elaborated"}` by the
+   dashboard Idea detail panel.
+2. The Idea assignment server actions return an error before calling the
+   service when `status === "elaborated"`.
+3. `assignIdea` rejects elaborated Ideas except for the narrow same-agent
+   instance-repin path, while `releaseIdea` only accepts open or elaborating
+   Ideas.
+
+The stored lifecycle is separate from assignment fields, so no data migration
+is required.
+
+## Goals And Non-Goals
+
+### Goals
+
+- Make the dashboard assignee block open the existing assignment modal for all
+  lifecycle stages.
+- Permit existing assignment and release operations for elaborated Ideas.
+- Keep assignment audit activities and existing permission checks intact.
+- Leave Idea status and linked Proposal/Task assignees unchanged.
+
+### Non-Goals
+
+- Adding new assignable users or agents.
+- Changing who is authorized to assign an Idea.
+- Cascading ownership to linked entities.
+- Reopening a completed Idea.
+- Introducing additional assignment notifications.
+
+## Design
+
+### UI
+
+The dashboard Idea detail panel always passes `editable` to `AssigneeSection`
+when an `onReassign` handler is present. The component keeps its existing
+accessible button, tooltip, and assigned/unassigned labels. No new modal or
+control is introduced.
+
+The legacy `/ideas` detail panel retains its existing assignment entry point;
+the shared modal behavior changes through the server actions.
+
+### Server Actions
+
+Remove the elaborated-status short circuits from:
+
+- self assignment,
+- agent assignment,
+- user assignment, and
+- release.
+
+All existing authentication, company scoping, fixed-CWD resolution,
+revalidation, and activity creation remain unchanged.
+
+### Service Layer
+
+`assignIdea` continues to validate the target Idea and optional AgentInstance,
+then updates only assignment fields. The elaborated-status rejection is
+removed. The existing instance-repin option remains accepted for compatibility
+but is no longer needed to bypass a lifecycle guard.
+
+`releaseIdea` clears assignment fields without transitioning lifecycle state.
+It accepts elaborated Ideas in addition to open and elaborating Ideas.
+
+### State And Side Effects
+
+Assignment writes do not update `Idea.status`, `elaborationStatus`, Proposal
+rows, or Task rows. Existing `assigned` activities continue to provide the
+audit trail for assignment actions. Release keeps its current side effects.
+
+## Risks And Mitigations
+
+- **Unexpected workflow restart:** tests assert that assignment updates do not
+  write lifecycle fields.
+- **Ownership cascade:** focused service tests assert only the Idea assignment
+  fields are updated.
+- **Regression in instance pinning:** existing agent-instance tests continue to
+  cover fixed-CWD and company validation paths.
+- **Hidden UI gate remains:** the dashboard panel and `AssigneeSection` tests
+  cover elaborated Ideas explicitly.
+
+## Verification
+
+Run focused Vitest suites for the assignee section, dashboard detail panel,
+Idea actions, and Idea service. Then run TypeScript checks through the existing
+test/build tooling as practical.

--- a/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/proposal.md
+++ b/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Idea Tracker currently disables its assignee control after an Idea reaches the
+`elaborated` lifecycle state. The server actions and service layer enforce the
+same restriction, so completed Ideas cannot be moved to a different owner for
+maintenance, attribution, or follow-up work.
+
+## What Changes
+
+- Keep the assignee block interactive for every Idea lifecycle stage.
+- Allow the existing self, agent, user, and release assignment paths to operate
+  on elaborated Ideas.
+- Reuse the current candidate lists, authorization checks, instance pin
+  resolution, activity recording, and wake behavior.
+- Preserve the Idea's lifecycle and derived status when its assignee changes.
+- Do not cascade an Idea assignment change to linked Proposals or Tasks.
+- Add focused UI, server-action, and service regression tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `idea-lifecycle-assignment`: Reassign or release an Idea at any lifecycle
+  stage without changing its workflow state or linked work ownership.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+The change affects the dashboard Idea detail assignee control, Idea assignment
+server actions, and the core Idea assignment/release service guards. It does
+not change schemas, candidate discovery, role permissions, Proposal ownership,
+Task ownership, or lifecycle transition rules.

--- a/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/specs/idea-lifecycle-assignment/spec.md
+++ b/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/specs/idea-lifecycle-assignment/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Idea assignment remains available across lifecycle stages
+
+The system SHALL allow an authorized user to open the existing Idea assignment
+control and assign an Idea to any candidate allowed by the current assignment
+rules, regardless of whether the Idea is open, elaborating, elaborated, or
+derived as complete.
+
+#### Scenario: Reassign an elaborated Idea
+
+- **WHEN** an authorized user opens an elaborated Idea in the Idea Tracker and
+  clicks its assignee block
+- **THEN** the existing assignment modal opens
+- **AND** selecting a valid user, agent, or agent instance updates the Idea
+  assignee
+
+#### Scenario: Release an elaborated Idea
+
+- **WHEN** an authorized user selects Release for an elaborated Idea
+- **THEN** the Idea assignee is cleared
+- **AND** the Idea remains elaborated
+
+### Requirement: Reassignment preserves workflow and linked ownership
+
+Changing an Idea assignee MUST update only the Idea assignment and its existing
+audit metadata. It MUST NOT change the Idea lifecycle state or the assignees of
+linked Proposals and Tasks.
+
+#### Scenario: Completed Idea remains complete after reassignment
+
+- **WHEN** an Idea whose derived status is complete is reassigned
+- **THEN** its stored lifecycle and derived completion status remain unchanged
+- **AND** an assignment activity is recorded through the existing activity path
+
+#### Scenario: Linked work ownership is unchanged
+
+- **WHEN** an Idea with linked Proposals or Tasks is reassigned
+- **THEN** no linked Proposal or Task assignee is modified
+
+### Requirement: Existing assignment policy remains authoritative
+
+Lifecycle-wide assignment SHALL reuse the current authentication,
+authorization, company scoping, candidate selection, and AgentInstance
+validation rules.
+
+#### Scenario: Invalid target remains rejected
+
+- **WHEN** a caller attempts to assign an Idea to a target rejected by the
+  current assignment policy
+- **THEN** the assignment fails without changing the Idea assignee or lifecycle
+  state

--- a/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/tasks.md
+++ b/openspec/changes/archive/2026-08-04-reassign-idea-across-lifecycle/tasks.md
@@ -1,0 +1,12 @@
+## 1. Enable lifecycle-wide assignment
+
+- [x] 1.1 Remove elaborated-stage UI gating from the Idea Tracker assignee block.
+- [x] 1.2 Remove elaborated-stage short circuits from Idea assignment actions.
+- [x] 1.3 Allow assign and release service operations for elaborated Ideas.
+
+## 2. Verify behavior
+
+- [x] 2.1 Add UI coverage for an interactive elaborated Idea assignee block.
+- [x] 2.2 Add action coverage for assigning and releasing elaborated Ideas.
+- [x] 2.3 Add service coverage that lifecycle state is preserved.
+- [x] 2.4 Run focused tests and OpenSpec validation.

--- a/openspec/specs/idea-lifecycle-assignment/spec.md
+++ b/openspec/specs/idea-lifecycle-assignment/spec.md
@@ -1,0 +1,55 @@
+# idea-lifecycle-assignment Specification
+
+## Purpose
+TBD - created by archiving change reassign-idea-across-lifecycle. Update Purpose after archive.
+## Requirements
+### Requirement: Idea assignment remains available across lifecycle stages
+
+The system SHALL allow an authorized user to open the existing Idea assignment
+control and assign an Idea to any candidate allowed by the current assignment
+rules, regardless of whether the Idea is open, elaborating, elaborated, or
+derived as complete.
+
+#### Scenario: Reassign an elaborated Idea
+
+- **WHEN** an authorized user opens an elaborated Idea in the Idea Tracker and
+  clicks its assignee block
+- **THEN** the existing assignment modal opens
+- **AND** selecting a valid user, agent, or agent instance updates the Idea
+  assignee
+
+#### Scenario: Release an elaborated Idea
+
+- **WHEN** an authorized user selects Release for an elaborated Idea
+- **THEN** the Idea assignee is cleared
+- **AND** the Idea remains elaborated
+
+### Requirement: Reassignment preserves workflow and linked ownership
+
+Changing an Idea assignee MUST update only the Idea assignment and its existing
+audit metadata. It MUST NOT change the Idea lifecycle state or the assignees of
+linked Proposals and Tasks.
+
+#### Scenario: Completed Idea remains complete after reassignment
+
+- **WHEN** an Idea whose derived status is complete is reassigned
+- **THEN** its stored lifecycle and derived completion status remain unchanged
+- **AND** an assignment activity is recorded through the existing activity path
+
+#### Scenario: Linked work ownership is unchanged
+
+- **WHEN** an Idea with linked Proposals or Tasks is reassigned
+- **THEN** no linked Proposal or Task assignee is modified
+
+### Requirement: Existing assignment policy remains authoritative
+
+Lifecycle-wide assignment SHALL reuse the current authentication,
+authorization, company scoping, candidate selection, and AgentInstance
+validation rules.
+
+#### Scenario: Invalid target remains rejected
+
+- **WHEN** a caller attempts to assign an Idea to a target rejected by the
+  current assignment policy
+- **THEN** the assignment fails without changing the Idea assignee or lifecycle
+  state

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/assignee-section.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/assignee-section.test.tsx
@@ -5,7 +5,7 @@
 // both provided it renders as a clickable button (with an accessible
 // reassign/assign label) whose click invokes onReassign; otherwise it renders
 // as a non-interactive block (default render unchanged), so callers that omit
-// the props — and the elaborated (read-only) state — get no reassign entry.
+// the props get no reassign entry.
 
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -90,7 +90,7 @@ describe("AssigneeSection — reassign trigger", () => {
     expect(onReassign).toHaveBeenCalledTimes(1);
   });
 
-  it("renders non-interactively when editable is false (elaborated / read-only)", () => {
+  it("renders non-interactively when editable is false", () => {
     const onReassign = vi.fn();
     render(
       <AssigneeSection assignee={agentAssignee} editable={false} onReassign={onReassign} />

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
@@ -58,7 +58,11 @@ vi.mock("@/contexts/realtime-context", () => ({
 }));
 
 // Stub the tab/child views — they fetch their own data and are out of scope here.
-vi.mock("../elaboration-view", () => ({ ElaborationView: () => <div data-testid="elaboration-view" /> }));
+vi.mock("../elaboration-view", () => ({
+  ElaborationView: ({ canReassign }: { canReassign?: boolean }) => (
+    <div data-testid="elaboration-view" data-can-reassign={String(canReassign)} />
+  ),
+}));
 vi.mock("../proposal-view", () => ({ ProposalView: () => <div /> }));
 vi.mock("../overview-timeline", () => ({ OverviewTimeline: () => <div /> }));
 vi.mock("../reports-list", () => ({ ReportsList: () => <div /> }));
@@ -198,6 +202,17 @@ beforeEach(() => {
 });
 
 describe("dashboard IdeaDetailPanel — Verify Elaborate footer button", () => {
+  it.each(["open", "elaborating", "elaborated"])(
+    "keeps the assignee control interactive for %s Ideas",
+    async (status) => {
+      getIdeaActionMock.mockResolvedValue(ideaResponse({ status }));
+      renderPanel();
+      expect(
+        (await screen.findByTestId("elaboration-view")).getAttribute("data-can-reassign"),
+      ).toBe("true");
+    },
+  );
+
   it("renders an enabled Verify Elaborate button when every round is answered", async () => {
     renderPanel();
     const btn = (await screen.findByRole("button", { name: "Verify Elaborate" })) as HTMLButtonElement;

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/assignee-section.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/assignee-section.tsx
@@ -25,17 +25,14 @@ interface AssigneeSectionProps {
   // it calls onReassign (opens the assign modal). This replaces the panel's old
   // footer reassign button — the entry point now lives on the assignee itself.
   onReassign?: () => void;
-  // Gates the trigger the same way the removed footer button was gated
-  // (idea.status !== "elaborated"). When false/omitted the box is read-only.
+  // When false/omitted the box is read-only.
   editable?: boolean;
 }
 
 export function AssigneeSection({ assignee, onReassign, editable }: AssigneeSectionProps) {
   const tCommon = useTranslations("common");
 
-  // The reassign entry is active only while editable AND a handler is wired —
-  // read-only usages (e.g. an elaborated idea, or callers that omit the props)
-  // render exactly as before.
+  // The reassign entry is active only while editable AND a handler is wired.
   const interactive = editable === true && typeof onReassign === "function";
   const actionLabel = assignee ? tCommon("reassign") : tCommon("assign");
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -599,7 +599,7 @@ export function IdeaDetailPanel({
 
   const status = idea?.derivedStatus || "todo";
   const isContainer = idea?.isContainer === true;
-  const canAssign = idea ? idea.status !== "elaborated" : false;
+  const canAssign = idea !== null;
   // Shared enable-predicate (same helper as the /ideas idea-detail panel) so
   // the two surfaces never drift.
   const canVerify = canVerifyElaboration({

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/__tests__/reassign-instance-actions.test.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/__tests__/reassign-instance-actions.test.ts
@@ -7,12 +7,13 @@ vi.mock("@/lib/auth-server", () => ({
 }));
 
 const mockAssignIdea = vi.hoisted(() => vi.fn());
+const mockReleaseIdea = vi.hoisted(() => vi.fn());
 const mockGetIdeaByUuid = vi.hoisted(() => vi.fn());
 vi.mock("@/services/idea.service", () => ({
   // Sibling actions in the same module import these; stub them so the module
   // loads without pulling in prisma transitively.
   assignIdea: mockAssignIdea,
-  releaseIdea: vi.fn(),
+  releaseIdea: mockReleaseIdea,
   getIdeaByUuid: mockGetIdeaByUuid,
 }));
 
@@ -53,8 +54,11 @@ vi.mock("@/lib/logger", () => {
 });
 
 import {
+  claimIdeaAction,
   claimIdeaToAgentAction,
+  claimIdeaToUserAction,
   reassignIdeaInstanceNoWakeAction,
+  releaseIdeaAction,
 } from "../actions";
 
 const COMPANY_A = "company-a";
@@ -142,10 +146,7 @@ describe("reassignIdeaInstanceNoWakeAction", () => {
 
     expect(result).toEqual({ success: true });
     // Threads the durable instance pin into the non-waking service primitive so
-    // it promotes the row to assigneeType="agent_instance". Passes
-    // allowElaboratedInstanceRepin so a same-owning-agent cwd re-pin is honored
-    // even on an elaborated idea (the pin-then-wake surfaces act on elaborated
-    // ideas); assignIdea still enforces the same-agent guard for that exception.
+    // it promotes the row to assigneeType="agent_instance".
     expect(mockAssignIdea).toHaveBeenCalledTimes(1);
     expect(mockAssignIdea).toHaveBeenCalledWith({
       ideaUuid: IDEA_UUID,
@@ -199,12 +200,7 @@ describe("reassignIdeaInstanceNoWakeAction", () => {
     expect(mockCreateActivity).not.toHaveBeenCalled();
   });
 
-  it("delegates an elaborated idea to assignIdea with the same-agent re-pin flag (does NOT short-circuit)", async () => {
-    // The pin-then-wake surfaces (Start Development / Yolo / proposal
-    // approve-reject) act on ELABORATED ideas, so this action must NOT reject
-    // them up front — it delegates to assignIdea, opting into the narrow
-    // same-owning-agent cwd re-pin exception. assignIdea itself enforces that the
-    // instance belongs to the idea's current assignee agent.
+  it("delegates an elaborated idea to assignIdea", async () => {
     mockGetServerAuthContext.mockResolvedValue(humanAuth());
     mockGetIdeaByUuid.mockResolvedValue(makeIdeaRow({ status: "elaborated" }));
     mockAssignIdea.mockResolvedValue(undefined);
@@ -229,13 +225,10 @@ describe("reassignIdeaInstanceNoWakeAction", () => {
     expect(mockCreateActivity).not.toHaveBeenCalled();
   });
 
-  it("surfaces a clean error when assignIdea rejects a cross-agent re-pin on an elaborated idea", async () => {
-    // assignIdea throws "Cannot assign an elaborated Idea" when the instance's
-    // owning agent is NOT the idea's assignee agent (the same-agent guard fails).
-    // The action must surface a clean error without leaking the raw message.
+  it("surfaces a clean error when assignIdea rejects an invalid instance", async () => {
     mockGetServerAuthContext.mockResolvedValue(humanAuth());
     mockGetIdeaByUuid.mockResolvedValue(makeIdeaRow({ status: "elaborated" }));
-    mockAssignIdea.mockRejectedValue(new Error("Cannot assign an elaborated Idea"));
+    mockAssignIdea.mockRejectedValue(new Error("Agent instance not found"));
 
     const result = await reassignIdeaInstanceNoWakeAction(
       IDEA_UUID,
@@ -246,6 +239,52 @@ describe("reassignIdeaInstanceNoWakeAction", () => {
     expect(result).toEqual({ success: false, error: "Failed to reassign idea" });
     expect(mockCreateActivity).not.toHaveBeenCalled();
     expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe("elaborated Idea assignment actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerAuthContext.mockResolvedValue(humanAuth());
+    mockGetIdeaByUuid.mockResolvedValue(makeIdeaRow({ status: "elaborated" }));
+    mockAssignIdea.mockResolvedValue(undefined);
+    mockReleaseIdea.mockResolvedValue(undefined);
+    mockCreateActivity.mockResolvedValue(undefined);
+    mockResolveProjectAgentCwdTarget.mockResolvedValue({ source: "none" });
+  });
+
+  it("allows self assignment and records the existing assignment activity", async () => {
+    expect(await claimIdeaAction(IDEA_UUID)).toEqual({ success: true });
+    expect(mockAssignIdea).toHaveBeenCalledWith(expect.objectContaining({
+      ideaUuid: IDEA_UUID,
+      assigneeType: "user",
+      assigneeUuid: "user-1",
+    }));
+    expect(mockCreateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "assigned" }),
+    );
+  });
+
+  it("allows agent assignment with existing target resolution", async () => {
+    expect(await claimIdeaToAgentAction(IDEA_UUID, AGENT_UUID)).toEqual({ success: true });
+    expect(mockResolveProjectAgentCwdTarget).toHaveBeenCalled();
+    expect(mockAssignIdea).toHaveBeenCalledWith(expect.objectContaining({
+      assigneeType: "agent",
+      assigneeUuid: AGENT_UUID,
+    }));
+  });
+
+  it("allows user assignment", async () => {
+    expect(await claimIdeaToUserAction(IDEA_UUID, "user-2")).toEqual({ success: true });
+    expect(mockAssignIdea).toHaveBeenCalledWith(expect.objectContaining({
+      assigneeType: "user",
+      assigneeUuid: "user-2",
+    }));
+  });
+
+  it("allows release", async () => {
+    expect(await releaseIdeaAction(IDEA_UUID)).toEqual({ success: true });
+    expect(mockReleaseIdea).toHaveBeenCalledWith(IDEA_UUID);
   });
 });
 

--- a/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions.ts
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions.ts
@@ -26,11 +26,6 @@ export async function claimIdeaAction(ideaUuid: string) {
       return { success: false, error: "Idea not found" };
     }
 
-    // Elaborated ideas cannot be reassigned (lifecycle is done)
-    if (idea.status === "elaborated") {
-      return { success: false, error: "Idea is not available for assignment" };
-    }
-
     await assignIdea({
       ideaUuid,
       companyUuid: auth.companyUuid,
@@ -82,11 +77,6 @@ export async function claimIdeaToAgentAction(
     const idea = await getIdeaByUuid(auth.companyUuid, ideaUuid);
     if (!idea) {
       return { success: false, error: "Idea not found" };
-    }
-
-    // Elaborated ideas cannot be reassigned (lifecycle is done)
-    if (idea.status === "elaborated") {
-      return { success: false, error: "Idea is not available for assignment" };
     }
 
     const target = await resolveProjectAgentCwdTarget({
@@ -171,15 +161,6 @@ export async function reassignIdeaInstanceNoWakeAction(
       return { success: false, error: "Idea not found" };
     }
 
-    // NOTE: no status short-circuit here. This action is the pin step of the
-    // pin-then-wake flow, and its wake surfaces (Start Development / Yolo /
-    // proposal approve-reject) act on ALREADY-elaborated ideas — the pin MUST
-    // persist there for the wake to run in the chosen cwd. `assignIdea` still
-    // rejects an elaborated idea for a genuine REASSIGNMENT; we opt into the
-    // narrow same-owning-agent cwd re-pin exception via
-    // `allowElaboratedInstanceRepin` so a different agent can never be pinned
-    // onto an elaborated idea through this path.
-    //
     // Promote to agent_instance via the non-waking service primitive. A foreign
     // or missing instance is rejected inside assignIdea (resolveAssigneeFields
     // throws) BEFORE any assignee write, so the assignee is left unchanged.
@@ -219,11 +200,6 @@ export async function claimIdeaToUserAction(ideaUuid: string, userUuid: string) 
       return { success: false, error: "Idea not found" };
     }
 
-    // Elaborated ideas cannot be reassigned (lifecycle is done)
-    if (idea.status === "elaborated") {
-      return { success: false, error: "Idea is not available for assignment" };
-    }
-
     await assignIdea({
       ideaUuid,
       companyUuid: auth.companyUuid,
@@ -242,7 +218,7 @@ export async function claimIdeaToUserAction(ideaUuid: string, userUuid: string) 
   }
 }
 
-// Release idea (clear assignee, back to open)
+// Release idea (clear assignee; completed lifecycle state is preserved)
 export async function releaseIdeaAction(ideaUuid: string) {
   const auth = await getServerAuthContext();
   if (!auth) {
@@ -253,11 +229,6 @@ export async function releaseIdeaAction(ideaUuid: string) {
     const idea = await getIdeaByUuid(auth.companyUuid, ideaUuid);
     if (!idea) {
       return { success: false, error: "Idea not found" };
-    }
-
-    // Elaborated ideas cannot be released (lifecycle is done)
-    if (idea.status === "elaborated") {
-      return { success: false, error: "Idea cannot be released from current status" };
     }
 
     await releaseIdea(idea.uuid);

--- a/src/app/(dashboard)/projects/[uuid]/ideas/__tests__/idea-detail-verify.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/__tests__/idea-detail-verify.test.tsx
@@ -63,8 +63,14 @@ vi.mock("@/components/unified-comments", () => ({ UnifiedComments: () => <div />
 vi.mock("@/components/references-section", () => ({ ReferencesSection: () => <div /> }));
 vi.mock("@/components/markdown-content", () => ({ MarkdownContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
 vi.mock("@/components/mention-renderer", () => ({ ContentWithMentions: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
-vi.mock("./assign-idea-modal", () => ({ AssignIdeaModal: () => <div /> }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal", () => ({
+  AssignIdeaModal: () => <div data-testid="assign-idea-modal" />,
+}));
 vi.mock("@/app/(dashboard)/projects/[uuid]/dashboard/panels/move-idea-dialog", () => ({ MoveIdeaDialog: () => <div /> }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/dashboard/panels/actions", () => ({
+  getProposalsForIdeaAction: vi.fn().mockResolvedValue({ success: true, data: [] }),
+  getTasksForProposalAction: vi.fn().mockResolvedValue({ success: true, data: [] }),
+}));
 
 vi.mock("next-intl", async () => {
   const en = (await import("../../../../../../../messages/en.json")).default as Record<string, unknown>;
@@ -171,6 +177,18 @@ beforeEach(() => {
 });
 
 describe("/ideas IdeaDetailPanel — Verify Elaborate replaces Create Proposal", () => {
+  it("keeps reassignment available for an elaborated Idea and opens the modal", async () => {
+    const user = userEvent.setup();
+    renderPanel({ status: "elaborated", elaborationStatus: "resolved" });
+
+    const reassign = await screen.findByRole("button", { name: "Reassign" });
+    expect(screen.queryByTestId("assign-idea-modal")).toBeNull();
+
+    await user.click(reassign);
+
+    expect(screen.getByTestId("assign-idea-modal")).toBeTruthy();
+  });
+
   it("renders an enabled Verify Elaborate button when every round is answered", async () => {
     renderPanel();
     const btn = (await screen.findByRole("button", { name: "Verify Elaborate" })) as HTMLButtonElement;

--- a/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/ideas/idea-detail-panel.tsx
@@ -275,7 +275,6 @@ export function IdeaDetailPanel({
     return () => clearTimeout(timer);
   }, []);
 
-  const canAssign = idea.status !== "elaborated";
   // Shared enable-predicate (also used by the dashboard idea-tracker panel) so
   // the two surfaces never drift. Computed from the elaboration data already
   // loaded into this panel — no extra fetch.
@@ -692,29 +691,27 @@ export function IdeaDetailPanel({
               </>
             ) : (
               <>
-                {canAssign && (
-                  // Icon-only (Option C — declutter the action row): the (re)assign
-                  // label rides a shadcn Tooltip (+ aria-label for a11y) so the
-                  // stage primary CTA stays the only full-text button.
-                  <TooltipProvider delayDuration={300}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="shrink-0 h-8 w-8 border-border"
-                          onClick={() => setShowAssignModal(true)}
-                          aria-label={idea.assignee ? t("common.reassign") : t("common.assign")}
-                        >
-                          <User className="h-4 w-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {idea.assignee ? t("common.reassign") : t("common.assign")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
+                {/* Icon-only (Option C — declutter the action row): the (re)assign
+                    label rides a shadcn Tooltip (+ aria-label for a11y) so the
+                    stage primary CTA stays the only full-text button. */}
+                <TooltipProvider delayDuration={300}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="shrink-0 h-8 w-8 border-border"
+                        onClick={() => setShowAssignModal(true)}
+                        aria-label={idea.assignee ? t("common.reassign") : t("common.assign")}
+                      >
+                        <User className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {idea.assignee ? t("common.reassign") : t("common.assign")}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 {/* Middle area: help text or action buttons */}
                 <div className="flex-1 min-w-0 flex flex-wrap items-center gap-2">
                   {canSkipElaboration && (

--- a/src/hooks/__tests__/use-pin-then-wake.test.tsx
+++ b/src/hooks/__tests__/use-pin-then-wake.test.tsx
@@ -10,8 +10,8 @@
 //
 // Plus: preview miss / no-assignee → wake directly; a failed wake after a
 // successful reassign does NOT roll back the pin (retry allowed); the reassign
-// is best-effort (a rejected reassign still fires the wake — the elaborated-idea
-// case); cancelling the picker aborts both reassign and wake.
+// is best-effort (a rejected reassign still fires the wake); cancelling the
+// picker aborts both reassign and wake.
 
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -322,11 +322,11 @@ describe("usePinThenWake", () => {
     expect(reassign).not.toHaveBeenCalled();
   });
 
-  it("best-effort reassign: a rejected reassign still fires the wake (elaborated-idea case)", async () => {
-    // The reassign action rejects an elaborated idea; the wake must still fire.
+  it("best-effort reassign: a rejected instance pin still fires the wake", async () => {
+    // A stale or invalid instance pin must not suppress the wake.
     const reassign = vi
       .fn()
-      .mockResolvedValue({ success: false, error: "Idea is not available for assignment" });
+      .mockResolvedValue({ success: false, error: "Agent instance not found" });
     const wake = vi.fn().mockResolvedValue(undefined);
     render(
       <Harness

--- a/src/hooks/use-pin-then-wake.ts
+++ b/src/hooks/use-pin-then-wake.ts
@@ -24,14 +24,9 @@
 // the caller simply retries the wake. A pinned-but-not-woken idea is a valid
 // resting state.
 //
-// ELABORATED-IDEA NOTE: the non-waking reassign (task 1c) and the underlying
-// `assignIdea` service both reject an `elaborated` idea, whereas Start
-// Development / Yolo / Proposal-approve act on elaborated ideas. So the reassign
-// step is BEST-EFFORT: a failed reassign never blocks the wake. On an
-// `elaborating` idea (Verify Elaborate, or Yolo before elaboration) the pin
-// persists fully; on an `elaborated` idea the reassign is a no-op and the server
-// falls back to its own wake-target resolution (session-origin upgrade / HARD
-// pin) — the same behavior as before this change, so no regression.
+// The reassign step is BEST-EFFORT because the selected instance can disappear
+// or fail validation between preview and submission. A failed pin never blocks
+// the wake; the server falls back to its own wake-target resolution.
 
 import { useCallback, useEffect, useState } from "react";
 import { clientLogger } from "@/lib/logger-client";
@@ -174,9 +169,8 @@ export function usePinThenWake({
       try {
         const result = await reassignNoWake(ideaUuid, agentUuid, instanceUuid);
         if (!result.success) {
-          // Expected on an elaborated idea (reassign guard) — not an error; the
-          // server resolves the wake target itself. Kept at debug so real logs
-          // stay quiet.
+          // A stale or invalid instance does not invalidate the wake; the server
+          // resolves the wake target itself. Kept at debug so logs stay quiet.
           clientLogger.debug(
             "pin-then-wake reassign did not persist (continuing to wake)",
             result.error,

--- a/src/services/__tests__/idea.service.test.ts
+++ b/src/services/__tests__/idea.service.test.ts
@@ -38,9 +38,7 @@ const { mockPrisma, mockEventBus, mockFormatAssigneeComplete, mockFormatCreatedB
       updateMany: vi.fn(),
       count: vi.fn(),
     },
-    // AgentInstance lookups back the optional instance pin on claim/assign
-    // (add-agent-instance-addressing). findFirst is company-scoped: a foreign /
-    // missing instance resolves to null and the call is rejected.
+    // AgentInstance lookups back the optional instance pin on claim/assign.
     agentInstance: {
       findFirst: vi.fn(),
     },
@@ -63,25 +61,6 @@ vi.mock("@/lib/uuid-resolver", () => ({
   formatCreatedBy: mockFormatCreatedBy,
   formatReview: mockFormatReview,
   buildAssigneeMatch: mockBuildAssigneeMatch,
-  // Real logic (mirrors src/lib/uuid-resolver): an `agent` assignee resolves to
-  // itself; an `agent_instance` resolves to its owning agent via the (mocked)
-  // prisma.agentInstance lookup. Used by assignIdea's elaborated cwd-re-pin guard.
-  resolveAssigneeAgentUuid: async (
-    companyUuid: string,
-    assigneeType: string | null,
-    assigneeUuid: string | null,
-  ) => {
-    if (!assigneeType || !assigneeUuid) return null;
-    if (assigneeType === "agent") return assigneeUuid;
-    if (assigneeType === "agent_instance") {
-      const inst = await mockPrisma.agentInstance.findFirst({
-        where: { uuid: assigneeUuid, companyUuid },
-        select: { agentUuid: true },
-      });
-      return inst?.agentUuid ?? null;
-    }
-    return null;
-  },
 }));
 vi.mock("@/services/mention.service", () => ({
   parseMentions: mockParseMentions,
@@ -185,7 +164,6 @@ describe("createIdea", () => {
     });
 
     expect(result.content).toBeNull();
-  });
 });
 
 describe("claimIdea", () => {
@@ -493,32 +471,57 @@ describe("assignIdea", () => {
     ).rejects.toThrow("Idea not found");
   });
 
-  it("should throw if idea is elaborated", async () => {
+  it("reassigns an elaborated idea without changing its lifecycle", async () => {
     const existing = makeIdeaRecord({ status: "elaborated" });
+    const assigned = makeIdeaRecord({
+      status: "elaborated",
+      assigneeType: "user",
+      assigneeUuid: ACTOR_UUID,
+    });
     mockPrisma.idea.findFirst.mockResolvedValue(existing);
+    mockPrisma.idea.update.mockResolvedValue(assigned);
 
-    await expect(
-      assignIdea({
-        ideaUuid: IDEA_UUID,
-        companyUuid: COMPANY_UUID,
-        assigneeType: "user",
-        assigneeUuid: ACTOR_UUID,
-      })
-    ).rejects.toThrow("Cannot assign an elaborated Idea");
+    const result = await assignIdea({
+      ideaUuid: IDEA_UUID,
+      companyUuid: COMPANY_UUID,
+      assigneeType: "user",
+      assigneeUuid: ACTOR_UUID,
+    });
+
+    expect(mockPrisma.idea.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "elaborated",
+          assigneeType: "user",
+          assigneeUuid: ACTOR_UUID,
+        }),
+      }),
+    );
+    expect(result.status).toBe("elaborated");
   });
 
-  it("should throw if idea has legacy completed status (normalizes to elaborated)", async () => {
+  it("reassigns a legacy completed idea without rewriting its stored lifecycle", async () => {
     const existing = makeIdeaRecord({ status: "completed" });
+    const assigned = makeIdeaRecord({
+      status: "completed",
+      assigneeType: "user",
+      assigneeUuid: ACTOR_UUID,
+    });
     mockPrisma.idea.findFirst.mockResolvedValue(existing);
+    mockPrisma.idea.update.mockResolvedValue(assigned);
 
-    await expect(
-      assignIdea({
-        ideaUuid: IDEA_UUID,
-        companyUuid: COMPANY_UUID,
-        assigneeType: "user",
-        assigneeUuid: ACTOR_UUID,
-      })
-    ).rejects.toThrow("Cannot assign an elaborated Idea");
+    await assignIdea({
+      ideaUuid: IDEA_UUID,
+      companyUuid: COMPANY_UUID,
+      assigneeType: "user",
+      assigneeUuid: ACTOR_UUID,
+    });
+
+    expect(mockPrisma.idea.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "completed" }),
+      }),
+    );
   });
 
   // Re-assignment matrix (add-agent-instance-addressing): agent → different
@@ -602,25 +605,13 @@ describe("assignIdea", () => {
     );
   });
 
-  // Elaborated-idea cwd re-pin exception (pin-cwd-before-wake, task 1d). An
-  // elaborated idea rejects reassignment, EXCEPT a same-owning-agent cwd re-pin
-  // opted into via `allowElaboratedInstanceRepin` — the post-elaboration wakes
-  // (Start Development / Yolo / proposal approve-reject) must run in the pinned
-  // cwd, so the pin has to persist even though the idea is elaborated.
   const AGENT_X = "agent-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
-  it("allows a SAME-owning-agent cwd re-pin on an elaborated idea when opted in", async () => {
-    // Idea already assigned to a bare agent AGENT_X; pin instance A (owned by
-    // AGENT_X). The elaborated guard is bypassed because the owning agent matches.
+  it("allows an instance-pinned reassignment on an elaborated idea", async () => {
     mockPrisma.idea.findFirst.mockResolvedValue(
       makeIdeaRecord({ status: "elaborated", assigneeType: "agent", assigneeUuid: AGENT_X }),
     );
-    // 1st agentInstance.findFirst = the same-agent guard lookup (isSameOwningAgent
-    // → instance A owned by AGENT_X); 2nd = resolveAssigneeFields promoting to
-    // agent_instance. Both resolve to instance A.
-    mockPrisma.agentInstance.findFirst
-      .mockResolvedValueOnce({ agentUuid: AGENT_X })
-      .mockResolvedValueOnce({ uuid: INSTANCE_A });
+    mockPrisma.agentInstance.findFirst.mockResolvedValue({ uuid: INSTANCE_A });
     mockPrisma.idea.update.mockResolvedValue(
       makeIdeaRecord({ status: "elaborated", assigneeType: "agent_instance", assigneeUuid: INSTANCE_A }),
     );
@@ -635,22 +626,22 @@ describe("assignIdea", () => {
       allowElaboratedInstanceRepin: true,
     });
 
-    // The pin persisted (assigneeType promoted) despite the elaborated status.
     expect(mockPrisma.idea.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ assigneeType: "agent_instance", assigneeUuid: INSTANCE_A }),
+        data: expect.objectContaining({
+          status: "elaborated",
+          assigneeType: "agent_instance",
+          assigneeUuid: INSTANCE_A,
+        }),
       }),
     );
   });
 
-  it("rejects a DIFFERENT-agent instance re-pin on an elaborated idea even when opted in", async () => {
-    // Idea assigned to AGENT_X; the instance being pinned is owned by a DIFFERENT
-    // agent → the same-agent guard fails → still "Cannot assign an elaborated Idea".
+  it("retains instance validation when reassigning an elaborated idea", async () => {
     mockPrisma.idea.findFirst.mockResolvedValue(
       makeIdeaRecord({ status: "elaborated", assigneeType: "agent", assigneeUuid: AGENT_X }),
     );
-    // The guard lookup returns a foreign owning agent → not the same agent.
-    mockPrisma.agentInstance.findFirst.mockResolvedValue({ agentUuid: "other-agent" });
+    mockPrisma.agentInstance.findFirst.mockResolvedValue(null);
 
     await expect(
       assignIdea({
@@ -662,53 +653,8 @@ describe("assignIdea", () => {
         instanceUuid: INSTANCE_B,
         allowElaboratedInstanceRepin: true,
       }),
-    ).rejects.toThrow("Cannot assign an elaborated Idea");
+    ).rejects.toThrow("Agent instance not found");
 
-    expect(mockPrisma.idea.update).not.toHaveBeenCalled();
-  });
-
-  it("rejects an elaborated re-pin when the idea has no agent assignee (nothing to match)", async () => {
-    // A user-assigned (or unassigned) elaborated idea has no owning agent, so the
-    // same-agent guard can't pass → the elaborated rejection stands even with the
-    // flag set. This exercises the `!currentAgentUuid → false` guard branch.
-    mockPrisma.idea.findFirst.mockResolvedValue(
-      makeIdeaRecord({ status: "elaborated", assigneeType: "user", assigneeUuid: ACTOR_UUID }),
-    );
-
-    await expect(
-      assignIdea({
-        ideaUuid: IDEA_UUID,
-        companyUuid: COMPANY_UUID,
-        assigneeType: "agent",
-        assigneeUuid: AGENT_X,
-        assignedByUuid: "admin-uuid",
-        instanceUuid: INSTANCE_A,
-        allowElaboratedInstanceRepin: true,
-      }),
-    ).rejects.toThrow("Cannot assign an elaborated Idea");
-
-    expect(mockPrisma.idea.update).not.toHaveBeenCalled();
-  });
-
-  it("still rejects an elaborated re-pin when the flag is NOT set (default behavior unchanged)", async () => {
-    mockPrisma.idea.findFirst.mockResolvedValue(
-      makeIdeaRecord({ status: "elaborated", assigneeType: "agent", assigneeUuid: AGENT_X }),
-    );
-
-    await expect(
-      assignIdea({
-        ideaUuid: IDEA_UUID,
-        companyUuid: COMPANY_UUID,
-        assigneeType: "agent",
-        assigneeUuid: AGENT_X,
-        assignedByUuid: "admin-uuid",
-        instanceUuid: INSTANCE_A,
-        // allowElaboratedInstanceRepin omitted → defaults false
-      }),
-    ).rejects.toThrow("Cannot assign an elaborated Idea");
-
-    // Guard never even consulted — the flag gates it before any instance lookup.
-    expect(mockPrisma.agentInstance.findFirst).not.toHaveBeenCalled();
     expect(mockPrisma.idea.update).not.toHaveBeenCalled();
   });
 });
@@ -760,20 +706,33 @@ describe("releaseIdea", () => {
     await expect(releaseIdea(IDEA_UUID)).rejects.toThrow("Idea not found");
   });
 
-  it("should throw if idea is elaborated", async () => {
-    mockPrisma.idea.findUnique.mockResolvedValue(makeIdeaRecord({ status: "elaborated" }));
+  it.each(["elaborated", "closed"])(
+    "clears assignment for %s without changing lifecycle or elaboration state",
+    async (status) => {
+      const existing = makeIdeaRecord({
+        status,
+        elaborationDepth: "standard",
+        elaborationStatus: "resolved",
+      });
+      mockPrisma.idea.findUnique.mockResolvedValue(existing);
+      mockPrisma.idea.update.mockResolvedValue({
+        ...existing,
+        assigneeType: null,
+        assigneeUuid: null,
+      });
 
-    await expect(releaseIdea(IDEA_UUID)).rejects.toThrow(
-      "Cannot release an elaborated Idea"
-    );
-  });
+      await releaseIdea(IDEA_UUID);
 
-  it("should throw if idea has legacy closed status (normalizes to elaborated)", async () => {
-    mockPrisma.idea.findUnique.mockResolvedValue(makeIdeaRecord({ status: "closed" }));
-
-    await expect(releaseIdea(IDEA_UUID)).rejects.toThrow(
-      "Cannot release an elaborated Idea"
-    );
+      const update = mockPrisma.idea.update.mock.calls[0][0];
+      expect(update.data).not.toHaveProperty("status");
+      expect(update.data).not.toHaveProperty("elaborationDepth");
+      expect(update.data).not.toHaveProperty("elaborationStatus");
+      expect(update.data).toEqual(expect.objectContaining({
+        assigneeType: null,
+        assigneeUuid: null,
+      }));
+    },
+  );
   });
 });
 

--- a/src/services/idea.service.ts
+++ b/src/services/idea.service.ts
@@ -3,7 +3,7 @@
 // UUID-Based Architecture: All operations use UUIDs
 
 import { prisma } from "@/lib/prisma";
-import { formatAssigneeComplete, formatCreatedBy, buildAssigneeMatch, resolveAssigneeAgentUuid, type AssigneeCondition, type AssigneeInstanceInfo } from "@/lib/uuid-resolver";
+import { formatAssigneeComplete, formatCreatedBy, buildAssigneeMatch, type AssigneeCondition, type AssigneeInstanceInfo } from "@/lib/uuid-resolver";
 import type { AuthContext } from "@/types/auth";
 import { eventBus } from "@/lib/event-bus";
 import { AlreadyClaimedError, NotClaimedError, isPrismaNotFound } from "@/lib/errors";
@@ -807,33 +807,7 @@ export async function claimIdea({
   return formatIdeaResponse(idea);
 }
 
-// Assign Idea (reassign: works regardless of current assignee, any non-terminal status)
-// Does `instanceUuid` belong to the SAME agent that currently owns the idea's
-// assignment? Used to gate the elaborated-idea cwd re-pin: pinning a cwd of the
-// idea's own assignee agent is a wake-target refinement (allowed post-
-// elaboration), whereas pinning a different agent's instance would be a
-// reassignment (still blocked). Resolves both sides to their owning AGENT uuid
-// (an `agent_instance` assignee → its agent) before comparing. Returns false if
-// the idea has no agent assignee, or the instance is missing/foreign-company.
-async function isSameOwningAgentInstance(
-  companyUuid: string,
-  currentAssigneeType: string | null,
-  currentAssigneeUuid: string | null,
-  instanceUuid: string,
-): Promise<boolean> {
-  const currentAgentUuid = await resolveAssigneeAgentUuid(
-    companyUuid,
-    currentAssigneeType,
-    currentAssigneeUuid,
-  );
-  if (!currentAgentUuid) return false;
-  const instance = await prisma.agentInstance.findFirst({
-    where: { uuid: instanceUuid, companyUuid },
-    select: { agentUuid: true },
-  });
-  return instance?.agentUuid === currentAgentUuid;
-}
-
+// Assign Idea (reassign: works regardless of current assignee or lifecycle)
 export async function assignIdea({
   ideaUuid,
   companyUuid,
@@ -844,29 +818,11 @@ export async function assignIdea({
   cwdSource,
   cwdHost,
   runtimeCwd,
-  allowElaboratedInstanceRepin = false,
 }: IdeaClaimParams): Promise<IdeaResponse> {
   const existing = await prisma.idea.findFirst({
     where: { uuid: ideaUuid, companyUuid },
   });
   if (!existing) throw new Error("Idea not found");
-  const normalizedAssignStatus = normalizeIdeaStatus(existing.status);
-  if (normalizedAssignStatus === "elaborated") {
-    // An elaborated idea rejects reassignment — EXCEPT a same-owning-agent cwd
-    // re-pin (pin-cwd-before-wake). The post-elaboration wakes must run in the
-    // pinned cwd, so the pin has to persist even though the idea is elaborated.
-    // Guarded three ways: the caller opts in, an instance is actually being
-    // pinned, and the instance's owning agent equals the idea's current
-    // assignee owning agent (a cwd refinement, never an owner change).
-    const isSameAgentRepin =
-      allowElaboratedInstanceRepin &&
-      !!instanceUuid &&
-      (await isSameOwningAgentInstance(companyUuid, existing.assigneeType, existing.assigneeUuid, instanceUuid));
-    if (!isSameAgentRepin) {
-      throw new Error("Cannot assign an elaborated Idea");
-    }
-  }
-
   // If currently open, move to elaborating; otherwise keep current status
   const newStatus = existing.status === "open" ? "elaborating" : existing.status;
 
@@ -898,19 +854,21 @@ export async function assignIdea({
   return formatIdeaResponse(idea);
 }
 
-// Release Idea (clears assignee, resets to open; any non-terminal status)
+// Release Idea. Terminal lifecycle and elaboration state are preserved.
 export async function releaseIdea(uuid: string): Promise<IdeaResponse> {
   const existing = await prisma.idea.findUnique({ where: { uuid } });
   if (!existing) throw new Error("Idea not found");
   const normalizedReleaseStatus = normalizeIdeaStatus(existing.status);
-  if (normalizedReleaseStatus === "elaborated") {
-    throw new Error("Cannot release an elaborated Idea");
-  }
+  const isElaborated = normalizedReleaseStatus === "elaborated";
 
   const idea = await prisma.idea.update({
     where: { uuid },
     data: {
-      status: "open",
+      ...(!isElaborated && {
+        status: "open",
+        elaborationDepth: null,
+        elaborationStatus: null,
+      }),
       assigneeType: null,
       assigneeUuid: null,
       cwdSource: null,
@@ -918,8 +876,6 @@ export async function releaseIdea(uuid: string): Promise<IdeaResponse> {
       runtimeCwd: null,
       assignedAt: null,
       assignedByUuid: null,
-      elaborationDepth: null,
-      elaborationStatus: null,
     },
     include: {
       project: { select: { uuid: true, name: true } },


### PR DESCRIPTION
## Summary
- keep Idea assignment controls available for open, elaborating, and elaborated Ideas in both detail surfaces
- allow validated assignment and release operations after elaboration while preserving lifecycle and linked ownership
- archive the OpenSpec change and add focused UI, action, service, and pin-then-wake regression coverage

## Test plan
- [x] 104 focused Vitest tests
- [x] `pnpm exec tsc --noEmit --pretty false`
- [x] `openspec validate idea-lifecycle-assignment --type spec`
- [x] `git diff --check`
- [x] AWS CDK deployment completed
- [x] production `/api/health` reports `status: ok` and database connected

## Chorus
- Idea: `dc0714be-4c82-498d-a493-4d4b5c3d0176`
- Proposal: `6d145a12-0958-44cb-bc2a-5e7aecb5faf2`