### PR TITLE
fix(daemon): approve/reject proposal without a cwd picker

### DIFF
--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/README.md
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/README.md
@@ -1,0 +1,3 @@
+# fix-proposal-approve-no-cwd-picker
+
+Approve/Reject proposal without a cwd picker: auto-resolve the assignee wake target (pin / session-origin / single-online), suppress on ambiguity

--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/design.md
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/design.md
@@ -1,0 +1,168 @@
+# Technical Design: Approve / Reject without a cwd picker
+
+## Overview
+
+Two coordinated layers:
+
+1. **Client** — proposal approve/reject stop running the pin-then-wake
+   orchestration (which opens the dialog and, on single-online, persists a pin)
+   and instead call `approveProposalAction` / `rejectProposalAction` directly.
+2. **Server** — the wake chokepoint `createTurnAndResolveTarget` gains a
+   proposal-review-specific step that, for an un-pinned `proposal_approved` /
+   `proposal_rejected` wake, wakes **only** when exactly one connection is
+   online and otherwise **suppresses** (notify-only), replacing the
+   single-active narrow's "direct to the first online connection" for these two
+   actions.
+
+Both are required: removing the client dialog alone would leave the ≥2-cwd case
+falling to the server's single-active narrow (first-online, arbitrary) — the
+exact behavior the owner rejected.
+
+## Current wiring (grounding — verified in code)
+
+- **Client** `proposal-actions.tsx`: `handleApprove` / `handleReject` call
+  `startPinThenWake({ ideaUuid: inputIdeaUuid, wake })` (`use-pin-then-wake.ts`).
+  The hook fetches `GET /api/ideas/[uuid]/wake-preview`
+  (`wake-preview.service.ts` → `previewIdeaWakeTarget`) and branches:
+  - `direct` (already `agent_instance`-pinned, OR 0 online, OR no agent) → wake now.
+  - `auto_pin` (exactly 1 online) → `reassignBestEffort` (persist the sole
+    instance as an `agent_instance` pin), then wake.
+  - `pick` (≥2 online, bare agent) → open `WakeCwdPickerDialog`; on confirm,
+    `reassignBestEffort` the chosen instance, then wake.
+  The same hook backs five surfaces: Verify Elaborate, Start Development, Yolo,
+  and the two proposal actions.
+- **Server** `notification-turn.ts` `createTurnAndResolveTarget`:
+  `proposal_approved` / `proposal_rejected` map to the `task_assigned` trigger
+  (`NOTIFICATION_ACTION_TO_TURN_TRIGGER`), which is in
+  `RESIDUAL_CWD_UPGRADE_TRIGGERS`. The resolution ladder:
+  - **(3)** `resolvePinnedTarget` → `selectOriginConnection`: an instance/mention
+    hard pin online → `directed`; offline → `offline_pin` (notify-only); else
+    `online_first`.
+  - **(4)** idea session-origin upgrade (`resolveIdeaSessionOriginTarget`): if
+    still `online_first` and the idea has an ONLINE session origin → `directed`.
+  - **(4a)** agent-owner project-cwd pin (`resolveProjectOwnerCwdPin`): if still
+    `online_first` → re-select against the project pin (`directed` /
+    `offline_pin`).
+  - **(4b)** single-active-session narrow: if still `online_first`, promote to
+    `directed` on the first online connection (deterministic; the fix for
+    duplicate work across an agent's multiple cwds).
+  - `offline_pin` → `{ turn:null, targetConnectionUuid:null, suppressWake:true }`
+    (notify-only, every connection suppresses). `none` (no online connection) →
+    no turn, `suppressWake:false`.
+- The raw action survives on `ctx.action` even though `trigger` collapses to
+  `task_assigned` — so proposal actions are distinguishable at the chokepoint.
+- `suppressWake:true` is threaded by `notification.service` onto each recipient's
+  `new_notification` SSE event and consumed by `cli/event-router.mjs`
+  (`transport.suppressWake === true` → suppress on every connection). This is the
+  existing, well-tested mechanism the offline-pin case uses.
+
+## Client change (`proposal-actions.tsx`)
+
+- `handleApprove` / `handleReject` → call `runApproveWake(note)` /
+  `runRejectWake(reason)` directly (identical to the existing `!inputIdeaUuid`
+  branch), for all cases.
+- Remove: the `usePinThenWake({...})` call and its destructured
+  `startPinThenWake` / `pickerState` / `confirmPick` / `cancelPick` /
+  `isResolving`; the `<WakeCwdPickerDialog>` mount; the `usePinThenWake`,
+  `reassignIdeaInstanceNoWakeAction`, and `WakeCwdPickerDialog` imports; the
+  `isResolving` term from the approve/reject buttons' `disabled` conditions.
+- Remove the now-unused `inputIdeaAssigneeName` prop (used only by the picker);
+  `inputIdeaUuid` becomes unused too — drop it and update the parent proposal
+  page that passes these props.
+- Net effect: **no dialog** (pick removed), **no durable pin write** (auto_pin
+  reassign removed → elaboration Q4=a), **no toast** (Q6=a).
+- The shared hook / preview service / route / dialog component stay — the three
+  idea-panel surfaces still use them.
+
+## Server change (`notification-turn.ts` `createTurnAndResolveTarget`)
+
+Insert a new step **after 4a (project-owner pin) and before 4b (single-active
+narrow)**:
+
+```
+// (4a-bis) Proposal-review ambiguity suppression (idea 146a7a9b). Approving or
+// rejecting a proposal must resolve the assignee wake WITHOUT a cwd picker:
+// honor a pin / online session-origin / agent-owner project pin (steps 3/4/4a
+// above), else wake ONLY when the online target is unambiguous. With NO such
+// resolution AND two-or-more online connections, SUPPRESS the wake (notify-only)
+// rather than narrowing to an arbitrary first-online (the removed dialog's job).
+const isProposalReviewAction =
+  ctx.action === "proposal_approved" || ctx.action === "proposal_rejected";
+if (isProposalReviewAction && selection.kind === "online_first") {
+  const onlineCount = connections.filter(c => c.effectiveStatus === "online").length;
+  if (onlineCount >= 2) {
+    // Ambiguous: no single determinable cwd → notify-only, no wake, suppress on
+    // every connection. Same shape as offline_pin; the notification stands.
+    return { turn: null, targetConnectionUuid: null, runtimeCwd: null, suppressWake: true };
+  }
+  // Exactly one online → fall through; step 4b promotes it to `directed`.
+}
+```
+
+- **Gate** on `selection.kind === "online_first"` so any hard pin (step 3), online
+  session-origin (step 4), or agent-owner project pin (step 4a) already
+  short-circuited to `directed` / `offline_pin` and is never overridden —
+  elaboration Q5's "reuse existing pin precedence" holds exactly.
+- **Exactly-1** online → deliberately fall through to the existing step 4b, which
+  promotes `online_first` → `directed` on the sole connection (wakes it). No pin
+  is persisted — the server never writes an idea pin; the client `reassign` was
+  the only persist and it is removed (Q4=a).
+- **≥2** online → return the offline-pin shape (`suppressWake:true`, no turn).
+- **Offline** (`selection.kind === "none"`) → unchanged (no turn,
+  `suppressWake:false`; the notification stands).
+- Non-proposal residual triggers are untouched — the block is gated on
+  `ctx.action`, so `task_assigned` (real assignment), `elaboration`,
+  `mentioned`, etc. still reach step 4b and narrow as today.
+
+## Module Contracts
+
+- **Suppress signal:** `{ turn:null, targetConnectionUuid:null, runtimeCwd:null,
+  suppressWake:true }` — identical to the offline-pin return. Downstream:
+  `notification.service` stamps `suppressWake` on the per-recipient SSE event;
+  `cli/event-router.mjs` suppresses the wake on every connection. The
+  `Notification` row is still created upstream by `notification-listener`
+  (notify-only = Q3=a: keep notification, suppress wake).
+- **Action discrimination:** use `ctx.action ∈ {proposal_approved,
+  proposal_rejected}` — NOT `trigger` (which is `task_assigned` for both).
+
+## Final precedence ladder (proposal_approved / proposal_rejected)
+
+1. idea `AgentInstance` pin (step 3) → directed / offline_pin(notify-only)
+2. online idea session-origin (step 4) → directed
+3. agent-owner project fixed cwd (step 4a) → directed / offline_pin
+4. **[new] no pin, exactly 1 online → directed (that one, no persisted pin)**
+5. **[new] no pin, ≥2 online → notify-only (suppressWake)**
+6. fully offline → notify-only
+
+## Risks & Mitigations
+
+- **Shared wake code touched.** Mitigation: the new block is gated on
+  `ctx.action` (proposal-only) AND `selection.kind === "online_first"`; all
+  other triggers/paths are byte-identical.
+- **exactly-1 no longer persists a pin.** Intended (Q4=a); the case still wakes
+  via the step-4b directed narrow.
+- **Spec conflict with the single-active narrow** (which currently mandates
+  narrowing residual `online_first` to one). Mitigation: MODIFY
+  daemon-single-active-session to carve out the two proposal actions.
+- **Recipient is `proposal.createdByUuid`, not necessarily the idea worker.**
+  Unchanged and out of scope; pin resolution still walks lineage to the root
+  idea regardless of recipient identity, so pin/session-origin honoring is
+  correct for the common case (proposal creator == idea assignee).
+
+## Test Plan
+
+- **Server unit** (`notification-turn.test.ts`, mocked connections — the file's
+  existing pattern):
+  - `proposal_approved` + no pin + 2 online → `turn:null`, `targetConnectionUuid:null`, `suppressWake:true`.
+  - `proposal_approved` + no pin + 1 online → `directed` to it, `suppressWake:false`, turn created.
+  - `proposal_rejected` symmetric to both above.
+  - Regression: `proposal_approved` + online idea instance pin → directed to the pin (gate skipped).
+  - Regression: `proposal_approved` + online session-origin → directed there.
+  - Regression: `proposal_approved` + agent-owner project pin → directed there.
+  - Regression: `proposal_approved` + offline agent → `none`, no turn, `suppressWake:false`.
+  - Control: non-proposal `task_assigned` + no pin + 2 online → still narrows to one (single-active unchanged).
+- **Client**: `proposal-actions` renders no `WakeCwdPickerDialog`; approve/reject
+  invoke the action directly; the three idea-panel surfaces are unaffected.
+  Local Playwright (e2e-verification skill): open a pending proposal → Approve →
+  no dialog, action succeeds.
+- **design.pen** updated to drop the approve/reject cwd picker.

--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/proposal.md
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/proposal.md
@@ -1,0 +1,80 @@
+# Proposal: Approve / Reject a proposal without a cwd picker
+
+## Why
+
+When a human approves (or rejects) a proposal in the UI, Chorus currently pops a
+cwd/instance picker dialog (`WakeCwdPickerDialog`) whenever the proposal's input
+idea is assigned to a **bare agent** that is online in **two or more** cwds. This
+forces the reviewer to hand-pick a working directory just to approve — and, when
+the agent is online in exactly **one** cwd, the flow silently rewrites the idea's
+assignee into a durable `agent_instance` pin.
+
+Neither is what the reviewer wants at this gate. Approving/rejecting is a
+review decision, not a cwd-placement decision. The wake target should resolve
+**automatically**, mirroring the un-pinned `@mention` model, and MUST NOT
+interrupt the reviewer with a dialog under any circumstance at this stage.
+
+## What Changes
+
+**Scope: proposal Approve and Reject only.** Revoke / Close / Delete already do
+not prompt. The three idea-panel wake surfaces (Verify Elaborate, Start
+Development, Yolo) keep their existing pin-then-wake picker — this change does
+not touch them.
+
+After this change, the assignee wake fired by approving/rejecting a proposal
+resolves its target with **no dialog, ever**, using this ladder (owner-locked in
+elaboration round 1):
+
+1. **Has a pin** — the idea-level `AgentInstance` pin OR a project-level fixed
+   cwd (`ProjectAgentCwdPreference`) — → follow the pin (directed wake; an
+   offline pin stays notify-only). Existing precedence, reused verbatim.
+2. **The idea's existing online session-origin** → directed there (existing
+   behavior, unchanged).
+3. **No pin, exactly ONE online cwd** → wake that cwd (directed), **without
+   persisting a durable pin** on the idea.
+4. **No pin, TWO OR MORE online cwds** (ambiguous) → **notify-only**: the
+   notification is created but the daemon wake is suppressed on every connection
+   — no picker, no arbitrary online-first pick.
+5. **Fully offline** → notify-only (unchanged).
+
+"No notification" from the idea description is interpreted (per elaboration Q3)
+as **"no daemon wake"**: the in-app notification / activity record is preserved,
+matching an un-pinned offline `@mention`. No toast is shown after the action
+(elaboration Q6) — the approve/reject simply succeeds.
+
+## Capabilities (spec deltas)
+
+- **pin-cwd-before-wake** (MODIFIED) — the resolve-before-wake button flow drops
+  the two proposal entry points; only Verify Elaborate / Start Development / Yolo
+  consult the wake-target preview and pick/persist a cwd.
+- **daemon-single-active-session** (MODIFIED) — the deterministic
+  single-connection narrow carves out `proposal_approved` / `proposal_rejected`:
+  those follow the proposal-review resolution (suppress on ambiguity) instead of
+  being narrowed to the first-online connection.
+- **daemon-cwd-instance-addressing** (ADDED) — a new requirement specifying the
+  proposal approve/reject wake resolution: no picker; honor pin + online
+  session-origin + agent-owner project cwd; wake only on an unambiguous single
+  online connection; suppress (notify-only) on two or more online connections;
+  notify-only when offline.
+
+## Impact
+
+- **Client:** `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx`
+  — approve/reject call `approveProposalAction` / `rejectProposalAction`
+  directly (removing `usePinThenWake` + `WakeCwdPickerDialog`); its parent page
+  drops the now-unused `inputIdeaAssigneeName` (and `inputIdeaUuid`) props. The
+  shared `usePinThenWake` hook, `wake-preview.service`,
+  `/api/ideas/[uuid]/wake-preview` route, and `WakeCwdPickerDialog` component
+  **remain** (still used by the three idea-panel surfaces).
+- **Server:** `src/services/notification-turn.ts` `createTurnAndResolveTarget`
+  — a proposal-review ambiguity-suppression step before the single-active
+  narrow. ECS-deployable; no schema, migration, or permission change.
+- **design.pen:** the proposal-detail actions no longer show a cwd picker on
+  approve/reject.
+
+## Out of Scope
+
+- Verify Elaborate / Start Development / Yolo keep the picker.
+- The proposal-wake **recipient** (`proposal.createdByUuid` vs. the idea worker)
+  is unchanged — a separately-tracked concern.
+- No change to the online-first fallback for non-proposal triggers.

--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/specs/daemon-cwd-instance-addressing/spec.md
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/specs/daemon-cwd-instance-addressing/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Proposal approve/reject wakes SHALL resolve the assignee target without a picker and suppress on ambiguity
+
+A `proposal_approved` / `proposal_rejected` wake SHALL resolve its target working directory entirely on the server, with no client-side cwd picker or preview, under all circumstances — a human approving or rejecting a proposal in the UI is never shown a cwd dialog. The resolution SHALL honor the existing wake precedence in this order:
+
+1. A hard pin — the idea-level `AgentInstance` pin, or the agent-owner's project-fixed cwd
+   (`ProjectAgentCwdPreference`) — resolved exactly as for any autonomous idea-anchored wake:
+   an online pin yields a directed wake; an offline pin stays notify-only (no wake, never
+   re-routed).
+2. The idea's existing ONLINE session-origin connection (the proposal-writing wake session
+   origin), directed there — unchanged from the existing proposal-wake session-origin
+   behavior.
+
+When none of the above resolves a target (the selection would otherwise fall to
+agent-overall online-first), the wake SHALL be **unambiguous-online-only**. The online
+connection count is taken over the **recipient agent** — the wake's notification recipient
+(`proposal.createdByUuid`), which is the idea's assignee agent in the common flow (proposal
+creator == idea worker):
+
+- If the recipient agent has **exactly one** online connection, the wake SHALL be delivered
+  to that connection (a directed wake), and it SHALL NOT persist any durable `agent_instance`
+  pin on the idea as a side effect.
+- If the recipient agent has **two or more** online connections, the wake SHALL be
+  suppressed as notify-only: NO turn is created, NO connection is woken, `suppressWake` is
+  stamped so every connection suppresses its broadcast copy, and the already-recorded
+  notification stands as the plain record. The wake SHALL NOT be delivered to an arbitrary
+  first-online connection and SHALL NOT present a picker.
+- If the recipient agent has **no** online connection, the wake is notify-only exactly as
+  before (no turn; the notification stands).
+
+In every suppressed / notify-only case the in-app notification and activity record SHALL be
+preserved — only the daemon wake is suppressed. No confirmation dialog or cwd picker SHALL
+be shown for a proposal approve/reject at any point.
+
+#### Scenario: Approve with no pin and two online cwds is notify-only
+
+- **GIVEN** a pending proposal whose input idea is assigned to a bare agent with two online connections, no idea instance pin, no online session-origin, and no agent-owner project cwd pin
+- **WHEN** the proposal is approved and the `proposal_approved` wake is dispatched
+- **THEN** the wake MUST create no turn and wake no connection
+- **AND** it MUST stamp `suppressWake` so every online connection suppresses its broadcast copy
+- **AND** the notification MUST still be recorded as the plain record
+- **AND** no cwd picker MUST be presented
+
+#### Scenario: Approve with no pin and exactly one online cwd wakes that cwd
+
+- **GIVEN** a pending proposal whose input idea is assigned to a bare agent with exactly one online connection and no pin or session-origin
+- **WHEN** the proposal is approved and the `proposal_approved` wake is dispatched
+- **THEN** the wake MUST be delivered to that single online connection (directed)
+- **AND** it MUST NOT persist a durable `agent_instance` pin on the idea
+
+#### Scenario: Reject with no pin and two online cwds is notify-only
+
+- **GIVEN** a pending proposal whose input idea is assigned to a bare agent with two online connections and no pin or session-origin
+- **WHEN** the proposal is rejected and the `proposal_rejected` wake is dispatched
+- **THEN** the wake MUST be suppressed as notify-only (`suppressWake`, no turn) rather than delivered to a first-online connection
+
+#### Scenario: A pinned or session-origin idea still directs the approve wake
+
+- **GIVEN** a pending proposal whose input idea has an online idea-level instance pin (or an online session-origin, or an agent-owner project-fixed cwd)
+- **WHEN** the proposal is approved
+- **THEN** the wake MUST be directed to that resolved connection exactly as for any autonomous idea-anchored wake, regardless of how many other connections are online
+
+#### Scenario: An offline assignee approve is notify-only
+
+- **GIVEN** a pending proposal whose input idea's assignee agent has no online connection
+- **WHEN** the proposal is approved
+- **THEN** the wake MUST create no turn and the notification MUST stand as the plain record

--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/specs/daemon-single-active-session/spec.md
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/specs/daemon-single-active-session/spec.md
@@ -1,12 +1,5 @@
-# daemon-single-active-session Specification
+## MODIFIED Requirements
 
-## Purpose
-Guarantee that when the same agent has multiple online daemon connections, an un-pinned
-autonomous idea-anchored wake advances an entity on at most ONE connection — deterministically
-narrowing the wake instead of broadcasting to every connection — so concurrent sessions of one
-agent never duplicate work (duplicate elaboration rounds, near-duplicate comments) on the same
-entity.
-## Requirements
 ### Requirement: Deterministic single-connection narrow for autonomous idea-anchored wakes
 
 The wake chokepoint SHALL, for a residual-family (autonomous idea-anchored, including
@@ -83,4 +76,3 @@ is unchanged.
   `proposal_rejected` wake that resolves to `online_first`
 - **THEN** the narrow still applies and the wake is delivered to that single connection as a
   directed wake, unchanged
-

--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/specs/pin-cwd-before-wake/spec.md
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/specs/pin-cwd-before-wake/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Wake-triggering buttons SHALL resolve the cwd before waking per the preview outcome
+
+For the stage-advance wake entry points on the idea-detail panel — Verify Elaborate, Start Development, and Yolo — the UI SHALL, before firing the wake, consult the wake-target preview for the target Idea and act on its outcome:
+
+- **`pick`** → present the online-instance cwd picker; upon the user choosing an instance, call the non-waking instance-reassign action to persist that instance as the assignee, and only then fire the original wake action.
+- **`auto_pin`** → without prompting, call the non-waking instance-reassign action to persist the single online instance as the assignee, then fire the wake. (This honors the owner decision that a single online connection is durably pinned, not just transiently targeted.)
+- **`direct`** → fire the wake directly with no picker and no reassign.
+
+The picker SHALL reuse the shared online-only instance picker and SHALL offer only effectively-online instances. If the wake step fails after a reassign step (pick or auto_pin) succeeded, the persisted pin SHALL NOT be rolled back and the UI SHALL allow retrying the wake.
+
+The proposal review actions — Proposal approve and Proposal reject — SHALL NOT participate in this pin-then-wake flow: they SHALL NOT consult the wake-target preview, SHALL NOT present a cwd picker, and SHALL NOT persist a pin. Their wake target is resolved entirely on the server (see the daemon-cwd-instance-addressing capability's proposal-review wake resolution requirement).
+
+#### Scenario: A pick-outcome Yolo click prompts, pins, then wakes
+
+- **GIVEN** an Idea whose wake-target preview reports outcome `pick` with two online instances
+- **WHEN** the user clicks Yolo
+- **THEN** the UI MUST present the cwd picker of the two online instances
+- **AND** upon selection the UI MUST call the non-waking reassign to persist that instance
+- **AND** only then MUST it fire the Yolo wake
+
+#### Scenario: An auto_pin-outcome click persists then wakes without prompting
+
+- **GIVEN** an Idea whose wake-target preview reports outcome `auto_pin` with one online instance
+- **WHEN** the user clicks Start Development
+- **THEN** the UI MUST call the non-waking reassign to persist that single instance (no picker)
+- **AND** then MUST fire the Start Development wake
+
+#### Scenario: A direct-outcome click wakes immediately
+
+- **GIVEN** an Idea whose wake-target preview reports outcome `direct`
+- **WHEN** the user clicks Start Development
+- **THEN** the UI MUST fire the wake directly without presenting a picker and without reassigning
+
+#### Scenario: A persisted pin survives a failed wake
+
+- **GIVEN** the user picked (or auto-pinned) an instance and the non-waking reassign succeeded
+- **WHEN** the subsequent wake action fails
+- **THEN** the Idea MUST remain pinned to the chosen instance
+- **AND** the UI MUST allow retrying the wake without re-picking
+
+#### Scenario: Proposal approve/reject do not consult the pin-then-wake preview
+
+- **GIVEN** a pending Proposal whose input Idea is assigned to a bare agent with two online instances
+- **WHEN** the user clicks Approve (or Reject)
+- **THEN** the UI MUST NOT request the wake-target preview
+- **AND** MUST NOT present a cwd picker
+- **AND** MUST NOT persist a pin on the Idea
+- **AND** MUST fire the approve (or reject) action directly

--- a/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/tasks.md
+++ b/openspec/changes/archive/2026-08-19-fix-proposal-approve-no-cwd-picker/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## 1. Server: proposal-review ambiguity suppression
+- [ ] Add the `(4a-bis)` proposal-review block to `createTurnAndResolveTarget` in `src/services/notification-turn.ts` (gated on `ctx.action ∈ {proposal_approved, proposal_rejected}` and `selection.kind === "online_first"`; ≥2 online → `suppressWake` notify-only; exactly 1 → fall through to the step-4b directed narrow).
+- [ ] TDD red→green in `src/services/__tests__/notification-turn.test.ts` (approve/reject × {2 online → suppress, 1 online → directed}; regressions: instance pin / session-origin / project-owner pin still directed; offline → none; non-proposal `task_assigned` + 2 online still narrows).
+
+## 2. Client: remove the approve/reject cwd picker
+- [ ] `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx` — approve/reject call the server actions directly; remove `usePinThenWake`, `WakeCwdPickerDialog`, `reassignIdeaInstanceNoWakeAction`, and the now-unused `inputIdeaAssigneeName` / `inputIdeaUuid` props; drop `isResolving` from the button disabled state; clean up the parent page that passes the dropped props.
+- [ ] Confirm the shared hook / preview service / route / dialog remain intact for Verify Elaborate / Start Development / Yolo.
+- [ ] Update `docs/design.pen` to drop the approve/reject cwd picker.
+- [ ] Local Playwright verification (e2e-verification skill): a pending proposal → Approve shows no dialog and succeeds.

--- a/openspec/specs/daemon-cwd-instance-addressing/spec.md
+++ b/openspec/specs/daemon-cwd-instance-addressing/spec.md
@@ -354,3 +354,70 @@ Every daemon wake SHALL resolve exactly one runtime working directory before tra
 - **WHEN** one daemon runs wakes for two different runtime cwd values concurrently
 - **THEN** each wake MUST retain its own cwd, transcript namespace, execution state, and session continuation without cross-talk
 
+### Requirement: Proposal approve/reject wakes SHALL resolve the assignee target without a picker and suppress on ambiguity
+
+A `proposal_approved` / `proposal_rejected` wake SHALL resolve its target working directory entirely on the server, with no client-side cwd picker or preview, under all circumstances — a human approving or rejecting a proposal in the UI is never shown a cwd dialog. The resolution SHALL honor the existing wake precedence in this order:
+
+1. A hard pin — the idea-level `AgentInstance` pin, or the agent-owner's project-fixed cwd
+   (`ProjectAgentCwdPreference`) — resolved exactly as for any autonomous idea-anchored wake:
+   an online pin yields a directed wake; an offline pin stays notify-only (no wake, never
+   re-routed).
+2. The idea's existing ONLINE session-origin connection (the proposal-writing wake session
+   origin), directed there — unchanged from the existing proposal-wake session-origin
+   behavior.
+
+When none of the above resolves a target (the selection would otherwise fall to
+agent-overall online-first), the wake SHALL be **unambiguous-online-only**. The online
+connection count is taken over the **recipient agent** — the wake's notification recipient
+(`proposal.createdByUuid`), which is the idea's assignee agent in the common flow (proposal
+creator == idea worker):
+
+- If the recipient agent has **exactly one** online connection, the wake SHALL be delivered
+  to that connection (a directed wake), and it SHALL NOT persist any durable `agent_instance`
+  pin on the idea as a side effect.
+- If the recipient agent has **two or more** online connections, the wake SHALL be
+  suppressed as notify-only: NO turn is created, NO connection is woken, `suppressWake` is
+  stamped so every connection suppresses its broadcast copy, and the already-recorded
+  notification stands as the plain record. The wake SHALL NOT be delivered to an arbitrary
+  first-online connection and SHALL NOT present a picker.
+- If the recipient agent has **no** online connection, the wake is notify-only exactly as
+  before (no turn; the notification stands).
+
+In every suppressed / notify-only case the in-app notification and activity record SHALL be
+preserved — only the daemon wake is suppressed. No confirmation dialog or cwd picker SHALL
+be shown for a proposal approve/reject at any point.
+
+#### Scenario: Approve with no pin and two online cwds is notify-only
+
+- **GIVEN** a pending proposal whose input idea is assigned to a bare agent with two online connections, no idea instance pin, no online session-origin, and no agent-owner project cwd pin
+- **WHEN** the proposal is approved and the `proposal_approved` wake is dispatched
+- **THEN** the wake MUST create no turn and wake no connection
+- **AND** it MUST stamp `suppressWake` so every online connection suppresses its broadcast copy
+- **AND** the notification MUST still be recorded as the plain record
+- **AND** no cwd picker MUST be presented
+
+#### Scenario: Approve with no pin and exactly one online cwd wakes that cwd
+
+- **GIVEN** a pending proposal whose input idea is assigned to a bare agent with exactly one online connection and no pin or session-origin
+- **WHEN** the proposal is approved and the `proposal_approved` wake is dispatched
+- **THEN** the wake MUST be delivered to that single online connection (directed)
+- **AND** it MUST NOT persist a durable `agent_instance` pin on the idea
+
+#### Scenario: Reject with no pin and two online cwds is notify-only
+
+- **GIVEN** a pending proposal whose input idea is assigned to a bare agent with two online connections and no pin or session-origin
+- **WHEN** the proposal is rejected and the `proposal_rejected` wake is dispatched
+- **THEN** the wake MUST be suppressed as notify-only (`suppressWake`, no turn) rather than delivered to a first-online connection
+
+#### Scenario: A pinned or session-origin idea still directs the approve wake
+
+- **GIVEN** a pending proposal whose input idea has an online idea-level instance pin (or an online session-origin, or an agent-owner project-fixed cwd)
+- **WHEN** the proposal is approved
+- **THEN** the wake MUST be directed to that resolved connection exactly as for any autonomous idea-anchored wake, regardless of how many other connections are online
+
+#### Scenario: An offline assignee approve is notify-only
+
+- **GIVEN** a pending proposal whose input idea's assignee agent has no online connection
+- **WHEN** the proposal is approved
+- **THEN** the wake MUST create no turn and the notification MUST stand as the plain record
+

--- a/openspec/specs/pin-cwd-before-wake/spec.md
+++ b/openspec/specs/pin-cwd-before-wake/spec.md
@@ -71,13 +71,15 @@ The system SHALL provide a server action that promotes an Idea's (or Task's) ass
 
 ### Requirement: Wake-triggering buttons SHALL resolve the cwd before waking per the preview outcome
 
-For the stage-advance and proposal wake entry points — Verify Elaborate, Start Development, Yolo, Proposal approve, and Proposal reject — the UI SHALL, before firing the wake, consult the wake-target preview for the target Idea and act on its outcome:
+For the stage-advance wake entry points on the idea-detail panel — Verify Elaborate, Start Development, and Yolo — the UI SHALL, before firing the wake, consult the wake-target preview for the target Idea and act on its outcome:
 
 - **`pick`** → present the online-instance cwd picker; upon the user choosing an instance, call the non-waking instance-reassign action to persist that instance as the assignee, and only then fire the original wake action.
 - **`auto_pin`** → without prompting, call the non-waking instance-reassign action to persist the single online instance as the assignee, then fire the wake. (This honors the owner decision that a single online connection is durably pinned, not just transiently targeted.)
 - **`direct`** → fire the wake directly with no picker and no reassign.
 
-For the two proposal entry points (approve / reject), the UI SHALL resolve the target Idea uuid from the proposal (the proposal's input Idea) before requesting the idea-scoped preview. The picker SHALL reuse the shared online-only instance picker and SHALL offer only effectively-online instances. If the wake step fails after a reassign step (pick or auto_pin) succeeded, the persisted pin SHALL NOT be rolled back and the UI SHALL allow retrying the wake.
+The picker SHALL reuse the shared online-only instance picker and SHALL offer only effectively-online instances. If the wake step fails after a reassign step (pick or auto_pin) succeeded, the persisted pin SHALL NOT be rolled back and the UI SHALL allow retrying the wake.
+
+The proposal review actions — Proposal approve and Proposal reject — SHALL NOT participate in this pin-then-wake flow: they SHALL NOT consult the wake-target preview, SHALL NOT present a cwd picker, and SHALL NOT persist a pin. Their wake target is resolved entirely on the server (see the daemon-cwd-instance-addressing capability's proposal-review wake resolution requirement).
 
 #### Scenario: A pick-outcome Yolo click prompts, pins, then wakes
 
@@ -100,17 +102,19 @@ For the two proposal entry points (approve / reject), the UI SHALL resolve the t
 - **WHEN** the user clicks Start Development
 - **THEN** the UI MUST fire the wake directly without presenting a picker and without reassigning
 
-#### Scenario: Proposal approve resolves the idea before previewing
-
-- **GIVEN** a pending Proposal whose input Idea is assigned to a bare agent with two online instances and no online session-origin
-- **WHEN** the user clicks Approve
-- **THEN** the UI MUST resolve the Idea uuid from the proposal and request the idea-scoped wake-target preview
-- **AND** MUST present the picker (outcome `pick`) before firing the approve wake
-
 #### Scenario: A persisted pin survives a failed wake
 
 - **GIVEN** the user picked (or auto-pinned) an instance and the non-waking reassign succeeded
 - **WHEN** the subsequent wake action fails
 - **THEN** the Idea MUST remain pinned to the chosen instance
 - **AND** the UI MUST allow retrying the wake without re-picking
+
+#### Scenario: Proposal approve/reject do not consult the pin-then-wake preview
+
+- **GIVEN** a pending Proposal whose input Idea is assigned to a bare agent with two online instances
+- **WHEN** the user clicks Approve (or Reject)
+- **THEN** the UI MUST NOT request the wake-target preview
+- **AND** MUST NOT present a cwd picker
+- **AND** MUST NOT persist a pin on the Idea
+- **AND** MUST fire the approve (or reject) action directly
 

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/page.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/page.tsx
@@ -200,11 +200,6 @@ export default async function ProposalDetailPage({ params }: PageProps) {
             projectUuid={projectUuid}
             status={proposal.status}
             materializedEntities={materializedEntities}
-            // The proposal's input idea drives the approve/reject wake target, so
-            // the pin-then-wake preview is resolved from it (idea-scoped). null
-            // for a non-idea-input proposal → approve/reject wake with no preview.
-            inputIdeaUuid={sourceIdeas[0]?.uuid ?? null}
-            inputIdeaAssigneeName={sourceIdeas[0]?.assignee?.name ?? null}
           />
         </div>
       </div>

--- a/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx
@@ -22,9 +22,6 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { approveProposalAction, rejectProposalAction, closeProposalAction, revokeProposalAction, submitProposalAction, deleteProposalAction } from "./actions";
-import { reassignIdeaInstanceNoWakeAction } from "@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions";
-import { usePinThenWake } from "@/hooks/use-pin-then-wake";
-import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
 
 interface MaterializedEntities {
   tasks: { uuid: string; title: string; status: string }[];
@@ -36,33 +33,11 @@ interface ProposalActionsProps {
   projectUuid: string;
   status: string;
   materializedEntities?: MaterializedEntities | null;
-  // The proposal's input Idea uuid — approve/reject wake that idea's assignee, so
-  // the pin-then-wake preview is idea-scoped and resolved from the proposal
-  // BEFORE the wake (spec: "resolve the target Idea uuid from the proposal").
-  // null when the proposal has no input idea (e.g. document-input proposals) —
-  // then approve/reject wake directly with no preview.
-  inputIdeaUuid?: string | null;
-  // The input idea's assignee agent display name — shown in the cwd picker
-  // subtitle when the preview reports `pick`.
-  inputIdeaAssigneeName?: string | null;
 }
 
-export function ProposalActions({ proposalUuid, projectUuid, status, materializedEntities, inputIdeaUuid, inputIdeaAssigneeName }: ProposalActionsProps) {
+export function ProposalActions({ proposalUuid, projectUuid, status, materializedEntities }: ProposalActionsProps) {
   const t = useTranslations();
   const router = useRouter();
-  // Pin-then-wake: approve/reject wake the input idea's assignee. Resolve the
-  // idea-scoped preview and (pick) prompt for a cwd / (auto_pin) persist the
-  // sole cwd / (direct) wake as-is before firing the proposal action.
-  const {
-    start: startPinThenWake,
-    pickerState,
-    confirmPick,
-    cancelPick,
-    isResolving,
-  } = usePinThenWake({
-    reassignNoWake: reassignIdeaInstanceNoWakeAction,
-    previewIdeaUuid: inputIdeaUuid,
-  });
   const [isPending, startTransition] = useTransition();
   const [approveDialogOpen, setApproveDialogOpen] = useState(false);
   const [approveNote, setApproveNote] = useState("");
@@ -85,8 +60,8 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
     });
   };
 
-  // The actual approve wake — fired directly (direct/auto_pin) or after the human
-  // picks a cwd (pick). Captures the note at call time.
+  // Fire the approve action directly. The assignee wake target is resolved
+  // entirely on the server (no cwd picker at this gate — see idea 146a7a9b).
   const runApproveWake = (note: string | undefined) => {
     startTransition(async () => {
       const result = await approveProposalAction(proposalUuid, note);
@@ -100,14 +75,7 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
 
   const handleApprove = () => {
     const note = approveNote.trim() || undefined;
-    if (!inputIdeaUuid) {
-      // No input idea (e.g. document-input proposal) → nothing to pin; wake as-is.
-      runApproveWake(note);
-      return;
-    }
-    // Resolve the idea-scoped preview from the proposal's input idea, then
-    // pin-then-wake. On `pick` the picker opens over the approve dialog.
-    startPinThenWake({ ideaUuid: inputIdeaUuid, wake: () => runApproveWake(note) });
+    runApproveWake(note);
   };
 
   const runRejectWake = (reason: string) => {
@@ -122,12 +90,7 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
   };
 
   const handleReject = () => {
-    const reason = rejectReason;
-    if (!inputIdeaUuid) {
-      runRejectWake(reason);
-      return;
-    }
-    startPinThenWake({ ideaUuid: inputIdeaUuid, wake: () => runRejectWake(reason) });
+    runRejectWake(rejectReason);
   };
 
   const handleClose = () => {
@@ -263,7 +226,7 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
             </Button>
             <Button
               onClick={handleApprove}
-              disabled={isPending || isResolving}
+              disabled={isPending}
               className="bg-[#5A9E6F] hover:bg-[#4A8E5F] text-white"
             >
               {isPending ? t("common.processing") : t("common.approve")}
@@ -294,7 +257,7 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
             </Button>
             <Button
               onClick={handleReject}
-              disabled={isPending || isResolving || !rejectReason.trim()}
+              disabled={isPending || !rejectReason.trim()}
               className="bg-[#D32F2F] hover:bg-[#B71C1C] text-white"
             >
               {isPending ? t("common.processing") : t("common.reject")}
@@ -424,16 +387,6 @@ export function ProposalActions({ proposalUuid, projectUuid, status, materialize
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      {/* Pin-then-wake cwd picker for approve/reject — opens on the `pick`
-          outcome of the input idea's wake-target preview. */}
-      <WakeCwdPickerDialog
-        open={pickerState !== null}
-        agentName={inputIdeaAssigneeName ?? ""}
-        instances={pickerState?.instances ?? []}
-        onConfirm={confirmPick}
-        onCancel={cancelPick}
-      />
     </>
   );
 }

--- a/src/services/__tests__/notification-turn.test.ts
+++ b/src/services/__tests__/notification-turn.test.ts
@@ -2144,27 +2144,25 @@ describe("createTurnAndResolveTarget — generalized idea-session-origin upgrade
 
   // ----- FALLBACKS: no session / offline origin → Step 4b narrow to online-first (directed) -----
 
-  it("proposal_approved with NO existing idea session narrows to online-first (Step 4b directed)", async () => {
-    const onlineFirst = "conn-online-first";
+  it("proposal_approved with NO existing idea session and TWO online connections is notify-only (proposal-review ambiguity suppression, idea 146a7a9b)", async () => {
     mockListConnectionsForAgent.mockResolvedValue([
-      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-online-first", host: "host-A", cwd: "/home/u/dev/a" }),
       onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
     ]);
-    // Default mockDaemonSessionFindFirst → null (no existing idea session) → step 4 declines,
-    // Step 4b narrows.
+    // Default mockDaemonSessionFindFirst → null (no existing idea session) → step 4 declines.
+    // The proposal-review carve-out (step 4a-bis) now SUPPRESSES on ≥2 online instead of the
+    // step-4b narrow to first-online (the removed cwd picker's arbitrary pick — the owner
+    // rejected auto-picking a cwd at the approve/reject gate).
 
-    const { turn, targetConnectionUuid } = await createTurnAndResolveTarget(
+    const { turn, targetConnectionUuid, suppressWake } = await createTurnAndResolveTarget(
       ctx({ action: "proposal_approved", entityType: "proposal", entityUuid: "proposal-1" }),
     );
 
-    expect(turn?.status).toBe("pending");
-    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
-      expect.objectContaining({ originConnectionUuid: onlineFirst }),
-    );
-    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
-      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
-    );
-    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(turn).toBeNull();
+    expect(targetConnectionUuid).toBeNull();
+    expect(suppressWake).toBe(true);
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+    expect(mockDeliverTurnPing).not.toHaveBeenCalled();
   });
 
   it("proposal_approved whose idea session origin is OFFLINE narrows to online-first, NOT the dead origin (Step 4b)", async () => {
@@ -2615,6 +2613,195 @@ describe("createTurnAndResolveTarget — Step 4b single-active-session narrow", 
     expect(suppressWake).toBe(false);
     expect(mockDeliverTurnPing).toHaveBeenCalledWith(
       expect.objectContaining({ originConnectionUuid: only, turnUuid: turn?.uuid }),
+    );
+  });
+});
+
+// ===== Step 4a-bis — proposal-review ambiguity suppression (idea 146a7a9b) =====
+//
+// Approving / rejecting a proposal in the UI must resolve the assignee wake WITHOUT a cwd
+// picker (the client dialog is removed). The server carve-out sits BETWEEN step 4a (project-
+// owner pin) and step 4b (single-active narrow): for a `proposal_approved` / `proposal_rejected`
+// wake that is STILL `online_first` after steps 3/4/4a (no instance/mention pin, no online idea
+// session-origin, no agent-owner project cwd pin), it wakes ONLY when the online target is
+// unambiguous — exactly one online connection (falls through to step 4b, directed) — and
+// SUPPRESSES (notify-only, offline-pin-shaped result) when two-or-more connections are online.
+// It NEVER narrows to an arbitrary first-online (the removed dialog's job), NEVER persists a
+// durable idea pin, and is gated on `ctx.action` so it carves out ONLY the two proposal actions.
+describe("createTurnAndResolveTarget — proposal-review ambiguity suppression (idea 146a7a9b)", () => {
+  // A proposal entity: its lineage resolves to the canonical idea anchor (default
+  // mockResolveRootIdea / mockResolveDirectIdeaUuid → ideaUuid, a plain-agent idea → no pin).
+  const proposalCtx = (overrides: Partial<WakeNotificationContext> = {}) =>
+    ctx({ entityType: "proposal", entityUuid: "proposal-1", ...overrides });
+
+  // ----- ≥2 online, no pin → notify-only (SUPPRESS) for approve AND reject -----
+
+  for (const action of ["proposal_approved", "proposal_rejected"]) {
+    it(`${action} with no pin and TWO online connections is notify-only (suppressWake, no turn, no pin persisted)`, async () => {
+      mockListConnectionsForAgent.mockResolvedValue([
+        onlineConn({ uuid: "conn-A", host: "host-A", cwd: "/home/u/dev/a" }),
+        onlineConn({ uuid: "conn-B", host: "host-B", cwd: "/home/u/dev/b" }),
+      ]);
+      // Defaults: proposal lineage → ideaUuid (plain agent, no instance pin), no idea session
+      // origin (mockDaemonSessionFindFirst → null), projectUuid unset → step 4a skipped.
+
+      const { turn, targetConnectionUuid, runtimeCwd, suppressWake } =
+        await createTurnAndResolveTarget(proposalCtx({ action }));
+
+      // Offline-pin-shaped result: NO turn, NO target, suppressWake TRUE (every connection
+      // suppresses its broadcast copy via cli/event-router.mjs). The notification stands.
+      expect(turn).toBeNull();
+      expect(targetConnectionUuid).toBeNull();
+      expect(runtimeCwd).toBeNull();
+      expect(suppressWake).toBe(true);
+      // Ambiguity suppression, NOT the step-4b narrow: no connection is woken.
+      expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+      expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+      expect(mockDeliverTurnPing).not.toHaveBeenCalled();
+      // The server NEVER writes a durable idea/instance pin (no session re-point either).
+      expect(mockDaemonSessionUpdate).not.toHaveBeenCalled();
+      // Notify-only is normal, not an error.
+      expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+  }
+
+  // ----- exactly 1 online, no pin → directed to it (falls through to step 4b) -----
+
+  for (const action of ["proposal_approved", "proposal_rejected"]) {
+    it(`${action} with no pin and EXACTLY ONE online connection is directed to it (turn created, no pin persisted)`, async () => {
+      const only = "conn-only";
+      mockListConnectionsForAgent.mockResolvedValue([
+        onlineConn({ uuid: only, host: "host-A", cwd: "/home/u/dev/a" }),
+      ]);
+
+      const { turn, targetConnectionUuid, suppressWake } =
+        await createTurnAndResolveTarget(proposalCtx({ action }));
+
+      // Exactly one online → unambiguous → step 4b promotes online_first → directed on it.
+      expect(turn?.status).toBe("pending");
+      expect(targetConnectionUuid).toBe(only);
+      expect(suppressWake).toBe(false);
+      expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ originConnectionUuid: only }),
+      );
+      expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+        expect.objectContaining({ originConnectionUuid: only, turnUuid: turn?.uuid }),
+      );
+      // No durable idea pin is persisted for the single-online wake.
+      expect(mockDaemonSessionUpdate).not.toHaveBeenCalled();
+    });
+  }
+
+  // ----- Regression: any resolved pin/origin still directs the wake (block skipped) -----
+
+  it("proposal_approved with an ONLINE idea instance pin is directed to the pin (new block skipped)", async () => {
+    const pinnedHost = "pin-host";
+    const pinnedCwd = "/home/u/dev/pinned";
+    const pinnedConnUuid = "conn-pinned";
+    // The root idea is pinned to a same-agent instance → resolvePinnedTarget (step 3) resolves
+    // it, selection is `directed` BEFORE the new online_first-gated block.
+    pinIdeaToInstance(pinnedHost, pinnedCwd);
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "x", cwd: "/x" }),
+      onlineConn({ uuid: pinnedConnUuid, host: pinnedHost, cwd: pinnedCwd }),
+    ]);
+
+    const { turn, targetConnectionUuid, suppressWake } =
+      await createTurnAndResolveTarget(proposalCtx({ action: "proposal_approved" }));
+
+    // Directed to the pin even though 2 connections are online — the suppression block only
+    // fires on `online_first`.
+    expect(targetConnectionUuid).toBe(pinnedConnUuid);
+    expect(suppressWake).toBe(false);
+    expect(turn?.status).toBe("pending");
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: pinnedConnUuid }),
+    );
+  });
+
+  it("proposal_approved with an ONLINE idea session-origin is directed there (new block skipped)", async () => {
+    const ideaOriginConn = "conn-idea-origin";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: ideaOriginConn, host: "host-B", cwd: "/home/u/dev/idea" }),
+    ]);
+    // The idea already has an online session origin → step 4 upgrades selection to `directed`.
+    mockDaemonSessionFindFirst.mockResolvedValue({ originConnectionUuid: ideaOriginConn });
+
+    const { targetConnectionUuid, suppressWake } =
+      await createTurnAndResolveTarget(proposalCtx({ action: "proposal_approved" }));
+
+    expect(targetConnectionUuid).toBe(ideaOriginConn);
+    expect(suppressWake).toBe(false);
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: ideaOriginConn }),
+    );
+  });
+
+  it("proposal_approved with an agent-owner project-fixed cwd is directed there (new block skipped)", async () => {
+    const projHost = "proj-host";
+    const projCwd = "/home/u/dev/project-cwd";
+    const projConnUuid = "conn-project-pin";
+    const projectUuid = "project-x";
+    mockAgentFindFirst.mockResolvedValue({ ownerUuid: "owner-1" });
+    mockPreferenceFindFirst.mockResolvedValue({ host: projHost, cwd: projCwd });
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: "conn-online-first", host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: projConnUuid, host: projHost, cwd: projCwd }),
+    ]);
+    // No idea session origin (default null) → step 4 declines; step 4a resolves the project pin
+    // to `directed` BEFORE the new block, so it is skipped even with 2 connections online.
+
+    const { targetConnectionUuid, suppressWake } = await createTurnAndResolveTarget(
+      proposalCtx({ action: "proposal_approved", projectUuid }),
+    );
+
+    expect(targetConnectionUuid).toBe(projConnUuid);
+    expect(suppressWake).toBe(false);
+    expect(mockResolveOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: projConnUuid }),
+    );
+  });
+
+  it("proposal_approved for a fully-offline agent yields none (no turn, suppressWake FALSE)", async () => {
+    // No online connection at all → selection is `none`, not `online_first`, so the new block
+    // is skipped and the fully-offline notify-only path runs (suppressWake stays FALSE — nobody
+    // is connected to suppress; distinct from the ≥2-online ambiguity suppression).
+    mockListConnectionsForAgent.mockResolvedValue([
+      offlineConn({ uuid: "conn-offline", host: "host-A", cwd: "/home/u/dev/a" }),
+    ]);
+
+    const { turn, targetConnectionUuid, suppressWake } =
+      await createTurnAndResolveTarget(proposalCtx({ action: "proposal_approved" }));
+
+    expect(turn).toBeNull();
+    expect(targetConnectionUuid).toBeNull();
+    expect(suppressWake).toBe(false);
+    expect(mockResolveOrCreateSession).not.toHaveBeenCalled();
+    expect(mockCreatePendingTurn).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  // ----- Control: the carve-out is gated on ctx.action — non-proposal wakes still narrow -----
+
+  it("control: a NON-proposal task_assigned with no pin and TWO online connections still narrows to exactly one (single-active intact)", async () => {
+    const onlineFirst = "conn-online-first";
+    mockListConnectionsForAgent.mockResolvedValue([
+      onlineConn({ uuid: onlineFirst, host: "host-A", cwd: "/home/u/dev/a" }),
+      onlineConn({ uuid: "conn-second", host: "host-B", cwd: "/home/u/dev/b" }),
+    ]);
+
+    const { turn, targetConnectionUuid, suppressWake } = await createTurnAndResolveTarget(
+      ctx({ action: "task_assigned", entityType: "task", entityUuid: taskUuid }),
+    );
+
+    // task_assigned is NOT a proposal-review action → the carve-out is skipped and Step 4b
+    // narrows to the deterministic online-first connection (directed), NOT suppressed.
+    expect(turn?.status).toBe("pending");
+    expect(targetConnectionUuid).toBe(onlineFirst);
+    expect(suppressWake).toBe(false);
+    expect(mockDeliverTurnPing).toHaveBeenCalledWith(
+      expect.objectContaining({ originConnectionUuid: onlineFirst, turnUuid: turn?.uuid }),
     );
   });
 });

--- a/src/services/notification-turn.ts
+++ b/src/services/notification-turn.ts
@@ -880,6 +880,52 @@ export async function createTurnAndResolveTarget(
       }
     }
 
+    // (4a-bis) Proposal-review ambiguity suppression (idea 146a7a9b). Approving or rejecting a
+    // proposal in the UI must resolve the assignee wake WITHOUT ever popping a cwd picker (the
+    // client dialog is removed): honor a hard pin (step 3), an online idea session-origin (step
+    // 4), or the agent-owner project cwd pin (step 4a) — all of which already short-circuited to
+    // `directed` / `offline_pin` ABOVE and are NEVER overridden here — else wake ONLY when the
+    // online target is UNAMBIGUOUS. With NO such resolution (selection is STILL `online_first`)
+    // AND two-or-more online connections, there is no single determinable cwd, so SUPPRESS the
+    // wake as notify-only (the offline_pin-shaped result) rather than letting step 4b narrow to
+    // an arbitrary first-online connection — that arbitrary pick was the removed dialog's job and
+    // is exactly what the owner rejected at this review gate. With EXACTLY ONE online connection
+    // the target is unambiguous: fall through to step 4b, which promotes online_first → directed
+    // on that sole connection and wakes it.
+    //
+    // Discriminated on `ctx.action` (the RAW notification action) — NOT `trigger`, which
+    // collapses `proposal_approved` / `proposal_rejected` into `task_assigned`
+    // (NOTIFICATION_ACTION_TO_TURN_TRIGGER) — so ONLY the two proposal-review actions carve out
+    // of the narrow; every other residual trigger (task_assigned, elaboration, mentioned, …)
+    // still reaches step 4b and narrows as today. Gated ALSO on `selection.kind === "online_first"`
+    // so any hard pin, online session-origin, or project pin above (which produced `directed` /
+    // `offline_pin`) is preserved verbatim (elaboration Q5 precedence). No durable pin is
+    // persisted — the server never writes an idea pin; the removed client reassign was the only
+    // persist (elaboration Q4). The recipient (proposal.createdByUuid) is unchanged — out of scope.
+    const isProposalReviewAction =
+      ctx.action === "proposal_approved" || ctx.action === "proposal_rejected";
+    if (isProposalReviewAction && selection.kind === "online_first") {
+      const onlineCount = connections.filter(
+        (c) => c.effectiveStatus === "online",
+      ).length;
+      if (onlineCount >= 2) {
+        // Ambiguous: no pin / session-origin / project pin resolved a single cwd and the
+        // recipient agent is online in two-or-more cwds → notify-only. Same shape as an offline
+        // pin: NO turn, NO target, suppressWake TRUE so every connection suppresses its broadcast
+        // copy via cli/event-router.mjs. The already-created Notification stands as the plain
+        // record. No picker, no arbitrary online-first pick.
+        return {
+          turn: null,
+          targetConnectionUuid: null,
+          runtimeCwd: null,
+          suppressWake: true,
+        };
+      }
+      // Exactly one online → unambiguous. Deliberately fall through to step 4b, which promotes
+      // this online_first selection to `directed` on the sole connection and wakes it. No pin
+      // is persisted.
+    }
+
     // (4b) Single-active-session narrow (idea 62920792 / daemon-single-active-session). When
     // a residual-family wake (the RESIDUAL_CWD_UPGRADE_TRIGGERS set — the autonomous
     // idea-anchored family task_assigned / elaboration / elaboration_verified /


### PR DESCRIPTION
## Why
Approving or rejecting a proposal in the UI popped a cwd picker (`WakeCwdPickerDialog`) whenever the input idea's assignee was a bare agent online in ≥2 cwds, and silently pinned the idea on the exactly-1 case. Approving/rejecting is a review decision, not a cwd-placement decision — the wake target should resolve automatically, like an un-pinned @mention, and never interrupt with a dialog at this stage.

Idea `146a7a9b`. Elaboration-locked behavior (owner-answered).

## What changed
**Scope: proposal Approve + Reject only** (Revoke/Close/Delete already don't prompt; the idea-panel Verify-Elaborate / Start-Development / Yolo surfaces keep their picker).

- **Server** — `src/services/notification-turn.ts` `createTurnAndResolveTarget` gains a proposal-review ambiguity-suppression step **(4a-bis)**, gated on `ctx.action ∈ {proposal_approved, proposal_rejected}` and `selection.kind === "online_first"` (so a pin / online session-origin / agent-owner project cwd resolved in steps 3/4/4a is never overridden). With no such resolution: exactly 1 online connection → falls through to the single-active narrow (directed, no persisted pin); ≥2 online → returns the offline-pin-shaped notify-only result (`suppressWake: true`, no turn) so every connection suppresses and the in-app notification still stands. Reuses the existing `offline_pin` transport — no schema/permission change.
- **Client** — `src/app/(dashboard)/projects/[uuid]/proposals/[proposalUuid]/proposal-actions.tsx` calls `approveProposalAction` / `rejectProposalAction` directly; the `usePinThenWake` orchestration and `WakeCwdPickerDialog` mount are removed (no dialog, no persisted pin, no toast). The shared hook / preview service / route / dialog remain intact for the three idea-panel surfaces.
- **OpenSpec** — change `fix-proposal-approve-no-cwd-picker` archived: `pin-cwd-before-wake` and `daemon-single-active-session` MODIFIED (carve the ≥2-online proposal case out of the narrow), `daemon-cwd-instance-addressing` ADDED (proposal-review wake resolution).

## Testing
- `npx vitest run notification-turn` → **121/121** (TDD red→green: approve+reject × {2-online suppress, 1-online directed} + regressions + a non-proposal control).
- `npx tsc --noEmit` clean. ESLint clean for the touched files.
- Task-reviewer PASS (both tasks) + idea-level code-review gateway PASS.

## Deferred live verification (headless env limits, not defects)
- Interactive Playwright approve/reject click + light/dark visual was blocked by a **pre-existing** dev-only Turbopack/dagre 500 on the proposal detail page (`Can't resolve './lib/debug'`; `/graph` 500s too; unrelated to this diff). The `<WakeCwdPickerDialog>` mount is fully removed, so the picker structurally cannot render — worth a prod/webpack or human confirm.
- `docs/design.pen` could not be edited headlessly (Pencil MCP needs a live editor); the picker is a transient pop-over likely not depicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)