### PR TITLE
chore: release v0.16.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "chorus",
       "source": "./public/chorus-plugin",
       "description": "Chorus AI-DLC collaboration platform plugin. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "category": "project-management",
       "tags": ["ai-dlc", "collaboration", "mcp", "session", "multi-agent"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.16.0] - 2026-08-09
+
+### Added
+- **Documentation site surfaced to agents & users**: Wired the live docs site (https://doc.chorus-ai.dev) into three entry points — a new `docs` router skill on all six skill surfaces (Claude Code, Codex, OpenClaw, Kiro, Pi, standalone) that reads the root-only `/llms.txt` index and fetches raw Markdown per page, a localized Documentation link in each README (en/zh/ko/ja) header, and a language-aware Documentation entry in the landing-page nav. (#477)
+
+### Fixed
+- **Codex skill-invocation hints**: Corrected Codex skill docs to use the proper `$`-prefix invocation form (e.g. `$develop`, `$yolo`) instead of the slash form. (#477)
+
+### Plugin
+- **Plugin & skill versions → 0.16.0**: Claude Code, Codex, OpenClaw, Kiro, and Pi plugin and skill distributions plus the standalone skill bumped to 0.16.0. (#477)
+
+---
+
 ## [0.15.1] - 2026-08-05
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,8 @@
 
 <p align="center"><a href="README.md">English</a> · <a href="README.zh.md">中文</a> · <a href="README.ko.md">한국어</a> · <strong>日本語</strong></p>
 
+<p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 ドキュメント</strong></a></p>
+
 Chorus は Agent Harness です — LLM エージェントを包み込み、セッションのライフサイクル、課題の状態、サブエージェントのオーケストレーション、可観測性、障害復旧を管理する基盤層です。細かく設定可能な権限を持つ複数の AI エージェントと人間が、要件から納品までの全ワークフローを通じて協働できるようにします。
 
 **[AI-DLC（AI-Driven Development Lifecycle）](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** の方法論に着想を得ています。中核となる理念は **Reversed Conversation** — AI が提案し、人間が検証します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,6 +15,8 @@
 
 <p align="center"><a href="README.md">English</a> · <a href="README.zh.md">中文</a> · <strong>한국어</strong> · <a href="README.ja.md">日本語</a></p>
 
+<p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 문서</strong></a></p>
+
 Chorus는 Agent Harness입니다 — LLM 에이전트를 감싸 세션 라이프사이클, 작업 상태, 하위 에이전트 오케스트레이션, 관측 가능성, 장애 복구를 관리하는 인프라 계층입니다. 세밀하게 설정 가능한 권한을 가진 여러 AI 에이전트와 사람이 요구사항부터 배포까지 전체 워크플로를 통해 협업할 수 있게 해줍니다.
 
 **[AI-DLC(AI-Driven Development Lifecycle)](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** 방법론에서 영감을 받았습니다. 핵심 철학은 **Reversed Conversation** — AI가 제안하고, 사람이 검증합니다.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 <p align="center"><strong>English</strong> · <a href="README.zh.md">中文</a> · <a href="README.ko.md">한국어</a> · <a href="README.ja.md">日本語</a></p>
 
+<p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 Documentation</strong></a></p>
+
 Chorus is an agent harness — the infrastructure that wraps around LLM agents to manage session lifecycle, task state, sub-agent orchestration, observability, and failure recovery. It lets multiple AI Agents (with fine-grained, configurable permissions) and humans collaborate through the full workflow from requirements to delivery.
 
 Inspired by the **[AI-DLC (AI-Driven Development Lifecycle)](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** methodology. Core philosophy: **Reversed Conversation** — AI proposes, humans verify.

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,6 +6,8 @@
 
 <p align="center"><a href="README.md">English</a> · <strong>中文</strong> · <a href="README.ko.md">한국어</a> · <a href="README.ja.md">日本語</a></p>
 
+<p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 文档</strong></a></p>
+
 Chorus 是一个 Agent Harness——包裹在 LLM 外面的基础设施层，负责管理会话生命周期、任务状态、子 Agent 编排、可观测性和故障恢复。它让多个具备细粒度权限配置的 AI Agent 和人类在同一平台上协作，完成从需求到交付的全流程。
 
 受 **[AI-DLC（AI-Driven Development Lifecycle）](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** 方法论启发。核心理念：**Reversed Conversation**——AI 提议，人类验证。

--- a/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/README.md
+++ b/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/README.md
@@ -1,0 +1,3 @@
+# add-docs-site-skill-and-links
+
+Add a standalone chorus-docs skill guiding agents to the live docs site (llms.txt + .md), plus README and landing-nav links

--- a/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/design.md
+++ b/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/design.md
@@ -1,0 +1,87 @@
+# Design: docs-site skill and product links
+
+## Context
+
+- Live docs site: `https://doc.chorus-ai.dev`. Agent-friendly access:
+  - `https://doc.chorus-ai.dev/llms.txt` — link index (title + one-line summary + `.md` URL per page).
+  - Any page + `.md` → raw Markdown (e.g. `/guides/getting-started.md`). The docs build emits both HTML and `.md` for every route.
+- Locales on the docs site: `en` (unprefixed root), `zh`, `ja`, `ko` (path-prefixed).
+- Skill content lives in **six parallel surfaces** (per `.claude/skills/plugin-maintenance/SKILL.md`):
+  1. `public/chorus-plugin/skills/<name>/SKILL.md` — Claude Code
+  2. `plugins/chorus/skills/<name>/SKILL.md` — Codex
+  3. `packages/openclaw-plugin/skills/<name>/SKILL.md` — OpenClaw
+  4. `public/kiro-plugin/.kiro/skills/chorus-<name>/SKILL.md` — Kiro (prefix)
+  5. `packages/chorus-pi/skills/<name>/SKILL.md` — Pi
+  6. `public/skill/<name>-chorus/SKILL.md` — standalone (suffix)
+
+## Goals / Non-Goals
+
+**Goals**
+- One new agent-facing skill that routes agents to the docs site, on all six surfaces, correctly registered on each.
+- The skill discoverable from the `chorus` overview (Skill Routing row) on all six overview surfaces.
+- README (×4 locales) and landing nav link to the docs site.
+
+**Non-Goals**
+- No change to the `chorus-doc` repo.
+- No hardcoded page catalog in the skill (avoids staleness — the site's own `/llms.txt` is the index).
+- No new locales for README or landing beyond what already exists.
+- Not fixing the docs-repo `docs.chorus-ai.dev` vs `doc.chorus-ai.dev` mismatch (upstream, out of scope; recorded in proposal Impact).
+
+## Decisions
+
+### D1 — Skill base name per surface
+The user's shorthand is "chorus-doc". Per-surface naming convention (from plugin-maintenance) is applied so invocation is not redundant:
+
+| Surface | Folder / file | Invocation |
+|---|---|---|
+| Claude Code | `skills/docs/SKILL.md` | `/chorus:docs` |
+| Codex | `skills/docs/SKILL.md` | `$docs` |
+| OpenClaw | `skills/docs/SKILL.md` | `/docs` |
+| Kiro | `.kiro/skills/chorus-docs/SKILL.md` | `/chorus-docs` |
+| Pi | `skills/docs/SKILL.md` | `/skill:docs` |
+| standalone | `public/skill/docs-chorus/SKILL.md` | download by URL |
+
+`name:` frontmatter matches the folder base (`docs`, except Kiro `chorus-docs` and standalone `docs-chorus`, mirroring how the existing skills name themselves on each surface).
+
+### D2 — Skill is a thin router, not a page catalog
+Body outline (adapt tone per surface — MUST/NEVER for plugin ports, "prefer/consider" for standalone):
+- **When to use:** the user asks how to use / configure / deploy / operate Chorus (UI workflow, agent setup, plugin setup, API/MCP, deployment, troubleshooting) — anything covered by product documentation rather than the live AI-DLC workflow this agent is driving.
+- **Access convention:**
+  1. Fetch `https://doc.chorus-ai.dev/llms.txt` — the index of every page with a one-line summary and its `.md` URL.
+  2. Pick the relevant page(s) from the index and fetch the raw Markdown by appending `.md` to the page URL.
+  3. Ground the answer in the fetched docs; cite/link the human-facing page (HTML URL, i.e. the `.md` URL without the suffix) so the user can open it.
+- **Locale note:** `en` is the root; `zh` / `ja` / `ko` are path-prefixed (`/zh/...`). Match the user's language when available; the `.md` convention applies to prefixed pages too.
+- **Relationship:** complements the workflow skills (`idea` / `proposal` / `develop` / `review` / `yolo`), which drive the AI-DLC pipeline. `docs` answers "how do I use the product" questions.
+- **No hardcoded page list** — the index is the source of truth; do not enumerate pages in the skill body.
+- Fetch mechanism is left to the agent's available tooling (WebFetch / curl / built-in) — the skill states the convention, not a specific tool binding, so it works across harnesses.
+
+### D3 — Registration per surface (the non-obvious part)
+- **Folder-discovered (no manifest edit):** Claude Code, Codex (`"skills": "./skills/"`), OpenClaw (`"skills": ["./skills"]`), Pi (`"skills": ["./skills"]`). Dropping the folder is sufficient.
+- **standalone** — must add `docs-chorus/SKILL.md` to the file map in **both** the `chorus` and `moltbot` blocks of `public/skill/package.json`, and add a `docs` trigger keyword to both `triggers` arrays.
+- **Kiro** — must add `chorus-docs` to the `SKILLS=` list in `public/install-kiro.sh` **and** add `skill://.kiro/skills/chorus-docs/SKILL.md` to `resources[]` in `public/kiro-plugin/.kiro/agents/chorus.json`.
+
+### D4 — Overview cross-reference
+Add one Skill-Routing row (or equivalent list entry) naming the new skill on each overview surface:
+- CC/Codex/OpenClaw/Pi/standalone: `skills/chorus/SKILL.md` (and `public/skill/chorus/SKILL.md`) "Skill Routing" table — a new row, e.g. **Docs** | `/docs` (adapt invocation token per surface) | "Consult the live Chorus documentation site to guide product usage".
+- Kiro: `public/kiro-plugin/.kiro/steering/chorus.md` (its overview) — add the equivalent line.
+
+### D5 — README docs link
+Add a single prominent "Documentation" link immediately after the existing language-switch `<p align="center">` line, in each of README.md / README.zh.md / README.ko.md / README.ja.md. Label localized ("Documentation" / "文档" / "문서" / "ドキュメント"); URL `https://doc.chorus-ai.dev` for all four (site auto-serves per-locale; the READMEs already differ per language and a single canonical URL is simplest and correct). Keep the existing badges block untouched (owner chose a link, not a shields badge).
+
+### D6 — Landing nav Documentation entry
+- `packages/landing/src/i18n/translations/en.json` + `zh.json`: add `nav.docs` key ("Documentation" / "文档").
+- `packages/landing/src/components/Nav.astro`:
+  - Compute `const docsUrl = lang === 'zh' ? 'https://doc.chorus-ai.dev/zh' : 'https://doc.chorus-ai.dev';` (language-aware, D per elaboration Q5).
+  - Desktop `.nav-links`: add `<a href={docsUrl} target="_blank" rel="noopener noreferrer">{t(lang, 'nav.docs')}</a>` adjacent to Blog (order: Features / Showcase / Agents / Docs / Blog).
+  - Mobile `#mobile-menu`: add the same link in the same position.
+  - New tab (`target="_blank"`) because the docs site is a separate deployment (elaboration Q6).
+
+## Risks / Trade-offs
+
+- **Docs-site link rot:** if a page slug changes, the skill still works (it reads `/llms.txt` fresh each time); only the README/landing root link is fixed, and the root is stable.
+- **Six-surface drift:** the new skill must stay in sync across surfaces. Mitigated by authoring one canonical body and porting with the intentional per-surface phrasing differences (tone, invocation token, tool namespacing) called out in plugin-maintenance.
+- **Upstream URL mismatch** (`docs.` vs `doc.`): we consistently use the live `doc.chorus-ai.dev`; documented as a known upstream issue so a later reader doesn't "fix" our correct links to match the dead default.
+
+## Migration / Rollout
+
+Pure additive. No schema, no data, no runtime behavior change. Version frontmatter bumped for touched skill surfaces per plugin-maintenance Version Bump Checklist (the release itself is a separate step, not part of this change).

--- a/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/proposal.md
+++ b/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/proposal.md
@@ -1,0 +1,38 @@
+# Add docs-site skill and product links
+
+## Why
+
+The standalone Chorus documentation site is live at **https://doc.chorus-ai.dev** (en / zh / ja / ko), built by the docs-site theme idea. It is agent-friendly: the root `/llms.txt` is a link index, and appending `.md` to any page URL returns raw Markdown. But nothing inside the product points to it:
+
+- **Agents** have no instruction to consult the docs site. When a user asks "how do I use / configure / deploy / operate Chorus", an agent answers from memory instead of the authoritative, current docs.
+- **README** (en / zh / ko / ja) — the first thing a GitHub visitor reads — has no link to the docs.
+- **Landing page** (`packages/landing`) nav has Features / Showcase / Agents / Blog, but no Documentation entry.
+
+This change wires the live site into the three product entry points so both humans and agents can find and use it.
+
+## What Changes
+
+1. **New `docs` skill** across all six skill surfaces (Claude Code, Codex, OpenClaw, Kiro, Pi, standalone), matching where the existing stage skills (`idea`, `proposal`, …) live. The skill is a **thin router**: it teaches the agent the docs-site access convention — read `/llms.txt` first for the index, then fetch any page with `.md` appended for raw Markdown — and to ground user-facing "how to use Chorus" guidance in those docs rather than memory. It deliberately does **not** hardcode a page list (which would go stale as the docs site changes).
+   - Registration is per-surface: folder-discovered on Claude Code / Codex / OpenClaw / Pi; explicitly listed for standalone (`public/skill/package.json` file maps + triggers) and Kiro (`install-kiro.sh` `SKILLS=` + `agents/chorus.json` `resources[]`).
+   - Per-surface base name follows each surface's convention: `docs` (CC/Codex/OpenClaw/Pi), `chorus-docs` (Kiro prefix), `docs-chorus` (standalone suffix). The user's shorthand "chorus-doc" refers to the concept; `/chorus:chorus-doc` would be redundant.
+
+2. **Cross-reference from the `chorus` overview skill** — add one Skill-Routing row pointing at the new `docs` skill, so it is discoverable from the platform overview (all six overview surfaces; Kiro's overview is `steering/chorus.md`).
+
+3. **README docs link** — add a prominent "Documentation" link to the top of all four README locales (en / zh / ko / ja), near the language-switch line.
+
+4. **Landing-page Documentation nav** — add a "Documentation" entry to the landing nav (`Nav.astro`), in both the desktop links and the mobile menu, with `en` / `zh` i18n copy. It opens in a new tab (external site) and is placed adjacent to Blog. Target is language-aware: the `en` landing links to the docs-site root; the `zh` landing links to `/zh`.
+
+## Capabilities
+
+- `docs-site-skill` — the new agent-facing skill and its cross-reference from the overview.
+- `readme-docs-link` — the docs link in all four README locales.
+- `landing-docs-nav` — the Documentation nav entry on the landing page.
+
+## Impact
+
+- **Skill surfaces:** one new `SKILL.md` per surface (six files), plus registration edits on standalone + Kiro, plus one routing row in each of the six overviews. Version frontmatter bumped per the plugin-maintenance checklist for the surfaces touched.
+- **README:** four files, header only.
+- **Landing:** `Nav.astro` + `en.json` / `zh.json` nav keys.
+- **Out of scope / not modified:**
+  - The `chorus-doc` repository itself is untouched (this change lives entirely in the `ai-pm` repo).
+  - **Known upstream bug, recorded not fixed:** the docs-site repo's `DOCS_SITE_URL` default and its generated `llms.txt` internal links point to `docs.chorus-ai.dev` (with an "s"), which is currently a dead host; the live site is `doc.chorus-ai.dev`. All links added here use the live `doc.chorus-ai.dev`. Fixing the docs-repo mismatch is a separate concern in that repo.

--- a/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/specs/docs-site-skill/spec.md
+++ b/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/specs/docs-site-skill/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Docs-site routing skill on every surface
+
+Chorus SHALL provide an agent-facing "docs" skill that routes agents to the live Chorus documentation site to answer product-usage questions. The skill SHALL exist on all six skill surfaces (Claude Code, Codex, OpenClaw, Kiro, Pi, standalone), following each surface's naming convention (`docs`; Kiro `chorus-docs`; standalone `docs-chorus`).
+
+The skill SHALL teach the docs-site access convention: read `https://doc.chorus-ai.dev/llms.txt` as the index first, then fetch any page's raw Markdown by appending `.md` to its URL, and ground product-usage answers in the fetched docs rather than memory. The skill SHALL NOT hardcode a page catalog. The skill SHALL use the live host `doc.chorus-ai.dev`.
+
+#### Scenario: User asks how to use Chorus and the agent consults the docs
+
+- **WHEN** a user asks an agent how to use, configure, deploy, or operate Chorus, and the docs skill is available
+- **THEN** the skill directs the agent to fetch `/llms.txt`, select the relevant page(s) from the index, fetch their `.md` raw Markdown, and answer from that content while linking the human-facing page
+
+#### Scenario: Skill is registered on each surface
+
+- **WHEN** the plugin/skill package for any of the six surfaces is loaded
+- **THEN** the docs skill is discoverable — folder-present for Claude Code / Codex / OpenClaw / Pi, listed in `public/skill/package.json` (both `chorus` and `moltbot` file maps + a `docs` trigger) for standalone, and listed in `install-kiro.sh` `SKILLS=` plus `agents/chorus.json` `resources[]` for Kiro
+
+#### Scenario: Docs skill is cross-referenced from the overview
+
+- **WHEN** an agent reads the `chorus` overview skill (or Kiro's `steering/chorus.md`)
+- **THEN** a Skill-Routing entry names the docs skill so it is reachable from the platform overview on all six overview surfaces

--- a/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/specs/landing-docs-nav/spec.md
+++ b/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/specs/landing-docs-nav/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Landing page navigation includes a Documentation entry
+
+The landing page navigation SHALL include a "Documentation" entry linking to the live documentation site, in both the desktop nav links and the mobile menu, with `en` and `zh` i18n copy (`nav.docs`). The entry SHALL open in a new tab and its target SHALL be language-aware: the `en` landing links to `https://doc.chorus-ai.dev`, the `zh` landing links to `https://doc.chorus-ai.dev/zh`.
+
+#### Scenario: Visitor clicks Documentation on the English landing page
+
+- **WHEN** a visitor on the `en` landing page clicks the Documentation nav entry
+- **THEN** the docs site root `https://doc.chorus-ai.dev` opens in a new browser tab
+
+#### Scenario: Visitor clicks Documentation on the Chinese landing page
+
+- **WHEN** a visitor on the `zh` landing page clicks the Documentation nav entry
+- **THEN** the Chinese docs section `https://doc.chorus-ai.dev/zh` opens in a new browser tab
+
+#### Scenario: Documentation entry present on mobile
+
+- **WHEN** the landing page is viewed at a mobile width and the menu is opened
+- **THEN** the Documentation entry appears in the mobile menu with the localized `nav.docs` label

--- a/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/specs/readme-docs-link/spec.md
+++ b/openspec/changes/archive/2026-08-09-add-docs-site-skill-and-links/specs/readme-docs-link/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: README links to the documentation site
+
+Every README locale (README.md, README.zh.md, README.ko.md, README.ja.md) SHALL carry a prominent link to the live documentation site `https://doc.chorus-ai.dev`, placed near the top (adjacent to the language-switch line), with a locale-appropriate label.
+
+#### Scenario: Reader opens any localized README
+
+- **WHEN** a visitor reads any of the four README locales on GitHub
+- **THEN** a "Documentation"-style link (localized label) to `https://doc.chorus-ai.dev` is visible near the header, above the main content
+
+#### Scenario: Existing header elements preserved
+
+- **WHEN** the docs link is added
+- **THEN** the existing banner image, tagline, language-switch line, and badges block remain intact and correctly rendered

--- a/openspec/specs/docs-site-skill/spec.md
+++ b/openspec/specs/docs-site-skill/spec.md
@@ -1,0 +1,26 @@
+# docs-site-skill Specification
+
+## Purpose
+Define the agent-facing "docs" skill that routes agents to the live Chorus documentation site (index via `/llms.txt`, raw Markdown via appended `.md`) so both humans and agents can find and ground product-usage guidance in current docs, present on all six skill surfaces and cross-referenced from the overview.
+## Requirements
+### Requirement: Docs-site routing skill on every surface
+
+Chorus SHALL provide an agent-facing "docs" skill that routes agents to the live Chorus documentation site to answer product-usage questions. The skill SHALL exist on all six skill surfaces (Claude Code, Codex, OpenClaw, Kiro, Pi, standalone), following each surface's naming convention (`docs`; Kiro `chorus-docs`; standalone `docs-chorus`).
+
+The skill SHALL teach the docs-site access convention: read `https://doc.chorus-ai.dev/llms.txt` as the index first, then fetch any page's raw Markdown by appending `.md` to its URL, and ground product-usage answers in the fetched docs rather than memory. The skill SHALL NOT hardcode a page catalog. The skill SHALL use the live host `doc.chorus-ai.dev`.
+
+#### Scenario: User asks how to use Chorus and the agent consults the docs
+
+- **WHEN** a user asks an agent how to use, configure, deploy, or operate Chorus, and the docs skill is available
+- **THEN** the skill directs the agent to fetch `/llms.txt`, select the relevant page(s) from the index, fetch their `.md` raw Markdown, and answer from that content while linking the human-facing page
+
+#### Scenario: Skill is registered on each surface
+
+- **WHEN** the plugin/skill package for any of the six surfaces is loaded
+- **THEN** the docs skill is discoverable — folder-present for Claude Code / Codex / OpenClaw / Pi, listed in `public/skill/package.json` (both `chorus` and `moltbot` file maps + a `docs` trigger) for standalone, and listed in `install-kiro.sh` `SKILLS=` plus `agents/chorus.json` `resources[]` for Kiro
+
+#### Scenario: Docs skill is cross-referenced from the overview
+
+- **WHEN** an agent reads the `chorus` overview skill (or Kiro's `steering/chorus.md`)
+- **THEN** a Skill-Routing entry names the docs skill so it is reachable from the platform overview on all six overview surfaces
+

--- a/openspec/specs/landing-docs-nav/spec.md
+++ b/openspec/specs/landing-docs-nav/spec.md
@@ -1,0 +1,24 @@
+# landing-docs-nav Specification
+
+## Purpose
+Provide a language-aware "Documentation" entry in the landing-page navigation (desktop and mobile) that opens the live docs site in a new tab, with the target matched to the landing page's locale.
+## Requirements
+### Requirement: Landing page navigation includes a Documentation entry
+
+The landing page navigation SHALL include a "Documentation" entry linking to the live documentation site, in both the desktop nav links and the mobile menu, with `en` and `zh` i18n copy (`nav.docs`). The entry SHALL open in a new tab and its target SHALL be language-aware: the `en` landing links to `https://doc.chorus-ai.dev`, the `zh` landing links to `https://doc.chorus-ai.dev/zh`.
+
+#### Scenario: Visitor clicks Documentation on the English landing page
+
+- **WHEN** a visitor on the `en` landing page clicks the Documentation nav entry
+- **THEN** the docs site root `https://doc.chorus-ai.dev` opens in a new browser tab
+
+#### Scenario: Visitor clicks Documentation on the Chinese landing page
+
+- **WHEN** a visitor on the `zh` landing page clicks the Documentation nav entry
+- **THEN** the Chinese docs section `https://doc.chorus-ai.dev/zh` opens in a new browser tab
+
+#### Scenario: Documentation entry present on mobile
+
+- **WHEN** the landing page is viewed at a mobile width and the menu is opened
+- **THEN** the Documentation entry appears in the mobile menu with the localized `nav.docs` label
+

--- a/openspec/specs/readme-docs-link/spec.md
+++ b/openspec/specs/readme-docs-link/spec.md
@@ -1,0 +1,19 @@
+# readme-docs-link Specification
+
+## Purpose
+Ensure every README locale (en / zh / ko / ja) links prominently to the live documentation site near its header, without disturbing the existing banner, tagline, language switch, or badges.
+## Requirements
+### Requirement: README links to the documentation site
+
+Every README locale (README.md, README.zh.md, README.ko.md, README.ja.md) SHALL carry a prominent link to the live documentation site `https://doc.chorus-ai.dev`, placed near the top (adjacent to the language-switch line), with a locale-appropriate label.
+
+#### Scenario: Reader opens any localized README
+
+- **WHEN** a visitor reads any of the four README locales on GitHub
+- **THEN** a "Documentation"-style link (localized label) to `https://doc.chorus-ai.dev` is visible near the header, above the main content
+
+#### Scenario: Existing header elements preserved
+
+- **WHEN** the docs link is added
+- **THEN** the existing banner image, tagline, language-switch line, and badges block remain intact and correctly rendered
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "The Agent Harness for AI-Human Collaboration — session lifecycle, task state, sub-agent orchestration, observability, and failure recovery",
   "homepage": "https://github.com/Chorus-AIDLC/Chorus",
   "repository": {

--- a/packages/chorus-pi/extensions/chorus.ts
+++ b/packages/chorus-pi/extensions/chorus.ts
@@ -119,7 +119,7 @@ async function mcpCall<T = unknown>(tool: string, args: Record<string, unknown> 
       params: {
         protocolVersion: "2025-03-26",
         capabilities: {},
-        clientInfo: { name: "chorus-pi", version: "0.15.0" },
+        clientInfo: { name: "chorus-pi", version: "0.16.0" },
       },
     }),
   });

--- a/packages/chorus-pi/package.json
+++ b/packages/chorus-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus-pi",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Chorus AI-DLC collaboration platform extension for the Pi coding agent. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware extension hooks. The Chorus MCP server is auto-discovered from the repo's .mcp.json by pi-mcp-adapter — no installer required.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/packages/chorus-pi/skills/chorus/SKILL.md
+++ b/packages/chorus-pi/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -418,6 +418,7 @@ This is the core overview skill. For stage-specific workflows, use:
 | **Planning** | `/skill:proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
 | **Development** | `/skill:develop` | Claim Tasks, report work, session & parallel sub-agent integration |
 | **Review** | `/skill:review` | Approve/reject Proposals, verify Tasks, project governance |
+| **Docs** | `/skill:docs` | Consult the live Chorus documentation site to answer product-usage questions — UI workflow, agent/plugin setup, API/MCP, deployment, operations |
 | **OpenSpec mode** | `openspec-aware` | Opt-in **shared sub-procedure** invoked by `/skill:proposal`, `/skill:develop`, and `/skill:yolo` whenever the user has the `openspec` CLI installed. Scaffolds `openspec/changes/<slug>/` on disk and mirrors files into Chorus document drafts. Skips silently in fallback mode. See `skills/openspec-aware/SKILL.md`. |
 
 ### Getting Started

--- a/packages/chorus-pi/skills/develop/SKILL.md
+++ b/packages/chorus-pi/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/chorus-pi/skills/docs/SKILL.md
+++ b/packages/chorus-pi/skills/docs/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docs
+description: Chorus documentation router — consult the live Chorus docs site to answer product-usage questions (UI workflow, agent/plugin setup, API/MCP, deployment, operations).
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.16.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Docs Skill
+
+This skill is a **thin router to the live Chorus documentation site** (`https://doc.chorus-ai.dev`). Use it to answer questions about **how to use, configure, deploy, or operate Chorus** — grounding the answer in the current published docs instead of memory.
+
+It is **not** a workflow skill: it does not drive the AI-DLC pipeline. For that, use `/skill:idea`, `/skill:proposal`, `/skill:develop`, `/skill:review`, or `/skill:yolo`.
+
+---
+
+## When to Use
+
+Use this skill whenever the user asks a **product-usage** question about Chorus, such as:
+
+- **UI workflow** — how the Idea → Proposal → Task → Verify pipeline works in the web app, what a control does, how statuses flow.
+- **Agent setup** — creating an API key, permissions and role presets, connecting an agent.
+- **Plugin setup** — installing/configuring the Claude Code / Codex / OpenClaw / Kiro / Pi plugin.
+- **API / MCP** — the REST API, the MCP tool surface, authentication, real-time events.
+- **Deployment** — self-hosting, the CDK stack, environment configuration.
+- **Operations / troubleshooting** — running Chorus, diagnosing connection or setup problems.
+
+Do **NOT** use it to *drive* the pipeline (claiming ideas, writing proposals, executing tasks) — that is what the stage skills above are for. This skill answers "how does the product work / how do I set it up"; the stage skills *do* the work.
+
+---
+
+## Access Convention
+
+The docs site is agent-friendly. Follow this three-step convention every time. **Do NOT** answer from memory, and **do NOT** hardcode a page list — the index is the source of truth and pages change over time.
+
+1. **Fetch the index.** Get `https://doc.chorus-ai.dev/llms.txt` — a machine-readable index that lists every documentation page with a one-line summary and its `.md` URL. **The index is a single, unlocalized file that lives ONLY at the root `/llms.txt`. Never prefix it with a locale — `https://doc.chorus-ai.dev/zh/llms.txt` (and `/ja/`, `/ko/`) does NOT exist and returns 404.**
+2. **Fetch the relevant page(s) as raw Markdown.** Pick the page(s) that match the question from the index, then fetch the raw Markdown by **appending `.md`** to the page URL (e.g. `https://doc.chorus-ai.dev/guides/getting-started` → `https://doc.chorus-ai.dev/guides/getting-started.md`).
+3. **Ground the answer and link the human page.** Base your answer on the fetched Markdown, and link the human-facing page (the `.md` URL **without** the `.md` suffix) so the user can open it in a browser.
+
+Use whatever web-fetch capability your environment provides (your built-in fetch tool, `curl`, etc.) — this skill states the convention, not a specific tool binding.
+
+---
+
+## Locale
+
+The `/llms.txt` index itself is **not** localized — there is exactly one, at the root. Localization applies to **pages**, not the index:
+
+- The index always lives at `https://doc.chorus-ai.dev/llms.txt` and lists the root (`en`) page URLs. **Do not look for `/zh/llms.txt` — it does not exist.**
+- `en` is the root (unprefixed): `https://doc.chorus-ai.dev/...`
+- `zh`, `ja`, `ko` are **path-prefixed pages**: take a page path from the index and prepend the locale — `https://doc.chorus-ai.dev/zh/...`, `/ja/...`, `/ko/...`
+- Appending `.md` works on the prefixed pages too (e.g. `https://doc.chorus-ai.dev/zh/guides/getting-started.md`).
+- **Match the user's language** when the docs exist in it; fall back to `en` otherwise.
+
+---
+
+## Relationship to the Workflow Skills
+
+This skill **complements** the AI-DLC workflow skills — it does not replace them:
+
+| The user wants to… | Use |
+|--------------------|-----|
+| Learn how to use / configure / deploy / operate Chorus | **this skill** (`/skill:docs`) |
+| Drive an idea / write a proposal / execute or verify a task | `/skill:idea`, `/skill:proposal`, `/skill:develop`, `/skill:review`, `/skill:yolo` |
+
+Always use the live host `doc.chorus-ai.dev`. `docs.chorus-ai.dev` (with an "s") is a dead link — never use it.

--- a/packages/chorus-pi/skills/idea/SKILL.md
+++ b/packages/chorus-pi/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/chorus-pi/skills/openspec-aware/SKILL.md
+++ b/packages/chorus-pi/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Pi. Detec
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/chorus-pi/skills/proposal/SKILL.md
+++ b/packages/chorus-pi/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/chorus-pi/skills/quick-dev/SKILL.md
+++ b/packages/chorus-pi/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/chorus-pi/skills/review/SKILL.md
+++ b/packages/chorus-pi/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/chorus-pi/skills/yolo/SKILL.md
+++ b/packages/chorus-pi/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/landing/src/components/Nav.astro
+++ b/packages/landing/src/components/Nav.astro
@@ -10,6 +10,7 @@ const { lang } = Astro.props;
 const pre = langPrefix(lang);
 const githubUrl = "https://github.com/Chorus-AIDLC/chorus";
 const dockerUrl = "https://hub.docker.com/r/chorusaidlc/chorus-app";
+const docsUrl = lang === 'zh' ? 'https://doc.chorus-ai.dev/zh' : 'https://doc.chorus-ai.dev';
 const altLang = lang === 'en' ? 'zh' : 'en';
 const altUrl = getAlternateUrl(Astro.url) + '?lang=' + altLang;
 const enUrl = (lang === 'en' ? Astro.url.pathname : getAlternateUrl(Astro.url)) + '?lang=en';
@@ -27,6 +28,7 @@ const currentLabel = lang === 'en' ? 'EN' : '中文';
       <a href={`${pre}/#features`}>{t(lang, 'nav.features')}</a>
       <a href={`${pre}/#showcase`}>{t(lang, 'nav.showcase')}</a>
       <a href={`${pre}/#agents`}>{t(lang, 'nav.agents')}</a>
+      <a href={docsUrl} target="_blank" rel="noopener noreferrer">{t(lang, 'nav.docs')}</a>
       <a href={`${pre}/blog/`}>{t(lang, 'nav.blog')}</a>
     </div>
     <div class="nav-actions">
@@ -64,6 +66,7 @@ const currentLabel = lang === 'en' ? 'EN' : '中文';
     <a href={`${pre}/#features`}>{t(lang, 'nav.features')}</a>
     <a href={`${pre}/#showcase`}>{t(lang, 'nav.showcase')}</a>
     <a href={`${pre}/#agents`}>{t(lang, 'nav.agents')}</a>
+    <a href={docsUrl} target="_blank" rel="noopener noreferrer">{t(lang, 'nav.docs')}</a>
     <a href={`${pre}/blog/`}>{t(lang, 'nav.blog')}</a>
     <div class="mobile-divider"></div>
     <div class="mobile-lang">

--- a/packages/landing/src/i18n/translations/en.json
+++ b/packages/landing/src/i18n/translations/en.json
@@ -4,6 +4,7 @@
     "showcase": "Showcase",
     "agents": "Agents",
     "blog": "Blog",
+    "docs": "Documentation",
     "dockerHub": "Docker Hub",
     "github": "GitHub",
     "menu": "Menu"

--- a/packages/landing/src/i18n/translations/zh.json
+++ b/packages/landing/src/i18n/translations/zh.json
@@ -4,6 +4,7 @@
     "showcase": "展示",
     "agents": "Agent",
     "blog": "博客",
+    "docs": "文档",
     "dockerHub": "Docker Hub",
     "github": "GitHub",
     "menu": "菜单"

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chorus-aidlc/chorus-openclaw-plugin",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "OpenClaw plugin for Chorus AI-DLC collaboration platform — native MCP + SSE real-time events",
   "license": "MIT",
   "type": "module",

--- a/packages/openclaw-plugin/skills/brainstorm/SKILL.md
+++ b/packages/openclaw-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/chorus/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -454,6 +454,7 @@ This is the core overview skill. For stage-specific workflows, use:
 | **Planning** | `/proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
 | **Development** | `/develop` | Claim Tasks, report work, manual session & sub-agent management |
 | **Review** | `/review` | Approve/reject Proposals, verify Tasks, project governance |
+| **Docs** | `/docs` | Consult the live Chorus documentation site to answer product-usage questions — UI workflow, agent/plugin setup, API/MCP, deployment, operations |
 | **OpenSpec mode** | `openspec-aware` | Opt-in **shared sub-procedure** invoked by `/proposal`, `/develop`, and `/yolo` whenever the user has the `openspec` CLI installed. Scaffolds `openspec/changes/<slug>/` on disk and mirrors files into Chorus document drafts via the `chorus-api.sh` wrapper. Runs an inline three-check detection (no SessionStart hook on OpenClaw). Skips silently in fallback mode. |
 
 ### Getting Started

--- a/packages/openclaw-plugin/skills/code-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/code-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Final ship-time review of an Idea's aggregate code change — the w
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/develop/SKILL.md
+++ b/packages/openclaw-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/docs/SKILL.md
+++ b/packages/openclaw-plugin/skills/docs/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docs
+description: Chorus documentation router — consult the live Chorus docs site to answer product-usage questions (UI workflow, agent/plugin setup, API/MCP, deployment, operations).
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.16.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Docs Skill
+
+This skill is a **thin router to the live Chorus documentation site** (`https://doc.chorus-ai.dev`). Use it to answer questions about **how to use, configure, deploy, or operate Chorus** — grounding the answer in the current published docs instead of memory.
+
+It is **not** a workflow skill: it does not drive the AI-DLC pipeline. For that, use `/idea`, `/proposal`, `/develop`, `/review`, or `/yolo`.
+
+---
+
+## When to Use
+
+Use this skill whenever the user asks a **product-usage** question about Chorus, such as:
+
+- **UI workflow** — how the Idea → Proposal → Task → Verify pipeline works in the web app, what a control does, how statuses flow.
+- **Agent setup** — creating an API key, permissions and role presets, connecting an agent.
+- **Plugin setup** — installing/configuring the Claude Code / Codex / OpenClaw / Kiro / Pi plugin.
+- **API / MCP** — the REST API, the MCP tool surface, authentication, real-time events.
+- **Deployment** — self-hosting, the CDK stack, environment configuration.
+- **Operations / troubleshooting** — running Chorus, diagnosing connection or setup problems.
+
+Do **NOT** use it to *drive* the pipeline (claiming ideas, writing proposals, executing tasks) — that is what the stage skills above are for. This skill answers "how does the product work / how do I set it up"; the stage skills *do* the work.
+
+---
+
+## Access Convention
+
+The docs site is agent-friendly. Follow this three-step convention every time. **Do NOT** answer from memory, and **do NOT** hardcode a page list — the index is the source of truth and pages change over time.
+
+1. **Fetch the index.** Get `https://doc.chorus-ai.dev/llms.txt` — a machine-readable index that lists every documentation page with a one-line summary and its `.md` URL. **The index is a single, unlocalized file that lives ONLY at the root `/llms.txt`. Never prefix it with a locale — `https://doc.chorus-ai.dev/zh/llms.txt` (and `/ja/`, `/ko/`) does NOT exist and returns 404.**
+2. **Fetch the relevant page(s) as raw Markdown.** Pick the page(s) that match the question from the index, then fetch the raw Markdown by **appending `.md`** to the page URL (e.g. `https://doc.chorus-ai.dev/guides/getting-started` → `https://doc.chorus-ai.dev/guides/getting-started.md`).
+3. **Ground the answer and link the human page.** Base your answer on the fetched Markdown, and link the human-facing page (the `.md` URL **without** the `.md` suffix) so the user can open it in a browser.
+
+Use whatever web-fetch capability your environment provides (your built-in fetch tool, `curl`, etc.) — this skill states the convention, not a specific tool binding.
+
+---
+
+## Locale
+
+The `/llms.txt` index itself is **not** localized — there is exactly one, at the root. Localization applies to **pages**, not the index:
+
+- The index always lives at `https://doc.chorus-ai.dev/llms.txt` and lists the root (`en`) page URLs. **Do not look for `/zh/llms.txt` — it does not exist.**
+- `en` is the root (unprefixed): `https://doc.chorus-ai.dev/...`
+- `zh`, `ja`, `ko` are **path-prefixed pages**: take a page path from the index and prepend the locale — `https://doc.chorus-ai.dev/zh/...`, `/ja/...`, `/ko/...`
+- Appending `.md` works on the prefixed pages too (e.g. `https://doc.chorus-ai.dev/zh/guides/getting-started.md`).
+- **Match the user's language** when the docs exist in it; fall back to `en` otherwise.
+
+---
+
+## Relationship to the Workflow Skills
+
+This skill **complements** the AI-DLC workflow skills — it does not replace them:
+
+| The user wants to… | Use |
+|--------------------|-----|
+| Learn how to use / configure / deploy / operate Chorus | **this skill** (`/docs`) |
+| Drive an idea / write a proposal / execute or verify a task | `/idea`, `/proposal`, `/develop`, `/review`, `/yolo` |
+
+Always use the live host `doc.chorus-ai.dev`. `docs.chorus-ai.dev` (with an "s") is a dead link — never use it.

--- a/packages/openclaw-plugin/skills/idea/SKILL.md
+++ b/packages/openclaw-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
+++ b/packages/openclaw-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows on OpenClaw.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial read-only review of a submitted Chorus proposal — doc
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/proposal/SKILL.md
+++ b/packages/openclaw-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/quick-dev/SKILL.md
+++ b/packages/openclaw-plugin/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/review/SKILL.md
+++ b/packages/openclaw-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
+++ b/packages/openclaw-plugin/skills/task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial verification of a submitted Chorus task against its AC 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/packages/openclaw-plugin/skills/yolo/SKILL.md
+++ b/packages/openclaw-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/.codex-plugin/plugin.json
+++ b/plugins/chorus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Chorus AI-DLC collaboration platform plugin for Codex CLI. Provides skills for every stage of the AI-DLC lifecycle, read-only reviewer subagents, and session-aware hooks. MCP server is configured separately via the install script.",
   "author": {
     "name": "Chorus-AIDLC"

--- a/plugins/chorus/hooks/chorus-mcp-call.sh
+++ b/plugins/chorus/hooks/chorus-mcp-call.sh
@@ -54,7 +54,7 @@ ACCEPT="Accept: application/json, text/event-stream"
 CT="Content-Type: application/json"
 
 INIT=$(cat <<JSON
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.15.0"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-codex-hook","version":"0.16.0"}}}
 JSON
 )
 

--- a/plugins/chorus/skills/brainstorm/SKILL.md
+++ b/plugins/chorus/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/chorus-code-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-code-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus code-review gateway — the final ship-time revie
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus code-review gateway

--- a/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-proposal-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus proposal reviewer. Fetches a proposal via MCP, au
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus proposal reviewer

--- a/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
+++ b/plugins/chorus/skills/chorus-task-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: 'Read-only Chorus task reviewer. Fetches a task plus its acceptance
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
   short-description: Adversarial Chorus task reviewer

--- a/plugins/chorus/skills/chorus/SKILL.md
+++ b/plugins/chorus/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -139,7 +139,7 @@ A **report** is a short idea-completion summary persisted as a `type="report"` D
 
 A **reference** is a first-class external-evidence link (`docs` / `repo` / `issue_pr` / `paper_blog`) attached to an idea / proposal / task via `chorus_add_reference`, or inline at creation via the `references[]` param on `chorus_pm_create_idea` / `chorus_pm_create_proposal` / `chorus_create_tasks`. References read back inline through the `chorus_get_*` tools.
 
-**Make it a reflex:** the moment you come across an external link that is evidence for what you're working on — a precedent issue/PR, a reference implementation, official docs, a paper/blog — attach it, and **prefer attaching inline at creation time** rather than after the fact. See `/idea` (Step 4.4) for the type-selection criteria and a worked example.
+**Make it a reflex:** the moment you come across an external link that is evidence for what you're working on — a precedent issue/PR, a reference implementation, official docs, a paper/blog — attach it, and **prefer attaching inline at creation time** rather than after the fact. See `$idea` (Step 4.4) for the type-selection criteria and a worked example.
 
 ### Proposals
 
@@ -198,7 +198,7 @@ Use @mentions to notify specific users or agents. Mention syntax: `@[DisplayName
 3. Mentioned users/agents automatically receive a notification
 
 **When to @mention:**
-- **Elaboration completion** — confirm understanding with the answerer before validating (see `/idea`)
+- **Elaboration completion** — confirm understanding with the answerer before validating (see `$idea`)
 - **Proposal creation/update** — notify stakeholders when submitting
 - **Task submission** — notify PM/owner for significant decisions
 - **Blocking issues** — notify relevant person for human input
@@ -376,12 +376,13 @@ This is the core overview skill. For stage-specific workflows, use:
 
 | Stage | Skill | Description |
 |-------|-------|-------------|
-| **Full Auto** | `/yolo` | Full-auto AI-DLC pipeline — from prompt to done. Automates Idea → Proposal → Execute → Verify with adversarial reviewers |
-| **Quick Dev** | `/quick-dev` | Skip Idea→Proposal, create tasks directly, execute, and verify |
-| **Ideation** | `/idea` | Claim Ideas, run elaboration rounds, prepare for proposal |
-| **Planning** | `/proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
-| **Development** | `/develop` | Claim Tasks, report work, and coordinate sub-agent workers |
-| **Review** | `/review` | Approve/reject Proposals, verify Tasks, project governance |
+| **Full Auto** | `$yolo` | Full-auto AI-DLC pipeline — from prompt to done. Automates Idea → Proposal → Execute → Verify with adversarial reviewers |
+| **Quick Dev** | `$quick-dev` | Skip Idea→Proposal, create tasks directly, execute, and verify |
+| **Ideation** | `$idea` | Claim Ideas, run elaboration rounds, prepare for proposal |
+| **Planning** | `$proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
+| **Development** | `$develop` | Claim Tasks, report work, and coordinate sub-agent workers |
+| **Review** | `$review` | Approve/reject Proposals, verify Tasks, project governance |
+| **Docs** | `$docs` | Consult the live Chorus documentation site to answer product-usage questions — UI workflow, agent/plugin setup, API/MCP, deployment, operations |
 | **OpenSpec mode** | `openspec-aware` | Opt-in **shared sub-procedure** invoked by `proposal`, `develop`, and `yolo` whenever the user has the `openspec` CLI installed. Scaffolds `openspec/changes/<slug>/` on disk and mirrors files into Chorus document drafts via the `chorus-mcp-call.sh` wrapper. Skips silently in fallback mode. See `~/.codex/skills/openspec-aware/SKILL.md`. |
 
 ### Getting Started
@@ -389,6 +390,6 @@ This is the core overview skill. For stage-specific workflows, use:
 1. Call `chorus_checkin()` to learn your role and assignments
 2. Based on your role, use the appropriate skill:
    - **Full Auto** → `$yolo` — give a prompt, agent handles everything (requires Admin-preset permissions: write on every resource + approve/verify admin bits)
-   - PM Agent → `/idea` then `/proposal`
-   - Developer Agent → `/develop`
-   - Admin Agent → `/review` (also has access to all PM and Developer tools)
+   - PM Agent → `$idea` then `$proposal`
+   - Developer Agent → `$develop`
+   - Admin Agent → `$review` (also has access to all PM and Developer tools)

--- a/plugins/chorus/skills/develop/SKILL.md
+++ b/plugins/chorus/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, and spawn
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -17,7 +17,7 @@ This skill covers the **Development** stage of the AI-DLC workflow: claiming Tas
 
 ## Overview
 
-Developer Agents take Tasks created by PM Agents (via `/proposal`) and turn them into working code. Each task follows:
+Developer Agents take Tasks created by PM Agents (via `$proposal`) and turn them into working code. Each task follows:
 
 ```
 claim --> in_progress --> report work --> self-check AC --> submit for verify --> Admin /review
@@ -50,7 +50,7 @@ For multi-agent parallel execution, the main agent uses Codex's `spawn_agent` to
 |------|---------|
 | `chorus_report_criteria_self_check` | Report self-check results (passed/failed + optional evidence) on structured acceptance criteria |
 
-**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+**Shared tools** (checkin, query, comment, search, notifications): see `$chorus`
 
 ---
 
@@ -363,6 +363,6 @@ chorus_add_comment({ targetType: "task", targetUuid: "<task-uuid>", content: "Re
 
 ## Next
 
-- After submitting for verification, an Admin reviews using `/review`
+- After submitting for verification, an Admin reviews using `$review`
 - **Human "Yolo" wake:** a `yolo_requested` wake (the human clicked **Yolo** on the idea-detail panel) means: drive the WHOLE idea to done via the yolo skill (the full-auto AI-DLC pipeline), not just the execute stage — read the idea's current state and resume from whatever phase it is in. It is stage-adaptive, and it must never merge or push a PR without explicit human approval.
-- For platform overview and shared tools, see `/chorus`
+- For platform overview and shared tools, see `$chorus`

--- a/plugins/chorus/skills/docs/SKILL.md
+++ b/plugins/chorus/skills/docs/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docs
+description: Chorus documentation router — consult the live Chorus docs site to answer product-usage questions (UI workflow, agent/plugin setup, API/MCP, deployment, operations).
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.16.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Docs Skill
+
+This skill is a **thin router to the live Chorus documentation site** (`https://doc.chorus-ai.dev`). Use it to answer questions about **how to use, configure, deploy, or operate Chorus** — grounding the answer in the current published docs instead of memory.
+
+It is **not** a workflow skill: it does not drive the AI-DLC pipeline. For that, use `$idea`, `$proposal`, `$develop`, `$review`, or `$yolo`.
+
+---
+
+## When to Use
+
+Use this skill whenever the user asks a **product-usage** question about Chorus, such as:
+
+- **UI workflow** — how the Idea → Proposal → Task → Verify pipeline works in the web app, what a control does, how statuses flow.
+- **Agent setup** — creating an API key, permissions and role presets, connecting an agent.
+- **Plugin setup** — installing/configuring the Claude Code / Codex / OpenClaw / Kiro / Pi plugin (Codex reads MCP config from `~/.codex/config.toml`).
+- **API / MCP** — the REST API, the MCP tool surface, authentication, real-time events.
+- **Deployment** — self-hosting, the CDK stack, environment configuration.
+- **Operations / troubleshooting** — running Chorus, diagnosing connection or setup problems.
+
+Do **NOT** use it to *drive* the pipeline (claiming ideas, writing proposals, executing tasks) — that is what the stage skills above are for. This skill answers "how does the product work / how do I set it up"; the stage skills *do* the work.
+
+---
+
+## Access Convention
+
+The docs site is agent-friendly. Follow this three-step convention every time. **Do NOT** answer from memory, and **do NOT** hardcode a page list — the index is the source of truth and pages change over time.
+
+1. **Fetch the index.** Get `https://doc.chorus-ai.dev/llms.txt` — a machine-readable index that lists every documentation page with a one-line summary and its `.md` URL. **The index is a single, unlocalized file that lives ONLY at the root `/llms.txt`. Never prefix it with a locale — `https://doc.chorus-ai.dev/zh/llms.txt` (and `/ja/`, `/ko/`) does NOT exist and returns 404.**
+2. **Fetch the relevant page(s) as raw Markdown.** Pick the page(s) that match the question from the index, then fetch the raw Markdown by **appending `.md`** to the page URL (e.g. `https://doc.chorus-ai.dev/guides/getting-started` → `https://doc.chorus-ai.dev/guides/getting-started.md`).
+3. **Ground the answer and link the human page.** Base your answer on the fetched Markdown, and link the human-facing page (the `.md` URL **without** the `.md` suffix) so the user can open it in a browser.
+
+Use whatever web-fetch capability your environment provides (your built-in fetch tool, `curl`, etc.) — this skill states the convention, not a specific tool binding.
+
+---
+
+## Locale
+
+The `/llms.txt` index itself is **not** localized — there is exactly one, at the root. Localization applies to **pages**, not the index:
+
+- The index always lives at `https://doc.chorus-ai.dev/llms.txt` and lists the root (`en`) page URLs. **Do not look for `/zh/llms.txt` — it does not exist.**
+- `en` is the root (unprefixed): `https://doc.chorus-ai.dev/...`
+- `zh`, `ja`, `ko` are **path-prefixed pages**: take a page path from the index and prepend the locale — `https://doc.chorus-ai.dev/zh/...`, `/ja/...`, `/ko/...`
+- Appending `.md` works on the prefixed pages too (e.g. `https://doc.chorus-ai.dev/zh/guides/getting-started.md`).
+- **Match the user's language** when the docs exist in it; fall back to `en` otherwise.
+
+---
+
+## Relationship to the Workflow Skills
+
+This skill **complements** the AI-DLC workflow skills — it does not replace them:
+
+| The user wants to… | Use |
+|--------------------|-----|
+| Learn how to use / configure / deploy / operate Chorus | **this skill** (`$docs`) |
+| Drive an idea / write a proposal / execute or verify a task | `$idea`, `$proposal`, `$develop`, `$review`, `$yolo` |
+
+Always use the live host `doc.chorus-ai.dev`. `docs.chorus-ai.dev` (with an "s") is a dead link — never use it.

--- a/plugins/chorus/skills/idea/SKILL.md
+++ b/plugins/chorus/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -17,7 +17,7 @@ This skill covers the **Ideation** stage of the AI-DLC workflow: claiming Ideas,
 
 ## Overview
 
-Ideas are the starting point of the AI-DLC pipeline. Humans (or Admin agents) create Ideas describing what they need. The PM Agent claims an Idea, runs elaboration to clarify requirements, and then moves on to `/proposal` to create a Proposal with document and task drafts.
+Ideas are the starting point of the AI-DLC pipeline. Humans (or Admin agents) create Ideas describing what they need. The PM Agent claims an Idea, runs elaboration to clarify requirements, and then moves on to `$proposal` to create a Proposal with document and task drafts.
 
 **Idea status lifecycle (3 stored states):**
 
@@ -51,7 +51,7 @@ All post-elaboration progress (planning, building, verifying, done) is **derived
 | `chorus_answer_elaboration` | Submit answers for an elaboration round (`roundUuid` optional — auto-locates the active round) |
 | `chorus_get_elaboration` | Get full elaboration state (rounds, questions, answers) |
 
-**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+**Shared tools** (checkin, query, comment, search, notifications): see `$chorus`
 
 ---
 
@@ -151,9 +151,9 @@ chorus_pm_create_idea({
 If the Idea is fuzzy and you'd struggle to enumerate concrete multi-choice questions, offer the user a brainstorm prelude before structured elaboration. Present two choices to the user (existing convention used elsewhere in this skill — see Step 5's `AskUserQuestion` usage for the host-specific prompt mechanism): `"Already clear, run structured elaboration"` and `"Brainstorm first to explore directions"`.
 
 - **"Already clear":** Skip to Step 5.
-- **"Brainstorm first":** Invoke the `/brainstorm` skill. See `/brainstorm` for the dialogue cadence and synthesis rules — do NOT re-implement them here.
+- **"Brainstorm first":** Invoke the `$brainstorm` skill. See `$brainstorm` for the dialogue cadence and synthesis rules — do NOT re-implement them here.
 
-When `/brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
+When `$brainstorm` returns, you own the lifecycle decision (the brainstorm skill deliberately leaves it to you):
 
 - If the synthesized round answers cover everything → obtain human confirmation, then call `chorus_pm_validate_elaboration` to resolve the elaboration. (Resolve needs `idea:admin` — see Step 5.6 if your key is `pm_agent`-preset.)
 - If gaps remain → call `chorus_pm_start_elaboration` again to open a structured Round 2. Pick the depth yourself — do NOT re-prompt the user.
@@ -341,6 +341,6 @@ When a theme is created via the conversational "help me break this into child id
 
 ## Next
 
-- Once elaboration is resolved, use `/proposal` to create a Proposal with document and task drafts
+- Once elaboration is resolved, use `$proposal` to create a Proposal with document and task drafts
 - **Human "Yolo" handoff:** the idea-detail panel shows a **Yolo** button at any incomplete stage (enabled while the assignee agent is online), confirmed via a dialog before it fires. A `yolo_requested` wake means: drive the WHOLE idea to done via the yolo skill (the full-auto AI-DLC pipeline) — read the idea's current state first and resume from whatever phase it is in, never assuming a fixed stage. Complete through done + the completion report, but never merge or push a PR without explicit human approval.
-- For platform overview and shared tools, see `/chorus`
+- For platform overview and shared tools, see `$chorus`

--- a/plugins/chorus/skills/openspec-aware/SKILL.md
+++ b/plugins/chorus/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Codex. De
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/plugins/chorus/skills/proposal/SKILL.md
+++ b/plugins/chorus/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -17,7 +17,7 @@ This skill covers the **Planning** stage of the AI-DLC workflow: creating Propos
 
 ## Overview
 
-After an Idea's elaboration is resolved (see `/idea`), the PM Agent creates a Proposal — a container that holds document drafts and task drafts. On Admin approval, these drafts materialize into real Documents and Tasks.
+After an Idea's elaboration is resolved (see `$idea`), the PM Agent creates a Proposal — a container that holds document drafts and task drafts. On Admin approval, these drafts materialize into real Documents and Tasks.
 
 ```
 Elaboration resolved --> Create Proposal --> Add drafts --> Validate --> Submit --> Admin /review
@@ -61,7 +61,7 @@ Elaboration resolved --> Create Proposal --> Add drafts --> Validate --> Submit 
 | `chorus_pm_update_document` | Update document content (increments version) |
 | `chorus_update_task` (with `addDependsOn` / `removeDependsOn`) | Add or remove dependencies on existing tasks (with cycle detection) |
 
-**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+**Shared tools** (checkin, query, comment, search, notifications): see `$chorus`
 
 ---
 
@@ -83,7 +83,7 @@ chorus_pm_create_proposal({
 
 **Multiple Ideas:** You can combine multiple ideas into one proposal by passing multiple UUIDs in `inputUuids`.
 
-> **A theme cannot be a proposal input** — `chorus_pm_create_proposal` rejects any input idea with `isContainer = true`. Derive a child idea from the theme and write the proposal on the child instead. (See the theme-ideas section of the `/idea` skill.)
+> **A theme cannot be a proposal input** — `chorus_pm_create_proposal` rejects any input idea with `isContainer = true`. Derive a child idea from the theme and write the proposal on the child instead. (See the theme-ideas section of the `$idea` skill.)
 
 ### Step 1.5: Detect OpenSpec mode
 
@@ -203,7 +203,7 @@ When validation passes:
 chorus_pm_submit_proposal({ proposalUuid: "<proposal-uuid>" })
 ```
 
-This changes the status from `draft` to `pending`. An Admin will review it (see `/review`).
+This changes the status from `draft` to `pending`. An Admin will review it (see `$review`).
 
 Add a comment explaining your reasoning:
 
@@ -376,7 +376,7 @@ Each task should correspond to an **independently runnable and testable function
 
 ## Next
 
-- After submission, an Admin will review using `/review`
-- After approval, Developers claim tasks using `/develop`
-- For Idea elaboration, see `/idea`
-- For platform overview, see `/chorus`
+- After submission, an Admin will review using `$review`
+- After approval, Developers claim tasks using `$develop`
+- For Idea elaboration, see `$idea`
+- For platform overview, see `$chorus`

--- a/plugins/chorus/skills/quick-dev/SKILL.md
+++ b/plugins/chorus/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -36,7 +36,7 @@ check explicit task:admin permission → create/claim → implement → self-che
 - Stakeholder elaboration is needed to clarify requirements
 - The work impacts architecture or shared components significantly
 
-For complex work, use `/idea` + `/proposal` instead.
+For complex work, use `$idea` + `$proposal` instead.
 
 ---
 
@@ -164,7 +164,7 @@ This handoff applies in interactive and headless daemon sessions. Do not use an 
 
 ## Tips
 
-- Keep Quick Tasks small — if you need more than 2-3 tasks, consider using `/proposal`
+- Keep Quick Tasks small — if you need more than 2-3 tasks, consider using `$proposal`
 - **Acceptance criteria are required at creation time** — `chorus_create_tasks` rejects tasks without them. They are your self-check contract; specific, testable AC enables autonomous verification and makes the entire workflow self-contained
 - Use `chorus_update_task` to refine tasks (including AC) after creation rather than deleting and recreating
 - Pass `proposalUuid` to attach follow-up or gap-filling tasks to an existing proposal — this keeps related work grouped in the same project context and DAG
@@ -175,7 +175,7 @@ This handoff applies in interactive and headless daemon sessions. Do not use an 
 
 ## Next
 
-- For full task lifecycle details, see `/develop`
-- For admin verification, see `/review`
-- For the standard planning flow, see `/idea` and `/proposal`
-- For platform overview, see `/chorus`
+- For full task lifecycle details, see `$develop`
+- For admin verification, see `$review`
+- For the standard planning flow, see `$idea` and `$proposal`
+- For platform overview, see `$chorus`

--- a/plugins/chorus/skills/review/SKILL.md
+++ b/plugins/chorus/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -20,8 +20,8 @@ This skill covers the **Review** stage of the AI-DLC workflow: approving or reje
 Admin Agent has **full access to all Chorus operations**. You are the **human proxy role** — acting on behalf of the project owner to ensure quality and manage the AI-DLC lifecycle.
 
 Key responsibilities:
-- **Proposal review** — approve or reject Proposals submitted by PM Agents (see `/proposal`)
-- **Task verification** — verify or reopen Tasks submitted by Developer Agents (see `/develop`)
+- **Proposal review** — approve or reject Proposals submitted by PM Agents (see `$proposal`)
+- **Task verification** — verify or reopen Tasks submitted by Developer Agents (see `$develop`)
 - **Project governance** — create projects/ideas, manage groups, close/delete entities
 
 ---
@@ -56,7 +56,7 @@ Key responsibilities:
 
 **All PM tools** (`chorus_pm_*`, `chorus_*_idea`) and **all Developer tools** (`chorus_*_task`, `chorus_report_work`) are also available to Admin.
 
-**Shared tools** (checkin, query, comment, search, notifications): see `/chorus`
+**Shared tools** (checkin, query, comment, search, notifications): see `$chorus`
 
 ---
 
@@ -299,7 +299,7 @@ chorus_admin_close_idea({ ideaUuid: "<idea-uuid>" })
 chorus_admin_delete_idea({ ideaUuid: "<idea-uuid>" })
 ```
 
-> **Note:** Creating ideas is a PM tool (`chorus_pm_create_idea`). See `/idea`.
+> **Note:** Creating ideas is a PM tool (`chorus_pm_create_idea`). See `$idea`.
 
 #### Document Management
 
@@ -348,7 +348,7 @@ chorus_pm_update_document({ documentUuid: "<doc-uuid>", content: "Updated..." })
 
 ## Next
 
-- For platform overview and shared tools, see `/chorus`
-- For Idea elaboration (before proposals), see `/idea`
-- For Proposal creation (what you're reviewing), see `/proposal`
-- For Developer workflow (what you're verifying), see `/develop`
+- For platform overview and shared tools, see `$chorus`
+- For Idea elaboration (before proposals), see `$idea`
+- For Proposal creation (what you're reviewing), see `$proposal`
+- For Developer workflow (what you're verifying), see `$develop`

--- a/plugins/chorus/skills/yolo/SKILL.md
+++ b/plugins/chorus/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -17,7 +17,7 @@ Full-auto AI-DLC pipeline. User provides a prompt; agent drives the entire lifec
 
 ## Overview
 
-`/yolo` automates the complete AI-DLC workflow. You provide a natural language description of what you want built, and the agent handles everything:
+`$yolo` automates the complete AI-DLC workflow. You provide a natural language description of what you want built, and the agent handles everything:
 
 1. **Planning** -- create project, idea, self-elaboration, proposal with docs & tasks
 2. **Proposal Review** -- proposal-reviewer adversarial loop
@@ -26,7 +26,7 @@ Full-auto AI-DLC pipeline. User provides a prompt; agent drives the entire lifec
 5. **Report** -- completion summary
 
 ```
-/yolo <prompt>
+$yolo <prompt>
        |
        v
   Project + Idea + Elaboration + Proposal
@@ -47,7 +47,7 @@ Full-auto AI-DLC pipeline. User provides a prompt; agent drives the entire lifec
   Done. Report summary.
 ```
 
-**Escape hatch:** Ctrl+C at any time. All created entities (project, idea, proposal, tasks) persist in Chorus. Resume manually via `/develop` or `/review`.
+**Escape hatch:** Ctrl+C at any time. All created entities (project, idea, proposal, tasks) persist in Chorus. Resume manually via `$develop` or `$review`.
 
 ---
 
@@ -71,7 +71,7 @@ need = { idea: ["write"], proposal: ["write","admin"],
 
 for resource, actions in need:
   missing = [a for a in actions if a not in (perms[resource] or [])]
-  if missing: ABORT "/yolo needs {resource}: {missing}. Use an Admin-preset API key."
+  if missing: ABORT "$yolo needs {resource}: {missing}. Use an Admin-preset API key."
 ```
 
 ---
@@ -79,8 +79,8 @@ for resource, actions in need:
 ## Input
 
 ```
-/yolo <natural language prompt>
-/yolo <prompt> --project <project-uuid>
+$yolo <natural language prompt>
+$yolo <prompt> --project <project-uuid>
 ```
 
 - `<prompt>` -- what you want built (becomes the Idea content)
@@ -136,7 +136,7 @@ chorus_claim_idea({ ideaUuid: "<idea-uuid>" })
 
 #### Step 1.3: Self-Elaboration
 
-In /yolo mode, the agent generates elaboration questions and answers them itself -- no `AskUserQuestion` calls. This preserves an audit trail without interrupting the user.
+In $yolo mode, the agent generates elaboration questions and answers them itself -- no `AskUserQuestion` calls. This preserves an audit trail without interrupting the user.
 
 > **Self-elaboration is still a loop.** If answering your own questions surfaces a **new question, contradiction, or gap**, loop back to `chorus_pm_start_elaboration` for another self-answered round before resolving — don't force a resolve over unresolved ambiguity. There is no human gate in YOLO, so the loop exits on **your** judgment that nothing material is left open (round cap 10). Steps 1–2 are one round; repeat them as needed, then resolve once in Step 3.
 
@@ -172,7 +172,7 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-3. **Resolve** — in YOLO mode the agent resolves elaboration **autonomously, with no human-confirmation gate** (the human-confirmation requirement that applies to the interactive `/idea` flow is explicitly waived under `/yolo` automation):
+3. **Resolve** — in YOLO mode the agent resolves elaboration **autonomously, with no human-confirmation gate** (the human-confirmation requirement that applies to the interactive `$idea` flow is explicitly waived under `$yolo` automation):
 
    ```
    chorus_pm_validate_elaboration({
@@ -180,7 +180,7 @@ In /yolo mode, the agent generates elaboration questions and answers them itself
    })
    ```
 
-   > `chorus_pm_validate_elaboration` requires `idea:admin`. `/yolo` already mandates an Admin-preset key in Prerequisites, so this is satisfied. To open another self-elaboration round instead of resolving, just call `chorus_pm_start_elaboration` again.
+   > `chorus_pm_validate_elaboration` requires `idea:admin`. `$yolo` already mandates an Admin-preset key in Prerequisites, so this is satisfied. To open another self-elaboration round instead of resolving, just call `chorus_pm_start_elaboration` again.
 
 #### Step 1.4: Create Proposal
 
@@ -380,7 +380,7 @@ If parallel spawn is not practical (rate limits, token budget, or simpler debugg
 
 ```
 for each task in unblocked:
-  # Follow the /develop workflow directly as main agent
+  # Follow the $develop workflow directly as main agent
   chorus_claim_task({ taskUuid: "<task-uuid>" })
   chorus_update_task({ taskUuid: "<task-uuid>", status: "in_progress" })
 
@@ -507,7 +507,7 @@ ESCALATE: "Idea '{title}' failed code review after {maxCodeReviewRounds} rounds.
 After all waves complete, output a markdown summary:
 
 ```markdown
-## /yolo Complete
+## $yolo Complete
 
 **Project:** <project-name> (<project-uuid>)
 **Proposal:** <proposal-title> (<proposal-uuid>)
@@ -546,7 +546,7 @@ A successful `$yolo` run always finishes the Idea — call `chorus_create_report
 | Proposal reviewer FAIL after maxRounds | Stop pipeline, report persisting BLOCKERs, suggest manual review |
 | Task reviewer FAIL after maxRounds | Flag task as escalation-needed, continue with other tasks |
 | Sub-agent crash / no submit | Log error, skip task, pick it up in next wave if possible |
-| Ctrl+C | All entities persist in Chorus. User can resume via `/develop` or `/review` |
+| Ctrl+C | All entities persist in Chorus. User can resume via `$develop` or `$review` |
 
 ---
 
@@ -556,14 +556,14 @@ A successful `$yolo` run always finishes the Idea — call `chorus_create_report
 - The proposal-reviewer is your quality gate -- if it keeps FAILing, the prompt may be too vague
 - Watch the wave count -- if tasks keep getting reopened, consider Ctrl+C and manually reviewing the feedback
 - All audit trail is preserved: elaboration Q&A, reviewer VERDICTs, work reports. Check Chorus UI for full history
-- For small/simple tasks, consider `/quick-dev` instead -- it skips the Idea->Proposal overhead
+- For small/simple tasks, consider `$quick-dev` instead -- it skips the Idea->Proposal overhead
 - Sub-agents share your API key; ensure it has the permissions listed in Prerequisites before starting
 
 ---
 
 ## Next
 
-- To manually review proposals: `/review`
-- To manually develop tasks: `/develop`
-- To create quick standalone tasks: `/quick-dev`
-- For platform overview: `/chorus`
+- To manually review proposals: `$review`
+- To manually develop tasks: `$develop`
+- To create quick standalone tasks: `$quick-dev`
+- For platform overview: `$chorus`

--- a/public/chorus-plugin/.claude-plugin/plugin.json
+++ b/public/chorus-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chorus",
   "description": "Chorus AI-DLC collaboration platform plugin for Claude Code. Automates session lifecycle, provides MCP tools for PM/Developer/Admin workflows, and enables multi-agent team observability.",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": {
     "name": "Chorus-AIDLC"
   },

--- a/public/chorus-plugin/skills/brainstorm/SKILL.md
+++ b/public/chorus-plugin/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -418,6 +418,7 @@ This is the core overview skill. For stage-specific workflows, use:
 | **Planning** | `/proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
 | **Development** | `/develop` | Claim Tasks, report work, session & sub-agent management, Agent Teams integration |
 | **Review** | `/review` | Approve/reject Proposals, verify Tasks, project governance |
+| **Docs** | `/docs` | Consult the live Chorus documentation site to answer product-usage questions — UI workflow, agent/plugin setup, API/MCP, deployment, operations |
 | **OpenSpec mode** | `openspec-aware` | Opt-in **shared sub-procedure** invoked by `/proposal`, `/develop`, and `/yolo` whenever the user has the `openspec` CLI installed. Scaffolds `openspec/changes/<slug>/` on disk and mirrors files into Chorus document drafts via the `chorus-api.sh` wrapper. Skips silently in fallback mode. See `.claude/skills/openspec-aware/SKILL.md`. |
 
 ### Getting Started

--- a/public/chorus-plugin/skills/develop/SKILL.md
+++ b/public/chorus-plugin/skills/develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/docs/SKILL.md
+++ b/public/chorus-plugin/skills/docs/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docs
+description: Chorus documentation router — consult the live Chorus docs site to answer product-usage questions (UI workflow, agent/plugin setup, API/MCP, deployment, operations).
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.16.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Docs Skill
+
+This skill is a **thin router to the live Chorus documentation site** (`https://doc.chorus-ai.dev`). Use it to answer questions about **how to use, configure, deploy, or operate Chorus** — grounding the answer in the current published docs instead of memory.
+
+It is **not** a workflow skill: it does not drive the AI-DLC pipeline. For that, use `/idea`, `/proposal`, `/develop`, `/review`, or `/yolo`.
+
+---
+
+## When to Use
+
+Use this skill whenever the user asks a **product-usage** question about Chorus, such as:
+
+- **UI workflow** — how the Idea → Proposal → Task → Verify pipeline works in the web app, what a control does, how statuses flow.
+- **Agent setup** — creating an API key, permissions and role presets, connecting an agent.
+- **Plugin setup** — installing/configuring the Claude Code / Codex / OpenClaw / Kiro / Pi plugin.
+- **API / MCP** — the REST API, the MCP tool surface, authentication, real-time events.
+- **Deployment** — self-hosting, the CDK stack, environment configuration.
+- **Operations / troubleshooting** — running Chorus, diagnosing connection or setup problems.
+
+Do **NOT** use it to *drive* the pipeline (claiming ideas, writing proposals, executing tasks) — that is what the stage skills above are for. This skill answers "how does the product work / how do I set it up"; the stage skills *do* the work.
+
+---
+
+## Access Convention
+
+The docs site is agent-friendly. Follow this three-step convention every time. **Do NOT** answer from memory, and **do NOT** hardcode a page list — the index is the source of truth and pages change over time.
+
+1. **Fetch the index.** Get `https://doc.chorus-ai.dev/llms.txt` — a machine-readable index that lists every documentation page with a one-line summary and its `.md` URL. **The index is a single, unlocalized file that lives ONLY at the root `/llms.txt`. Never prefix it with a locale — `https://doc.chorus-ai.dev/zh/llms.txt` (and `/ja/`, `/ko/`) does NOT exist and returns 404.**
+2. **Fetch the relevant page(s) as raw Markdown.** Pick the page(s) that match the question from the index, then fetch the raw Markdown by **appending `.md`** to the page URL (e.g. `https://doc.chorus-ai.dev/guides/getting-started` → `https://doc.chorus-ai.dev/guides/getting-started.md`).
+3. **Ground the answer and link the human page.** Base your answer on the fetched Markdown, and link the human-facing page (the `.md` URL **without** the `.md` suffix) so the user can open it in a browser.
+
+Use whatever web-fetch capability your environment provides (your built-in fetch tool, `curl`, etc.) — this skill states the convention, not a specific tool binding.
+
+---
+
+## Locale
+
+The `/llms.txt` index itself is **not** localized — there is exactly one, at the root. Localization applies to **pages**, not the index:
+
+- The index always lives at `https://doc.chorus-ai.dev/llms.txt` and lists the root (`en`) page URLs. **Do not look for `/zh/llms.txt` — it does not exist.**
+- `en` is the root (unprefixed): `https://doc.chorus-ai.dev/...`
+- `zh`, `ja`, `ko` are **path-prefixed pages**: take a page path from the index and prepend the locale — `https://doc.chorus-ai.dev/zh/...`, `/ja/...`, `/ko/...`
+- Appending `.md` works on the prefixed pages too (e.g. `https://doc.chorus-ai.dev/zh/guides/getting-started.md`).
+- **Match the user's language** when the docs exist in it; fall back to `en` otherwise.
+
+---
+
+## Relationship to the Workflow Skills
+
+This skill **complements** the AI-DLC workflow skills — it does not replace them:
+
+| The user wants to… | Use |
+|--------------------|-----|
+| Learn how to use / configure / deploy / operate Chorus | **this skill** (`/docs`) |
+| Drive an idea / write a proposal / execute or verify a task | `/idea`, `/proposal`, `/develop`, `/review`, `/yolo` |
+
+Always use the live host `doc.chorus-ai.dev`. `docs.chorus-ai.dev` (with an "s") is a dead link — never use it.

--- a/public/chorus-plugin/skills/idea/SKILL.md
+++ b/public/chorus-plugin/skills/idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/openspec-aware/SKILL.md
+++ b/public/chorus-plugin/skills/openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Claude Co
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/proposal/SKILL.md
+++ b/public/chorus-plugin/skills/proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/quick-dev/SKILL.md
+++ b/public/chorus-plugin/skills/quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/review/SKILL.md
+++ b/public/chorus-plugin/skills/review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/chorus-plugin/skills/yolo/SKILL.md
+++ b/public/chorus-plugin/skills/yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/install-kiro.sh
+++ b/public/install-kiro.sh
@@ -42,7 +42,7 @@ is_tty() { [ -t 0 ] && [ -t 1 ]; }
 # ---------- config: the artifact manifest (single source of truth) ----------
 # These lists drive BOTH the local copy and the remote download, so the two
 # source modes can never diverge.
-SKILLS="chorus-idea chorus-proposal chorus-develop chorus-yolo chorus-review chorus-quick-dev chorus-brainstorm chorus-openspec-aware"
+SKILLS="chorus-idea chorus-proposal chorus-develop chorus-yolo chorus-review chorus-quick-dev chorus-brainstorm chorus-openspec-aware chorus-docs"
 REVIEWER_AGENTS="chorus-code-reviewer chorus-proposal-reviewer chorus-task-reviewer"
 HOOK_SCRIPTS="on-agent-spawn.sh on-stop.sh on-post-submit-proposal.sh on-post-submit-for-verify.sh on-post-verify-task.sh chorus-api.sh verify-document-roundtrip.sh test-syntax.sh"
 

--- a/public/kiro-plugin/.kiro/agents/chorus.json
+++ b/public/kiro-plugin/.kiro/agents/chorus.json
@@ -19,6 +19,7 @@
     "skill://.kiro/skills/chorus-quick-dev/SKILL.md",
     "skill://.kiro/skills/chorus-brainstorm/SKILL.md",
     "skill://.kiro/skills/chorus-openspec-aware/SKILL.md",
+    "skill://.kiro/skills/chorus-docs/SKILL.md",
     "file://.kiro/steering/chorus.md"
   ],
   "hooks": {

--- a/public/kiro-plugin/.kiro/skills/chorus-brainstorm/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/skills/chorus-develop/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-develop/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, manage se
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/skills/chorus-docs/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-docs/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: chorus-docs
+description: Chorus documentation router — consult the live Chorus docs site to answer product-usage questions (UI workflow, agent/plugin setup, API/MCP, deployment, operations).
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.16.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Chorus Docs Skill
+
+This skill is a **thin router to the live Chorus documentation site** (`https://doc.chorus-ai.dev`). Use it to answer questions about **how to use, configure, deploy, or operate Chorus** — grounding the answer in the current published docs instead of memory.
+
+It is **not** a workflow skill: it does not drive the AI-DLC pipeline. For that, use `/chorus-idea`, `/chorus-proposal`, `/chorus-develop`, `/chorus-review`, or `/chorus-yolo`.
+
+---
+
+## When to Use
+
+Use this skill whenever the user asks a **product-usage** question about Chorus, such as:
+
+- **UI workflow** — how the Idea → Proposal → Task → Verify pipeline works in the web app, what a control does, how statuses flow.
+- **Agent setup** — creating an API key, permissions and role presets, connecting an agent.
+- **Plugin setup** — installing/configuring the Claude Code / Codex / OpenClaw / Kiro / Pi plugin.
+- **API / MCP** — the REST API, the MCP tool surface, authentication, real-time events.
+- **Deployment** — self-hosting, the CDK stack, environment configuration.
+- **Operations / troubleshooting** — running Chorus, diagnosing connection or setup problems.
+
+Do **NOT** use it to *drive* the pipeline (claiming ideas, writing proposals, executing tasks) — that is what the stage skills above are for. This skill answers "how does the product work / how do I set it up"; the stage skills *do* the work.
+
+---
+
+## Access Convention
+
+The docs site is agent-friendly. Follow this three-step convention every time. **Do NOT** answer from memory, and **do NOT** hardcode a page list — the index is the source of truth and pages change over time.
+
+1. **Fetch the index.** Get `https://doc.chorus-ai.dev/llms.txt` — a machine-readable index that lists every documentation page with a one-line summary and its `.md` URL. **The index is a single, unlocalized file that lives ONLY at the root `/llms.txt`. Never prefix it with a locale — `https://doc.chorus-ai.dev/zh/llms.txt` (and `/ja/`, `/ko/`) does NOT exist and returns 404.**
+2. **Fetch the relevant page(s) as raw Markdown.** Pick the page(s) that match the question from the index, then fetch the raw Markdown by **appending `.md`** to the page URL (e.g. `https://doc.chorus-ai.dev/guides/getting-started` → `https://doc.chorus-ai.dev/guides/getting-started.md`).
+3. **Ground the answer and link the human page.** Base your answer on the fetched Markdown, and link the human-facing page (the `.md` URL **without** the `.md` suffix) so the user can open it in a browser.
+
+Use whatever web-fetch capability your environment provides (your built-in fetch tool, `curl`, etc.) — this skill states the convention, not a specific tool binding.
+
+---
+
+## Locale
+
+The `/llms.txt` index itself is **not** localized — there is exactly one, at the root. Localization applies to **pages**, not the index:
+
+- The index always lives at `https://doc.chorus-ai.dev/llms.txt` and lists the root (`en`) page URLs. **Do not look for `/zh/llms.txt` — it does not exist.**
+- `en` is the root (unprefixed): `https://doc.chorus-ai.dev/...`
+- `zh`, `ja`, `ko` are **path-prefixed pages**: take a page path from the index and prepend the locale — `https://doc.chorus-ai.dev/zh/...`, `/ja/...`, `/ko/...`
+- Appending `.md` works on the prefixed pages too (e.g. `https://doc.chorus-ai.dev/zh/guides/getting-started.md`).
+- **Match the user's language** when the docs exist in it; fall back to `en` otherwise.
+
+---
+
+## Relationship to the Workflow Skills
+
+This skill **complements** the AI-DLC workflow skills — it does not replace them:
+
+| The user wants to… | Use |
+|--------------------|-----|
+| Learn how to use / configure / deploy / operate Chorus | **this skill** (`/chorus-docs`) |
+| Drive an idea / write a proposal / execute or verify a task | `/chorus-idea`, `/chorus-proposal`, `/chorus-develop`, `/chorus-review`, `/chorus-yolo` |
+
+Always use the live host `doc.chorus-ai.dev`. `docs.chorus-ai.dev` (with an "s") is a dead link — never use it.

--- a/public/kiro-plugin/.kiro/skills/chorus-idea/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-idea/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/skills/chorus-openspec-aware/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-openspec-aware/SKILL.md
@@ -4,7 +4,7 @@ description: Opt-in OpenSpec-mode authoring for Chorus PM workflows in Kiro CLI.
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/skills/chorus-proposal/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-proposal/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/skills/chorus-quick-dev/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-quick-dev/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/skills/chorus-review/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-review/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/skills/chorus-yolo/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-yolo/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — from prompt to done. Automates the en
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.15.0"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/kiro-plugin/.kiro/steering/chorus.md
+++ b/public/kiro-plugin/.kiro/steering/chorus.md
@@ -394,6 +394,7 @@ The `chorus` main agent owns `/chorus` and pre-loads all skills below. For stage
 | **Planning** | `/chorus-proposal` | Create Proposals with document & task drafts, manage dependency DAG, submit for review |
 | **Development** | `/chorus-develop` | Claim Tasks, report work, session & subagent management |
 | **Review** | `/chorus-review` | Approve/reject Proposals, verify Tasks, project governance |
+| **Docs** | `/chorus-docs` | Consult the live Chorus documentation site to answer product-usage questions — UI workflow, agent/plugin setup, API/MCP, deployment, operations |
 | **OpenSpec mode** | `/chorus-openspec-aware` | Opt-in **shared sub-procedure** invoked by `/chorus-proposal`, `/chorus-develop`, and `/chorus-yolo` whenever the user has the `openspec` CLI installed. Scaffolds `openspec/changes/<slug>/` on disk and mirrors files into Chorus document drafts via the `chorus-api.sh` wrapper. Skips silently in fallback mode. |
 
 ### Getting Started

--- a/public/kiro-plugin/bin/chorus-api.sh
+++ b/public/kiro-plugin/bin/chorus-api.sh
@@ -240,7 +240,7 @@ cmd_mcp_tool() {
     # Step 1: Initialize MCP session
     local init_payload
     init_payload=$(cat <<JSONEOF
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-hook","version":"0.15.0"}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chorus-hook","version":"0.16.0"}}}
 JSONEOF
 )
 

--- a/public/skill/brainstorm-chorus/SKILL.md
+++ b/public/skill/brainstorm-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Optional divergent-then-convergent dialogue for fuzzy ideas. Invoke
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus AI Agent collaboration platform — overview, common tools, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---
@@ -458,6 +458,7 @@ This is the core overview skill. For stage-specific workflows, download and read
 | **Planning** | `proposal-chorus` | `<BASE_URL>/skill/proposal-chorus/SKILL.md` |
 | **Development** | `develop-chorus` | `<BASE_URL>/skill/develop-chorus/SKILL.md` |
 | **Review** | `review-chorus` | `<BASE_URL>/skill/review-chorus/SKILL.md` |
+| **Docs** | `docs-chorus` | `<BASE_URL>/skill/docs-chorus/SKILL.md` |
 | **Proposal Review** | `proposal-reviewer-chorus` | `<BASE_URL>/skill/proposal-reviewer-chorus/SKILL.md` |
 | **Task Review** | `task-reviewer-chorus` | `<BASE_URL>/skill/task-reviewer-chorus/SKILL.md` |
 | **Code Review (ship gateway)** | `code-reviewer-chorus` | `<BASE_URL>/skill/code-reviewer-chorus/SKILL.md` |

--- a/public/skill/code-reviewer-chorus/SKILL.md
+++ b/public/skill/code-reviewer-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Read-only adversarial Chorus code-review gateway — independently 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/develop-chorus/SKILL.md
+++ b/public/skill/develop-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Development workflow — claim tasks, report work, self-chec
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/docs-chorus/SKILL.md
+++ b/public/skill/docs-chorus/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: docs-chorus
+description: Chorus documentation router — consult the live Chorus docs site to answer product-usage questions (UI workflow, agent/plugin setup, API/MCP, deployment, operations).
+license: AGPL-3.0
+metadata:
+  author: chorus
+  version: "0.16.0"
+  category: project-management
+  mcp_server: chorus
+---
+
+# Docs Skill
+
+This skill is a **thin router to the live Chorus documentation site** (`https://doc.chorus-ai.dev`). Use it to answer questions about **how to use, configure, deploy, or operate Chorus** — grounding the answer in the current published docs rather than memory.
+
+It is not a workflow skill: it does not drive the AI-DLC pipeline. For that, prefer the stage skills — `idea-chorus`, `proposal-chorus`, `develop-chorus`, `review-chorus`, or `yolo-chorus` (`<BASE_URL>/skill/<name>/SKILL.md`).
+
+---
+
+## When to Use
+
+Consider this skill whenever the user asks a **product-usage** question about Chorus, such as:
+
+- **UI workflow** — how the Idea → Proposal → Task → Verify pipeline works in the web app, what a control does, how statuses flow.
+- **Agent setup** — creating an API key, permissions and role presets, connecting an agent.
+- **Plugin setup** — installing/configuring the Claude Code / Codex / OpenClaw / Kiro / Pi plugin, or the standalone skill.
+- **API / MCP** — the REST API, the MCP tool surface, authentication, real-time events.
+- **Deployment** — self-hosting, the CDK stack, environment configuration.
+- **Operations / troubleshooting** — running Chorus, diagnosing connection or setup problems.
+
+Prefer *not* to use it to drive the pipeline (claiming ideas, writing proposals, executing tasks) — that is what the stage skills above are for. This skill answers "how does the product work / how do I set it up"; the stage skills do the work.
+
+---
+
+## Access Convention
+
+The docs site is agent-friendly. Prefer this three-step convention every time. Rather than answering from memory, ground the answer in the docs, and avoid hardcoding a page list — the index is the source of truth and pages change over time.
+
+1. **Fetch the index.** Get `https://doc.chorus-ai.dev/llms.txt` — a machine-readable index that lists every documentation page with a one-line summary and its `.md` URL. Note the index is a single, unlocalized file that lives only at the root `/llms.txt`; there is no locale-prefixed variant, so `https://doc.chorus-ai.dev/zh/llms.txt` (and `/ja/`, `/ko/`) is not a real URL — don't request it.
+2. **Fetch the relevant page(s) as raw Markdown.** Pick the page(s) that match the question from the index, then fetch the raw Markdown by appending `.md` to the page URL (e.g. `https://doc.chorus-ai.dev/guides/getting-started` → `https://doc.chorus-ai.dev/guides/getting-started.md`).
+3. **Ground the answer and link the human page.** Base your answer on the fetched Markdown, and link the human-facing page (the `.md` URL without the `.md` suffix) so the user can open it in a browser.
+
+Use whatever web-fetch capability your environment provides (your IDE's fetch tool, `curl`, etc.) — this skill states the convention, not a specific tool binding.
+
+> Note: `<BASE_URL>` (your own Chorus instance) and the docs site are different hosts. The docs site is the fixed public host `https://doc.chorus-ai.dev`; use it regardless of where your Chorus instance is deployed.
+
+---
+
+## Locale
+
+The `/llms.txt` index itself is not localized — there is just one, at the root. Localization applies to pages, not the index:
+
+- The index always lives at `https://doc.chorus-ai.dev/llms.txt` and lists the root (`en`) page URLs; there is no `/zh/llms.txt`.
+- `en` is the root (unprefixed): `https://doc.chorus-ai.dev/...`
+- `zh`, `ja`, `ko` are path-prefixed pages: take a page path from the index and prepend the locale — `https://doc.chorus-ai.dev/zh/...`, `/ja/...`, `/ko/...`
+- Appending `.md` works on the prefixed pages too (e.g. `https://doc.chorus-ai.dev/zh/guides/getting-started.md`).
+- Match the user's language when the docs exist in it; fall back to `en` otherwise.
+
+---
+
+## Relationship to the Workflow Skills
+
+This skill complements the AI-DLC workflow skills — it does not replace them:
+
+| The user wants to… | Prefer |
+|--------------------|--------|
+| Learn how to use / configure / deploy / operate Chorus | **this skill** (`docs-chorus`) |
+| Drive an idea / write a proposal / execute or verify a task | `idea-chorus`, `proposal-chorus`, `develop-chorus`, `review-chorus`, `yolo-chorus` |
+
+Use the live host `doc.chorus-ai.dev`. `docs.chorus-ai.dev` (with an "s") is a dead link — prefer not to use it.

--- a/public/skill/idea-chorus/SKILL.md
+++ b/public/skill/idea-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Idea workflow — claim ideas, run elaboration rounds, and p
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/package.json
+++ b/public/skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chorus-skill",
-  "version": "0.14.6",
+  "version": "0.16.0",
   "description": "Chorus AI Agent collaboration platform skill. Supports PM, Developer, and Admin roles via MCP tools for the Idea-Proposal-Task workflow.",
   "author": "chorus",
   "license": "AGPL-3.0",
@@ -29,7 +29,8 @@
       "proposal-reviewer-chorus/SKILL.md": "/skill/proposal-reviewer-chorus/SKILL.md",
       "task-reviewer-chorus/SKILL.md": "/skill/task-reviewer-chorus/SKILL.md",
       "code-reviewer-chorus/SKILL.md": "/skill/code-reviewer-chorus/SKILL.md",
-      "yolo-chorus/SKILL.md": "/skill/yolo-chorus/SKILL.md"
+      "yolo-chorus/SKILL.md": "/skill/yolo-chorus/SKILL.md",
+      "docs-chorus/SKILL.md": "/skill/docs-chorus/SKILL.md"
     },
     "requires": {
       "mcp": ["chorus"]
@@ -47,7 +48,8 @@
       "project management",
       "yolo",
       "review agent",
-      "verify"
+      "verify",
+      "docs"
     ]
   },
   "moltbot": {
@@ -63,7 +65,8 @@
       "proposal-reviewer-chorus/SKILL.md": "/skill/proposal-reviewer-chorus/SKILL.md",
       "task-reviewer-chorus/SKILL.md": "/skill/task-reviewer-chorus/SKILL.md",
       "code-reviewer-chorus/SKILL.md": "/skill/code-reviewer-chorus/SKILL.md",
-      "yolo-chorus/SKILL.md": "/skill/yolo-chorus/SKILL.md"
+      "yolo-chorus/SKILL.md": "/skill/yolo-chorus/SKILL.md",
+      "docs-chorus/SKILL.md": "/skill/docs-chorus/SKILL.md"
     },
     "requires": {
       "mcp": ["chorus"]
@@ -81,7 +84,8 @@
       "project management",
       "yolo",
       "review agent",
-      "verify"
+      "verify",
+      "docs"
     ]
   }
 }

--- a/public/skill/proposal-chorus/SKILL.md
+++ b/public/skill/proposal-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Proposal workflow — create proposals with document and tas
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/proposal-reviewer-chorus/SKILL.md
+++ b/public/skill/proposal-reviewer-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Read-only adversarial Chorus proposal reviewer — audits PRD/task 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/quick-dev-chorus/SKILL.md
+++ b/public/skill/quick-dev-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Quick Task workflow — skip Idea→Proposal, create tasks directly
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/review-chorus/SKILL.md
+++ b/public/skill/review-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Chorus Review workflow — approve/reject proposals, verify tasks, 
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/task-reviewer-chorus/SKILL.md
+++ b/public/skill/task-reviewer-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Read-only adversarial Chorus task reviewer — independently verifi
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---

--- a/public/skill/yolo-chorus/SKILL.md
+++ b/public/skill/yolo-chorus/SKILL.md
@@ -4,7 +4,7 @@ description: Full-auto AI-DLC pipeline — drive a single prompt from Idea throu
 license: AGPL-3.0
 metadata:
   author: chorus
-  version: "0.14.6"
+  version: "0.16.0"
   category: project-management
   mcp_server: chorus
 ---


### PR DESCRIPTION
Release **v0.16.0** — version bump and CHANGELOG update.

## Summary
Promotes the docs-site integration work (PR #477) from `develop` to `main` and cuts the v0.16.0 release.

### Added
- **Documentation site surfaced to agents & users**: live docs site (https://doc.chorus-ai.dev) wired into three entry points — a new `docs` router skill on all six skill surfaces, a localized Documentation link in each README (en/zh/ko/ja) header, and a language-aware Documentation entry in the landing-page nav. (#477)

### Fixed
- **Codex skill-invocation hints**: corrected to the `$`-prefix form. (#477)

### Plugin
- **Plugin & skill versions → 0.16.0**: all plugin + skill surfaces plus the standalone skill bumped to 0.16.0. (#477)

## Test plan
- [x] CI `test` check on develop (PR #477) passed
- [ ] CI green on this release PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)