### PR TITLE
feat(daemon): polish multi-agent project scope — cwd badge, wake pin, presence count

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -321,6 +321,7 @@
     "cwd": "Directory",
     "status": "Status",
     "unknown": "Unknown",
+    "openAgentChat": "Open {agent}'s conversation",
     "manage": "Manage in project settings",
     "availability": {
       "ready": "Available",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -321,6 +321,7 @@
     "cwd": "ディレクトリ",
     "status": "状態",
     "unknown": "不明",
+    "openAgentChat": "{agent} の会話を開く",
     "manage": "プロジェクト設定で管理",
     "availability": {
       "ready": "利用可能",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -321,6 +321,7 @@
     "cwd": "디렉터리",
     "status": "상태",
     "unknown": "알 수 없음",
+    "openAgentChat": "{agent}의 대화 열기",
     "manage": "프로젝트 설정에서 관리",
     "availability": {
       "ready": "사용 가능",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -321,6 +321,7 @@
     "cwd": "目录",
     "status": "状态",
     "unknown": "未知",
+    "openAgentChat": "打开 {agent} 的对话",
     "manage": "在项目设置中管理",
     "availability": {
       "ready": "可用",

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/README.md
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/README.md
@@ -1,0 +1,3 @@
+# daemon-multi-agent-project-polish
+
+Polish multi-agent daemon project scope: distinguishable overview cwd badges, autonomous wake resolves the agent-owner project cwd pin, presence pill counts distinct agents

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/design.md
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/design.md
@@ -1,0 +1,156 @@
+# Technical Design: Polish multi-agent daemon project scope
+
+## Overview
+
+Three independent, small changes. Two are frontend-only over existing data; one
+is a server-side addition to the wake cwd-resolution chain. No schema change, no
+migration, no new permission bit, no API contract change.
+
+## 1. Overview cwd badge — agent-identifiable (`project-agent-cwd`)
+
+**Where:** `src/app/(dashboard)/projects/[uuid]/dashboard/project-cwd-summary.tsx`
+(mounted from `dashboard-content.tsx` next to the project title).
+
+**Today:** each badge renders only `preference.cwd` (truncated, `font-mono`) with
+`title={`${agent.name}: ${preference.cwd}`}` — the agent name is visible only on
+hover; the local `FixedCwdPreference` interface deliberately drops everything but
+`agent.{uuid,name}` and `preference.cwd`.
+
+**Target:** the visible badge content becomes a **colored agent identity dot +
+the agent name**; the **cwd path moves into the hover tooltip** (`title`).
+
+- The color dot MUST use the existing per-agent color helper
+  **`getAgentColor(agentName)` from `src/lib/agent-color.ts`** (deterministic
+  hash → `AGENT_COLOR_PALETTE`), whose palette is documented as "distinguishable
+  on both light and dark backgrounds" — so no new hue function is introduced and
+  no `dark:` variant is required for the dot. (Note: the presence roster's
+  `PillDot` / `StatusDot` are *status*-colored, not per-agent — do NOT reuse
+  those for identity; `getAgentColor` is the per-agent one.) The dot color is
+  applied inline (data-driven); if any surrounding chrome needs a dark variant,
+  follow the project's inline-CSS-variable + scoped `.dark` rule pattern.
+- Keep the badge compact; `agent.name` may truncate but the dot + name make each
+  badge distinguishable at a glance. The tooltip shows the full cwd path (and
+  host when present).
+- The dot color derives from `agent.name`, which the local `FixedCwdPreference`
+  shape already carries — no new field and no API change. (`agent.uuid` is already
+  the badge `key`.)
+
+**Data source (unchanged):** `GET /api/projects/[uuid]/agent-cwds` →
+`listAgentCwdOptions` already returns `agent.{uuid,name}`, `preference.{host,cwd,status}`.
+
+**i18n / theme:** any new/relocated string uses `t()` in both `en` and `zh`; the
+badge renders correctly in light and dark themes.
+
+## 2. Autonomous wake resolves the agent-owner's project pin (`project-cwd-anchoring`)
+
+**Where:** `src/services/notification-turn.ts` — `createTurnAndResolveTarget`
+(the wake resolver). The new step lands here, **not** in `resolvePinnedTarget`
+(the pre-selection precedence sub-chain that feeds `selectOriginConnection`) — see
+"Why the project pin must NOT go into `resolvePinnedTarget`" below.
+
+**Today (precedence).** `createTurnAndResolveTarget` does:
+`pin = resolvePinnedTarget(ctx, trigger)` (pre-resolved target → temporary → mention
+→ task instance-pin → own-idea pin → root-idea inheritance → `null`), then
+`selection = selectOriginConnection(connections, pin)`. **Then a critical second
+step (lines ~753-766): the idea-session-origin upgrade** — for autonomous
+idea-anchored triggers, *when and only when* `selection.kind === "online_first"`
+(i.e. the idea has no instance pin), selection is upgraded to the idea's existing
+**online** session origin (where its conversation already lives). This is the fix
+for the proposal-approve/reject random-cwd wake (b729713b). Only if that upgrade
+finds nothing does the wake stay a raw first-online-connection pick ("first cwd").
+The UI/mention/stage-advance paths pre-resolve the project pin and thread it via
+`ctx.resolvedCwdSource`; a plain autonomous wake carries none, so today it skips
+the project pin (the DEC-5 "never infer cwd from project" stance lives here).
+
+**Why the project pin must NOT go into `resolvePinnedTarget`.** Returning a hard
+pin there makes `selectOriginConnection` classify the selection `directed` /
+`offline_pin`, which **bypasses** the session-origin upgrade (it only fires on
+`online_first`). That would let a project pin override a live online conversation
+and, with strict-offline, stall an idea whose conversation is online in cwd A to
+notify-only when the project pin (cwd B) is offline — a regression of b729713b.
+
+**Change (correct placement).** Add ONE new step in `createTurnAndResolveTarget`
+**after** the idea-session-origin upgrade block, still gated on
+`selection.kind === "online_first"` (so neither an instance pin nor an online
+session-origin applied):
+
+1. Only for the autonomous triggers (the `task_assigned` family already handled by
+   the upgrade block). Require `ctx.projectUuid` and `ctx.recipientUuid` (both
+   already on `WakeNotificationContext`).
+2. Resolve the agent's **owner** (`Agent.ownerUuid`, company-scoped). Per the
+   owner's elaboration decision, autonomous wakes use the **agent owner's** pin
+   (the `ProjectAgentCwdPreference` is keyed per user).
+3. Look up `ProjectAgentCwdPreference` by
+   `(userUuid = agent.ownerUuid, projectUuid, agentUuid = ctx.recipientUuid)`,
+   preferring to reuse `resolveProjectAgentCwdTarget`'s `project_fixed` branch
+   (`project-agent-cwd.service.ts`) so normalization/anchor logic stays in one place.
+4. If a preference exists → rebuild `selection = selectOriginConnection(connections,
+   projectPin)` with a **hard** pin from its `(host, cwd)`: `directed` if that
+   exact `(host, cwd)` is online, `offline_pin` if not.
+5. If no preference exists → leave `selection` as `online_first` (unchanged).
+
+**Resulting precedence:** instance pin → online idea-session-origin (b729713b) →
+**project-owner pin (new)** → raw online-first. The project pin replaces exactly
+the "first cwd" fallback the idea complains about, and never disrupts a live online
+conversation.
+
+**Offline behavior (owner decision Q3 = strict):** when the project pin's
+`(host, cwd)` has no online connection, the resulting `offline_pin` means the wake
+MUST NOT fall back to another cwd — it follows the existing fixed-anchor hard-pin
+failure behavior (`suppressWake` / notify-only for a recoverable wake; reconnect
+backfill only to the original host+cwd).
+
+**Scope note:** autonomous wake path only. Paths that already thread a resolved
+target (`ctx.resolvedCwdSource !== "unconfigured"`) never reach `online_first`, so
+the new step cannot override them.
+
+## 3. Presence count by distinct agent (`agent-connection-observability`)
+
+**Where:** `src/components/daemon-presence-entry.tsx` (the single bottom-right
+floating entry). It already derives `onlineAgentGroups` via
+`groupConnectionsByAgent(onlineConnectionsOnly(connections, ...))` and renders
+`.length`-worth of roster rows, but the pill *number* uses the provider's
+`computeOnlineCount(connections)` (`agent-presence-context.tsx`), which counts
+online **connections** `(agent, host, cwd)`.
+
+**Change:** the pill's displayed number and its `onlineUnit` pluralization use
+the **distinct online agent** count — `onlineAgentGroups.length` — so an agent
+online across multiple hosts/cwds counts once. Dedup keys on `agentUuid` (stable),
+never `agentName` (nullable / can collide). The existing `onlineUnit` string
+("{count} agents online") already matches this unit.
+
+**Kept as-is:** `computeOnlineCount` and the connection-oriented "View all" modal
+(`connections-view.tsx`) — the modal is a connection list and its counts stay
+connection-based. If the implementer finds the modal *labels* its number
+"agents", make it unit-consistent there too; otherwise leave it.
+
+**Tests:** update the specs that lock the current per-connection semantics —
+`agent-presence-context.test.tsx`, `instance-group.test.ts`,
+`daemon-presence-entry.test.tsx` — to assert distinct-agent counting for the pill.
+
+## Module Contracts
+
+- The badge (Task 1) and the count (Task 3) are independent frontend surfaces;
+  neither shares state with the other.
+- The wake fallback (Task 2) is server-side only and does not touch either
+  frontend surface.
+- All three tasks are independently runnable/testable and have no ordering
+  dependency.
+
+## Risks & Mitigations
+
+- **Reversing DEC-5.** Intentional and scoped to the autonomous wake path; the UI
+  paths already resolve the project pin, so this makes the two paths consistent
+  rather than introducing new divergence. Documented in `notification-turn.ts`
+  where the DEC-5 note lives.
+- **Wrong owner's pin.** The preference is per-user; using the agent owner's pin
+  is the owner's explicit decision. If the agent owner has no pin for this
+  (project, agent), behavior is unchanged (online-first).
+- **Count change breaks existing tests.** Expected — the tests encode the old
+  semantics; they are updated as part of Task 3, not worked around.
+- **Dark-theme dot color.** `getAgentColor`'s `AGENT_COLOR_PALETTE` is already
+  chosen to read on both light and dark backgrounds, so the inline dot color needs
+  no `dark:` variant. (Data-driven colors can't use `dark:` classes anyway.)
+- **Precedence regression (b729713b random-cwd fix).** Mitigated by placing the project
+  pin after the session-origin upgrade and gating on `online_first`; covered by a
+  dedicated precedence test in Task 2.

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/proposal.md
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/proposal.md
@@ -1,0 +1,88 @@
+# Polish multi-agent daemon project scope
+
+## Why
+
+The multi-agent daemon work (idea `c5e806bb`, PR #483) let one daemon serve N
+independent agents, each with its own working directory (cwd). Three rough edges
+surfaced once people ran multiple agents / multiple cwds in the same project:
+
+1. **Overview cwd badges are indistinguishable.** On the project overview
+   (dashboard) header, each configured agent's cwd shows as a badge that renders
+   *only* the cwd path — the agent's name is hidden in a hover tooltip. Two
+   agents' badges look identical (same icon, same styling), and cwds that share a
+   long common prefix truncate to the same visible string. You cannot tell whose
+   cwd is whose without hovering each one.
+
+2. **Autonomous wake ignores the project cwd pin.** When an agent has a fixed
+   project-level cwd pin but a wake is minted autonomously (a plain
+   `task_assigned` / `idea_claimed` / `proposal_*` activity, with no idea/task
+   instance pin and no UI-threaded target), the server never consults the project
+   pin and falls straight to "first online connection". So the agent can wake in
+   the wrong cwd even though the project explicitly pinned one.
+
+3. **Presence count is per-cwd-instance, not per-agent.** The bottom-right
+   floating presence pill is labeled "agents online" but counts daemon
+   *connections* — one `(agent, host, cwd)` each. An agent online in three cwds is
+   counted as three. The number should reflect distinct agents, regardless of how
+   many cwds each exposes.
+
+These are all follow-on polish to already-shipped multi-agent behavior — no new
+data model, no new permission bit.
+
+## What Changes
+
+- **Overview cwd badge (`project-agent-cwd`):** each project-overview cwd badge
+  becomes agent-identifiable — a colored agent identity dot plus the visible
+  agent name — and the cwd path moves into the hover tooltip. Uses the agent
+  name / host already returned by `GET /api/projects/[uuid]/agent-cwds`; no API,
+  service, or schema change.
+
+- **Autonomous wake resolves the agent-owner's project pin
+  (`project-cwd-anchoring`):** on the server-side wake path, the project pin
+  replaces exactly the raw first-online ("first cwd") fallback. It sits **below**
+  the existing higher-priority steps — an instance pin and an existing *online*
+  idea-session-origin (the b729713b live-conversation fix) both still win, so a
+  live conversation is never rerouted. Only when the selection would otherwise be
+  a raw first-online pick does Chorus consult the `ProjectAgentCwdPreference` of
+  the **agent's owner** for the wake's `(project, agent)` and, if one exists, use
+  its `(host, cwd)` as a **hard** anchor. Per existing fixed-anchor hard-pin
+  behavior and the owner's strict-offline decision, if that pinned cwd is offline
+  the wake stays notify-only / does not reroute. No preference → unchanged
+  online-first. This closes the gap where autonomous wakes bypassed the "fixed
+  project cwd is authoritative" contract.
+
+- **Presence count by distinct agent (`agent-connection-observability`):** the
+  bottom-right floating entry's online count reflects the number of distinct
+  online agents (an agent online across multiple hosts/cwds counts once),
+  matching its "agents online" label. Frontend-only; the connection-oriented
+  "View all" modal keeps its connection list unchanged.
+
+## Capabilities
+
+- `project-agent-cwd` — ADDED: project-overview cwd summary identifies each Agent.
+- `project-cwd-anchoring` — ADDED: autonomous wakes resolve the agent-owner's
+  fixed project cwd as a hard anchor.
+- `agent-connection-observability` — MODIFIED: the floating-entry online count
+  counts distinct online agents rather than connections.
+
+## Impact
+
+- **Frontend:** `project-cwd-summary.tsx` (badge), `daemon-presence-entry.tsx`
+  (count display), plus updated component tests that currently lock per-connection
+  count semantics.
+- **Backend:** `notification-turn.ts` `createTurnAndResolveTarget` gains a
+  project-pin fallback step placed **after** the idea-session-origin upgrade and
+  gated on `selection.kind === "online_first"` (reads `ProjectAgentCwdPreference`
+  for the agent owner); no schema change, no migration, no new permission bit.
+- **Behavior reversal (scoped):** intentionally reverses the prior "cwd is NEVER
+  inferred from the project" decision (DEC-5) **only** for the autonomous wake
+  path, bringing it in line with the `project-cwd-anchoring` contract that UI
+  paths already honor.
+
+## Out of Scope
+
+- Changing the "View all" daemon connections modal's count/labeling (it remains a
+  connection list).
+- Per-user pin selection UI or any change to how project cwd pins are *set*.
+- Any new "第三" scope item — the source idea skipped that number; owner confirmed
+  there is no third item.

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/specs/agent-connection-observability/spec.md
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/specs/agent-connection-observability/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: The dashboard SHALL surface daemon connections through a single bottom-right floating entry
+The dashboard SHALL surface the caller's visible daemon connections through a **single floating entry pinned to the bottom-right of the viewport**, present on every dashboard page, replacing BOTH the resident sidebar presence pill and the separate bottom-right pixel-canvas widget button. There SHALL be no presence pill in the sidebar rail or mobile drawer, and no second standalone bottom-right widget button; the floating entry is the one affordance for daemon presence and conversation.
+
+The floating entry SHALL be driven by the single shell-level presence data source (the same source that backs the connection list and the chat modal), so it is company-wide and remains live across route changes without starting a second poll of the connection list.
+
+The change SHALL preserve the standing guarantees established when the standalone `/agent-connections` page was retired: there SHALL be no standalone `/agent-connections` page route and no `RadioTower` global-navigation item for it, a request to the former `/agent-connections` path SHALL be redirected rather than returning a broken route, and no surface SHALL be labeled "Daemons".
+
+The entry's trigger button SHALL display a glanceable status indicator that distinguishes, without silently conflating them, an idle state when the online count is zero (which MUST remain visible rather than disappearing), a loading state (a muted placeholder that does not flash a misleading count), and a request-failure state (a distinguished unavailable indicator that MUST NOT render as "0 online"). For a non-zero online count the button SHALL surface an online-count badge and a liveness dot that honors the user's reduced-motion preference (a static dot when reduced motion is preferred).
+
+The online count surfaced by the entry SHALL be the number of **distinct online Agents** — an Agent online across multiple hosts or cwds SHALL count once — so the number matches the entry's "agents online" label. The count SHALL NOT be the number of daemon connections or `(agent, host, cwd)` instances, and it SHALL key on Agent identity (`agentUuid`), never on the nullable display name. The connection-oriented "View all" modal's own connection list and counts are out of scope of this rule and remain connection-based.
+
+#### Scenario: A single floating entry appears bottom-right on every dashboard page
+
+- **GIVEN** an authenticated user on any dashboard page (project or global)
+- **WHEN** the shell renders
+- **THEN** a single floating entry MUST be pinned to the bottom-right of the viewport
+- **AND** there MUST be no presence pill in the sidebar rail or mobile drawer
+- **AND** there MUST be no separate standalone bottom-right widget button beside it
+
+#### Scenario: The zero state stays visible and is distinct from failure
+
+- **GIVEN** an authenticated user with zero online Agents and a successful fetch
+- **WHEN** the entry button renders
+- **THEN** it MUST show a visible idle "0 online" state rather than disappearing
+- **AND** when instead the fetch fails, the button MUST show a distinguished unavailable state that is NOT presented as "0 online"
+
+#### Scenario: A non-zero online count shows distinct online Agents with reduced-motion-aware liveness
+
+- **GIVEN** a user with at least one online Agent
+- **WHEN** the entry button renders
+- **THEN** it MUST surface an online-count badge reflecting the number of distinct online Agents
+- **AND** the liveness dot MUST animate only when the user has not requested reduced motion (otherwise a static dot conveys online status)
+
+#### Scenario: One Agent online in multiple cwds counts once
+
+- **GIVEN** a single Agent that is online through three daemon connections on three different cwds and no other Agent is online
+- **WHEN** the entry button renders its online-count badge
+- **THEN** the badge MUST show a count of 1
+- **AND** the count MUST NOT reflect the three underlying connections
+
+#### Scenario: The entry uses the shared presence source with no duplicate polling
+
+- **GIVEN** the dashboard shell is mounted
+- **WHEN** the floating entry button, its popover, and the opened chat modal are showing connection data
+- **THEN** they MUST be driven by one shared shell-level presence data source
+- **AND** opening the popover or the chat modal MUST NOT start a second independent poll of the connection list
+
+#### Scenario: The former standalone page stays removed and redirected
+
+- **GIVEN** the change is implemented
+- **WHEN** a request is made to the former `/agent-connections` path
+- **THEN** there MUST be no standalone page route and no `RadioTower` global-nav item for it
+- **AND** the request MUST be redirected rather than rendering a broken route
+- **AND** no surface MUST be labeled "Daemons"

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/specs/project-agent-cwd/spec.md
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/specs/project-agent-cwd/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Project overview cwd summary identifies each Agent
+The project overview cwd summary SHALL make each configured Agent's cwd badge visually attributable to a specific Agent without hovering. Each badge SHALL show a colored Agent identity dot together with the visible Agent name as the primary label, and SHALL move the full cwd path into the badge's hover tooltip. The identity dot SHALL derive its color from the app's shared deterministic per-Agent color helper (a stable hash of the Agent name into a fixed palette chosen to read on both light and dark backgrounds) rather than introducing a new color scheme or reusing the status-colored presence dot, and SHALL render correctly in both themes. This change SHALL remain frontend-only over the existing `GET /api/projects/[uuid]/agent-cwds` data (which already returns the Agent name and host); it SHALL NOT change that API, its service, the database schema, add a migration, or add a new permission bit. Every user-facing string SHALL resolve from the locale catalog in both supported locales.
+
+#### Scenario: Two Agents' badges are distinguishable at a glance
+- **WHEN** a project has fixed cwd preferences for two different Agents whose cwds share a long common path prefix
+- **THEN** each badge MUST display that Agent's identity color dot and visible name
+- **AND** the two badges MUST be distinguishable without hovering either one
+
+#### Scenario: The cwd path is available on hover
+- **WHEN** a user hovers a cwd badge in the overview summary
+- **THEN** the badge's tooltip MUST show the full cwd path for that Agent
+
+#### Scenario: The identity dot uses the shared deterministic per-Agent color
+- **WHEN** the overview summary renders an Agent's cwd badge
+- **THEN** the badge's identity dot MUST take its color from the shared deterministic per-Agent color helper (same Agent → same color) rather than the status-colored presence dot
+- **AND** the dot MUST render legibly in both the light and dark themes
+
+#### Scenario: No backend change is introduced
+- **WHEN** the badge change is implemented
+- **THEN** it MUST read the existing `GET /api/projects/[uuid]/agent-cwds` response without modifying that API or its service
+- **AND** it MUST NOT change the database schema, add a migration, or add a new permission bit

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/specs/project-cwd-anchoring/spec.md
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/specs/project-cwd-anchoring/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Autonomous wakes resolve the agent-owner's fixed project cwd
+Autonomous server-minted wakes SHALL resolve a fixed project-Agent cwd before falling back to raw first-online-connection selection, closing the gap where only UI-threaded and stage-advance wakes honored the fixed anchor. The project pin SHALL replace exactly the first-online ("first cwd") fallback and SHALL sit below the existing higher-priority resolution steps: it SHALL apply only when the selection would otherwise be a raw first-online pick — that is, when no idea/task instance pin, no pre-resolved cwd target, and no existing ONLINE idea-session-origin apply. An existing online idea-session-origin (the cwd where the idea's live conversation already runs) SHALL take precedence over the project pin so a live conversation is never rerouted. When those higher-priority steps do not apply, Chorus SHALL look up the `ProjectAgentCwdPreference` of that **Agent's owner** for the wake's `(project, Agent)` pair, and when one exists SHALL treat its `(host, cwd)` as a hard execution anchor and SHALL NOT select the first online connection. When the Agent owner has no preference for that `(project, Agent)`, resolution SHALL fall back to the existing online-first behavior unchanged. This change SHALL add no database schema change, no migration, and no new permission bit.
+
+#### Scenario: Autonomous wake uses the owner's project pin instead of the first cwd
+- **WHEN** an autonomous wake is minted for an Agent that has a fixed project cwd pin set by its owner, the Idea/Task carries no instance pin, and the Agent is online in that pinned cwd plus another cwd
+- **THEN** the wake MUST target the owner-pinned `(host, cwd)`
+- **AND** it MUST NOT select the other (first-online) cwd
+
+#### Scenario: Pinned cwd offline does not reroute
+- **WHEN** an autonomous wake resolves to the owner's fixed project cwd but that `(host, cwd)` has no online connection, while the same Agent is online in a different cwd
+- **THEN** the wake MUST NOT reroute to the other online cwd
+- **AND** it MUST follow the existing fixed-anchor hard-pin failure behavior (notify-only for a recoverable wake, reconnect backfill only to the original host and cwd)
+
+#### Scenario: An online idea-session-origin outranks the project pin
+- **WHEN** an autonomous idea-anchored wake has no instance pin, the idea already has an online session-origin in cwd A, and the Agent owner's project pin names a different cwd B
+- **THEN** the wake MUST target the existing online session-origin cwd A (the live conversation)
+- **AND** it MUST NOT reroute to the project-pinned cwd B
+
+#### Scenario: No owner preference falls back to online-first
+- **WHEN** an autonomous wake is minted for an Agent whose owner has no fixed project cwd preference for that project and Agent
+- **THEN** resolution MUST fall back to the existing online-first selection unchanged
+
+#### Scenario: Pre-resolved and instance-pinned wakes are unaffected
+- **WHEN** a wake already carries a pre-resolved cwd target or an idea/task instance pin
+- **THEN** its existing resolution precedence MUST be preserved
+- **AND** the owner-project-pin step MUST NOT override it

--- a/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/tasks.md
+++ b/openspec/changes/archive/2026-08-13-daemon-multi-agent-project-polish/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+## 1. Overview cwd badge — agent-identifiable
+- [ ] 1.1 In `project-cwd-summary.tsx`, render a colored agent identity dot + visible agent name; move the cwd path into the hover tooltip
+- [ ] 1.2 Thread `agent.uuid` into the local `FixedCwdPreference` shape and derive the dot color from the existing agent-color helper (light + dark)
+- [ ] 1.3 i18n both locales; component test asserts two agents' badges are distinguishable and cwd is in the tooltip
+
+## 2. Autonomous wake resolves the agent-owner's project cwd pin
+- [ ] 2.1 In `notification-turn.ts` `resolvePinnedTarget`, add a project-pin step after root-idea inheritance and before returning null
+- [ ] 2.2 Resolve the agent owner (`Agent.ownerUuid`) and look up `ProjectAgentCwdPreference` for `(owner, project, agent)`, reusing `resolveProjectAgentCwdTarget`'s `project_fixed` branch; return a hard pin
+- [ ] 2.3 Verify hard-pin offline behavior (no reroute) and online-first fallback when no owner preference; unit tests cover pin-hit, offline-no-reroute, and no-preference fallback
+
+## 3. Presence pill counts distinct online agents
+- [ ] 3.1 In `daemon-presence-entry.tsx`, display the distinct-online-agent count (`onlineAgentGroups.length`) for the pill number + `onlineUnit` pluralization
+- [ ] 3.2 Update `agent-presence-context.test.tsx`, `instance-group.test.ts`, `daemon-presence-entry.test.tsx` to assert distinct-agent counting

--- a/openspec/specs/agent-connection-observability/spec.md
+++ b/openspec/specs/agent-connection-observability/spec.md
@@ -296,7 +296,6 @@ When the frontend has local execution state, it MAY apply an activity rank befor
 - **THEN** the visible agent group order and cwd sub-row order MUST remain unchanged
 
 ### Requirement: The dashboard SHALL surface daemon connections through a single bottom-right floating entry
-
 The dashboard SHALL surface the caller's visible daemon connections through a **single floating entry pinned to the bottom-right of the viewport**, present on every dashboard page, replacing BOTH the resident sidebar presence pill and the separate bottom-right pixel-canvas widget button. There SHALL be no presence pill in the sidebar rail or mobile drawer, and no second standalone bottom-right widget button; the floating entry is the one affordance for daemon presence and conversation.
 
 The floating entry SHALL be driven by the single shell-level presence data source (the same source that backs the connection list and the chat modal), so it is company-wide and remains live across route changes without starting a second poll of the connection list.
@@ -304,6 +303,8 @@ The floating entry SHALL be driven by the single shell-level presence data sourc
 The change SHALL preserve the standing guarantees established when the standalone `/agent-connections` page was retired: there SHALL be no standalone `/agent-connections` page route and no `RadioTower` global-navigation item for it, a request to the former `/agent-connections` path SHALL be redirected rather than returning a broken route, and no surface SHALL be labeled "Daemons".
 
 The entry's trigger button SHALL display a glanceable status indicator that distinguishes, without silently conflating them, an idle state when the online count is zero (which MUST remain visible rather than disappearing), a loading state (a muted placeholder that does not flash a misleading count), and a request-failure state (a distinguished unavailable indicator that MUST NOT render as "0 online"). For a non-zero online count the button SHALL surface an online-count badge and a liveness dot that honors the user's reduced-motion preference (a static dot when reduced motion is preferred).
+
+The online count surfaced by the entry SHALL be the number of **distinct online Agents** — an Agent online across multiple hosts or cwds SHALL count once — so the number matches the entry's "agents online" label. The count SHALL NOT be the number of daemon connections or `(agent, host, cwd)` instances, and it SHALL key on Agent identity (`agentUuid`), never on the nullable display name. The connection-oriented "View all" modal's own connection list and counts are out of scope of this rule and remain connection-based.
 
 #### Scenario: A single floating entry appears bottom-right on every dashboard page
 
@@ -315,17 +316,24 @@ The entry's trigger button SHALL display a glanceable status indicator that dist
 
 #### Scenario: The zero state stays visible and is distinct from failure
 
-- **GIVEN** an authenticated user with zero online connections and a successful fetch
+- **GIVEN** an authenticated user with zero online Agents and a successful fetch
 - **WHEN** the entry button renders
 - **THEN** it MUST show a visible idle "0 online" state rather than disappearing
 - **AND** when instead the fetch fails, the button MUST show a distinguished unavailable state that is NOT presented as "0 online"
 
-#### Scenario: A non-zero online count shows a badge and reduced-motion-aware liveness
+#### Scenario: A non-zero online count shows distinct online Agents with reduced-motion-aware liveness
 
-- **GIVEN** a user with at least one online connection
+- **GIVEN** a user with at least one online Agent
 - **WHEN** the entry button renders
-- **THEN** it MUST surface an online-count badge reflecting the number of online connections
+- **THEN** it MUST surface an online-count badge reflecting the number of distinct online Agents
 - **AND** the liveness dot MUST animate only when the user has not requested reduced motion (otherwise a static dot conveys online status)
+
+#### Scenario: One Agent online in multiple cwds counts once
+
+- **GIVEN** a single Agent that is online through three daemon connections on three different cwds and no other Agent is online
+- **WHEN** the entry button renders its online-count badge
+- **THEN** the badge MUST show a count of 1
+- **AND** the count MUST NOT reflect the three underlying connections
 
 #### Scenario: The entry uses the shared presence source with no duplicate polling
 

--- a/openspec/specs/project-agent-cwd/spec.md
+++ b/openspec/specs/project-agent-cwd/spec.md
@@ -173,3 +173,26 @@ control.
 #### Scenario: Project form has no cwd value
 - **WHEN** an Agent has neither a saved preference nor a selected cwd draft
 - **THEN** the Project form MUST allow submission without cwd validation for that Agent
+
+### Requirement: Project overview cwd summary identifies each Agent
+The project overview cwd summary SHALL make each configured Agent's cwd badge visually attributable to a specific Agent without hovering. Each badge SHALL show a colored Agent identity dot together with the visible Agent name as the primary label, and SHALL move the full cwd path into the badge's hover tooltip. The identity dot SHALL derive its color from the app's shared deterministic per-Agent color helper (a stable hash of the Agent name into a fixed palette chosen to read on both light and dark backgrounds) rather than introducing a new color scheme or reusing the status-colored presence dot, and SHALL render correctly in both themes. This change SHALL remain frontend-only over the existing `GET /api/projects/[uuid]/agent-cwds` data (which already returns the Agent name and host); it SHALL NOT change that API, its service, the database schema, add a migration, or add a new permission bit. Every user-facing string SHALL resolve from the locale catalog in both supported locales.
+
+#### Scenario: Two Agents' badges are distinguishable at a glance
+- **WHEN** a project has fixed cwd preferences for two different Agents whose cwds share a long common path prefix
+- **THEN** each badge MUST display that Agent's identity color dot and visible name
+- **AND** the two badges MUST be distinguishable without hovering either one
+
+#### Scenario: The cwd path is available on hover
+- **WHEN** a user hovers a cwd badge in the overview summary
+- **THEN** the badge's tooltip MUST show the full cwd path for that Agent
+
+#### Scenario: The identity dot uses the shared deterministic per-Agent color
+- **WHEN** the overview summary renders an Agent's cwd badge
+- **THEN** the badge's identity dot MUST take its color from the shared deterministic per-Agent color helper (same Agent → same color) rather than the status-colored presence dot
+- **AND** the dot MUST render legibly in both the light and dark themes
+
+#### Scenario: No backend change is introduced
+- **WHEN** the badge change is implemented
+- **THEN** it MUST read the existing `GET /api/projects/[uuid]/agent-cwds` response without modifying that API or its service
+- **AND** it MUST NOT change the database schema, add a migration, or add a new permission bit
+

--- a/openspec/specs/project-cwd-anchoring/spec.md
+++ b/openspec/specs/project-cwd-anchoring/spec.md
@@ -108,3 +108,31 @@ anchor card while retaining fixed-target execution behavior.
 - **WHEN** a project has independent fixed cwd preferences for Agent A and Agent B
 - **THEN** selecting either Agent outside the Proposal header MUST display only that Agent's anchor
 - **AND** changing one preference MUST NOT alter the other Agent's UI or resolution
+
+### Requirement: Autonomous wakes resolve the agent-owner's fixed project cwd
+Autonomous server-minted wakes SHALL resolve a fixed project-Agent cwd before falling back to raw first-online-connection selection, closing the gap where only UI-threaded and stage-advance wakes honored the fixed anchor. The project pin SHALL replace exactly the first-online ("first cwd") fallback and SHALL sit below the existing higher-priority resolution steps: it SHALL apply only when the selection would otherwise be a raw first-online pick — that is, when no idea/task instance pin, no pre-resolved cwd target, and no existing ONLINE idea-session-origin apply. An existing online idea-session-origin (the cwd where the idea's live conversation already runs) SHALL take precedence over the project pin so a live conversation is never rerouted. When those higher-priority steps do not apply, Chorus SHALL look up the `ProjectAgentCwdPreference` of that **Agent's owner** for the wake's `(project, Agent)` pair, and when one exists SHALL treat its `(host, cwd)` as a hard execution anchor and SHALL NOT select the first online connection. When the Agent owner has no preference for that `(project, Agent)`, resolution SHALL fall back to the existing online-first behavior unchanged. This change SHALL add no database schema change, no migration, and no new permission bit.
+
+#### Scenario: Autonomous wake uses the owner's project pin instead of the first cwd
+- **WHEN** an autonomous wake is minted for an Agent that has a fixed project cwd pin set by its owner, the Idea/Task carries no instance pin, and the Agent is online in that pinned cwd plus another cwd
+- **THEN** the wake MUST target the owner-pinned `(host, cwd)`
+- **AND** it MUST NOT select the other (first-online) cwd
+
+#### Scenario: Pinned cwd offline does not reroute
+- **WHEN** an autonomous wake resolves to the owner's fixed project cwd but that `(host, cwd)` has no online connection, while the same Agent is online in a different cwd
+- **THEN** the wake MUST NOT reroute to the other online cwd
+- **AND** it MUST follow the existing fixed-anchor hard-pin failure behavior (notify-only for a recoverable wake, reconnect backfill only to the original host and cwd)
+
+#### Scenario: An online idea-session-origin outranks the project pin
+- **WHEN** an autonomous idea-anchored wake has no instance pin, the idea already has an online session-origin in cwd A, and the Agent owner's project pin names a different cwd B
+- **THEN** the wake MUST target the existing online session-origin cwd A (the live conversation)
+- **AND** it MUST NOT reroute to the project-pinned cwd B
+
+#### Scenario: No owner preference falls back to online-first
+- **WHEN** an autonomous wake is minted for an Agent whose owner has no fixed project cwd preference for that project and Agent
+- **THEN** resolution MUST fall back to the existing online-first selection unchanged
+
+#### Scenario: Pre-resolved and instance-pinned wakes are unaffected
+- **WHEN** a wake already carries a pre-resolved cwd target or an idea/task instance pin
+- **THEN** its existing resolution precedence MUST be preserved
+- **AND** the owner-project-pin step MUST NOT override it
+

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/project-cwd-summary.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/project-cwd-summary.test.tsx
@@ -12,6 +12,13 @@ vi.mock("@/lib/auth-client", () => ({
 }));
 
 import { ProjectCwdSummary } from "../project-cwd-summary";
+import { getAgentColor } from "@/lib/agent-color";
+
+// React/jsdom serialize an inline hex color to `rgb(...)`; convert for comparison.
+function hexToRgb(hex: string): string {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+}
 
 function response(cwd: string | null) {
   return Promise.resolve({
@@ -27,12 +34,16 @@ function response(cwd: string | null) {
   });
 }
 
+function badgeFor(name: string): HTMLElement | null {
+  return screen.getByText(name).closest("span[title]") as HTMLElement | null;
+}
+
 describe("ProjectCwdSummary", () => {
   beforeEach(() => {
     authFetch.mockReset();
   });
 
-  it("renders configured Agent cwd values beside the project title", async () => {
+  it("shows the agent name as the visible label with the cwd in the tooltip", async () => {
     authFetch.mockImplementationOnce(() => Promise.resolve({
       ok: true,
       json: async () => ({
@@ -55,9 +66,51 @@ describe("ProjectCwdSummary", () => {
     render(<ProjectCwdSummary projectUuid="project-1" />);
 
     const summary = await screen.findByLabelText("title");
-    expect(summary.textContent).toContain("/work/dynamic-project");
     expect(summary.getAttribute("class")).toContain("flex-wrap");
+    // Agent name is visible; the cwd path is in the badge tooltip, not the label.
+    expect(await screen.findByText("Claude")).toBeTruthy();
+    expect(badgeFor("Claude")?.getAttribute("title")).toBe("/work/dynamic-project");
+    expect(summary.textContent).not.toContain("/work/dynamic-project");
+    // Agent with no preference is filtered out entirely.
     expect(screen.queryByText("Codex")).toBeNull();
+  });
+
+  it("distinguishes multiple agents by a per-agent identity dot even with common-prefix cwds", async () => {
+    authFetch.mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: async () => ({
+        data: {
+          agents: [
+            {
+              agent: { uuid: "a1", name: "Claude" },
+              preference: { cwd: "/home/ubuntu/dev/ai-pm" },
+            },
+            {
+              agent: { uuid: "a2", name: "Codex" },
+              preference: { cwd: "/home/ubuntu/dev/ai-pm-worktree" },
+            },
+          ],
+        },
+      }),
+    }));
+
+    render(<ProjectCwdSummary projectUuid="project-1" />);
+
+    // Both agents are identifiable by their visible names (no hover needed)...
+    expect(await screen.findByText("Claude")).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+    // ...and each cwd lives in its own badge tooltip.
+    expect(badgeFor("Claude")?.getAttribute("title")).toBe("/home/ubuntu/dev/ai-pm");
+    expect(badgeFor("Codex")?.getAttribute("title")).toBe(
+      "/home/ubuntu/dev/ai-pm-worktree",
+    );
+    // Each identity dot is colored by the shared per-agent palette helper.
+    const dots = screen.getAllByTestId("cwd-agent-dot");
+    expect(dots).toHaveLength(2);
+    expect(dots[0].style.backgroundColor).toBe(hexToRgb(getAgentColor("Claude")));
+    expect(dots[1].style.backgroundColor).toBe(hexToRgb(getAgentColor("Codex")));
+    // Distinct agents → distinct dot colors.
+    expect(dots[0].style.backgroundColor).not.toBe(dots[1].style.backgroundColor);
   });
 
   it("reloads the fixed cwd marker after the project settings save event", async () => {
@@ -75,7 +128,11 @@ describe("ProjectCwdSummary", () => {
       }));
     });
 
-    expect(await screen.findByText("/workspace/fixed")).toBeTruthy();
+    // Agent name becomes visible; the cwd is carried in the badge tooltip.
+    const label = await screen.findByText("Agent One");
+    expect(label.closest("span[title]")?.getAttribute("title")).toBe(
+      "/workspace/fixed",
+    );
     expect(authFetch).toHaveBeenCalledTimes(2);
   });
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/project-cwd-summary.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/project-cwd-summary.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
-import { act, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next-intl", () => ({
@@ -11,6 +13,25 @@ vi.mock("@/lib/auth-client", () => ({
   authFetch: (...args: unknown[]) => authFetch(...args),
 }));
 
+// The badge is clickable → opens the agent's daemon chat via the presence context.
+const openChatForAgent = vi.fn();
+vi.mock("@/contexts/agent-presence-context", () => ({
+  useAgentPresenceOptional: () => ({ openChatForAgent }),
+}));
+
+// Mock the Radix-based Tooltip primitive: Radix's hover/pointer open path is unreliable in
+// jsdom, so we render TooltipContent inline (in a portal-like sibling, NOT inside the badge)
+// to deterministically assert MY wiring — that the cwd is passed as the tooltip content and
+// is NOT part of the badge's visible label. Radix's actual open-on-hover is its own contract.
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="cwd-tooltip">{children}</div>
+  ),
+}));
+
 import { ProjectCwdSummary } from "../project-cwd-summary";
 import { getAgentColor } from "@/lib/agent-color";
 
@@ -20,103 +41,103 @@ function hexToRgb(hex: string): string {
   return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
 }
 
-function response(cwd: string | null) {
+function agentsResponse(
+  agents: { uuid: string; name: string; host?: string; cwd: string | null }[],
+) {
   return Promise.resolve({
     ok: true,
     json: async () => ({
       data: {
-        agents: [{
-          agent: { uuid: "agent-1", name: "Agent One" },
-          preference: cwd ? { cwd } : null,
-        }],
+        agents: agents.map((a) => ({
+          agent: { uuid: a.uuid, name: a.name },
+          preference: a.cwd ? { host: a.host ?? "host-1", cwd: a.cwd } : null,
+        })),
       },
     }),
   });
 }
 
-function badgeFor(name: string): HTMLElement | null {
-  return screen.getByText(name).closest("span[title]") as HTMLElement | null;
+function badgeButton(name: string): HTMLButtonElement {
+  return screen.getByText(name).closest("button") as HTMLButtonElement;
 }
 
 describe("ProjectCwdSummary", () => {
   beforeEach(() => {
     authFetch.mockReset();
+    openChatForAgent.mockReset();
   });
 
-  it("shows the agent name as the visible label with the cwd in the tooltip", async () => {
-    authFetch.mockImplementationOnce(() => Promise.resolve({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: {
-          agents: [
-            {
-              agent: { uuid: "agent-1", name: "Claude" },
-              preference: { cwd: "/work/dynamic-project" },
-            },
-            {
-              agent: { uuid: "agent-2", name: "Codex" },
-              preference: null,
-            },
-          ],
-        },
-      }),
-    }));
+  it("shows the agent NAME as the visible badge label and puts the cwd in the tooltip (not the label)", async () => {
+    authFetch.mockImplementationOnce(() =>
+      agentsResponse([
+        { uuid: "agent-1", name: "Claude", cwd: "/work/dynamic-project" },
+        { uuid: "agent-2", name: "Codex", cwd: null },
+      ]),
+    );
 
     render(<ProjectCwdSummary projectUuid="project-1" />);
 
-    const summary = await screen.findByLabelText("title");
-    expect(summary.getAttribute("class")).toContain("flex-wrap");
-    // Agent name is visible; the cwd path is in the badge tooltip, not the label.
-    expect(await screen.findByText("Claude")).toBeTruthy();
-    expect(badgeFor("Claude")?.getAttribute("title")).toBe("/work/dynamic-project");
-    expect(summary.textContent).not.toContain("/work/dynamic-project");
-    // Agent with no preference is filtered out entirely.
+    await screen.findByText("Claude");
+    // The badge's own visible label is the agent name — the cwd is NOT in the button text
+    // (this is the regression: previously the cwd was the only visible content).
+    const btn = badgeButton("Claude");
+    expect(btn.textContent).toContain("Claude");
+    expect(btn.textContent).not.toContain("/work/dynamic-project");
+    // The cwd IS wired into the tooltip content.
+    expect(within(screen.getByTestId("cwd-tooltip")).getByText("/work/dynamic-project")).toBeTruthy();
+    // Agent with no preference is filtered out.
     expect(screen.queryByText("Codex")).toBeNull();
   });
 
   it("distinguishes multiple agents by a per-agent identity dot even with common-prefix cwds", async () => {
-    authFetch.mockImplementationOnce(() => Promise.resolve({
-      ok: true,
-      json: async () => ({
-        data: {
-          agents: [
-            {
-              agent: { uuid: "a1", name: "Claude" },
-              preference: { cwd: "/home/ubuntu/dev/ai-pm" },
-            },
-            {
-              agent: { uuid: "a2", name: "Codex" },
-              preference: { cwd: "/home/ubuntu/dev/ai-pm-worktree" },
-            },
-          ],
-        },
-      }),
-    }));
+    authFetch.mockImplementationOnce(() =>
+      agentsResponse([
+        { uuid: "a1", name: "Claude", cwd: "/home/ubuntu/dev/ai-pm" },
+        { uuid: "a2", name: "Codex", cwd: "/home/ubuntu/dev/ai-pm-worktree" },
+      ]),
+    );
 
     render(<ProjectCwdSummary projectUuid="project-1" />);
 
-    // Both agents are identifiable by their visible names (no hover needed)...
     expect(await screen.findByText("Claude")).toBeTruthy();
     expect(screen.getByText("Codex")).toBeTruthy();
-    // ...and each cwd lives in its own badge tooltip.
-    expect(badgeFor("Claude")?.getAttribute("title")).toBe("/home/ubuntu/dev/ai-pm");
-    expect(badgeFor("Codex")?.getAttribute("title")).toBe(
-      "/home/ubuntu/dev/ai-pm-worktree",
-    );
-    // Each identity dot is colored by the shared per-agent palette helper.
     const dots = screen.getAllByTestId("cwd-agent-dot");
     expect(dots).toHaveLength(2);
     expect(dots[0].style.backgroundColor).toBe(hexToRgb(getAgentColor("Claude")));
     expect(dots[1].style.backgroundColor).toBe(hexToRgb(getAgentColor("Codex")));
-    // Distinct agents → distinct dot colors.
     expect(dots[0].style.backgroundColor).not.toBe(dots[1].style.backgroundColor);
+    // Each agent's cwd lives in its own tooltip.
+    const tips = screen.getAllByTestId("cwd-tooltip").map((el) => el.textContent);
+    expect(tips).toContain("/home/ubuntu/dev/ai-pm");
+    expect(tips).toContain("/home/ubuntu/dev/ai-pm-worktree");
+  });
+
+  it("opens the agent's chat (pinned to its host+cwd) when the badge is clicked", async () => {
+    authFetch.mockImplementationOnce(() =>
+      agentsResponse([
+        { uuid: "a1", name: "Claude", host: "host-A", cwd: "/work/alpha" },
+      ]),
+    );
+
+    const user = userEvent.setup();
+    render(<ProjectCwdSummary projectUuid="project-1" />);
+
+    await screen.findByText("Claude");
+    await user.click(badgeButton("Claude"));
+
+    expect(openChatForAgent).toHaveBeenCalledTimes(1);
+    expect(openChatForAgent).toHaveBeenCalledWith("a1", {
+      host: "host-A",
+      cwd: "/work/alpha",
+    });
   });
 
   it("reloads the fixed cwd marker after the project settings save event", async () => {
     authFetch
-      .mockImplementationOnce(() => response(null))
-      .mockImplementationOnce(() => response("/workspace/fixed"));
+      .mockImplementationOnce(() => agentsResponse([{ uuid: "agent-1", name: "Agent One", cwd: null }]))
+      .mockImplementationOnce(() =>
+        agentsResponse([{ uuid: "agent-1", name: "Agent One", cwd: "/workspace/fixed" }]),
+      );
 
     render(<ProjectCwdSummary projectUuid="project-1" />);
     await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
@@ -128,16 +149,13 @@ describe("ProjectCwdSummary", () => {
       }));
     });
 
-    // Agent name becomes visible; the cwd is carried in the badge tooltip.
-    const label = await screen.findByText("Agent One");
-    expect(label.closest("span[title]")?.getAttribute("title")).toBe(
-      "/workspace/fixed",
-    );
+    expect(await screen.findByText("Agent One")).toBeTruthy();
+    expect(within(screen.getByTestId("cwd-tooltip")).getByText("/workspace/fixed")).toBeTruthy();
     expect(authFetch).toHaveBeenCalledTimes(2);
   });
 
   it("ignores cwd updates for another project", async () => {
-    authFetch.mockImplementation(() => response(null));
+    authFetch.mockImplementation(() => agentsResponse([{ uuid: "agent-1", name: "Agent One", cwd: null }]));
     render(<ProjectCwdSummary projectUuid="project-1" />);
     await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/project-cwd-summary.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/project-cwd-summary.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { FolderLock } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { authFetch } from "@/lib/auth-client";
+import { getAgentColor } from "@/lib/agent-color";
 
 interface FixedCwdPreference {
   agent: { uuid: string; name: string };
@@ -56,14 +56,23 @@ export function ProjectCwdSummary({ projectUuid }: { projectUuid: string }) {
       aria-label={t("title")}
     >
       {preferences.map(({ agent, preference }) => (
+        // Each badge is led by a per-agent identity dot (getAgentColor hashes the
+        // agent name into a light/dark-safe palette) + the visible agent name, so
+        // multiple agents' badges are distinguishable at a glance. The cwd path —
+        // often sharing a long common prefix across agents — moves into the tooltip.
         <span
           key={agent.uuid}
           className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[11px] text-muted-foreground"
-          title={`${agent.name}: ${preference!.cwd}`}
+          title={preference!.cwd}
         >
-          <FolderLock className="size-3.5 shrink-0 text-primary" aria-hidden />
-          <span className="max-w-[min(18rem,65vw)] truncate font-mono">
-            {preference!.cwd}
+          <span
+            data-testid="cwd-agent-dot"
+            className="size-2 shrink-0 rounded-full"
+            style={{ backgroundColor: getAgentColor(agent.name) }}
+            aria-hidden
+          />
+          <span className="max-w-[min(12rem,50vw)] truncate font-medium text-foreground">
+            {agent.name}
           </span>
         </span>
       ))}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/project-cwd-summary.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/project-cwd-summary.tsx
@@ -4,16 +4,29 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { authFetch } from "@/lib/auth-client";
 import { getAgentColor } from "@/lib/agent-color";
+import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface FixedCwdPreference {
   agent: { uuid: string; name: string };
   preference: {
+    host: string;
     cwd: string;
   } | null;
 }
 
 export function ProjectCwdSummary({ projectUuid }: { projectUuid: string }) {
   const t = useTranslations("fixedCwdAnchor");
+  // Optional: the overview lives under the shell-level AgentPresenceProvider, but use the
+  // non-throwing variant so the badge still renders (name + cwd tooltip) if it is ever
+  // mounted outside a provider — clicking just no-ops there.
+  const presence = useAgentPresenceOptional();
   const [preferences, setPreferences] = useState<FixedCwdPreference[]>([]);
 
   const load = useCallback(async () => {
@@ -51,31 +64,48 @@ export function ProjectCwdSummary({ projectUuid }: { projectUuid: string }) {
   if (preferences.length === 0) return null;
 
   return (
-    <div
-      className="flex min-w-0 flex-wrap items-center gap-1.5"
-      aria-label={t("title")}
-    >
-      {preferences.map(({ agent, preference }) => (
-        // Each badge is led by a per-agent identity dot (getAgentColor hashes the
-        // agent name into a light/dark-safe palette) + the visible agent name, so
-        // multiple agents' badges are distinguishable at a glance. The cwd path —
-        // often sharing a long common prefix across agents — moves into the tooltip.
-        <span
-          key={agent.uuid}
-          className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[11px] text-muted-foreground"
-          title={preference!.cwd}
-        >
-          <span
-            data-testid="cwd-agent-dot"
-            className="size-2 shrink-0 rounded-full"
-            style={{ backgroundColor: getAgentColor(agent.name) }}
-            aria-hidden
-          />
-          <span className="max-w-[min(12rem,50vw)] truncate font-medium text-foreground">
-            {agent.name}
-          </span>
-        </span>
-      ))}
-    </div>
+    <TooltipProvider>
+      <div
+        className="flex min-w-0 flex-wrap items-center gap-1.5"
+        aria-label={t("title")}
+      >
+        {preferences.map(({ agent, preference }) => (
+          // Each badge is led by a per-agent identity dot (getAgentColor hashes the agent
+          // name into a light/dark-safe palette) + the visible agent name, so multiple
+          // agents' badges are distinguishable at a glance. The cwd path — often sharing a
+          // long common prefix across agents — shows in a real (immediate) tooltip on
+          // hover/focus, and clicking the badge opens that agent's daemon chat.
+          <Tooltip key={agent.uuid}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                aria-label={t("openAgentChat", { agent: agent.name })}
+                onClick={() =>
+                  presence?.openChatForAgent(agent.uuid, {
+                    host: preference!.host,
+                    cwd: preference!.cwd,
+                  })
+                }
+                className="inline-flex h-auto max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[11px] font-normal text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              >
+                <span
+                  data-testid="cwd-agent-dot"
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: getAgentColor(agent.name) }}
+                  aria-hidden
+                />
+                <span className="max-w-[min(12rem,50vw)] truncate font-medium text-foreground">
+                  {agent.name}
+                </span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="font-mono">
+              {preference!.cwd}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/src/components/__tests__/daemon-presence-entry.test.tsx
+++ b/src/components/__tests__/daemon-presence-entry.test.tsx
@@ -231,11 +231,18 @@ describe("DaemonPresenceEntry — three presence states", () => {
     expect(text).not.toMatch(/\d/);
   });
 
-  it("online (count > 0): emphasizes the count, shows the plural unit, and renders the pulsing-green dot", () => {
+  it("online (multiple distinct agents): shows the DISTINCT-AGENT count (not per-connection), plural unit, pulsing dot", () => {
+    // Three distinct agents online. The provider's connection-based onlineCount is set to a
+    // DIFFERENT (bogus) value to prove the pill uses the distinct-agent count
+    // (onlineAgentGroups.length), never the per-connection onlineCount.
     setPresence({
       status: "ok",
-      onlineCount: 3,
-      connections: [makeConnection()],
+      onlineCount: 7,
+      connections: [
+        makeConnection({ uuid: "c1", agentUuid: "agent-1", host: "h1", cwd: "/a" }),
+        makeConnection({ uuid: "c2", agentUuid: "agent-2", host: "h2", cwd: "/b" }),
+        makeConnection({ uuid: "c3", agentUuid: "agent-3", host: "h3", cwd: "/c" }),
+      ],
     });
     const { container } = render(<DaemonPresenceEntry />);
 
@@ -243,9 +250,33 @@ describe("DaemonPresenceEntry — three presence states", () => {
     const text = trigger.textContent ?? "";
     expect(text).toContain("3");
     expect(text).toContain("agents online");
+    // Must NOT reflect the per-connection count from the provider.
+    expect(text).not.toContain("7");
     // The pulsing-green dot reuses motion-safe:animate-ping (static under
     // reduced motion). The error/idle dots never carry it.
     expect(container.querySelector(".motion-safe\\:animate-ping")).not.toBeNull();
+  });
+
+  it("one agent online across multiple cwds counts ONCE (distinct-agent, not per-connection)", () => {
+    // Same agentUuid on three (host, cwd) connections → the provider counts 3 connections,
+    // but the pill must show a single distinct agent (the headline of idea 5b8ee573 point 4).
+    setPresence({
+      status: "ok",
+      onlineCount: 3,
+      connections: [
+        makeConnection({ uuid: "c1", agentUuid: "agent-1", host: "h", cwd: "/one" }),
+        makeConnection({ uuid: "c2", agentUuid: "agent-1", host: "h", cwd: "/two" }),
+        makeConnection({ uuid: "c3", agentUuid: "agent-1", host: "h", cwd: "/three" }),
+      ],
+    });
+    render(<DaemonPresenceEntry />);
+
+    const trigger = screen.getByRole("button", { name: TRIGGER_LABEL });
+    const text = trigger.textContent ?? "";
+    expect(text).toContain("1");
+    expect(text).toContain("agent online");
+    expect(text).not.toContain("agents online"); // singular, not plural
+    expect(text).not.toContain("3"); // NOT the per-connection count
   });
 
   it("online (count === 1): uses the SINGULAR unit 'agent online'", () => {

--- a/src/components/daemon-presence-entry.tsx
+++ b/src/components/daemon-presence-entry.tsx
@@ -68,7 +68,6 @@ export function DaemonPresenceEntry() {
   const t = useTranslations("agentPresence");
   const {
     status,
-    onlineCount,
     connections,
     executionsByConnection,
     setModalOpen,
@@ -79,7 +78,21 @@ export function DaemonPresenceEntry() {
   // "View activity" affordance is omitted entirely — not merely disabled.
   const pixel = usePixelActivityOptional();
 
-  const dotState = deriveDotState(status, onlineCount);
+  // Online-only presence: filter to the ONLINE connection set FIRST, then group by
+  // agent. `onlineAgentGroups.length` is the number of DISTINCT agents with >= 1 online
+  // instance (grouped on agentUuid, never the nullable agentName), which is what the
+  // pill's "agents online" count and its dot state reflect — an agent online across
+  // multiple hosts/cwds counts ONCE. The provider's `onlineCount` stays connection-based
+  // for the connection-oriented "View all" modal; the pill is agent-oriented.
+  // `onlineConnectionsOnly` also applies the stable identity sort, so raw refresh array
+  // order cannot make the roster jump.
+  const onlineAgentGroups = groupConnectionsByAgent(
+    onlineConnectionsOnly(connections, executionsByConnection),
+    executionsByConnection,
+  ).filter((g) => g.onlineCount > 0);
+  const onlineAgentCount = onlineAgentGroups.length;
+
+  const dotState = deriveDotState(status, onlineAgentCount);
 
   // The trigger body. Error must NEVER read as "0 online" (no silent error);
   // loading is a muted placeholder with no count flash; idle and online show the
@@ -99,7 +112,7 @@ export function DaemonPresenceEntry() {
     );
   } else {
     const onlineTint =
-      onlineCount > 0
+      onlineAgentCount > 0
         ? "text-[#15803D] dark:text-[#4FD07A]"
         : "text-foreground/80";
     body = (
@@ -107,24 +120,14 @@ export function DaemonPresenceEntry() {
         <span
           className={`text-[15px] font-semibold leading-none tabular-nums ${onlineTint}`}
         >
-          {onlineCount}
+          {onlineAgentCount}
         </span>
         <span className="truncate text-muted-foreground">
-          {t("onlineUnit", { count: onlineCount })}
+          {t("onlineUnit", { count: onlineAgentCount })}
         </span>
       </span>
     );
   }
-
-  // Online-only presence: filter to the ONLINE connection set FIRST, then group.
-  // The roster lists only live (host, cwd) instances — an offline instance never
-  // appears, and an agent with zero online instances produces no group at all.
-  // `onlineConnectionsOnly` also applies the stable identity sort, so raw refresh
-  // array order cannot make the roster jump.
-  const onlineAgentGroups = groupConnectionsByAgent(
-    onlineConnectionsOnly(connections, executionsByConnection),
-    executionsByConnection,
-  ).filter((g) => g.onlineCount > 0);
 
   return (
     <div className="fixed bottom-4 right-4 md:bottom-6 md:right-6 z-40">

--- a/src/services/__tests__/cwd-pin-chain.integration.test.ts
+++ b/src/services/__tests__/cwd-pin-chain.integration.test.ts
@@ -68,6 +68,7 @@ function makeStore() {
     project: [] as Row[],
     user: [] as Row[],
     agent: [] as Row[],
+    projectAgentCwdPreference: [] as Row[],
   };
   let autoId = 1;
   let autoUuid = 1;
@@ -319,6 +320,11 @@ function buildPrismaFake(store: Store) {
       findFirst: vi.fn(async (args: Row) => findFirst("agent", args)),
       findMany: vi.fn(async (args: Row) => findMany("agent", args)),
       count: vi.fn(async (args: Row) => count("agent", args)),
+    },
+    // idea 5b8ee573: the autonomous-wake project-owner cwd fallback reads this. Empty here
+    // (no fixed preference seeded) → the un-pinned wake stays online-first, unchanged.
+    projectAgentCwdPreference: {
+      findFirst: vi.fn(async (args: Row) => findFirst("projectAgentCwdPreference", args)),
     },
     project: {
       findUnique: vi.fn(async (args: Row) => findFirst("project", { where: args.where })),

--- a/src/services/__tests__/daemon-session-conversation.integration.test.ts
+++ b/src/services/__tests__/daemon-session-conversation.integration.test.ts
@@ -64,6 +64,8 @@ function makeStore() {
     task: [] as Row[],
     idea: [] as Row[],
     agentInstance: [] as Row[],
+    agent: [] as Row[],
+    projectAgentCwdPreference: [] as Row[],
   };
   let autoId = 1;
   let autoUuid = 1;
@@ -306,6 +308,15 @@ function buildPrismaFake(store: Store) {
     },
     agentInstance: {
       findFirst: vi.fn(async (args: Row) => findFirst("agentInstance", args)),
+    },
+    // idea 5b8ee573: the autonomous-wake project-owner cwd fallback reads the agent's owner
+    // then that owner's project cwd preference. This suite exercises UN-pinned online-first
+    // wakes with no agent/preference rows → both resolve null → online-first, unchanged.
+    agent: {
+      findFirst: vi.fn(async (args: Row) => findFirst("agent", args)),
+    },
+    projectAgentCwdPreference: {
+      findFirst: vi.fn(async (args: Row) => findFirst("projectAgentCwdPreference", args)),
     },
     notification: {
       create: vi.fn(async (args: Row) => {

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -41,8 +41,12 @@ const mockDaemonSessionFindFirst = vi.hoisted(() => vi.fn());
 // `${idea}::${conn}` thread. Mock update so we can assert the re-point without a DB.
 const mockDaemonSessionUpdate = vi.hoisted(() => vi.fn());
 const mockPreferenceFindFirst = vi.hoisted(() => vi.fn());
+// idea 5b8ee573: the autonomous-wake project-owner cwd fallback reads the agent's owner
+// (prisma.agent.findFirst) then that owner's ProjectAgentCwdPreference. Mock agent too.
+const mockAgentFindFirst = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/prisma", () => ({
   prisma: {
+    agent: { findFirst: mockAgentFindFirst },
     task: { findFirst: mockTaskFindFirst },
     idea: { findFirst: mockIdeaFindFirst },
     agentInstance: { findFirst: mockAgentInstanceFindFirst },
@@ -243,6 +247,11 @@ beforeEach(() => {
   // asserts on its args.
   mockDaemonSessionUpdate.mockResolvedValue({});
   mockPreferenceFindFirst.mockResolvedValue(null);
+  // Default: the wake's agent has an owner, but that owner has NO project cwd preference
+  // (mockPreferenceFindFirst → null) — so the project-owner cwd fallback is a no-op and every
+  // existing test keeps its unchanged online-first behavior. Tests that also leave projectUuid
+  // unset on the ctx skip the fallback entirely (its `ctx.projectUuid` gate is false).
+  mockAgentFindFirst.mockResolvedValue({ ownerUuid: "owner-0000-0000-0000-000000000001" });
 });
 
 describe("project-Agent fixed cwd resolution", () => {
@@ -2162,5 +2171,152 @@ describe("createTurnAndResolveTarget — generalized idea-session-origin upgrade
     );
     expect(mockDeliverTurnPing).not.toHaveBeenCalled();
     expect(targetConnectionUuid).toBeNull();
+  });
+});
+
+// ===== Project-owner fixed-cwd fallback (idea 5b8ee573 / project-cwd-anchoring) =====
+//
+// The autonomous wake path now honors the AGENT OWNER's fixed project cwd as the online-first
+// REPLACEMENT — applied in createTurnAndResolveTarget AFTER the idea-session-origin upgrade and
+// gated on `selection.kind === "online_first"`. Precedence: instance pin → online session-origin
+// (b729713b) → project-owner pin (this) → raw online-first. Strict offline (owner Q3): an offline
+// pinned cwd is offline_pin (suppressWake, notify-only), never re-routed.
+describe("createTurnAndResolveTarget — project-owner fixed-cwd fallback (idea 5b8ee573)", () => {
+  const ownerUuid = "owner-0000-0000-0000-000000000001";
+  const projectUuid = "project-0000-0000-0000-000000000001";
+  const projHost = "proj-host";
+  const projCwd = "/home/u/dev/project-cwd";
+  const projConnUuid = "conn-project-pin";
+
+  it("targets the agent-owner's fixed project cwd instead of the first online cwd (project-pin hit)", async () => {
+    // Plain-agent task, no idea session → selection stays online_first. The owner pinned a
+    // project cwd that is ONLINE (but NOT the online-first entry) → the wake targets it.
+    mockAgentFindFirst.mockResolvedValue({ ownerUuid });
+    mockPreferenceFindFirst.mockResolvedValue({ host: projHost, cwd: projCwd });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: projConnUuid, host: projHost, cwd: projCwd }),
+    ]);
+
+    const { turn, targetConnectionUuid, suppressWake } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", projectUuid }),
+    );
+
+    // The owner's pin is read for (owner, project, agent)...
+    expect(mockAgentFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ uuid: agentUuid, companyUuid }) }),
+    );
+    expect(mockPreferenceFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userUuid: ownerUuid, projectUuid, agentUuid, companyUuid }),
+      }),
+    );
+    // ...and the wake is directed to the pinned cwd, NOT the online-first entry.
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: projConnUuid }),
+    );
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: "conn-online-first" }),
+    );
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: projConnUuid, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(projConnUuid);
+    expect(suppressWake).toBe(false);
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("an ONLINE idea-session-origin OUTRANKS the project pin (live conversation is never rerouted)", async () => {
+    // The idea already has an online session-origin on cwd A → the session-origin upgrade fires
+    // FIRST (selection becomes directed), so the project pin (cwd B) is never even consulted.
+    const ideaOriginConn = "conn-idea-origin";
+    mockAgentFindFirst.mockResolvedValue({ ownerUuid });
+    mockPreferenceFindFirst.mockResolvedValue({ host: projHost, cwd: projCwd });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: ideaOriginConn, host: "host-idea", cwd: "/home/u/dev/idea" }),
+      onlineConn({ uuid: projConnUuid, host: projHost, cwd: projCwd }),
+    ]);
+    mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: ideaOriginConn });
+
+    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", projectUuid }),
+    );
+
+    // Directed to the live session origin (cwd A), NOT the project pin (cwd B).
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: ideaOriginConn }),
+    );
+    expect(targetConnectionUuid).toBe(ideaOriginConn);
+    // The project pin is never consulted once the session-origin upgrade wins.
+    expect(mockPreferenceFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("strict offline: an offline project-pinned cwd is notify-only (suppressWake), never re-routed", async () => {
+    // The owner's pinned cwd is OFFLINE while the agent is online elsewhere. Per owner Q3 the
+    // wake must NOT re-route — it becomes offline_pin (suppressWake TRUE, no turn, no ping).
+    mockAgentFindFirst.mockResolvedValue({ ownerUuid });
+    mockPreferenceFindFirst.mockResolvedValue({ host: projHost, cwd: projCwd });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-elsewhere", host: "host-A", cwd: "/home/u/dev/a" }),
+      offlineConn({ uuid: projConnUuid, host: projHost, cwd: projCwd }),
+    ]);
+
+    const { turn, targetConnectionUuid, suppressWake } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", projectUuid }),
+    );
+
+    expect(turn).toBeNull();
+    expect(targetConnectionUuid).toBeNull();
+    expect(suppressWake).toBe(true);
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    // Crucially, it did NOT re-route to the online-elsewhere connection.
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: "conn-online-elsewhere" }),
+    );
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("no owner preference → unchanged online-first fallback", async () => {
+    // The owner has NO fixed project cwd for this (project, agent) → makePinnedTarget yields
+    // null → selection stays online_first, byte-identical to before.
+    mockAgentFindFirst.mockResolvedValue({ ownerUuid });
+    mockPreferenceFindFirst.mockResolvedValue(null);
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+
+    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", projectUuid }),
+    );
+
+    expect(mockPreferenceFindFirst).toHaveBeenCalled();
+    expect(turn?.status).toBe("pending");
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    // Un-pinned broadcast → no directed target.
+    expect(targetConnectionUuid).toBeNull();
+  });
+
+  it("agent with no owner → project pin skipped → online-first (short-circuit, no preference read)", async () => {
+    mockAgentFindFirst.mockResolvedValue({ ownerUuid: null });
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+
+    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", projectUuid }),
+    );
+
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+    expect(targetConnectionUuid).toBeNull();
+    // No owner → the preference is never queried.
+    expect(mockPreferenceFindFirst).not.toHaveBeenCalled();
   });
 });

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -303,9 +303,12 @@ function makePinnedTarget(
 
 /**
  * Resolve the wake's pinned target instance — the durable `(host, cwd)` an owner chose
- * (cwd-addressable instances) — or null when the wake carries no pin. DEC-5: the cwd is
- * NEVER inferred from the project; the ONLY pin sources are the explicit owner choices
- * below, resolved in PRIORITY ORDER and tagged with their origin (`soft`):
+ * (cwd-addressable instances) — or null when the wake carries no pin. DEC-5 (SCOPED): THIS
+ * resolver NEVER infers cwd from the project; its ONLY pin sources are the explicit owner
+ * choices below, resolved in PRIORITY ORDER and tagged with their origin (`soft`). The one
+ * project-derived fallback — the agent-owner's fixed project cwd — is applied by the caller
+ * (createTurnAndResolveTarget step 4a), BELOW the session-origin upgrade, replacing only the
+ * online-first pick; see there:
  *
  *  1. mention pin (HARD, `soft:false`) — `trigger === "mentioned"`: a human typed an
  *     exact place in the mention markup, threaded onto the context
@@ -427,6 +430,54 @@ async function resolvePinnedTarget(
   // inherit (it resolves against its own agent → online-first).
   const rootIdeaUuid = await resolveRootIdeaUuidForPin(ctx);
   return resolveIdeaInstancePin(ctx, rootIdeaUuid);
+}
+
+/**
+ * Autonomous-wake project cwd fallback (idea 5b8ee573 / project-cwd-anchoring). Resolve the
+ * AGENT OWNER's fixed project cwd preference for `(project, agent)` into a HARD PinnedTarget,
+ * or null when the agent has no owner or the owner set no preference (→ caller keeps the
+ * unchanged online-first selection). This is the ONLY place the wake path derives a cwd from
+ * the project — a SCOPED reversal of DEC-5 — and the caller (createTurnAndResolveTarget step
+ * 4a) applies it BELOW the idea-session-origin upgrade, so a live online conversation is never
+ * rerouted. The preference is stored PER USER (`@@unique([userUuid, projectUuid, agentUuid])`);
+ * per the owner's elaboration decision an autonomous wake reads the AGENT OWNER's row. The
+ * pin is HARD (`soft:false`): `makePinnedTarget` normalizes to the registry sentinels and
+ * returns null for an empty `(host, cwd)`, so an unset/invalid preference falls through to
+ * online-first rather than stalling on a garbage pin.
+ */
+async function resolveProjectOwnerCwdPin(
+  companyUuid: string,
+  agentUuid: string,
+  projectUuid: string,
+): Promise<PinnedTarget | null> {
+  try {
+    const agent = await prisma.agent.findFirst({
+      where: { uuid: agentUuid, companyUuid },
+      select: { ownerUuid: true },
+    });
+    if (!agent?.ownerUuid) return null;
+    const preference = await prisma.projectAgentCwdPreference.findFirst({
+      where: {
+        companyUuid,
+        userUuid: agent.ownerUuid,
+        projectUuid,
+        agentUuid,
+      },
+      select: { host: true, cwd: true },
+    });
+    if (!preference) return null;
+    return makePinnedTarget(preference.host, preference.cwd, false);
+  } catch (error) {
+    // The project-owner cwd fallback is a BEST-EFFORT replacement for the online-first
+    // pick. A failure resolving it must NOT drop the wake: log VISIBLY (no silent errors)
+    // and degrade to the unchanged online-first selection rather than aborting the whole
+    // turn via the caller's catch.
+    turnLogger.warn(
+      { err: error, companyUuid, agentUuid, projectUuid },
+      "resolveProjectOwnerCwdPin failed; degrading to online-first",
+    );
+    return null;
+  }
 }
 
 /**
@@ -659,7 +710,8 @@ export interface WakeTurnResult {
  *  3. Resolve the wake's pinned target instance via assignment LINEAGE (cwd-addressable
  *     instances): the mention's `(host, cwd)` for a `mentioned` wake; else the Task's own
  *     `agent_instance` override, then the root Idea's `agent_instance` assignee under the
- *     same-agent guard; else none (DEC-5: NEVER inferred from the project). ALL pins are
+ *     same-agent guard; else none here (DEC-5 is now SCOPED — this lineage step never infers
+ *     from the project, but step 4a below adds the agent-owner project-cwd fallback). ALL pins are
  *     HARD now (owner choice B). Select the ONLINE origin, classified by HOW it was chosen:
  *       - `directed`     — pin matched an ONLINE connection (turn delivered to ONLY it).
  *       - `online_first` — un-pinned → first online (broadcast → online-first).
@@ -672,6 +724,11 @@ export interface WakeTurnResult {
  *     session-origin heuristic apply: if the idea has an existing ONLINE session origin,
  *     UPGRADE the selection to `directed` on that origin so the proposal-writing wake lands
  *     where the idea's conversation already lives — else stay `online_first`.
+ *  4a. Project-owner cwd fallback (idea 5b8ee573): if selection is STILL `online_first` after
+ *     step 4 (no instance pin, no online session-origin) for an autonomous idea-anchored /
+ *     stage-advance trigger, resolve the AGENT OWNER's fixed project cwd and, when set,
+ *     re-select against it as a HARD pin — replacing the arbitrary "first cwd". Offline
+ *     pinned cwd → `offline_pin` (notify-only), never re-routed.
  *  5. Derive the session id: the entity's `directIdeaUuid` via lineage when the entityType
  *     is lineage-walkable, else the entity uuid (ad-hoc). For a CROSS-CWD directed mention
  *     (the resolved target differs from the idea's existing session origin), the resolved
@@ -716,9 +773,11 @@ export async function createTurnAndResolveTarget(
       ctx.companyUuid,
       ctx.recipientUuid,
     );
-    // The wake's pinned (host, cwd), or null when un-pinned. DEC-5: cwd is only ever the
-    // explicit pin — never inferred from the project.
-    const pin = await resolvePinnedTarget(ctx, trigger);
+    // The wake's pinned (host, cwd), or null when un-pinned. DEC-5 (SCOPED): the
+    // assignment-lineage resolver NEVER infers cwd from the project; the ONE project-
+    // derived fallback — the agent-owner's fixed project cwd — is applied later in step 4a,
+    // BELOW the session-origin upgrade, replacing only the online-first pick.
+    let pin = await resolvePinnedTarget(ctx, trigger);
     // Pin-aware selection, classified by HOW the origin was chosen (drives directed
     // delivery). A PINNED wake whose pin matched no online connection is `offline_pin` →
     // notify-only with NO online-first fallback (REVERSES #354).
@@ -762,6 +821,33 @@ export async function createTurnAndResolveTarget(
       );
       if (ideaTarget) {
         selection = { kind: "directed", connection: ideaTarget };
+      }
+    }
+
+    // (4a) Project-owner fixed-cwd fallback (idea 5b8ee573 / project-cwd-anchoring): when
+    // the wake would OTHERWISE pick a raw first-online cwd — no instance pin (resolvePinned-
+    // Target) AND no online session-origin upgrade above (selection still `online_first`) —
+    // honor the AGENT OWNER's fixed project cwd instead of the arbitrary "first cwd". This is
+    // the ONE deliberate, SCOPED reversal of DEC-5 ("never infer cwd from project"): it runs
+    // only here, on the autonomous idea-anchored / stage-advance path, gated on the same
+    // trigger family as the session-origin upgrade — so it can never override an instance pin
+    // or a live online conversation (the b729713b fix wins, resolved above). HARD pin (owner
+    // elaboration Q3 = strict): an offline pinned cwd becomes `offline_pin` (notify-only,
+    // reconnect-backfill only to the original host+cwd), never re-routed. No owner or no
+    // preference → `makePinnedTarget` null → selection stays `online_first`, unchanged.
+    if (
+      selection.kind === "online_first" &&
+      IDEA_SESSION_ORIGIN_UPGRADE_TRIGGERS.has(trigger) &&
+      ctx.projectUuid
+    ) {
+      const projectPin = await resolveProjectOwnerCwdPin(
+        ctx.companyUuid,
+        ctx.recipientUuid,
+        ctx.projectUuid,
+      );
+      if (projectPin) {
+        pin = projectPin;
+        selection = selectOriginConnection(connections, projectPin);
       }
     }
 


### PR DESCRIPTION
Follow-up polish to the multi-agent daemon (#483, idea `5b8ee573`). Three project-scope fixes; no schema/migration/permission change.

## Changes
- **Overview cwd badge** (`project-cwd-summary.tsx`): each badge now leads with a colored per-agent identity dot (`getAgentColor`, an existing name-hash palette that reads on both light/dark) + the visible agent name; the cwd path moves into the hover tooltip. Previously only the cwd was visible (agent name hidden in the tooltip), so multiple agents' badges looked identical.
- **Autonomous wake → agent-owner project cwd** (`notification-turn.ts`): new step 4a in `createTurnAndResolveTarget`, placed **after** the idea-session-origin upgrade and gated on `selection.kind === "online_first"`, resolves the agent owner's `ProjectAgentCwdPreference` as a **hard** pin. It replaces only the arbitrary first-cwd fallback — an instance pin and a live online conversation (the b729713b fix) both still win. Offline pinned cwd → `offline_pin`/notify-only, never rerouted; a lookup error degrades to online-first rather than dropping the wake. Precedence: instance pin → online session-origin → project-owner pin → online-first.
- **Presence pill counts distinct agents** (`daemon-presence-entry.tsx`): the bottom-right pill number/unit now use `onlineAgentGroups.length` (distinct agents, keyed on `agentUuid`) instead of the per-connection count, so one agent online across N cwds counts once. `computeOnlineCount` and the connection-oriented "View all" modal stay connection-based.

## Verification
- `tsc --noEmit` exit 0; eslint clean on changed source.
- Changed-file tests green incl. new cases; wake-path service + integration tests green. Ship-time code-review gateway: PASS WITH NOTES (no blockers).
- Elaboration decisions: whose pin = agent owner; offline = strict; badge = dot+name / cwd-in-tooltip; count = per distinct agent.

## Notes
- `design.pen` not yet updated for the two UI surfaces (badge + pill) — needs a human pass.
- Non-blocking: badge colors by agent *name* while presence dedups by `agentUuid`; same-named distinct agents would share a dot color (per-spec name hashing).
- OpenSpec change `daemon-multi-agent-project-polish` archived in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)