### PR TITLE
feat(daemon): wake coalescing — merge queued same-session wakes into one turn

### DIFF
--- a/cli/__tests__/prompts.test.mjs
+++ b/cli/__tests__/prompts.test.mjs
@@ -1,0 +1,257 @@
+// cli/__tests__/prompts.test.mjs
+// Unit tests for buildBatchPrompt (add-daemon-wake-coalescing, tech design §C2).
+// Written TDD-first, BEFORE the implementation.
+//
+// buildBatchPrompt merges the same-session wakes that piled up while the agent was
+// busy into ONE prompt:
+//   - size 1  → byte-identical to buildPrompt(n) (the single-event path is unchanged);
+//   - size >1 → the headless preamble ONCE, then a short backlog preamble, then one
+//               labeled block per event in arrival order, reusing the per-action body;
+//   - events sharing (action, entityUuid) collapse into one block noting the count and
+//     showing the NEWEST message — EXCEPT human_instruction, which is NEVER collapsed
+//     (its text lives only on the turn, not re-fetchable, so collapsing would drop chat);
+//   - events whose per-action body is null (empty human_instruction, non-wake action)
+//     are omitted.
+//
+// The prompt bodies themselves are covered by wake-orchestration.test.mjs; here we only
+// assert the batch composition on top of them, so this file stays independent of the
+// modules (waker/event-router/wake-queue) that other tasks touch.
+import { describe, it, expect } from "vitest";
+import { buildPrompt, buildBatchPrompt, HEADLESS_PREAMBLE } from "../prompts.mjs";
+
+/** A representative task_assigned notification; spread `mk({...})` to vary it. */
+const BASE = {
+  uuid: "n-0",
+  projectUuid: "proj-1",
+  entityType: "task",
+  entityUuid: "task-1",
+  entityTitle: "Build the thing",
+  action: "task_assigned",
+  message: "",
+  actorType: "user",
+  actorUuid: "user-1",
+  actorName: "Alice",
+};
+const mk = (o) => ({ ...BASE, ...o });
+
+/** Count non-overlapping occurrences of `needle` in `hay`. */
+function occurrences(hay, needle) {
+  return hay.split(needle).length - 1;
+}
+
+describe("buildBatchPrompt — single-event path is byte-identical to buildPrompt", () => {
+  // AC: buildBatchPrompt([n]) === buildPrompt(n) byte-for-byte across representative actions.
+  const reps = [
+    mk({ action: "task_assigned" }),
+    mk({ action: "mentioned", entityType: "idea", entityUuid: "idea-9", message: "@agent take a look" }),
+    mk({
+      action: "proposal_approved",
+      entityType: "proposal",
+      entityUuid: "prop-1",
+      entityTitle: "My Proposal",
+      message: 'Proposal "My Proposal" has been approved. Note: ship it',
+    }),
+    mk({ action: "elaboration_verified", entityType: "idea", entityUuid: "idea-2", entityTitle: "Elab" }),
+    mk({ action: "start_development", entityType: "idea", entityUuid: "idea-3", entityTitle: "Dev" }),
+    mk({ action: "yolo_requested", entityType: "idea", entityUuid: "idea-4", entityTitle: "Yolo" }),
+    mk({ action: "resource_resumed", entityType: "task", entityUuid: "task-7" }),
+    mk({ action: "human_instruction", entityType: "idea", entityUuid: "idea-5", instructionText: "please rebase onto main" }),
+  ];
+  for (const n of reps) {
+    it(`[${n.action}] buildBatchPrompt([n]) === buildPrompt(n)`, () => {
+      const single = buildPrompt(n);
+      expect(single).not.toBeNull(); // sanity: these actions all produce a body
+      expect(buildBatchPrompt([n])).toBe(single);
+    });
+  }
+
+  it("a single empty human_instruction yields null, exactly like buildPrompt", () => {
+    const n = mk({ action: "human_instruction", instructionText: "   " });
+    expect(buildPrompt(n)).toBeNull();
+    expect(buildBatchPrompt([n])).toBe(buildPrompt(n));
+    expect(buildBatchPrompt([n])).toBeNull();
+  });
+
+  it("collapses to the single-event path when only one event has a renderable body", () => {
+    // A batch of 2 where one is an empty human_instruction reduces to the lone real
+    // event and is byte-identical to its single-event prompt (no backlog preamble).
+    const empty = mk({ action: "human_instruction", instructionText: "" });
+    const real = mk({ action: "mentioned", entityType: "idea", entityUuid: "idea-9", message: "@agent hi" });
+    expect(buildBatchPrompt([empty, real])).toBe(buildPrompt(real));
+  });
+});
+
+describe("buildBatchPrompt — N>1 composition", () => {
+  it("emits exactly one headless preamble, one backlog preamble, and N ordered labeled blocks", () => {
+    // AC: For N>1 events, output has exactly one HEADLESS_PREAMBLE + one backlog
+    // preamble + labeled blocks in arrival order.
+    const a = mk({ action: "task_assigned", entityUuid: "task-A", entityTitle: "Alpha" });
+    const b = mk({ action: "mentioned", entityType: "idea", entityUuid: "idea-B", entityTitle: "Bravo", message: "@agent see this" });
+    const c = mk({ action: "task_reopened", entityUuid: "task-C", entityTitle: "Charlie" });
+    const p = buildBatchPrompt([a, b, c]);
+
+    // headless preamble appears exactly once, at the very top
+    expect(occurrences(p, HEADLESS_PREAMBLE)).toBe(1);
+    expect(p.startsWith(HEADLESS_PREAMBLE)).toBe(true);
+
+    // exactly one backlog preamble, stating the count (3 renderable events)
+    expect(occurrences(p, "queued Chorus events on this session")).toBe(1);
+    expect(p).toContain("You have 3 queued Chorus events on this session");
+
+    // three labeled blocks, in arrival order
+    expect(occurrences(p, "### Event ")).toBe(3);
+    expect(p).toContain("### Event 1 — task_assigned on task task-A");
+    expect(p).toContain("### Event 2 — mentioned on idea idea-B");
+    expect(p).toContain("### Event 3 — task_reopened on task task-C");
+
+    // arrival order preserved in the rendered text
+    expect(p.indexOf("### Event 1")).toBeLessThan(p.indexOf("### Event 2"));
+    expect(p.indexOf("### Event 2")).toBeLessThan(p.indexOf("### Event 3"));
+    expect(p.indexOf("task-A")).toBeLessThan(p.indexOf("idea-B"));
+    expect(p.indexOf("idea-B")).toBeLessThan(p.indexOf("task-C"));
+  });
+
+  it("each block keeps its own per-action tool hints and @mention guidance", () => {
+    // AC: Each event block still carries its per-action tool hints and @mention guidance.
+    const t = mk({
+      action: "task_assigned",
+      entityUuid: "task-A",
+      entityTitle: "Alpha",
+      actorName: "Alice",
+      actorType: "user",
+      actorUuid: "user-1",
+    });
+    const m = mk({
+      action: "mentioned",
+      entityType: "idea",
+      entityUuid: "idea-B",
+      entityTitle: "Bravo",
+      message: "@agent hey",
+      actorName: "Bob",
+      actorType: "user",
+      actorUuid: "user-2",
+    });
+    const p = buildBatchPrompt([t, m]);
+    // task_assigned tool hints + its own @mention (Alice)
+    expect(p).toContain("chorus_get_task");
+    expect(p).toContain("chorus_claim_task");
+    expect(p).toContain("@[Alice](user:user-1)");
+    // mentioned tool hints + its own @mention (Bob)
+    expect(p).toContain("chorus_get_comments");
+    expect(p).toContain("@[Bob](user:user-2)");
+  });
+});
+
+describe("buildBatchPrompt — same-(action,entityUuid) collapse", () => {
+  it("collapses repeated same-entity events into one block noting the count and the newest message", () => {
+    // AC: Multiple events with the same (action, entityUuid) collapse into one block
+    // noting the count and showing the newest message.
+    const base = { action: "mentioned", entityType: "idea", entityUuid: "idea-X", entityTitle: "X" };
+    const m1 = mk({ ...base, uuid: "m1", message: "OLDESTMENTIONTEXT" });
+    const m2 = mk({ ...base, uuid: "m2", message: "MIDDLEMENTIONTEXT" });
+    const m3 = mk({ ...base, uuid: "m3", message: "NEWESTMENTIONTEXT" });
+    const p = buildBatchPrompt([m1, m2, m3]);
+
+    // one collapsed block for idea-X
+    expect(occurrences(p, "### Event ")).toBe(1);
+    expect(occurrences(p, "on idea idea-X")).toBe(1);
+
+    // the block notes the occurrence count and the action
+    expect(p).toContain("3 mentioned events");
+
+    // shows the NEWEST message; the two older ones are dropped (not re-fetchable? no —
+    // comments ARE re-derivable, hence collapse is safe here)
+    expect(p).toContain("NEWESTMENTIONTEXT");
+    expect(p).not.toContain("OLDESTMENTIONTEXT");
+    expect(p).not.toContain("MIDDLEMENTIONTEXT");
+  });
+
+  it("keeps distinct (action, entityUuid) events as separate blocks (no over-collapse)", () => {
+    const m1 = mk({ action: "mentioned", entityType: "idea", entityUuid: "idea-X", message: "@agent one" });
+    const m2 = mk({ action: "mentioned", entityType: "idea", entityUuid: "idea-Y", message: "@agent two" });
+    // same entity but DIFFERENT action → not collapsed with the mention on idea-X
+    const r = mk({ action: "task_reopened", entityType: "task", entityUuid: "idea-X", entityTitle: "reopened" });
+    const p = buildBatchPrompt([m1, m2, r]);
+    expect(occurrences(p, "### Event ")).toBe(3);
+    expect(p).toContain("on idea idea-X");
+    expect(p).toContain("on idea idea-Y");
+    expect(p).toContain("on task idea-X");
+  });
+
+  it("a collapsed group holds its first-seen slot while a human_instruction interleaves", () => {
+    const m1 = mk({ uuid: "m1", action: "mentioned", entityType: "idea", entityUuid: "idea-X", message: "OLDERMENTION" });
+    const h1 = mk({ uuid: "h1", action: "human_instruction", entityType: "idea", entityUuid: "idea-X", instructionText: "CHATBETWEEN" });
+    const m2 = mk({ uuid: "m2", action: "mentioned", entityType: "idea", entityUuid: "idea-X", message: "NEWERMENTION" });
+    const p = buildBatchPrompt([m1, h1, m2]);
+
+    // two blocks: the collapsed mention (at m1's first-seen slot) + the chat message
+    expect(occurrences(p, "### Event ")).toBe(2);
+    expect(p).toContain("### Event 1 — mentioned on idea idea-X");
+    expect(p).toContain("### Event 2 — human_instruction on idea idea-X");
+    // newest mention shown, older dropped; chat preserved in full
+    expect(p).toContain("NEWERMENTION");
+    expect(p).not.toContain("OLDERMENTION");
+    expect(p).toContain("CHATBETWEEN");
+    // N counts every renderable event (3), not the block count (2)
+    expect(p).toContain("You have 3 queued Chorus events");
+  });
+});
+
+describe("buildBatchPrompt — human_instruction is NEVER collapsed", () => {
+  it("renders three same-session chat messages as three full blocks in arrival order", () => {
+    // AC: human_instruction is EXEMPT from collapse: three queued chat messages render
+    // as three full blocks in arrival order, none dropped or reduced to newest-only.
+    // (Round-1 BLOCKER-2: every human_instruction carries entityUuid=directIdeaUuid, so
+    // collapsing by (action, entityUuid) would drop all but the newest.)
+    const base = { action: "human_instruction", entityType: "idea", entityUuid: "idea-D" };
+    const h1 = mk({ ...base, uuid: "h1", instructionText: "ALPHAINSTRUCTION" });
+    const h2 = mk({ ...base, uuid: "h2", instructionText: "BRAVOINSTRUCTION" });
+    const h3 = mk({ ...base, uuid: "h3", instructionText: "CHARLIEINSTRUCTION" });
+    const p = buildBatchPrompt([h1, h2, h3]);
+
+    // three separate blocks despite identical (action, entityUuid)
+    expect(occurrences(p, "### Event ")).toBe(3);
+    expect(occurrences(p, "human_instruction on idea idea-D")).toBe(3);
+
+    // all three instruction texts present in full — none collapsed away
+    expect(p).toContain("ALPHAINSTRUCTION");
+    expect(p).toContain("BRAVOINSTRUCTION");
+    expect(p).toContain("CHARLIEINSTRUCTION");
+
+    // arrival order preserved
+    expect(p.indexOf("ALPHAINSTRUCTION")).toBeLessThan(p.indexOf("BRAVOINSTRUCTION"));
+    expect(p.indexOf("BRAVOINSTRUCTION")).toBeLessThan(p.indexOf("CHARLIEINSTRUCTION"));
+
+    // and it is NOT reduced to a single "3 occurrences" collapse block
+    expect(p).not.toContain("3 human_instruction events");
+    expect(p).toContain("You have 3 queued Chorus events");
+  });
+});
+
+describe("buildBatchPrompt — null-body events are omitted", () => {
+  it("omits empty human_instruction events from a multi-event batch", () => {
+    // AC: Events whose body is null (empty human_instruction) are omitted from the batch.
+    const empty = mk({ action: "human_instruction", entityType: "idea", entityUuid: "idea-D", instructionText: "   " });
+    const m = mk({ action: "mentioned", entityType: "idea", entityUuid: "idea-E", message: "@agent real one" });
+    const t = mk({ action: "task_assigned", entityUuid: "task-F", entityTitle: "F" });
+    const p = buildBatchPrompt([empty, m, t]);
+
+    // only the two real events render
+    expect(occurrences(p, "### Event ")).toBe(2);
+    expect(p).toContain("You have 2 queued Chorus events");
+    expect(p).toContain("on idea idea-E");
+    expect(p).toContain("on task task-F");
+    // the empty instruction contributed no block at all
+    expect(p).not.toContain("human_instruction");
+  });
+
+  it("returns null when every event in the batch has a null body", () => {
+    const e1 = mk({ action: "human_instruction", instructionText: "" });
+    const e2 = mk({ action: "count_update" }); // non-wake action → null body
+    expect(buildBatchPrompt([e1, e2])).toBeNull();
+  });
+
+  it("returns null for an empty batch", () => {
+    expect(buildBatchPrompt([])).toBeNull();
+  });
+});

--- a/cli/__tests__/upload-hooks.test.mjs
+++ b/cli/__tests__/upload-hooks.test.mjs
@@ -349,11 +349,16 @@ describe("execution upload end-to-end through router/queue/waker", () => {
       fetchImpl,
     });
 
-    const queue = new WakeQueue({ logger: silent });
     const spawner = {
       wake: vi.fn(async () => ({ sessionId: "sid", exitCode: 0, isNew: true })),
     };
     waker = makeWaker(hooks, { spawner }).waker;
+    // The queue now coalesces DATA items and runs them via runBatch → waker.wakeBatch
+    // (add-daemon-wake-coalescing); wire it exactly as daemon.mjs does.
+    const queue = new WakeQueue({
+      logger: silent,
+      runBatch: (key, items) => waker.wakeBatch(items.map((i) => i.notification), key, items[0].attribution),
+    });
     const mcpClient = { callTool: vi.fn(async () => ({ notifications: [TASK_NOTIF] })) };
     const router = new EventRouter({
       mcpClient,

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -3,7 +3,7 @@
 // failure isolation, and the no-op upload hooks (cli-daemon spec
 // "Task-dispatch wake" + "Reserved upload hooks").
 import { describe, it, expect, vi } from "vitest";
-import { buildPrompt, WAKE_ACTIONS, HEADLESS_PREAMBLE } from "../prompts.mjs";
+import { buildPrompt, buildBatchPrompt, WAKE_ACTIONS, HEADLESS_PREAMBLE } from "../prompts.mjs";
 import { createNoopUploadHooks } from "../upload-hooks.mjs";
 import { Waker } from "../waker.mjs";
 import { EventRouter } from "../event-router.mjs";
@@ -345,6 +345,8 @@ function makeWaker(overrides = {}) {
   const isNewSessionFn = overrides.isNewSessionFn ?? vi.fn(() => true);
   // Interrupt reporter (子3): injected spy so tests assert user-vs-crash reporting.
   const reportInterrupt = overrides.reportInterrupt ?? vi.fn(async () => {});
+  // Turn reporter (子1 / coalescing): injected spy so tests can assert coalescedCount.
+  const advanceTurn = overrides.advanceTurn ?? vi.fn(async () => {});
   const waker = new Waker({
     creds: { url: "https://c", apiKey: "cho_x" },
     lineage,
@@ -355,8 +357,9 @@ function makeWaker(overrides = {}) {
     writeMcpConfigFn,
     isNewSessionFn,
     reportInterrupt,
+    advanceTurn,
   });
-  return { waker, spawner, lineage, hooks, writeMcpConfigFn, isNewSessionFn, reportInterrupt };
+  return { waker, spawner, lineage, hooks, writeMcpConfigFn, isNewSessionFn, reportInterrupt, advanceTurn };
 }
 
 describe("Waker.wake full loop", () => {
@@ -509,6 +512,153 @@ describe("Waker.wake full loop", () => {
     expect(snap).toHaveLength(1);
     expect(snap[0].rootIdeaUuid).toBe(ROOT_IDEA);
     expect(snap[0].status).toBe("queued");
+  });
+});
+
+describe("Waker.wakeBatch (coalescing §C3)", () => {
+  // Two @mentions on DISTINCT child tasks that both resolve to idea D — so neither item
+  // equals the session anchor idea:D. The reviewer NOTE case: the anchor is SYNTHESIZED.
+  const ATTR = { key: `idea:${DIRECT_IDEA}`, rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA };
+  const MENTION_A = { ...TASK_NOTIF, uuid: "a", action: "mentioned", entityType: "task", entityUuid: "task-a", message: "look at A" };
+  const MENTION_B = { ...TASK_NOTIF, uuid: "b", action: "mentioned", entityType: "task", entityUuid: "task-b", message: "look at B" };
+  // A synthetic control-channel resume (子3): entity-generic, NEVER a persisted notification, so
+  // it creates NO server pending turn — it must NOT count toward coalescedCount (BLOCKER-2), or
+  // the server's take:(coalescedCount-1) settlement over-reaches and drops a separate pending turn.
+  const RESUME = { action: "resource_resumed", entityType: "task", entityUuid: "task-r" };
+
+  // A spawner that fires onChild (where the → running turn-advance hangs off) then exits clean.
+  const spawnerWithChild = () => ({
+    wake: vi.fn(async ({ sessionId, onChild, onMessage }) => {
+      onChild?.({ pid: 1, on: () => {}, kill: () => {} });
+      onMessage?.({ type: "system", session_id: sessionId });
+      return { sessionId, exitCode: 0, isNew: true };
+    }),
+  });
+
+  it("spawns exactly ONE subprocess for N notifications, with the prompt built via buildBatchPrompt", async () => {
+    const { waker, spawner } = makeWaker();
+    await waker.wakeBatch([MENTION_A, MENTION_B], ATTR.key, ATTR);
+
+    expect(spawner.wake).toHaveBeenCalledTimes(1); // ONE subprocess for the whole batch
+    const args = spawner.wake.mock.calls[0][0];
+    // The merged prompt is exactly buildBatchPrompt's output — backlog preamble + both blocks.
+    expect(args.prompt).toBe(buildBatchPrompt([MENTION_A, MENTION_B]));
+    expect(args.prompt).toContain("task-a");
+    expect(args.prompt).toContain("task-b");
+    expect(args.prompt).toContain("queued Chorus events");
+    // The session anchor = the direct idea (one --resume turn).
+    expect(args.sessionId).toBe(DIRECT_IDEA);
+  });
+
+  it("emits ONE running row synthesized as idea:<directIdeaUuid> (NOT one of the merged items) and drops the merged resources", async () => {
+    let snapshotDuringRun;
+    const { waker } = makeWaker({
+      spawner: {
+        wake: vi.fn(async ({ sessionId }) => {
+          snapshotDuringRun = waker.buildExecutionSnapshot();
+          return { sessionId, exitCode: 0, isNew: true };
+        }),
+      },
+    });
+    // The router marks each merged resource queued before enqueue — replicate that.
+    waker.markQueued(MENTION_A, ATTR.key, ATTR);
+    waker.markQueued(MENTION_B, ATTR.key, ATTR);
+    expect(waker.buildExecutionSnapshot().map((e) => e.entityUuid).sort()).toEqual(["task-a", "task-b"]);
+
+    await waker.wakeBatch([MENTION_A, MENTION_B], ATTR.key, ATTR);
+
+    // During the run: exactly ONE running row = the SYNTHESIZED idea anchor — even though
+    // neither merged item is idea:D.
+    expect(snapshotDuringRun).toHaveLength(1);
+    expect(snapshotDuringRun[0]).toMatchObject({
+      entityType: "idea",
+      entityUuid: DIRECT_IDEA,
+      status: "running",
+      rootIdeaUuid: ROOT_IDEA,
+    });
+    // The merged-away resources are ABSENT so reconcileSnapshot ends their queued rows.
+    const uuids = snapshotDuringRun.map((e) => e.entityUuid);
+    expect(uuids).not.toContain("task-a");
+    expect(uuids).not.toContain("task-b");
+    // After the wake everything is gone (the anchor leaves the active set too).
+    expect(waker.buildExecutionSnapshot()).toHaveLength(0);
+  });
+
+  it("advances the ONE running turn keyed by sessionId and reports coalescedCount = N on the running edge", async () => {
+    const advanceTurn = vi.fn(async () => {});
+    const { waker } = makeWaker({ advanceTurn, spawner: spawnerWithChild() });
+    await waker.wakeBatch([MENTION_A, MENTION_B], ATTR.key, ATTR);
+
+    // Exactly one turn: running then ended.
+    expect(advanceTurn.mock.calls.map((c) => c[0].status)).toEqual(["running", "ended"]);
+    const running = advanceTurn.mock.calls.find((c) => c[0].status === "running")[0];
+    expect(running.sessionId).toBe(DIRECT_IDEA);
+    expect(running.coalescedCount).toBe(2);
+    // The terminal edge carries no coalescedCount (it rides only the running-transition).
+    expect(advanceTurn.mock.calls.find((c) => c[0].status === "ended")[0]).not.toHaveProperty("coalescedCount");
+  });
+
+  it("EXCLUDES a synthetic resource_resumed from coalescedCount (no server pending turn): [resource_resumed, mentionA, mentionB] → 2, not 3", async () => {
+    // BLOCKER-2: the batch has 3 physical items but only 2 are TURN-BACKED (the mentions each
+    // created a server pending turn; resource_resumed did not). The wire count must be 2 so the
+    // server settles (2 − 1) = 1 same-session pending turn — never over-reaching into a
+    // genuinely-separate post-drain turn (which it would silently mark `merged` and drop).
+    const advanceTurn = vi.fn(async () => {});
+    const { waker } = makeWaker({ advanceTurn, spawner: spawnerWithChild() });
+    await waker.wakeBatch([RESUME, MENTION_A, MENTION_B], ATTR.key, ATTR);
+
+    const running = advanceTurn.mock.calls.find((c) => c[0].status === "running")[0];
+    expect(running.coalescedCount).toBe(2); // NOT 3
+  });
+
+  it("a batch that reduces to ONE turn-backed item after excluding resource_resumed reports 1 → omitted from the wire (no settlement)", async () => {
+    // [resource_resumed, mention] → 1 turn-backed item → default 1, which the client omits from
+    // the running-edge payload, so the server runs no settlement (default window of 1). The
+    // batch still runs as ONE coalesced turn: a physical batch of 2 → the synthesized idea anchor.
+    const advanceTurn = vi.fn(async () => {});
+    const { waker } = makeWaker({ advanceTurn, spawner: spawnerWithChild() });
+    await waker.wakeBatch([RESUME, MENTION_A], ATTR.key, ATTR);
+
+    const running = advanceTurn.mock.calls.find((c) => c[0].status === "running")[0];
+    expect(running).not.toHaveProperty("coalescedCount"); // 1 → omitted on the wire
+    // Anchor synthesis still keys off the PHYSICAL batch size (2 > 1) — the fix touched only
+    // the wire count, not the coalescing/anchor design.
+    expect(running.entityType).toBe("idea");
+    expect(running.entityUuid).toBe(DIRECT_IDEA);
+  });
+
+  it("a single-item batch is anchored on the item's OWN entity (ad-hoc: no idea synthesis)", async () => {
+    // A batch of one keeps the item's own entity as the running row (byte-identical to the
+    // pre-coalescing single wake) — the idea-anchor synthesis is a coalesced-only behavior.
+    let snapshotDuringRun;
+    const { waker } = makeWaker({
+      spawner: {
+        wake: vi.fn(async ({ sessionId }) => {
+          snapshotDuringRun = waker.buildExecutionSnapshot();
+          return { sessionId, exitCode: 0, isNew: true };
+        }),
+      },
+    });
+    await waker.wakeBatch([MENTION_A], ATTR.key, ATTR);
+    expect(snapshotDuringRun).toHaveLength(1);
+    expect(snapshotDuringRun[0].entityUuid).toBe("task-a"); // the item, NOT idea:D
+  });
+
+  it("wake(n) is a thin wakeBatch([n]) — single-wake prompt + turn accounting unchanged, coalescedCount omitted", async () => {
+    const advanceTurn = vi.fn(async () => {});
+    const { waker, spawner } = makeWaker({ advanceTurn, spawner: spawnerWithChild() });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    // ONE subprocess; prompt byte-identical to buildPrompt(n) (== buildBatchPrompt([n])).
+    expect(spawner.wake).toHaveBeenCalledTimes(1);
+    expect(spawner.wake.mock.calls[0][0].prompt).toBe(buildPrompt(TASK_NOTIF));
+    // The running advance carries the item's OWN entity (task-1), NOT the idea anchor, and
+    // NO coalescedCount (a single wake reports 1, which the client omits).
+    const running = advanceTurn.mock.calls.find((c) => c[0].status === "running")[0];
+    expect(running.entityType).toBe("task");
+    expect(running.entityUuid).toBe("task-1");
+    expect(running).not.toHaveProperty("coalescedCount");
   });
 });
 
@@ -757,14 +907,14 @@ describe("EventRouter dispatch", () => {
     return { router, mcpClient };
   }
 
-  it("routes a task_assigned notification onto the queue under its direct-idea key", async () => {
+  it("routes a task_assigned notification onto the queue under its direct-idea key, as a DATA payload", async () => {
     const enqueued = [];
-    const queue = { enqueue: (key, task) => enqueued.push({ key, task }) };
+    const queue = { enqueue: (key, item) => enqueued.push({ key, item }) };
     const attribution = { key: `idea:${DIRECT_IDEA}`, rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA };
     const waker = {
       keyFor: vi.fn(async () => attribution),
       markQueued: vi.fn(),
-      wake: vi.fn(async () => {}),
+      wakeBatch: vi.fn(async () => {}),
     };
     const { router } = makeRouter([TASK_NOTIF], waker, queue);
 
@@ -775,9 +925,10 @@ describe("EventRouter dispatch", () => {
     expect(enqueued[0].key).toBe(`idea:${DIRECT_IDEA}`);
     // markQueued got the resolved attribution (so the snapshot can report the root)
     expect(waker.markQueued).toHaveBeenCalledWith(TASK_NOTIF, `idea:${DIRECT_IDEA}`, attribution);
-    // running the enqueued task calls waker.wake with the notification + key + attribution
-    await enqueued[0].task();
-    expect(waker.wake).toHaveBeenCalledWith(TASK_NOTIF, `idea:${DIRECT_IDEA}`, attribution);
+    // The enqueued value is now the opaque DATA item { notification, attribution } — NOT a
+    // thunk. The queue coalesces same-key items and hands the batch to runBatch → wakeBatch
+    // (wired in daemon.mjs); the router no longer invokes the waker directly.
+    expect(enqueued[0].item).toEqual({ notification: TASK_NOTIF, attribution });
   });
 
   it("ignores non-new_notification events and non-wake actions", async () => {
@@ -812,34 +963,122 @@ describe("EventRouter dispatch", () => {
     expect(seen.has("notif-1")).toBe(true);
   });
 
-  it("two same-direct-idea notifications do not spawn concurrently (serialized via the real queue)", async () => {
-    const queue = new WakeQueue({ logger: silent });
-    let concurrent = 0;
-    let maxConcurrent = 0;
+  it("coalesces same-key dispatches that pile up during a running batch into ONE wakeBatch → ONE subprocess", async () => {
+    // Router → queue → waker.wakeBatch integration (add-daemon-wake-coalescing §C1/§C4).
+    // The first batch is held open on a gate so later same-key dispatches pile up; when the
+    // slot frees they drain together into ONE coalesced batch (one subprocess, one prompt).
+    let started = 0;
+    let release;
+    const gate = new Promise((r) => (release = r));
+    const prompts = [];
     const spawner = {
-      wake: vi.fn(async ({ sessionId }) => {
-        concurrent++;
-        maxConcurrent = Math.max(maxConcurrent, concurrent);
-        await new Promise((r) => setTimeout(r, 5));
-        concurrent--;
+      wake: vi.fn(async ({ sessionId, prompt, onChild }) => {
+        started++;
+        prompts.push(prompt);
+        onChild?.({ pid: started, on: () => {}, kill: () => {} }); // fires the → running turn-advance
+        if (started === 1) await gate; // hold batch #1 open
         return { sessionId, exitCode: 0, isNew: true };
       }),
     };
-    // Both notifications resolve to the SAME direct idea → same key → serialized.
+    const advanceTurn = vi.fn(async () => {});
+    // All notifications resolve to the SAME direct idea → same key.
+    const { waker } = makeWaker({
+      spawner,
+      advanceTurn,
+      lineage: { resolve: async () => ({ rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA }) },
+    });
+    const queue = new WakeQueue({
+      logger: silent,
+      runBatch: (key, items) => waker.wakeBatch(items.map((i) => i.notification), key, items[0].attribution),
+    });
+    const notifA = { ...TASK_NOTIF, uuid: "a", entityUuid: "task-a" };
+    const notifB = { ...TASK_NOTIF, uuid: "b", entityUuid: "task-b" };
+    const notifC = { ...TASK_NOTIF, uuid: "c", entityUuid: "task-c" };
+    const { router } = makeRouter([notifA, notifB, notifC], waker, queue);
+
+    router.dispatch({ type: "new_notification", notificationUuid: "a" });
+    await new Promise((r) => setTimeout(r, 15)); // batch [a] is running, hanging on the gate
+    expect(spawner.wake).toHaveBeenCalledTimes(1);
+
+    // Two more same-key dispatches while [a] runs → they MUST coalesce into ONE batch.
+    router.dispatch({ type: "new_notification", notificationUuid: "b" });
+    router.dispatch({ type: "new_notification", notificationUuid: "c" });
+    await new Promise((r) => setTimeout(r, 15));
+    expect(spawner.wake).toHaveBeenCalledTimes(1); // still serialized — nothing new spawned
+
+    release();
+    await new Promise((r) => setTimeout(r, 15));
+    expect(spawner.wake).toHaveBeenCalledTimes(2); // [a], then the coalesced [b,c] — ONE more
+
+    // The coalesced batch's single prompt merged BOTH b and c under one backlog preamble.
+    const coalesced = prompts[1];
+    expect(coalesced).toContain("task-b");
+    expect(coalesced).toContain("task-c");
+    expect(coalesced).toContain("queued Chorus events");
+    // coalescedCount = 2 is reported on the coalesced batch's running edge (single wakes omit it).
+    const runningAdvances = advanceTurn.mock.calls.filter((c) => c[0].status === "running");
+    expect(runningAdvances.some((c) => c[0].coalescedCount === 2)).toBe(true);
+    expect(runningAdvances.filter((c) => "coalescedCount" in c[0])).toHaveLength(1); // only the batch of 2
+  });
+
+  it("a human_instruction and an autonomous wake for the same session land on one key and merge", async () => {
+    // Q3: chat backlog coalesces WITH autonomous events. A human_instruction (turn-keyed
+    // dispatch) and a mention (notification path) for the same session share the direct-idea
+    // key, so a held batch lets them pile up and drain together as one coalesced turn.
+    let started = 0;
+    let release;
+    const gate = new Promise((r) => (release = r));
+    const prompts = [];
+    const spawner = {
+      wake: vi.fn(async ({ sessionId, prompt }) => {
+        started++;
+        prompts.push(prompt);
+        if (started === 1) await gate;
+        return { sessionId, exitCode: 0, isNew: true };
+      }),
+    };
     const { waker } = makeWaker({
       spawner,
       lineage: { resolve: async () => ({ rootIdeaUuid: ROOT_IDEA, directIdeaUuid: DIRECT_IDEA }) },
     });
-    const notifA = { ...TASK_NOTIF, uuid: "a" };
-    const notifB = { ...TASK_NOTIF, uuid: "b" };
-    const { router } = makeRouter([notifA, notifB], waker, queue);
+    const queue = new WakeQueue({
+      logger: silent,
+      runBatch: (key, items) => waker.wakeBatch(items.map((i) => i.notification), key, items[0].attribution),
+    });
+    const mention = { ...TASK_NOTIF, uuid: "m1", action: "mentioned", entityType: "idea", entityUuid: DIRECT_IDEA, message: "hey look" };
+    const { router } = makeRouter([mention], waker, queue);
 
-    router.dispatch({ type: "new_notification", notificationUuid: "a" });
-    router.dispatch({ type: "new_notification", notificationUuid: "b" });
-    await new Promise((r) => setTimeout(r, 40));
+    // Batch #1 opens on a human_instruction and hangs on the gate.
+    router.dispatchPendingTurn({
+      turnUuid: "t-hold",
+      sessionId: DIRECT_IDEA,
+      directIdeaUuid: DIRECT_IDEA,
+      trigger: "human_instruction",
+      promptText: "first instruction (holds the slot)",
+    });
+    await new Promise((r) => setTimeout(r, 15));
+    expect(spawner.wake).toHaveBeenCalledTimes(1);
 
-    expect(spawner.wake).toHaveBeenCalledTimes(2);
-    expect(maxConcurrent).toBe(1); // same direct idea → never concurrent
+    // While it runs: a second human_instruction AND an autonomous mention, same session.
+    router.dispatchPendingTurn({
+      turnUuid: "t-2",
+      sessionId: DIRECT_IDEA,
+      directIdeaUuid: DIRECT_IDEA,
+      trigger: "human_instruction",
+      promptText: "deploy the retry fix now",
+    });
+    router.dispatch({ type: "new_notification", notificationUuid: "m1" });
+    await new Promise((r) => setTimeout(r, 15));
+    expect(spawner.wake).toHaveBeenCalledTimes(1); // both piled up on the same key
+
+    release();
+    await new Promise((r) => setTimeout(r, 15));
+    expect(spawner.wake).toHaveBeenCalledTimes(2); // ONE coalesced batch for the chat + mention
+
+    const merged = prompts[1];
+    expect(merged).toContain("deploy the retry fix now"); // human_instruction body, in full
+    expect(merged).toContain("hey look"); // the autonomous mention merged in
+    expect(merged).toContain("queued Chorus events"); // backlog preamble
   });
 
   it("dispatchResume stamps resumedFrom on the synthetic wake only for known reasons (add-crash-execution-resume)", async () => {

--- a/cli/__tests__/wake-queue.test.mjs
+++ b/cli/__tests__/wake-queue.test.mjs
@@ -1,7 +1,15 @@
 // cli/__tests__/wake-queue.test.mjs
-// Covers cli-daemon spec "Per-root-idea wake serialization" — the BLOCKER fix
-// from proposal review. Three scenarios: same-key serial, cross-key concurrent,
-// failed task doesn't wedge the key.
+// Covers cli-daemon spec "Per-root-idea wake serialization" + the coalescing
+// contract from design.md §C1 (daemon-wake-coalescing). The queue no longer runs
+// opaque thunks — it carries opaque DATA items and, when a key's slot frees,
+// drains the ENTIRE pending array for that key and calls a single
+// runBatch(key, items) callback (supplied at construction). Natural batching
+// only: NO debounce/collect timer, NO batch-size cap.
+//
+// Invariants under test: same-key serialization (next batch waits for the
+// current runBatch to settle), cross-key concurrency bounded by maxConcurrency,
+// coalescing (piled-up same-key items → one runBatch with all items),
+// poisoned-batch isolation, and drain()/stop() graceful shutdown.
 import { describe, it, expect } from "vitest";
 import { WakeQueue } from "../wake-queue.mjs";
 
@@ -12,176 +20,274 @@ function deferred() {
   return { promise, release: () => resolve() };
 }
 
+/** Flush the microtask queue only (NO macrotask/timer) — used to prove that
+ *  coalescing fires on slot-free without any debounce timer. */
+async function flushMicrotasks(n = 30) {
+  for (let i = 0; i < n; i++) await Promise.resolve();
+}
+
+/** Let both micro- and macro-tasks flush (a single timer tick). */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
 const silent = { info() {}, warn() {}, error() {} };
 
+describe("WakeQueue coalescing", () => {
+  it("coalesces same-key items that pile up during a running batch into ONE runBatch with all items", async () => {
+    const batches = [];
+    const firstStarted = deferred();
+    const gate = deferred(); // holds the first batch open so later items pile up
+    const q = new WakeQueue({
+      logger: silent,
+      runBatch: async (key, items) => {
+        batches.push({ key, items });
+        if (batches.length === 1) {
+          firstStarted.release();
+          await gate.promise;
+        }
+      },
+    });
+
+    // First enqueue claims the free slot immediately → batch of 1.
+    q.enqueue("K", { n: 1 });
+    await firstStarted.promise; // batch 1 is now in-flight, holding the key
+
+    // These arrive while batch 1 runs → they MUST coalesce into one batch.
+    q.enqueue("K", { n: 2 });
+    q.enqueue("K", { n: 3 });
+    q.enqueue("K", { n: 4 });
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0].items).toEqual([{ n: 1 }]);
+
+    gate.release(); // slot frees → drain [2,3,4] as ONE batch
+    await tick();
+
+    expect(batches).toHaveLength(2);
+    expect(batches[1].key).toBe("K");
+    expect(batches[1].items).toEqual([{ n: 2 }, { n: 3 }, { n: 4 }]);
+  });
+
+  it("coalesced batch fires on slot-free via microtasks only (no debounce timer)", async () => {
+    const sizes = [];
+    const gate = deferred();
+    const q = new WakeQueue({
+      logger: silent,
+      runBatch: async (_key, items) => {
+        sizes.push(items.length);
+        if (sizes.length === 1) await gate.promise;
+      },
+    });
+    q.enqueue("K", { n: 1 });
+    await flushMicrotasks();
+    q.enqueue("K", { n: 2 });
+    q.enqueue("K", { n: 3 });
+    gate.release();
+    await flushMicrotasks(); // NO setTimeout — only microtasks
+    expect(sizes).toEqual([1, 2]); // 2nd batch (size 2) ran with no timer gate
+  });
+
+  it("drains the entire pending array with no batch-size cap", async () => {
+    const sizes = [];
+    const gate = deferred();
+    const q = new WakeQueue({
+      maxConcurrency: 2,
+      logger: silent,
+      runBatch: async (_key, items) => {
+        sizes.push(items.length);
+        if (sizes.length === 1) await gate.promise;
+      },
+    });
+    q.enqueue("K", { n: 0 });
+    await tick();
+    for (let i = 1; i <= 100; i++) q.enqueue("K", { n: i });
+    gate.release();
+    await tick();
+    expect(sizes).toEqual([1, 100]); // all 100 piled-up items in ONE batch
+  });
+});
+
 describe("WakeQueue same-key serialization", () => {
-  it("runs two same-key tasks strictly sequentially (2nd waits for 1st)", async () => {
-    const q = new WakeQueue({ logger: silent });
-    const order = [];
-    const d1 = deferred();
-    const d2 = deferred();
-
-    q.enqueue("root-1", async () => {
-      order.push("start-1");
-      await d1.promise;
-      order.push("end-1");
-    });
-    q.enqueue("root-1", async () => {
-      order.push("start-2");
-      await d2.promise;
-      order.push("end-2");
+  it("does not start a key's next batch until the current batch's runBatch settles", async () => {
+    const events = [];
+    const gate1 = deferred();
+    const q = new WakeQueue({
+      logger: silent,
+      runBatch: async (_key, items) => {
+        const label = items.map((i) => i.n).join(",");
+        events.push(`start:${label}`);
+        if (items[0].n === 1) await gate1.promise;
+        events.push(`end:${label}`);
+      },
     });
 
-    // Let microtasks flush: only task 1 should have started.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(order).toEqual(["start-1"]);
+    q.enqueue("K", { n: 1 });
+    await tick(); // batch 1 in-flight, blocked on gate1
+    q.enqueue("K", { n: 2 });
+    q.enqueue("K", { n: 3 });
+    await tick();
+    expect(events).toEqual(["start:1"]); // batch 2 must NOT have started
 
-    // Finish task 1 → task 2 starts only now.
-    d1.release();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(order).toEqual(["start-1", "end-1", "start-2"]);
-
-    d2.release();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(order).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+    gate1.release();
+    await tick();
+    expect(events).toEqual(["start:1", "end:1", "start:2,3", "end:2,3"]);
   });
 });
 
 describe("WakeQueue cross-key concurrency", () => {
-  it("runs tasks for different keys concurrently", async () => {
-    const q = new WakeQueue({ maxConcurrency: 4, logger: silent });
+  it("runs batches for different keys concurrently", async () => {
     const started = [];
-    const dA = deferred();
-    const dB = deferred();
-
-    q.enqueue("root-A", async () => {
-      started.push("A");
-      await dA.promise;
-    });
-    q.enqueue("root-B", async () => {
-      started.push("B");
-      await dB.promise;
+    const gates = { A: deferred(), B: deferred() };
+    const q = new WakeQueue({
+      maxConcurrency: 4,
+      logger: silent,
+      runBatch: async (key) => {
+        started.push(key);
+        await gates[key].promise;
+      },
     });
 
-    await new Promise((r) => setTimeout(r, 0));
+    q.enqueue("A", {});
+    q.enqueue("B", {});
+    await tick();
     // Both started without either finishing → genuinely concurrent.
     expect(started.sort()).toEqual(["A", "B"]);
-    dA.release();
-    dB.release();
-    await new Promise((r) => setTimeout(r, 0));
+    gates.A.release();
+    gates.B.release();
+    await tick();
   });
 
   it("respects the global concurrency cap", async () => {
-    const q = new WakeQueue({ maxConcurrency: 2, logger: silent });
     let active = 0;
     let maxActive = 0;
-    const defs = [];
-    for (let i = 0; i < 5; i++) {
-      const d = deferred();
-      defs.push(d);
-      q.enqueue(`key-${i}`, async () => {
+    const gates = [];
+    const q = new WakeQueue({
+      maxConcurrency: 2,
+      logger: silent,
+      runBatch: async (_key, items) => {
         active++;
         maxActive = Math.max(maxActive, active);
-        await d.promise;
+        await items[0].gate.promise;
         active--;
-      });
+      },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      const d = deferred();
+      gates.push(d);
+      q.enqueue(`key-${i}`, { gate: d });
     }
-    await new Promise((r) => setTimeout(r, 0));
+    await tick();
     expect(maxActive).toBe(2); // never more than the cap at once
-    defs.forEach((d) => d.release());
-    await new Promise((r) => setTimeout(r, 0));
+    gates.forEach((d) => d.release());
+    await tick();
   });
 });
 
 describe("WakeQueue failure isolation", () => {
-  it("a throwing task is logged and the next same-key task still runs", async () => {
+  it("a throwing runBatch is logged and the key's next batch still runs", async () => {
     const warns = [];
-    const q = new WakeQueue({ logger: { ...silent, warn: (m) => warns.push(m) } });
     const ran = [];
-
-    q.enqueue("root-1", async () => {
-      ran.push("first");
-      throw new Error("boom");
+    const gate1 = deferred();
+    const q = new WakeQueue({
+      logger: { ...silent, warn: (m) => warns.push(m) },
+      runBatch: async (_key, items) => {
+        ran.push(items.map((i) => i.n));
+        if (items[0].n === 1) {
+          await gate1.promise;
+          throw new Error("boom");
+        }
+      },
     });
-    q.enqueue("root-1", async () => {
-      ran.push("second");
-    });
 
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ran).toEqual(["first", "second"]); // poisoned task didn't wedge the key
-    expect(warns.join("")).toMatch(/wake task for root-1 failed/);
+    q.enqueue("K", { n: 1 });
+    await tick(); // batch 1 in-flight
+    q.enqueue("K", { n: 2 }); // piles up while batch 1 runs
+    gate1.release();
+    await tick();
+
+    expect(ran).toEqual([[1], [2]]); // poisoned batch didn't wedge the key
+    expect(warns.join("")).toMatch(/wake batch for K failed/);
   });
 });
 
 describe("WakeQueue enqueue is non-blocking", () => {
-  it("enqueue returns synchronously before the task runs", async () => {
-    const q = new WakeQueue({ logger: silent });
+  it("enqueue returns synchronously before runBatch runs", async () => {
     let ran = false;
-    q.enqueue("k", async () => {
-      ran = true;
+    const q = new WakeQueue({
+      logger: silent,
+      runBatch: async () => {
+        ran = true;
+      },
     });
-    // Synchronously after enqueue, the task has not run yet.
+    q.enqueue("k", {});
+    // Synchronously after enqueue, the batch has not run yet.
     expect(ran).toBe(false);
-    await new Promise((r) => setTimeout(r, 0));
+    await tick();
     expect(ran).toBe(true);
   });
 });
 
 describe("WakeQueue graceful shutdown (stop + drain)", () => {
-  it("stop() prevents queued-but-unstarted tasks from ever starting", async () => {
-    const q = new WakeQueue({ maxConcurrency: 1, logger: silent });
-    const d1 = deferred();
+  it("stop() prevents queued-but-unstarted batches from ever starting", async () => {
     const order = [];
-
-    q.enqueue("k1", async () => {
-      order.push("start-1");
-      await d1.promise;
-      order.push("end-1");
+    const gate1 = deferred();
+    const q = new WakeQueue({
+      maxConcurrency: 1,
+      logger: silent,
+      runBatch: async (key) => {
+        order.push(`start:${key}`);
+        if (key === "k1") await gate1.promise;
+        order.push(`end:${key}`);
+      },
     });
-    q.enqueue("k2", async () => {
-      order.push("start-2");
-    });
 
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(order).toEqual(["start-1"]); // k2 waits on the concurrency slot
+    q.enqueue("k1", {});
+    q.enqueue("k2", {});
+    await tick();
+    expect(order).toEqual(["start:k1"]); // k2 waits on the concurrency slot
 
     q.stop(); // shutdown begins — k2 must never start
-    d1.release();
+    gate1.release();
     await new Promise((r) => setTimeout(r, 10));
-    expect(order).toEqual(["start-1", "end-1"]);
+    expect(order).toEqual(["start:k1", "end:k1"]);
   });
 
-  it("drain resolves true once in-flight tasks finish (pending ones don't block it)", async () => {
-    const q = new WakeQueue({ maxConcurrency: 1, logger: silent });
-    const d1 = deferred();
-    q.enqueue("k1", async () => {
-      await d1.promise;
+  it("drain resolves true once in-flight batches finish (pending ones don't block it)", async () => {
+    const gate1 = deferred();
+    const q = new WakeQueue({
+      maxConcurrency: 1,
+      logger: silent,
+      runBatch: async (key) => {
+        if (key === "k1") await gate1.promise;
+      },
     });
-    q.enqueue("k2", async () => {}); // queued, never starts after stop()
-    await Promise.resolve();
+    q.enqueue("k1", {});
+    q.enqueue("k2", {}); // queued, never starts after stop()
+    await tick();
     q.stop();
 
     const drainP = q.drain(2_000);
-    d1.release();
+    gate1.release();
     await expect(drainP).resolves.toBe(true);
   });
 
-  it("drain resolves false when an in-flight task outlives the bound (shutdown never hangs)", async () => {
-    const q = new WakeQueue({ logger: silent });
-    const never = deferred(); // task that never finishes (unkillable wake)
-    q.enqueue("k1", async () => {
-      await never.promise;
+  it("drain resolves false when an in-flight batch outlives the bound (shutdown never hangs)", async () => {
+    const never = deferred(); // batch that never finishes (unkillable wake)
+    const q = new WakeQueue({
+      logger: silent,
+      runBatch: async () => {
+        await never.promise;
+      },
     });
-    await Promise.resolve();
+    q.enqueue("k1", {});
+    await tick();
 
     await expect(q.drain(120)).resolves.toBe(false);
     never.release(); // cleanup
   });
 
   it("drain on an idle queue resolves true immediately", async () => {
-    const q = new WakeQueue({ logger: silent });
+    const q = new WakeQueue({ logger: silent, runBatch: async () => {} });
     await expect(q.drain(0)).resolves.toBe(true);
   });
 });

--- a/cli/daemon-rest-client.mjs
+++ b/cli/daemon-rest-client.mjs
@@ -7,7 +7,8 @@
 // The five operations and their EXACT server payload shapes (verified against
 // src/app/api/daemon/*/route.ts — the server is NOT changed by this work):
 //   turnAdvance      → POST /api/daemon/turn-advance
-//                      { connectionUuid, sessionId, status, entityType?, entityUuid? }
+//                      { connectionUuid, sessionId, status, entityType?, entityUuid?,
+//                        coalescedCount? }
 //   transcript       → POST /api/daemon/transcript
 //                      { sessionId, messages: [{ role, text }] }
 //   executionState   → POST /api/daemon/execution-state
@@ -70,7 +71,7 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
  *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
  * }} opts
  * @returns {{
- *   turnAdvance: (p: { sessionId: string, backendSessionId?: string|null, status: string, entityType?: string|null, entityUuid?: string|null }) => Promise<DaemonRestResult>,
+ *   turnAdvance: (p: { sessionId: string, backendSessionId?: string|null, status: string, entityType?: string|null, entityUuid?: string|null, coalescedCount?: number }) => Promise<DaemonRestResult>,
  *   transcript: (p: { sessionId: string, messages: Array<{ role: string, text: string }> }) => Promise<DaemonRestResult>,
  *   executionState: (p: { executions: Array<Record<string, unknown>> }) => Promise<DaemonRestResult>,
  *   reportInterrupt: (p: { entityType: string, entityUuid: string, reason: string }) => Promise<DaemonRestResult>,
@@ -147,7 +148,7 @@ export function createDaemonRestClient(opts) {
      * the turn's usage. Both ride the terminal edge only. Requires the connectionUuid (the
      * server addresses the turn against a connection the agent owns).
      */
-    async turnAdvance({ sessionId, status, entityType, entityUuid, interruptedReason, transcriptRelayError, usage, backendSessionId }) {
+    async turnAdvance({ sessionId, status, entityType, entityUuid, interruptedReason, transcriptRelayError, usage, backendSessionId, coalescedCount }) {
       const connectionUuid = getConnectionUuid();
       if (!connectionUuid) {
         const error = `cannot advance turn for session ${sessionId} → ${status} — no connection uuid yet`;
@@ -173,6 +174,13 @@ export function createDaemonRestClient(opts) {
         // The whole normalized TokenUsage object, nested under `usage`, only on a terminal edge.
         ...(usage && isTerminal ? { usage } : {}),
         ...(backendSessionId && isTerminal ? { backendSessionId } : {}),
+        // Coalesced-wake count (add-daemon-wake-coalescing): meaningful ONLY on the → running
+        // edge, where the server settles the next (count − 1) same-session pending turns to
+        // `merged`. Sent only when a real batch coalesced (> 1); a single wake (default 1)
+        // omits it so the wire — and every existing turn-advance test — stays byte-identical.
+        ...(status === "running" && typeof coalescedCount === "number" && coalescedCount > 1
+          ? { coalescedCount }
+          : {}),
       };
       return post(
         "turn-advance",

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -8,6 +8,12 @@
 // so a human can `claude --resume <idea-uuid>`); new-vs-resume is decided by
 // probing the on-disk transcript — there is no persisted session-id map.
 //
+// Wake coalescing (add-daemon-wake-coalescing): the WakeQueue is PER-CONNECTION
+// and serializes per DIRECT idea (= per session). Wakes that pile up on the same
+// key while a turn runs are drained together and delivered as ONE batch — a
+// single runBatch → waker.wakeBatch → one `claude --resume` turn — so N
+// same-session queued wakes coalesce into one turn, never N sequential turns.
+//
 // Connection / session / transcript reporting to the server is intentionally
 // NOT done here — the no-op UploadHooks reserve those seams for the derived
 // observability idea.
@@ -147,10 +153,7 @@ export function buildDaemon(creds, deps = {}) {
   // passed through so the Codex backend can export the daemon key into the woken
   // process env (the Claude backend ignores creds — it gets its key via --mcp-config).
   const spawner = deps.spawner ?? selectSpawner(agentType, { logger, permissionMode, creds });
-  // The WakeQueue serializes per DIRECT idea (keyFor's key). It is shared across all
-  // path-connections: serialization-per-idea still holds, and maxConcurrency caps the
-  // whole process's in-flight wakes rather than per-cwd — the right global budget.
-  const queue = new WakeQueue({ maxConcurrency: deps.maxConcurrency ?? 4, logger });
+  const maxConcurrency = deps.maxConcurrency ?? 4;
 
   // ===== Multi-path: the SET of cwds this daemon serves (T3 — FR-5) =====
   // Each declared path becomes one INDEPENDENT connection (own SSE self-report + own
@@ -338,6 +341,11 @@ export function buildDaemon(creds, deps = {}) {
         selectWaker(notification).markQueued(notification, key, attribution),
       wake: (notification, key, attribution) =>
         selectWaker(notification).wake(notification, key, attribution),
+      // Coalesced batch (add-daemon-wake-coalescing): every item shares the key → the same
+      // session → the same cwd (a session's cwd is pinned), so route the whole batch to the
+      // waker selected by the first item's runtimeCwd.
+      wakeBatch: (notifications, key, attribution) =>
+        selectWaker(notifications[0]).wakeBatch(notifications, key, attribution),
       markInterrupting(entityType, entityUuid) {
         for (const candidate of runtimeWakers.values()) {
           if (candidate.executions.has(`${entityType}:${entityUuid}`)) {
@@ -351,6 +359,19 @@ export function buildDaemon(creds, deps = {}) {
       buildExecutionSnapshot: () =>
         [...runtimeWakers.values()].flatMap((candidate) => candidate.buildExecutionSnapshot()),
     };
+    // The WakeQueue serializes per DIRECT idea (keyFor's key) and coalesces same-key pending
+    // wakes into one batch (add-daemon-wake-coalescing §C1/§C4). It is PER-CONNECTION so the
+    // batch runs on THIS connection's own waker facade — the runBatch drains the per-key data
+    // items { notification, attribution } and hands the whole batch to waker.wakeBatch (all
+    // items on one key share the session anchor, so items[0].attribution is the batch
+    // attribution). maxConcurrency caps this connection's in-flight batches.
+    const queue = new WakeQueue({
+      maxConcurrency,
+      logger,
+      runBatch: (key, items) =>
+        waker.wakeBatch(items.map((i) => i.notification), key, items[0].attribution),
+    });
+
     // The router reads THIS connection's own uuid lazily (same source the control handler
     // uses) to suppress a DIRECTED (pinned) wake stamped for a different connection
     // (fix-pinned-wake-directed-delivery, T2). Null until the SSE handshake assigns it — a
@@ -483,6 +504,7 @@ export function buildDaemon(creds, deps = {}) {
       connectionState,
       waker,
       runtimeWakers,
+      queue,
       router,
       backfill,
       sseListener,
@@ -501,9 +523,11 @@ export function buildDaemon(creds, deps = {}) {
     mcpClient,
     lineage,
     spawner,
-    queue,
     // Back-compat single-connection aliases (the common single-path case). The full
-    // set is exposed as `connections` for multi-path inspection/tests.
+    // set is exposed as `connections` for multi-path inspection/tests. The WakeQueue is
+    // now per-connection (add-daemon-wake-coalescing) so its runBatch can run on the right
+    // connection's waker facade; the primary connection's queue is aliased here.
+    queue: primary.queue,
     waker: primary.waker,
     router: primary.router,
     sseListener: primary.sseListener,
@@ -526,8 +550,10 @@ export function buildDaemon(creds, deps = {}) {
       //    and latch the queue (queued-but-unstarted wakes never spawn).
       for (const c of connections) {
         c.sseListener.disconnect?.();
+        // Latch each connection's OWN queue (queues are per-connection now — add-daemon-
+        // wake-coalescing) so queued-but-unstarted wakes never spawn.
+        c.queue?.stop?.();
       }
-      queue.stop();
       // 2. Interrupt every in-flight wake subprocess via the shared kill escalation.
       //    Each wake's exit path — seeing shuttingDown — reports its turn
       //    interrupted(shutdown) and suppresses the execution crash report.
@@ -538,7 +564,11 @@ export function buildDaemon(creds, deps = {}) {
       //    the kill escalation window plus a hard 5s cap for the exit path's REST
       //    reports. A wake that outlives this does NOT hang the shutdown — its
       //    orphaned turn is the server-side offline reconcile's job (the backstop).
-      const drained = await queue.drain(sigintTimeoutMs + 5_000);
+      //    Drain every connection's queue in parallel; `drained` is true only if all did.
+      const drainResults = await Promise.all(
+        connections.map((c) => c.queue?.drain?.(sigintTimeoutMs + 5_000) ?? true),
+      );
+      const drained = drainResults.every(Boolean);
       if (!drained) {
         logger.warn(
           "[Chorus] shutdown: in-flight wake(s) did not finish within the bound — exiting anyway (server reconcile will finalize their turns)",

--- a/cli/event-router.mjs
+++ b/cli/event-router.mjs
@@ -37,8 +37,8 @@ export class EventRouter {
   /**
    * @param {{
    *   mcpClient: { callTool: (name: string, args?: Record<string, unknown>) => Promise<any> },
-   *   waker: { keyFor: (n: any) => Promise<{ key: string, rootIdeaUuid: string|null, directIdeaUuid: string|null }>, wake: (n: any, key: string, attribution?: any) => Promise<void>, markQueued?: (n: any, key: string, attribution?: any) => void },
-   *   queue: { enqueue: (key: string, task: () => Promise<void>) => void },
+   *   waker: { keyFor: (n: any) => Promise<{ key: string, rootIdeaUuid: string|null, directIdeaUuid: string|null }>, wakeBatch: (ns: any[], key: string, attribution?: any) => Promise<void>, markQueued?: (n: any, key: string, attribution?: any) => void },
+   *   queue: { enqueue: (key: string, item: { notification: any, attribution: any }) => void },
    *   wakeActions: Set<string>,
    *   getConnectionUuid?: () => (string|null),  This daemon's registered connection uuid
    *                                             (null until the SSE handshake reports it).
@@ -383,7 +383,10 @@ export class EventRouter {
     } catch (err) {
       this.logger.warn(`[Chorus] markQueued failed for pending turn ${turnUuid}: ${err}`);
     }
-    this.queue.enqueue(key, () => this.waker.wake(n, key, attribution));
+    // Enqueue an opaque DATA payload (add-daemon-wake-coalescing §C4), NOT a thunk: the
+    // queue coalesces all same-key pending items and hands the whole batch to its runBatch
+    // (wired to waker.wakeBatch in daemon.mjs). markQueued was already called per-item above.
+    this.queue.enqueue(key, { notification: n, attribution });
   }
 
   /**
@@ -531,6 +534,9 @@ export class EventRouter {
     } catch (err) {
       this.logger.warn(`[Chorus] markQueued failed for ${label}: ${err}`);
     }
-    this.queue.enqueue(key, () => this.waker.wake(n, key, attribution));
+    // Enqueue an opaque DATA payload (add-daemon-wake-coalescing §C4), NOT a thunk: the
+    // queue coalesces all same-key pending items and hands the whole batch to its runBatch
+    // (wired to waker.wakeBatch in daemon.mjs). markQueued was already called per-item above.
+    this.queue.enqueue(key, { notification: n, attribution });
   }
 }

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -100,6 +100,96 @@ export function buildPrompt(n) {
 }
 
 /**
+ * Build ONE combined wake prompt for a coalesced batch of same-session notifications
+ * (add-daemon-wake-coalescing, tech design §C2). The daemon serializes wakes per session
+ * key; while a turn runs, later same-key wakes pile up and — when the slot frees — are
+ * drained together into a single `claude --resume` turn. This composes their one prompt.
+ *
+ * Rules:
+ *  - **Size 1** → delegate to `buildPrompt(n)` verbatim, so the single-event path is
+ *    BYTE-IDENTICAL to today (and all current prompt tests keep passing). This is keyed on
+ *    the count of RENDERABLE events (non-null body): a batch that reduces to a single
+ *    renderable event — e.g. a real wake plus an empty `human_instruction` — also takes
+ *    the single-event path.
+ *  - **Size > 1 renderable** → `HEADLESS_PREAMBLE` ONCE (it is a per-turn guard, paid once
+ *    per turn, not per event), then a short backlog preamble, then one labeled block per
+ *    event in ARRIVAL order, each block being the reused per-action `buildPromptBody(n)` so
+ *    every event keeps its own tool hints and @mention guidance.
+ *  - **Same-entity collapse (Q2)**: events sharing `(action, entityUuid)` collapse into one
+ *    block at the group's FIRST-SEEN position, noting the occurrence count and showing the
+ *    NEWEST message. This is safe only because such actions' full content is re-derivable
+ *    server-side (comments via chorus_get_comments, task lifecycle via chorus_get_*).
+ *  - **`human_instruction` is NEVER collapsed (Q3, Round-1 BLOCKER-2)**: every queued chat
+ *    message carries `action=human_instruction` and `entityUuid=directIdeaUuid`, and its
+ *    text lives ONLY on the turn/notification (not re-fetchable), so collapsing to
+ *    newest-only would silently drop earlier chat and defeat the feature. Each renders its
+ *    full body as its own block, in arrival order.
+ *  - Events whose body is null (empty `human_instruction`, non-wake action) are omitted; a
+ *    batch with no renderable event returns null (the router then spawns nothing).
+ *
+ * @param {NotificationDetail[]} notifications  Arrival-ordered batch (FIFO drain order).
+ * @returns {string | null}
+ */
+export function buildBatchPrompt(notifications) {
+  if (!Array.isArray(notifications) || notifications.length === 0) return null;
+
+  // Keep only events with a renderable per-action body, in arrival order.
+  const items = [];
+  for (const n of notifications) {
+    const body = buildPromptBody(n);
+    if (body != null) items.push({ n, body });
+  }
+  if (items.length === 0) return null;
+  // One renderable event → byte-identical single-event prompt (delegates to buildPrompt so
+  // the exact "PREAMBLE\n\nbody" shape is preserved). Covers a true batch of size 1 and a
+  // batch that reduced to one renderable event after null-body events were dropped.
+  if (items.length === 1) return buildPrompt(items[0].n);
+
+  // Group into ordered blocks. Collapsible actions merge by (action, entityUuid) at their
+  // first-seen slot; human_instruction is exempt and always gets its own block.
+  const blocks = [];
+  const collapseIndex = new Map(); // "action::entityUuid" -> index into `blocks`
+  for (const { n, body } of items) {
+    if (n.action === "human_instruction") {
+      blocks.push({ notif: n, body, count: 1 });
+      continue;
+    }
+    const groupKey = `${n.action}::${n.entityUuid ?? ""}`;
+    const existing = collapseIndex.get(groupKey);
+    if (existing != null) {
+      const g = blocks[existing];
+      g.count += 1;
+      g.notif = n; // newest wins (arrival order → last member is newest)
+      g.body = body; // newest body
+    } else {
+      collapseIndex.set(groupKey, blocks.length);
+      blocks.push({ notif: n, body, count: 1 });
+    }
+  }
+
+  // Backlog preamble. N = number of renderable events that arrived (not the collapsed block
+  // count) — collapse is a rendering optimization; each collapsed block states its own count.
+  const backlogPreamble =
+    `You have ${items.length} queued Chorus events on this session that arrived while you ` +
+    `were busy — handle them together, in order; each is labeled with its type below.`;
+
+  const rendered = blocks.map((g, idx) => {
+    const n = g.notif;
+    const entityType = n.entityType || "session";
+    const entityUuid = n.entityUuid || "";
+    const header = `### Event ${idx + 1} — ${n.action} on ${entityType} ${entityUuid}`.replace(/\s+$/, "");
+    const collapseNote =
+      g.count > 1
+        ? `\n(${g.count} ${n.action} events on this ${entityType} arrived — showing the newest ` +
+          `below; earlier ones are re-derivable via the entity's own chorus_get_* tools.)`
+        : "";
+    return `${header}${collapseNote}\n\n${g.body}`;
+  });
+
+  return [HEADLESS_PREAMBLE, backlogPreamble, ...rendered].join("\n\n");
+}
+
+/**
  * The per-action wake body (without the headless preamble). Mirrors the OpenClaw
  * event-router handlers; returns null for actions that have no wake.
  * @param {NotificationDetail} n

--- a/cli/turn-reporter.mjs
+++ b/cli/turn-reporter.mjs
@@ -52,7 +52,7 @@ export const TURN_INTERRUPT_REASONS = new Set([
  *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
  *   fetchImpl?: typeof fetch,             Injectable for tests.
  * }} opts
- * @returns {(params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown"|"invalid_path"|null, transcriptRelayError?: string|null, usage?: import("./upload-hooks.mjs").TokenUsage|null }) => Promise<void>}
+ * @returns {(params: { sessionId: string, status: "running"|"ended"|"interrupted", entityType?: string|null, entityUuid?: string|null, interruptedReason?: "user"|"crash"|"shutdown"|"invalid_path"|null, transcriptRelayError?: string|null, usage?: import("./upload-hooks.mjs").TokenUsage|null, coalescedCount?: number }) => Promise<void>}
  */
 export function createTurnReporter(opts) {
   const logger = opts.logger ?? NOOP_LOGGER;
@@ -76,6 +76,7 @@ export function createTurnReporter(opts) {
     transcriptRelayError,
     usage,
     backendSessionId,
+    coalescedCount,
   }) {
     if (typeof sessionId !== "string" || !sessionId || !TURN_STATUSES.has(status)) {
       logger.warn(
@@ -111,6 +112,9 @@ export function createTurnReporter(opts) {
       // only on a terminal edge. No validation here — usage is an opaque nested object.
       usage,
       backendSessionId,
+      // Coalesced-wake count (add-daemon-wake-coalescing): threaded straight through; the
+      // client sends it only on the → running edge and only when > 1 (a single wake omits it).
+      coalescedCount,
     });
   };
 }

--- a/cli/wake-queue.mjs
+++ b/cli/wake-queue.mjs
@@ -1,14 +1,22 @@
 // cli/wake-queue.mjs
-// Per-key FIFO scheduler with a global concurrency cap. This is what makes the
-// idea_root session anchor safe (cli-daemon spec "Per-root-idea wake
-// serialization", design.md "Concurrency model"):
-//   • within one key (root idea) → strictly serial, FIFO. The 2nd wake waits
-//     for the 1st subprocess to exit, so we never run two
+// Per-key FIFO scheduler with a global concurrency cap, coalescing same-key
+// wakes into batches. This is what makes the idea_root session anchor safe
+// (cli-daemon spec "Per-root-idea wake serialization", design.md "Concurrency
+// model") AND implements daemon-wake-coalescing (design.md §C1):
+//   • within one key (root idea) → strictly serial, FIFO. The next batch waits
+//     for the current runBatch to settle, so we never run two
 //     `claude --resume <sameSessionId>` against one session.
+//   • coalescing: when a key's slot frees, the ENTIRE pending array for that key
+//     is drained (splice) and delivered to runBatch ONCE as a single batch. So
+//     N events that pile up while the previous turn runs become ONE turn.
+//     Natural batching only — NO debounce/collect timer, NO batch-size cap.
 //   • across keys → concurrent, bounded by maxConcurrency.
 //   • enqueue() returns immediately — never blocks the SSE loop.
-//   • a task that throws is logged and the next task for that key proceeds (a
-//     poisoned wake must not wedge the key's queue forever).
+//   • a batch whose runBatch throws is logged and the next batch for that key
+//     proceeds (a poisoned wake must not wedge the key's queue forever).
+// The queue carries opaque DATA items (the router passes `{ notification,
+// attribution }`); it never introspects them — the runBatch callback (supplied
+// at construction, wired to waker.wakeBatch in daemon.mjs) does.
 // Plain ESM, zero deps, in-memory.
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
@@ -18,41 +26,49 @@ export class WakeQueue {
    * @param {{
    *   maxConcurrency?: number,
    *   logger?: { info(m:string):void, warn(m:string):void, error(m:string):void },
+   *   runBatch?: (key: string, items: any[]) => Promise<void>,
    * }} [opts]
    */
   constructor(opts = {}) {
     this.maxConcurrency = opts.maxConcurrency ?? 4;
     this.logger = opts.logger ?? NOOP_LOGGER;
-    /** @type {Map<string, Array<() => Promise<void>>>} pending tasks per key. */
+    // The batch runner: called ONCE per drained batch with every pending item
+    // for the key. Defaults to a no-op so an unwired queue never throws (the
+    // daemon always supplies the real waker.wakeBatch runner).
+    this.runBatch = opts.runBatch ?? (async () => {});
+    /** @type {Map<string, any[]>} pending data items per key. */
     this.pending = new Map();
-    /** @type {Set<string>} keys with a task currently running. */
+    /** @type {Set<string>} keys with a batch currently running. */
     this.running = new Set();
     /** @type {string[]} keys waiting for a global concurrency slot. */
     this.readyKeys = [];
     this.activeCount = 0;
-    // Graceful-shutdown latch: once set, #pump starts NOTHING new — in-flight tasks
-    // finish (drain observes them) but queued work stays queued and dies with the
-    // process. Never cleared; a stopping queue is on its way out.
+    // Graceful-shutdown latch: once set, #pump starts NOTHING new — in-flight
+    // batches finish (drain observes them) but queued work stays queued and dies
+    // with the process. Never cleared; a stopping queue is on its way out.
     this.stopped = false;
   }
 
-  /** Stop starting new tasks (graceful shutdown). In-flight tasks are unaffected. */
+  /** Stop starting new batches (graceful shutdown). In-flight batches are unaffected. */
   stop() {
     this.stopped = true;
   }
 
   /**
-   * Enqueue a wake task under a key. Returns immediately. The task is a thunk
-   * returning a promise (the actual wake). Same key → serialized; different
-   * keys → concurrent up to maxConcurrency.
+   * Enqueue an opaque data item under a key. Returns immediately. Items on the
+   * same key coalesce: while a key's batch runs, later items pile up and are
+   * drained together as ONE batch when the slot frees. Different keys run
+   * concurrently up to maxConcurrency.
    * @param {string} key
-   * @param {() => Promise<void>} task
+   * @param {any} item  opaque data (e.g. `{ notification, attribution }`)
    */
-  enqueue(key, task) {
+  enqueue(key, item) {
     if (!this.pending.has(key)) this.pending.set(key, []);
-    this.pending.get(key).push(task);
+    this.pending.get(key).push(item);
     // A key becomes "ready" to claim a global slot only when it's not already
-    // running (serial-per-key) and not already queued for a slot.
+    // running (serial-per-key) and not already queued for a slot. While it IS
+    // running, later items simply accumulate in `pending` and are picked up by
+    // the next batch — this is where coalescing happens.
     if (!this.running.has(key) && !this.readyKeys.includes(key)) {
       this.readyKeys.push(key);
     }
@@ -65,7 +81,7 @@ export class WakeQueue {
   }
 
   /**
-   * Snapshot of the keys with a task currently running (observability read).
+   * Snapshot of the keys with a batch currently running (observability read).
    * Returns a fresh array so a caller can't mutate the internal Set.
    * @returns {string[]}
    */
@@ -74,7 +90,7 @@ export class WakeQueue {
   }
 
   /**
-   * Snapshot of the keys that have at least one task still waiting to run —
+   * Snapshot of the keys that have at least one item still waiting to run —
    * i.e. enqueued but not yet started (observability read). A key that is
    * currently running with no further queued work is NOT pending. Returns a
    * fresh array so a caller can't mutate internal state.
@@ -85,13 +101,13 @@ export class WakeQueue {
   }
 
   /**
-   * Wait (bounded) for every in-flight task to finish — the graceful-shutdown drain
+   * Wait (bounded) for every in-flight batch to finish — the graceful-shutdown drain
    * (fix-daemon-exit-orphan-running-turn). Resolves `true` when the queue went idle
-   * (no active task) within `timeoutMs`, `false` on timeout — the caller exits
+   * (no active batch) within `timeoutMs`, `false` on timeout — the caller exits
    * anyway and leaves the rest to the server-side reconcile backstop. Pending
-   * (not-yet-started) tasks are NOT waited for: a shutting-down daemon stops
+   * (not-yet-started) items are NOT waited for: a shutting-down daemon stops
    * starting new work, so only the in-flight subprocesses (and their exit reports)
-   * matter. Polling (50ms) keeps this zero-dep and independent of task internals.
+   * matter. Polling (50ms) keeps this zero-dep and independent of batch internals.
    * @param {number} timeoutMs
    * @returns {Promise<boolean>}
    */
@@ -112,33 +128,39 @@ export class WakeQueue {
       if (this.running.has(key)) continue; // already running under another slot
       const queue = this.pending.get(key);
       if (!queue || queue.length === 0) continue;
-      this.#runNext(key);
+      this.#startBatch(key);
     }
   }
 
-  /** Run the next task for a key, then chain to the following one. */
-  #runNext(key) {
+  /**
+   * Drain the ENTIRE pending array for a key into one batch and run it, then
+   * chain to the following batch. No batch-size cap (design.md §C1, Q7).
+   */
+  #startBatch(key) {
     const queue = this.pending.get(key);
     if (!queue || queue.length === 0) {
       this.running.delete(key);
       return;
     }
-    const task = queue.shift();
+    // Coalesce: take everything pending for this key right now as one batch.
+    // Items that arrive after this splice accumulate for the NEXT batch.
+    const items = queue.splice(0);
     this.running.add(key);
     this.activeCount++;
 
     Promise.resolve()
-      .then(task)
+      .then(() => this.runBatch(key, items))
       .catch((err) => {
-        // Poisoned wake: log, do NOT let it wedge the key's queue.
-        this.logger.warn(`[Chorus] wake task for ${key} failed: ${err}`);
+        // Poisoned batch: log, do NOT let it wedge the key's queue.
+        this.logger.warn(`[Chorus] wake batch for ${key} failed: ${err}`);
       })
       .finally(() => {
         this.activeCount--;
         const remaining = this.pending.get(key);
         if (remaining && remaining.length > 0) {
-          // Same key still has work → it must run serially. Re-mark ready;
-          // #pump will pick it up (respecting the global cap).
+          // Same key accumulated more work while this batch ran → it must run
+          // serially as the next batch. Re-mark ready; #pump will pick it up
+          // (respecting the global cap).
           if (!this.readyKeys.includes(key)) this.readyKeys.push(key);
           this.running.delete(key); // free the key so #pump can re-claim it
         } else {

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -12,11 +12,14 @@
 // the server-resolved root, NEVER re-derived from the (direct-idea) serialization
 // key.
 //
-// Module contract (design.md): Waker.wake(notification, key, attribution) →
-// Promise<void>. A failure is logged and swallowed — it must never crash the
-// daemon (no-silent-errors: visible log, no throw).
+// Module contract (design.md): Waker.wakeBatch(notifications, key, attribution) →
+// Promise<void> runs ONE coalesced turn for a batch of same-session notifications
+// (add-daemon-wake-coalescing); Waker.wake(n, key, attribution) is a thin wrapper =
+// wakeBatch([n], ...) so a batch of one is byte-identical to the pre-coalescing single
+// wake. A failure is logged and swallowed — it must never crash the daemon
+// (no-silent-errors: visible log, no throw).
 
-import { buildPrompt } from "./prompts.mjs";
+import { buildBatchPrompt } from "./prompts.mjs";
 import { writeMcpConfig } from "./mcp-config.mjs";
 import { isNewSession } from "./claude-spawner.mjs";
 import { killProcessTree, DEFAULT_SIGINT_TIMEOUT_MS } from "./process-killer.mjs";
@@ -320,49 +323,122 @@ export class Waker {
   }
 
   /**
-   * Run one wake. Never throws.
+   * Run one wake. Never throws. Thin wrapper over {@link wakeBatch} with a batch of one,
+   * so a single wake is byte-identical to the pre-coalescing behavior (prompt, execution
+   * row, turn accounting, coalescedCount = 1).
    * @param {import("./prompts.mjs").NotificationDetail} notification
    * @param {string} key  The serialization key (from keyFor) — anchored on the direct idea.
    * @param {{ rootIdeaUuid?: string|null, directIdeaUuid?: string|null }} [attribution]
-   *   Server-resolved ids from keyFor. `rootIdeaUuid` → execution snapshot;
-   *   `directIdeaUuid` → the deterministic Claude session id (when the entity has
-   *   an idea ancestor). When there is no direct idea, the session is anchored on
-   *   the entity's own uuid instead (see below).
    */
   async wake(notification, key, attribution) {
+    return this.wakeBatch([notification], key, attribution);
+  }
+
+  /**
+   * Run ONE coalesced turn for a batch of same-session notifications
+   * (add-daemon-wake-coalescing, Tech Design §C3). The WakeQueue drains all same-key
+   * pending wakes and hands them here as one batch; this composes their single combined
+   * prompt (buildBatchPrompt), spawns ONE subprocess (one `claude --resume <anchor>`), and
+   * accounts for the whole thing as ONE running turn. Never throws.
+   *
+   * A batch of ONE is byte-identical to the pre-coalescing single wake: `buildBatchPrompt`
+   * delegates to `buildPrompt`, the execution row + turn-advance carry the item's OWN
+   * entity, and `coalescedCount = 1` (so the wire is unchanged).
+   *
+   * Execution snapshot (Q6): a coalesced batch (> 1) is anchored on the SESSION, so it emits
+   * ONE running row synthesized from `attribution` — `idea:<directIdeaUuid>` (NOT necessarily
+   * one of the merged items — a batch of mentions on child tasks A+B under idea D has no
+   * `idea:D` item, yet the anchor IS `idea:D`), else the ad-hoc entity. Every drained/merged
+   * resource is removed from the executions map so the server reconcile ends its queued row.
+   *
+   * @param {import("./prompts.mjs").NotificationDetail[]} notifications  Arrival-ordered batch.
+   * @param {string} key  The serialization key (from keyFor) — shared by every item.
+   * @param {{ rootIdeaUuid?: string|null, directIdeaUuid?: string|null }} [attribution]
+   *   Server-resolved ids (shared across the batch — the key IS `idea:<directIdeaUuid>`, so
+   *   all items carry the same ids). `rootIdeaUuid` → snapshot; `directIdeaUuid` → session anchor.
+   */
+  async wakeBatch(notifications, key, attribution) {
     let cfg;
-    const entity = this.#entityOf(notification);
-    const execKey = entity ? this.#execKey(entity.entityType, entity.entityUuid) : null;
+    const list = Array.isArray(notifications) ? notifications : [];
+    // Physical batch size — how many wakes were coalesced into this one turn. Drives the
+    // session-anchor synthesis (a coalesced batch shows ONE synthesized idea row) and the
+    // arrival log label. Independent of the wire count below.
+    const batchSize = list.length;
+    // The number of coalesced wakes reported to the server on the running-transition so it can
+    // settle the next (coalescedCount − 1) same-session pending turns. Counted as ONLY the
+    // TURN-BACKED items: each notification-backed wake created a server-side pending
+    // DaemonSessionTurn at the chokepoint, so those are the turns the server can settle.
+    //
+    // A synthetic `resource_resumed` (子3 control-channel resume) is EXCLUDED: it is NEVER a
+    // persisted notification and creates NO server pending turn (src/services/notification-turn.ts
+    // deliberately omits it from the trigger map), so counting it would inflate N. An inflated N
+    // lets the server's `take: coalescedCount-1` seq-window settlement over-reach and mark a
+    // genuinely-separate post-drain pending turn as `merged` — which getPendingTurnsForConnection
+    // then never re-dispatches, silently dropping a piled-up chat message (defeats Q3).
+    // `resource_resumed` is the ONLY synthetic, non-notification wake action; every other
+    // WAKE_ACTIONS entry (incl. human_instruction) is notification-backed and turn-creating. A
+    // batch that reduces to 0 or 1 turn-backed items reports ≤ 1, which the client omits from the
+    // wire (see #advanceTurn) so no settlement runs.
+    const coalescedCount = list.filter((n) => n?.action !== "resource_resumed").length;
+    const first = list[0];
     // Both ids come from the resolved `attribution` (supplied by keyFor via the
     // router) and are threaded SEPARATELY — NEVER sliced from `key`. The ROOT idea
     // is reported in the snapshot; the DIRECT idea is the preferred session anchor.
     const rootIdeaUuid = attribution?.rootIdeaUuid ?? null;
     const directIdeaUuid = attribution?.directIdeaUuid ?? null;
+    // The resources markQueued tracked for THIS batch — every item's own entity. They must
+    // all leave the executions map when the batch settles so the server reconcile ends the
+    // queued rows the batch coalesced away (a coalesced batch shows only ONE running row).
+    const drainedExecKeys = [];
+    for (const n of list) {
+      const e = this.#entityOf(n);
+      if (e) drainedExecKeys.push(this.#execKey(e.entityType, e.entityUuid));
+    }
+    // The session-anchor resource for the ONE running row:
+    //  - a coalesced batch (> 1) is anchored on the SESSION, synthesized from attribution:
+    //    idea:<directIdeaUuid> when idea-anchored (NOT necessarily one of the merged items),
+    //    else the ad-hoc entity (all ad-hoc items share one entity → the first item's entity).
+    //  - a single wake (batch of one) keeps the item's OWN entity — byte-identical to before.
+    const entity =
+      batchSize > 1 && directIdeaUuid
+        ? { entityType: "idea", entityUuid: directIdeaUuid }
+        : this.#entityOf(first);
+    const execKey = entity ? this.#execKey(entity.entityType, entity.entityUuid) : null;
     // Per-wake lifecycle logging: stamp the start so completion can report a
     // duration. `Date.now()` is fine here (runtime metric, not a resume seed).
     const startMs = Date.now();
     const target = entity ? `${entity.entityType}:${entity.entityUuid}` : key;
-    const sessionId = directIdeaUuid ?? notification.entityUuid ?? null;
+    const sessionId = directIdeaUuid ?? first?.entityUuid ?? null;
     const requestedRuntimeCwd =
-      typeof notification?.runtimeCwd === "string" && notification.runtimeCwd
-        ? notification.runtimeCwd
+      typeof first?.runtimeCwd === "string" && first.runtimeCwd
+        ? first.runtimeCwd
         : null;
+    // Arrival label: the single action for a batch of one, else a batch count (the physical
+    // number of merged events — includes any resource_resumed, which is a real wake even
+    // though it is not turn-backed for settlement).
+    const arrivalAction =
+      batchSize > 1 ? `coalesced batch of ${batchSize}` : first?.action;
     try {
-      const prompt = buildPrompt(notification);
+      const prompt = buildBatchPrompt(list);
       if (!prompt) {
-        this.logger.info(`[Chorus] no wake prompt for action "${notification.action}" — skipping`);
+        this.logger.info(`[Chorus] no wake prompt for ${arrivalAction} on ${key} — skipping`);
         return;
       }
 
-      // Lifecycle line 1 — arrival: which action targets which idea/task/entity.
-      this.logger.info(`[Chorus] ▶ wake: ${notification.action} → ${target}`);
+      // Lifecycle line 1 — arrival: which action(s) target which idea/task/entity.
+      this.logger.info(`[Chorus] ▶ wake: ${arrivalAction} → ${target}`);
 
-      // Transition this resource to RUNNING with a start timestamp and emit a
-      // fresh snapshot, so the server/UI sees it leave the queue and begin
-      // executing. Report the server-resolved ROOT idea (not the direct-idea key).
-      // `child` starts null and is filled in by the spawner's onChild the moment the
-      // subprocess spawns (子3) — so the control handler can target it for interrupt.
+      // Transition to RUNNING and emit a fresh snapshot. First REMOVE every merged/drained
+      // resource (so the server reconcile ends their queued rows), then set the ONE
+      // synthesized anchor running row with a start timestamp — so the server/UI sees the
+      // batch as a single running entry with no leftover queued entries. Report the
+      // server-resolved ROOT idea (not the direct-idea key). `child` starts null and is
+      // filled in by the spawner's onChild the moment the subprocess spawns (子3) — so the
+      // control handler can target it for interrupt.
       if (entity && execKey) {
+        for (const dk of drainedExecKeys) {
+          if (dk !== execKey) this.executions.delete(dk);
+        }
         this.executions.set(execKey, {
           entityType: entity.entityType,
           entityUuid: entity.entityUuid,
@@ -416,7 +492,7 @@ export class Waker {
         this.logger.info(`[Chorus] dispatching session ${sessionId ?? "(none)"}`);
       }
       if (this.verbose) {
-        this.logger.info(`[Chorus]   cwd=${cwd} action=${notification.action} root=${rootIdeaUuid ?? "(none)"}`);
+        this.logger.info(`[Chorus]   cwd=${cwd} action=${arrivalAction} root=${rootIdeaUuid ?? "(none)"}`);
       }
 
       cfg = this.writeMcpConfigFn(this.creds);
@@ -456,7 +532,10 @@ export class Waker {
             turnAdvancedToRunning = true;
             // Fire-and-forget; #advanceTurn swallows + logs its own failures so a
             // turn-report error never crashes the spawn callback (no-silent-errors).
-            this.#advanceTurn(sessionId, "running", entity).catch(() => {});
+            // The coalescedCount rides this → running edge so the server settles the
+            // (count − 1) same-session pending turns coalesced into this one (a single
+            // wake reports 1, which the client omits from the wire).
+            this.#advanceTurn(sessionId, "running", entity, null, null, null, null, coalescedCount).catch(() => {});
           }
         },
         onMessage: (message) => {
@@ -577,7 +656,7 @@ export class Waker {
       );
       if (this.verbose) {
         this.logger.info(
-          `[Chorus]   action=${notification.action} session=${result?.sessionId} key=${key}`
+          `[Chorus]   action=${arrivalAction} session=${result?.sessionId} key=${key}`
         );
       }
     } catch (err) {
@@ -593,17 +672,22 @@ export class Waker {
         );
       }
     } finally {
-      // Wake finished (cleanly or not): the resource leaves the active set. Drop
-      // it and emit a fresh snapshot so the server ends its running/queued row.
-      // The server reconcile is snapshot-authoritative, so absence == ended. Also
-      // clear the per-entity interrupting flag so it can never leak into a later
-      // wake of the same entity.
+      // Wake finished (cleanly or not): EVERY resource this batch touched leaves the active
+      // set — the running anchor AND any drained/merged resources that were never promoted to
+      // the running row (e.g. a null-prompt batch that returned before the running transition,
+      // so their queued rows still linger). Drop them all and emit ONE fresh snapshot so the
+      // server ends their running/queued rows. The server reconcile is snapshot-authoritative,
+      // so absence == ended. Also clear the anchor's interrupting flag so it can never leak
+      // into a later wake of the same entity.
+      let changed = false;
+      for (const dk of drainedExecKeys) {
+        if (this.executions.delete(dk)) changed = true;
+      }
       if (execKey) {
         this.interrupting.delete(execKey);
-        if (this.executions.delete(execKey)) {
-          this.#emitExecutionChange();
-        }
+        if (this.executions.delete(execKey)) changed = true;
       }
+      if (changed) this.#emitExecutionChange();
       try {
         cfg?.cleanup?.();
       } catch {
@@ -647,8 +731,12 @@ export class Waker {
    * @param {string|null} [transcriptRelayError]
    * @param {import("./upload-hooks.mjs").TokenUsage|null} [usage]  Per-turn token usage
    *   (daemon-token-usage); forwarded only on a terminal edge, mirroring transcriptRelayError.
+   * @param {string|null} [backendSessionId]
+   * @param {number} [coalescedCount]  Number of wakes coalesced into this turn
+   *   (add-daemon-wake-coalescing); forwarded only on the → running edge and only when > 1,
+   *   so a single wake (default 1) leaves the field absent — byte-identical to before.
    */
-  async #advanceTurn(sessionId, status, entity, interruptedReason = null, transcriptRelayError = null, usage = null, backendSessionId = null) {
+  async #advanceTurn(sessionId, status, entity, interruptedReason = null, transcriptRelayError = null, usage = null, backendSessionId = null, coalescedCount = 1) {
     try {
       await this.advanceTurn({
         sessionId,
@@ -659,6 +747,7 @@ export class Waker {
         ...(transcriptRelayError ? { transcriptRelayError } : {}),
         ...(usage ? { usage } : {}),
         ...(backendSessionId ? { backendSessionId } : {}),
+        ...(status === "running" && coalescedCount > 1 ? { coalescedCount } : {}),
       });
     } catch (err) {
       this.logger.warn(

--- a/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/README.md
+++ b/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/README.md
@@ -1,0 +1,3 @@
+# add-daemon-wake-coalescing
+
+Daemon coalesces queued same-session wakes into one turn

--- a/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/design.md
+++ b/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/design.md
@@ -1,0 +1,224 @@
+# Design — Daemon Wake Coalescing
+
+## Context
+
+Today's wake flow (per `cli/daemon.mjs` header): SSE `new_notification` →
+`EventRouter` → `WakeQueue` → `Waker` (spawn/resume `claude`).
+
+- **`WakeQueue`** (`cli/wake-queue.mjs`): per-key FIFO with a global concurrency
+  cap. `enqueue(key, task)` pushes an **opaque thunk** `() => waker.wake(n, key, attr)`.
+  `#runNext(key)` `shift()`s **one** thunk per slot; same key is strictly serial,
+  different keys run concurrently up to `maxConcurrency`.
+- **`Waker.wake(notification, key, attribution)`** (`cli/waker.mjs`): builds the
+  prompt via `buildPrompt(n)` (one notification), decides new-vs-`--resume` by
+  probing the on-disk transcript, spawns the subprocess, tracks the execution row
+  (`markQueued` → running → settle), and advances the server turn
+  (`turn-advance`: running → ended/interrupted).
+- **`keyFor(n)`** returns `key = idea:<directIdeaUuid>` (idea-anchored session) or
+  `entity:<type>:<uuid>` (ad-hoc). The `human_instruction` re-dispatch path
+  (`event-router.mjs`) keys the **same** way — so autonomous wakes and chat
+  messages for one session already land on the **same** queue key. This is the
+  hinge that makes Q1+Q3 (merge chat with autonomous) implementable.
+- **Server** creates one **pending** `DaemonSessionTurn` per wake-worthy
+  notification at the notification chokepoint (`src/services/notification-turn.ts`
+  → `createPendingTurn`); the daemon only advances lifecycle. Turn `status` and
+  `trigger` are free String columns (no DB enum). Execution rows
+  (`DaemonExecution`) accept only `running`/`queued` from the daemon;
+  `reconcileSnapshot` ends any active row **absent** from the next uploaded
+  snapshot.
+
+## Goals / Non-goals
+
+- **Goal**: when a key's slot frees, deliver **all** pending same-key events in one
+  turn; single-turn accounting; no stuck queued rows.
+- **Non-goal**: any timer/debounce; size-based splitting; changing concurrency,
+  wake-action set, or cross-key behavior.
+
+## Decisions (from elaboration Round 1)
+
+| Q | Decision | Design consequence |
+|---|----------|--------------------|
+| Q1 scope | Merge **all** same-session events, label each in prompt | Queue coalesces by key only; no trigger filtering, no exemption for yolo/start_development |
+| Q2 stale | Collapse same-entity duplicates | `buildBatchPrompt` groups by `(action, entityUuid)`; one block per group with an occurrence count + newest content |
+| Q3 human_instruction | In v1 | Route the `human_instruction` deliver/backfill lane through the same coalescing enqueue |
+| Q4 window | Natural batching, no timer | Drain-what's-present at slot-free; no `setTimeout` |
+| Q5 prompt | Backlog preamble + per-event blocks | `buildBatchPrompt` reuses `buildPromptBody(n)` per block |
+| Q6 accounting | Single turn; mark merged resources delivered | One running exec row + drop the rest from the snapshot; server settles superseded pending turns |
+| Q7 cap | No cap | Drain the entire pending list for the key |
+
+## Architecture
+
+Coalescing MUST be **daemon-side**: the "natural batching" window (Q4) is defined
+by daemon runtime timing (what piled up while the previous turn ran), which the
+server cannot observe. The server's only role is settling the turn ledger.
+
+### C1 — `WakeQueue` becomes payload-carrying (`cli/wake-queue.mjs`)
+
+Change the per-key pending list from opaque thunks to **data items**, and give the
+queue a single batch runner:
+
+- Constructor: `new WakeQueue({ maxConcurrency, logger, runBatch })` where
+  `runBatch(key, items) => Promise<void>`.
+- `enqueue(key, item)` pushes an opaque data `item` (the router passes
+  `{ notification, attribution }`).
+- When a slot frees for a key, drain the **entire** pending array for that key
+  (`splice(0)`) and call `runBatch(key, items)` **once**. No cap (Q7).
+- Preserve every existing invariant: strict per-key serialization (the next batch
+  waits for the current batch to finish), the global `maxConcurrency` cap,
+  poisoned-batch isolation (a throwing `runBatch` is logged and the key's next
+  batch still proceeds), and `drain()`/`stop()` graceful-shutdown semantics.
+
+Natural batching falls out for free: items that arrive while batch N runs
+accumulate and become batch N+1 when the slot re-frees.
+
+> Back-compat note for tests: the queue no longer runs thunks. Existing
+> `wake-queue` unit tests are updated in lockstep (TDD) to the `runBatch` +
+> data-item contract. The queue stays plain ESM, zero-dep, in-memory.
+
+### C2 — `buildBatchPrompt(notifications)` (`cli/prompts.mjs`)
+
+- **Size 1** → delegate to `buildPrompt(n)` verbatim (byte-identical single-event
+  path; all current prompt tests keep passing).
+- **Size > 1**:
+  1. `HEADLESS_PREAMBLE` (unchanged, paid once).
+  2. A backlog preamble: "You have N queued Chorus events on this session that
+     arrived while you were busy. Handle them together, in order. Each event is
+     labeled with its type below."
+  3. **Same-entity/same-action collapse (Q2), with a `human_instruction`
+     exemption**: group notifications by `(action, entityUuid)` preserving
+     first-seen order. For a group with >1 member, render one block noting the
+     count and the **newest** message; a singleton renders its normal block.
+     **`human_instruction` is NEVER collapsed** — every chat message renders its
+     full `instructionText` as its own block, in arrival order. Rationale: chat
+     text lives ONLY on the turn/notification and is not re-fetchable (unlike
+     comments, which the agent can re-read via `chorus_get_comments`), so
+     collapsing to "newest only" would silently drop earlier instructions and
+     defeat Q3 ("一次看完积压消息"). Collapse therefore applies only to actions whose
+     full content is re-derivable server-side (mentions/comments, task lifecycle);
+     `human_instruction` (and any future free-text-carrying action) is exempt.
+  4. Per block: a header line `### Event i — <action> on <entityType> <entityUuid>`
+     followed by `buildPromptBody(n)` (reused, so each event keeps its own
+     `@mention` guidance and tool hints). Blocks that produce a `null` body (empty
+     `human_instruction`) are skipped.
+- Ordering is arrival order (the queue drains FIFO).
+
+### C3 — `Waker.wakeBatch(notifications, key, attribution)` (`cli/waker.mjs`)
+
+Refactor the existing single-wake body so the subprocess machinery (transcript
+new-vs-resume probe, spawn, interrupt-child registration, usage capture,
+turn-advance) is shared, and add the batch entry point:
+
+- Build the merged prompt with `buildBatchPrompt(notifications)`.
+- **Execution snapshot (Q6)**: the coalesced run is anchored on the session, so
+  emit **one** running execution row for the session-anchor resource and **remove**
+  the merged resources from the `executions` map before emitting the snapshot. The
+  server's `reconcileSnapshot` then ends those absent rows and SSE clears them from
+  the UI's "queued" bucket — no new status value needed.
+  - **Synthesize the anchor row (reviewer NOTE)**: the running row is
+    `idea:<directIdeaUuid>` (or the ad-hoc entity), which is **not necessarily one
+    of the merged items** — e.g. a batch of `@mention` notifications on child
+    tasks A and B under idea D has no `idea:D` item, yet the session anchor IS
+    `idea:D`. So the anchor execution row must be **synthesized** from the batch
+    attribution (`directIdeaUuid`/session id), not assumed to be one of the drained
+    resources. All the drained resources (A, B, …) are removed from the snapshot.
+- **Turn (Q6)**: advance the one running turn (running → ended) exactly as today,
+  keyed by `sessionId`, **and report `coalescedCount = notifications.length`** on
+  the running-transition so the server can settle the coalesced-away turns (C4).
+  The count travels via the existing `turn-advance` call (a new optional field —
+  see C4); `wake` (batch size 1) reports `coalescedCount = 1`, so its behavior is
+  unchanged.
+- `wake(n, key, attr)` is retained as a thin `wakeBatch([n], key, attr)` wrapper
+  (or the router calls `wakeBatch` directly) so a batch of size 1 is unchanged.
+
+### C4 — Router enqueues payloads; server settles superseded pending turns
+
+- **`cli/event-router.mjs`**: every `queue.enqueue(key, () => waker.wake(...))`
+  becomes `queue.enqueue(key, { notification, attribution })`. This covers the
+  live notification path (`#resolveAndEnqueue`), the `human_instruction` +
+  autonomous re-dispatch (`dispatchPendingTurn` / `#redispatchAutonomousTurn`),
+  and the synthetic resume (`dispatchResume`). `markQueued` is still called
+  per-item before enqueue so each resource shows "queued" until its batch runs.
+  `daemon.mjs` builds the queue with `runBatch = (key, items) =>
+  waker.wakeBatch(items.map(i => i.notification), key, items[0].attribution)`.
+  (All items on one key share the session anchor, so `items[0].attribution` is the
+  batch attribution; `rootIdeaUuid`/`directIdeaUuid` are identical across the batch
+  because the key IS `idea:<directIdeaUuid>`.)
+- **`src/services/daemon-session.service.ts` + `POST /api/daemon/turn-advance`**:
+  settle the coalesced-away pending turns using the daemon's reported
+  `coalescedCount`. **Why not "strictly-older":** `advanceTurnForWake` advances the
+  **OLDEST** pending turn to `running` (`orderBy: { seq: "asc" }`,
+  daemon-session.service.ts ~L1745–1759). So the running turn IS the oldest and the
+  "strictly-older" set is empty — the N−1 *newer* coalesced-away turns would stay
+  `pending` and, because pending turns are the reconnect-backfill source
+  (`getPendingTurnsForConnection`, ~L1847), would re-dispatch as **duplicate wakes**
+  on reconnect. That was the Round-1 BLOCKER-1.
+  - **Fix (race-safe, count-driven):** the daemon reports
+    `coalescedCount = N` on the running-transition. The server, after advancing the
+    oldest pending turn (seq `X`) to `running`, settles the **next `N−1` pending
+    turns of the same session by ascending seq** (i.e. seq `> X`, limit `N−1`) to a
+    terminal String status `"merged"`. Because the daemon drains its per-key queue
+    **FIFO** and the server assigns `seq` monotonically in arrival order, "the N
+    oldest pending turns" is exactly the batch the daemon coalesced. A notification
+    that arrives **after** the daemon's drain has a higher seq beyond the first N,
+    so it is **not** settled and correctly survives for the next batch — no race,
+    no lost instruction.
+  - `coalescedCount` is a new **optional** field on the `turn-advance` zod body
+    (default `1`); `status` stays a free String column, so **no Prisma migration**.
+    `"merged"` is added to any server-side turn-status vocabulary/whitelist and the
+    conversation/turn read renders it as a settled (non-error) turn.
+  - Guardrails: only strictly-newer (`seq > X`) same-session `pending` turns are
+    touched, capped at `N−1`; the running turn itself and turns of other sessions
+    are never affected.
+
+## Data flow (coalesced turn)
+
+```
+busy turn running on key K (idea:<D>)
+  ├─ SSE mention on task A  → markQueued(A)  → enqueue(K,{n_A})   [A: queued]
+  ├─ SSE mention on idea D  → markQueued(D)  → enqueue(K,{n_D})   [D: queued]
+  └─ human_instruction ×2   → markQueued(D)  → enqueue(K,{n_h1}), enqueue(K,{n_h2})
+slot frees → drain K = [n_A, n_D, n_h1, n_h2]
+  → wakeBatch([...], K, attr)
+       prompt = preamble + block(mention A) + block(mention D + 2 chats collapsed by entity/action)
+       exec snapshot: D running (synthesized anchor); A dropped → reconcile ends A's queued row
+       one claude --resume <D> turn; turn-advance running→ended, coalescedCount=4
+server: advance oldest pending (seq X) → running; settle next 3 pending (seq>X) → "merged"
+```
+
+## Testing strategy
+
+- **Daemon unit tests (headless-verifiable via `pnpm test` / node test runner):**
+  - `wake-queue`: multiple `enqueue` on one key before the slot frees → exactly
+    one `runBatch` with all items; per-key serialization preserved; cross-key
+    concurrency preserved; poisoned batch does not wedge; `drain()`/`stop()`.
+  - `prompts.buildBatchPrompt`: size 1 == `buildPrompt`; size N has one preamble +
+    N labeled blocks in order; same-entity/action collapse; null bodies skipped.
+  - `waker.wakeBatch`: single subprocess spawned for N items; snapshot emits one
+    running + drops the rest; turn advanced once.
+  - `event-router`: N same-key dispatches enqueue N items on one key; the runBatch
+    coalesces; human_instruction + autonomous share the key.
+- **Server unit test:** advance-to-running settles older same-session pending
+  turns to `merged`; unrelated sessions untouched; a single non-coalesced turn is
+  unchanged.
+- **Live e2e (hand off to human — headless cannot restart the daemon or drive a
+  real multi-event burst):** restart `chorus-daemon.service`, send a burst while
+  the agent is busy, confirm ONE turn carries all events and the queued rows clear.
+
+## Risks / mitigations
+
+- **Mixing a whole-idea trigger (`yolo_requested`/`start_development`) with a plain
+  mention in one turn** — owner explicitly chose this (Q1). Mitigation: each event
+  is a clearly-labeled block, so the agent sees "one of the events is a Yolo
+  directive" and acts accordingly; the whole-idea directive naturally dominates.
+- **Prompt size with no cap (Q7=b)** — natural batching bounds a batch to "one
+  turn's worth" of piled-up events; same-entity collapse (Q2) further shrinks it.
+  Accepted per owner.
+- **Attribution divergence across a batch** — guarded: the queue key IS
+  `idea:<directIdeaUuid>`, so all batched items share `directIdeaUuid`/`rootIdeaUuid`.
+  Ad-hoc keys are `entity:<type>:<uuid>` (single entity), also consistent.
+- **Coalesced-away pending-turn settlement racing a slow daemon** — the settlement
+  is keyed to the running-transition and touches only the next `N−1` **strictly-newer**
+  (`seq > X`) same-session `pending` turns (capped by the daemon's reported
+  `coalescedCount`), so it can never cancel the running turn, never touch another
+  session, and never settle a turn that arrived after the drain (its higher seq
+  falls beyond `N`, so it survives for the next batch).

--- a/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/proposal.md
+++ b/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/proposal.md
@@ -1,0 +1,79 @@
+# Daemon Wake Coalescing
+
+## Why
+
+The daemon serializes wakes per session key (`WakeQueue`, keyed on the direct idea
+or the ad-hoc session). While the agent is busy running a turn for a key, every
+later wake for that **same** key is enqueued as its own task and, when the slot
+frees, runs as its **own** `claude --resume` turn — `buildPrompt(n)` only ever
+carries a single notification. So N events that piled up during one turn become N
+sequential turns, each re-loading context and re-orienting the agent.
+
+This is wasteful and unnatural in exactly the cases that happen most:
+
+- A human sends several chat messages (`human_instruction`) in a row while the
+  agent is mid-turn — each becomes a separate turn instead of one "here is my
+  backlog" turn.
+- A burst of autonomous events on one idea (several `@mention` comments, a
+  sequence of task status changes) stacks up on the same key and drips through
+  one turn at a time.
+
+The idea: while queued wakes are **still pending (not yet started)**, merge them
+so that when the key's slot frees, **all** the piled-up events are delivered in a
+**single** turn (one `claude --resume` call) with one combined prompt.
+
+## What Changes
+
+- **Coalesce pending same-key wakes.** When a session key's execution slot frees,
+  the `WakeQueue` drains **all** currently-pending wakes for that key and runs
+  them as **one** batch (one subprocess), instead of one wake per turn. Natural
+  batching only — no debounce timer; the batch is exactly "whatever piled up while
+  the previous turn ran." (Elaboration Q4=a, Q7=b: no cap.)
+- **Merge everything on one session, labeled per event.** All events sharing a
+  session key merge into the one turn regardless of trigger type (mention +
+  task_assigned + human_instruction + start_development + yolo_requested all
+  together); the combined prompt states each event's **type and content** in its
+  own labeled block. (Q1: owner free-text — "只要是一个 session 上的，所有事件都合并，
+  只是在 PE 里写清楚各个事件的类型和事件.")
+- **Include human chat backlog in v1.** Multiple queued `human_instruction`
+  messages are part of the same coalescing — they land on the same session key as
+  autonomous wakes and merge with them. (Q3=a.)
+- **Backlog-preamble prompt, per-event blocks, same-entity collapse.** One
+  "you have N queued events, handle them together, in order" preamble followed by
+  one labeled block per event (reusing the existing per-action body). Repeated
+  same-entity/same-action events collapse into one block ("3 new comments on idea
+  X", newest shown). (Q5=a, Q2=b.)
+- **Single-turn accounting; no stuck queued rows.** A coalesced batch is one
+  running turn; the merged-away resources are dropped from the daemon's execution
+  snapshot so the server reconcile ends them and the UI never shows them stuck in
+  "queued". The daemon reports the coalesced event count; server-side, after the
+  oldest pending turn advances to `running`, the next `count − 1` pending turns of
+  the session (by seq) are settled to `merged` so coalesced-away turns are not left
+  dangling `pending` (which would re-dispatch as duplicate wakes on reconnect).
+  (Q6=a.)
+
+Out of scope: any debounce/collect window; per-event token/size-based splitting;
+changing cross-key concurrency; changing what counts as a wake action.
+
+## Capabilities
+
+- `daemon-wake-coalescing` (new) — the coalescing scheduler behavior, the batch
+  prompt composition, single-turn execution accounting, and the server-side
+  settlement of superseded pending turns.
+
+## Impact
+
+- **Daemon (`cli/*.mjs`)**: `wake-queue.mjs` (batch draining), `prompts.mjs`
+  (`buildBatchPrompt`), `waker.mjs` (`wakeBatch` + snapshot clearing),
+  `event-router.mjs` (enqueue payloads instead of thunks; route human_instruction
+  + autonomous + resume through the same batch lane), `daemon.mjs` (wire the batch
+  runner). Ships by `systemctl --user restart chorus-daemon.service` — no ECS deploy.
+- **Server (`src/services`, `src/app/api`)**: `POST /api/daemon/turn-advance`
+  gains an optional `coalescedCount` field (default 1); `daemon-session.service.ts`
+  advance-turn path settles the next `count − 1` same-session pending turns (by seq)
+  to `merged` on the running-transition. `status` is a free String column, so **no
+  Prisma migration** is required.
+- **Behavioral only for the UI**: queued rows clear via the existing
+  execution-snapshot reconcile + SSE; no new UI, no new status enum, no new screen.
+- **Backwards compatible**: a single queued wake (batch size 1) is byte-identical
+  to today's single-wake prompt and turn accounting.

--- a/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/specs/daemon-wake-coalescing/spec.md
+++ b/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/specs/daemon-wake-coalescing/spec.md
@@ -1,0 +1,94 @@
+# daemon-wake-coalescing
+
+## ADDED Requirements
+
+### Requirement: Coalesce pending same-key wakes into one batch
+The daemon's wake scheduler SHALL, when a session key's execution slot becomes
+free, drain ALL currently-pending wakes for that key and run them as a SINGLE
+batch (one subprocess / one `claude --resume` turn), rather than one turn per
+wake. Batching SHALL be natural only — the scheduler MUST NOT introduce a
+debounce or collect timer, and MUST NOT cap the number of events merged into a
+batch. Per-key serialization (the next batch waits for the current batch to
+finish) and the global cross-key concurrency cap SHALL be preserved.
+
+#### Scenario: Multiple same-key wakes arrive while the key is busy
+- **WHEN** a wake for key K is executing and three more wakes for key K are enqueued before it finishes
+- **THEN** when the executing wake finishes and the slot frees, the three enqueued wakes are drained together and run as one batch (one subprocess), not three separate turns
+
+#### Scenario: Wakes for different keys still run concurrently
+- **WHEN** wakes are enqueued for two different session keys and a concurrency slot is available
+- **THEN** the two keys run concurrently (each as its own batch), unaffected by coalescing, up to the configured concurrency cap
+
+#### Scenario: A single pending wake is unchanged
+- **WHEN** exactly one wake is pending for a key when its slot frees
+- **THEN** it runs as a batch of one, producing a prompt and turn accounting byte-identical to the pre-coalescing single-wake behavior
+
+#### Scenario: A poisoned batch does not wedge the key
+- **WHEN** a batch for key K throws during execution
+- **THEN** the failure is logged and the next batch for key K is still able to run
+
+### Requirement: Merge all same-session events regardless of trigger
+The daemon SHALL coalesce every pending wake sharing a session key into the one
+batch regardless of the wake's trigger type — autonomous notifications (mention,
+task_assigned, proposal_*, elaboration_*, task lifecycle), human_instruction chat
+messages, whole-idea directives (start_development, yolo_requested), and resume
+all merge when they share the key. The combined prompt SHALL state each event's
+type and content so the agent can act on each.
+
+#### Scenario: Chat messages and autonomous events on one session merge
+- **WHEN** two human_instruction chat messages and a mention notification for the same session are pending together
+- **THEN** all three are delivered in one turn, each shown as its own labeled event block, and the human_instruction bodies are included
+
+#### Scenario: A whole-idea directive merged with other events is labeled, not dropped
+- **WHEN** a yolo_requested (or start_development) wake and a mention wake for the same session are pending together
+- **THEN** both appear as labeled event blocks in the one turn's prompt; neither is silently dropped or run as a hidden separate turn
+
+### Requirement: Batch prompt uses a backlog preamble with per-event blocks and same-entity collapse
+For a batch of more than one event, the daemon SHALL build a single prompt that
+begins with the headless preamble and a short backlog preamble, followed by one
+labeled block per event in arrival order, reusing the existing per-action prompt
+body for each block. Multiple events that share the same entity and action SHALL
+be collapsed into one block that states the occurrence count and shows the newest
+message — EXCEPT `human_instruction`, which SHALL NEVER be collapsed: every chat
+message SHALL render its full body as its own block, in arrival order, because its
+text lives only on the turn and is not re-fetchable. Events whose body would be
+empty SHALL be omitted from the prompt.
+
+#### Scenario: Three comments on one idea collapse to one block
+- **WHEN** three `mentioned` events on the same idea are in one batch
+- **THEN** the prompt contains a single block for that idea noting three occurrences and showing the newest comment, not three near-duplicate blocks
+
+#### Scenario: Multiple chat messages are each shown in full
+- **WHEN** three `human_instruction` chat messages for the same session are in one batch
+- **THEN** all three instruction texts appear in full, as three separate blocks in arrival order — none is collapsed away or reduced to "newest only"
+
+#### Scenario: Distinct events render as separate ordered blocks
+- **WHEN** a batch contains events for different entities or different actions
+- **THEN** each renders as its own labeled block, ordered by arrival, under one shared backlog preamble
+
+### Requirement: A coalesced batch is accounted as a single turn without stuck queued rows
+A coalesced batch SHALL be reported as one running turn. The daemon SHALL emit an
+execution snapshot in which the merged-away resources are no longer present as
+"queued" (the session-anchor running row is synthesized from the batch attribution,
+not assumed to be one of the merged resources), so the server reconcile ends them
+and the UI does not show them stuck in the queued state. The daemon SHALL report
+the coalesced event count on the running-transition, and the server SHALL settle
+the coalesced-away pending turns of that session — after advancing the oldest
+pending turn to `running`, it marks the next `count − 1` pending turns of the same
+session, by ascending seq, to a terminal `merged` state — so coalesced-away turns
+do not linger as `pending` (which would otherwise re-dispatch as duplicate wakes on
+reconnect). A pending turn created after the batch was drained (higher seq, beyond
+the reported count) SHALL survive for the next batch. No new execution-status value
+and no database migration are required.
+
+#### Scenario: Merged-away queued resources clear from the UI
+- **WHEN** four resources were shown queued for a session and they are coalesced into one running batch
+- **THEN** the next execution snapshot no longer lists the merged-away resources as queued, and after reconcile the UI shows one running entry and no leftover queued entries for that session
+
+#### Scenario: Coalesced-away pending turns are settled by count
+- **WHEN** the daemon coalesces N pending wakes for a session into one running batch and reports coalescedCount = N
+- **THEN** the server advances the oldest pending turn of that session to `running` and marks the next N−1 pending turns (by ascending seq) as terminal `merged`, leaving turns of unrelated sessions untouched
+
+#### Scenario: A turn arriving after the drain survives
+- **WHEN** a new notification for the session arrives after the daemon drained its queue (its pending turn has a seq beyond the reported count)
+- **THEN** that turn is NOT settled as merged and remains `pending` for the next batch

--- a/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/tasks.md
+++ b/openspec/changes/archive/2026-08-14-add-daemon-wake-coalescing/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — Daemon Wake Coalescing
+
+> Chorus task drafts are the source of truth; this list mirrors them for OpenSpec validation.
+
+## 1. WakeQueue batch draining (daemon core)
+- [ ] Convert per-key pending list to data items; add `runBatch(key, items)` runner
+- [ ] Drain the whole pending list on slot-free (no cap, no timer); preserve serialization, concurrency cap, poisoned-batch isolation, drain()/stop()
+- [ ] Update `wake-queue` unit tests to the new contract
+
+## 2. buildBatchPrompt (daemon prompt)
+- [ ] Size-1 delegates to `buildPrompt` (byte-identical)
+- [ ] Size-N: headless + backlog preamble + per-event labeled blocks in arrival order
+- [ ] Same-entity/action collapse (Q2); skip null bodies
+- [ ] Unit tests
+
+## 3. wakeBatch + snapshot clearing + router wiring (daemon)
+- [ ] Refactor `wake` core; add `wakeBatch(notifications, key, attribution)` (single subprocess)
+- [ ] Emit one running exec row for the session anchor; drop merged-away resources from the snapshot
+- [ ] Route notification/human_instruction/autonomous/resume enqueues as `{notification, attribution}` payloads; wire `daemon.mjs` runBatch
+- [ ] Unit tests (event-router + waker)
+
+## 4. Server settles superseded pending turns
+- [ ] On advance-to-running for a session, mark strictly-older same-session `pending` turns as terminal `merged`
+- [ ] Unrelated sessions untouched; single non-coalesced turn unchanged; no migration
+- [ ] Service unit test
+
+## 5. Docs
+- [ ] Note coalescing wake behavior where daemon wake behavior is documented (skill/docs), if applicable

--- a/openspec/specs/daemon-wake-coalescing/spec.md
+++ b/openspec/specs/daemon-wake-coalescing/spec.md
@@ -1,0 +1,101 @@
+# daemon-wake-coalescing Specification
+
+## Purpose
+Defines how the daemon's wake scheduler coalesces multiple pending same-session
+(same-key) wakes into a single batch — one subprocess / one `claude --resume`
+turn — instead of one turn per wake, and how that single turn is accounted so the
+coalesced-away pending turns are settled (not left stuck as `queued`/`pending`).
+Batching is natural only (no debounce/collect timer, no batch-size cap);
+per-key serialization and the global cross-key concurrency cap are preserved.
+## Requirements
+### Requirement: Coalesce pending same-key wakes into one batch
+The daemon's wake scheduler SHALL, when a session key's execution slot becomes
+free, drain ALL currently-pending wakes for that key and run them as a SINGLE
+batch (one subprocess / one `claude --resume` turn), rather than one turn per
+wake. Batching SHALL be natural only — the scheduler MUST NOT introduce a
+debounce or collect timer, and MUST NOT cap the number of events merged into a
+batch. Per-key serialization (the next batch waits for the current batch to
+finish) and the global cross-key concurrency cap SHALL be preserved.
+
+#### Scenario: Multiple same-key wakes arrive while the key is busy
+- **WHEN** a wake for key K is executing and three more wakes for key K are enqueued before it finishes
+- **THEN** when the executing wake finishes and the slot frees, the three enqueued wakes are drained together and run as one batch (one subprocess), not three separate turns
+
+#### Scenario: Wakes for different keys still run concurrently
+- **WHEN** wakes are enqueued for two different session keys and a concurrency slot is available
+- **THEN** the two keys run concurrently (each as its own batch), unaffected by coalescing, up to the configured concurrency cap
+
+#### Scenario: A single pending wake is unchanged
+- **WHEN** exactly one wake is pending for a key when its slot frees
+- **THEN** it runs as a batch of one, producing a prompt and turn accounting byte-identical to the pre-coalescing single-wake behavior
+
+#### Scenario: A poisoned batch does not wedge the key
+- **WHEN** a batch for key K throws during execution
+- **THEN** the failure is logged and the next batch for key K is still able to run
+
+### Requirement: Merge all same-session events regardless of trigger
+The daemon SHALL coalesce every pending wake sharing a session key into the one
+batch regardless of the wake's trigger type — autonomous notifications (mention,
+task_assigned, proposal_*, elaboration_*, task lifecycle), human_instruction chat
+messages, whole-idea directives (start_development, yolo_requested), and resume
+all merge when they share the key. The combined prompt SHALL state each event's
+type and content so the agent can act on each.
+
+#### Scenario: Chat messages and autonomous events on one session merge
+- **WHEN** two human_instruction chat messages and a mention notification for the same session are pending together
+- **THEN** all three are delivered in one turn, each shown as its own labeled event block, and the human_instruction bodies are included
+
+#### Scenario: A whole-idea directive merged with other events is labeled, not dropped
+- **WHEN** a yolo_requested (or start_development) wake and a mention wake for the same session are pending together
+- **THEN** both appear as labeled event blocks in the one turn's prompt; neither is silently dropped or run as a hidden separate turn
+
+### Requirement: Batch prompt uses a backlog preamble with per-event blocks and same-entity collapse
+For a batch of more than one event, the daemon SHALL build a single prompt that
+begins with the headless preamble and a short backlog preamble, followed by one
+labeled block per event in arrival order, reusing the existing per-action prompt
+body for each block. Multiple events that share the same entity and action SHALL
+be collapsed into one block that states the occurrence count and shows the newest
+message — EXCEPT `human_instruction`, which SHALL NEVER be collapsed: every chat
+message SHALL render its full body as its own block, in arrival order, because its
+text lives only on the turn and is not re-fetchable. Events whose body would be
+empty SHALL be omitted from the prompt.
+
+#### Scenario: Three comments on one idea collapse to one block
+- **WHEN** three `mentioned` events on the same idea are in one batch
+- **THEN** the prompt contains a single block for that idea noting three occurrences and showing the newest comment, not three near-duplicate blocks
+
+#### Scenario: Multiple chat messages are each shown in full
+- **WHEN** three `human_instruction` chat messages for the same session are in one batch
+- **THEN** all three instruction texts appear in full, as three separate blocks in arrival order — none is collapsed away or reduced to "newest only"
+
+#### Scenario: Distinct events render as separate ordered blocks
+- **WHEN** a batch contains events for different entities or different actions
+- **THEN** each renders as its own labeled block, ordered by arrival, under one shared backlog preamble
+
+### Requirement: A coalesced batch is accounted as a single turn without stuck queued rows
+A coalesced batch SHALL be reported as one running turn. The daemon SHALL emit an
+execution snapshot in which the merged-away resources are no longer present as
+"queued" (the session-anchor running row is synthesized from the batch attribution,
+not assumed to be one of the merged resources), so the server reconcile ends them
+and the UI does not show them stuck in the queued state. The daemon SHALL report
+the coalesced event count on the running-transition, and the server SHALL settle
+the coalesced-away pending turns of that session — after advancing the oldest
+pending turn to `running`, it marks the next `count − 1` pending turns of the same
+session, by ascending seq, to a terminal `merged` state — so coalesced-away turns
+do not linger as `pending` (which would otherwise re-dispatch as duplicate wakes on
+reconnect). A pending turn created after the batch was drained (higher seq, beyond
+the reported count) SHALL survive for the next batch. No new execution-status value
+and no database migration are required.
+
+#### Scenario: Merged-away queued resources clear from the UI
+- **WHEN** four resources were shown queued for a session and they are coalesced into one running batch
+- **THEN** the next execution snapshot no longer lists the merged-away resources as queued, and after reconcile the UI shows one running entry and no leftover queued entries for that session
+
+#### Scenario: Coalesced-away pending turns are settled by count
+- **WHEN** the daemon coalesces N pending wakes for a session into one running batch and reports coalescedCount = N
+- **THEN** the server advances the oldest pending turn of that session to `running` and marks the next N−1 pending turns (by ascending seq) as terminal `merged`, leaving turns of unrelated sessions untouched
+
+#### Scenario: A turn arriving after the drain survives
+- **WHEN** a new notification for the session arrives after the daemon drained its queue (its pending turn has a seq beyond the reported count)
+- **THEN** that turn is NOT settled as merged and remains `pending` for the next batch
+

--- a/src/app/api/daemon/turn-advance/__tests__/route.test.ts
+++ b/src/app/api/daemon/turn-advance/__tests__/route.test.ts
@@ -317,6 +317,38 @@ describe("POST /api/daemon/turn-advance", () => {
     expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
   });
 
+  it("threads an explicit coalescedCount through to the service (daemon-wake-coalescing)", async () => {
+    const res = await POST(
+      postRequest({ connectionUuid, sessionId, status: "running", coalescedCount: 4 }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(200);
+    expect(mockAdvanceTurnForWake.mock.calls[0][0].coalescedCount).toBe(4);
+  });
+
+  it("defaults coalescedCount to 1 when the body omits it (single-wake, byte-identical)", async () => {
+    await POST(postRequest({ connectionUuid, sessionId, status: "running" }), emptyCtx);
+    expect(mockAdvanceTurnForWake.mock.calls[0][0].coalescedCount).toBe(1);
+  });
+
+  it("rejects coalescedCount < 1 at the zod boundary (422, service not called)", async () => {
+    const res = await POST(
+      postRequest({ connectionUuid, sessionId, status: "running", coalescedCount: 0 }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-integer coalescedCount (422)", async () => {
+    const res = await POST(
+      postRequest({ connectionUuid, sessionId, status: "running", coalescedCount: 2.5 }),
+      emptyCtx,
+    );
+    expect(res.status).toBe(422);
+    expect(mockAdvanceTurnForWake).not.toHaveBeenCalled();
+  });
+
   it("rejects a bad status at the zod boundary (422)", async () => {
     const res = await POST(postRequest({ connectionUuid, sessionId, status: "weird" }), emptyCtx);
     expect(res.status).toBe(422);

--- a/src/app/api/daemon/turn-advance/route.ts
+++ b/src/app/api/daemon/turn-advance/route.ts
@@ -45,6 +45,11 @@ const bodySchema = z
     sessionId: z.string().min(1),
     backendSessionId: z.string().trim().min(1).max(200).nullish(),
     status: z.enum([...TURN_STATUSES]),
+    // Number of same-session wakes the daemon coalesced into THIS batch (daemon-wake-
+    // coalescing). Optional, defaults to 1 (a single, non-coalesced wake). Meaningful on the
+    // running-transition: the service settles the next `coalescedCount − 1` pending turns of
+    // the session to `merged`. Positive integer; a smaller/fractional value is a client bug.
+    coalescedCount: z.number().int().min(1).default(1),
     entityType: z.enum([...EXECUTION_ENTITY_TYPES]).optional(),
     entityUuid: z.string().min(1).optional(),
     startedAt: z.coerce.date().nullish(),
@@ -106,6 +111,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     sessionId,
     backendSessionId,
     status,
+    coalescedCount,
     entityType,
     entityUuid,
     startedAt,
@@ -131,6 +137,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     sessionId,
     backendSessionId: backendSessionId ?? undefined,
     status,
+    coalescedCount,
     entityType: entityType ?? null,
     entityUuid: entityUuid ?? null,
     startedAt: startedAt ?? undefined,

--- a/src/services/__tests__/daemon-instruction-injection.integration.test.ts
+++ b/src/services/__tests__/daemon-instruction-injection.integration.test.ts
@@ -646,26 +646,31 @@ describe("AC2 — origin-only live delivery: the deliver_turn control event targ
     // A shared seen set across router + backfill (the real idempotency contract).
     const seen = new Set<string>();
     const enqueued: { key: string; n: Row }[] = [];
-    // The WakeQueue is the injected boundary: enqueue(key, task) records the wake instead
-    // of spawning a real `claude` (a true headless e2e is not runnable here — see file
-    // header / AC5 note). We also RUN the task so the wake's body is exercised.
-    const queue = {
-      enqueue: (key: string, task: () => Promise<void>) => {
-        enqueued.push({ key, n: {} });
-        // Fire-and-forget the wake body (no real subprocess; the waker.wake stub just
-        // records its args). Errors are swallowed like the real queue would log them.
-        void task();
-      },
-    };
     const wokeWith: Row[] = [];
+    // The waker facade the queue's runBatch drives. dispatchPendingTurn reconstructs the wake's
+    // session anchor directly from the turn — record what it would wake with. daemon.mjs wires
+    // the queue's runBatch → waker.wakeBatch (add-daemon-wake-coalescing), so the stub exposes
+    // wakeBatch and records every coalesced notification (a batch of one here).
     const waker = {
-      // dispatchPendingTurn reconstructs the wake's session anchor directly from the
-      // turn — record what it would wake with.
       keyFor: vi.fn(),
       markQueued: vi.fn(),
-      wake: vi.fn(async (n: Row) => {
-        wokeWith.push(n);
+      wakeBatch: vi.fn(async (notifications: Row[], _key?: string, _attribution?: Row) => {
+        for (const n of notifications) wokeWith.push(n);
       }),
+    };
+    // The WakeQueue is the injected boundary: enqueue records the wake instead of spawning a
+    // real `claude` (a true headless e2e is not runnable here — see file header / AC5 note).
+    // Post add-daemon-wake-coalescing the enqueued value is an opaque DATA payload
+    // { notification, attribution } (NOT a thunk); the real queue coalesces same-key items and
+    // hands the batch to its runBatch. Mirror daemon.mjs's runBatch exactly — each enqueue here
+    // is a single item, so drive waker.wakeBatch with a batch of one.
+    const queue = {
+      enqueue: (key: string, item: { notification: Row; attribution: Row }) => {
+        enqueued.push({ key, n: item.notification });
+        // Fire-and-forget the wake body; waker.wakeBatch just records its args. Errors are
+        // swallowed like the real queue would log them.
+        void waker.wakeBatch([item.notification], key, item.attribution);
+      },
     };
     const router = new EventRouter({
       mcpClient: { callTool: vi.fn(async () => ({ notifications: [] })) },
@@ -791,19 +796,23 @@ describe("AC3 — durability: a lost live ping is recovered by the reconnect pen
     //     the REAL pending-turns route → REAL dispatchPendingTurn. Shared seen set. ---
     const seen = new Set<string>();
     const enqueued: string[] = [];
-    const queue = {
-      enqueue: (key: string, task: () => Promise<void>) => {
-        enqueued.push(key);
-        void task();
-      },
-    };
     const wokeWith: Row[] = [];
+    // The waker facade the queue's runBatch drives (daemon.mjs wires runBatch → waker.wakeBatch,
+    // add-daemon-wake-coalescing). Record every coalesced notification (a batch of one here).
     const waker = {
       keyFor: vi.fn(),
       markQueued: vi.fn(),
-      wake: vi.fn(async (n: Row) => {
-        wokeWith.push(n);
+      wakeBatch: vi.fn(async (notifications: Row[], _key?: string, _attribution?: Row) => {
+        for (const n of notifications) wokeWith.push(n);
       }),
+    };
+    // Enqueue now carries an opaque DATA payload { notification, attribution } (NOT a thunk);
+    // mirror daemon.mjs's runBatch and drive waker.wakeBatch with the single-item batch.
+    const queue = {
+      enqueue: (key: string, item: { notification: Row; attribution: Row }) => {
+        enqueued.push(key);
+        void waker.wakeBatch([item.notification], key, item.attribution);
+      },
     };
     const router = new EventRouter({
       mcpClient: { callTool: vi.fn(async () => ({ notifications: [] })) },

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -16,6 +16,7 @@ const mockPrisma = vi.hoisted(() => ({
     findMany: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
   },
   daemonTranscriptMessage: {
     findFirst: vi.fn(),
@@ -66,6 +67,7 @@ vi.mock("@/services/daemon-connection.service", () => ({
 import {
   TURN_TRIGGERS,
   TURN_STATUSES,
+  MERGED_TURN_STATUS,
   SESSION_STATUSES,
   TRANSCRIPT_ROLES,
   MAX_TRANSCRIPT_MESSAGES_PER_SESSION,
@@ -166,6 +168,7 @@ beforeEach(() => {
   mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
   mockPrisma.daemonSessionTurn.create.mockResolvedValue(turnRow());
   mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow());
+  mockPrisma.daemonSessionTurn.updateMany.mockResolvedValue({ count: 0 });
   mockPrisma.daemonTranscriptMessage.findFirst.mockResolvedValue(null);
   mockPrisma.daemonTranscriptMessage.findMany.mockResolvedValue([]);
   mockPrisma.daemonTranscriptMessage.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) =>
@@ -212,6 +215,13 @@ describe("constants", () => {
 
   it("TURN_STATUSES are the strict forward lifecycle pending/running/ended|interrupted", () => {
     expect([...TURN_STATUSES]).toEqual(["pending", "running", "ended", "interrupted"]);
+  });
+
+  it("MERGED_TURN_STATUS is 'merged' and is a SERVER-ONLY settlement status — NOT in the daemon-reportable TURN_STATUSES", () => {
+    // A coalesced-away pending turn is settled to this terminal status by the server; the
+    // daemon never reports it, so it must stay out of the turn-advance lifecycle enum.
+    expect(MERGED_TURN_STATUS).toBe("merged");
+    expect([...TURN_STATUSES]).not.toContain(MERGED_TURN_STATUS);
   });
 
   it("SESSION_STATUSES are active/ended", () => {
@@ -1016,6 +1026,21 @@ describe("getSessionTurns", () => {
     mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
     const result = await getSessionTurns({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid);
     expect(result).toEqual([]);
+  });
+
+  it("renders a 'merged' turn (coalesced-away) without error — a settled, non-error status passes through toTurnView", async () => {
+    // AC: a server-settled `merged` turn must read back cleanly alongside ordinary turns —
+    // TurnView.status is a free string, so the read never rejects it as unknown/error.
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([
+      turnRow({ uuid: "t1", seq: 1, status: "ended" }),
+      turnRow({ uuid: "t2", seq: 2, status: "merged" }),
+    ]);
+    const result = await getSessionTurns({ type: "user", companyUuid, actorUuid: ownerUuid }, sessionUuid);
+    expect(result?.map((t) => ({ uuid: t.uuid, status: t.status }))).toEqual([
+      { uuid: "t1", status: "ended" },
+      { uuid: "t2", status: "merged" },
+    ]);
   });
 
   it("PROPAGATES a query error (read, does not swallow)", async () => {
@@ -2243,6 +2268,135 @@ describe("advanceTurnForWake", () => {
     });
     expect(res).toMatchObject({ ok: false, reason: "invalid_transition", from: "ended", to: "running" });
     expect(mockPrisma.daemonSessionTurn.update).not.toHaveBeenCalled();
+  });
+});
+
+// ===== advanceTurnForWake — coalesced-away pending-turn settlement (daemon-wake-coalescing) =====
+describe("advanceTurnForWake — coalescedCount settlement of superseded pending turns", () => {
+  // Set up a legal pending→running advance where the OLDEST pending turn resolves at `seq`
+  // (the settlement filter needs the running turn's seq).
+  function runningTransition(runningSeq = 10) {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    // findFirst resolves the oldest pending turn by status — now carrying its seq.
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: turnUuid, seq: runningSeq });
+    // advanceTurn chokepoint lookups for a legal pending→running write.
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({ uuid: turnUuid, sessionUuid, status: "pending" });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow({ status: "running", seq: runningSeq }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+  }
+
+  it("resolves the running turn's seq (findFirst select includes seq) so the settlement can filter seq > X", async () => {
+    runningTransition(10);
+    await advanceTurnForWake({ companyUuid, agentUuid, connectionUuid, sessionId, status: "running", coalescedCount: 2 });
+    // The FROM-status resolve must select seq (the settlement's seq>X anchor).
+    expect(mockPrisma.daemonSessionTurn.findFirst.mock.calls[0][0].select).toEqual({ uuid: true, seq: true });
+  });
+
+  it("on →running with coalescedCount=N, settles the next N-1 pending turns of the SAME session (by ascending seq, seq > X) to 'merged'", async () => {
+    runningTransition(10);
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([{ uuid: "turn-2" }, { uuid: "turn-3" }]);
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "running",
+      coalescedCount: 3,
+    });
+    expect(res).toMatchObject({ ok: true });
+
+    // The N-1 coalesced-away turns are the next PENDING ones by ascending seq, seq > X(=10), capped at N-1(=2).
+    const findArg = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
+    expect(findArg.where).toEqual({ sessionUuid, status: "pending", seq: { gt: 10 } });
+    expect(findArg.orderBy).toEqual({ seq: "asc" });
+    expect(findArg.take).toBe(2);
+
+    // They are settled to the terminal 'merged' status by uuid — nothing else touched.
+    expect(mockPrisma.daemonSessionTurn.updateMany).toHaveBeenCalledWith({
+      where: { uuid: { in: ["turn-2", "turn-3"] } },
+      data: { status: MERGED_TURN_STATUS },
+    });
+    expect(MERGED_TURN_STATUS).toBe("merged");
+  });
+
+  it("caps the settlement at N-1: a pending turn beyond the first N (arrived after the drain) is NOT selected and survives as pending", async () => {
+    runningTransition(10);
+    // coalescedCount=2 → only the single (N-1) oldest pending tail turn is the coalesced batch;
+    // the `take: 1` cap guarantees any later-arriving higher-seq turn is never selected.
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([{ uuid: "turn-2" }]);
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "running",
+      coalescedCount: 2,
+    });
+    expect(res).toMatchObject({ ok: true });
+
+    const findArg = mockPrisma.daemonSessionTurn.findMany.mock.calls[0][0];
+    expect(findArg.take).toBe(1);
+    expect(findArg.where.seq).toEqual({ gt: 10 });
+    expect(mockPrisma.daemonSessionTurn.updateMany).toHaveBeenCalledWith({
+      where: { uuid: { in: ["turn-2"] } },
+      data: { status: MERGED_TURN_STATUS },
+    });
+  });
+
+  it("coalescedCount=1 (default, omitted) settles NOTHING — no settlement query, no updateMany, other pending turns untouched", async () => {
+    runningTransition(10);
+    const res = await advanceTurnForWake({ companyUuid, agentUuid, connectionUuid, sessionId, status: "running" });
+    expect(res).toMatchObject({ ok: true });
+    // Only the running-transition ran; no coalesced-settlement read or write.
+    expect(mockPrisma.daemonSessionTurn.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonSessionTurn.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("explicit coalescedCount=1 also settles nothing (byte-identical to the pre-coalescing single-wake path)", async () => {
+    runningTransition(10);
+    await advanceTurnForWake({ companyUuid, agentUuid, connectionUuid, sessionId, status: "running", coalescedCount: 1 });
+    expect(mockPrisma.daemonSessionTurn.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("settlement is bound to the RUNNING transition — a terminal edge (→ended) with coalescedCount>1 settles nothing", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: turnUuid, seq: 10 });
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({ uuid: turnUuid, sessionUuid, status: "running" });
+    mockPrisma.daemonSessionTurn.update.mockResolvedValue(turnRow({ status: "ended" }));
+    mockPrisma.daemonSession.findUnique.mockResolvedValue({ companyUuid });
+
+    await advanceTurnForWake({ companyUuid, agentUuid, connectionUuid, sessionId, status: "ended", coalescedCount: 3 });
+    expect(mockPrisma.daemonSessionTurn.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("does NOT settle when the running-transition itself fails (invalid_transition) — no half-applied merge", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({ uuid: sessionUuid });
+    mockPrisma.daemonSessionTurn.findFirst.mockResolvedValue({ uuid: turnUuid, seq: 10 });
+    // The resolved turn is already `running`, so advanceTurn rejects pending→running.
+    mockPrisma.daemonSessionTurn.findUnique.mockResolvedValue({ uuid: turnUuid, sessionUuid, status: "running" });
+
+    const res = await advanceTurnForWake({
+      companyUuid,
+      agentUuid,
+      connectionUuid,
+      sessionId,
+      status: "running",
+      coalescedCount: 3,
+    });
+    expect(res.ok).toBe(false);
+    expect(mockPrisma.daemonSessionTurn.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("skips the updateMany when there are no coalesced-away pending turns to settle (settlement query returns empty)", async () => {
+    runningTransition(10);
+    mockPrisma.daemonSessionTurn.findMany.mockResolvedValue([]);
+
+    await advanceTurnForWake({ companyUuid, agentUuid, connectionUuid, sessionId, status: "running", coalescedCount: 3 });
+    // The settlement read still ran once, but with nothing to settle no write is issued.
+    expect(mockPrisma.daemonSessionTurn.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.daemonSessionTurn.updateMany).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -67,6 +67,18 @@ export type TurnTrigger = (typeof TURN_TRIGGERS)[number];
 export const TURN_STATUSES = ["pending", "running", "ended", "interrupted"] as const;
 export type TurnStatus = (typeof TURN_STATUSES)[number];
 
+// A SERVER-ONLY terminal turn status (daemon-wake-coalescing). Assigned when a pending
+// turn is COALESCED AWAY — an earlier same-session wake drained it into one batch, so it
+// will never run on its own. Deliberately NOT a member of TURN_STATUSES (the daemon-
+// reportable lifecycle enum the turn-advance route validates against): the daemon never
+// reports `merged`; the server assigns it directly on the running-transition (see
+// `advanceTurnForWake`). Terminal like `ended`/`interrupted`, and crucially NOT `pending`,
+// so `getPendingTurnsForConnection` (which filters `status = "pending"`) never re-dispatches
+// a coalesced-away turn as a duplicate wake on reconnect. `status` is a free String column,
+// so this value needs NO Prisma migration and NO new DB enum; the conversation read
+// (`toTurnView`) passes it through verbatim as a settled, non-error turn.
+export const MERGED_TURN_STATUS = "merged" as const;
+
 // Discriminator vocabulary for `status = interrupted`. `user`/`crash`/`shutdown` are
 // daemon-reported outcomes; `offline` is reserved to SERVER-side reconcile of a turn
 // whose origin connection went stale — the turn-advance route rejects a daemon
@@ -175,7 +187,7 @@ export interface TurnView {
   seq: number;
   trigger: string;
   promptText: string | null;
-  status: string; // pending | running | ended | interrupted
+  status: string; // pending | running | ended | interrupted | merged (server-only, coalesced-away)
   interruptedReason: string | null; // user | crash | shutdown | offline; set iff interrupted
   // Transcript-relay failure annotation (fix #444 follow-up): non-null when the daemon KNEW
   // this turn's transcript upload finally failed (retry exhausted / non-2xx / network) even
@@ -1699,6 +1711,12 @@ export async function advanceTurnForWake(params: {
   // Per-turn token usage forwarded from the daemon's exit-path report (daemon-token-usage).
   // Persisted verbatim on the terminal edge only; ignored on → running.
   usage?: TokenUsage | null;
+  // Number of same-session wakes the daemon coalesced into THIS one batch (daemon-wake-
+  // coalescing). Reported on the running-transition; defaults to 1 (a single, non-coalesced
+  // wake → no settlement, byte-identical to the pre-coalescing path). When > 1, after the
+  // oldest pending turn advances to `running`, the next `coalescedCount − 1` pending turns of
+  // the same session (by ascending seq) are settled to `merged` — see below.
+  coalescedCount?: number;
 }): Promise<AdvanceTurnForWakeResult> {
   // Resolve the agent's OWN session by its business key (company + agent fenced).
   const session = await prisma.daemonSession.findFirst({
@@ -1755,7 +1773,8 @@ export async function advanceTurnForWake(params: {
     },
     // Oldest-first so a `→running` advance picks up the next queued turn in FIFO order.
     orderBy: { seq: "asc" },
-    select: { uuid: true },
+    // `seq` anchors the coalesced-away settlement below (the `seq > X` filter).
+    select: { uuid: true, seq: true },
   });
   if (!turn) return { ok: false, reason: "not_found" };
 
@@ -1804,9 +1823,47 @@ export async function advanceTurnForWake(params: {
     ...(params.usage !== undefined ? { usage: params.usage } : {}),
   });
 
-  if (result.ok) return { ok: true, turn: result.turn };
-  if (result.reason === "not_found") return { ok: false, reason: "not_found" };
-  return { ok: false, reason: "invalid_transition", from: result.from, to: result.to };
+  if (!result.ok) {
+    if (result.reason === "not_found") return { ok: false, reason: "not_found" };
+    return { ok: false, reason: "invalid_transition", from: result.from, to: result.to };
+  }
+
+  // ── Coalesced-away pending-turn settlement (daemon-wake-coalescing) ────────────────────
+  // The daemon merges the wakes that piled up during the previous turn into ONE batch and
+  // reports how many it coalesced (`coalescedCount = N`). We have JUST advanced the OLDEST
+  // pending turn (seq `turn.seq`) to `running`; the remaining N−1 turns of that same batch
+  // are exactly the NEXT N−1 pending turns of this session by ascending seq. Settle them to
+  // the terminal `merged` status so they do not linger `pending` and re-dispatch as duplicate
+  // wakes on reconnect (`getPendingTurnsForConnection` filters `status = "pending"`).
+  //
+  // Race-safety: the daemon drains its per-key queue FIFO and the server assigns `seq`
+  // monotonically in arrival order, so "the N oldest pending turns" IS the coalesced batch.
+  // A notification that arrives AFTER the drain has a higher seq beyond the first N — the
+  // `take: N−1` cap never selects it, so it correctly survives for the next batch. The
+  // `seq > turn.seq` fence + same-session scope also guarantee the running turn itself and
+  // every OTHER session are never touched. `coalescedCount` defaults to 1 → no settlement,
+  // byte-identical to the pre-coalescing single-wake path.
+  const coalescedCount = params.coalescedCount ?? 1;
+  if (params.status === "running" && coalescedCount > 1) {
+    const superseded = await prisma.daemonSessionTurn.findMany({
+      where: {
+        sessionUuid: session.uuid,
+        status: "pending",
+        seq: { gt: turn.seq },
+      },
+      orderBy: { seq: "asc" },
+      take: coalescedCount - 1,
+      select: { uuid: true },
+    });
+    if (superseded.length > 0) {
+      await prisma.daemonSessionTurn.updateMany({
+        where: { uuid: { in: superseded.map((t) => t.uuid) } },
+        data: { status: MERGED_TURN_STATUS },
+      });
+    }
+  }
+
+  return { ok: true, turn: result.turn };
 }
 
 // ===== Backfill read: unstarted (pending) turns for a connection's sessions =====


### PR DESCRIPTION
## What

When a session key's `WakeQueue` slot frees, the daemon now drains **all** still-pending same-session wakes and delivers them in **one** `claude --resume` turn (a combined prompt), instead of running one turn per wake. Idea `c179b6ee`, proposal `b51ca84f` (OpenSpec `add-daemon-wake-coalescing`, archived in this branch).

## Why

Bursts on one session — a user sending several chat messages while the agent is busy, or a flurry of autonomous events on one idea — used to become N sequential `claude --resume` turns, each re-loading context. Coalescing turns that backlog into a single "here's everything that piled up" turn.

## How

- **`cli/wake-queue.mjs`** — per-key pending list holds `{notification, attribution}` data items; `runBatch(key, items)` drains the whole per-key array on slot-free. Natural batching only — no debounce timer, no size cap. Per-key serialization + cross-key concurrency preserved.
- **`cli/prompts.mjs`** — `buildBatchPrompt(notifications)`: size-1 is byte-identical to `buildPrompt`; size-N = backlog preamble + one labeled block per event, reusing each per-action body. Same-`(action,entity)` events collapse to count + newest, **except `human_instruction`** (never collapsed — chat text lives only on the turn and isn't re-fetchable).
- **`cli/waker.mjs`** — `wakeBatch(notifications)`: one subprocess; the running execution row is **synthesized** from the batch anchor (`idea:<directIdeaUuid>` / ad-hoc entity) and merged-away resources are dropped from the snapshot (server reconcile ends them → queued rows clear). Reports `coalescedCount` (counting only turn-backed items — excludes synthetic `resource_resumed`). `wake(n)` is now a thin `wakeBatch([n])` wrapper (single-wake byte-identical).
- **`cli/daemon.mjs`** — `WakeQueue` is now **per-connection** so `runBatch` dispatches each batch to the correct connection's waker (correct cwd). Concurrency cap is now per-connection.
- **`cli/turn-reporter.mjs` / `cli/daemon-rest-client.mjs`** — thread `coalescedCount` (optional, default 1; sent on the wire only on the running edge when > 1).
- **`src/app/api/daemon/turn-advance/route.ts` + `src/services/daemon-session.service.ts`** — accept `coalescedCount`; on the →running transition, settle the next `N-1` same-session pending turns (by seq) to a terminal `merged` status so coalesced-away turns don't re-dispatch as duplicate wakes on reconnect. `status` is a free String column — **no migration**.

## Testing

- New/updated unit + integration tests across `wake-queue`, `prompts`, `waker`/`wake-orchestration`, `event-router`, `turn-advance` route, and `daemon-session.service`. `npx tsc --noEmit` clean.
- Code-review gateway on the aggregate change: PASS (Round 2). Round 1 caught two aggregate-level defects (a stale fake-queue in an integration test; a `coalescedCount` over-count including `resource_resumed`) — both fixed.
- **Not done here:** live daemon e2e requires `systemctl --user restart chorus-daemon.service` (the daemon half takes effect on restart, not via deploy) + a real burst against a busy session.
- Known noise: `cli/__tests__/` shows 15 pre-existing `runDaemon`-entry/`daemon.json` failures unrelated to this change (identical on base `0.16.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)