### PR TITLE
feat(daemon): single-active-session narrow so concurrent sessions don't duplicate work

### DIFF
--- a/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/README.md
+++ b/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/README.md
@@ -1,0 +1,3 @@
+# add-daemon-single-active-session-guard
+
+Deterministically narrow un-pinned autonomous idea-anchored wakes to one connection so the same agent's concurrent daemon sessions don't duplicate work

--- a/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/design.md
+++ b/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/design.md
@@ -1,0 +1,144 @@
+# Design: Daemon single-active-session guard (Step 4b narrow)
+
+## Context
+
+The server-side wake chokepoint `createTurnAndResolveTarget`
+(`src/services/notification-turn.ts`) resolves, for every wake-triggering notification
+destined for a daemon agent, an `OriginSelection`:
+
+```
+type OriginSelection =
+  | { kind: "directed";     connection: ConnectionView }  // deliver to ONLY this conn
+  | { kind: "online_first"; connection: ConnectionView }  // BROADCAST → online-first
+  | { kind: "offline_pin" }                                // notify-only, suppress all
+  | { kind: "none" };                                      // agent fully offline
+```
+
+Mapping to the wire (consumed by `cli/event-router.mjs`):
+
+| selection | targetConnectionUuid | suppressWake | daemon effect |
+|---|---|---|---|
+| `directed` | origin.uuid | false | Case 3 wake on target; Case 2 suppress on others |
+| `online_first` | null | false | **Case 4 broadcast → every online connection wakes** |
+| `offline_pin` | null | true | Case 1 suppress on all (notify-only) |
+| `none` | null | false | nobody online |
+
+The existing narrowing ladder (all gated on `RESIDUAL_CWD_UPGRADE_TRIGGERS`):
+
+1. **Step 3** `resolvePinnedTarget` → instance/mention **cwd pin** (HARD). Match online →
+   `directed`; offline → `offline_pin`.
+2. **Step 4** `resolveIdeaSessionOriginTarget` → if the idea already has an ONLINE
+   `DaemonSession.originConnectionUuid`, upgrade `online_first` → `directed` there.
+3. **Step 4a** `resolveProjectOwnerCwdPin` → the agent owner's `ProjectAgentCwdPreference`
+   `(host, cwd)` for this project; re-select against it as a HARD pin.
+
+**Gap:** when none of the above narrows (no instance pin, no online idea origin, no project
+pin) the selection stays `online_first` → Case 4 broadcast. This is the fan-out that lets
+the same agent's concurrent connections each advance the same entity.
+
+## Decision
+
+Insert **Step 4b** immediately after step 4a and before the terminal `offline_pin`/`none`
+gate:
+
+```ts
+// (4b) Single-active-session narrow (idea 62920792). A residual-family (autonomous
+// idea-anchored, incl. un-pinned @mention) wake still `online_first` after steps 4 and 4a
+// would broadcast to EVERY online connection of the agent. Deterministically narrow to the
+// ONE online-first connection already chosen by selectOriginConnection and promote it to
+// `directed`, so exactly one connection wakes (deliver_turn) and the rest suppress.
+if (
+  RESIDUAL_CWD_UPGRADE_TRIGGERS.has(trigger) &&
+  selection.kind === "online_first"
+) {
+  selection = { kind: "directed", connection: selection.connection };
+}
+```
+
+That is the whole functional change. Everything downstream — the cross-cwd session
+re-point, the `deliver_turn` ping, the `targetConnectionUuid` stamp, the `directedRuntimeCwd`
+= `origin.cwd` derivation — is the **existing** `directed` path and is reused unchanged.
+
+### Why this is correct and convergent
+
+- **Determinism.** `listConnectionsForAgent` returns connections via `sortConnectionViews`,
+  which orders **online-first then by a stable identity tie-break** (`agentName → agentUuid
+  → cwd → host → clientType → uuid`) and **deliberately excludes timestamps**. So the
+  "first online" connection is a pure function of the current online set — two wakes that
+  observe the same online set pick the *same* connection.
+- **Convergence under concurrency (the bug).** Two near-simultaneous wakes W1, W2 for the
+  same `(agent, idea)` with two online connections `[Y, Z]`:
+  - Both compute `online_first = Y` (stable sort) → Step 4b → `directed(Y)`.
+  - Both stamp `targetConnectionUuid = Y`. Y wakes (Case 3) for both; Z suppresses (Case 2).
+  - Y's per-connection `WakeQueue` keys both by the idea and **coalesces them into one
+    subprocess** (existing wake-coalescing). The server settles the superseded turn to
+    `merged`. Net: one advancement, not two.
+  - If W1 lands first and creates the idea's `DaemonSession` origin on Y, W2 is narrowed by
+    **step 4** (origin online) rather than 4b — same target Y. Either path converges.
+- **Precedence preserved.** Step 4b only fires when `selection.kind === "online_first"`, i.e.
+  after steps 3/4/4a declined. A cwd pin, an online idea origin, or a project pin all short-
+  circuit it (they yield `directed`/`offline_pin`). So the owner's order — cwd pin → project
+  pin → narrow — holds exactly.
+- **Directed/pinned untouched (Q6).** Human-directed and pinned wakes resolve `directed` or
+  `offline_pin` in step 3 and never reach `online_first`; `human_instruction` is excluded
+  from `RESIDUAL_CWD_UPGRADE_TRIGGERS` and owns its own send path. Un-pinned `@mention` IS in
+  the residual family, so it also narrows to one connection (a *pinned* mention stays step-3
+  directed) — consistent with "single active per (agent, idea)".
+- **Offline / single-connection degrade.** `offline_pin` and `none` never have kind
+  `online_first`, so Step 4b cannot alter them. With exactly one online connection, "narrow
+  to first online" is that connection — `directed` to the only candidate, behaviorally
+  equivalent to the prior broadcast-to-one, but now with an explicit target + ping.
+
+### Spawn cwd is unchanged
+
+For a narrowed wake `pin` is null, so `runtimeCwd = null` and
+`directedRuntimeCwd = runtimeCwd ?? origin.cwd ?? null = origin.cwd`. The delivery target IS
+`origin`, whose own bound cwd is `origin.cwd`, so telling it to spawn in `origin.cwd` is a
+no-op relative to today's broadcast-to-online-first (which used that connection's own cwd).
+No misroute; when `origin.cwd` is null the stamp falls back to null and the daemon uses the
+connection's bound cwd, exactly as before.
+
+### Session re-point interaction
+
+The existing `if (directed && directIdeaUuid)` re-point (line ~947) fires for a narrowed
+wake only when a session row already exists with a *different, offline* origin (an online
+origin would have been caught by step 4). Re-pointing the idea's canonical session to the
+now-active online connection is the intended "follow the instance" behavior (idea 2ddd1d11,
+Q1=a) and is safe for `--resume` (the daemon probes the transcript per-cwd). For the common
+first-wake case there is no session yet → no re-point, just create-on-origin.
+
+## Risks / Mitigations
+
+- **Over-narrowing an intended second cwd.** If a human genuinely wants two cwds working one
+  idea concurrently, they pin (step 3) or the project preference (4a) selects — both precede
+  4b. Absent any pin there is no basis to prefer a cwd, and running two autonomous sessions
+  on one idea is exactly the defect. Accepted per Q6=a / Q1 free-text ("project 也没 pin 则收窄").
+- **Chosen connection races offline between resolve and delivery.** Handled by the existing
+  Case 2/3 logic + reconnect backfill; the next wake re-narrows to the next deterministic
+  online connection. No regression versus today.
+- **Failure isolation.** Step 4b is pure in-memory selection mutation (no I/O), inside the
+  existing try/catch that logs visibly and never aborts the already-created notification.
+
+## Alternatives considered (rejected)
+
+- **Server action-idempotency only (Q1=b)** — leave routing, dedup rounds/comments. Rejected:
+  treats symptoms, not the fan-out; N subprocesses still spin up and burn tokens.
+- **Daemon cross-connection lock (Q1=c)** — a shared claim across connections. Rejected: the
+  daemon has N independent per-connection queues with no shared view; the lock would live
+  server-side anyway, which is what Step 4b already is, more cheaply.
+
+## Testing
+
+Unit tests in `src/services/__tests__/notification-turn.test.ts`:
+
+1. Residual-family (`task_assigned`, `elaboration`, un-pinned `mentioned`) + un-pinned +
+   two online connections → `directed` with `targetConnectionUuid` = the deterministic
+   first-online connection (was `online_first`/null before).
+2. Two invocations with the same connection set → the **same** `targetConnectionUuid`
+   (convergence).
+3. Step 4 still wins: when the idea has an ONLINE session origin, target is that origin
+   (Step 4b does not override it).
+4. Step 3 pin and `offline_pin` unaffected (pinned online → its target; pinned offline →
+   `suppressWake:true`, no narrow).
+5. `none` (no online connection) unaffected — no turn, no target.
+6. `human_instruction` excluded — stays on its own path (no narrow).

--- a/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/proposal.md
+++ b/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/proposal.md
@@ -1,0 +1,79 @@
+# Proposal: Daemon single-active-session guard
+
+## Why
+
+When the same agent has **multiple daemon connections** online (two cwds, or two hosts),
+an un-pinned **autonomous idea-anchored** wake is broadcast to *every* online connection
+of that agent. Each connection spawns its own headless session, and each independently
+advances the same entity — producing **duplicate elaboration rounds** and **near-duplicate
+comments**.
+
+Root cause, confirmed in the code:
+
+- Wake-coalescing is **per-connection** — `WakeQueue`/`seen` are built inside
+  `buildConnection(cwd, index)` (`cli/daemon.mjs`). Two connections of the same agent can
+  never see each other's queue, so coalescing does not span them.
+- The server resolves an un-pinned autonomous wake to `online_first` and emits it with
+  `targetConnectionUuid: null, suppressWake: false`. On the daemon that is **Case 4**
+  (`cli/event-router.mjs`) — "broadcast to every online connection, byte-identical" — so
+  each connection wakes.
+
+Live evidence (deployed server, 2026-08-17): a gateway SKIP wake fanned out to concurrent
+Codex sessions that each wrote a duplicate evidence comment on one idea; symmetrically, an
+actor idea received two near-simultaneous PASS confirmations from concurrent gateway
+sessions of the same agent. This is the exact hazard.
+
+## What Changes
+
+Close the fan-out at the **single server chokepoint** every connection passes through:
+`createTurnAndResolveTarget` in `src/services/notification-turn.ts`. That function already
+runs an ordered connection-selection ladder — instance/mention **cwd pin** (step 3),
+**idea-session-origin** upgrade (step 4), **project-owner cwd pin** (step 4a) — and only
+falls through to a broadcast when *none* of those narrows the wake.
+
+Add one terminal step — **Step 4b: deterministic single-connection narrow**. For a
+residual-family (autonomous idea-anchored, incl. un-pinned `@mention`) trigger whose
+selection is still `online_first` after steps 4 and 4a, promote the already-chosen
+online-first connection to a **directed** selection. The wake is then delivered to that one
+connection (existing `deliver_turn` ping + `targetConnectionUuid` stamp) and every other
+connection suppresses its broadcast copy (existing Case 2).
+
+Because the connection list is sorted by a **stable, timestamp-free** comparator
+(`sortConnectionViews`: online-first + identity tie-break), concurrent wakes for the same
+`(agent, idea)` deterministically converge on the **same** connection — whose existing
+per-connection coalescing then folds them into one run. Once that connection builds the
+idea's `DaemonSession` origin, step 4 pins subsequent wakes there. Bootstrap + self-sustaining.
+
+### In scope (elaboration Round 1)
+
+- **Q1 (a + free-text):** server routing narrowing only; selection order = cwd pin →
+  project pin → deterministic narrow. The first two already exist; only the narrow is new.
+- **Q2 (a):** guard keyed on `(agent, idea/entity)` — realized by the idea-anchored
+  `sessionId` + deterministic per-agent connection order.
+- **Q3 (a):** primary fix only.
+- **Q6 (a):** applies to autonomous / residual-family wakes only; human-directed / pinned
+  wakes (resolved `directed`/`offline_pin` in step 3) and `human_instruction` (own send
+  path) are never affected.
+
+### Out of scope (deferred)
+
+- Elaboration round-creation idempotency (Q3=a excludes it). Recorded owner preference for
+  a *future* iteration: **reject-with-error** (Q4=b) if it is later built.
+- Server-side comment de-duplication (Q5=a — the routing fix removes the second author).
+- A generic "one running/pending turn per (agent, entity)" guard on `createPendingTurn`.
+
+## Capabilities
+
+- `daemon-single-active-session` — new capability: the deterministic single-connection
+  narrow that guarantees at most one of an agent's connections wakes for an un-pinned
+  autonomous idea-anchored wake.
+
+## Impact
+
+- **Code:** one new step (~10 lines) in `createTurnAndResolveTarget`
+  (`src/services/notification-turn.ts`). No schema change, no new model, no daemon change
+  (the daemon already honors `targetConnectionUuid`/`suppressWake`).
+- **Behavior:** un-pinned autonomous idea-anchored wakes now target one connection instead
+  of broadcasting. Pinned/directed/offline/single-connection cases are byte-identical to
+  today. No UI surface — no `docs/design.pen` change required.
+- **Tests:** unit coverage in `src/services/__tests__/notification-turn.test.ts`.

--- a/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/specs/daemon-single-active-session/spec.md
+++ b/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/specs/daemon-single-active-session/spec.md
@@ -1,0 +1,55 @@
+# daemon-single-active-session
+
+## ADDED Requirements
+
+### Requirement: Deterministic single-connection narrow for autonomous idea-anchored wakes
+
+The wake chokepoint SHALL, for a residual-family (autonomous idea-anchored, including
+un-pinned `@mention`) trigger whose connection selection would otherwise remain
+`online_first` after the instance-pin, idea-session-origin, and project-owner-cwd-pin
+steps, narrow the wake to exactly one online connection — the deterministic first-online
+connection from the agent's stable connection ordering — and deliver it as a directed wake
+so that no more than one of the agent's connections wakes for that wake.
+
+The narrow SHALL preserve the existing selection precedence: it applies only when no
+instance/mention cwd pin matched, no online idea-session origin exists, and no project-owner
+cwd pin matched. It SHALL NOT alter human-directed, pinned, offline-pin, or fully-offline
+selections.
+
+#### Scenario: Un-pinned autonomous idea-anchored wake with multiple online connections narrows to one
+
+- **WHEN** an agent has two or more online connections and receives an un-pinned autonomous
+  idea-anchored wake (e.g. `task_assigned` / `elaboration`) that resolves to `online_first`
+- **THEN** the wake is delivered to exactly one connection (a directed wake carrying that
+  connection as `targetConnectionUuid`) and every other connection suppresses its broadcast copy
+
+#### Scenario: Concurrent wakes for the same idea converge on the same connection
+
+- **WHEN** two wakes for the same `(agent, idea)` are resolved against the same set of online
+  connections
+- **THEN** both resolve to the same target connection, so the same agent's concurrent
+  sessions do not each independently advance the idea
+
+#### Scenario: An online idea-session origin still takes precedence over the narrow
+
+- **WHEN** the idea already has an online `DaemonSession` origin connection
+- **THEN** the wake is directed to that origin connection and the deterministic narrow does
+  not override it
+
+#### Scenario: Pinned and directed wakes are never narrowed
+
+- **WHEN** a wake carries an instance/mention cwd pin, or is a `human_instruction`
+- **THEN** the narrow does not apply: an online pin is delivered to its pinned connection, an
+  offline pin stays notify-only, and `human_instruction` follows its own send path
+
+#### Scenario: Un-pinned mention narrows but a pinned mention stays directed
+
+- **WHEN** an agent with multiple online connections receives an un-pinned `@mention` wake
+- **THEN** the wake narrows to one connection; **AND WHEN** the mention carries an explicit
+  `(host, cwd)` pin, it is delivered to that pinned connection instead (unchanged)
+
+#### Scenario: Fully offline or single-connection agents are unaffected
+
+- **WHEN** the agent has no online connection, or exactly one online connection
+- **THEN** behavior is unchanged: no online connection yields no turn, and a single online
+  connection receives the wake as before

--- a/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/tasks.md
+++ b/openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## 1. Implement Step 4b deterministic single-connection narrow
+
+- [ ] 1.1 Add Step 4b to `createTurnAndResolveTarget` in `src/services/notification-turn.ts`
+      (after step 4a, before the `offline_pin`/`none` gate): promote a residual-family
+      `online_first` selection to `directed` on the already-chosen online-first connection.
+- [ ] 1.2 Add unit tests in `src/services/__tests__/notification-turn.test.ts` covering:
+      narrow fires for un-pinned residual triggers with multiple online connections;
+      convergence (same connection set → same target); step-4 origin precedence;
+      pinned/offline-pin/none/`human_instruction` unaffected; un-pinned vs pinned mention.
+- [ ] 1.3 `pnpm test` (notification-turn), `npx tsc --noEmit`, and `pnpm lint` all green.

--- a/openspec/specs/daemon-single-active-session/spec.md
+++ b/openspec/specs/daemon-single-active-session/spec.md
@@ -1,0 +1,62 @@
+# daemon-single-active-session Specification
+
+## Purpose
+Guarantee that when the same agent has multiple online daemon connections, an un-pinned
+autonomous idea-anchored wake advances an entity on at most ONE connection — deterministically
+narrowing the wake instead of broadcasting to every connection — so concurrent sessions of one
+agent never duplicate work (duplicate elaboration rounds, near-duplicate comments) on the same
+entity.
+
+## Requirements
+### Requirement: Deterministic single-connection narrow for autonomous idea-anchored wakes
+
+The wake chokepoint SHALL, for a residual-family (autonomous idea-anchored, including
+un-pinned `@mention`) trigger whose connection selection would otherwise remain
+`online_first` after the instance-pin, idea-session-origin, and project-owner-cwd-pin
+steps, narrow the wake to exactly one online connection — the deterministic first-online
+connection from the agent's stable connection ordering — and deliver it as a directed wake
+so that no more than one of the agent's connections wakes for that wake.
+
+The narrow SHALL preserve the existing selection precedence: it applies only when no
+instance/mention cwd pin matched, no online idea-session origin exists, and no project-owner
+cwd pin matched. It SHALL NOT alter human-directed, pinned, offline-pin, or fully-offline
+selections.
+
+#### Scenario: Un-pinned autonomous idea-anchored wake with multiple online connections narrows to one
+
+- **WHEN** an agent has two or more online connections and receives an un-pinned autonomous
+  idea-anchored wake (e.g. `task_assigned` / `elaboration`) that resolves to `online_first`
+- **THEN** the wake is delivered to exactly one connection (a directed wake carrying that
+  connection as `targetConnectionUuid`) and every other connection suppresses its broadcast copy
+
+#### Scenario: Concurrent wakes for the same idea converge on the same connection
+
+- **WHEN** two wakes for the same `(agent, idea)` are resolved against the same set of online
+  connections
+- **THEN** both resolve to the same target connection, so the same agent's concurrent
+  sessions do not each independently advance the idea
+
+#### Scenario: An online idea-session origin still takes precedence over the narrow
+
+- **WHEN** the idea already has an online `DaemonSession` origin connection
+- **THEN** the wake is directed to that origin connection and the deterministic narrow does
+  not override it
+
+#### Scenario: Pinned and directed wakes are never narrowed
+
+- **WHEN** a wake carries an instance/mention cwd pin, or is a `human_instruction`
+- **THEN** the narrow does not apply: an online pin is delivered to its pinned connection, an
+  offline pin stays notify-only, and `human_instruction` follows its own send path
+
+#### Scenario: Un-pinned mention narrows but a pinned mention stays directed
+
+- **WHEN** an agent with multiple online connections receives an un-pinned `@mention` wake
+- **THEN** the wake narrows to one connection; **AND WHEN** the mention carries an explicit
+  `(host, cwd)` pin, it is delivered to that pinned connection instead (unchanged)
+
+#### Scenario: Fully offline or single-connection agents are unaffected
+
+- **WHEN** the agent has no online connection, or exactly one online connection
+- **THEN** behavior is unchanged: no online connection yields no turn, and a single online
+  connection receives the wake as before
+

--- a/src/__tests__/integration/agent-instance-addressing.integration.test.ts
+++ b/src/__tests__/integration/agent-instance-addressing.integration.test.ts
@@ -198,14 +198,15 @@ describe("AgentInstance addressing — pin → inherit → degrade → re-pin li
     // resolves against agent Y's OWN online-first connection, NOT instance A.
     //
     // This is LOAD-BEARING: agent Y's instance is seeded at the SAME (host, cwd)
-    // place as instance A (differing only by owning agent). If the guard were
-    // removed and Y inherited A's place, selectOriginConnection would find Y's
-    // ONLINE connection at that exact place and return DIRECTED (targetConnectionUuid
-    // === connY). Because the guard holds, the pin yields nothing for Y and the
-    // selection is online_first → null directed target.
+    // place as instance A (differing only by owning agent). Because the same-agent
+    // guard holds, the root-idea pin yields NOTHING for Y — so selection is
+    // online_first, and Step 4b then narrows it to agent Y's OWN online connection
+    // (connY, directed). The invariant that MUST hold is that the resolved connection
+    // and session belong to agent Y — never instance A / connA (which is owned by
+    // agent X): a leak across the agent boundary would be the real regression.
     const result = await createTurnAndResolveTarget(taskWake(s, s.taskCross, s.agentY));
-    // online_first selection for agent Y → its own connection, NOT directed.
-    expect(result.targetConnectionUuid).toBeNull(); // a broken guard would make this connY
+    // Step 4b narrows to agent Y's own online-first connection (never agent X's connA).
+    expect(result.targetConnectionUuid).toBe(s.connY);
     expect(result.suppressWake).toBe(false);
     expect(result.turn).not.toBeNull();
     // The turn's session is owned by agent Y's connection — never instance A/connA.
@@ -330,12 +331,17 @@ describe("AgentInstance addressing — pin → inherit → degrade → re-pin li
     expect(ideaRow.assigneeType).toBe("agent");
     expect(ideaRow.assigneeUuid).toBe(s.agentX);
 
-    // With no pin to inherit, the wake goes online-first (no directed target,
-    // no suppression). A turn is still created on the agent's first online conn.
+    // With no pin to inherit, selection is online_first and Step 4b narrows the wake to
+    // the agent's first online connection (directed, no suppression) — which is the same
+    // connection the turn's session is created on.
     const result = await createTurnAndResolveTarget(taskWake(s, s.taskInherit, s.agentX));
-    expect(result.targetConnectionUuid).toBeNull();
     expect(result.suppressWake).toBe(false);
     expect(result.turn).not.toBeNull();
+    const revertSession = agentInstanceStore.daemonSessions.find(
+      (ss) => ss.uuid === result.turn!.sessionUuid,
+    )!;
+    expect(result.targetConnectionUuid).toBe(revertSession.originConnectionUuid);
+    expect(result.targetConnectionUuid).not.toBeNull();
   });
 
   it("AC#2 (no silent drop): the instance-pinned idea is NEVER dropped from the agent's ideaTracker across the lifecycle", async () => {

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -1024,9 +1024,12 @@ describe("createTurnAndResolveTarget — directed live delivery", () => {
     expect(mockDeliverTurnPing).not.toHaveBeenCalled();
   });
 
-  // ----- (3) un-pinned → no ping, no target (broadcast → online-first, unchanged) -----
+  // ----- (3) un-pinned residual → Step 4b narrow: DIRECTED to the deterministic online-first
+  // connection (single-active-session guard, idea 62920792). Previously these broadcast with a
+  // null target; now no instance/origin/project pin means "narrow to one connection" so the
+  // same agent's other connections don't each wake. -----
 
-  it("an un-pinned mentioned wake emits NO ping and surfaces NO target (broadcast → online-first, unchanged)", async () => {
+  it("an un-pinned mentioned wake narrows to the deterministic online-first connection (Step 4b)", async () => {
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
@@ -1037,31 +1040,36 @@ describe("createTurnAndResolveTarget — directed live delivery", () => {
       ctx({ action: "mentioned" }),
     );
 
-    // Turn IS created (online-first), but NO directed delivery — exactly as before.
+    // Turn IS created on the online-first origin AND, with Step 4b, the wake is now DIRECTED
+    // there (ping + target) so the second online connection suppresses its broadcast copy.
     expect(turn?.status).toBe("pending");
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
-    // An un-pinned wake does NOT suppress — the daemon broadcast wakes online-first,
-    // byte-identical to before. This is the other half of the offline-pin discriminator.
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    // Still NOT an offline-pin suppress-all: the single narrowed connection wakes.
     expect(suppressWake).toBe(false);
   });
 
-  it("an un-pinned task_assigned wake (no Task pin) emits NO ping and surfaces NO target", async () => {
+  it("an un-pinned task_assigned wake (no Task pin) narrows to the online-first connection (Step 4b)", async () => {
     // Defaults: Task and root idea are both plain `agent` → no instance pin resolved.
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
 
-    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
       ctx({ action: "task_assigned" }),
     );
 
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
   });
 
   // ----- (4) elaboration_verified → idea's existing online session origin + fallbacks ----
@@ -1097,47 +1105,54 @@ describe("createTurnAndResolveTarget — directed live delivery", () => {
     expect(targetConnectionUuid).toBe(ideaOriginConn);
   });
 
-  it("elaboration_verified with NO existing session falls back to online-first (no ping, no target)", async () => {
+  it("elaboration_verified with NO existing session narrows to online-first (Step 4b directed)", async () => {
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
-    // Default mockDaemonSessionFindFirst → null (no existing idea session).
+    // Default mockDaemonSessionFindFirst → null (no existing idea session), so step 4 declines
+    // and Step 4b narrows the wake to the deterministic online-first connection.
 
     const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
       ctx({ action: "elaboration_verified", entityType: "idea", entityUuid: ideaUuid }),
     );
 
-    // Turn IS created online-first (the pre-change behavior), but no directed delivery.
+    // Turn created on the online-first origin, and Step 4b directs the wake there.
     expect(turn?.status).toBe("pending");
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
   });
 
-  it("elaboration_verified whose idea session origin is OFFLINE falls back to online-first (no ping, no target)", async () => {
+  it("elaboration_verified whose idea session origin is OFFLINE narrows to online-first, NOT the dead origin (Step 4b)", async () => {
     const onlineFirst = "conn-online-first";
     const offlineIdeaOrigin = "conn-idea-origin-offline";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
       offlineConn({ uuid: offlineIdeaOrigin, host: "host-B", cwd: "/home/u/dev/idea" }),
     ]);
-    // The idea session exists but its origin connection is OFFLINE → not wakeable.
+    // The idea session exists but its origin connection is OFFLINE → step 4 declines (not
+    // wakeable), so Step 4b narrows to the online-first connection — never the dead origin.
     mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: offlineIdeaOrigin });
 
     const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
       ctx({ action: "elaboration_verified", entityType: "idea", entityUuid: ideaUuid }),
     );
 
-    // Offline origin is not wakeable → online-first fallback, no directed delivery.
     expect(turn?.status).toBe("pending");
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(targetConnectionUuid).not.toBe(offlineIdeaOrigin);
   });
 
   // ----- (4b) start_development → same session-origin upgrade as elaboration_verified ----
@@ -1169,10 +1184,10 @@ describe("createTurnAndResolveTarget — directed live delivery", () => {
     expect(targetConnectionUuid).toBe(ideaOriginConn);
   });
 
-  it("start_development whose idea session origin is OFFLINE falls back to online-first (no ping, no target)", async () => {
+  it("start_development whose idea session origin is OFFLINE narrows to online-first, NOT the dead origin (Step 4b)", async () => {
     // Residual divergence (proposal review note 3): the server action validated
     // "any connection online", but the idea's session ORIGIN may still be offline.
-    // The wake must then fall back to online-first instead of pinging a dead origin.
+    // Step 4 declines a dead origin, so Step 4b narrows to online-first (single-active).
     const onlineFirst = "conn-online-first";
     const offlineIdeaOrigin = "conn-idea-origin-offline";
     mockListConnectionsForAgent.mockResolvedValue([
@@ -1189,14 +1204,18 @@ describe("createTurnAndResolveTarget — directed live delivery", () => {
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(targetConnectionUuid).not.toBe(offlineIdeaOrigin);
   });
 
-  it("start_development with NO existing idea session falls back to online-first (no ping, no target)", async () => {
+  it("start_development with NO existing idea session narrows to online-first (Step 4b directed)", async () => {
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
     // Default mockDaemonSessionFindFirst → null (no existing idea session).
 
@@ -1208,8 +1227,10 @@ describe("createTurnAndResolveTarget — directed live delivery", () => {
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
   });
 
   // ----- (5) cross-cwd directed idea wake → RE-POINT the canonical session, never fork -----
@@ -1706,9 +1727,10 @@ describe("createTurnAndResolveTarget — instance-based pin lineage (T11)", () =
 
   // ----- (3) cross-agent → NO inherit (the same-agent guard blocks it) -----
 
-  it("does NOT inherit the root-idea instance when it belongs to a DIFFERENT agent (same-agent guard) → online-first", async () => {
+  it("does NOT inherit the root-idea instance when it belongs to a DIFFERENT agent (same-agent guard) → narrows to online-first, NOT the idea's instance", async () => {
     // The idea is pinned to an instance of ANOTHER agent. The wake's target is `agentUuid`,
-    // so the guard blocks inheritance and the wake resolves against its OWN agent (online-first).
+    // so the guard blocks inheritance; genuinely un-pinned, Step 4b narrows to the wake's OWN
+    // agent's online-first connection — never the other agent's idea-instance connection.
     pinIdeaToInstance(ideaHost, ideaCwd, { instanceAgentUuid: otherAgentUuid });
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
@@ -1721,7 +1743,7 @@ describe("createTurnAndResolveTarget — instance-based pin lineage (T11)", () =
       ctx({ action: "task_assigned" }),
     );
 
-    // No pin inherited → un-pinned online-first, NOT the idea's instance.
+    // No pin inherited → un-pinned → Step 4b narrows to online-first, NOT the idea's instance.
     expect(turn?.status).toBe("pending");
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
@@ -1729,20 +1751,24 @@ describe("createTurnAndResolveTarget — instance-based pin lineage (T11)", () =
     expect(mockResolveOrCreateSession).not.toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: ideaConnUuid }),
     );
-    // The same-agent guard blocked inheritance → genuinely un-pinned → online-first, no
-    // directed delivery (this is NOT a HARD-pin offline_pin: no pin was ever resolved).
-    expect(targetConnectionUuid).toBeNull();
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    // Narrowed (directed) to online-first — this is NOT a HARD-pin offline_pin (no pin was
+    // ever resolved), and NOT the guarded idea instance.
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(targetConnectionUuid).not.toBe(ideaConnUuid);
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
   });
 
-  // ----- a stale instance row (assignment points at a deleted instance) → online-first -----
+  // ----- a stale instance row (assignment points at a deleted instance) → narrows to online-first -----
 
-  it("treats a missing AgentInstance row (stale assignment) as no pin → online-first", async () => {
+  it("treats a missing AgentInstance row (stale assignment) as no pin → narrows to online-first (Step 4b)", async () => {
     mockTaskFindFirst.mockResolvedValue({ assigneeType: "agent_instance", assigneeUuid: "ghost-inst" });
     mockAgentInstanceFindFirst.mockResolvedValue(null); // instance row no longer exists
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
 
     const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
@@ -1753,7 +1779,10 @@ describe("createTurnAndResolveTarget — instance-based pin lineage (T11)", () =
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(targetConnectionUuid).toBeNull();
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
   });
 
   // ----- idea_claimed gains pin-reading via the own-idea step (2.5) -----
@@ -2113,14 +2142,16 @@ describe("createTurnAndResolveTarget — generalized idea-session-origin upgrade
     expect(targetConnectionUuid).toBe(pinnedConnUuid);
   });
 
-  // ----- FALLBACKS: no session / offline origin → online-first, no target -----
+  // ----- FALLBACKS: no session / offline origin → Step 4b narrow to online-first (directed) -----
 
-  it("proposal_approved with NO existing idea session falls back to online-first (no ping, no target)", async () => {
+  it("proposal_approved with NO existing idea session narrows to online-first (Step 4b directed)", async () => {
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
-    // Default mockDaemonSessionFindFirst → null (no existing idea session).
+    // Default mockDaemonSessionFindFirst → null (no existing idea session) → step 4 declines,
+    // Step 4b narrows.
 
     const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
       ctx({ action: "proposal_approved", entityType: "proposal", entityUuid: "proposal-1" }),
@@ -2130,11 +2161,13 @@ describe("createTurnAndResolveTarget — generalized idea-session-origin upgrade
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
   });
 
-  it("proposal_approved whose idea session origin is OFFLINE falls back to online-first (no ping, no target)", async () => {
+  it("proposal_approved whose idea session origin is OFFLINE narrows to online-first, NOT the dead origin (Step 4b)", async () => {
     const onlineFirst = "conn-online-first";
     const offlineOrigin = "conn-idea-origin-offline";
     mockListConnectionsForAgent.mockResolvedValue([
@@ -2150,19 +2183,23 @@ describe("createTurnAndResolveTarget — generalized idea-session-origin upgrade
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalled();
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(targetConnectionUuid).not.toBe(offlineOrigin);
   });
 
-  // ----- NO-LINEAGE NO-OP: a standalone task_assigned (directIdeaUuid null) stays online-first -----
+  // ----- NO-LINEAGE: a standalone task_assigned (directIdeaUuid null) still narrows (Step 4b
+  // keys on the entity, not an idea anchor) — the step-4 idea-origin null-guard is unaffected. -----
 
-  it("a standalone task_assigned with NO idea lineage (directIdeaUuid null) stays online-first (null-guard)", async () => {
-    // The entity resolves to no idea anchor. Even with an (irrelevant) session row present,
-    // resolveIdeaSessionOriginTarget's null-guard short-circuits → online-first, no target.
+  it("a standalone task_assigned with NO idea lineage (directIdeaUuid null) narrows to online-first (Step 4b, ad-hoc entity)", async () => {
+    // The entity resolves to no idea anchor, so resolveIdeaSessionOriginTarget's null-guard
+    // short-circuits step 4; Step 4b still narrows the ad-hoc entity wake to one connection so
+    // the same agent's other connections don't each pick up the standalone task.
     mockResolveDirectIdeaUuid.mockResolvedValue(null);
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
 
     const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
@@ -2170,12 +2207,15 @@ describe("createTurnAndResolveTarget — generalized idea-session-origin upgrade
     );
 
     expect(turn?.status).toBe("pending");
-    // Ad-hoc session keyed on the entity uuid, pinned online-first.
+    // Ad-hoc session keyed on the entity uuid (directIdeaUuid null → no re-point), narrowed
+    // to online-first and directed there.
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: taskUuid, directIdeaUuid: null, originConnectionUuid: onlineFirst }),
     );
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
-    expect(targetConnectionUuid).toBeNull();
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
+    expect(targetConnectionUuid).toBe(onlineFirst);
   });
 
   // ----- EXCLUSION: human_instruction is NOT upgraded; mentioned IS now upgraded -----
@@ -2327,14 +2367,16 @@ describe("createTurnAndResolveTarget — project-owner fixed-cwd fallback (idea 
     expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
-  it("no owner preference → unchanged online-first fallback", async () => {
+  it("no owner preference → project pin declines → Step 4b narrows to online-first (directed)", async () => {
     // The owner has NO fixed project cwd for this (project, agent) → makePinnedTarget yields
-    // null → selection stays online_first, byte-identical to before.
+    // null → selection stays online_first, and Step 4b then narrows it to the single online
+    // connection (directed).
     mockAgentFindFirst.mockResolvedValue({ ownerUuid });
     mockPreferenceFindFirst.mockResolvedValue(null);
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
 
     const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
@@ -2346,25 +2388,29 @@ describe("createTurnAndResolveTarget — project-owner fixed-cwd fallback (idea 
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    // Un-pinned broadcast → no directed target.
-    expect(targetConnectionUuid).toBeNull();
+    // Project pin declined → Step 4b narrows to the deterministic online-first connection.
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
+    );
   });
 
-  it("agent with no owner → project pin skipped → online-first (short-circuit, no preference read)", async () => {
+  it("agent with no owner → project pin skipped → Step 4b narrows to online-first (no preference read)", async () => {
     mockAgentFindFirst.mockResolvedValue({ ownerUuid: null });
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
 
-    const { targetConnectionUuid } = await createTurnAndResolveTarget(
+    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
       ctx({ action: "task_assigned", projectUuid }),
     );
 
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
-    expect(targetConnectionUuid).toBeNull();
+    expect(targetConnectionUuid).toBe(onlineFirst);
     // No owner → the preference is never queried.
     expect(mockPreferenceFindFirst).not.toHaveBeenCalled();
   });
@@ -2422,12 +2468,15 @@ describe("createTurnAndResolveTarget — un-pinned @mention residual cwd upgrade
     expect(mockPreferenceFindFirst).toHaveBeenCalled();
   });
 
-  it("stays online-first for an un-pinned mention with no idea session and no owner project pin (unchanged)", async () => {
+  it("narrows to online-first for an un-pinned mention with no idea session and no owner project pin (Step 4b)", async () => {
     const onlineFirst = "conn-online-first";
     mockListConnectionsForAgent.mockResolvedValue([
       onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/b" }),
     ]);
-    // Defaults: no session (mockDaemonSessionFindFirst → null), no preference.
+    // Defaults: no session (mockDaemonSessionFindFirst → null), no preference → steps 4/4a
+    // decline, so Step 4b narrows the un-pinned mention to the deterministic online-first
+    // connection (a pinned mention would have short-circuited as a HARD pin in step 3).
 
     const result = await createTurnAndResolveTarget(
       ctx({
@@ -2438,8 +2487,10 @@ describe("createTurnAndResolveTarget — un-pinned @mention residual cwd upgrade
       }),
     );
 
-    expect(result.targetConnectionUuid).toBeNull();
-    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+    expect(result.targetConnectionUuid).toBe(onlineFirst);
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: result.turn?.uuid }),
+    );
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
     );
@@ -2496,6 +2547,74 @@ describe("createTurnAndResolveTarget — un-pinned @mention residual cwd upgrade
     expect(result.targetConnectionUuid).toBeNull();
     expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: onlineFirst }),
+    );
+  });
+});
+
+// ===== Step 4b — single-active-session narrow (idea 62920792) =====
+//
+// The load-bearing guarantee: when NO instance pin (step 3), NO online idea session-origin
+// (step 4), and NO project-owner cwd pin (step 4a) narrows an autonomous idea-anchored wake,
+// Step 4b deterministically narrows it to ONE online connection so the same agent's other
+// connections don't each wake and duplicate work. Convergence relies on the connection list
+// being stably ordered (listConnectionsForAgent → sortConnectionViews) — these tests assert
+// that two wakes for the same (agent, idea) resolve to the SAME connection.
+describe("createTurnAndResolveTarget — Step 4b single-active-session narrow", () => {
+  it("two wakes for the same (agent, idea) against the same online set converge on the SAME connection", async () => {
+    // The exact bug: two concurrent sessions of one agent both advancing one idea. With no
+    // pin/origin, both must resolve to the same narrowed target so only one connection wakes.
+    const connections = [
+      onlineConn({ uuid: "conn-A", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-B", host: "host-B", cwd: "/home/u/dev/b" }),
+    ];
+    mockListConnectionsForAgent.mockResolvedValue(connections);
+    // No idea session yet, no project pin → both wakes fall to Step 4b. (`elaboration_answered`
+    // is the notification action that maps to the `elaboration` trigger.)
+
+    const first = await createTurnAndResolveTarget(
+      ctx({ action: "elaboration_answered", entityType: "idea", entityUuid: ideaUuid }),
+    );
+    const second = await createTurnAndResolveTarget(
+      ctx({ action: "elaboration_answered", entityType: "idea", entityUuid: ideaUuid }),
+    );
+
+    expect(first.targetConnectionUuid).not.toBeNull();
+    expect(second.targetConnectionUuid).toBe(first.targetConnectionUuid);
+  });
+
+  it("narrows to the first ONLINE connection, skipping an offline connection that sorts earlier", async () => {
+    // Determinism is "online-first", not merely "first row": an offline connection at the head
+    // of the list must be skipped so the narrow lands on a wakeable connection.
+    const onlineTarget = "conn-online";
+    mockListConnectionsForAgent.mockResolvedValue([
+      offlineConn({ uuid: "conn-offline", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: onlineTarget, host: "host-B", cwd: "/home/u/dev/b" }),
+    ]);
+
+    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned" }),
+    );
+
+    expect(targetConnectionUuid).toBe(onlineTarget);
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineTarget, turnUuid: turn?.uuid }),
+    );
+  });
+
+  it("with exactly ONE online connection, narrows to itself (directed, not a broadcast)", async () => {
+    const only = "conn-only";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: only, host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+
+    const { turn, targetConnectionUuid, suppressWake } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned" }),
+    );
+
+    expect(targetConnectionUuid).toBe(only);
+    expect(suppressWake).toBe(false);
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: only, turnUuid: turn?.uuid }),
     );
   });
 });

--- a/src/services/daemon-connection.service.ts
+++ b/src/services/daemon-connection.service.ts
@@ -811,8 +811,9 @@ export async function touchConnection(
 /**
  * List the daemon connections visible to a *user* owner: every connection whose
  * agent is owned by `ownerUuid`, scoped to `companyUuid`. Projected to
- * `ConnectionView` (with server-derived `effectiveStatus`) and ordered
- * online-first then `lastSeenAt` desc.
+ * `ConnectionView` (with server-derived `effectiveStatus`) and ordered by
+ * `sortConnectionViews` — online-first then a STABLE, timestamp-free identity
+ * tie-break (NOT `lastSeenAt`, so heartbeats never reorder an equivalent set).
  */
 export async function listConnectionsForOwner(
   companyUuid: string,
@@ -831,7 +832,10 @@ export async function listConnectionsForOwner(
 /**
  * List the daemon connections owned by a single agent (`agentUuid`), scoped to
  * `companyUuid` — the agent-key analogue of owner-scoping ("am I registered?").
- * Projected to `ConnectionView` and ordered online-first then `lastSeenAt` desc.
+ * Projected to `ConnectionView` and ordered by `sortConnectionViews` — online-first
+ * then a STABLE, timestamp-free identity tie-break (NOT `lastSeenAt`). The
+ * single-active-session narrow (notification-turn Step 4b) relies on this determinism:
+ * concurrent same-idea wakes observing the same online set pick the same connection.
  */
 export async function listConnectionsForAgent(
   companyUuid: string,

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -880,6 +880,46 @@ export async function createTurnAndResolveTarget(
       }
     }
 
+    // (4b) Single-active-session narrow (idea 62920792 / daemon-single-active-session). When
+    // a residual-family wake (the RESIDUAL_CWD_UPGRADE_TRIGGERS set — the autonomous
+    // idea-anchored family task_assigned / elaboration / elaboration_verified /
+    // start_development / yolo_requested PLUS the un-pinned `mentioned` wake) is STILL
+    // `online_first` after steps 4 and 4a — no instance/mention cwd pin (step 3), no ONLINE
+    // idea session-origin (step 4), no agent-owner project cwd pin (step 4a) — it would emit
+    // `targetConnectionUuid: null, suppressWake: false` and the daemon would BROADCAST it to
+    // EVERY online connection of the agent (event-router Case 4). With the same agent online
+    // in multiple cwds/hosts, each connection then spawns its own headless session and each
+    // independently advances the same entity — the duplicate elaboration rounds / near-dup
+    // comments this idea fixes. Deterministically NARROW to the ONE online-first connection
+    // already chosen by `selectOriginConnection` and promote it to `directed`, so the wake is
+    // delivered to that single connection (the existing `deliver_turn` ping + `targetConnection-
+    // Uuid` stamp) and every OTHER connection suppresses its broadcast copy (Case 2).
+    //
+    // Convergence (the guarantee): `listConnectionsForAgent` orders connections via
+    // `sortConnectionViews`, which is online-first with a STABLE, timestamp-free identity
+    // tie-break — so "first online" is a pure function of the current online set. Two
+    // near-simultaneous wakes for the same (agent, idea) observe the same set and pick the
+    // SAME connection; its per-connection WakeQueue then coalesces them into one run
+    // (daemon-wake-coalescing), and once that connection builds the idea's DaemonSession
+    // origin, step 4 pins subsequent wakes there. Bootstrap + self-sustaining, keyed on
+    // (agent, idea) via the idea-anchored sessionId.
+    //
+    // Precedence & scope: this fires ONLY on `online_first`, i.e. after steps 3/4/4a all
+    // declined — a cwd pin, an online idea origin, or a project pin all short-circuit it
+    // (they yield `directed` / `offline_pin`), so the owner's cwd-pin → project-pin → narrow
+    // order holds exactly. Human-directed / pinned wakes never reach `online_first`
+    // (`directed` / `offline_pin` in step 3); `human_instruction` is excluded from the
+    // residual set and owns its own send path. `offline_pin` / `none` never have kind
+    // `online_first`, so they are untouched (offline degrade unchanged). A single online
+    // connection narrows to itself (behaviorally identical to the prior broadcast-to-one, now
+    // with an explicit target). No I/O — a pure in-memory selection promotion.
+    if (
+      RESIDUAL_CWD_UPGRADE_TRIGGERS.has(trigger) &&
+      selection.kind === "online_first"
+    ) {
+      selection = { kind: "directed", connection: selection.connection };
+    }
+
     // offline_pin / none → NOTHING to wake. NO turn, NO ping, NO target. The already-
     // created Notification stands as the plain record. offline_pin specifically does NOT
     // fall back to online-first (the user-visible defect being fixed).


### PR DESCRIPTION
## Summary
Closes the daemon **Case-4 fan-out**: an un-pinned autonomous idea-anchored wake was broadcast to *every* online connection of the same agent, so concurrent headless sessions each independently advanced the same entity — producing duplicate elaboration rounds and near-duplicate comments (observed live in multi-agent orchestration).

Adds one terminal step — **Step 4b: deterministic single-connection narrow** — to `createTurnAndResolveTarget`. For a residual-family (autonomous idea-anchored, incl. un-pinned `@mention`) trigger still `online_first` after the instance-pin / idea-session-origin / project-owner-cwd-pin steps, the already-chosen online-first connection is promoted to `directed`, so exactly one connection wakes (`deliver_turn` + `targetConnectionUuid`) and the rest suppress their broadcast copy. Reuses the existing directed path — **no schema, no daemon change**.

Convergence is guaranteed because `sortConnectionViews` is stable + timestamp-free: concurrent same-idea wakes pick the *same* connection, which the existing per-connection wake-coalescing folds into one run; once that connection builds the idea's `DaemonSession` origin, step 4 sustains the pin.

Scope is routing-only per elaboration Round 1 (idea `62920792`): Q1=a, Q2=a `(agent, idea)`, Q3=a, Q6=a. Round-creation idempotency + comment dedup are explicitly deferred.

## Changed files
| File | Change |
|------|--------|
| `src/services/notification-turn.ts` | Add Step 4b narrow (residual `online_first` → `directed`) |
| `src/services/daemon-connection.service.ts` | Fix stale `"lastSeenAt desc"` docstrings (ordering is now load-bearing) |
| `src/services/__tests__/notification-turn.test.ts` | Flip 14 assertions to the new directed-narrow contract; add Step 4b + convergence tests |
| `src/__tests__/integration/agent-instance-addressing.integration.test.ts` | Flip 2 assertions (cross-agent-leak invariant preserved) |
| `openspec/specs/daemon-single-active-session/` + `openspec/changes/archive/2026-08-17-add-daemon-single-active-session-guard/` | New capability spec + archived change |

## Test plan
- [x] `npx vitest run src/services/__tests__/notification-turn.test.ts` → 112/112
- [x] Related integration suites (cwd-pin-chain, daemon-multipath-e2e, daemon-conversation-repoint, agent-instance-addressing, …) → 198 pass
- [x] `npx tsc --noEmit` clean; `eslint` on changed source → 0 errors
- [ ] Live acceptance in throwaway project `860cc7a6` with @Codex👷 (concurrent multi-connection wake → single directed connection; precedence preserved; offline degrade)

> Note: 15 `cli/__tests__/daemon-*.test.mjs` failures are pre-existing on `develop` (daemon CLI process-startup/credential tests; fail identically with this branch's `src/` edits stashed) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)