### PR TITLE
docs: reposition as the harness above your coding agents + slim READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
   <img src="packages/landing/public/images/chorus-slug.png" alt="Chorus" width="240" />
 </p>
 
-<p align="center"><strong>AI と人間の協働のための Agent Harness</strong></p>
+<p align="center"><strong>あなたのコーディングエージェントの上に乗せる Harness。エージェントが提案し、人間が検証し、ソフトウェアが届く。</strong></p>
 
 <p align="center">
   <a href="https://discord.gg/SwcCMaMmR">
@@ -15,9 +15,9 @@
 
 <p align="center"><a href="README.md">English</a> · <a href="README.zh.md">中文</a> · <a href="README.ko.md">한국어</a> · <strong>日本語</strong></p>
 
-<p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 ドキュメント</strong></a></p>
+<p align="center"><a href="https://doc.chorus-ai.dev/ja/"><strong>📖 ドキュメント</strong></a></p>
 
-Chorus は Agent Harness です — LLM エージェントを包み込み、セッションのライフサイクル、課題の状態、サブエージェントのオーケストレーション、可観測性、障害復旧を管理する基盤層です。細かく設定可能な権限を持つ複数の AI エージェントと人間が、要件から納品までの全ワークフローを通じて協働できるようにします。
+Chorus は、あなたのコーディングエージェントの上に乗せる Harness です。コーディングエージェントがモデルを harness してコードを書くように、Chorus はさらに一段上の Harness として、そうしたエージェントのチーム全体とあなたを、ひとつのパイプラインにまとめます。エージェントが提案し、人間が検証し、アイデアが届けられるソフトウェアへと変わります。その下層では、マルチエージェントで人間が関与する協働を破綻させないためのものを引き受けます：セッションのライフサイクル、課題の状態、サブエージェントのオーケストレーション、可観測性、障害復旧。すべての AI エージェントは、細かく設定可能な権限を持ちます。
 
 **[AI-DLC（AI-Driven Development Lifecycle）](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** の方法論に着想を得ています。中核となる理念は **Reversed Conversation** — AI が提案し、人間が検証します。
 
@@ -32,7 +32,7 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 作成      + 詳細化       + 起草                  + 報告      + 検証     + 完了
 ```
 
-各ステージの下に記載されているのは、そのステージでアクターに必要となる**権限**です — 人間、エージェント（プリセットまたは Custom）、あるいはその両方に付与できます。固定的なロールは存在せず、5 × 3 の権限マトリクスの任意の組み合わせが可能です。詳しくは [`docs/PERMISSIONS.md`](docs/PERMISSIONS.md) をご覧ください。
+各ステージの下に記載されているのは、そのステージでアクターに必要となる**権限**です — 人間、エージェント（プリセットまたは Custom）、あるいはその両方に付与できます。固定的なロールは存在せず、5 × 3 の権限マトリクスの任意の組み合わせが可能です。→ [エージェント権限](https://doc.chorus-ai.dev/ja/guides/manage-agents/)
 
 ---
 
@@ -54,119 +54,18 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 
 ## クイックスタート
 
-2 つのコマンドで Chorus をローカル実行できます — データベースも Docker も設定ファイルも不要です。
+2 つのコマンドだけです — データベースも Docker も設定ファイルも不要です。
 
 ```bash
 npm install -g @chorus-aidlc/chorus
 chorus
 ```
 
-これだけです。Chorus は組み込みの PostgreSQL（PGlite）で起動し、マイグレーションを自動実行して、**http://localhost:8637** で開きます。
+Chorus は組み込みの PostgreSQL（PGlite）で起動し、マイグレーションを自動実行して、**http://localhost:8637** で開きます。デフォルトのログイン情報：`admin@chorus.local` / `chorus`。
 
-> **注意：** PGlite は組み込みの単一プロセス PostgreSQL です — ローカルでの単一ユーザー利用には最適ですが、同時負荷がかかると接続処理に限界があります。複数のエージェントやユーザーを同時に動かす予定がある場合は、`DATABASE_URL=postgresql://...` で外部の PostgreSQL を使うか、フルの [Docker Compose](#docker-で始める推奨) スタックを利用してください。
+> 複数のエージェントを動かしたり、本番環境にデプロイしたりする場合は？外部の PostgreSQL、Docker、または AWS を利用してください → **[デプロイとセルフホスト](https://doc.chorus-ai.dev/ja/guides/deployment-overview/)**。
 
-デフォルトのログイン情報：`admin@chorus.local` / `chorus`
-
-### オプション
-
-```bash
-# カスタムポート
-chorus --port 3000
-
-# カスタムデータディレクトリ（デフォルト：~/.chorus-data）
-chorus --data-dir /path/to/data
-
-# カスタムの認証情報
-DEFAULT_USER=me@example.com DEFAULT_PASSWORD=secret chorus
-
-# 組み込みの PGlite の代わりに外部 PostgreSQL を使う
-DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
-```
-
-### その他のデプロイ方法
-
-| 方法 | コマンド |
-|--------|---------|
-| **npm**（最もシンプル） | `npm i -g @chorus-aidlc/chorus && chorus` |
-| **Docker（単体）** | [`docker compose -f docker-compose.local.yml up`](#docker-で始める推奨) |
-| **Docker（フルスタック）** | [`docker compose up`](#docker-で始める推奨)（PostgreSQL + Redis + Chorus） |
-| **AWS CDK** | [AWS へのデプロイ](#aws-へのデプロイ) |
-
-### `chorus daemon` — エージェントランタイムとして接続
-
-`chorus daemon` は、あなたのローカルマシンをエージェントランタイムとしてリモートの Chorus サーバーに接続し、Chorus から割り当てられた課題を実行します。
-
-> **エージェントバックエンド：** **Claude Code**（デフォルト）と **Codex** に対応しています — `--agent codex`（または `CHORUS_AGENT=codex`）で選択します。その他のエージェント CLI（Copilot など）への対応は、今後のリリースで予定しています。
-
-```bash
-chorus login                     # 認証（ブラウザを開きます）
-chorus daemon                    # デーモンをフォアグラウンドで起動
-chorus daemon -d                 # デーモンをバックグラウンドで起動（デタッチ）
-chorus daemon install            # 起動時に自動起動するサービスとしてインストール（Linux）— 推奨
-chorus daemon uninstall          # インストール済みのサービスを削除
-chorus daemon stop               # デーモンを停止（インストール時は systemd に委譲）
-chorus daemon stop --force       # 詰まった pid が停止を妨げる場合に pidfile を強制クリーン
-chorus daemon status             # デーモンの状態を確認
-chorus daemon restart            # デーモンを再起動
-chorus daemon logs               # デーモンのログを表示
-```
-
-**主な機能：**
-
-- **Claude Code と Codex バックエンド** — PATH 上の `claude`（または `codex`）CLI を自動検出します。`--agent codex` で選択します
-- **バックグラウンドモード** — `-d` フラグで実行し、`stop/restart/logs` で管理します
-- **起動時の自動起動サービス** — `chorus daemon install` は正しい `systemd --user` unit を生成して起動します（下記参照）。以降、`status/stop/restart/logs` は透過的に systemd へ委譲されます
-- **権限モード** — デフォルトは完全アクセス（yolo）です。`--chorus-only` で Chorus の MCP ツールのみに制限できます
-- **マルチパス** — 繰り返し指定できる `--cwd` で、1 つのデーモンから複数の作業ディレクトリを扱えます（下記参照）
-- **対話式セットアップ** — 未設定の場合、初回起動時に認証情報の入力を求めます
-
-デーモンには認証が必要です。先に `chorus login` を実行してください。実行していない場合は、初回起動時に対話形式で認証情報の入力を求めます（ターミナルで実行している場合）。
-
-#### 起動時／ログイン時に実行する — `chorus daemon install`
-
-```bash
-chorus daemon install --cwd ~/work/repo-a --cwd ~/work/repo-b   # インストールして今すぐ起動、ログイン時に自動起動
-chorus daemon uninstall                                         # サービスを無効化して削除
-```
-
-Linux では、`install` が `systemd --user` unit を生成し、デーモンを**フォアグラウンド**（`Type=simple`、`-d` なし）で実行します。これにより systemd がプロセスを直接管理し、その後 `daemon-reload` + `enable --now` を行います。unit には、あなたが渡した `--cwd`/`--agent`/`--chorus-only` フラグが取り込まれます。`chorus daemon -d` をラップした `Type=forking` の unit を**手書きしないでください** — デーモンは自己デーモン化するため systemd が追跡できず、再起動時にループします。正しい unit は `install` に書かせてください。macOS／Windows では、`install` が手動でインストールできる正しいテンプレートを表示します。unit が認証情報を読めるよう、先に `chorus login` を実行してください。詳細は [docs/DAEMON.md](docs/DAEMON.md) をご覧ください。
-
-#### 複数の作業ディレクトリを扱う
-
-1 つのデーモンは、複数のローカル作業ディレクトリを同時に扱えます — 宣言された各パスは、同じエージェントの下で独立した接続（それぞれ独自のセッション + ウェイクループ）として登録されます。パスは、デーモンが扱う**単なる**ディレクトリであり、プロジェクトとの紐付けは持ちません。
-
-```bash
-chorus daemon --cwd ~/work/repo-a --cwd ~/work/repo-b   # 繰り返し指定できるフラグ
-CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # または環境変数（`:` または `,` 区切り）
-```
-
-`--cwd` を指定しない場合、デーモンは起動元の 1 つのディレクトリのみを扱います。
-
-#### 設定ファイル — `~/.chorus/daemon.json`
-
-`chorus login` は認証情報をここに書き込みます（モード `0600`）。デーモンの調整項目を**同じ**ファイルに追記することもできます。すべてのフィールドは任意です。フラグと環境変数は、常にファイルより優先されます。
-
-```json
-{
-  "url": "https://chorus.example.com",
-  "apiKey": "cho_xxxxxxxxxxxxxxxxxxxxxxxx",
-  "agentUuid": "00000000-0000-0000-0000-000000000000",
-  "agentName": "My Daemon Agent",
-  "cwds": ["~/work/repo-a", "~/work/repo-b"],
-  "sigintTimeoutMs": 10000
-}
-```
-
-| フィールド | 型 | 書き込み元／用途 | 優先順位（高い順） |
-|-------|------|-----------------------|----------------------------|
-| `url` | string | リモート Chorus サーバーの URL | `--url` フラグ → `CHORUS_URL` → ファイル |
-| `apiKey` | string | エージェント API キー（`cho_…`） | `--api-key` フラグ → `CHORUS_API_KEY` → ファイル |
-| `agentUuid` / `agentName` | string | 認証された身元（ログイン時に記録） | `chorus login` が書き込み |
-| `cwds` | string[] | デーモンが扱う作業ディレクトリ（マルチパス） | `--cwd` フラグ → `CHORUS_DAEMON_CWDS` → ファイル → 起動ディレクトリ |
-| `sigintTimeoutMs` | number | SIGINT 後、強制終了までの猶予時間（ミリ秒、デフォルト `10000`） | `--sigint-timeout` フラグ → `CHORUS_DAEMON_SIGINT_TIMEOUT` → ファイル → `10000` |
-| `yoloAckAt` | string | 内部用 — TTY での yolo 確認のタイムスタンプ（自動管理） | — |
-
-起動時、デーモンのバナーが**実際に読み込んだ `daemon.json` のパス**（およびそのファイルが存在するかどうか）を表示するため、どのファイルを編集すべきか常に分かります。
+ローカルマシンを、割り当てられた課題を実行するエージェントランタイムにするには、`chorus daemon` を実行してください → **[デーモン運用](https://doc.chorus-ai.dev/ja/guides/daemon-operations/)** · **[リモートコントロール](https://doc.chorus-ai.dev/ja/guides/remote-control/)**。
 
 ---
 
@@ -182,7 +81,7 @@ CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # または環�
 
 ![Project Resource Graph](packages/landing/public/images/mind-map.png)
 
-Chorus はプロジェクト全体を自動でマインドマップに整理します — 着想・提案・文書・課題が 1 本のつながったツリーとして配置され — エージェントの動きをリアルタイムに反映し、作業の進行に合わせて各カードのステータスがライブで更新されます。
+着想・提案・文書・課題が 1 本のつながったツリーとして配置され、作業の進行に合わせて各カードのステータスがライブで更新されます。
 
 ### 提案 — AI エージェントがリアルタイムで計画を生成
 
@@ -190,112 +89,23 @@ Chorus はプロジェクト全体を自動でマインドマップに整理し�
 
 PM エージェントが要件を分析し、PRD と課題 DAG を含む提案を生成する様子を見られます — エージェントの活動を示すリアルタイムのプレゼンスインジケーター付きです。
 
-### ピクセルワークスペース — エージェントのリアルタイムな状態
-
-![Pixel Workspace](docs/images/pixcel-workspace-new.gif)
-
-左のパネルはピクセルワークスペースで、ピクセルのキャラクターが各エージェントのリアルタイムな作業状況を表します。右のパネルには、エージェントのターミナル出力がライブで表示されます。
-
 ### カンバン — リアルタイムな課題フロー
 
 ![Kanban Presence](packages/landing/public/images/kanban-presence.gif)
 
 カンバンボードはエージェントの作業に合わせて自動更新され、課題カードが To Do → In Progress → To Verify の間をリアルタイムで移動します。エージェントのプレゼンスインジケーターが、どのリソースが作業中かをハイライトします。
 
-### カンバンと課題 DAG
-
-![Kanban & Task DAG](packages/landing/public/images/kanban-dag.png)
-
-課題のステータスを追跡するカンバンボードと、実行順序や並行経路を示す依存関係 DAG を並べて表示します。
-
-### 着想と要件詳細化
-
-![Idea & Elaboration](packages/landing/public/images/idea-elaborate.png)
-
-PM エージェントは、提案を作成する前に、構造化された Q&A ラウンドを通じて要件を明確にします。パネルには、着想の詳細と、回答・カテゴリタグ付きの完了した詳細化ラウンドが並んで表示されます。
-
-### 提案のレビュー
-
-![Proposal Review](packages/landing/public/images/proposal.png)
-
-PM エージェントが生成した提案には、文書ドラフトと課題 DAG のドラフトが含まれます。管理者はこのパネルでレビューし、承認または却下します。
-
-### 受け入れ基準 — 二経路の検証
-
-![Acceptance Criteria](packages/landing/public/images/task-ac.png)
-
-開発エージェントのセルフチェックと管理者のレビューが、各受け入れ基準を独立して検証し、項目ごとに構造化された合格／不合格の根拠を残します。
-
-### ユニバーサル検索 — Cmd+K コマンドパレット
-
-![Universal Search](packages/landing/public/images/universal-search.png)
-
-6 種類すべてのエンティティ（課題・着想・提案・文書・プロジェクト・プロジェクトグループ）を横断して検索する Cmd+K コマンドパレットです。スコープの絞り込み（Global / Group / Project）、エンティティ種別ごとのフィルタタブ、キーボードナビゲーションに対応します。Web UI と AI エージェント（`chorus_search` MCP ツール経由）は、同じ検索バックエンドを共有します。
-
 ---
 
-## 機能
+## AI エージェントを接続する
 
-- **セッションのライフサイクル** — ハートビート・自動失効・障害復旧を備えた永続的なセッション
-- **課題 DAG** — 依存関係のモデリング、循環検出、インタラクティブな可視化
-- **カンバン** — ワーカーバッジとエージェントのプレゼンスを備えたリアルタイムな課題フロー
-- **マルチエージェント協働** — 並行実行のための Claude Code Agent Teams（Swarm モード）
-- **細粒度のエージェント権限** — 5 リソース × 3 アクションのグリッドと、プリセット + カスタムの組み合わせ（[詳細](docs/PERMISSIONS.md)）
-- **Chorus Plugin** — ライフサイクルフックが、セッションの作成／クローズ・ハートビート・コンテキスト注入を自動化します
-- **要件詳細化** — 提案作成前の構造化された Q&A ラウンド
-- **提案の承認フロー** — PM が起草し、管理者が承認すると、ドラフトが実際のエンティティとして具現化されます
-- **通知** — アプリ内 + SSE プッシュ + Redis Pub/Sub、ユーザーごとの設定に対応（[設計ドキュメント](src/app/api/notifications/README.md)）
-- **@メンション** — Tiptap の自動補完、権限スコープ付き検索、メンション通知（[設計ドキュメント](src/app/api/mentionables/README.md)）
-- **アクティビティストリーム** — セッション帰属付きの完全な監査証跡
-- **ユニバーサル検索** — 6 種類のエンティティを横断する Cmd+K、3 段階のスコープ、スニペット生成（[設計ドキュメント](docs/SEARCH.md)）
+最も手早い方法は、アプリ内のセットアップウィザードです：**Settings → Setup Guide** を開いてください。ウィザードが API キーを作成し、お使いのクライアント（Claude Code、Codex、Kiro、OpenCode、OpenClaw、Pi、その他 MCP 互換のエージェント）向けの正確なコマンドを表示します。
+
+クライアントごとの詳細なガイド → **[エージェントプラットフォーム](https://doc.chorus-ai.dev/ja/reference/agents/)**。
+
+API キーは **Settings → Agents → Create API Key** から作成します。キーは `cho_` で始まり、一度しか表示されません。
+
 ---
-
-## アーキテクチャ
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                 Chorus — Agent Harness (:8637)                    │
-│                                                                  │
-│  ┌── Harness Capabilities ───────────────────────────────────┐   │
-│  │  Session Lifecycle │ Task State Machine │ Context Inject   │   │
-│  │  Sub-Agent Orchestration │ Observability │ Failure Recovery│   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Chorus Plugin (lifecycle hooks) ────────────────────────┐   │
-│  │  SubagentStart/Stop │ Heartbeat │ Skill & Context Inject  │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── API Layer ──────────────────────────────────────────────┐   │
-│  │  /api/mcp  — MCP Streaming (50+ tools, permission-gated)  │   │
-│  │  /api/*    — REST API (Web UI + SSE push)                 │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Service Layer ──────────────────────────────────────────┐   │
-│  │  AI-DLC Workflow │ UUID-first │ Multi-tenant              │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Web UI (React 19 + Tailwind + shadcn/ui) ──────────────┐   │
-│  │  Kanban │ Task DAG │ Proposals │ Activity │ Sessions      │   │
-│  └───────────────────────────────────────────────────────────┘   │
-└──────────────────────────────────────────────────────────────────┘
-     ↑              ↑              ↑              ↑
-  Agent w/      Agent w/       Agent w/         Human
-  idea+proposal  task:write    *:admin perms   (Browser)
-   :write perms    perms      (proxy approval)
-   (LLM)          (LLM)         (LLM)
-                     │
-          ┌──────────▼──────────┐   ┌─────────────────────┐
-          │  PostgreSQL + Prisma │   │  Redis (optional)   │
-          └─────────────────────┘   │  Pub/Sub for SSE    │
-                                    └─────────────────────┘
-```
-
-### パッケージ
-
-| パッケージ | 説明 |
-|---------|-------------|
-| [`packages/openclaw-plugin`](packages/openclaw-plugin) | **OpenClaw Plugin** — 永続的な SSE + MCP ブリッジで [OpenClaw](https://openclaw.ai) と Chorus を接続します。 |
-| [`packages/chorus-cdk`](packages/chorus-cdk) | **AWS CDK** — Chorus を AWS にデプロイするための Infrastructure-as-code。 |
 
 ## 技術スタック
 
@@ -303,155 +113,25 @@ PM エージェントが生成した提案には、文書ドラフトと課題 D
 |-----------|-----------|
 | フレームワーク | Next.js 15 (App Router, Turbopack) |
 | 言語 | TypeScript 5 (strict mode) |
-| フロントエンド | React 19, Tailwind CSS 4, shadcn/ui (Radix UI) |
-| ORM | Prisma 7 |
-| データベース | PostgreSQL 16 |
-| キャッシュ／Pub-Sub | Redis 7 (ioredis) — 任意 |
-| エージェント連携 | MCP SDK 1.26 (HTTP Streamable Transport) |
+| フロントエンド | React 19, Tailwind CSS 4, shadcn/ui |
+| データ | PostgreSQL 16 + Prisma 7, Redis 7 (任意) |
+| エージェント連携 | MCP SDK (HTTP Streamable Transport) |
 | 認証 | OIDC + PKCE / API Key / SuperAdmin |
 | i18n | next-intl (en, zh, ko, ja) |
-| デプロイ | [Docker Hub](https://hub.docker.com/r/chorusaidlc/chorus-app) / Docker Compose / AWS CDK |
-
----
-
-## はじめに
-
-### Docker で始める（推奨）
-
-ビルドツールも外部データベースも不要です。イメージには [PGlite](https://pglite.dev)（組み込み PostgreSQL）が同梱されています：
-
-```bash
-git clone https://github.com/Chorus-AIDLC/chorus.git
-cd chorus
-
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose -f docker-compose.local.yml up -d
-```
-
-[http://localhost:8637](http://localhost:8637) を開き、上記の認証情報でログインしてください。
-
-> データは Docker ボリュームに永続化されます。組み込みモードは単一インスタンスのみです（Redis なし）。
-
-#### 本番デプロイ（PostgreSQL + Redis）
-
-複数レプリカでの本番環境向け：
-
-```bash
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose up -d
-```
-
-> すべての環境変数と設定オプションについては [Docker ドキュメント](docs/DOCKER.md) をご覧ください。
-
----
-
-### ローカル開発
-
-前提条件：Node.js 22+、pnpm 9+、Docker（PostgreSQL/Redis 用）
-
-```bash
-cp .env.example .env
-pnpm docker:db
-pnpm install
-pnpm db:migrate:dev
-pnpm dev
-# http://localhost:8637 を開く
-```
-
-### ローカル開発（Docker なし）
-
-前提条件：Node.js 22+、pnpm 9+
-
-```bash
-cp .env.example .env
-pnpm install
-pnpm dev:local        # 開発サーバー http://localhost:8637
-```
-
-PGlite はポート 5433 で組み込み PostgreSQL を実行します。データは `.pglite/` に保存されます — 削除するとリセットされます。
-
-### AWS へのデプロイ
-
-```bash
-./install.sh
-```
-
-対話式のインストーラーが、VPC・Aurora Serverless v2・ElastiCache Serverless・ECS Fargate・HTTPS 付き ALB をプロビジョニングします。設定は再デプロイ用に `default_deploy.sh` に保存されます。
-
-### AI エージェントを接続する
-
-最も手早い方法は、アプリ内のセットアップウィザードです：Web UI を開き、**Settings → Setup Guide → Open setup guide** に進み、お使いのクライアント（Claude Code、Codex、Kiro、OpenCode、OpenClaw、その他のエージェント）向けのステップバイステップの手順に従ってください。ウィザードが API キーを作成し、正確なコマンドを表示して、接続の確認まで案内します。
-
-詳細なドキュメントを読みたい場合は：
-
-| クライアント | ガイド |
-|--------|-------|
-| Claude Code | [CONNECT_CLAUDE_CODE.md](docs/CONNECT_CLAUDE_CODE.md) |
-| Codex CLI | [CONNECT_CODEX.md](docs/CONNECT_CODEX.md) |
-| Pi coding agent | [CONNECT_PI.md](docs/CONNECT_PI.md) |
-| Kiro CLI | [CONNECT_KIRO.md](docs/CONNECT_KIRO.md) |
-| OpenCode † | [CONNECT_OPENCODE.md](docs/CONNECT_OPENCODE.md) |
-| その他の MCP エージェント（Cursor、Continue、自作など） | [CONNECT_OTHER_AGENTS.md](docs/CONNECT_OTHER_AGENTS.md) |
-
-† OpenCode のサポートは、コミュニティがメンテナンスする [`opencode-chorus`](https://github.com/etnperlong/opencode-chorus) プラグイン（npm: [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus)）によって提供されています。作者は [@etnperlong](https://github.com/etnperlong) です。ありがとうございます！
-
-API キーは Web UI の **Settings → Agents → Create API Key** から作成します。キーは `cho_` で始まり、一度しか表示されません。
-
-![Create API Key](packages/landing/public/images/create-key.png)
-
----
-
-## スキルドキュメント
-
-| 方法 | 場所 | ユースケース |
-|--------|----------|----------|
-| **プラグイン同梱（Claude Code）** | `public/chorus-plugin/skills/` | Claude Code + Chorus プラグイン、自動化されたセッションとライフサイクルフック |
-| **プラグイン同梱（Codex CLI）** | `plugins/chorus/skills/` | Codex CLI + Chorus プラグイン、`$` プレフィックスのスラッシュコマンドを持つ移植版スキル |
-| **パッケージ同梱（Pi）** | `packages/chorus-pi/skills/` | Pi + Chorus パッケージ、自動化されたセッションとライフサイクルフック |
-| **スタンドアロン** | `public/skill/`（`/skill/` で配信） | その他の MCP 対応エージェント（Cursor、Continue、自作）、手動のセッション管理 |
-
-### OpenSpec モード（オプトイン、プラグイン 0.8.1+）
-
-[OpenSpec](https://github.com/Fission-AI/OpenSpec) CLI を
-インストールしている PM エージェントは、構造化された `proposal.md` +
-`design.md` + `specs/<capability>/spec.md` のレイアウトで提案を作成
-できます。ローカルファイルが作業コピー、Chorus の `documentDrafts`
-がそのミラーになります。レビュアーは、自由形式の Markdown ではなく、
-予測可能な形（`## ADDED Requirements`、`### Requirement:`、
-`#### Scenario:`）を目にします。`chorus_admin_verify_task` に対する
-PostToolUse フックが、OpenSpec 着想の最後の課題が検証されたときに
-`openspec archive <slug>` のリマインダーを注入するため、確定した
-仕様は承認直後に長期的な仕様セットへマージされます。このモードは
-厳密にオプトインです：`openspec` がインストールされていない場合、
-挙動は変わりません。Claude Code でのマスタースイッチは
-`enableOpenSpec`（プラグインの userConfig、デフォルト `true`）です。
-どちらのクライアントも `CHORUS_OPENSPEC_MODE=off` を尊重します。
-このモードで新しい MCP ツールやスキーマ変更が追加されることは
-ありません。正規のスキルは既存の `chorus_pm_*` のドラフト・文書
-ツールを再利用し、ミラー呼び出しは `chorus-api.sh` ラッパー経由で
-ルーティングして、数千行に及ぶ Markdown を LLM のコンテキストの外に
-保ちます。完全なガイドは
-[OPENSPEC_MODE.md](docs/OPENSPEC_MODE.md) をご覧ください。
+| デプロイ | npm / Docker / AWS CDK |
 
 ---
 
 ## ドキュメント
 
-| ドキュメント | 説明 |
-|----------|------------|
-| [PRD](docs/PRD_Chorus.md) | プロダクト要求仕様書 |
-| [Architecture](docs/ARCHITECTURE.md) | 技術アーキテクチャドキュメント |
-| [MCP Tools](docs/MCP_TOOLS.md) | MCP ツールリファレンス |
-| [Permissions](docs/PERMISSIONS.md) | エージェント権限モデル（5 × 3 マトリクス、プリセット、Custom モード） |
-| [Chorus Plugin](docs/chorus-plugin.md) | プラグイン設計とフックのドキュメント |
-| [OpenSpec Mode](docs/OPENSPEC_MODE.md) | PM エージェント向けのオプトイン OpenSpec 作成モード（プラグイン 0.8.1+） |
-| [Search](docs/SEARCH.md) | グローバル検索の技術設計 |
-| [AI-DLC Gap Analysis](docs/AIDLC_GAP_ANALYSIS.md) | AI-DLC 方法論のギャップ分析 |
-| [AIG Implementation Plan](docs/CHORUS_AIG_PLAN.md) | エージェントの透明性ロードマップ |
-| [Presence Design](docs/PRESENCE_DESIGN.md) | リアルタイムのエージェントプレゼンスシステム |
-| [Docker](docs/DOCKER.md) | Docker イメージの使い方とデプロイ |
-| [Logging](docs/LOGGING.md) | 構造化ロギングのアーキテクチャ |
-| [CLAUDE.md](CLAUDE.md) | 開発ガイド |
+**📖 完全なドキュメント：[doc.chorus-ai.dev](https://doc.chorus-ai.dev/ja/)**
+
+- [はじめに](https://doc.chorus-ai.dev/ja/guides/getting-started/)
+- [エージェントを接続する](https://doc.chorus-ai.dev/ja/reference/agents/)
+- [AI-DLC ワークフロー](https://doc.chorus-ai.dev/ja/guides/ai-dlc-workflow/)
+- [プラグインとコマンド](https://doc.chorus-ai.dev/ja/guides/plugin-commands/)
+- [MCP ツールリファレンス](https://doc.chorus-ai.dev/ja/reference/mcp-tools/)
+- [デプロイとセルフホスト](https://doc.chorus-ai.dev/ja/guides/deployment-overview/)
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
   <img src="packages/landing/public/images/chorus-slug.png" alt="Chorus" width="240" />
 </p>
 
-<p align="center"><strong>AI-인간 협업을 위한 Agent Harness</strong></p>
+<p align="center"><strong>당신의 코딩 에이전트 위에 얹는 Harness. 에이전트가 제안하고, 사람이 검증하고, 소프트웨어가 배포됩니다.</strong></p>
 
 <p align="center">
   <a href="https://discord.gg/SwcCMaMmR">
@@ -15,9 +15,9 @@
 
 <p align="center"><a href="README.md">English</a> · <a href="README.zh.md">中文</a> · <strong>한국어</strong> · <a href="README.ja.md">日本語</a></p>
 
-<p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 문서</strong></a></p>
+<p align="center"><a href="https://doc.chorus-ai.dev/ko/"><strong>📖 문서</strong></a></p>
 
-Chorus는 Agent Harness입니다 — LLM 에이전트를 감싸 세션 라이프사이클, 작업 상태, 하위 에이전트 오케스트레이션, 관측 가능성, 장애 복구를 관리하는 인프라 계층입니다. 세밀하게 설정 가능한 권한을 가진 여러 AI 에이전트와 사람이 요구사항부터 배포까지 전체 워크플로를 통해 협업할 수 있게 해줍니다.
+Chorus는 당신의 코딩 에이전트 위에 얹는 Harness입니다. 코딩 에이전트가 모델을 harness하여 코드를 작성한다면, Chorus는 그보다 한 단계 위의 Harness로서, 그런 에이전트 한 팀 전체와 당신을 하나의 파이프라인으로 묶습니다. 에이전트가 제안하고, 사람이 검증하고, 아이디어가 배포된 소프트웨어로 바뀝니다. 그 아래에서는 멀티 에이전트와 사람이 함께하는 협업이 흔들리지 않도록 하는 것들을 처리합니다: 세션 라이프사이클, 작업 상태, 하위 에이전트 오케스트레이션, 관측 가능성, 장애 복구. 모든 AI 에이전트는 세밀하게 설정 가능한 권한을 갖습니다.
 
 **[AI-DLC(AI-Driven Development Lifecycle)](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** 방법론에서 영감을 받았습니다. 핵심 철학은 **Reversed Conversation** — AI가 제안하고, 사람이 검증합니다.
 
@@ -32,7 +32,7 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 생성      + 구체화       + 초안                  + 보고      + 검증     + 종료
 ```
 
-각 단계 아래에 적힌 것은 해당 단계에서 액터에게 필요한 **권한**입니다 — 사람, 에이전트(프리셋 또는 Custom), 또는 둘 다에게 부여할 수 있습니다. 고정된 역할은 없으며, 5 × 3 권한 매트릭스의 어떤 조합도 가능합니다. 자세한 내용은 [`docs/PERMISSIONS.md`](docs/PERMISSIONS.md)를 참고하세요.
+각 단계 아래에 적힌 것은 해당 단계에서 액터에게 필요한 **권한**입니다 — 사람, 에이전트, 또는 둘 다에게 부여할 수 있습니다. 고정된 역할은 없으며, 5 × 3 권한 매트릭스의 어떤 조합도 가능합니다. → [에이전트 권한](https://doc.chorus-ai.dev/ko/guides/manage-agents/)
 
 ---
 
@@ -54,119 +54,18 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 
 ## 빠른 시작
 
-두 개의 명령으로 Chorus를 로컬에서 실행할 수 있습니다 — 데이터베이스도, Docker도, 설정 파일도 필요 없습니다.
+두 개의 명령이면 됩니다. 데이터베이스도, Docker도, 설정 파일도 필요 없습니다.
 
 ```bash
 npm install -g @chorus-aidlc/chorus
 chorus
 ```
 
-이게 전부입니다. Chorus는 내장 PostgreSQL(PGlite)로 시작해 마이그레이션을 자동으로 실행하고 **http://localhost:8637** 에서 열립니다.
+Chorus는 내장 PostgreSQL(PGlite)로 시작해 마이그레이션을 실행하고 **http://localhost:8637** 에서 열립니다. 기본 로그인: `admin@chorus.local` / `chorus`.
 
-> **참고:** PGlite는 내장형 단일 프로세스 PostgreSQL입니다 — 로컬 단일 사용자 용도에는 훌륭하지만, 동시 부하가 걸리면 커넥션 처리에 한계가 있습니다. 여러 에이전트나 사용자를 동시에 실행할 계획이라면 `DATABASE_URL=postgresql://...`로 외부 PostgreSQL을 사용하거나 전체 [Docker Compose](#docker로-시작하기-권장) 스택을 이용하세요.
+> 여러 에이전트를 실행하거나 프로덕션에 배포하시나요? 외부 PostgreSQL, Docker, 또는 AWS를 사용하세요 → **[배포 및 셀프 호스팅](https://doc.chorus-ai.dev/ko/guides/deployment-overview/)**.
 
-기본 로그인 정보: `admin@chorus.local` / `chorus`
-
-### 옵션
-
-```bash
-# 커스텀 포트
-chorus --port 3000
-
-# 커스텀 데이터 디렉터리(기본값: ~/.chorus-data)
-chorus --data-dir /path/to/data
-
-# 커스텀 인증 정보
-DEFAULT_USER=me@example.com DEFAULT_PASSWORD=secret chorus
-
-# 내장 PGlite 대신 외부 PostgreSQL 사용
-DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
-```
-
-### 그 밖의 배포 방법
-
-| 방법 | 명령 |
-|--------|---------|
-| **npm**(가장 간단) | `npm i -g @chorus-aidlc/chorus && chorus` |
-| **Docker(단독)** | [`docker compose -f docker-compose.local.yml up`](#docker로-시작하기-권장) |
-| **Docker(풀 스택)** | [`docker compose up`](#docker로-시작하기-권장)(PostgreSQL + Redis + Chorus) |
-| **AWS CDK** | [AWS에 배포](#aws에-배포) |
-
-### `chorus daemon` — 에이전트 런타임으로 연결
-
-`chorus daemon`은 여러분의 로컬 머신을 에이전트 런타임으로서 원격 Chorus 서버에 연결하고, Chorus가 배정한 작업을 실행합니다.
-
-> **에이전트 백엔드:** **Claude Code**(기본)와 **Codex**를 지원합니다 — `--agent codex`(또는 `CHORUS_AGENT=codex`)로 선택합니다. 다른 에이전트 CLI(Copilot 등)에 대한 지원은 향후 릴리스에서 예정되어 있습니다.
-
-```bash
-chorus login                     # 인증(브라우저를 엽니다)
-chorus daemon                    # 데몬을 포그라운드로 시작
-chorus daemon -d                 # 데몬을 백그라운드로 시작(디태치)
-chorus daemon install            # 부팅 시 자동 시작하는 서비스로 설치(Linux) — 권장
-chorus daemon uninstall          # 설치된 서비스를 제거
-chorus daemon stop               # 데몬을 중지(설치되어 있으면 systemd에 위임)
-chorus daemon stop --force       # 멈춘 pid가 중지를 막을 때 pidfile을 강제로 정리
-chorus daemon status             # 데몬 상태 확인
-chorus daemon restart            # 데몬 재시작
-chorus daemon logs               # 데몬 로그 보기
-```
-
-**주요 기능:**
-
-- **Claude Code & Codex 백엔드** — PATH에 있는 `claude`(또는 `codex`) CLI를 자동 감지합니다. `--agent codex`로 선택합니다
-- **백그라운드 모드** — `-d` 플래그로 실행하고, `stop/restart/logs`로 관리합니다
-- **부팅 자동 시작 서비스** — `chorus daemon install`이 올바른 `systemd --user` unit을 생성하고 시작합니다(아래 참고). 이후 `status/stop/restart/logs`는 투명하게 systemd에 위임됩니다
-- **권한 모드** — 기본값은 완전 접근(yolo)입니다. `--chorus-only`로 Chorus MCP 도구로만 제한할 수 있습니다
-- **멀티 패스** — 반복 지정 가능한 `--cwd`로 하나의 데몬에서 여러 작업 디렉터리를 서비스할 수 있습니다(아래 참고)
-- **대화식 설정** — 아직 구성되지 않은 경우, 최초 시작 시 인증 정보를 입력하도록 안내합니다
-
-데몬에는 인증이 필요합니다. 먼저 `chorus login`을 실행하세요. 실행하지 않았다면 최초 시작 시(터미널에서 실행 중인 경우) 대화식으로 인증 정보를 입력하도록 안내합니다.
-
-#### 부팅 / 로그인 시 실행 — `chorus daemon install`
-
-```bash
-chorus daemon install --cwd ~/work/repo-a --cwd ~/work/repo-b   # 설치하고 지금 시작, 로그인 시 자동 시작
-chorus daemon uninstall                                         # 서비스 비활성화 및 제거
-```
-
-Linux에서는 `install`이 `systemd --user` unit을 생성하여 데몬을 **포그라운드**(`Type=simple`, `-d` 없음)로 실행합니다. 이렇게 하면 systemd가 프로세스를 직접 소유하며, 이어서 `daemon-reload` + `enable --now`를 수행합니다. unit에는 여러분이 전달한 `--cwd`/`--agent`/`--chorus-only` 플래그가 담깁니다. `chorus daemon -d`를 감싼 `Type=forking` unit을 **직접 작성하지 마세요** — 데몬은 스스로 데몬화하기 때문에 systemd가 추적할 수 없고 재시작 시 루프에 빠집니다. 올바른 unit은 `install`이 작성하도록 맡기세요. macOS/Windows에서는 `install`이 직접 설치할 수 있는 올바른 템플릿을 출력합니다. unit이 인증 정보를 읽을 수 있도록 먼저 `chorus login`을 실행하세요. 자세한 내용은 [docs/DAEMON.md](docs/DAEMON.md)를 참고하세요.
-
-#### 여러 작업 디렉터리 서비스하기
-
-하나의 데몬은 여러 로컬 작업 디렉터리를 동시에 서비스할 수 있습니다 — 선언된 각 경로는 동일한 에이전트 아래에서 독립적인 연결(자체 세션 + 웨이크 루프)로 등록됩니다. 경로는 데몬이 서비스하는 **단지** 디렉터리일 뿐이며, 프로젝트와의 결합은 갖지 않습니다.
-
-```bash
-chorus daemon --cwd ~/work/repo-a --cwd ~/work/repo-b   # 반복 지정 가능한 플래그
-CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # 또는 환경 변수(`:` 또는 `,` 구분)
-```
-
-`--cwd`를 지정하지 않으면 데몬은 실행된 위치의 단일 디렉터리만 서비스합니다.
-
-#### 설정 파일 — `~/.chorus/daemon.json`
-
-`chorus login`은 인증 정보를 여기에 기록합니다(모드 `0600`). 데몬 조정 항목을 **같은** 파일에 추가할 수도 있습니다. 모든 필드는 선택 사항이며, 플래그와 환경 변수는 항상 파일보다 우선합니다.
-
-```json
-{
-  "url": "https://chorus.example.com",
-  "apiKey": "cho_xxxxxxxxxxxxxxxxxxxxxxxx",
-  "agentUuid": "00000000-0000-0000-0000-000000000000",
-  "agentName": "My Daemon Agent",
-  "cwds": ["~/work/repo-a", "~/work/repo-b"],
-  "sigintTimeoutMs": 10000
-}
-```
-
-| 필드 | 타입 | 기록 주체 / 용도 | 우선순위(높은 순) |
-|-------|------|-----------------------|----------------------------|
-| `url` | string | 원격 Chorus 서버 URL | `--url` 플래그 → `CHORUS_URL` → 파일 |
-| `apiKey` | string | 에이전트 API 키(`cho_…`) | `--api-key` 플래그 → `CHORUS_API_KEY` → 파일 |
-| `agentUuid` / `agentName` | string | 인증된 신원(로그인 시 기록) | `chorus login`이 기록 |
-| `cwds` | string[] | 데몬이 서비스하는 작업 디렉터리(멀티 패스) | `--cwd` 플래그 → `CHORUS_DAEMON_CWDS` → 파일 → 실행 디렉터리 |
-| `sigintTimeoutMs` | number | SIGINT 이후 강제 종료까지의 유예 시간(ms, 기본값 `10000`) | `--sigint-timeout` 플래그 → `CHORUS_DAEMON_SIGINT_TIMEOUT` → 파일 → `10000` |
-| `yoloAckAt` | string | 내부용 — TTY yolo 확인의 타임스탬프(자동 관리) | — |
-
-시작 시 데몬 배너가 **실제로 읽은 `daemon.json` 경로**(그리고 그 파일의 존재 여부)를 출력하므로, 어떤 파일을 편집해야 하는지 항상 알 수 있습니다.
+로컬 머신을 배정된 작업을 이어받는 에이전트 런타임으로 만들려면 `chorus daemon`을 실행하세요 → **[데몬 운영](https://doc.chorus-ai.dev/ko/guides/daemon-operations/)** · **[원격 제어](https://doc.chorus-ai.dev/ko/guides/remote-control/)**.
 
 ---
 
@@ -182,120 +81,31 @@ CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # 또는 환경
 
 ![Project Resource Graph](packages/landing/public/images/mind-map.png)
 
-Chorus는 프로젝트 전체를 마인드맵으로 자동 정리합니다 — 아이디어·제안·문서·작업이 하나로 연결된 트리로 배치되며 — 에이전트가 하는 일을 실시간으로 반영하고, 작업이 진행됨에 따라 각 카드의 상태가 실시간으로 업데이트됩니다.
+아이디어·제안·문서·작업이 하나로 연결된 트리로 배치되며, 에이전트가 작업하는 동안 각 카드의 상태가 실시간으로 업데이트됩니다.
 
 ### 제안 — AI 에이전트가 실시간으로 계획을 생성
 
 ![Proposal Presence](packages/landing/public/images/proposal-presence.gif)
 
-PM 에이전트가 요구사항을 분석하고 PRD와 작업 DAG를 포함한 제안을 생성하는 모습을 볼 수 있습니다 — 에이전트 활동을 보여주는 실시간 프레즌스 인디케이터와 함께 말이죠.
-
-### 픽셀 워크스페이스 — 에이전트의 실시간 상태
-
-![Pixel Workspace](docs/images/pixcel-workspace-new.gif)
-
-왼쪽 패널은 픽셀 워크스페이스로, 픽셀 캐릭터가 각 에이전트의 실시간 작업 상태를 나타냅니다. 오른쪽 패널에는 에이전트의 터미널 출력이 실시간으로 표시됩니다.
+PM 에이전트가 요구사항을 분석해 PRD와 작업 DAG를 생성하며, 실시간 프레즌스 인디케이터가 에이전트 활동을 보여줍니다.
 
 ### 칸반 — 실시간 작업 흐름
 
 ![Kanban Presence](packages/landing/public/images/kanban-presence.gif)
 
-칸반 보드는 에이전트의 작업에 맞춰 자동으로 업데이트되며, 작업 카드가 To Do → In Progress → To Verify 사이를 실시간으로 이동합니다. 에이전트 프레즌스 인디케이터가 어떤 리소스가 작업 중인지 하이라이트합니다.
-
-### 칸반 & 작업 DAG
-
-![Kanban & Task DAG](packages/landing/public/images/kanban-dag.png)
-
-작업 상태를 추적하는 칸반 보드와, 실행 순서 및 병렬 경로를 보여주는 의존성 DAG를 나란히 표시합니다.
-
-### 아이디어 & 요구사항 구체화
-
-![Idea & Elaboration](packages/landing/public/images/idea-elaborate.png)
-
-PM 에이전트는 제안을 만들기 전에 구조화된 Q&A 라운드를 통해 요구사항을 명확히 합니다. 패널에는 아이디어 상세 정보와 함께, 답변 및 카테고리 태그가 달린 완료된 구체화 라운드가 나란히 표시됩니다.
-
-### 제안 검토
-
-![Proposal Review](packages/landing/public/images/proposal.png)
-
-PM 에이전트가 생성한 제안에는 문서 초안과 작업 DAG 초안이 담깁니다. 관리자는 이 패널에서 검토하여 승인하거나 거부합니다.
-
-### 수락 기준 — 이중 경로 검증
-
-![Acceptance Criteria](packages/landing/public/images/task-ac.png)
-
-개발자 에이전트의 자체 점검과 관리자의 검토가 각 수락 기준을 독립적으로 검증하며, 모든 항목마다 구조화된 통과/실패 증빙을 남깁니다.
-
-### 유니버설 검색 — Cmd+K 커맨드 팔레트
-
-![Universal Search](packages/landing/public/images/universal-search.png)
-
-6가지 엔티티 유형(작업·아이디어·제안·문서·프로젝트·프로젝트 그룹)을 아우르는 검색을 위한 Cmd+K 커맨드 팔레트입니다. 범위 필터링(Global / Group / Project), 엔티티 유형별 필터 탭, 키보드 내비게이션을 지원합니다. Web UI와 AI 에이전트(`chorus_search` MCP 도구를 통해)는 동일한 검색 백엔드를 공유합니다.
+에이전트가 작업하는 동안 작업 카드가 To Do → In Progress → To Verify 사이를 이동하며, 지금 다뤄지는 항목에 프레즌스 인디케이터가 표시됩니다.
 
 ---
 
-## 기능
+## 에이전트 연결하기
 
-- **세션 라이프사이클** — 하트비트, 자동 만료, 장애 복구를 갖춘 영속적 세션
-- **작업 DAG** — 의존성 모델링, 순환 감지, 인터랙티브 시각화
-- **칸반** — 워커 배지와 에이전트 프레즌스를 갖춘 실시간 작업 흐름
-- **멀티 에이전트 협업** — 병렬 실행을 위한 Claude Code Agent Teams(Swarm 모드)
-- **세밀한 에이전트 권한** — 5 리소스 × 3 액션 그리드와 프리셋 + 커스텀 조합([상세](docs/PERMISSIONS.md))
-- **Chorus Plugin** — 라이프사이클 훅이 세션 생성/종료, 하트비트, 컨텍스트 주입을 자동화합니다
-- **요구사항 구체화** — 제안 생성 전의 구조화된 Q&A 라운드
-- **제안 승인 흐름** — PM이 초안을 작성하고 관리자가 승인하면, 초안이 실제 엔티티로 구체화됩니다
-- **알림** — 앱 내 + SSE 푸시 + Redis Pub/Sub, 사용자별 설정 지원([설계 문서](src/app/api/notifications/README.md))
-- **@멘션** — Tiptap 자동 완성, 권한 범위 검색, 멘션 알림([설계 문서](src/app/api/mentionables/README.md))
-- **액티비티 스트림** — 세션 귀속 정보가 포함된 완전한 감사 추적
-- **유니버설 검색** — 6가지 엔티티 유형을 아우르는 Cmd+K, 3단계 범위, 스니펫 생성([설계 문서](docs/SEARCH.md))
+가장 빠른 방법은 앱 내 마법사입니다: **Settings → Setup Guide**를 여세요. 마법사가 API 키를 만들고, 사용하는 클라이언트(Claude Code, Codex, Kiro, OpenCode, OpenClaw, Pi, 또는 그 밖의 MCP 호환 에이전트)에 맞는 정확한 명령을 보여줍니다.
+
+클라이언트별 전체 가이드 → **[에이전트 플랫폼](https://doc.chorus-ai.dev/ko/reference/agents/)**.
+
+API 키는 **Settings → Agents → Create API Key**에서 만듭니다. 키는 `cho_`로 시작하며 한 번만 표시됩니다.
+
 ---
-
-## 아키텍처
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                 Chorus — Agent Harness (:8637)                    │
-│                                                                  │
-│  ┌── Harness Capabilities ───────────────────────────────────┐   │
-│  │  Session Lifecycle │ Task State Machine │ Context Inject   │   │
-│  │  Sub-Agent Orchestration │ Observability │ Failure Recovery│   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Chorus Plugin (lifecycle hooks) ────────────────────────┐   │
-│  │  SubagentStart/Stop │ Heartbeat │ Skill & Context Inject  │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── API Layer ──────────────────────────────────────────────┐   │
-│  │  /api/mcp  — MCP Streaming (50+ tools, permission-gated)  │   │
-│  │  /api/*    — REST API (Web UI + SSE push)                 │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Service Layer ──────────────────────────────────────────┐   │
-│  │  AI-DLC Workflow │ UUID-first │ Multi-tenant              │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Web UI (React 19 + Tailwind + shadcn/ui) ──────────────┐   │
-│  │  Kanban │ Task DAG │ Proposals │ Activity │ Sessions      │   │
-│  └───────────────────────────────────────────────────────────┘   │
-└──────────────────────────────────────────────────────────────────┘
-     ↑              ↑              ↑              ↑
-  Agent w/      Agent w/       Agent w/         Human
-  idea+proposal  task:write    *:admin perms   (Browser)
-   :write perms    perms      (proxy approval)
-   (LLM)          (LLM)         (LLM)
-                     │
-          ┌──────────▼──────────┐   ┌─────────────────────┐
-          │  PostgreSQL + Prisma │   │  Redis (optional)   │
-          └─────────────────────┘   │  Pub/Sub for SSE    │
-                                    └─────────────────────┘
-```
-
-### 패키지
-
-| 패키지 | 설명 |
-|---------|-------------|
-| [`packages/openclaw-plugin`](packages/openclaw-plugin) | **OpenClaw Plugin** — 영속적인 SSE + MCP 브리지로 [OpenClaw](https://openclaw.ai)와 Chorus를 연결합니다. |
-| [`packages/chorus-cdk`](packages/chorus-cdk) | **AWS CDK** — Chorus를 AWS에 배포하기 위한 Infrastructure-as-code. |
 
 ## 기술 스택
 
@@ -303,154 +113,25 @@ PM 에이전트가 생성한 제안에는 문서 초안과 작업 DAG 초안이 
 |-----------|-----------|
 | 프레임워크 | Next.js 15 (App Router, Turbopack) |
 | 언어 | TypeScript 5 (strict mode) |
-| 프론트엔드 | React 19, Tailwind CSS 4, shadcn/ui (Radix UI) |
-| ORM | Prisma 7 |
-| 데이터베이스 | PostgreSQL 16 |
-| 캐시/Pub-Sub | Redis 7 (ioredis) — 선택 사항 |
-| 에이전트 연동 | MCP SDK 1.26 (HTTP Streamable Transport) |
+| 프론트엔드 | React 19, Tailwind CSS 4, shadcn/ui |
+| 데이터 | PostgreSQL 16 + Prisma 7, Redis 7 (optional) |
+| 에이전트 연동 | MCP SDK (HTTP Streamable Transport) |
 | 인증 | OIDC + PKCE / API Key / SuperAdmin |
 | i18n | next-intl (en, zh, ko, ja) |
-| 배포 | [Docker Hub](https://hub.docker.com/r/chorusaidlc/chorus-app) / Docker Compose / AWS CDK |
-
----
-
-## 시작하기
-
-### Docker로 시작하기 (권장)
-
-빌드 도구나 외부 데이터베이스가 필요 없습니다. 이미지에는 [PGlite](https://pglite.dev)(내장 PostgreSQL)가 함께 들어 있습니다:
-
-```bash
-git clone https://github.com/Chorus-AIDLC/chorus.git
-cd chorus
-
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose -f docker-compose.local.yml up -d
-```
-
-[http://localhost:8637](http://localhost:8637)을 열고 위의 인증 정보로 로그인하세요.
-
-> 데이터는 Docker 볼륨에 영속화됩니다. 내장 모드는 단일 인스턴스 전용입니다(Redis 없음).
-
-#### 프로덕션 배포 (PostgreSQL + Redis)
-
-여러 레플리카를 사용하는 프로덕션 환경용:
-
-```bash
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose up -d
-```
-
-> 모든 환경 변수와 설정 옵션은 [Docker 문서](docs/DOCKER.md)를 참고하세요.
-
----
-
-### 로컬 개발
-
-전제 조건: Node.js 22+, pnpm 9+, Docker(PostgreSQL/Redis용)
-
-```bash
-cp .env.example .env
-pnpm docker:db
-pnpm install
-pnpm db:migrate:dev
-pnpm dev
-# http://localhost:8637 을 여세요
-```
-
-### 로컬 개발 (Docker 없이)
-
-전제 조건: Node.js 22+, pnpm 9+
-
-```bash
-cp .env.example .env
-pnpm install
-pnpm dev:local        # 개발 서버 http://localhost:8637
-```
-
-PGlite는 포트 5433에서 내장 PostgreSQL을 실행합니다. 데이터는 `.pglite/`에 저장됩니다 — 삭제하면 초기화됩니다.
-
-### AWS에 배포
-
-```bash
-./install.sh
-```
-
-대화식 인스톨러가 VPC, Aurora Serverless v2, ElastiCache Serverless, ECS Fargate, HTTPS를 갖춘 ALB를 프로비저닝합니다. 설정은 재배포를 위해 `default_deploy.sh`에 저장됩니다.
-
-### AI 에이전트 연결하기
-
-가장 빠른 방법은 앱 내 설정 마법사입니다: Web UI를 열고 **Settings → Setup Guide → Open setup guide**로 이동한 뒤, 사용하는 클라이언트(Claude Code, Codex, Kiro, OpenCode, OpenClaw, 또는 그 밖의 에이전트)에 맞는 단계별 안내를 따르세요. 마법사가 API 키를 만들어 주고, 정확한 명령을 보여주며, 연결 확인까지 안내합니다.
-
-전체 문서를 읽고 싶다면:
-
-| 클라이언트 | 가이드 |
-|--------|-------|
-| Claude Code | [CONNECT_CLAUDE_CODE.md](docs/CONNECT_CLAUDE_CODE.md) |
-| Codex CLI | [CONNECT_CODEX.md](docs/CONNECT_CODEX.md) |
-| Pi coding agent | [CONNECT_PI.md](docs/CONNECT_PI.md) |
-| Kiro CLI | [CONNECT_KIRO.md](docs/CONNECT_KIRO.md) |
-| OpenCode † | [CONNECT_OPENCODE.md](docs/CONNECT_OPENCODE.md) |
-| 그 밖의 MCP 에이전트(Cursor, Continue, 커스텀 등) | [CONNECT_OTHER_AGENTS.md](docs/CONNECT_OTHER_AGENTS.md) |
-
-† OpenCode 지원은 커뮤니티가 유지 관리하는 [`opencode-chorus`](https://github.com/etnperlong/opencode-chorus) 플러그인(npm: [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus))으로 제공되며, 작성자는 [@etnperlong](https://github.com/etnperlong)입니다. 감사합니다!
-
-API 키는 Web UI의 **Settings → Agents → Create API Key**에서 만듭니다. 키는 `cho_`로 시작하며 한 번만 표시됩니다.
-
-![Create API Key](packages/landing/public/images/create-key.png)
-
----
-
-## 스킬 문서
-
-| 방법 | 위치 | 사용 사례 |
-|--------|----------|----------|
-| **플러그인 내장(Claude Code)** | `public/chorus-plugin/skills/` | Claude Code + Chorus 플러그인, 자동화된 세션과 라이프사이클 훅 |
-| **플러그인 내장(Codex CLI)** | `plugins/chorus/skills/` | Codex CLI + Chorus 플러그인, `$` 접두사 슬래시 명령을 갖춘 이식판 스킬 |
-| **패키지 내장(Pi)** | `packages/chorus-pi/skills/` | Pi + Chorus 패키지, 자동화된 세션과 라이프사이클 훅 |
-| **스탠드얼론** | `public/skill/`(`/skill/`에서 제공) | 그 밖의 MCP 지원 에이전트(Cursor, Continue, 커스텀), 수동 세션 관리 |
-
-### OpenSpec 모드 (옵트인, 플러그인 0.8.1+)
-
-[OpenSpec](https://github.com/Fission-AI/OpenSpec) CLI를 설치한 PM
-에이전트는 구조화된 `proposal.md` + `design.md` +
-`specs/<capability>/spec.md` 레이아웃으로 제안을 작성할 수
-있습니다. 로컬 파일이 작업 사본이고 Chorus의 `documentDrafts`가
-그 미러입니다. 리뷰어는 자유 형식의 Markdown이 아니라 예측
-가능한 형태(`## ADDED Requirements`, `### Requirement:`,
-`#### Scenario:`)를 보게 됩니다. `chorus_admin_verify_task`에 대한
-PostToolUse 훅이, OpenSpec 아이디어의 마지막 작업이 검증될 때
-`openspec archive <slug>` 리마인더를 주입하므로, 확정된 스펙은
-승인 직후 장기 스펙 세트에 병합됩니다. 이 모드는 엄격하게
-옵트인입니다: `openspec`이 설치되어 있지 않으면 동작은
-바뀌지 않습니다. Claude Code에서의 마스터 스위치는
-`enableOpenSpec`(플러그인 userConfig, 기본값 `true`)이며, 두
-클라이언트 모두 `CHORUS_OPENSPEC_MODE=off`를 존중합니다. 이
-모드에서 새로운 MCP 도구나 스키마 변경이 추가되는 일은
-없습니다. 정규 스킬은 기존의 `chorus_pm_*` 초안·문서 도구를
-재사용하며, 미러 호출은 `chorus-api.sh` 래퍼를 통해 라우팅하여
-수천 줄에 달하는 Markdown을 LLM 컨텍스트 밖에 둡니다. 전체
-가이드는 [OPENSPEC_MODE.md](docs/OPENSPEC_MODE.md)를 참고하세요.
+| 배포 | npm / Docker / AWS CDK |
 
 ---
 
 ## 문서
 
-| 문서 | 설명 |
-|----------|------------|
-| [PRD](docs/PRD_Chorus.md) | 제품 요구사항 문서 |
-| [Architecture](docs/ARCHITECTURE.md) | 기술 아키텍처 문서 |
-| [MCP Tools](docs/MCP_TOOLS.md) | MCP 도구 레퍼런스 |
-| [Permissions](docs/PERMISSIONS.md) | 에이전트 권한 모델(5 × 3 매트릭스, 프리셋, Custom 모드) |
-| [Chorus Plugin](docs/chorus-plugin.md) | 플러그인 설계 및 훅 문서 |
-| [OpenSpec Mode](docs/OPENSPEC_MODE.md) | PM 에이전트를 위한 옵트인 OpenSpec 작성 모드(플러그인 0.8.1+) |
-| [Search](docs/SEARCH.md) | 글로벌 검색 기술 설계 |
-| [AI-DLC Gap Analysis](docs/AIDLC_GAP_ANALYSIS.md) | AI-DLC 방법론 갭 분석 |
-| [AIG Implementation Plan](docs/CHORUS_AIG_PLAN.md) | 에이전트 투명성 로드맵 |
-| [Presence Design](docs/PRESENCE_DESIGN.md) | 실시간 에이전트 프레즌스 시스템 |
-| [Docker](docs/DOCKER.md) | Docker 이미지 사용법 및 배포 |
-| [Logging](docs/LOGGING.md) | 구조화 로깅 아키텍처 |
-| [CLAUDE.md](CLAUDE.md) | 개발 가이드 |
+**📖 전체 문서: [doc.chorus-ai.dev](https://doc.chorus-ai.dev/ko/)**
+
+- [시작하기](https://doc.chorus-ai.dev/ko/guides/getting-started/)
+- [에이전트 연결](https://doc.chorus-ai.dev/ko/reference/agents/)
+- [AI-DLC 워크플로](https://doc.chorus-ai.dev/ko/guides/ai-dlc-workflow/)
+- [플러그인 및 명령](https://doc.chorus-ai.dev/ko/guides/plugin-commands/)
+- [MCP 도구 레퍼런스](https://doc.chorus-ai.dev/ko/reference/mcp-tools/)
+- [배포 및 셀프 호스팅](https://doc.chorus-ai.dev/ko/guides/deployment-overview/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="packages/landing/public/images/chorus-slug.png" alt="Chorus" width="240" />
 </p>
 
-<p align="center"><strong>The Agent Harness for AI-Human Collaboration</strong></p>
+<p align="center"><strong>The harness for your coding agents. Agents propose, humans verify, software ships.</strong></p>
 
 <p align="center">
   <a href="https://discord.gg/SwcCMaMmR">
@@ -17,7 +17,7 @@
 
 <p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 Documentation</strong></a></p>
 
-Chorus is an agent harness — the infrastructure that wraps around LLM agents to manage session lifecycle, task state, sub-agent orchestration, observability, and failure recovery. It lets multiple AI Agents (with fine-grained, configurable permissions) and humans collaborate through the full workflow from requirements to delivery.
+Chorus is the harness for your coding agents. A coding agent harnesses a model to write code; Chorus is the harness one level up, taking a whole team of those agents, plus you, into a single pipeline where agents propose, humans verify, and ideas turn into delivered software. Underneath, it handles what holds multi-agent, human-in-the-loop work together: session lifecycle, task state, sub-agent orchestration, observability, and failure recovery. Every AI Agent gets fine-grained, configurable permissions.
 
 Inspired by the **[AI-DLC (AI-Driven Development Lifecycle)](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** methodology. Core philosophy: **Reversed Conversation** — AI proposes, humans verify.
 
@@ -32,7 +32,7 @@ Human     idea:write     proposal:write         task:write   *:admin    *:admin
 creates   + elaborate    + drafts                + reports   + verifies + closes
 ```
 
-The labels under each stage are the **permissions** an actor needs at that stage — granted to a human, an Agent (preset or Custom), or both. There are no fixed roles; any combination of the 5 × 3 permission matrix is possible. See [`docs/PERMISSIONS.md`](docs/PERMISSIONS.md).
+The labels under each stage are the **permissions** an actor needs there — granted to a human, an Agent, or both. There are no fixed roles; any combination of the 5 × 3 permission matrix works. → [Agent permissions](https://doc.chorus-ai.dev/guides/manage-agents/)
 
 ---
 
@@ -54,251 +54,58 @@ The labels under each stage are the **permissions** an actor needs at that stage
 
 ## Quick Start
 
-Run Chorus locally with two commands — no database, no Docker, no config files needed.
+Two commands. No database, no Docker, no config files.
 
 ```bash
 npm install -g @chorus-aidlc/chorus
 chorus
 ```
 
-That's it. Chorus starts with an embedded PostgreSQL (PGlite), runs migrations automatically, and opens at **http://localhost:8637**.
+Chorus starts with an embedded PostgreSQL (PGlite), runs migrations, and opens at **http://localhost:8637**. Default login: `admin@chorus.local` / `chorus`.
 
-> **Note:** PGlite is an embedded, single-process PostgreSQL — great for local single-user usage, but its connection handling has limits under concurrent load. If you plan to run multiple agents or users simultaneously, use an external PostgreSQL via `DATABASE_URL=postgresql://...` or the full [Docker Compose](#quick-start-with-docker-recommended) stack.
+> Running multiple agents or deploying to production? Use an external PostgreSQL, Docker, or AWS → **[Deploy & self-host](https://doc.chorus-ai.dev/guides/deployment-overview/)**.
 
-Default login: `admin@chorus.local` / `chorus`
-
-### Options
-
-```bash
-# Custom port
-chorus --port 3000
-
-# Custom data directory (default: ~/.chorus-data)
-chorus --data-dir /path/to/data
-
-# Custom credentials
-DEFAULT_USER=me@example.com DEFAULT_PASSWORD=secret chorus
-
-# Use an external PostgreSQL instead of embedded PGlite
-DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
-```
-
-### Other deployment options
-
-| Method | Command |
-|--------|---------|
-| **npm** (simplest) | `npm i -g @chorus-aidlc/chorus && chorus` |
-| **Docker (standalone)** | [`docker compose -f docker-compose.local.yml up`](#quick-start-with-docker-recommended) |
-| **Docker (full stack)** | [`docker compose up`](#quick-start-with-docker-recommended) (PostgreSQL + Redis + Chorus) |
-| **AWS CDK** | [Deploy to AWS](#deploy-to-aws) |
-
-### `chorus daemon` — Connect as Agent Runtime
-
-The `chorus daemon` connects your local machine to a remote Chorus server as an agent runtime and executes tasks assigned by Chorus.
-
-> **Agent backends:** **Claude Code** (default) and **Codex** are supported — select with `--agent codex` (or `CHORUS_AGENT=codex`). Support for other agent CLIs (Copilot, etc.) is planned for future releases.
-
-```bash
-chorus login                     # Authenticate (opens browser)
-chorus daemon                    # Start daemon in foreground
-chorus daemon -d                 # Start daemon in background (detached)
-chorus daemon install            # Install as a boot-autostart service (Linux) — recommended
-chorus daemon uninstall          # Remove the installed service
-chorus daemon stop               # Stop the daemon (delegates to systemd when installed)
-chorus daemon stop --force       # Force-clean the pidfile if a stuck pid blocks stop
-chorus daemon status             # Check daemon status
-chorus daemon restart            # Restart the daemon
-chorus daemon logs               # View daemon logs
-```
-
-**Key features:**
-
-- **Claude Code & Codex backends** — Auto-detects the `claude` (or `codex`) CLI on your PATH; pick with `--agent codex`
-- **Background mode** — Run with `-d` flag; manage with `stop/restart/logs`
-- **Boot-autostart service** — `chorus daemon install` generates a correct `systemd --user` unit and starts it (see below); `status/stop/restart/logs` then transparently delegate to systemd
-- **Permission modes** — Default is full access (yolo); use `--chorus-only` to restrict to Chorus MCP tools only
-- **Multi-path** — Serve several working directories from one daemon with repeatable `--cwd` (see below)
-- **Interactive setup** — Prompts for credentials on first start if not already configured
-
-The daemon requires authentication. Run `chorus login` first, or it will prompt for credentials interactively on first start (if running in a terminal).
-
-#### Run at boot / login — `chorus daemon install`
-
-```bash
-chorus daemon install --cwd ~/work/repo-a --cwd ~/work/repo-b   # install + start now, autostart at login
-chorus daemon uninstall                                         # disable + remove the service
-```
-
-On Linux, `install` generates a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, no `-d`) so systemd owns the process directly, then `daemon-reload` + `enable --now`. It captures the `--cwd`/`--agent`/`--chorus-only` flags you pass. Do **not** hand-write a `Type=forking` unit around `chorus daemon -d` — the daemon self-daemonizes, which systemd can't track and which loops on restart; let `install` write the right unit. On macOS/Windows, `install` prints a correct template you install manually. Run `chorus login` first so the unit can see your credentials. See [docs/DAEMON.md](docs/DAEMON.md) for details.
-
-#### Serve multiple working directories
-
-One daemon can serve several local working directories at once — each declared path registers as an independent connection (its own session + wake loop) under the same agent. A path is **just** a directory the daemon serves; it carries no project binding.
-
-```bash
-chorus daemon --cwd ~/work/repo-a --cwd ~/work/repo-b   # repeatable flag
-CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # or env (`:`- or `,`-separated)
-```
-
-With no `--cwd`, the daemon serves the single directory it was launched from.
-
-#### Configuration file — `~/.chorus/daemon.json`
-
-`chorus login` writes credentials here (mode `0600`). You can also add daemon tunables to the **same** file. Every field is optional; flags and environment variables always take precedence over the file.
-
-```json
-{
-  "url": "https://chorus.example.com",
-  "apiKey": "cho_xxxxxxxxxxxxxxxxxxxxxxxx",
-  "agentUuid": "00000000-0000-0000-0000-000000000000",
-  "agentName": "My Daemon Agent",
-  "cwds": ["~/work/repo-a", "~/work/repo-b"],
-  "agent": "codex",
-  "sigintTimeoutMs": 10000
-}
-```
-
-| Field | Type | Written by / used for | Precedence (highest first) |
-|-------|------|-----------------------|----------------------------|
-| `url` | string | Remote Chorus server URL | `--url` flag → `CHORUS_URL` → file |
-| `apiKey` | string | Agent API key (`cho_…`) | `--api-key` flag → `CHORUS_API_KEY` → file |
-| `agentUuid` / `agentName` | string | Authenticated identity (recorded at login) | written by `chorus login` |
-| `cwds` | string[] | Working directories the daemon serves (multi-path) | `--cwd` flag(s) → `CHORUS_DAEMON_CWDS` → file → launch dir |
-| `browseRoots` | string[] | Roots allowed for project and temporary directory browsing | `--browse-root` flag(s) → `CHORUS_DAEMON_BROWSE_ROOTS` → file → user home |
-| `agent` | string | Local agent backend to wake (`claude-code` / `codex` / `kiro`) | `--agent` flag → `CHORUS_AGENT` → file → `claude-code` |
-| `sigintTimeoutMs` | number | Grace window (ms) after SIGINT before a forceful kill (default `10000`) | `--sigint-timeout` flag → `CHORUS_DAEMON_SIGINT_TIMEOUT` → file → `10000` |
-| `yoloAckAt` | string | Internal — timestamp of a TTY yolo confirmation (managed automatically) | — |
-
-On startup the daemon banner prints the **exact `daemon.json` path it read** (and whether the file exists), so you always know which file to edit.
+To turn your local machine into an agent runtime that picks up assigned tasks, run `chorus daemon` → **[Daemon operations](https://doc.chorus-ai.dev/guides/daemon-operations/)** · **[Remote control](https://doc.chorus-ai.dev/guides/remote-control/)**.
 
 ---
 
-## Screenshots
+## See It in Action
 
-### Remote Agent Wake — Dispatch to a Directory, Watch It Run
+### Remote Agent Wake — dispatch to a directory, watch it run
 
 ![Remote Agent Wake](packages/landing/public/images/agent-daemon-wake.gif)
 
-Assign an idea to a specific directory on a remote agent, then open the conversation and watch the local Claude Code pick up the work and run in real time — no terminal, no manual resume.
+Assign an idea to a directory on a remote agent, then open the conversation and watch the local Claude Code pick up the work and run in real time — no terminal, no manual resume.
 
-### Project Resource Graph — The Whole Project as a Live Mind-Map
+### Project Resource Graph — the whole project as a live mind-map
 
 ![Project Resource Graph](packages/landing/public/images/mind-map.png)
 
-Chorus auto-organizes the entire project into a mind-map — Ideas, Proposals, Documents, and Tasks laid out as one connected tree — and reflects what the agents are doing in real time, with each card's status updating live as work progresses.
+Ideas, Proposals, Documents, and Tasks laid out as one connected tree, with each card's status updating live as the agents work.
 
-### Proposal — AI Agent Generates Plans in Real Time
+### Proposal — AI generates plans in real time
 
 ![Proposal Presence](packages/landing/public/images/proposal-presence.gif)
 
-Watch a PM Agent analyze requirements and generate a proposal with PRD and task DAG — with real-time presence indicators showing agent activity.
+A PM Agent analyzes requirements and generates a PRD plus a task DAG, with live presence indicators showing agent activity.
 
-### Pixel Workspace — Real-time Agent Status
-
-![Pixel Workspace](docs/images/pixcel-workspace-new.gif)
-
-The left panel is a pixel workspace where pixel characters represent each Agent's real-time working status; the right panel shows live Agent terminal output.
-
-### Kanban — Real-time Task Flow
+### Kanban — real-time task flow
 
 ![Kanban Presence](packages/landing/public/images/kanban-presence.gif)
 
-The Kanban board updates automatically as Agents work, with task cards flowing between To Do → In Progress → To Verify in real time. Agent presence indicators highlight which resources are being worked on.
-
-### Kanban & Task DAG
-
-![Kanban & Task DAG](packages/landing/public/images/kanban-dag.png)
-
-Kanban board for task status tracking alongside a dependency DAG showing execution order and parallel paths.
-
-### Idea & Requirements Elaboration
-
-![Idea & Elaboration](packages/landing/public/images/idea-elaborate.png)
-
-PM Agents clarify requirements through structured Q&A rounds before creating Proposals. The panel shows idea details alongside completed elaboration rounds with answers and category tags.
-
-### Proposal Review
-
-![Proposal Review](packages/landing/public/images/proposal.png)
-
-Proposals generated by the PM Agent contain document drafts and task DAG drafts. Admins review and approve or reject on this panel.
-
-### Acceptance Criteria — Dual-Path Verification
-
-![Acceptance Criteria](packages/landing/public/images/task-ac.png)
-
-Dev Agent self-checks and Admin reviews each acceptance criterion independently, with structured pass/fail evidence for every item.
-
-### Universal Search — Cmd+K Command Palette
-
-![Universal Search](packages/landing/public/images/universal-search.png)
-
-A Cmd+K command palette for searching across all 6 entity types (Tasks, Ideas, Proposals, Documents, Projects, Project Groups). Supports scope filtering (Global / Group / Project), filter tabs per entity type, and keyboard navigation. Both the Web UI and AI agents (via `chorus_search` MCP tool) share the same search backend.
+Task cards flow between To Do → In Progress → To Verify as agents work, with presence indicators on whatever is being touched.
 
 ---
 
-## Features
+## Connect an Agent
 
-- **Session Lifecycle** — Persistent sessions with heartbeats, auto-expiry, and failure recovery
-- **Task DAG** — Dependency modeling, cycle detection, and interactive visualization
-- **Kanban** — Real-time task flow with Worker badges and agent presence
-- **Multi-Agent Collaboration** — Claude Code Agent Teams (Swarm Mode) for parallel execution
-- **Fine-Grained Agent Permissions** — 5 resources × 3 actions grid with preset + custom combinations ([details](docs/PERMISSIONS.md))
-- **Chorus Plugin** — Lifecycle hooks automate session create/close, heartbeats, and context injection
-- **Requirements Elaboration** — Structured Q&A rounds before proposal creation
-- **Proposal Approval Flow** — PM drafts, Admin approves, drafts materialize into real entities
-- **Notifications** — In-app + SSE push + Redis Pub/Sub with per-user preferences ([design doc](src/app/api/notifications/README.md))
-- **@Mention** — Tiptap autocomplete, permission-scoped search, mention notifications ([design doc](src/app/api/mentionables/README.md))
-- **Activity Stream** — Full audit trail with session attribution
-- **Universal Search** — Cmd+K across 6 entity types, 3 scope levels, snippet generation ([design doc](docs/SEARCH.md))
+The fastest path is the in-app wizard: open **Settings → Setup Guide**. It creates the API key and shows the exact commands for your client — Claude Code, Codex, Kiro, OpenCode, OpenClaw, Pi, or any MCP-compatible agent.
+
+Full per-client guides → **[Agent platforms](https://doc.chorus-ai.dev/reference/agents/)**.
+
+API keys are created under **Settings → Agents → Create API Key**. They start with `cho_` and are shown only once.
+
 ---
-
-## Architecture
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                 Chorus — Agent Harness (:8637)                    │
-│                                                                  │
-│  ┌── Harness Capabilities ───────────────────────────────────┐   │
-│  │  Session Lifecycle │ Task State Machine │ Context Inject   │   │
-│  │  Sub-Agent Orchestration │ Observability │ Failure Recovery│   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Chorus Plugin (lifecycle hooks) ────────────────────────┐   │
-│  │  SubagentStart/Stop │ Heartbeat │ Skill & Context Inject  │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── API Layer ──────────────────────────────────────────────┐   │
-│  │  /api/mcp  — MCP Streaming (50+ tools, permission-gated)  │   │
-│  │  /api/*    — REST API (Web UI + SSE push)                 │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Service Layer ──────────────────────────────────────────┐   │
-│  │  AI-DLC Workflow │ UUID-first │ Multi-tenant              │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Web UI (React 19 + Tailwind + shadcn/ui) ──────────────┐   │
-│  │  Kanban │ Task DAG │ Proposals │ Activity │ Sessions      │   │
-│  └───────────────────────────────────────────────────────────┘   │
-└──────────────────────────────────────────────────────────────────┘
-     ↑              ↑              ↑              ↑
-  Agent w/      Agent w/       Agent w/         Human
-  idea+proposal  task:write    *:admin perms   (Browser)
-   :write perms    perms      (proxy approval)
-   (LLM)          (LLM)         (LLM)
-                     │
-          ┌──────────▼──────────┐   ┌─────────────────────┐
-          │  PostgreSQL + Prisma │   │  Redis (optional)   │
-          └─────────────────────┘   │  Pub/Sub for SSE    │
-                                    └─────────────────────┘
-```
-
-### Packages
-
-| Package | Description |
-|---------|-------------|
-| [`packages/openclaw-plugin`](packages/openclaw-plugin) | **OpenClaw Plugin** — Connects [OpenClaw](https://openclaw.ai) to Chorus via persistent SSE + MCP bridge. |
-| [`packages/chorus-cdk`](packages/chorus-cdk) | **AWS CDK** — Infrastructure-as-code for deploying Chorus to AWS. |
 
 ## Tech Stack
 
@@ -306,152 +113,25 @@ A Cmd+K command palette for searching across all 6 entity types (Tasks, Ideas, P
 |-----------|-----------|
 | Framework | Next.js 15 (App Router, Turbopack) |
 | Language | TypeScript 5 (strict mode) |
-| Frontend | React 19, Tailwind CSS 4, shadcn/ui (Radix UI) |
-| ORM | Prisma 7 |
-| Database | PostgreSQL 16 |
-| Cache/Pub-Sub | Redis 7 (ioredis) — optional |
-| Agent Integration | MCP SDK 1.26 (HTTP Streamable Transport) |
+| Frontend | React 19, Tailwind CSS 4, shadcn/ui |
+| Data | PostgreSQL 16 + Prisma 7, Redis 7 (optional) |
+| Agent Integration | MCP SDK (HTTP Streamable Transport) |
 | Auth | OIDC + PKCE / API Key / SuperAdmin |
 | i18n | next-intl (en, zh, ko, ja) |
-| Deployment | [Docker Hub](https://hub.docker.com/r/chorusaidlc/chorus-app) / Docker Compose / AWS CDK |
-
----
-
-## Getting Started
-
-### Quick Start with Docker (Recommended)
-
-No build tools or external databases required. The image bundles [PGlite](https://pglite.dev) (embedded PostgreSQL):
-
-```bash
-git clone https://github.com/Chorus-AIDLC/chorus.git
-cd chorus
-
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose -f docker-compose.local.yml up -d
-```
-
-Open [http://localhost:8637](http://localhost:8637) and log in with the credentials above.
-
-> Data is persisted in a Docker volume. The embedded mode is single-instance only (no Redis).
-
-#### Production Deployment (PostgreSQL + Redis)
-
-For production with multiple replicas:
-
-```bash
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose up -d
-```
-
-> See [Docker Documentation](docs/DOCKER.md) for all environment variables and configuration options.
-
----
-
-### Local Development
-
-Prerequisites: Node.js 22+, pnpm 9+, Docker (for PostgreSQL/Redis)
-
-```bash
-cp .env.example .env
-pnpm docker:db
-pnpm install
-pnpm db:migrate:dev
-pnpm dev
-# Open http://localhost:8637
-```
-
-### Local Development (no Docker)
-
-Prerequisites: Node.js 22+, pnpm 9+
-
-```bash
-cp .env.example .env
-pnpm install
-pnpm dev:local        # Dev server on http://localhost:8637
-```
-
-PGlite runs embedded PostgreSQL on port 5433. Data stored in `.pglite/` — delete to reset.
-
-### Deploy to AWS
-
-```bash
-./install.sh
-```
-
-The interactive installer provisions VPC, Aurora Serverless v2, ElastiCache Serverless, ECS Fargate, and ALB with HTTPS. Configuration saved to `default_deploy.sh` for re-deploys.
-
-### Connect AI Agents
-
-The fastest path is the in-app setup wizard: open the Web UI, go to **Settings → Setup Guide → Open setup guide**, and follow the step-by-step instructions for your client (Claude Code, Codex, Kiro, OpenCode, OpenClaw, or other agents). The wizard creates the API key for you, shows the exact commands, and walks through verifying the connection.
-
-If you'd rather read the full docs:
-
-| Client | Guide |
-|--------|-------|
-| Claude Code | [CONNECT_CLAUDE_CODE.md](docs/CONNECT_CLAUDE_CODE.md) |
-| Codex CLI | [CONNECT_CODEX.md](docs/CONNECT_CODEX.md) |
-| Pi coding agent | [CONNECT_PI.md](docs/CONNECT_PI.md) |
-| Kiro CLI | [CONNECT_KIRO.md](docs/CONNECT_KIRO.md) |
-| OpenCode † | [CONNECT_OPENCODE.md](docs/CONNECT_OPENCODE.md) |
-| Other MCP agents (Cursor, Continue, custom, …) | [CONNECT_OTHER_AGENTS.md](docs/CONNECT_OTHER_AGENTS.md) |
-
-† OpenCode support is provided by the community-maintained [`opencode-chorus`](https://github.com/etnperlong/opencode-chorus) plugin (npm: [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus)), authored by [@etnperlong](https://github.com/etnperlong). Thanks!
-
-Create API Keys in the Web UI under **Settings → Agents → Create API Key**. Keys start with `cho_` and are shown only once.
-
-![Create API Key](packages/landing/public/images/create-key.png)
-
----
-
-## Skill Documentation
-
-| Method | Location | Use Case |
-|--------|----------|----------|
-| **Plugin-embedded (Claude Code)** | `public/chorus-plugin/skills/` | Claude Code + Chorus plugin, automated Sessions and lifecycle hooks |
-| **Plugin-embedded (Codex CLI)** | `plugins/chorus/skills/` | Codex CLI + Chorus plugin, ported skills with `$`-prefixed slash commands |
-| **Package-embedded (Pi)** | `packages/chorus-pi/skills/` | Pi + Chorus package, automated Sessions and lifecycle hooks |
-| **Standalone** | `public/skill/` (served at `/skill/`) | Any other MCP-capable Agent (Cursor, Continue, custom), manual Session management |
-
-### OpenSpec mode (opt-in, plugin 0.8.1+)
-
-PM agents that have the [OpenSpec](https://github.com/Fission-AI/OpenSpec)
-CLI installed can author proposals in a structured `proposal.md` +
-`design.md` + `specs/<capability>/spec.md` layout. Local files are the
-working copy and Chorus `documentDrafts` are the mirror; reviewers see a
-predictable shape (`## ADDED Requirements`, `### Requirement:`,
-`#### Scenario:`) instead of free-form Markdown. A PostToolUse hook on
-`chorus_admin_verify_task` injects an `openspec archive <slug>` reminder
-when the last task of an OpenSpec idea is verified, so finalized specs
-are merged into the long-term spec set right after sign-off. The mode is
-strictly opt-in: when `openspec` is not installed, behavior is unchanged.
-Master switch on Claude Code is `enableOpenSpec` (plugin userConfig,
-default `true`); both clients also honor `CHORUS_OPENSPEC_MODE=off`. No
-new MCP tools or schema changes ship in this mode; the canonical skill
-reuses the existing `chorus_pm_*` draft and document tools, with mirror
-calls routed through the `chorus-api.sh` wrapper to keep multi-thousand-
-line markdown out of LLM context. See
-[OPENSPEC_MODE.md](docs/OPENSPEC_MODE.md) for the full guide.
+| Deployment | npm / Docker / AWS CDK |
 
 ---
 
 ## Documentation
 
-| Document | Description |
-|----------|------------|
-| [PRD](docs/PRD_Chorus.md) | Product Requirements Document |
-| [Architecture](docs/ARCHITECTURE.md) | Technical Architecture Document |
-| [MCP Tools](docs/MCP_TOOLS.md) | MCP Tools Reference |
-| [Permissions](docs/PERMISSIONS.md) | Agent permission model (5 × 3 matrix, presets, Custom mode) |
-| [Chorus Plugin](docs/chorus-plugin.md) | Plugin Design & Hook Documentation |
-| [OpenSpec Mode](docs/OPENSPEC_MODE.md) | Opt-in OpenSpec authoring mode for PM agents (Plugin 0.8.1+) |
-| [Search](docs/SEARCH.md) | Global Search Technical Design |
-| [AI-DLC Gap Analysis](docs/AIDLC_GAP_ANALYSIS.md) | AI-DLC Methodology Gap Analysis |
-| [AIG Implementation Plan](docs/CHORUS_AIG_PLAN.md) | Agent transparency roadmap |
-| [Presence Design](docs/PRESENCE_DESIGN.md) | Real-time agent presence system |
-| [Docker](docs/DOCKER.md) | Docker image usage & deployment |
-| [Logging](docs/LOGGING.md) | Structured logging architecture |
-| [CLAUDE.md](CLAUDE.md) | Development Guide |
+**📖 Full documentation: [doc.chorus-ai.dev](https://doc.chorus-ai.dev)**
+
+- [Getting started](https://doc.chorus-ai.dev/guides/getting-started/)
+- [Connect an agent](https://doc.chorus-ai.dev/reference/agents/)
+- [The AI-DLC workflow](https://doc.chorus-ai.dev/guides/ai-dlc-workflow/)
+- [Plugins & commands](https://doc.chorus-ai.dev/guides/plugin-commands/)
+- [MCP tools reference](https://doc.chorus-ai.dev/reference/mcp-tools/)
+- [Deploy & self-host](https://doc.chorus-ai.dev/guides/deployment-overview/)
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,15 +2,15 @@
   <img src="packages/landing/public/images/chorus-slug.png" alt="Chorus" width="240" />
 </p>
 
-<p align="center"><strong>面向 AI 与人类协作的 Agent Harness</strong></p>
+<p align="center"><strong>你的编程 Agent 之上的 Harness：Agent 提议，人类把关，软件交付。</strong></p>
 
 <p align="center"><a href="README.md">English</a> · <strong>中文</strong> · <a href="README.ko.md">한국어</a> · <a href="README.ja.md">日本語</a></p>
 
-<p align="center"><a href="https://doc.chorus-ai.dev"><strong>📖 文档</strong></a></p>
+<p align="center"><a href="https://doc.chorus-ai.dev/zh/"><strong>📖 文档</strong></a></p>
 
-Chorus 是一个 Agent Harness——包裹在 LLM 外面的基础设施层，负责管理会话生命周期、任务状态、子 Agent 编排、可观测性和故障恢复。它让多个具备细粒度权限配置的 AI Agent 和人类在同一平台上协作，完成从需求到交付的全流程。
+Chorus 是你的编程 Agent 之上的 Harness。编程 Agent 是把模型 harness 起来写代码的那层；Chorus 高它们一层，把多个这样的 Agent 和你收进同一条流水线：Agent 提议，你来验收，想法最终交付成软件，而不只是写代码。在底层，它把这套多 Agent、真人把关的协作稳稳跑起来所需的一切都处理好：会话生命周期、任务状态、子 Agent 编排、可观测性和故障恢复。每个 AI Agent 都有细粒度、可配置的权限。
 
-受 **[AI-DLC（AI-Driven Development Lifecycle）](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** 方法论启发。核心理念：**Reversed Conversation**——AI 提议，人类验证。
+受 **[AI-DLC（AI-Driven Development Lifecycle）](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)** 方法论启发。核心理念：**Reversed Conversation**：AI 提议，人类验证。
 
 ---
 
@@ -23,7 +23,7 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 提出      + 需求澄清     + 起草 PRD/任务         + 报告进度   + 验收     + 关闭
 ```
 
-每个阶段下方标的是「执行该阶段所需的权限」，可以由人类、Agent（预设或 Custom）或两者持有。没有固定角色，5 × 3 权限矩阵的任意组合都合法，详见 [`docs/PERMISSIONS.md`](docs/PERMISSIONS.md)（英文）。
+每个阶段下方标的是「执行该阶段所需的权限」，可以授予人类、Agent 或两者。没有固定角色，5 × 3 权限矩阵的任意组合都合法。→ [Agent 权限](https://doc.chorus-ai.dev/zh/guides/manage-agents/)
 
 ---
 
@@ -45,248 +45,58 @@ Idea ──> Proposal ──> [Document + Task DAG] ──> Execute ──> Veri
 
 ## 快速开始
 
-两条命令在本地运行 Chorus——无需数据库、无需 Docker、无需配置文件。
+两条命令即可，无需数据库、无需 Docker、无需配置文件。
 
 ```bash
 npm install -g @chorus-aidlc/chorus
 chorus
 ```
 
-Chorus 会自动启动内嵌 PostgreSQL (PGlite)、执行数据库迁移，然后在 **http://localhost:8637** 提供服务。
+Chorus 会自动启动内嵌 PostgreSQL (PGlite)、执行数据库迁移，然后在 **http://localhost:8637** 提供服务。默认登录账号：`admin@chorus.local` / `chorus`。
 
-> **提示：** PGlite 是嵌入式单进程 PostgreSQL，本地单人使用完全没问题，但并发能力有限。如果需要多人或多 Agent 同时使用，建议通过 `DATABASE_URL=postgresql://...` 连接外部 PostgreSQL，或使用完整的 [Docker Compose](#docker-一键启动推荐) 部署。
+> 需要运行多个 agent，或部署到生产环境？可使用外部 PostgreSQL、Docker 或 AWS → **[部署与自托管](https://doc.chorus-ai.dev/zh/guides/deployment-overview/)**。
 
-默认登录账号：`admin@chorus.local` / `chorus`
-
-### 参数选项
-
-```bash
-# 自定义端口
-chorus --port 3000
-
-# 自定义数据目录（默认：~/.chorus-data）
-chorus --data-dir /path/to/data
-
-# 自定义登录账号
-DEFAULT_USER=me@example.com DEFAULT_PASSWORD=secret chorus
-
-# 使用外部 PostgreSQL（跳过内嵌 PGlite）
-DATABASE_URL=postgresql://user:pass@host:5432/chorus chorus
-```
-
-### 其他部署方式
-
-| 方式 | 命令 |
-|------|------|
-| **npm**（最简单） | `npm i -g @chorus-aidlc/chorus && chorus` |
-| **Docker（单镜像）** | [`docker compose -f docker-compose.local.yml up`](#docker-一键启动推荐) |
-| **Docker（完整版）** | [`docker compose up`](#docker-一键启动推荐)（PostgreSQL + Redis + Chorus） |
-| **AWS CDK** | [部署到 AWS](#部署到-aws) |
-
-### `chorus daemon` — 作为 Agent 运行时连接
-
-`chorus daemon` 将你的本地机器作为 Agent 运行时连接到远程 Chorus 服务器并执行 Chorus 分配的任务。
-
-> **Agent 后端：** 支持 **Claude Code**（默认）和 **Codex**，用 `--agent codex`（或 `CHORUS_AGENT=codex`）切换。对其他 Agent CLI（Copilot 等）的支持计划在未来版本中实现。
-
-```bash
-chorus login                     # 认证（打开浏览器）
-chorus daemon                    # 前台启动 daemon
-chorus daemon -d                 # 后台启动 daemon（分离模式）
-chorus daemon install            # 安装为开机自启服务（Linux）—— 推荐
-chorus daemon uninstall          # 卸载已安装的服务
-chorus daemon stop               # 停止 daemon（已安装服务时委派给 systemd）
-chorus daemon stop --force       # pid 卡死时强制清理 pidfile
-chorus daemon status             # 查看 daemon 状态
-chorus daemon restart            # 重启 daemon
-chorus daemon logs               # 查看 daemon 日志
-```
-
-**主要特性：**
-
-- **Claude Code 与 Codex 后端** — 自动检测 PATH 中的 `claude`（或 `codex`）CLI；用 `--agent codex` 选择
-- **后台模式** — 使用 `-d` 标志后台运行；用 `stop/restart/logs` 管理
-- **开机自启服务** — `chorus daemon install` 生成正确的 `systemd --user` unit 并启动（见下文）；此后 `status/stop/restart/logs` 会自动委派给 systemd
-- **权限模式** — 默认完全访问（yolo）；使用 `--chorus-only` 限制为仅 Chorus MCP 工具
-- **多路径** — 用可重复的 `--cwd` 让单个 daemon 同时服务多个工作目录（见下文）
-- **交互式设置** — 首次启动时如未配置凭证会提示输入
-
-daemon 需要先认证。首次使用请先运行 `chorus login`，或者 daemon 会在首次启动时交互式提示输入凭证（如果在终端中运行）。
-
-#### 开机 / 登录时自启 —— `chorus daemon install`
-
-```bash
-chorus daemon install --cwd ~/work/repo-a --cwd ~/work/repo-b   # 立即安装并启动，登录时自启
-chorus daemon uninstall                                         # 停用并移除该服务
-```
-
-在 Linux 上，`install` 会生成一个 `systemd --user` unit，让 daemon 以**前台**方式运行（`Type=simple`，不带 `-d`），从而由 systemd 直接接管进程，然后 `daemon-reload` + `enable --now`。它会捕获你传入的 `--cwd`/`--agent`/`--chorus-only` 参数。**不要**手写 `Type=forking` + `chorus daemon -d` 的 unit —— daemon 会自我 daemon 化，systemd 追踪不到，重启时会陷入死循环；交给 `install` 写正确的 unit。在 macOS/Windows 上，`install` 会打印一份可手动安装的正确模板。请先运行 `chorus login`，让 unit 能读到凭证。详见 [docs/DAEMON.md](docs/DAEMON.md)。
-
-#### 服务多个工作目录
-
-一个 daemon 可以同时服务多个本地工作目录——每个声明的路径会注册为一条独立连接（各自拥有会话与唤起循环），归属同一个 Agent。路径**仅仅**是 daemon 服务的目录，不携带任何项目绑定。
-
-```bash
-chorus daemon --cwd ~/work/repo-a --cwd ~/work/repo-b   # 可重复传入
-CHORUS_DAEMON_CWDS="~/work/repo-a:~/work/repo-b" chorus daemon   # 或用环境变量（`:` 或 `,` 分隔）
-```
-
-不传 `--cwd` 时，daemon 只服务它的启动目录这一个路径。
-
-#### 配置文件 —— `~/.chorus/daemon.json`
-
-`chorus login` 会把凭证写入此文件（权限 `0600`）。你也可以把 daemon 的调优项写进**同一个**文件。所有字段都是可选的；命令行参数和环境变量的优先级始终高于文件。
-
-```json
-{
-  "url": "https://chorus.example.com",
-  "apiKey": "cho_xxxxxxxxxxxxxxxxxxxxxxxx",
-  "agentUuid": "00000000-0000-0000-0000-000000000000",
-  "agentName": "My Daemon Agent",
-  "cwds": ["~/work/repo-a", "~/work/repo-b"],
-  "sigintTimeoutMs": 10000
-}
-```
-
-| 字段 | 类型 | 写入方 / 用途 | 优先级（从高到低） |
-|------|------|---------------|--------------------|
-| `url` | string | 远程 Chorus 服务器 URL | `--url` 参数 → `CHORUS_URL` → 文件 |
-| `apiKey` | string | Agent API Key（`cho_…`） | `--api-key` 参数 → `CHORUS_API_KEY` → 文件 |
-| `agentUuid` / `agentName` | string | 认证身份（登录时记录） | 由 `chorus login` 写入 |
-| `cwds` | string[] | daemon 服务的工作目录（多路径） | `--cwd` 参数 → `CHORUS_DAEMON_CWDS` → 文件 → 启动目录 |
-| `sigintTimeoutMs` | number | SIGINT 后强制结束前的宽限窗口（毫秒，默认 `10000`） | `--sigint-timeout` 参数 → `CHORUS_DAEMON_SIGINT_TIMEOUT` → 文件 → `10000` |
-| `yoloAckAt` | string | 内部字段——TTY 下 yolo 确认的时间戳（自动管理） | — |
-
-daemon 启动时的横幅会打印它**实际读取的 `daemon.json` 路径**（以及该文件是否存在），让你随时清楚该编辑哪个文件。
+想把本地机器变成领取任务的 agent 运行时，运行 `chorus daemon` → **[Daemon 运维](https://doc.chorus-ai.dev/zh/guides/daemon-operations/)** · **[远程控制](https://doc.chorus-ai.dev/zh/guides/remote-control/)**。
 
 ---
 
 ## 界面预览
 
-### 远程唤醒 Agent——派活到指定目录，实时看它跑
+### 远程唤醒 Agent：派活到指定目录，实时看它跑
 
 ![远程唤醒 Agent](packages/landing/public/images/agent-daemon-wake.gif)
 
 把一条想法派给远程 Agent 的某个目录，打开对话窗口，就能实时看到本地的 Claude Code 接活、开跑，全程不用碰终端，也不用手动 resume。
 
-### 项目资源图谱——整个项目一张实时思维导图
+### 项目资源图谱：整个项目一张实时思维导图
 
 ![项目资源图谱](packages/landing/public/images/mind-map.png)
 
-Chorus 自动把整个项目整理成一张思维导图——想法、提案、文档、任务连成一棵树，还能实时反映 Agent 的动作，每张卡片的状态随着工作推进自动更新。
+想法、提案、文档、任务连成一棵树，每张卡片的状态随着 Agent 工作实时更新。
 
-### Proposal——AI Agent 实时生成计划
+### Proposal：AI Agent 实时生成计划
 
 ![Proposal Presence](packages/landing/public/images/proposal-presence.gif)
 
 PM Agent 分析需求并实时生成包含 PRD 和任务 DAG 的提案，Presence 指示器实时显示 Agent 活动状态。
 
-### Pixel Workspace——Agent 实时工作状态
-
-![Pixel Workspace](docs/images/pixcel-workspace-new.gif)
-
-左侧为像素工作室，用像素小人代表每个 Agent 的实时工作状态；右侧为 Agent 终端实时输出。
-
-### Kanban——任务状态实时流转
+### Kanban：任务状态实时流转
 
 ![Kanban Presence](packages/landing/public/images/kanban-presence.gif)
 
 Kanban 看板随 Agent 工作进度自动更新，任务卡片在 To Do → In Progress → To Verify 之间实时流转。Presence 指示器高亮显示正在被操作的资源。
 
-### 看板 & 任务 DAG
-
-![Kanban & Task DAG](packages/landing/public/images/kanban-dag.png)
-
-看板追踪任务状态，DAG 展示依赖关系和并行路径，一目了然。
-
-### Idea & 需求细化
-
-![Idea & Elaboration](packages/landing/public/images/idea-elaborate.png)
-
-PM Agent 在创建 Proposal 前，通过结构化问答轮次澄清需求。面板展示 Idea 详情及已完成的细化轮次。
-
-### 提案审阅
-
-![Proposal Review](packages/landing/public/images/proposal.png)
-
-PM Agent 生成的 Proposal 包含文档草稿和任务 DAG 草稿，Admin 在此面板审阅并决定批准或驳回。
-
-### 验收标准——双路验证
-
-![Acceptance Criteria](packages/landing/public/images/task-ac.png)
-
-Dev Agent 自检 + Admin 独立审核，每条验收标准都有结构化的通过/失败证据。
-
-### Universal Search——Cmd+K 全局搜索
-
-![Universal Search](packages/landing/public/images/universal-search.png)
-
-Cmd+K 命令面板，支持跨 6 种实体类型搜索。支持范围筛选（全局/项目组/单项目）、按类型切换 Tab、键盘导航。Web UI 和 AI Agent（通过 `chorus_search` MCP 工具）共享同一搜索后端。
-
 ---
 
-## 功能特性
+## 连接 Agent
 
-- **会话生命周期** — 持久化 Session，心跳检测，自动过期与故障恢复
-- **任务 DAG** — 依赖建模、环检测、交互式可视化
-- **Kanban** — 实时任务流转，Worker 徽标与 Agent Presence
-- **Multi-Agent 协作** — Claude Code Agent Teams (Swarm Mode) 并行执行
-- **细粒度 Agent 权限** — 5 类资源 × 3 个动作组成的权限网格，支持预设 + 自定义组合（[详细说明](docs/PERMISSIONS.md) · 英文）
-- **Chorus Plugin** — 生命周期钩子自动管理 Session 创建/关闭、心跳、上下文注入
-- **需求澄清** — Proposal 创建前的结构化问答轮次
-- **Proposal 审批流** — PM 起草，Admin 审批，草稿物化为正式实体
-- **通知系统** — 应用内 + SSE 推送 + Redis Pub/Sub，支持个人偏好设置（[设计文档](src/app/api/notifications/README.md)）
-- **@Mention** — Tiptap 自动补全、权限隔离搜索、mention 通知（[设计文档](src/app/api/mentionables/README.md)）
-- **活动流** — 全操作审计 + Session 归因
-- **全局搜索** — Cmd+K 跨 6 种实体类型、3 级范围筛选、片段生成（[设计文档](docs/SEARCH.md)）
+最快的方式是应用内的 setup 向导：打开 **Settings → Setup Guide**。它会创建 API Key，并给出适配你所用客户端的完整命令，无论是 Claude Code、Codex、Kiro、OpenCode、OpenClaw、Pi，还是任何兼容 MCP 的 agent。
+
+按客户端分的完整接入指南 → **[Agent 接入平台](https://doc.chorus-ai.dev/zh/reference/agents/)**。
+
+在 **Settings → Agents → Create API Key** 创建 API Key。Key 以 `cho_` 开头，仅在创建时显示一次。
+
 ---
-
-## 架构
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                 Chorus — Agent Harness (:8637)                    │
-│                                                                  │
-│  ┌── Harness Capabilities ───────────────────────────────────┐   │
-│  │  Session Lifecycle │ Task State Machine │ Context Inject   │   │
-│  │  Sub-Agent Orchestration │ Observability │ Failure Recovery│   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Chorus Plugin (lifecycle hooks) ────────────────────────┐   │
-│  │  SubagentStart/Stop │ Heartbeat │ Skill & Context Inject  │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── API Layer ──────────────────────────────────────────────┐   │
-│  │  /api/mcp  — MCP Streaming (50+ tools, permission-gated)  │   │
-│  │  /api/*    — REST API (Web UI + SSE push)                 │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Service Layer ──────────────────────────────────────────┐   │
-│  │  AI-DLC Workflow │ UUID-first │ Multi-tenant              │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│                                                                  │
-│  ┌── Web UI (React 19 + Tailwind + shadcn/ui) ──────────────┐   │
-│  │  Kanban │ Task DAG │ Proposals │ Activity │ Sessions      │   │
-│  └───────────────────────────────────────────────────────────┘   │
-└──────────────────────────────────────────────────────────────────┘
-     ↑              ↑              ↑              ↑
-  Agent w/      Agent w/       Agent w/         人类
-  idea+proposal  task:write    *:admin perms   （浏览器）
-   :write perms    perms      （代理人类审批）
-   (LLM)          (LLM)         (LLM)
-                     │
-          ┌──────────▼──────────┐   ┌─────────────────────┐
-          │  PostgreSQL + Prisma │   │  Redis（可选）       │
-          └─────────────────────┘   │  Pub/Sub 事件分发   │
-                                    └─────────────────────┘
-```
-
-### 子包
-
-| 包 | 说明 |
-|---|------|
-| [`packages/openclaw-plugin`](packages/openclaw-plugin) | **OpenClaw 插件** — 通过 SSE 长连接 + MCP 工具桥接 [OpenClaw](https://openclaw.ai) 与 Chorus。 |
-| [`packages/chorus-cdk`](packages/chorus-cdk) | **AWS CDK** — Chorus 的 AWS 基础设施即代码。 |
 
 ## 技术栈
 
@@ -294,132 +104,25 @@ Cmd+K 命令面板，支持跨 6 种实体类型搜索。支持范围筛选（�
 |------|------|
 | 框架 | Next.js 15 (App Router, Turbopack) |
 | 语言 | TypeScript 5 (strict mode) |
-| 前端 | React 19, Tailwind CSS 4, shadcn/ui (Radix UI) |
-| ORM | Prisma 7 |
-| 数据库 | PostgreSQL 16 |
-| 缓存/消息 | Redis 7 (ioredis) — 可选 |
-| Agent 集成 | MCP SDK 1.26 (HTTP Streamable Transport) |
+| 前端 | React 19, Tailwind CSS 4, shadcn/ui |
+| 数据 | PostgreSQL 16 + Prisma 7, Redis 7（可选） |
+| Agent 集成 | MCP SDK (HTTP Streamable Transport) |
 | 认证 | OIDC + PKCE / API Key / SuperAdmin |
 | i18n | next-intl (en, zh, ko, ja) |
-| 部署 | [Docker Hub](https://hub.docker.com/r/chorusaidlc/chorus-app) / Docker Compose / AWS CDK |
-
----
-
-## 快速开始
-
-### Docker 一键启动（推荐）
-
-无需构建工具或外部数据库。镜像内置 [PGlite](https://pglite.dev)（嵌入式 PostgreSQL）：
-
-```bash
-git clone https://github.com/Chorus-AIDLC/chorus.git
-cd chorus
-
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose -f docker-compose.local.yml up -d
-```
-
-访问 [http://localhost:8637](http://localhost:8637)，用上面设置的账号登录。
-
-> 数据持久化在 Docker 卷中。嵌入模式仅支持单实例（无 Redis）。
-
-#### 生产部署（PostgreSQL + Redis）
-
-多副本生产环境：
-
-```bash
-DEFAULT_USER=admin@example.com DEFAULT_PASSWORD=changeme \
-  docker compose up -d
-```
-
-> 完整环境变量和配置选项见 [Docker 文档](docs/DOCKER.md)。
-
----
-
-### 本地开发
-
-前置条件：Node.js 22+、pnpm 9+、Docker（用于 PostgreSQL/Redis）
-
-```bash
-cp .env.example .env
-pnpm docker:db
-pnpm install
-pnpm db:migrate:dev
-pnpm dev
-# 访问 http://localhost:8637
-```
-
-### 本地开发（无需 Docker）
-
-前置条件：Node.js 22+、pnpm 9+
-
-```bash
-cp .env.example .env
-pnpm install
-pnpm dev:local        # 开发服务器 http://localhost:8637
-```
-
-PGlite 在端口 5433 运行嵌入式 PostgreSQL。数据存储在 `.pglite/`，删除即可重置。
-
-### 部署到 AWS
-
-```bash
-./install.sh
-```
-
-交互式安装器自动创建 VPC、Aurora Serverless v2、ElastiCache Serverless、ECS Fargate 和 ALB（HTTPS）。配置保存到 `default_deploy.sh` 供后续重新部署。
-
-### 连接 AI Agent
-
-最快的方式是用应用内的 setup 向导：打开 Web UI，进入 **Settings → Setup Guide → 打开设置向导**，按照向导给出的分步指引接入自己的客户端（Claude Code、Codex、Kiro、OpenCode、OpenClaw 或其他 agent）。向导会帮你创建 API Key、展示完整命令，并引导你验证连接。
-
-如果偏好文档：
-
-| 客户端 | 接入文档 |
-|--------|---------|
-| Claude Code | [CONNECT_CLAUDE_CODE.zh.md](docs/CONNECT_CLAUDE_CODE.zh.md) |
-| Codex CLI | [CONNECT_CODEX.zh.md](docs/CONNECT_CODEX.zh.md) |
-| Pi coding agent | [CONNECT_PI.md](docs/CONNECT_PI.md) |
-| Kiro CLI | [CONNECT_KIRO.md](docs/CONNECT_KIRO.md) |
-| OpenCode † | [CONNECT_OPENCODE.zh.md](docs/CONNECT_OPENCODE.zh.md) |
-| 其他 MCP agent（Cursor / Continue / 自研等） | [CONNECT_OTHER_AGENTS.zh.md](docs/CONNECT_OTHER_AGENTS.zh.md) |
-
-† OpenCode 的接入由社区维护的 [`opencode-chorus`](https://github.com/etnperlong/opencode-chorus) 插件提供（npm: [`opencode-chorus`](https://www.npmjs.com/package/opencode-chorus)），作者 [@etnperlong](https://github.com/etnperlong)，特此感谢！
-
-在 Web UI 的 **Settings → Agents → Create API Key** 创建 API Key。Key 以 `cho_` 开头，仅在创建时显示一次。
-
-![Create API Key](packages/landing/public/images/create-key.png)
-
----
-
-## Skill 文档
-
-| 方式 | 位置 | 适用场景 |
-|------|------|---------|
-| **Plugin 内嵌（Claude Code）** | `public/chorus-plugin/skills/` | Claude Code + Chorus 插件，Session 自动化与生命周期 hook |
-| **Plugin 内嵌（Codex CLI）** | `plugins/chorus/skills/` | Codex CLI + Chorus 插件，移植版技能（`$` 前缀斜杠命令）|
-| **Package 内嵌（Pi）** | `packages/chorus-pi/skills/` | Pi + Chorus package，Session 自动化与生命周期 hook |
-| **独立分发** | `public/skill/`（`/skill/` 路径静态托管）| 其他 MCP 客户端（Cursor / Continue / 自研），手动 Session 管理 |
+| 部署 | npm / Docker / AWS CDK |
 
 ---
 
 ## 文档
 
-| 文档 | 说明 |
-|------|------|
-| [PRD](docs/PRD_Chorus.md) | 产品需求文档 |
-| [Architecture](docs/ARCHITECTURE.md) | 技术架构文档 |
-| [MCP Tools](docs/MCP_TOOLS.md) | MCP 工具参考 |
-| [Permissions](docs/PERMISSIONS.md) | Agent 权限模型（5 × 3 矩阵 + 预设 + Custom） |
-| [Chorus Plugin](docs/chorus-plugin.md) | 插件设计与 Hook 说明 |
-| [OpenSpec Mode](docs/OPENSPEC_MODE.md) | OpenSpec 模式（Plugin 0.8.1+，opt-in） |
-| [Search](docs/SEARCH.md) | 全局搜索技术设计 |
-| [AI-DLC Gap Analysis](docs/AIDLC_GAP_ANALYSIS.md) | AI-DLC 方法论差距分析 |
-| [AIG Implementation Plan](docs/CHORUS_AIG_PLAN.md) | Agent 透明度路线图 |
-| [Presence Design](docs/PRESENCE_DESIGN.md) | 实时 Agent Presence 系统 |
-| [Docker](docs/DOCKER.md) | Docker 镜像使用与部署 |
-| [Logging](docs/LOGGING.md) | 结构化日志架构 |
-| [CLAUDE.md](CLAUDE.md) | 项目开发规范 |
+**📖 完整文档：[doc.chorus-ai.dev](https://doc.chorus-ai.dev/zh/)**
+
+- [快速上手](https://doc.chorus-ai.dev/zh/guides/getting-started/)
+- [连接 agent](https://doc.chorus-ai.dev/zh/reference/agents/)
+- [AI-DLC 工作流](https://doc.chorus-ai.dev/zh/guides/ai-dlc-workflow/)
+- [插件与命令](https://doc.chorus-ai.dev/zh/guides/plugin-commands/)
+- [MCP 工具参考](https://doc.chorus-ai.dev/zh/reference/mcp-tools/)
+- [部署与自托管](https://doc.chorus-ai.dev/zh/guides/deployment-overview/)
 
 ---
 

--- a/packages/landing/src/i18n/translations/en.json
+++ b/packages/landing/src/i18n/translations/en.json
@@ -10,9 +10,9 @@
     "menu": "Menu"
   },
   "hero": {
-    "badge": "The Agent Harness",
-    "title": "The Model Is the Brain. <highlight>Chorus</highlight> Is Everything Else.",
-    "subtitle": "Chorus wraps AI agents in a structured pipeline — from idea elaboration to task verification — so teams of agents can ship projects, not just write functions. AI proposes, humans verify."
+    "badge": "The harness for your coding agents",
+    "title": "The model reasons. The agent codes. <highlight>Chorus</highlight> ships.",
+    "subtitle": "Chorus is the layer above the coding agents you already use. It harnesses a whole team of them, plus you, into one shared pipeline. Agents propose, humans verify, and ideas turn into delivered software."
   },
   "pipeline": {
     "steps": [
@@ -45,8 +45,8 @@
   },
   "features": {
     "label": "Features",
-    "title": "What the Harness Handles",
-    "subtitle": "Everything outside the model that enables AI-human collaboration — from session management to human review loops.",
+    "title": "What Chorus Runs",
+    "subtitle": "Everything it takes to turn a team of coding agents and a human reviewer into shipped software, from session management to human review loops.",
     "items": [
       {
         "title": "Zero Context Injection",
@@ -238,8 +238,8 @@
     "next": "Next"
   },
   "meta": {
-    "siteTitle": "Chorus - The Agent Harness for AI-Human Collaboration",
-    "siteDescription": "Chorus is the agent harness for AI-human collaboration. AI proposes, humans verify.",
+    "siteTitle": "Chorus - The harness for your coding agents",
+    "siteDescription": "Chorus is the harness for your coding agents: agents propose, humans verify, and ideas turn into delivered software.",
     "blogTitle": "Blog - Chorus"
   }
 }

--- a/packages/landing/src/i18n/translations/zh.json
+++ b/packages/landing/src/i18n/translations/zh.json
@@ -10,9 +10,9 @@
     "menu": "菜单"
   },
   "hero": {
-    "badge": "The Agent Harness",
-    "title": "模型是大脑，<highlight>Chorus</highlight> 是除此之外的一切。",
-    "subtitle": "Chorus 为 AI Agent 提供完整的项目迭代环境 —— 从需求澄清到任务验收的结构化流水线 —— 让 Agent 团队能交付项目，而不只是写代码。AI 提议，人类把关。"
+    "badge": "你的编程 Agent 之上的 Harness",
+    "title": "模型负责推理，Agent 负责写代码，<highlight>Chorus</highlight> 负责交付。",
+    "subtitle": "你的编程 Agent 只管写代码，Chorus 高它们一层：把多个 Agent 和你收进同一条流水线，Agent 提议，你来验收，交付的是软件，不只是代码。"
   },
   "pipeline": {
     "steps": [
@@ -45,8 +45,8 @@
   },
   "features": {
     "label": "核心能力",
-    "title": "Harness 帮你搞定的事",
-    "subtitle": "模型之外，让 AI 和人顺畅协作所需的一切 —— 从会话管理到人工审核闭环。",
+    "title": "Chorus 帮你搞定的事",
+    "subtitle": "让一队编程 Agent 和一个把关的人把软件真正交付出来，靠的就是这些：从会话管理到人工审核闭环。",
     "items": [
       {
         "title": "零上下文注入",
@@ -238,8 +238,8 @@
     "next": "下一篇"
   },
   "meta": {
-    "siteTitle": "Chorus - AI-Human 协作的 Agent Harness",
-    "siteDescription": "Chorus 是 AI-Human 协作的 Agent Harness。AI 提议，人类把关。",
+    "siteTitle": "Chorus - 你的编程 Agent 之上的 Harness",
+    "siteDescription": "Chorus 是你的编程 Agent 之上的 Harness：Agent 提议，人类把关，想法最终交付成软件。",
     "blogTitle": "博客 - Chorus"
   }
 }

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -17,7 +17,7 @@ import Footer from '../components/Footer.astro';
 const lang = 'en' as const;
 ---
 
-<Layout title="Chorus - The Agent Harness for AI-Human Collaboration" lang={lang}>
+<Layout title="Chorus - The harness for your coding agents" lang={lang}>
   <Nav lang={lang} />
   <Hero lang={lang} />
   <Pipeline lang={lang} />


### PR DESCRIPTION
## Summary
- **Reposition**: "harness" now names Chorus **one level above** the coding agents you already use, instead of self-labeling at the coding-agent (Claude Code / Codex) layer — which is where the term now conventionally lands. Hero becomes `The model reasons. The agent codes. Chorus ships.`
- **Chinese de-translationese**: dropped `之上的一层` / `统一驾驭进` / `可交付的` from landing + README (no em dashes).
- **Slim READMEs**: all four cut from ~461 to ~130-140 lines; deep reference content now links to `doc.chorus-ai.dev` (localized per language).

## Changed files
| File | Change |
|------|--------|
| `README.md` / `.zh` / `.ko` / `.ja` | Reposition + slim to ~130-140 lines; link deep sections to the docs site |
| `packages/landing/src/i18n/translations/en.json` | Hero / badge / features / meta reposition copy |
| `packages/landing/src/i18n/translations/zh.json` | Same, de-translationese Chinese |
| `packages/landing/src/pages/index.astro` | Hardcoded page `<title>` |

## Kept vs moved
- **Kept**: positioning, AI-DLC workflow diagram, What's New (5 entries), Quick Start, 4 demos, compact Tech Stack.
- **Moved to docs site**: daemon section + `daemon.json` table, deploy blocks, connect-agent table, Skill/OpenSpec docs, `docs/*.md` index, Architecture diagram, Packages.

## Test plan
- [x] `packages/landing` builds clean (52 pages) with the new copy rendered; old hero strings gone from `dist`
- [x] All four READMEs: 8 sections, 5 What's New entries, 4 demos, localized `doc.chorus-ai.dev` links, no in-repo `docs/*.md`/`CLAUDE.md` links, zh has no em dashes
- [x] zh release links → `/zh/blog/` (Chinese posts exist); ko/ja → `/blog/` (landing has no ko/ja locale)
- No app code changed (docs + landing package only)

Generated with [Claude Code](https://claude.com/claude-code)