### PR TITLE
docs: v0.16.0 release blog post + README What's New

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -38,6 +38,8 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 
 ## 最近の更新
 
+**[v0.16.0](https://chorus-ai.dev/blog/chorus-v0.16.0-release/)** — エージェントをドキュメントサイト（[doc.chorus-ai.dev](https://doc.chorus-ai.dev)）へ案内する `docs` スキルを追加し、記憶に頼らず現在のドキュメントを読んで回答するようにしました。
+
 **[v0.15.0](https://chorus-ai.dev/blog/chorus-v0.15.0-release/)** — プロジェクト単位の Agent 作業ディレクトリ：各ユーザーがプロジェクト内の Agent ごとにホストと cwd を設定し、デーモンが許可したルートだけを参照できます。割り当て、ウェイク、再開、後続ターンで同じ実行先を使い、進行中のセッションは移動しません。Codex は再開可能なバックエンド thread ID を別に保存し、不要になった Chorus の session 管理手順を削除しました。
 
 **[v0.14.1](https://chorus-ai.dev/blog/chorus-v0.14.1-release/)** — Amazon Kiro CLI が 4 つ目の接続方法になりました（Kiro CLI v2）：ワンコマンドの `install-kiro.sh` プラグインと `--agent kiro` デーモンバックエンド、加えていくつかのデーモン修正。

--- a/README.ko.md
+++ b/README.ko.md
@@ -38,6 +38,8 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 
 ## 최근 업데이트
 
+**[v0.16.0](https://chorus-ai.dev/blog/chorus-v0.16.0-release/)** — 에이전트를 문서 사이트([doc.chorus-ai.dev](https://doc.chorus-ai.dev))로 안내하는 `docs` 스킬을 추가해, 기억에 의존하지 않고 현재 문서를 읽고 답하도록 했습니다.
+
 **[v0.15.0](https://chorus-ai.dev/blog/chorus-v0.15.0-release/)** — 프로젝트별 Agent 작업 디렉터리: 각 사용자가 프로젝트의 Agent마다 호스트와 cwd를 지정하고, 데몬이 허용한 루트만 탐색할 수 있습니다. 배정, 웨이크, 재개, 후속 턴에서 같은 실행 위치를 사용하며 진행 중인 세션은 이동하지 않습니다. Codex는 재개 가능한 백엔드 thread ID를 별도로 저장하고, 더 이상 필요하지 않은 Chorus session 관리 단계를 제거했습니다.
 
 **[v0.14.1](https://chorus-ai.dev/blog/chorus-v0.14.1-release/)** — Amazon Kiro CLI가 네 번째 연결 방식이 되었습니다(Kiro CLI v2): 명령 한 줄로 설치하는 `install-kiro.sh` 플러그인과 `--agent kiro` 데몬 백엔드, 여기에 몇 가지 데몬 수정.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The labels under each stage are the **permissions** an actor needs at that stage
 
 ## What's New
 
+**[v0.16.0](https://chorus-ai.dev/blog/chorus-v0.16.0-release/)** — A `docs` skill that points agents at the live docs site ([doc.chorus-ai.dev](https://doc.chorus-ai.dev)), so they answer from the current docs instead of reciting from memory.
+
 **[v0.15.0](https://chorus-ai.dev/blog/chorus-v0.15.0-release/)** — Project-level Agent working directories: each user can bind every Agent in a project to a host and cwd, browse only daemon-approved roots, and use the same target across assignment, wake, resume, and later turns without moving active sessions. Codex now persists its resumable backend thread ID separately and drops obsolete Chorus session-management steps.
 
 **[v0.14.1](https://chorus-ai.dev/blog/chorus-v0.14.1-release/)** — Amazon Kiro CLI is the fourth way to connect (Kiro CLI v2): a one-command `install-kiro.sh` plugin and a `--agent kiro` daemon backend, plus daemon fixes.

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,6 +29,8 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 
 ## 最近更新
 
+**[v0.16.0](https://chorus-ai.dev/zh/blog/chorus-v0.16.0-release/)** — 新增 `docs` skill，引导 Agent 查阅文档站点（[doc.chorus-ai.dev](https://doc.chorus-ai.dev)），基于当前文档作答，而不是凭记忆复述。
+
 **[v0.15.0](https://chorus-ai.dev/zh/blog/chorus-v0.15.0-release/)** — 项目级 Agent 工作目录：每位用户可以为项目中的每个 Agent 绑定主机和 cwd，只浏览 daemon 允许的目录，并让任务分配、唤醒、恢复和后续对话使用同一个执行位置，且不迁移进行中的会话。Codex 现在会单独保存可恢复的后端 thread ID，并移除不再需要的 Chorus session 管理步骤。
 
 **[v0.14.1](https://chorus-ai.dev/zh/blog/chorus-v0.14.1-release/)** — Amazon Kiro CLI 成为第四种接入方式（Kiro CLI v2）：一条命令的 `install-kiro.sh` 插件，以及 `--agent kiro` 的 daemon 后端，另有若干 daemon 修复。

--- a/packages/landing/src/content/blog/chorus-v0.16.0-release.md
+++ b/packages/landing/src/content/blog/chorus-v0.16.0-release.md
@@ -1,0 +1,58 @@
+---
+title: "Chorus v0.16.0: Let agents read the docs, not recall them"
+description: "When a user asks an agent how Chorus works, is it reading today's docs or reciting what it saw in training?"
+date: 2026-08-09
+lang: en
+postSlug: chorus-v0.16.0-release
+---
+
+# Chorus v0.16.0: Let agents read the docs, not recall them
+
+Ask an agent how a Chorus feature works and it usually answers right away. But that answer comes from what the model saw during training, not from how the product behaves now. After a feature changes, a flow is reworked, or a parameter is renamed, an answer from memory drifts from reality, and the user can rarely tell the difference on the spot.
+
+Chorus v0.16.0 connects the documentation site to the product and adds a `docs` skill that points agents at the current docs before they answer.
+
+## A documentation site built for agents
+
+The Chorus docs site is deployed at https://doc.chorus-ai.dev. Alongside the human-facing pages, it exposes two entry points that are easy for an agent to read:
+
+- `/llms.txt` at the root is an index that lists every page with a one-line summary;
+- append `.md` to any page URL to fetch that page as plain Markdown.
+
+There is a single index, at the site root, and it is not localized. The pages themselves are available in multiple languages by path prefix.
+
+## The docs skill
+
+The new `docs` skill is a thin router. It does not cache any documentation. It defines an access convention instead:
+
+1. read the `/llms.txt` index and pick the pages that match the question;
+2. append `.md` to a page URL and fetch the raw Markdown;
+3. answer from what was fetched, and link the human-readable page.
+
+So the answer is grounded in the docs published right now, not in training memory. The skill hardcodes no page list; pages come and go through the index.
+
+The skill ships to all six skill surfaces: Claude Code, Codex, OpenClaw, Kiro, Pi, and the standalone skill.
+
+## For people too
+
+The human path to the docs is filled in as well. All four READMEs (English, Chinese, Korean, Japanese) carry a documentation link in the header, and the landing page gains a Documentation entry in the top nav that points to the matching language.
+
+## Summary
+
+v0.16.0 is about one thing: when a user asks an agent how to use Chorus, the agent can now read the current docs before answering instead of reciting memory that may already be stale.
+
+---
+
+## Upgrade
+
+```bash
+npx @chorus-aidlc/chorus@0.16.0
+```
+
+After release, see the complete changes on [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.16.0).
+
+Questions or feedback? Open an issue on [GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) or start a thread in [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions).
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.16.0](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.16.0)

--- a/packages/landing/src/content/blog/zh-chorus-v0.16.0-release.md
+++ b/packages/landing/src/content/blog/zh-chorus-v0.16.0-release.md
@@ -1,0 +1,58 @@
+---
+title: "Chorus v0.16.0：让 Agent 查文档，而不是凭记忆回答"
+description: "当用户问 Agent 怎么用 Chorus，它是在复述训练时的记忆，还是在读此刻的文档？"
+date: 2026-08-09
+lang: zh
+postSlug: chorus-v0.16.0-release
+---
+
+# Chorus v0.16.0：让 Agent 查文档，而不是凭记忆回答
+
+用户让 Agent 解释某个 Chorus 功能怎么用，Agent 往往会直接回答。但这个回答来自模型训练时见过的内容，而不是产品当前的真实行为。功能改过、流程调整过、参数换过之后，凭记忆给出的答案会和实际不一致，用户又很难当场分辨。
+
+Chorus v0.16.0 把文档站点接入产品，并新增一个 `docs` skill，引导 Agent 在回答前先查阅当前文档。
+
+## 面向 Agent 的文档站点
+
+Chorus 的文档站点部署在 https://doc.chorus-ai.dev。除了给人阅读的页面，它还提供便于 Agent 读取的入口：
+
+- 根目录下的 `/llms.txt` 是一份索引，列出每个文档页面和它的一句话摘要；
+- 任意页面 URL 追加 `.md`，即可取到该页的纯 Markdown 原文。
+
+索引只有一份，位于站点根目录，不分语言。页面本身按路径前缀提供多语言版本。
+
+## docs skill
+
+新的 `docs` skill 是一个轻量路由。它不缓存文档内容，而是约定一套访问流程：
+
+1. 先读 `/llms.txt` 索引，按问题挑出相关页面；
+2. 给页面 URL 追加 `.md`，取回原文；
+3. 基于取回的内容作答，并附上对应的人类可读页面链接。
+
+这样 Agent 的回答基于此刻发布的文档，而不是训练记忆。skill 不内置页面清单，页面增减都以索引为准。
+
+该 skill 覆盖全部六个技能载体：Claude Code、Codex、OpenClaw、Kiro、Pi，以及独立 skill。
+
+## 同时面向用户
+
+文档入口也补齐了给人的路径。英文、中文、韩文、日文四种 README 的头部都加上了文档链接，落地页顶部导航新增「文档」入口，并按语言指向对应版本。
+
+## 总结
+
+v0.16.0 的改动集中在一件事：用户问 Agent 怎么用 Chorus，Agent 现在可以先读当前文档再回答，而不是复述可能已经过时的记忆。
+
+---
+
+## 升级
+
+```bash
+npx @chorus-aidlc/chorus@0.16.0
+```
+
+发布后可在 [GitHub Releases](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.16.0) 查看完整变更。
+
+问题和反馈可提交至 [GitHub Issues](https://github.com/Chorus-AIDLC/Chorus/issues) 或 [Discussions](https://github.com/Chorus-AIDLC/Chorus/discussions)。
+
+---
+
+**GitHub**: [Chorus-AIDLC/Chorus](https://github.com/Chorus-AIDLC/Chorus) | **Release**: [v0.16.0](https://github.com/Chorus-AIDLC/Chorus/releases/tag/v0.16.0)


### PR DESCRIPTION
## Summary
- Bilingual (zh/en) v0.16.0 release blog post for the docs-site skill
- v0.16.0 What's New entry across all four README locales (en/zh/ko/ja)

## Changed files
| File | Change |
|------|--------|
| `packages/landing/src/content/blog/zh-chorus-v0.16.0-release.md` | New Chinese release post |
| `packages/landing/src/content/blog/chorus-v0.16.0-release.md` | New English release post |
| `README.md` / `README.zh.md` / `README.ko.md` / `README.ja.md` | v0.16.0 What's New line |

## Test plan
- [x] Content-only change; no code paths touched
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)