### PR TITLE
fix: remove redundant cwd card from proposal header

### DIFF
--- a/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/README.md
+++ b/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/README.md
@@ -1,0 +1,3 @@
+# remove-redundant-fixed-cwd-prompts
+
+Remove fixed working-directory UI outside the Project Overview title summary while preserving runtime behavior.

--- a/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/design.md
+++ b/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`ProposalActions` currently reads `fixedTarget` from `usePinThenWake` and renders a `FixedCwdAnchor` before the actions menu. The card is informational only and crowds the Proposal header. Other call sites use the same component in different workflows and are explicitly out of scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove the fixed-cwd card from the Proposal header.
+- Preserve Proposal actions and pin-then-wake behavior.
+- Keep all other UI and runtime behavior byte-for-byte unchanged where practical.
+
+**Non-Goals:**
+
+- Removing or editing `FixedCwdAnchor`.
+- Changing Idea, Task, conversational entry, Project Overview, or Project Settings UI.
+- Changing cwd selection, fixed-target resolution, persistence, wake, or resume behavior.
+
+## Decisions
+
+### Remove only the Proposal render path
+
+Delete the `FixedCwdAnchor` import, stop destructuring the unused `fixedTarget`, and remove the conditional render in `ProposalActions`.
+
+Alternative considered: remove every call site using the shared component. The latest human instruction explicitly rejects that broader scope.
+
+### Keep the hook and shared component unchanged
+
+`usePinThenWake` remains responsible for Proposal action routing. Only its unused presentation return value is no longer consumed in this component. The shared card remains available to all other callers.
+
+Alternative considered: add a prop to hide the card. The card is rendered directly by `ProposalActions`, so a new abstraction would add complexity without value.
+
+## Risks / Trade-offs
+
+- [A broad cleanup could alter other pages] -> Limit the code diff to `proposal-actions.tsx` and assert other `FixedCwdAnchor` call sites still exist.
+- [Removing `fixedTarget` could affect action routing] -> Remove only the destructured return value; leave the hook invocation and callbacks unchanged.
+
+## Migration Plan
+
+1. Apply the three-line Proposal-only cleanup.
+2. Run focused lint/type/test checks and inspect the final diff for single-file scope.
+3. Verify the Proposal header in a browser while confirming another fixed-cwd surface remains unchanged.
+
+Rollback is a source revert; there is no data migration.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/proposal.md
+++ b/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Proposal header repeats a large fixed working-directory card beside proposal actions even though the user does not choose or change the target there. Removing this one card reduces clutter without changing any other cwd surface or behavior.
+
+## What Changes
+
+- Remove the `FixedCwdAnchor` card from the Proposal header action area.
+- Keep every other `FixedCwdAnchor` call site unchanged.
+- Keep the shared component, Project Overview summary, Project Settings management, cwd pickers, and all fixed-target runtime behavior unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `project-cwd-anchoring`: Make the Proposal header an explicit exception to the read-only anchor-summary requirement.
+
+## Impact
+
+- Changes only `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx`.
+- Does not change shared components, other pages, APIs, persistence, daemon routing, or assignment semantics.

--- a/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/specs/project-cwd-anchoring/spec.md
+++ b/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/specs/project-cwd-anchoring/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Fixed-anchor UI suppresses cwd selection
+
+Every project workflow surface that would otherwise ask for an Agent instance or cwd SHALL
+hide that picker when a fixed target exists. Assignment and stage-entry surfaces other
+than the Proposal header MUST display a read-only anchor summary and a route to manage the
+preference in Project Settings. The Proposal header MUST suppress its redundant read-only
+anchor card while retaining fixed-target execution behavior.
+
+#### Scenario: Fixed target is ready
+- **WHEN** a fixed Agent target is available on an assignment or stage-entry surface other than the Proposal header
+- **THEN** the surface MUST display the resolved host and cwd
+- **AND** no selectable instance or temporary-directory control may be rendered
+
+#### Scenario: Proposal header has a fixed target
+- **WHEN** Proposal actions resolve a fixed Agent target
+- **THEN** the Proposal header MUST NOT render `FixedCwdAnchor`
+- **AND** proposal actions MUST retain the fixed target for execution without showing an alternate cwd picker
+
+#### Scenario: Multiple Agents have fixed targets
+- **WHEN** a project has independent fixed cwd preferences for Agent A and Agent B
+- **THEN** selecting either Agent outside the Proposal header MUST display only that Agent's anchor
+- **AND** changing one preference MUST NOT alter the other Agent's UI or resolution

--- a/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/tasks.md
+++ b/openspec/changes/archive/2026-08-05-remove-redundant-fixed-cwd-prompts/tasks.md
@@ -1,0 +1,8 @@
+## 1. Proposal Header Cleanup
+
+- [ ] 1.1 Remove the `FixedCwdAnchor` import, `fixedTarget` destructuring, and card render from `ProposalActions` only.
+
+## 2. Verification
+
+- [ ] 2.1 Verify all other `FixedCwdAnchor` call sites and cwd controls remain unchanged.
+- [ ] 2.2 Run focused tests, type checks, UI lint, and browser acceptance for the Proposal header.

--- a/openspec/specs/project-cwd-anchoring/spec.md
+++ b/openspec/specs/project-cwd-anchoring/spec.md
@@ -89,15 +89,22 @@ project preference changes.
 ### Requirement: Fixed-anchor UI suppresses cwd selection
 
 Every project workflow surface that would otherwise ask for an Agent instance or cwd SHALL
-hide that picker when a fixed target exists. The surface MUST display a read-only anchor
-summary and a route to manage the preference in project settings.
+hide that picker when a fixed target exists. Assignment and stage-entry surfaces other
+than the Proposal header MUST display a read-only anchor summary and a route to manage the
+preference in Project Settings. The Proposal header MUST suppress its redundant read-only
+anchor card while retaining fixed-target execution behavior.
 
 #### Scenario: Fixed target is ready
-- **WHEN** a fixed Agent target is available on an assignment or stage-entry surface
+- **WHEN** a fixed Agent target is available on an assignment or stage-entry surface other than the Proposal header
 - **THEN** the surface MUST display the resolved host and cwd
 - **AND** no selectable instance or temporary-directory control may be rendered
 
+#### Scenario: Proposal header has a fixed target
+- **WHEN** Proposal actions resolve a fixed Agent target
+- **THEN** the Proposal header MUST NOT render `FixedCwdAnchor`
+- **AND** proposal actions MUST retain the fixed target for execution without showing an alternate cwd picker
+
 #### Scenario: Multiple Agents have fixed targets
 - **WHEN** a project has independent fixed cwd preferences for Agent A and Agent B
-- **THEN** selecting either Agent MUST display only that Agent's anchor
+- **THEN** selecting either Agent outside the Proposal header MUST display only that Agent's anchor
 - **AND** changing one preference MUST NOT alter the other Agent's UI or resolution

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx
@@ -25,7 +25,6 @@ import { approveProposalAction, rejectProposalAction, closeProposalAction, revok
 import { reassignIdeaInstanceNoWakeAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions";
 import { usePinThenWake } from "@/hooks/use-pin-then-wake";
 import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
-import { FixedCwdAnchor } from "@/components/agent-presence/fixed-cwd-anchor";
 
 interface MaterializedEntities {
   tasks: { uuid: string; title: string; status: string }[];
@@ -60,7 +59,6 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
     confirmPick,
     cancelPick,
     isResolving,
-    fixedTarget,
   } = usePinThenWake({
     reassignNoWake: reassignIdeaInstanceNoWakeAction,
     previewIdeaUuid: inputIdeaUuid,
@@ -167,7 +165,6 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
 
   return (
     <>
-      {fixedTarget && <FixedCwdAnchor target={fixedTarget} />}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button


### PR DESCRIPTION
## Summary
- remove the fixed working-directory card from the Proposal header only
- preserve every other `FixedCwdAnchor` call site and all cwd behavior
- archive the OpenSpec change and update the cumulative anchoring spec

## Test plan
- [x] `pnpm exec eslint src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx`
- [x] `pnpm exec tsc --noEmit`
- [x] 18 related Vitest tests
- [x] Impeccable UI detector
- [x] Chorus task reviewer and aggregate code reviewer
- [x] Online browser acceptance after deployment

## Deployment
- Production: https://chorus.yfeichen.people.amazon.dev
- ECS task definition: `ChorusServiceTaskDefinition9979C7F4:307`
- Verified the Proposal header omits the cwd card and the Idea detail card remains unchanged.