### PR TITLE
feat: add GitHub + Docs resource links to settings and onboarding

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1775,5 +1775,11 @@
     "pinToSidebar": "Pin to sidebar",
     "removeFromRecent": "Remove from recent",
     "moreActions": "More actions for {name}"
+  },
+  "resourceLinks": {
+    "github": "GitHub",
+    "docs": "Docs",
+    "githubAria": "Open the Chorus GitHub repository (opens in a new tab)",
+    "docsAria": "Open the Chorus documentation site (opens in a new tab)"
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1775,5 +1775,11 @@
     "pinToSidebar": "サイドバーにピン留め",
     "removeFromRecent": "最近から削除",
     "moreActions": "{name} のその他の操作"
+  },
+  "resourceLinks": {
+    "github": "GitHub",
+    "docs": "ドキュメント",
+    "githubAria": "Chorus の GitHub リポジトリを開く（新しいタブで開きます）",
+    "docsAria": "Chorus のドキュメントサイトを開く（新しいタブで開きます）"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1775,5 +1775,11 @@
     "pinToSidebar": "사이드바에 고정",
     "removeFromRecent": "최근에서 제거",
     "moreActions": "{name} 추가 작업"
+  },
+  "resourceLinks": {
+    "github": "GitHub",
+    "docs": "문서",
+    "githubAria": "Chorus GitHub 저장소 열기(새 탭에서 열림)",
+    "docsAria": "Chorus 문서 사이트 열기(새 탭에서 열림)"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1775,5 +1775,11 @@
     "pinToSidebar": "置顶到侧边栏",
     "removeFromRecent": "从最近移除",
     "moreActions": "{name} 的更多操作"
+  },
+  "resourceLinks": {
+    "github": "GitHub",
+    "docs": "文档",
+    "githubAria": "打开 Chorus GitHub 仓库（在新标签页打开）",
+    "docsAria": "打开 Chorus 文档站（在新标签页打开）"
   }
 }

--- a/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/README.md
+++ b/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/README.md
@@ -1,0 +1,3 @@
+# add-resource-links-settings-onboarding
+
+Show GitHub and Docs entry buttons on the settings page header and onboarding wizard footer

--- a/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/design.md
+++ b/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/design.md
@@ -1,0 +1,78 @@
+## Context
+
+The docs site (`https://doc.chorus-ai.dev`) is live and localized: `en` is the unprefixed root, and `zh` / `ja` / `ko` are path-prefixed (`/zh`, `/ja`, `/ko`). The GitHub repo is `https://github.com/Chorus-AIDLC/Chorus`. The app's active UI locale is available client-side via `useLocale()` from `@/contexts/locale-context` (persisted in `localStorage` under `chorus-locale`). The supported locale set is `['en', 'zh', 'ko', 'ja']` (`src/i18n/config.ts`).
+
+Both target surfaces are client components:
+- `src/app/(dashboard)/settings/page.tsx` — `"use client"`, already calls `useTranslations()` and `useLocale()`, header lives in a `mb-8` block with an `<h1>`.
+- `src/app/onboarding/components/OnboardingWizard.tsx` — `"use client"`, renders step content inside a centered `max-w-2xl` column, already has a global skip `<Button>` below the steps.
+
+## Goals / Non-Goals
+
+**Goals**
+- One reusable control, two placements, consistent look.
+- Docs link resolves to the locale-matched docs URL; GitHub link is fixed.
+- Links open in a new tab without leaking the referrer/opener.
+- Fully i18n'd labels + accessible names across en/zh/ja/ko.
+- Correct in both light and dark themes.
+
+**Non-Goals**
+- No sidebar or top help-menu entry (explicitly declined in elaboration).
+- No extra resources (What's New, community/feedback).
+- No server-side rendering of the control (locale is a client concern here).
+
+## Decisions
+
+### Component contract — `src/components/resource-links.tsx`
+
+```tsx
+"use client";
+interface ResourceLinksProps {
+  /** layout variant: "inline" for the settings header row, "footer" for the onboarding footer */
+  variant?: "inline" | "footer";
+  className?: string;
+}
+```
+
+- Renders two `<Button asChild variant="outline" size="sm">` wrapping `<a href … target="_blank" rel="noopener noreferrer">`, each with a `lucide-react` icon (`Github`, `BookOpen`) + a translated label.
+- Uses `useLocale()` to compute the docs href; uses `useTranslations("resourceLinks")` for labels + aria-labels.
+- `variant` only tweaks container spacing/justification (`inline` → `flex gap-2`; `footer` → centered `flex gap-3`). Button styling is identical so the two placements read as one system.
+- Uses semantic tokens only (`variant="outline"` already theme-aware) — no hardcoded hex, so light/dark both work for free.
+
+### Docs URL resolution
+
+Single pure helper, colocated in the component (small enough not to warrant its own module, but extractable):
+
+```ts
+const DOCS_BASE = "https://doc.chorus-ai.dev";
+function docsUrlForLocale(locale: string): string {
+  return locale === "en" ? DOCS_BASE : `${DOCS_BASE}/${locale}`;
+}
+```
+
+`en` → root; every other supported locale (`zh`, `ja`, `ko`) → `/{locale}`. This matches the docs skill's documented locale layout. If an unexpected locale value ever appears, it degrades to `/{locale}` which is harmless (worst case a 404 the user can navigate back from) — but the supported set is fixed, so this won't happen in practice.
+
+### GitHub URL
+
+Constant `https://github.com/Chorus-AIDLC/Chorus`. No locale variance.
+
+### Placement
+
+- **Settings**: wrap the existing header `<h1>` + subtitle and the new `<ResourceLinks variant="inline" />` in a `flex items-start justify-between` row so the buttons sit top-right, title left. On narrow screens the buttons wrap below the title (`flex-wrap` / responsive), no layout break.
+- **Onboarding**: render `<ResourceLinks variant="footer" />` once in `OnboardingWizard` **below** the step content and the existing skip link, so it is present on every step (steps 0–5). It sits outside the `AnimatePresence` step swap, so it does not animate in/out per step.
+
+### Open behavior
+
+`target="_blank"` + `rel="noopener noreferrer"` on both anchors — new tab, no opener/referrer leak. Chosen per elaboration (open in new tab, don't interrupt the current flow).
+
+## Risks / Trade-offs
+
+- **Locale drift**: if a new docs locale is added but not to `locales`, the docs link would 404 for that locale. Mitigation: `docsUrlForLocale` is driven by the same locale set the rest of the app uses, so they move together.
+- **Onboarding footer crowding**: the wizard already has a skip link; adding a second row could feel busy. Mitigation: `footer` variant uses muted `outline` buttons and sits below skip, visually secondary to the primary step CTA.
+
+## Migration Plan
+
+Additive only — new component + two call sites + new i18n keys. No data migration, no flags. Ships in one change.
+
+## Open Questions
+
+None — all resolved in elaboration (scope = GitHub+Docs only; settings header top-right; onboarding persistent footer; icon+text; docs follows locale; new tab).

--- a/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/proposal.md
+++ b/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Chorus now has a dedicated documentation site (`https://doc.chorus-ai.dev`, localized for en / zh / ja / ko), but there is no in-product entry point to it or to the GitHub repository. Users who want to read the docs or find the source have to know the URLs by heart. Surfacing GitHub and Docs buttons where users naturally look for help — the settings page and the onboarding flow — closes that gap.
+
+## What Changes
+
+- Add a small **resource links** control that renders two external-link buttons, **GitHub** and **Docs** (icon + text), each opening in a new tab (`target="_blank"` + `rel="noopener noreferrer"`).
+- The **Docs** button follows the current UI locale: `en` → `https://doc.chorus-ai.dev`, `zh` → `/zh`, `ja` → `/ja`, `ko` → `/ko`. The **GitHub** button always points at `https://github.com/Chorus-AIDLC/Chorus`.
+- Render the control at the **top-right of the settings page header** (aligned with the page title).
+- Render the control as a **persistent footer** in the onboarding wizard, visible on **every** step of the flow.
+- Add the required i18n strings (`resourceLinks.github`, `resourceLinks.docs`, and aria labels) to all four locale files (en, zh, ja, ko).
+- No new global entries (sidebar / help menu) and no extra links (What's New / community) — scope is intentionally the two buttons in the two locations.
+
+## Capabilities
+
+### New Capabilities
+- `resource-links`: A reusable in-product control that surfaces the GitHub repository and the localized documentation site as external-link buttons, placed on the settings page and the onboarding wizard.
+
+### Modified Capabilities
+<!-- none — no existing spec's requirements change -->
+
+## Impact
+
+- **New component**: `src/components/resource-links.tsx` (client component; reads current locale via `useLocale`).
+- **Modified**: `src/app/(dashboard)/settings/page.tsx` (header region) and `src/app/onboarding/components/OnboardingWizard.tsx` (persistent footer).
+- **i18n**: new `resourceLinks.*` keys in `messages/{en,zh,ja,ko}.json`.
+- **Dependencies**: none new — uses existing shadcn `Button`, `lucide-react` icons (`Github`, `BookOpen` / `ExternalLink`), and the existing `useLocale` context.
+- No backend, API, schema, or permission changes.

--- a/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/specs/resource-links/spec.md
+++ b/openspec/changes/archive/2026-08-10-add-resource-links-settings-onboarding/specs/resource-links/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Resource links control
+The system SHALL provide a reusable resource-links control that renders exactly two external-link buttons — a GitHub button and a Docs button — each shown as an icon plus a translated text label, and each opening its destination in a new browser tab with `rel="noopener noreferrer"`.
+
+#### Scenario: GitHub button target
+- **WHEN** a user activates the GitHub button
+- **THEN** a new tab opens at `https://github.com/Chorus-AIDLC/Chorus`
+- **AND** the original tab is unchanged and retains no `window.opener` reference to the new tab
+
+#### Scenario: Docs button opens in a new tab
+- **WHEN** a user activates the Docs button
+- **THEN** the localized documentation site opens in a new browser tab
+- **AND** the original tab is unchanged and retains no `window.opener` reference to the new tab
+
+#### Scenario: Labels are localized
+- **WHEN** the control renders under any supported UI locale (en, zh, ja, ko)
+- **THEN** both buttons display labels and accessible names from that locale's `resourceLinks` translations, with no hardcoded English fallback text
+
+### Requirement: Docs link follows the current UI locale
+The Docs button destination SHALL be derived from the active UI locale: the `en` locale SHALL link to the documentation site root `https://doc.chorus-ai.dev`, and every other supported locale SHALL link to the locale-prefixed path `https://doc.chorus-ai.dev/<locale>`.
+
+#### Scenario: English locale links to root
+- **WHEN** the active UI locale is `en`
+- **THEN** the Docs button href is `https://doc.chorus-ai.dev`
+
+#### Scenario: Non-English locale links to prefixed path
+- **WHEN** the active UI locale is `zh`, `ja`, or `ko`
+- **THEN** the Docs button href is `https://doc.chorus-ai.dev/<locale>` (e.g. `https://doc.chorus-ai.dev/zh`)
+
+### Requirement: Placement on settings and onboarding
+The resource-links control SHALL appear at the top-right of the settings page header and as a persistent footer within the onboarding wizard that is visible on every step of the flow.
+
+#### Scenario: Settings page header
+- **WHEN** a user views the settings page
+- **THEN** the GitHub and Docs buttons are rendered in the page header aligned to the top-right, alongside the page title
+
+#### Scenario: Onboarding wizard footer on every step
+- **WHEN** a user is on any step of the onboarding wizard
+- **THEN** the GitHub and Docs buttons are visible in the wizard footer
+
+### Requirement: Theme correctness
+The resource-links control SHALL render correctly in both light and dark themes, using semantic design tokens rather than hardcoded colors.
+
+#### Scenario: Dark theme rendering
+- **WHEN** the app is in dark theme
+- **THEN** the buttons, icons, and labels remain legible with theme-appropriate contrast and no fixed-light color artifacts

--- a/openspec/specs/resource-links/spec.md
+++ b/openspec/specs/resource-links/spec.md
@@ -1,0 +1,51 @@
+# resource-links Specification
+
+## Purpose
+TBD - created by archiving change add-resource-links-settings-onboarding. Update Purpose after archive.
+## Requirements
+### Requirement: Resource links control
+The system SHALL provide a reusable resource-links control that renders exactly two external-link buttons — a GitHub button and a Docs button — each shown as an icon plus a translated text label, and each opening its destination in a new browser tab with `rel="noopener noreferrer"`.
+
+#### Scenario: GitHub button target
+- **WHEN** a user activates the GitHub button
+- **THEN** a new tab opens at `https://github.com/Chorus-AIDLC/Chorus`
+- **AND** the original tab is unchanged and retains no `window.opener` reference to the new tab
+
+#### Scenario: Docs button opens in a new tab
+- **WHEN** a user activates the Docs button
+- **THEN** the localized documentation site opens in a new browser tab
+- **AND** the original tab is unchanged and retains no `window.opener` reference to the new tab
+
+#### Scenario: Labels are localized
+- **WHEN** the control renders under any supported UI locale (en, zh, ja, ko)
+- **THEN** both buttons display labels and accessible names from that locale's `resourceLinks` translations, with no hardcoded English fallback text
+
+### Requirement: Docs link follows the current UI locale
+The Docs button destination SHALL be derived from the active UI locale: the `en` locale SHALL link to the documentation site root `https://doc.chorus-ai.dev`, and every other supported locale SHALL link to the locale-prefixed path `https://doc.chorus-ai.dev/<locale>`.
+
+#### Scenario: English locale links to root
+- **WHEN** the active UI locale is `en`
+- **THEN** the Docs button href is `https://doc.chorus-ai.dev`
+
+#### Scenario: Non-English locale links to prefixed path
+- **WHEN** the active UI locale is `zh`, `ja`, or `ko`
+- **THEN** the Docs button href is `https://doc.chorus-ai.dev/<locale>` (e.g. `https://doc.chorus-ai.dev/zh`)
+
+### Requirement: Placement on settings and onboarding
+The resource-links control SHALL appear at the top-right of the settings page header and as a persistent footer within the onboarding wizard that is visible on every step of the flow.
+
+#### Scenario: Settings page header
+- **WHEN** a user views the settings page
+- **THEN** the GitHub and Docs buttons are rendered in the page header aligned to the top-right, alongside the page title
+
+#### Scenario: Onboarding wizard footer on every step
+- **WHEN** a user is on any step of the onboarding wizard
+- **THEN** the GitHub and Docs buttons are visible in the wizard footer
+
+### Requirement: Theme correctness
+The resource-links control SHALL render correctly in both light and dark themes, using semantic design tokens rather than hardcoded colors.
+
+#### Scenario: Dark theme rendering
+- **WHEN** the app is in dark theme
+- **THEN** the buttons, icons, and labels remain legible with theme-appropriate contrast and no fixed-light color artifacts
+

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Plus, Key, X, Globe, ChevronDown, ChevronRight, Activity, Bell, Pencil, Rocket } from "lucide-react";
 import Link from "next/link";
 import { AgentCreateForm } from "@/components/AgentCreateForm";
+import { ResourceLinks } from "@/components/resource-links";
 import { AgentFormFields } from "@/components/AgentFormFields";
 import type { AgentPermissionPickerChange } from "@/components/AgentPermissionPicker";
 import { Badge } from "@/components/ui/badge";
@@ -262,11 +263,14 @@ export default function SettingsPage() {
       <div className="mb-6 text-xs text-[#9A9A9A]">{t("settings.breadcrumb")}</div>
 
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-2xl font-semibold text-foreground">{t("settings.title")}</h1>
-        <p className="mt-1 text-[13px] text-muted-foreground">
-          {t("settings.subtitle")}
-        </p>
+      <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">{t("settings.title")}</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            {t("settings.subtitle")}
+          </p>
+        </div>
+        <ResourceLinks variant="inline" />
       </div>
 
       {/* Language Section */}

--- a/src/app/onboarding/components/OnboardingWizard.tsx
+++ b/src/app/onboarding/components/OnboardingWizard.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "@/hooks/use-progress-router";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { AnimatePresence } from "framer-motion";
+import { ResourceLinks } from "@/components/resource-links";
 import { StepIndicator } from "./StepIndicator";
 import { WelcomeStep } from "./WelcomeStep";
 import { CreateAgentStep } from "./CreateAgentStep";
@@ -110,6 +111,11 @@ export function OnboardingWizard() {
           {t("skip")}
         </Button>
       )}
+
+      {/* Persistent resource links footer — visible on every step so users can
+          reach the GitHub repo and docs site at any point in onboarding. Kept
+          outside AnimatePresence so it does not animate in/out per step. */}
+      <ResourceLinks variant="footer" />
     </div>
   );
 }

--- a/src/components/resource-links.tsx
+++ b/src/components/resource-links.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+// Renders the two external "resource" entry points — the GitHub repository and
+// the localized documentation site — as icon+text buttons. Used on the settings
+// page header and the onboarding wizard footer so users can always find where
+// to read the docs or view the source.
+
+import { Github, BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { useLocale } from "@/contexts/locale-context";
+import { cn } from "@/lib/utils";
+
+const GITHUB_URL = "https://github.com/Chorus-AIDLC/Chorus";
+const DOCS_BASE = "https://doc.chorus-ai.dev";
+
+// The docs site serves `en` at the unprefixed root and every other locale under
+// a `/<locale>` path prefix (zh / ja / ko). Keep this in lockstep with the app's
+// supported locale set in src/i18n/config.ts.
+export function docsUrlForLocale(locale: string): string {
+  return locale === "en" ? DOCS_BASE : `${DOCS_BASE}/${locale}`;
+}
+
+interface ResourceLinksProps {
+  /**
+   * Layout variant. "inline" packs the buttons tightly for a header row;
+   * "footer" centers them for the onboarding wizard footer. Button styling is
+   * identical across variants so the two placements read as one system.
+   */
+  variant?: "inline" | "footer";
+  className?: string;
+}
+
+export function ResourceLinks({
+  variant = "inline",
+  className,
+}: ResourceLinksProps) {
+  const t = useTranslations("resourceLinks");
+  const { locale } = useLocale();
+
+  const docsUrl = docsUrlForLocale(locale);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2",
+        variant === "footer" && "justify-center gap-3",
+        className,
+      )}
+    >
+      <Button variant="outline" size="sm" asChild>
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={t("githubAria")}
+        >
+          <Github className="h-4 w-4" />
+          {t("github")}
+        </a>
+      </Button>
+      <Button variant="outline" size="sm" asChild>
+        <a
+          href={docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={t("docsAria")}
+        >
+          <BookOpen className="h-4 w-4" />
+          {t("docs")}
+        </a>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Surface the GitHub repo and the localized docs site as in-product entry points, so users can reach them from the two places they look for help: the settings page and onboarding.
- New reusable `ResourceLinks` component with two layout variants: `inline` (settings header, top-right) and `footer` (onboarding wizard, persistent across every step).
- **Docs** link follows the current UI locale — `en` → `https://doc.chorus-ai.dev`, `zh`/`ja`/`ko` → `https://doc.chorus-ai.dev/<locale>`. **GitHub** is a fixed URL (`https://github.com/Chorus-AIDLC/Chorus`).
- Both buttons open in a new tab with `rel="noopener noreferrer"`; icon + text, shadcn `outline` variant (theme-adaptive).
- Adds a `resourceLinks` i18n section (github/docs + aria labels) to all four locales (en/zh/ja/ko).

## Changed files
| File | Change |
|------|--------|
| `src/components/resource-links.tsx` | **New** — `ResourceLinks` component + pure `docsUrlForLocale()` helper |
| `src/app/(dashboard)/settings/page.tsx` | Header wrapped in `flex justify-between`; `<ResourceLinks variant="inline" />` top-right |
| `src/app/onboarding/components/OnboardingWizard.tsx` | `<ResourceLinks variant="footer" />` rendered unconditionally at root (outside `AnimatePresence`) so it shows on every step |
| `messages/{en,zh,ja,ko}.json` | New `resourceLinks` section (additive) |
| `openspec/specs/resource-links/spec.md` + archived change | OpenSpec: new `resource-links` capability, change archived |

## Test plan
- [x] `npx tsc --noEmit` — exit 0
- [x] eslint on the 3 changed source files — 0 errors (repo has pre-existing baseline lint errors in untouched files)
- [x] i18n parity tests green; full `pnpm test` 4766 passed
- [x] Live e2e on local dev server: buttons render on settings + onboarding; hrefs correct; `target=_blank`+`rel=noopener noreferrer`; switching to 中文 flips Docs → `/zh` while GitHub stays fixed; verified in both light and dark themes (screenshots captured)
- [ ] `docs/design.pen` update deferred — Pencil MCP needs a GUI editor unavailable in the headless session (follow-up for a human with the desktop editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)