### PR TITLE
fix(daemon-chat): show loading skeleton in conversation list, not ambiguous empty state

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1564,7 +1564,6 @@
     "loadMore": "Load more",
     "loadEarlier": "Load earlier messages",
     "loadingEarlier": "Loading earlier…",
-    "loading": "Loading conversations…",
     "transcriptLoading": "Loading transcript…",
     "mobileBack": "Conversations",
     "conversationAdHoc": "Conversation {id}",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1564,7 +1564,6 @@
     "loadMore": "さらに読み込む",
     "loadEarlier": "以前のメッセージを読み込む",
     "loadingEarlier": "以前のメッセージを読み込み中…",
-    "loading": "会話を読み込み中…",
     "transcriptLoading": "トランスクリプトを読み込み中…",
     "mobileBack": "会話",
     "conversationAdHoc": "会話 {id}",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1564,7 +1564,6 @@
     "loadMore": "더 보기",
     "loadEarlier": "이전 메시지 불러오기",
     "loadingEarlier": "이전 메시지를 불러오는 중…",
-    "loading": "대화를 불러오는 중…",
     "transcriptLoading": "대화 기록을 불러오는 중…",
     "mobileBack": "대화",
     "conversationAdHoc": "대화 {id}",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1564,7 +1564,6 @@
     "loadMore": "加载更多",
     "loadEarlier": "加载更早的消息",
     "loadingEarlier": "正在加载更早…",
-    "loading": "正在加载对话…",
     "transcriptLoading": "正在加载记录…",
     "mobileBack": "对话",
     "conversationAdHoc": "对话 {id}",

--- a/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/README.md
+++ b/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/README.md
@@ -1,0 +1,3 @@
+# daemon-chat-list-loading-state
+
+Show a loading state in the daemon chat conversation list while it loads, instead of the ambiguous empty state

--- a/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/design.md
+++ b/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/design.md
@@ -1,0 +1,122 @@
+# Design: daemon chat conversation-list loading state
+
+## Context
+
+`DaemonChat` (`src/components/agent-presence/chat/daemon-chat.tsx`) is the two-pane chat
+modal. Its left pane is `ConversationList`
+(`src/components/agent-presence/chat/conversation-list.tsx`), a purely presentational
+component that renders the `rows` array it is given and shows an empty state when
+`rows.length === 0`.
+
+Two independent async sources feed the chat body:
+
+1. **Presence `status`** — from the shell-level `useAgentPresence()` provider
+   (connections poll). Values: `"loading" | "ok" | ...`.
+2. **List `listStatus`** — local to `DaemonChat`, tracks its own
+   `GET /api/daemon-sessions` fetch. Values: `"loading" | "ok" | "error"`. Set to
+   `"loading"` only at initial mount (its `useState` seed); `fetchSessions` sets it to
+   `"ok"` on success or `"error"` on failure — **it never resets to `"loading"`**, so the
+   15s `setInterval` poll and any re-fetch update the list without returning to a loading
+   state.
+
+### The bug
+
+Current derived states (`daemon-chat.tsx:772-782`):
+
+```ts
+const loading = status === "loading" && listStatus === "loading";
+const showListError = listStatus === "error" && sessions.length === 0;
+const noConversations = listStatus === "ok" && sessions.length === 0;
+const noAgentsAtAll = noConversations && agents.length === 0;
+```
+
+Because `loading` is an **AND** of two independently-settling sources, the interval
+`[status becomes "ok"] .. [listStatus becomes "ok"]` has `loading === false` while the
+list is still loading. In that window none of the four states are true, so the render
+falls through to the two-pane branch, `ConversationList` gets `rows === []`, and shows the
+`noSessions` empty card — indistinguishable from a genuinely empty list. This is the
+reported ambiguity.
+
+## Decision
+
+### 1. Fix the loading gate
+
+Make the chat body's loading state depend on the **list** fetch alone:
+
+```ts
+const listLoading = listStatus === "loading";
+```
+
+Rename/repurpose the existing `loading` to this. Rationale: the conversation list is the
+thing whose emptiness is ambiguous, and its load status is exactly `listStatus`. The
+presence `status` gates agent *names*, not the list's population, so AND-ing it in only
+created the leak. Ordering of the derived branches is unchanged (`listLoading` first, then
+`showListError`, then `noAgentsAtAll`, then the two-pane body), so the error and
+no-agents cards keep priority over the normal list.
+
+Because `listStatus` only ever returns to `"loading"` via the initial `useState` seed
+(never re-set by `fetchSessions`), this naturally satisfies the "first load + agent switch
+only, silent on 15s poll" requirement: the background poll keeps `listStatus === "ok"`, so
+`listLoading` stays false and the skeleton never re-appears. (Agent switch does not
+re-fetch the list — the full list for all agents is already loaded and filtered
+client-side by `selectedAgentUuid` — so switching agents is instant and shows no skeleton;
+the "agent switch" case in the elaboration answer is subsumed by "list not yet loaded".)
+
+### 2. Skeleton in the conversation-list pane
+
+The loading affordance belongs **inside `ConversationList`**, replacing its
+`rows.length === 0` empty branch when a new `loading` prop is true, so the agent Select and
+"New conversation" button (the list's chrome) stay visible and the skeleton sits in the
+list card exactly where rows will land — the smoothest visual transition (elaboration
+q1 = Skeleton).
+
+- Add an optional `loading?: boolean` prop to `ConversationList`.
+- When `loading` is true, render the list card with a stack of ~5 `Skeleton` placeholder
+  rows (from `@/components/ui/skeleton`) in place of both the empty state and the rows.
+  Each placeholder mirrors a real row's geometry: a small leading dot-sized skeleton, a
+  wider title-line skeleton, and a short meta-line skeleton, padded like the real
+  `Row` (`px-4 py-3.5`), separated by the same hairline divider.
+- The list header count (`rows.length`) is not meaningful mid-load; render a neutral
+  placeholder (e.g. blank or a tiny skeleton) for the count while loading so it doesn't
+  flash `0`.
+
+`DaemonChat` passes `loading={listLoading}` to `ConversationList` in **both** the mobile
+and desktop instances. The container-level branch is simplified: instead of a top-level
+`loading ? <p>…</p>` text branch, the two-pane body renders always (once past the error /
+no-agents cards) and the list pane shows its own skeleton — so the header stays visible and
+the layout doesn't jump. The right pane during load shows the existing
+`NewConversationPane` (nothing selected), which is already a valid, non-error default.
+
+Alternative considered: keep the container-level `loading` text branch and only fix the
+gate. Rejected — it produces a bare centered "Loading conversations…" line with no list
+chrome, a visual regression from the polished two-pane layout, and does not satisfy the
+skeleton choice.
+
+### 3. Error path unchanged
+
+`showListError` (list error with nothing cached) keeps priority over the normal two-pane
+body and is evaluated after `listLoading`. Since `listStatus` moves `loading → error` on
+failure, `listLoading` is false in the error case and `showListError` wins — the existing
+`WifiOff` error card renders, never the empty state. No change needed beyond confirming the
+branch order; covered by a scenario + test.
+
+## Risks / trade-offs
+
+- **Very fast loads flash the skeleton briefly.** Acceptable — a sub-frame skeleton is
+  strictly better than the current ambiguous empty card, and matches the app's existing
+  skeleton usage (e.g. `idea-tracker-list.tsx`). No artificial min-display delay is added
+  (avoids added latency perception).
+- **`ConversationList` gains a prop.** Small, backward-compatible (optional, defaults to
+  non-loading). Its existing tests keep passing without the prop.
+
+## Testing
+
+- Unit/component test for `ConversationList`: `loading` true → renders skeleton rows, not
+  the `noSessions` empty state; `loading` false + empty rows → renders empty state;
+  `loading` false + rows → renders rows.
+- `DaemonChat` state-derivation: assert the previously-leaking combination
+  (`status === "ok"`, `listStatus === "loading"`, empty sessions) now yields the loading
+  state, not the empty state; and that `listStatus === "error"` yields the error card.
+- Manual e2e (Playwright MCP) on the running dev server: open the daemon chat modal, throttle
+  the `/api/daemon-sessions` response, confirm the skeleton shows during load and the empty
+  state only after a settled empty load, in both light and dark themes.

--- a/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/proposal.md
+++ b/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/proposal.md
@@ -1,0 +1,61 @@
+# Show a loading state in the daemon chat conversation list
+
+## Why
+
+In the daemon session chat window (the "View all" modal), the left-pane **conversation
+list** shows an empty-state card — "No conversations for this agent" — **before the
+session list has finished loading**. That empty state is byte-for-byte identical to the
+one shown when an agent genuinely has zero conversations, so during the first-load window
+the user is told they have no conversations when in fact the data is still in flight. It
+is ambiguous and reads as data loss.
+
+Root cause is in `DaemonChat` (`daemon-chat.tsx`). The loading flag is:
+
+```ts
+const loading = status === "loading" && listStatus === "loading";
+```
+
+`status` (the shell-level presence/connections poll) and `listStatus` (this component's
+own `GET /api/daemon-sessions` fetch) settle **independently**. There is a window where
+`status === "ok"` but `listStatus === "loading"`, so `loading` is `false`, all three
+other derived states (`showListError`, `noConversations`, `noAgentsAtAll`) are also
+`false` (they each require `listStatus === "ok"` or an error), and control falls through
+to the two-pane branch. `ConversationList` then receives an empty `rows` array and renders
+its `rows.length === 0` empty state — the ambiguous "No conversations" card.
+
+## What Changes
+
+- **Fix the loading gate** so the chat body treats the conversation list as loading
+  whenever `listStatus === "loading"` — no longer AND-ed with the independent presence
+  `status`. This closes the leak window that shows the empty state prematurely.
+- **Add a skeleton loading affordance** to the conversation-list pane: a small stack of
+  `Skeleton` placeholder rows shaped like real conversation rows, shown while the list is
+  loading, instead of the empty state. Reuses the existing `@/components/ui/skeleton`
+  primitive (theme-adaptive, works in light and dark for free).
+- **Show the loading state only on first load and agent switch, not on the 15s poll.**
+  The list already re-fetches every 15s and on agent switch; `fetchSessions` only sets
+  `listStatus` back to a non-`ok` value on genuine failure, so once the first load
+  succeeds the background poll updates the list silently without flashing the skeleton.
+  This is preserved (and verified) — the skeleton must not blink on every poll tick.
+- **Verify the error path stays distinct.** A list-load failure with nothing cached must
+  still show the existing error card (`loadErrorTitle` / `loadErrorBody`), never the empty
+  state. Confirm this is unaffected by the gate change.
+
+## Capabilities
+
+- `daemon-session-conversation` — adds one UI requirement governing the conversation
+  list's loading / empty / error state disambiguation.
+
+## Impact
+
+- **Affected code:** `src/components/agent-presence/chat/daemon-chat.tsx` (loading gate +
+  passing a loading flag), `src/components/agent-presence/chat/conversation-list.tsx`
+  (render skeleton rows when loading). Possibly one small `daemonChat` i18n key if a
+  loading label is surfaced; `daemonChat.loading` already exists and is reused.
+- **Scope:** left conversation-list pane only. The right transcript pane already has its
+  own loading state (`TranscriptView`'s `loading` prop) and is out of scope.
+- **No backend, schema, or API changes.** Pure client-side rendering fix.
+- **i18n:** any new user-facing string is added to both `messages/en.json` and
+  `messages/zh.json`. No hardcoded text.
+- **Themes:** the skeleton uses the semantic `bg-accent` token and works in both light
+  and dark themes with no extra work.

--- a/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/specs/daemon-session-conversation/spec.md
+++ b/openspec/changes/archive/2026-08-10-daemon-chat-list-loading-state/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: The daemon chat conversation list SHALL show a loading state while it loads, distinct from its empty state
+
+The daemon session chat conversation list (the left pane of the "View all" chat modal) SHALL render a loading affordance — a set of skeleton placeholder rows — while its session data is still being fetched, and SHALL render its "no conversations" empty state ONLY after the fetch has completed and genuinely returned no conversations for the selected agent. The loading state and the empty state SHALL be visually distinct so a user can never mistake an in-flight load for an empty list.
+
+The loading affordance SHALL be gated on the conversation list's OWN fetch status alone, not on the independently-settling presence/connections status, so the empty state is never shown during the window where connections have loaded but the session list has not. The loading affordance SHALL appear on the first load (and any load where the list has no data yet), and SHALL NOT re-appear on the periodic background refresh once a first load has succeeded — the background refresh updates the list silently without flashing the loading state.
+
+A load failure with no cached conversations SHALL continue to show the distinct error card, never the empty state and never an indefinite loading state.
+
+#### Scenario: Loading state shows while the list is still fetching
+
+- **GIVEN** the daemon chat modal is open and the conversation list fetch has not yet completed
+- **WHEN** the connections/presence status has already settled to loaded but the session list is still loading
+- **THEN** the conversation list MUST render the loading affordance (skeleton placeholder rows)
+- **AND** it MUST NOT render the "no conversations" empty state
+
+#### Scenario: Empty state shows only after a settled empty load
+
+- **GIVEN** the conversation list fetch has completed successfully
+- **WHEN** the selected agent has zero conversations
+- **THEN** the conversation list MUST render the "no conversations" empty state
+- **AND** it MUST NOT render the loading affordance
+
+#### Scenario: Rows show after a settled non-empty load
+
+- **GIVEN** the conversation list fetch has completed successfully
+- **WHEN** the selected agent has one or more conversations
+- **THEN** the conversation list MUST render the conversation rows
+- **AND** it MUST NOT render either the loading affordance or the empty state
+
+#### Scenario: Background refresh does not flash the loading state
+
+- **GIVEN** the conversation list has completed its first successful load and is showing rows or the empty state
+- **WHEN** the periodic background refresh re-fetches the session list
+- **THEN** the conversation list MUST continue showing its settled content without re-rendering the loading affordance
+
+#### Scenario: A load failure shows the error card, not the empty or loading state
+
+- **GIVEN** the conversation list fetch fails and there are no cached conversations
+- **WHEN** the chat body decides what to render
+- **THEN** it MUST render the distinct load-error card
+- **AND** it MUST NOT render the "no conversations" empty state or the loading affordance

--- a/openspec/specs/daemon-session-conversation/spec.md
+++ b/openspec/specs/daemon-session-conversation/spec.md
@@ -394,8 +394,8 @@ turns.
 
 ### Requirement: A successful instruction send clears the composer
 
-When an instruction send is accepted by the server (HTTP 2xx), the daemon-session reply UI
-SHALL clear the compose input as the success signal. It SHALL NOT show a success toast
+The daemon-session reply UI SHALL clear the compose input as the success signal when an
+instruction send is accepted by the server (HTTP 2xx). It SHALL NOT show a success toast
 (that was tried and read as noise); blind re-sends are made harmless server-side by the
 idempotent-collapse requirement rather than discouraged by a toast. Send failures SHALL
 continue to surface their server-provided reason.
@@ -461,4 +461,46 @@ strings SHALL be localized in every supported locale (en, zh, ko, ja).
 - **WHEN** a relay-failure reason accompanies a `→ running` transition
 - **THEN** the server ignores it (the annotation is terminal-only), so a resumed turn
   never carries a stale relay failure.
+
+### Requirement: The daemon chat conversation list SHALL show a loading state while it loads, distinct from its empty state
+
+The daemon session chat conversation list (the left pane of the "View all" chat modal) SHALL render a loading affordance — a set of skeleton placeholder rows — while its session data is still being fetched, and SHALL render its "no conversations" empty state ONLY after the fetch has completed and genuinely returned no conversations for the selected agent. The loading state and the empty state SHALL be visually distinct so a user can never mistake an in-flight load for an empty list.
+
+The loading affordance SHALL be gated on the conversation list's OWN fetch status alone, not on the independently-settling presence/connections status, so the empty state is never shown during the window where connections have loaded but the session list has not. The loading affordance SHALL appear on the first load (and any load where the list has no data yet), and SHALL NOT re-appear on the periodic background refresh once a first load has succeeded — the background refresh updates the list silently without flashing the loading state.
+
+A load failure with no cached conversations SHALL continue to show the distinct error card, never the empty state and never an indefinite loading state.
+
+#### Scenario: Loading state shows while the list is still fetching
+
+- **GIVEN** the daemon chat modal is open and the conversation list fetch has not yet completed
+- **WHEN** the connections/presence status has already settled to loaded but the session list is still loading
+- **THEN** the conversation list MUST render the loading affordance (skeleton placeholder rows)
+- **AND** it MUST NOT render the "no conversations" empty state
+
+#### Scenario: Empty state shows only after a settled empty load
+
+- **GIVEN** the conversation list fetch has completed successfully
+- **WHEN** the selected agent has zero conversations
+- **THEN** the conversation list MUST render the "no conversations" empty state
+- **AND** it MUST NOT render the loading affordance
+
+#### Scenario: Rows show after a settled non-empty load
+
+- **GIVEN** the conversation list fetch has completed successfully
+- **WHEN** the selected agent has one or more conversations
+- **THEN** the conversation list MUST render the conversation rows
+- **AND** it MUST NOT render either the loading affordance or the empty state
+
+#### Scenario: Background refresh does not flash the loading state
+
+- **GIVEN** the conversation list has completed its first successful load and is showing rows or the empty state
+- **WHEN** the periodic background refresh re-fetches the session list
+- **THEN** the conversation list MUST continue showing its settled content without re-rendering the loading affordance
+
+#### Scenario: A load failure shows the error card, not the empty or loading state
+
+- **GIVEN** the conversation list fetch fails and there are no cached conversations
+- **WHEN** the chat body decides what to render
+- **THEN** it MUST render the distinct load-error card
+- **AND** it MUST NOT render the "no conversations" empty state or the loading affordance
 

--- a/src/components/agent-presence/chat/__tests__/conversation-list.test.tsx
+++ b/src/components/agent-presence/chat/__tests__/conversation-list.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+//
+// ConversationList — the LEFT pane of the daemon chat modal. These tests cover the
+// list card's three mutually-exclusive body states, the crux of the "loading vs empty"
+// disambiguation fix: while the session list is still loading the card MUST show skeleton
+// placeholder rows (not the empty state), so an in-flight load is never mistaken for a
+// genuinely empty list. next-intl is mocked to resolve real en.json strings so a missing
+// key surfaces as its dotted path (same harness as the other agent-presence tests). The
+// relative-time hooks are stubbed to keep rendering deterministic and Date-free.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("next-intl", async () => {
+  const en = (await import("../../../../../messages/en.json")).default as Record<
+    string,
+    unknown
+  >;
+  function resolve(namespace: string, key: string): string {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    let node: unknown = en;
+    for (const p of fullKey.split(".")) {
+      if (node && typeof node === "object" && p in (node as Record<string, unknown>)) {
+        node = (node as Record<string, unknown>)[p];
+      } else {
+        return fullKey;
+      }
+    }
+    return typeof node === "string" ? node : fullKey;
+  }
+  return {
+    useTranslations:
+      (namespace = "") =>
+      (key: string) =>
+        resolve(namespace, key),
+  };
+});
+
+// Stub the relative-time hooks so rendering is deterministic (no Date, no interval timer).
+vi.mock("../../hooks", () => ({
+  useNowTick: () => 0,
+  useRelativeTime: () => () => "just now",
+}));
+
+import {
+  ConversationList,
+  type AgentOption,
+  type ConversationRow,
+} from "@/components/agent-presence/chat/conversation-list";
+
+const AGENTS: AgentOption[] = [{ agentUuid: "agent-1", agentName: "Admin Claude" }];
+
+function makeRow(uuid: string, title: string): ConversationRow {
+  return {
+    session: {
+      uuid,
+      agentUuid: "agent-1",
+      sessionId: uuid,
+      directIdeaUuid: null,
+      originConnectionUuid: "conn-1",
+      status: "active",
+      title,
+      lastTurnAt: "2026-08-10T00:00:00.000Z",
+      originOnline: true,
+      firstInstruction: title,
+      ideaTitle: null,
+    },
+    title,
+    ideaAnchored: false,
+    status: null,
+  };
+}
+
+function renderList(overrides: Partial<React.ComponentProps<typeof ConversationList>> = {}) {
+  return render(
+    <ConversationList
+      agents={AGENTS}
+      selectedAgentUuid="agent-1"
+      onSelectAgent={() => {}}
+      rows={[]}
+      selectedSessionUuid={null}
+      onSelectSession={() => {}}
+      onNewConversation={() => {}}
+      visibleCount={12}
+      onLoadMore={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+afterEach(() => cleanup());
+beforeEach(() => vi.clearAllMocks());
+
+describe("ConversationList body state", () => {
+  it("loading=true → renders skeleton rows, NOT the empty state", () => {
+    renderList({ loading: true, rows: [] });
+    // Skeleton container present.
+    expect(screen.getByTestId("conversation-list-skeleton")).toBeTruthy();
+    // Empty-state copy absent.
+    expect(screen.queryByText("No conversations for this agent")).toBeNull();
+    // The list chrome (New conversation button) stays visible during loading.
+    expect(screen.getByText("New conversation")).toBeTruthy();
+  });
+
+  it("loading=false + empty rows → renders the empty state, no skeleton", () => {
+    renderList({ loading: false, rows: [] });
+    expect(screen.getByText("No conversations for this agent")).toBeTruthy();
+    expect(screen.queryByTestId("conversation-list-skeleton")).toBeNull();
+  });
+
+  it("defaults to non-loading when the prop is omitted (empty state)", () => {
+    renderList({ rows: [] });
+    expect(screen.getByText("No conversations for this agent")).toBeTruthy();
+    expect(screen.queryByTestId("conversation-list-skeleton")).toBeNull();
+  });
+
+  it("loading=false + rows → renders the rows, no skeleton and no empty state", () => {
+    renderList({
+      loading: false,
+      rows: [makeRow("s-1", "First conversation"), makeRow("s-2", "Second conversation")],
+    });
+    expect(screen.getByText("First conversation")).toBeTruthy();
+    expect(screen.getByText("Second conversation")).toBeTruthy();
+    expect(screen.queryByTestId("conversation-list-skeleton")).toBeNull();
+    expect(screen.queryByText("No conversations for this agent")).toBeNull();
+  });
+
+  it("loading=true takes priority even when rows exist (mid-refresh with stale data is not our path, but the guard holds)", () => {
+    renderList({ loading: true, rows: [makeRow("s-1", "Stale row")] });
+    expect(screen.getByTestId("conversation-list-skeleton")).toBeTruthy();
+    expect(screen.queryByText("Stale row")).toBeNull();
+  });
+});

--- a/src/components/agent-presence/chat/__tests__/daemon-chat-body-state.test.ts
+++ b/src/components/agent-presence/chat/__tests__/daemon-chat-body-state.test.ts
@@ -1,0 +1,56 @@
+// deriveChatBodyState — the pure body-state derivation extracted from DaemonChat. These
+// tests pin the loading-vs-empty-vs-error precedence, the crux of the
+// daemon-chat-list-loading-state fix: the conversation list's loading affordance is gated
+// on the LIST fetch status alone, so the empty state can never show while the list is still
+// loading (the bug was `loading = status === "loading" && listStatus === "loading"`, an AND
+// of two independently-settling sources that left a leak window).
+
+import { describe, expect, it } from "vitest";
+import { deriveChatBodyState } from "@/components/agent-presence/chat/daemon-chat";
+
+describe("deriveChatBodyState", () => {
+  it("first load (listStatus loading, empty) → body with listLoading true (NOT empty)", () => {
+    const r = deriveChatBodyState({ listStatus: "loading", sessionCount: 0, agentCount: 0 });
+    expect(r.body).toBe("body");
+    expect(r.listLoading).toBe(true);
+  });
+
+  it("the previously-leaking combo (presence settled, list still loading) → listLoading, not empty", () => {
+    // The presence `status` is intentionally NOT an input anymore — listStatus alone drives
+    // the loading affordance, so even with agents present and no sessions yet, it's loading.
+    const r = deriveChatBodyState({ listStatus: "loading", sessionCount: 0, agentCount: 3 });
+    expect(r.listLoading).toBe(true);
+    // Not a settled empty → the list pane shows its skeleton, never the no-agents card.
+    expect(r.body).toBe("body");
+  });
+
+  it("settled empty with agents → normal body (composer), not loading", () => {
+    const r = deriveChatBodyState({ listStatus: "ok", sessionCount: 0, agentCount: 2 });
+    expect(r.body).toBe("body");
+    expect(r.listLoading).toBe(false);
+  });
+
+  it("settled empty with NO agents and no history → no-agents card", () => {
+    const r = deriveChatBodyState({ listStatus: "ok", sessionCount: 0, agentCount: 0 });
+    expect(r.body).toBe("no-agents");
+    expect(r.listLoading).toBe(false);
+  });
+
+  it("settled with sessions → normal body, not loading", () => {
+    const r = deriveChatBodyState({ listStatus: "ok", sessionCount: 5, agentCount: 1 });
+    expect(r.body).toBe("body");
+    expect(r.listLoading).toBe(false);
+  });
+
+  it("error with nothing cached → error card, not empty and not loading", () => {
+    const r = deriveChatBodyState({ listStatus: "error", sessionCount: 0, agentCount: 0 });
+    expect(r.body).toBe("error");
+    expect(r.listLoading).toBe(false);
+  });
+
+  it("error but sessions were cached → keep showing the cached body, not the error card", () => {
+    const r = deriveChatBodyState({ listStatus: "error", sessionCount: 4, agentCount: 1 });
+    expect(r.body).toBe("body");
+    expect(r.listLoading).toBe(false);
+  });
+});

--- a/src/components/agent-presence/chat/conversation-list.tsx
+++ b/src/components/agent-presence/chat/conversation-list.tsx
@@ -20,6 +20,7 @@ import { MessageCirclePlus, PauseCircle, Sparkles, TriangleAlert } from "lucide-
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Select,
   SelectContent,
@@ -155,6 +156,29 @@ function Row({
   );
 }
 
+// A loading placeholder shaped like a real `Row`: a leading dot-sized square, a wide
+// title-line, and a short meta-line, padded identically (`px-4 py-3.5`). Purely
+// decorative (aria-hidden) — the accessible "loading" affordance is the list card's
+// `aria-busy`. Reuses the semantic `bg-accent` Skeleton token, so it adapts to light /
+// dark for free (no `dark:` variant needed).
+function SkeletonRow() {
+  return (
+    <div aria-hidden className="flex w-full items-center gap-3 px-4 py-3.5">
+      <span className="flex w-2.5 shrink-0 justify-center">
+        <Skeleton className="h-2.5 w-2.5 rounded-full" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <Skeleton className="h-3.5 w-3/4 rounded" />
+        <Skeleton className="mt-1.5 h-2.5 w-1/3 rounded" />
+      </span>
+    </div>
+  );
+}
+
+// How many placeholder rows the loading state renders — enough to fill the list card
+// without implying a specific count.
+const SKELETON_ROW_COUNT = 5;
+
 export function ConversationList({
   agents,
   selectedAgentUuid,
@@ -165,6 +189,7 @@ export function ConversationList({
   onNewConversation,
   visibleCount,
   onLoadMore,
+  loading = false,
 }: {
   agents: AgentOption[];
   selectedAgentUuid: string | null;
@@ -182,6 +207,12 @@ export function ConversationList({
   // so it survives a re-render); "Load more" grows it.
   visibleCount: number;
   onLoadMore: () => void;
+  // True while the session list is still loading (first load / no data yet). Renders
+  // skeleton placeholder rows INSTEAD of the empty state, so an in-flight load is never
+  // mistaken for a genuinely empty list. Defaults to false so existing call sites are
+  // unaffected. The container gates this on its list-fetch status alone, so the periodic
+  // background refresh does not re-trigger it once a first load has succeeded.
+  loading?: boolean;
 }) {
   const t = useTranslations("daemonChat");
   const nowMs = useNowTick();
@@ -238,17 +269,42 @@ export function ConversationList({
       </div>
 
       {/* Conversation list card. */}
-      <Card className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden rounded-2xl border-border bg-card p-0 shadow-none">
+      <Card
+        aria-busy={loading}
+        className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden rounded-2xl border-border bg-card p-0 shadow-none"
+      >
         <div className="flex items-center justify-between px-4 py-3.5">
           <span className="font-mono text-[11px] font-medium uppercase tracking-[1px] text-muted-foreground">
             {t("listHeader")}
           </span>
-          <span className="font-mono text-[11px] font-medium text-muted-foreground">
-            {rows.length}
-          </span>
+          {/* Count is meaningless mid-load — render a neutral placeholder instead of
+              flashing `0` before the first fetch settles. */}
+          {loading ? (
+            <Skeleton aria-hidden className="h-3 w-4 rounded" />
+          ) : (
+            <span className="font-mono text-[11px] font-medium text-muted-foreground">
+              {rows.length}
+            </span>
+          )}
         </div>
         <div className="h-px w-full bg-[#EFEBE4] dark:bg-[#201e1b]" />
-        {rows.length === 0 ? (
+        {loading ? (
+          // Loading: skeleton placeholder rows, shaped like real rows, INSTEAD of the
+          // empty state — so an in-flight load is never mistaken for an empty list.
+          <div
+            data-testid="conversation-list-skeleton"
+            className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+          >
+            {Array.from({ length: SKELETON_ROW_COUNT }).map((_, idx) => (
+              <div key={idx}>
+                <SkeletonRow />
+                {idx < SKELETON_ROW_COUNT - 1 && (
+                  <div className="h-px w-full bg-[#F2EEE7] dark:bg-[#201e1a]" />
+                )}
+              </div>
+            ))}
+          </div>
+        ) : rows.length === 0 ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-8 text-center">
             <p className="text-[13px] font-medium text-muted-foreground">
               {t("noSessions.title")}

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -179,6 +179,46 @@ export function applyTranscriptEvent(
   return next;
 }
 
+// Which top-level card the chat body shows, plus whether the conversation list is still
+// loading. Extracted as a PURE function (like `applyTranscriptEvent` / `mergeTurnPage`
+// above) so the loading-vs-empty-vs-error precedence is unit-testable without mounting the
+// whole context-heavy component.
+//
+// The crux of the daemon-chat-list-loading-state fix: `listLoading` is gated on the LIST's
+// own fetch status ALONE — NOT AND-ed with the shell presence `status`, which settles
+// independently. AND-ing them left a window (`status === "ok"` but `listStatus ===
+// "loading"`) where nothing matched and the list fell through to its empty state, reading
+// as "no conversations" while the fetch was still in flight. Gating on `listStatus` closes
+// that window: during first load `listLoading` is true and the list pane renders its
+// skeleton. `fetchSessions` only ever sets `listStatus` to `"ok"` / `"error"` (never back
+// to `"loading"`), so the 15s background poll never re-raises the skeleton after first load.
+//
+// Precedence (unchanged from before, minus the removed top-level loading text branch):
+//   error card  >  no-agents card  >  the two-pane body (whose list shows a skeleton while
+//   `listLoading`).
+export type ChatBodyState = "error" | "no-agents" | "body";
+
+export function deriveChatBodyState(args: {
+  listStatus: "loading" | "ok" | "error";
+  sessionCount: number;
+  agentCount: number;
+}): { body: ChatBodyState; listLoading: boolean } {
+  const listLoading = args.listStatus === "loading";
+  // A list-load failure with nothing cached → a distinct error card (no silent empty).
+  const showListError = args.listStatus === "error" && args.sessionCount === 0;
+  // Genuinely-no-history — only after a SETTLED load (`listStatus === "ok"`), so an
+  // in-flight load never reads as empty.
+  const noConversations = args.listStatus === "ok" && args.sessionCount === 0;
+  // The only remaining dead-end: no agent to talk to AND no history.
+  const noAgentsAtAll = noConversations && args.agentCount === 0;
+  const body: ChatBodyState = showListError
+    ? "error"
+    : noAgentsAtAll
+      ? "no-agents"
+      : "body";
+  return { body, listLoading };
+}
+
 export function DaemonChat() {
   const t = useTranslations("daemonChat");
   const {
@@ -769,17 +809,17 @@ export function DaemonChat() {
   }, [focusTarget, clearChatFocusTarget, handleSessionStarted]);
 
   // ===== States =====
-  const loading = status === "loading" && listStatus === "loading";
-  // A list-load failure with nothing cached → a distinct error card (no silent empty).
-  const showListError =
-    listStatus === "error" && sessions.length === 0;
-  // Genuinely-no-history. We no longer dead-end here: an agent that is connected can
-  // start a NEW conversation straight from this state (the right pane / drill-down is
-  // the composer). The calm "nothing yet" card is reserved for the case where there
-  // is also no agent to talk to at all (no connections AND no history).
-  const noConversations =
-    listStatus === "ok" && sessions.length === 0;
-  const noAgentsAtAll = noConversations && agents.length === 0;
+  // The chat body's card + list-loading flag, derived by the pure `deriveChatBodyState`
+  // helper (see its doc for the loading-vs-empty leak this fixes). The list pane shows a
+  // skeleton whenever `listLoading` — gated on the LIST fetch status alone, NOT AND-ed with
+  // the independently-settling presence `status`, so the empty state never shows mid-load.
+  const { body: bodyState, listLoading } = deriveChatBodyState({
+    listStatus,
+    sessionCount: sessions.length,
+    agentCount: agents.length,
+  });
+  const showListError = bodyState === "error";
+  const noAgentsAtAll = bodyState === "no-agents";
 
   // The transcript pane is reused on both breakpoints, differing ONLY in the reply
   // composer's action-row geometry: desktop two-pane keeps it inline (actions on the
@@ -867,10 +907,11 @@ export function DaemonChat() {
           </h2>
         </header>
 
-        {/* Body */}
-        {loading ? (
-          <p className="text-sm text-muted-foreground">{t("loading")}</p>
-        ) : showListError ? (
+        {/* Body — the conversation list's own skeleton (via ConversationList's `loading`
+            prop) covers the first-load window, so there is no top-level loading text branch:
+            the header + two-pane layout stay mounted and don't jump. The error / no-agents
+            cards keep priority over the normal body. */}
+        {showListError ? (
           <Card className="items-center gap-3 rounded-2xl border-[#E7D9C9] dark:border-[#33302a] bg-[#FFF9F3] dark:bg-[#2a2113] p-8 text-center shadow-none md:p-12">
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#D9770615]">
               <WifiOff className="h-6 w-6 text-[#B45309] dark:text-[#E0A34E]" />
@@ -922,6 +963,7 @@ export function DaemonChat() {
                 onNewConversation={startNewConversation}
                 visibleCount={visibleCount}
                 onLoadMore={() => setVisibleCount((n) => n + PAGE_SIZE)}
+                loading={listLoading}
               />
             </div>
 
@@ -941,6 +983,7 @@ export function DaemonChat() {
                   onNewConversation={startNewConversation}
                   visibleCount={visibleCount}
                   onLoadMore={() => setVisibleCount((n) => n + PAGE_SIZE)}
+                  loading={listLoading}
                 />
               </div>
 


### PR DESCRIPTION
## Summary

The daemon session chat window's left **conversation list** showed its "No conversations" empty-state card **before the session list finished loading** — byte-for-byte identical to a genuinely empty list, so during first load the user was told they had no conversations while the data was still in flight.

Root cause (`daemon-chat.tsx`): the loading flag was `loading = status === "loading" && listStatus === "loading"` — an AND of two **independently-settling** sources (the shell presence poll `status` and this component's own session-list fetch `listStatus`). In the window where `status === "ok"` but `listStatus === "loading"`, none of the four derived states matched, control fell through to the two-pane body, and `ConversationList` rendered its empty state for an empty `rows` array.

## What changed

- **Gate loading on `listStatus` alone.** Extracted a pure, exported `deriveChatBodyState({ listStatus, sessionCount, agentCount })` helper (precedence: `error > no-agents > body`) that computes `listLoading = listStatus === "loading"` — no longer AND-ed with the presence `status`. This closes the leak window.
- **Skeleton loading affordance.** Added an optional `loading` prop + `SkeletonRow` placeholder rows to `ConversationList`, shown while loading instead of the empty state. Row-shaped, uses the semantic `bg-accent` token so it adapts to light/dark automatically. Header count shows a neutral skeleton (no `0` flash); the agent Select + "New conversation" chrome stay visible.
- **First-load only, silent on poll.** `fetchSessions` only ever sets `listStatus` to `"ok"`/`"error"`, never back to `"loading"`, so the 15s background poll never re-flashes the skeleton after the first successful load. Agent switch is a client-side filter (no refetch), so it never flashes either.
- **Error path stays distinct.** A list-load failure with nothing cached still shows the `WifiOff` error card, never the empty state.
- **Cleanup.** Removed the now-orphaned `daemonChat.loading` i18n key from all four locales (en/zh/ko/ja). Fixed a pre-existing OpenSpec requirement whose first physical line lacked `SHALL` (surfaced by `openspec archive`).

## Changed files

| File | Change |
|------|--------|
| `src/components/agent-presence/chat/daemon-chat.tsx` | `deriveChatBodyState` helper; gate loading on `listStatus`; pass `loading` to both ConversationList instances; drop the top-level loading-text branch |
| `src/components/agent-presence/chat/conversation-list.tsx` | `loading` prop + `SkeletonRow`; neutral header-count skeleton; `aria-busy` |
| `src/components/agent-presence/chat/__tests__/conversation-list.test.tsx` | New — 5 tests (loading/empty/rows body states) |
| `src/components/agent-presence/chat/__tests__/daemon-chat-body-state.test.ts` | New — 7 tests (state derivation) |
| `messages/{en,zh,ko,ja}.json` | Remove orphaned `daemonChat.loading` key |
| `openspec/…` | Archived change + updated cumulative `daemon-session-conversation` spec |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` full suite — 4778 passed / 0 failed (12 new tests)
- [x] Changed files lint clean (repo-wide `pnpm lint` has 28 pre-existing errors on `develop` in unrelated files)
- [x] Production build passes; deployed to live and verified `/login` 200
- [ ] `docs/design.pen` update — deferred to human follow-up (Pencil MCP needs a GUI editor, unavailable headless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)