### PR TITLE
fix(daemon): report Claude --resume anchor as backendSessionId

### DIFF
--- a/cli/__tests__/claude-spawner.test.mjs
+++ b/cli/__tests__/claude-spawner.test.mjs
@@ -199,7 +199,7 @@ describe("ClaudeSpawner.wake", () => {
     child.emit("close", 0);
 
     const result = await p;
-    expect(result).toEqual({ sessionId: SID, exitCode: 0, isNew: true });
+    expect(result).toEqual({ sessionId: SID, backendSessionId: SID, exitCode: 0, isNew: true });
 
     // argv: no prompt; spawned without shell
     const [path, args, opts] = spawnImpl.mock.calls[0];
@@ -229,6 +229,24 @@ describe("ClaudeSpawner.wake", () => {
     expect(onMessage).toHaveBeenCalledWith({ type: "assistant", session_id: SID });
   });
 
+  it("reports backendSessionId = the --resume anchor (not a fork-diverged stream session_id)", async () => {
+    // A fork-on-resume claude can emit a DIFFERENT session_id on the stream than the
+    // anchor the daemon resumed with. The resumable value the UI copies must be the
+    // anchor (`SID`) — the id the transcript file and `--resume` are keyed on — NOT
+    // the observed stream id. `sessionId` still reflects the observed stream value.
+    const forked = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    const child = makeFakeChild();
+    const spawner = new ClaudeSpawner({ claudePath: "/c", spawnImpl: () => child, logger: silent });
+
+    const p = spawner.wake({ prompt: "go", sessionId: SID, isNew: false });
+    child.stdout.emit("data", `{"type":"system","session_id":"${forked}"}\n`);
+    child.emit("close", 0);
+    const result = await p;
+
+    expect(result.backendSessionId).toBe(SID); // the resume anchor, verbatim
+    expect(result.sessionId).toBe(forked); // observed stream id, unchanged behavior
+  });
+
   it("REFUSES to spawn (visible log, no subprocess) when the session id is not a valid UUID", async () => {
     const errs = [];
     const spawnImpl = vi.fn();
@@ -240,6 +258,9 @@ describe("ClaudeSpawner.wake", () => {
     const result = await spawner.wake({ prompt: "x", sessionId: "not-a-uuid", isNew: true });
     expect(spawnImpl).not.toHaveBeenCalled(); // never spawned
     expect(result.exitCode).toBeNull();
+    // Uniform return shape: the pre-spawn refusal carries backendSessionId (null — no
+    // turn ran, nothing to resume), matching the codex-spawner shape convention.
+    expect(result.backendSessionId).toBeNull();
     expect(errs.join("")).toMatch(/not a valid lowercase UUID/);
   });
 
@@ -387,7 +408,7 @@ describe("ClaudeSpawner.wake — detached spawn + onChild (子3)", () => {
     expect(child.stdin.writes.join("")).toBe("PROMPT"); // prompt over stdin
     expect(child.stdin.end).toHaveBeenCalled();
     expect(onMessage).toHaveBeenCalledWith({ type: "system", session_id: SID }); // NDJSON parsed
-    expect(result).toEqual({ sessionId: SID, exitCode: 0, isNew: true });
+    expect(result).toEqual({ sessionId: SID, backendSessionId: SID, exitCode: 0, isNew: true });
   });
 
   it("does NOT set detached on Windows (taskkill walks the tree by pid)", async () => {

--- a/cli/claude-spawner.mjs
+++ b/cli/claude-spawner.mjs
@@ -284,7 +284,11 @@ export class ClaudeSpawner {
    *   so the waker can store the handle in its execution registry for the interrupt
    *   path BEFORE this promise resolves. It is invoked once, synchronously, only on a
    *   successful spawn; a spawn failure never calls it.
-   * @returns {Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }>}
+   * @returns {Promise<{ sessionId: string, backendSessionId: string|null, exitCode: number|null, isNew: boolean }>}
+   *   `backendSessionId` is the Claude `--resume` anchor (the input `sessionId`) on a
+   *   terminal resolution after a spawn, so the conversation UI can offer a resumable
+   *   id — mirrors codex-spawner's shape. `null` on the pre-spawn failure paths (no
+   *   turn ran, nothing to resume).
    */
   async wake({ prompt, sessionId, isNew, mcpConfigPath, cwd, onMessage, onChild }) {
     const id = sessionId;
@@ -295,14 +299,14 @@ export class ClaudeSpawner {
       this.logger.error(
         `[Chorus] refusing to spawn: session id is not a valid lowercase UUID: ${id}`
       );
-      return { sessionId: typeof id === "string" ? id : "", exitCode: null, isNew: Boolean(isNew) };
+      return { sessionId: typeof id === "string" ? id : "", backendSessionId: null, exitCode: null, isNew: Boolean(isNew) };
     }
 
     const claudePath = this.claudePath ?? resolveClaudePath();
     if (!claudePath) {
       // No crash — surface visibly and resolve with a failure result.
       this.logger.error("[Chorus] cannot locate the `claude` executable on PATH; skipping wake");
-      return { sessionId: id, exitCode: null, isNew };
+      return { sessionId: id, backendSessionId: null, exitCode: null, isNew };
     }
 
     const args = buildArgs({ sessionId: id, isNew, mcpConfigPath, permissionMode: this.permissionMode });
@@ -345,7 +349,7 @@ export class ClaudeSpawner {
         });
       } catch (err) {
         this.logger.error(`[Chorus] failed to spawn claude: ${err}`);
-        resolve({ sessionId: id, exitCode: null, isNew });
+        resolve({ sessionId: id, backendSessionId: null, exitCode: null, isNew });
         return;
       }
 
@@ -391,14 +395,19 @@ export class ClaudeSpawner {
       child.on("error", (err) => {
         // e.g. ENOENT if the resolved path vanished — log, don't throw.
         this.logger.error(`[Chorus] claude process error: ${err}`);
-        resolve({ sessionId: observedSessionId, exitCode: null, isNew });
+        // backendSessionId is the `--resume` anchor (`id`), NOT observedSessionId:
+        // a fork-on-resume claude can emit a new stream session_id, but the daemon
+        // resumes and files the transcript under `id`, so `id` is the resumable value.
+        resolve({ sessionId: observedSessionId, backendSessionId: id, exitCode: null, isNew });
       });
 
       child.on("close", (code) => {
         if (code !== 0) {
           this.logger.warn(`[Chorus] claude exited with code ${code}`);
         }
-        resolve({ sessionId: observedSessionId, exitCode: code, isNew });
+        // backendSessionId is the `--resume` anchor (`id`), NOT observedSessionId (see
+        // the process-error handler above for why the anchor is the resumable value).
+        resolve({ sessionId: observedSessionId, backendSessionId: id, exitCode: code, isNew });
       });
 
       // Guard against an ASYNC stdin error (EPIPE): if claude exits/closes

--- a/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/README.md
+++ b/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/README.md
@@ -1,0 +1,3 @@
+# unify-backend-session-resume-id
+
+Report a usable resume id for Claude and Kiro daemon sessions, unifying the copy-session control across all backends

--- a/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/design.md
+++ b/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/design.md
@@ -1,0 +1,135 @@
+# Design — Restore the Claude Code session resume id
+
+## Context
+
+`DaemonSession` stores two ids (prisma `schema.prisma` → `DaemonSession`):
+
+- `sessionId` — the Chorus routing/business key. For an idea-anchored session it is
+  the `directIdeaUuid`; for an ad-hoc session a server-generated uuid. Unique per
+  agent (`@@unique([agentUuid, sessionId])`).
+- `backendSessionId` — "Backend-owned resume identity, distinct from Chorus's
+  routing key" — nullable.
+
+The transcript header control `CopySessionIdButton`
+(`src/components/agent-presence/chat/transcript-view.tsx`) renders only when
+`session.backendSessionId` is non-null and copies it verbatim. The governing spec
+`openspec/specs/backend-session-resume-id/spec.md` explicitly forbids the UI from
+falling back to the business key when `backendSessionId` is null (and a unit test,
+`copy-session-id-button.test.tsx`, locks this in).
+
+`backendSessionId` is populated through one already-generic path:
+
+```
+spawner.wake() → { …, backendSessionId }        (per backend)
+  → waker.#advanceTurn(sessionId, "ended"|"interrupted", …, result.backendSessionId)
+  → daemon-rest-client.turnAdvance({ …, backendSessionId })   // sent only on terminal edge
+  → POST /api/daemon/turn-advance
+  → daemon-session.service.advanceTurnForWake(...)            // first-write + idempotent/conflict guard
+```
+
+Only the **first hop** is backend-specific. Codex's spawner returns a
+`backendSessionId` (its `thread_id`); Claude's does not — so its column stays null
+and the button never shows. This is the entire root cause of the Claude regression.
+
+## Goals / Non-goals
+
+**Goals**
+- Claude Code daemon sessions populate a usable `backendSessionId`, so the existing
+  copy control appears for them exactly as it does for Codex.
+- Do it through the one uniform mechanism (spawner reports the id its own resume
+  command accepts); no special-casing in the UI, server, or transport.
+
+**Non-goals**
+- No change to what the button copies (still the bare id — elaboration q2=a).
+- No change to the UI, render gate, server route, service, or schema.
+- No "copy full resume command", transcript copy, or session fork (elaboration
+  q2=a / q4=a explicitly scope those out).
+- **Kiro is out of scope** — see "Kiro deferral" below.
+- No backfill of historical sessions — the value is populated on the next terminal
+  turn per session; pre-existing sessions with no report stay null (consistent with
+  the "Historical session has no backend identifier" scenario already in the spec).
+
+## Decisions
+
+### D1 — Fix in the spawner return, not the UI
+
+The elaboration answer q3=a ("reuse `sessionId`, only relax the display condition")
+expresses the **intent**: for Claude the usable resume anchor *is* `sessionId`, so
+don't invent a new value. But implementing that as a UI fallback
+(`backendSessionId ?? sessionId`) is rejected: the shipped spec + unit test require
+the header to **not** fall back to the business key, precisely because for Codex the
+business key is a routing uuid that does **not** resume anything. A blind fallback
+would resurrect a broken button for Codex sessions that legitimately have no
+backend id yet.
+
+Instead we realize q3=a's intent through the existing `backendSessionId` channel:
+the Claude spawner **reports** its `--resume` anchor as `backendSessionId`. Net
+effect for Claude is identical to "reuse sessionId" (the copied value equals
+`session.sessionId`), but it flows through the one code path that is already
+correct for every backend and keeps the "no fallback" invariant intact.
+
+### D2 — Claude: report the `--resume` anchor (= the Chorus business key)
+
+`cli/claude-spawner.mjs` spawns a **new** session with `--session-id <sessionId>`
+and **resumes** with `--resume <sessionId>`; `isNewSession` probes the on-disk
+transcript at `<configDir>/projects/<cwd>/<sessionId>.jsonl`. So the durable value
+that `claude --resume <id>` accepts in that cwd is `sessionId` (the `id` argument),
+and it is also the transcript filename. The spawner therefore reports:
+
+```js
+// terminal returns (close / error), mirroring the shape Codex uses:
+resolve({ sessionId: observedSessionId, backendSessionId: id, exitCode: code, isNew });
+```
+
+- `id` is the input `sessionId`, already validated as a lowercase UUID by
+  `isValidSessionId` before spawn — safe to persist.
+- The stream-observed `session_id` (`observedSessionId`) is **not** used as the
+  resume id: on a fork-on-resume Claude version it can differ from the anchor the
+  daemon (and the `<sessionId>.jsonl` file) are keyed on, so `id` is the value that
+  reliably resumes the conversation Chorus tracks. `observedSessionId` continues to
+  populate the returned `sessionId` field unchanged (no behavior change there).
+- For Claude, `backendSessionId === sessionId` by construction. That is expected —
+  Claude's resume anchor genuinely *is* the value the daemon chose as the business
+  key. The server's first-write/idempotent guard (`advanceTurnForWake` in
+  `daemon-session.service.ts`) has no "must differ from the business key" check, so
+  persisting an equal value is harmless.
+
+### D3 — No downstream changes
+
+The waker forwards `result.backendSessionId` on the terminal edge only
+(`waker.#advanceTurn`, proven by `waker-turn-lifecycle.test.mjs`), the REST client
+sends it only when `backendSessionId && isTerminal`, and the server persists it
+with an idempotent/conflict guard. All three are backend-agnostic and already
+tested. The UI already renders the button from `session.backendSessionId`. So the
+diff is confined to one spawner file + its unit test.
+
+### Kiro deferral
+
+The elaboration (idea 228f56b6, q1=c) asked to cover Kiro too. During proposal
+review this was found **not** to be a spawner-return change:
+`cli/kiro-spawner.mjs` obtains a Kiro resume id by diffing the CLI session store
+before/after a run, but the daemon always runs `kiro-cli chat --no-interactive`,
+and that mode does **not** persist a session to the store (live-verified comment at
+`kiro-spawner.mjs:361-368`). So on every headless run the diff finds zero new
+sessions, the captured id is null, `backendSessionId` stays null, and the button
+never appears — and even if reported, `--resume-id` could not re-open a
+never-persisted conversation. Making Kiro resumable requires a separate
+investigation (how to get a durable resumable id out of headless kiro-cli, or
+whether kiro-cli must be invoked differently). Tracked as a derived child idea of
+228f56b6; not in this patch.
+
+## Risks / Trade-offs
+
+- **Claude fork-on-resume**: some Claude Code versions emit a new `session_id` when
+  resuming. Mitigation: we report the anchor `id`, not the observed stream id, so
+  the copied value always matches the daemon's resume path and the on-disk
+  transcript filename. (D2.)
+- **First-turn latency**: `backendSessionId` is written on the terminal turn edge,
+  so a brand-new session shows the button only after its first turn completes.
+  This already matches Codex behavior; no regression.
+
+## Migration
+
+None. No schema change; the column already exists. No data backfill (by design —
+see Non-goals). No i18n keys (label unchanged). No `design.pen` change (no new or
+modified screen; the control already exists and its appearance is unchanged).

--- a/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/proposal.md
+++ b/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/proposal.md
@@ -1,0 +1,76 @@
+# Restore the Claude Code session resume id (unify Claude + Codex)
+
+## Why
+
+The daemon session chat UI has a "Copy session ID" control in the transcript
+header. It renders **iff** the session's `backendSessionId` is non-null and copies
+that value verbatim, so a human can resume the same conversation locally (e.g.
+`claude --resume <id>` / `codex exec resume <id>`).
+
+Today the button appears **only for Codex** conversations. It is missing for
+**Claude Code** — a regression:
+
+- Before PR #467 the control read `session.sessionId` (which, for Claude, *is* the
+  `--resume` anchor — the daemon spawns with `--session-id <sessionId>` and owns the
+  `<sessionId>.jsonl` transcript), so it showed for every backend.
+- PR #467 (`fix(codex): persist resumable session id`) rewired the control to read
+  `backendSessionId` to make Codex work — and, as a side effect, removed it for
+  Claude Code, whose spawner never reports a `backendSessionId`.
+
+The root cause is uniform: `backendSessionId` is populated only when a spawner
+*returns* it on the terminal turn edge. Codex returns it; Claude does not. The
+transport that carries it (waker → REST client → server persist, with an
+idempotent/conflict guard) is already backend-agnostic.
+
+## What Changes
+
+Make the **Claude Code** daemon spawner report the resume identifier its own
+`--resume` command accepts, so the existing copy control lights up for Claude
+exactly as it does for Codex:
+
+- **Claude Code** — the spawner reports `backendSessionId` = the session's Claude
+  `--resume` anchor (the id the daemon itself resumes with) on terminal turns.
+  This restores the pre-#467 behavior via the current `backendSessionId` path,
+  with no UI fallback.
+- **Codex** — unchanged (already reports its `thread_id`).
+- **No UI change and no server change.** The transcript header, the
+  `CopySessionIdButton` render gate (`backendSessionId` non-null), the copied
+  value (bare id), and the persist path all stay exactly as they are. The button
+  reappears purely because Claude now populates a usable `backendSessionId`.
+
+### Kiro is explicitly out of scope (deferred to a follow-up idea)
+
+The original elaboration asked to unify **all** backends including Kiro (idea
+228f56b6, q1=c). Investigation during proposal review found the Kiro half is not a
+simple spawner-return change: the daemon always runs `kiro-cli chat
+--no-interactive`, and that mode does **not** persist a session to the Kiro CLI
+store (live-verified in `cli/kiro-spawner.mjs`), so there is no captured resume id
+to report and `--resume-id` cannot re-open the conversation. Making Kiro resumable
+needs its own investigation (how to obtain a durable, resumable id from headless
+kiro-cli) and is tracked as a **derived child idea**, not forced into this 0.16.1
+patch.
+
+Behavior confirmed by the elaboration on idea 228f56b6: copy the **bare id**
+(q2=a), reuse the Claude anchor rather than change plumbing (q3=a — realized here
+as the spawner reporting that anchor through the existing `backendSessionId`
+channel, which keeps the shipped "no fallback to business key" spec intact), the
+control's meaning is "copy a resumable id for local resume" (q4=a), and this ships
+as a 0.16.1 patch (q5=a).
+
+## Capabilities
+
+- `backend-session-resume-id` — extend the existing capability from Codex-only to
+  also cover the Claude Code backend.
+
+## Impact
+
+- **Code:** `cli/claude-spawner.mjs` (spawner `wake()` return shape only). No
+  changes to the waker, REST client, server route, service, schema, or any React
+  component.
+- **Tests:** new spawner unit test asserting the terminal return carries
+  `backendSessionId`; the existing waker/REST-client/UI tests already cover the
+  downstream chain.
+- **Docs:** OpenSpec delta spec for `backend-session-resume-id`.
+- **No migration, no i18n, no design.pen change** (no new or modified screen; the
+  control already exists and is unchanged — only the data feeding its render gate
+  changes).

--- a/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/specs/backend-session-resume-id/spec.md
+++ b/openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/specs/backend-session-resume-id/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Claude Code sessions report a usable resume identifier
+The Claude Code daemon backend MUST report, through the existing authenticated turn
+lifecycle channel, the resume identifier that its own `--resume` command accepts,
+so that the conversation UI's session-id copy control appears for Claude Code
+conversations exactly as it does for Codex. The reported identifier MUST be the
+session's Claude `--resume` anchor.
+
+#### Scenario: Claude Code session reports its resume anchor
+- **WHEN** a Claude Code daemon session completes a turn
+- **THEN** the daemon reports the session's Claude `--resume` anchor as the backend resume identifier, and the server stores it as the session's backend resume identifier
+
+#### Scenario: Copy control appears for a Claude Code session with a stored identifier
+- **WHEN** a user views a Claude Code conversation whose stored backend resume identifier is non-null
+- **THEN** the existing session-id copy control is shown and copies that identifier verbatim
+
+### Requirement: Copied Claude identifier resumes the same conversation
+For a Claude Code-backed conversation, the persisted backend resume identifier MUST
+be accepted by the installed Claude Code CLI's `--resume` option in the session's
+working directory and identify the same conversation the Chorus session tracks.
+
+#### Scenario: User resumes a Claude conversation from the copied id
+- **WHEN** the user runs `claude --resume <copied-id>` in the session's working directory
+- **THEN** Claude Code resumes the same conversation represented by the Chorus session

--- a/openspec/specs/backend-session-resume-id/spec.md
+++ b/openspec/specs/backend-session-resume-id/spec.md
@@ -55,3 +55,27 @@ For a Codex-backed conversation, the persisted backend session ID MUST be accept
 - **WHEN** the user runs `codex exec resume <copied-id>` in the session's working directory
 - **THEN** Codex resumes the same thread represented by the Chorus conversation
 
+### Requirement: Claude Code sessions report a usable resume identifier
+The Claude Code daemon backend MUST report, through the existing authenticated turn
+lifecycle channel, the resume identifier that its own `--resume` command accepts,
+so that the conversation UI's session-id copy control appears for Claude Code
+conversations exactly as it does for Codex. The reported identifier MUST be the
+session's Claude `--resume` anchor.
+
+#### Scenario: Claude Code session reports its resume anchor
+- **WHEN** a Claude Code daemon session completes a turn
+- **THEN** the daemon reports the session's Claude `--resume` anchor as the backend resume identifier, and the server stores it as the session's backend resume identifier
+
+#### Scenario: Copy control appears for a Claude Code session with a stored identifier
+- **WHEN** a user views a Claude Code conversation whose stored backend resume identifier is non-null
+- **THEN** the existing session-id copy control is shown and copies that identifier verbatim
+
+### Requirement: Copied Claude identifier resumes the same conversation
+For a Claude Code-backed conversation, the persisted backend resume identifier MUST
+be accepted by the installed Claude Code CLI's `--resume` option in the session's
+working directory and identify the same conversation the Chorus session tracks.
+
+#### Scenario: User resumes a Claude conversation from the copied id
+- **WHEN** the user runs `claude --resume <copied-id>` in the session's working directory
+- **THEN** Claude Code resumes the same conversation represented by the Chorus session
+


### PR DESCRIPTION
## Summary

Restores the daemon-chat **"Copy session ID"** control for Claude Code, which regressed in #467.

The control renders only when a session's `backendSessionId` is non-null and copies it verbatim (so a human can `claude --resume <id>` locally). #467 rewired it from `sessionId` → `backendSessionId` to make Codex work, and as a side effect removed it for Claude Code — whose `--resume` anchor **is** the `sessionId`, and whose spawner never reported a `backendSessionId`.

Fix: `cli/claude-spawner.mjs` now reports `backendSessionId = the --resume anchor` (the input `sessionId`, also the `<sessionId>.jsonl` transcript filename) on both terminal resolutions, and `null` on the pre-spawn early returns — mirroring the shape `codex-spawner.mjs` already returns. It reports the **anchor**, not the stream-observed `session_id` (which can fork-diverge on resume).

No UI / server / waker / rest-client change — the terminal-edge forwarding of `result.backendSessionId` was already backend-agnostic, so the button reappears purely from the spawner now populating the value. The "no fallback to the Chorus business key" invariant in the `backend-session-resume-id` spec is preserved (no UI `?? sessionId` fallback).

**Kiro is deliberately out of scope:** headless `kiro-cli chat --no-interactive` does not persist a resumable session id, so it needs its own investigation (tracked as a separate follow-up idea). Codex already reports its `thread_id`.

## Changed files
| File | Change |
|------|--------|
| `cli/claude-spawner.mjs` | `wake()` returns `backendSessionId` (anchor on terminal edges, null on early returns) + JSDoc |
| `cli/__tests__/claude-spawner.test.mjs` | Updated assertions + new fork-divergence test (`backendSessionId===anchor`, `sessionId===observed`) |
| `openspec/specs/backend-session-resume-id/spec.md` | Cumulative spec: +2 requirements (Claude reports/resumes) |
| `openspec/changes/archive/2026-08-10-unify-backend-session-resume-id/` | Archived OpenSpec change (proposal/design/spec) |

## Test plan
- [x] `pnpm test cli/__tests__/claude-spawner.test.mjs` → 42 passed (incl. fork-divergence assertion)
- [x] `pnpm test cli/__tests__/waker-turn-lifecycle.test.mjs cli/__tests__/spawner-select.test.mjs` → 31 passed (downstream forwarding unaffected)
- [x] `npx tsc --noEmit` clean; `npx eslint` on changed files clean
- [x] Ship-time code review: PASS (113 related tests green)
- [x] Deployed to the live env and verified `/login` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)