### PR TITLE
feat(daemon): prompt for agent backend in login / --add / install add flows

### DIFF
--- a/cli/__tests__/agent-backend-prompt.test.mjs
+++ b/cli/__tests__/agent-backend-prompt.test.mjs
@@ -1,0 +1,90 @@
+// cli/__tests__/agent-backend-prompt.test.mjs
+// Unit tests for the shared agent-backend menu (daemon-add-agent-type-prompt).
+// promptAgentBackend is pure with injected IO — no real TTY. It returns the
+// chosen backend value, or `undefined` ("no explicit choice → inherit the daemon
+// default") on Enter / out-of-range / garbage / non-TTY.
+import { describe, it, expect, vi } from "vitest";
+import { AGENT_MENU, promptAgentBackend } from "../agent-backend-prompt.mjs";
+import { KNOWN_AGENTS } from "../daemon-agent.mjs";
+
+describe("AGENT_MENU", () => {
+  it("advertises claude-code / codex / kiro (dsh de-advertised)", () => {
+    expect(AGENT_MENU.map((r) => r.value)).toEqual(["claude-code", "codex", "kiro"]);
+    // Every advertised value must be a KNOWN_AGENTS backend.
+    for (const row of AGENT_MENU) expect(KNOWN_AGENTS).toContain(row.value);
+    // dsh stays reachable by name but is NOT advertised in the numbered menu.
+    expect(AGENT_MENU.map((r) => r.value)).not.toContain("dsh");
+  });
+});
+
+describe("promptAgentBackend", () => {
+  function deps(over = {}) {
+    return {
+      ask: vi.fn(async () => ""),
+      log: vi.fn(),
+      isTTY: true,
+      ...over,
+    };
+  }
+
+  it("returns undefined immediately on a non-TTY (no prompt, no output)", async () => {
+    const ask = vi.fn(async () => "2");
+    const log = vi.fn();
+    const r = await promptAgentBackend({ ask, log, isTTY: false });
+    expect(r).toBeUndefined();
+    expect(ask).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when no ask function is provided", async () => {
+    const r = await promptAgentBackend({ isTTY: true });
+    expect(r).toBeUndefined();
+  });
+
+  it("renders every AGENT_MENU row in the menu text", async () => {
+    const o = deps({ ask: vi.fn(async () => "") });
+    await promptAgentBackend(o);
+    const printed = o.log.mock.calls.flat().join("\n");
+    for (const row of AGENT_MENU) expect(printed).toContain(row.label);
+  });
+
+  it("Enter (empty answer) returns undefined → inherit the default", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "") }));
+    expect(r).toBeUndefined();
+  });
+
+  it("a whitespace-only answer is treated as empty → undefined", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "   ") }));
+    expect(r).toBeUndefined();
+  });
+
+  it("a numeric selection picks the matching backend", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "2") }));
+    expect(r).toBe("codex"); // 2) Codex CLI
+  });
+
+  it("the first menu entry (1) selects claude-code", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "1") }));
+    expect(r).toBe("claude-code");
+  });
+
+  it("accepts a backend typed by name", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "kiro") }));
+    expect(r).toBe("kiro");
+  });
+
+  it("accepts a de-advertised backend (dsh) typed by name", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "dsh") }));
+    expect(r).toBe("dsh");
+  });
+
+  it("an out-of-range number returns undefined (no explicit choice)", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "99") }));
+    expect(r).toBeUndefined();
+  });
+
+  it("garbage / unknown text returns undefined", async () => {
+    const r = await promptAgentBackend(deps({ ask: vi.fn(async () => "banana") }));
+    expect(r).toBeUndefined();
+  });
+});

--- a/cli/__tests__/login-add-agent.test.mjs
+++ b/cli/__tests__/login-add-agent.test.mjs
@@ -116,10 +116,86 @@ describe("runLogin --add", () => {
   });
 });
 
+describe("runLogin — agent backend capture", () => {
+  const baseDeps = (over = {}) => ({
+    validate: async () => ({ name: "Bot", uuid: "id1" }),
+    prompt: async () => "",
+    log: () => {},
+    errLog: () => {},
+    ...over,
+  });
+
+  it("--add: a TTY menu pick sets agentType on the appended entry", async () => {
+    const appendAgent = vi.fn(() => ({ ok: true, path: "/cfg/daemon.json", agents: [{}, {}], index: 1 }));
+    const rc = await runLogin(
+      { url: "u1", apiKey: "k1", add: true },
+      baseDeps({ appendAgent, isTTY: true, promptBackend: async () => "codex" }),
+    );
+    expect(rc).toBe(0);
+    expect(appendAgent).toHaveBeenCalledWith({
+      url: "u1", apiKey: "k1", agentUuid: "id1", agentName: "Bot", agentType: "codex",
+    });
+  });
+
+  it("--add: Enter at the menu (undefined) appends WITHOUT an agentType key", async () => {
+    const appendAgent = vi.fn(() => ({ ok: true, path: "/cfg/daemon.json", agents: [{}, {}], index: 1 }));
+    const rc = await runLogin(
+      { url: "u1", apiKey: "k1", add: true },
+      baseDeps({ appendAgent, isTTY: true, promptBackend: async () => undefined }),
+    );
+    expect(rc).toBe(0);
+    expect(appendAgent).toHaveBeenCalledWith({
+      url: "u1", apiKey: "k1", agentUuid: "id1", agentName: "Bot",
+    });
+  });
+
+  it("single-agent: --agent kiro writes the top-level `agent` field", async () => {
+    const written = [];
+    const write = vi.fn((data) => { written.push(data); return "/p"; });
+    const rc = await runLogin(
+      { url: "u1", apiKey: "k1", agent: "kiro" },
+      baseDeps({ write }),
+    );
+    expect(rc).toBe(0);
+    expect(written).toEqual([
+      { url: "u1", apiKey: "k1", agentUuid: "id1", agentName: "Bot", agent: "kiro" },
+    ]);
+  });
+
+  it("single-agent: no choice (undefined) writes NO top-level `agent` key", async () => {
+    const written = [];
+    const write = vi.fn((data) => { written.push(data); return "/p"; });
+    const rc = await runLogin(
+      { url: "u1", apiKey: "k1" },
+      baseDeps({ write, isTTY: true, promptBackend: async () => undefined }),
+    );
+    expect(rc).toBe(0);
+    expect(written).toEqual([
+      { url: "u1", apiKey: "k1", agentUuid: "id1", agentName: "Bot" },
+    ]);
+  });
+
+  it("single-agent non-TTY with no --agent: no menu, no block, no backend key", async () => {
+    // Uses the REAL promptAgentBackend (not injected). isTTY:false must make it
+    // return immediately without touching `prompt`, and write no `agent` key.
+    const written = [];
+    const write = vi.fn((data) => { written.push(data); return "/p"; });
+    const prompt = vi.fn(async () => { throw new Error("prompt must not be called on non-TTY"); });
+    const rc = await runLogin(
+      { url: "u1", apiKey: "k1" },
+      baseDeps({ write, prompt, isTTY: false }),
+    );
+    expect(rc).toBe(0);
+    expect(written).toEqual([
+      { url: "u1", apiKey: "k1", agentUuid: "id1", agentName: "Bot" },
+    ]);
+  });
+});
+
 describe("install wizard — multi-add loop", () => {
-  it("adds a second agent when the operator answers yes once", async () => {
-    // prompt sequence: "add another?"→y, url, key, "add another?"→n
-    const answers = ["y", "u2", "k2", "n"];
+  it("adds a second agent when the operator answers yes once (Enter at backend = inherit)", async () => {
+    // prompt sequence: "add another?"→y, url, key, backend-menu→Enter(inherit), "add another?"→n
+    const answers = ["y", "u2", "k2", "", "n"];
     const prompt = vi.fn(async () => answers.shift() ?? "");
     const appendAgent = vi.fn(() => ({ ok: true, agents: [{}, {}], index: 1 }));
     const res = await resolveInstallCredentials(
@@ -139,7 +215,62 @@ describe("install wizard — multi-add loop", () => {
     );
     expect(res.ok).toBe(true);
     expect(appendAgent).toHaveBeenCalledTimes(1);
+    // Enter at the backend menu → no agentType (entry inherits the daemon default).
     expect(appendAgent).toHaveBeenCalledWith({ url: "u2", apiKey: "k2", agentUuid: "id", agentName: "Bot" });
+  });
+
+  it("install loop: a backend menu pick sets agentType on the appended entry", async () => {
+    // "add another?"→y, url, key, backend-menu→"2" (Codex), "add another?"→n
+    const answers = ["y", "u2", "k2", "2", "n"];
+    const prompt = vi.fn(async () => answers.shift() ?? "");
+    const appendAgent = vi.fn(() => ({ ok: true, agents: [{}, {}], index: 1 }));
+    const res = await resolveInstallCredentials(
+      { url: "u1", apiKey: "k1", add: true },
+      {},
+      {
+        isTTY: true,
+        skip: false,
+        resolve: () => ({ url: "u1", apiKey: "k1", source: "flag" }),
+        validate: async () => ({ uuid: "id", name: "Bot" }),
+        writeConfig: () => {},
+        prompt,
+        appendAgent,
+        log: () => {},
+        errLog: () => {},
+      },
+    );
+    expect(res.ok).toBe(true);
+    expect(appendAgent).toHaveBeenCalledWith({
+      url: "u2", apiKey: "k2", agentUuid: "id", agentName: "Bot", agentType: "codex",
+    });
+  });
+
+  it("install loop: --agent is honored (no backend menu prompt)", async () => {
+    // With --agent kiro, the loop must NOT ask a backend question — sequence is
+    // "add another?"→y, url, key, "add another?"→n (no backend slot consumed).
+    const answers = ["y", "u2", "k2", "n"];
+    const prompt = vi.fn(async () => answers.shift() ?? "");
+    const appendAgent = vi.fn(() => ({ ok: true, agents: [{}, {}], index: 1 }));
+    const res = await resolveInstallCredentials(
+      { url: "u1", apiKey: "k1", agent: "kiro", add: true },
+      {},
+      {
+        isTTY: true,
+        skip: false,
+        resolve: () => ({ url: "u1", apiKey: "k1", source: "flag" }),
+        validate: async () => ({ uuid: "id", name: "Bot" }),
+        writeConfig: () => {},
+        prompt,
+        appendAgent,
+        log: () => {},
+        errLog: () => {},
+      },
+    );
+    expect(res.ok).toBe(true);
+    expect(appendAgent).toHaveBeenCalledTimes(1);
+    expect(appendAgent).toHaveBeenCalledWith({
+      url: "u2", apiKey: "k2", agentUuid: "id", agentName: "Bot", agentType: "kiro",
+    });
   });
 
   it("non-TTY / skip run never prompts for extra agents (single-agent install unchanged)", async () => {

--- a/cli/agent-backend-prompt.mjs
+++ b/cli/agent-backend-prompt.mjs
@@ -1,0 +1,93 @@
+// cli/agent-backend-prompt.mjs
+// Single source of truth for the interactive "which agent backend?" menu shared
+// by the daemon credential-capture entry points: `chorus login` (single-agent),
+// `chorus login --add` / `chorus daemon add`, and the `chorus install` "add
+// another agent" loop (see cli/login.mjs, cli/daemon-install-config.mjs).
+//
+// The same AGENT_MENU list also feeds resolveInstallAgent's daemon-level backend
+// prompt in daemon-install-config.mjs, so every surface advertises EXACTLY the
+// same backends and never drifts — re-advertising a backend (e.g. dsh) is a
+// one-line edit here that all prompts pick up.
+//
+// promptAgentBackend deliberately differs from resolveInstallAgent's inline menu
+// in ONE way: an empty / unrecognized answer returns `undefined` ("no explicit
+// choice") rather than DEFAULT_AGENT, so the add/login callers can OMIT the
+// backend field and let resolve-time inheritance apply (the daemon top-level
+// default). resolveInstallAgent must always produce a concrete daemon-level
+// backend, so it keeps its own empty→DEFAULT_AGENT behavior and does NOT use
+// this helper.
+//
+// Lives in its own module to avoid an import cycle: daemon-install-config.mjs
+// already imports appendAgentConfig from login.mjs, so the shared menu cannot
+// live in either of those files.
+
+import { KNOWN_AGENTS } from "./daemon-agent.mjs";
+
+/**
+ * The interactive agent-backend menu. Order mirrors KNOWN_AGENTS with claude-code
+ * first (it is the default). Kept as the single shared list so the numbered
+ * prompt and the accepted values never drift across entry points.
+ *
+ * NOTE: the dsh JSON-RPC daemon backend is temporarily de-advertised (offline).
+ * The code path (probeAgentCli/resolveDshPath, spawner-select, dsh-spawner) is
+ * kept dormant — re-add this menu entry to bring it back online. It remains
+ * reachable by name (e.g. `--agent dsh`, or typing "dsh" at the prompt).
+ */
+export const AGENT_MENU = [
+  { value: "claude-code", label: "Claude Code (default)" },
+  { value: "codex", label: "Codex CLI" },
+  { value: "kiro", label: "Kiro CLI" },
+];
+
+/** A non-empty trimmed string, or undefined. */
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Prompt the operator to pick an agent backend for the agent being configured,
+ * shared by the add / login / install-add flows.
+ *
+ * Returns the chosen backend value, or `undefined` when the operator makes no
+ * explicit choice — meaning "inherit the daemon default" (the caller then omits
+ * the `agentType` / top-level `agent` field). `undefined` is returned when:
+ *   - `isTTY` is false (non-interactive / piped) — returns immediately, prints
+ *     nothing, never blocks (mirrors resolveInstallAgent / resolveDaemonCwds);
+ *   - the answer is empty (Enter);
+ *   - the answer is an out-of-range number or is otherwise unrecognized.
+ *
+ * Accepts either a menu number (1..AGENT_MENU.length) or a KNOWN_AGENTS value
+ * typed by name (e.g. "codex", or "dsh" even though it is de-advertised).
+ *
+ * @param {{
+ *   ask: (query: string, opts?: object) => Promise<string>,
+ *   log?: (m: string) => void,
+ *   isTTY?: boolean,
+ * }} deps
+ * @returns {Promise<string|undefined>}
+ */
+export async function promptAgentBackend({ ask, log = () => {}, isTTY = false } = {}) {
+  // Non-TTY (piped / scripted) must never block on a menu — return immediately
+  // with no output. The caller falls back to --agent or inherits the default.
+  if (!isTTY || typeof ask !== "function") return undefined;
+
+  log("[Chorus] Which agent backend should this agent use?");
+  for (let i = 0; i < AGENT_MENU.length; i += 1) {
+    log(`[Chorus]   ${i + 1}) ${AGENT_MENU[i].label}`);
+  }
+  const answer = nonEmpty(
+    await ask(`Select [1-${AGENT_MENU.length}] (Enter to inherit the daemon default): `),
+  );
+  if (!answer) return undefined; // Enter → inherit default.
+
+  const n = Number(answer);
+  if (Number.isInteger(n) && n >= 1 && n <= AGENT_MENU.length) {
+    return AGENT_MENU[n - 1].value;
+  }
+  // A backend typed by name (muscle memory). KNOWN_AGENTS includes de-advertised
+  // backends (dsh), so a by-name pick can still reach them.
+  if (KNOWN_AGENTS.includes(answer)) return answer;
+
+  // Out-of-range / garbage → no explicit choice; the caller inherits the default.
+  return undefined;
+}

--- a/cli/client-args.mjs
+++ b/cli/client-args.mjs
@@ -126,7 +126,8 @@ OPTIONS
   --agent <type>           Local agent backend to wake         (env: CHORUS_AGENT)
                            (claude-code | codex | kiro; default: claude-code)
                            (Also configurable as "agent":"…" in ~/.chorus/daemon.json;
-                           'chorus daemon install' prompts for it interactively.)
+                           'chorus daemon install' and 'chorus login' (incl. --add)
+                           prompt for it interactively on a TTY.)
   --yolo                   Full autonomy for the woken agent   (env: CHORUS_YOLO=1)
                            (--dangerously-skip-permissions: Bash, file writes, any
                            command). This is the DEFAULT permission mode.
@@ -205,10 +206,15 @@ OPTIONS
   --api-key <cho_...>      Agent API key                       (env: CHORUS_API_KEY)
   --add                    Add this key as an ADDITIONAL agent (multi-agent daemon)
                            instead of overwriting the single credential
+  --agent <type>           Agent backend for THIS agent         (env: CHORUS_AGENT)
+                           (claude-code | codex | kiro). On a TTY, login (and
+                           --add) prompt for it when omitted; Enter inherits the
+                           daemon default (claude-code) and writes no backend.
   -h, --help               Show this help message
 
-  With no flags, login prompts interactively for the URL and a masked API key,
-  validates them against the server, and on success saves the credentials.
+  With no flags, login prompts interactively for the URL, a masked API key, and
+  (on a TTY) the agent backend, validates them against the server, and on success
+  saves the credentials.
 
   With --add, the validated key is appended to the daemon.json 'agents[]' array
   so one daemon can serve several independent agents (see docs/DAEMON.md). The

--- a/cli/daemon-install-config.mjs
+++ b/cli/daemon-install-config.mjs
@@ -27,6 +27,7 @@ import { updateDaemonConfig, appendAgentConfig, prompt as defaultPrompt } from "
 import { validateAndFetchIdentity } from "./chorus-client.mjs";
 import { normalizeCwd, cleanCwdList } from "./daemon-config.mjs";
 import { KNOWN_AGENTS, DEFAULT_AGENT } from "./daemon-agent.mjs";
+import { AGENT_MENU, promptAgentBackend } from "./agent-backend-prompt.mjs";
 import { agentNotFoundWarningLine } from "./daemon-banner.mjs";
 import { resolveClaudePath } from "./claude-spawner.mjs";
 import { resolveCodexPath } from "./codex-spawner.mjs";
@@ -161,12 +162,20 @@ export async function resolveInstallCredentials(flags = {}, env = {}, opts = {})
         );
         continue;
       }
-      const res = appendAgent({ url: u, apiKey: k, agentUuid: id.uuid, agentName: id.name });
+      // Which backend for this agent? Explicit --agent wins; otherwise the menu
+      // (we're already on a TTY here). undefined → omit agentType so the entry
+      // inherits the daemon default at resolve time (never a literal claude-code).
+      let at = nonEmpty(flags.agent);
+      if (!at) at = await promptAgentBackend({ ask, log, isTTY });
+      const agentObj = { url: u, apiKey: k, agentUuid: id.uuid, agentName: id.name };
+      if (at) agentObj.agentType = at;
+      const res = appendAgent(agentObj);
       if (!res.ok) {
         errLog(`[Chorus] agent ${id.name} (${id.uuid}) is already configured — skipping.`);
         continue;
       }
-      log(`[Chorus] added agent ${id.name} (${id.uuid}) — this daemon now serves ${res.agents.length} agents.`);
+      const backendNote = at ? ` (backend: ${at})` : "";
+      log(`[Chorus] added agent ${id.name} (${id.uuid})${backendNote} — this daemon now serves ${res.agents.length} agents.`);
     }
   }
 
@@ -280,19 +289,12 @@ export async function resolveInstallBrowseRoots(flags = {}, opts = {}) {
   return { browseRoots };
 }
 
-/**
- * The interactive agent-backend menu. Order mirrors KNOWN_AGENTS with claude-code
- * first (it is the default). Kept beside the resolver so the numbered prompt and
- * the accepted values never drift.
- */
-const AGENT_MENU = [
-  { value: "claude-code", label: "Claude Code (default)" },
-  { value: "codex", label: "Codex CLI" },
-  { value: "kiro", label: "Kiro CLI" },
-  // NOTE: the dsh JSON-RPC daemon backend is temporarily de-advertised (offline).
-  // The code path (probeAgentCli/resolveDshPath, spawner-select, dsh-spawner) is
-  // kept dormant — re-add this menu entry to bring it back online. See CONNECT_DSH.
-];
+// The interactive agent-backend menu (`AGENT_MENU`) now lives in
+// ./agent-backend-prompt.mjs as the single source of truth shared with the
+// add/login flows (imported above), so every backend prompt advertises the same
+// list and never drifts. resolveInstallAgent keeps its own inline menu render
+// below (its empty→DEFAULT_AGENT semantics differ from promptAgentBackend's
+// empty→undefined) but reads the same AGENT_MENU rows.
 
 /** Probe the selected backend's CLI on PATH. Returns the resolved path or null.
  * Injectable per backend so the check is testable without a real PATH. */

--- a/cli/login.mjs
+++ b/cli/login.mjs
@@ -9,6 +9,7 @@ import { createInterface } from "node:readline";
 
 import { loginFilePath } from "./credentials.mjs";
 import { validateAndFetchIdentity } from "./chorus-client.mjs";
+import { promptAgentBackend } from "./agent-backend-prompt.mjs";
 
 /**
  * Prompt for a line of input. When `mask` is true, typed characters are not
@@ -219,12 +220,21 @@ export function appendAgentConfig(agentObj, deps = {}) {
  * single flat credential — so one daemon can serve several agents. On an invalid
  * key, or a duplicate, nothing is written.
  *
+ * The agent backend (agent type) is captured too: an explicit `--agent` wins,
+ * otherwise an interactive menu is offered on a TTY (skipped on a non-TTY so a
+ * scripted login never blocks). No choice → nothing is written for the backend
+ * (the `--add` entry omits `agentType`; the single-agent config omits the
+ * top-level `agent`), so it inherits the daemon default — never a literal
+ * `claude-code`. See {@link promptAgentBackend}.
+ *
  * @param {{ url?: string, apiKey?: string, agent?: string, add?: boolean }} flags
  * @param {{
  *   validate?: typeof validateAndFetchIdentity,
  *   write?: typeof writeLoginFile,
  *   appendAgent?: typeof appendAgentConfig,
  *   prompt?: typeof prompt,
+ *   promptBackend?: typeof promptAgentBackend,
+ *   isTTY?: boolean,
  *   log?: (m: string) => void,
  *   errLog?: (m: string) => void,
  * }} [deps]
@@ -235,6 +245,8 @@ export async function runLogin(flags = {}, deps = {}) {
   const write = deps.write ?? writeLoginFile;
   const appendAgent = deps.appendAgent ?? appendAgentConfig;
   const ask = deps.prompt ?? prompt;
+  const promptBackend = deps.promptBackend ?? promptAgentBackend;
+  const isTTY = deps.isTTY ?? Boolean(process.stdin.isTTY);
   const log = deps.log ?? ((m) => process.stdout.write(m + "\n"));
   const errLog = deps.errLog ?? ((m) => process.stderr.write(m + "\n"));
 
@@ -259,10 +271,16 @@ export async function runLogin(flags = {}, deps = {}) {
     return 1;
   }
 
+  // Which agent backend should this agent use? Explicit --agent wins; otherwise
+  // offer the interactive menu on a TTY. `undefined` = no explicit choice → we
+  // write NO backend key so it inherits the daemon default (never claude-code).
+  let agentType = nonEmpty(flags.agent);
+  if (!agentType) agentType = await promptBackend({ ask, log, isTTY });
+
   // --add: append as an additional agent (multi-agent) instead of overwriting.
   if (flags.add) {
     const agentObj = { url, apiKey, agentUuid: identity.uuid, agentName: identity.name };
-    if (nonEmpty(flags.agent)) agentObj.agentType = nonEmpty(flags.agent);
+    if (agentType) agentObj.agentType = agentType;
     const res = appendAgent(agentObj);
     if (!res.ok) {
       errLog(
@@ -270,13 +288,17 @@ export async function runLogin(flags = {}, deps = {}) {
       );
       return 1;
     }
-    log(`Added agent ${identity.name} (${identity.uuid}) as agents[${res.index}] in ${res.path}.`);
+    const backendNote = agentType ? ` — backend: ${agentType}` : "";
+    log(`Added agent ${identity.name} (${identity.uuid}) as agents[${res.index}] in ${res.path}${backendNote}.`);
     log(`This daemon now serves ${res.agents.length} agent(s).`);
     return 0;
   }
 
-  const path = write({ url, apiKey, agentUuid: identity.uuid, agentName: identity.name });
-  log(`Logged in as ${identity.name} (${identity.uuid}).`);
+  const loginData = { url, apiKey, agentUuid: identity.uuid, agentName: identity.name };
+  if (agentType) loginData.agent = agentType;
+  const path = write(loginData);
+  const backendNote = agentType ? ` — backend: ${agentType}` : "";
+  log(`Logged in as ${identity.name} (${identity.uuid})${backendNote}.`);
   log(`Credentials saved to ${path}.`);
   return 0;
 }

--- a/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/README.md
+++ b/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/README.md
@@ -1,0 +1,3 @@
+# daemon-add-agent-type-prompt
+
+Prompt for agent type (backend) in daemon add / login / install add flows

--- a/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/design.md
+++ b/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/design.md
@@ -1,0 +1,168 @@
+# Technical Design: agent-type prompt in add / login / install flows
+
+## Overview
+
+Add a single shared "which backend?" prompt and wire it into the three
+credential-capture entry points. No runtime/spawn changes — the daemon already
+resolves and spawns a per-agent backend from `agent` (top-level default) and
+per-entry `agentType`. This change only fills the capture gap.
+
+## Current state (verified)
+
+- `cli/daemon-install-config.mjs`
+  - `AGENT_MENU` (private const): `[{claude-code, "…(default)"}, {codex}, {kiro}]`
+    — `dsh` intentionally omitted (de-advertised, offline).
+  - `resolveInstallAgent(flags, env, opts)`: resolves the **daemon-level**
+    backend (`--agent` > `CHORUS_AGENT` > stored `agent` > TTY menu > default),
+    persists top-level `agent`, probes the CLI. The install *first* agent is
+    thus already covered; only the "Add another agent?" loop (≈ lines 143-171)
+    is missing the prompt — it calls `appendAgent({url,apiKey,agentUuid,agentName})`.
+- `cli/login.mjs`
+  - `runLogin(flags, deps)`: prompts URL + key. `--add` branch sets
+    `agentObj.agentType` only when `flags.agent` is non-empty; the single-agent
+    branch writes `{url,apiKey,agentUuid,agentName}` and never touches backend.
+  - `appendAgentConfig(agentObj, deps)`: accepts an optional `agentType` field
+    and writes it verbatim into the new `agents[]` entry — no change needed.
+- `cli/daemon-agent.mjs`: `KNOWN_AGENTS = [claude-code, codex, kiro, dsh]`,
+  `DEFAULT_AGENT = claude-code`. `resolveAgentType` falls back
+  flag>env>file>default; unknown values are a hard error.
+- `cli/daemon-config.mjs`: per-entry `agentType` else top-level default; unknown
+  `agentType` is a hard error. Empty per-entry `agentType` → inherits top-level.
+
+## Architecture
+
+### New module: `cli/agent-backend-prompt.mjs`
+
+Owns the menu list and the interactive selection so both `login.mjs` and
+`daemon-install-config.mjs` share one source of truth (avoids an import cycle:
+`daemon-install-config.mjs` already imports `appendAgentConfig` from
+`login.mjs`, so the menu cannot live in either file).
+
+```
+export const AGENT_MENU = [ {value,label}, … ]   // moved verbatim from daemon-install-config
+
+// Interactive numbered menu. Returns the chosen backend value, or undefined
+// when the operator presses Enter / declines / it is not a TTY.
+export async function promptAgentBackend({ ask, log, isTTY }) : Promise<string|undefined>
+```
+
+Contract:
+- **Not a TTY** (or `isTTY` false) → return `undefined` immediately, print
+  nothing, never block.
+- **TTY** → print the same numbered list `resolveInstallAgent` prints. Read one
+  line.
+  - Empty (Enter) → `undefined` (**inherit default** — the answer to the
+    "default" elaboration question).
+  - A valid number `1..N` → that row's `value`.
+  - A KNOWN_AGENTS value typed by name (muscle memory) → that value.
+  - Anything else → `undefined` (treated as "no explicit choice"; do not error,
+    do not loop — the caller's default/inherit path takes over).
+
+> Difference from `resolveInstallAgent`'s inline menu: there, empty/garbage
+> falls to `DEFAULT_AGENT` because the daemon-level `agent` must always be
+> concrete. Here, empty/garbage returns `undefined` so callers can *omit* the
+> field and let resolve-time inheritance apply. This is the deliberate
+> semantic for the add flows.
+
+### `resolveInstallAgent` refactor (no behavior change)
+
+Import `AGENT_MENU` from the new module instead of the local const; delete the
+local copy. Its own empty/garbage → `DEFAULT_AGENT` logic stays exactly as-is
+(it does NOT use `promptAgentBackend`, whose undefined-on-empty semantics differ).
+Existing `resolveInstallAgent` tests must still pass unchanged.
+
+### `runLogin` wiring (`cli/login.mjs`)
+
+After URL + key are collected and validated, resolve the backend once:
+
+```
+let agentType = nonEmpty(flags.agent);              // explicit flag wins
+if (!agentType) agentType = await promptBackend({ ask, log, isTTY });  // TTY menu, else undefined
+```
+
+- `isTTY` comes from a new injectable dep (default `process.stdin.isTTY`), so
+  a non-TTY / piped login never blocks on the menu — mirrors `resolveInstallAgent`.
+- Inject `promptBackend` as `deps.promptBackend` (default the shared
+  `promptAgentBackend`) for unit testing.
+
+**`--add` branch:** set `agentObj.agentType = agentType` only when defined
+(unchanged behavior when `--agent` was passed; new behavior via the menu). When
+`undefined`, omit the field → entry inherits daemon default.
+
+**Single-agent branch:** pass `agent: agentType` into `writeLoginFile` only when
+defined so the top-level `agent` field is written; when `undefined`, write
+nothing (resolves to claude-code). `writeLoginFile`/`updateDaemonConfig` already
+merge partial fields, so adding `agent` to the payload is additive.
+
+> `--agent` is already parsed by `client-args.mjs` into `flags.agent`; the value
+> is validated downstream by `resolveAgentType` at daemon start (unknown → hard
+> error), so `runLogin` does not need to re-validate. It MAY echo the chosen
+> backend in its success line for confirmation.
+
+### install add-loop wiring (`cli/daemon-install-config.mjs`)
+
+Inside the existing `for` loop, after `u`/`k` are read and validated, before
+`appendAgent(...)`:
+
+```
+let at = nonEmpty(flags.agent);
+if (!at) at = await promptAgentBackend({ ask, log, isTTY });
+const agentObj = { url: u, apiKey: k, agentUuid: id.uuid, agentName: id.name };
+if (at) agentObj.agentType = at;
+appendAgent(agentObj);
+```
+
+`isTTY`/`ask` are already in scope in this loop. When `at` is undefined the entry
+omits `agentType` and inherits the daemon default (the install's own
+`resolveInstallAgent` result).
+
+## Module Contracts
+
+- **Selection → persistence mapping:** append flows write per-entry
+  `agentType`; single-agent login writes top-level `agent`. Both fields already
+  exist and are read by `resolveAgentType` / the multi-agent normalizer.
+- **"No choice" sentinel:** `promptAgentBackend` returns `undefined`. Every
+  caller MUST treat `undefined` as "omit the field / inherit", never as a
+  literal string. No caller writes `"claude-code"` on an empty selection.
+- **Menu source of truth:** callers never hardcode the backend list; they import
+  `AGENT_MENU`. Adding/removing a backend (e.g. re-advertising `dsh`) is a
+  one-line edit in `agent-backend-prompt.mjs` that all prompts pick up.
+
+## Testing
+
+Vitest, existing thresholds (95% lines / 85% branches). Mock stdin via injected
+`ask`/`isTTY`/`promptBackend` seams — no real TTY.
+
+- `agent-backend-prompt` unit: menu text lists `AGENT_MENU` rows; Enter →
+  `undefined`; `"2"` → `codex`; `"codex"` by name → `codex`; out-of-range /
+  garbage → `undefined`; `isTTY:false` → `undefined` with no prompt call.
+- `runLogin`: `--agent codex --add` → entry `agentType:"codex"`; menu pick in
+  `--add` → `agentType` set; Enter in `--add` → no `agentType` key; single-agent
+  `--agent kiro` → top-level `agent:"kiro"`; single-agent Enter → no `agent`
+  key; non-TTY (no flag) → no prompt, no backend written; duplicate-key refusal
+  path unchanged.
+- install add-loop: menu pick → appended entry carries `agentType`; Enter → no
+  `agentType`; `--agent` honored; validation-fail / duplicate skip paths
+  unchanged.
+- `resolveInstallAgent`: existing suite passes unchanged after the `AGENT_MENU`
+  import move.
+
+## Risks & Mitigations
+
+- **Blocking a non-TTY login on the new menu.** Mitigation: `isTTY` guard in
+  both `promptAgentBackend` and `runLogin`; default from `process.stdin.isTTY`;
+  covered by a non-TTY test.
+- **Import cycle** (`login.mjs` ↔ `daemon-install-config.mjs`). Mitigation: menu
+  lives in the standalone `agent-backend-prompt.mjs`; neither importer imports
+  the other for it.
+- **Pinning an explicit backend that then differs from a later daemon `--agent`
+  default.** Accepted: explicit selection is intentional and wins; only the
+  *empty* selection inherits. Documented in the "No choice" contract.
+- **dsh confusion** (elaboration mentioned dsh, menu omits it). Mitigation:
+  reuse `AGENT_MENU` verbatim; do not re-add dsh here.
+
+## Out of scope
+
+- Editing an existing agent's backend via a command (elaboration answer:
+  add-time only; hand-edit `daemon.json`).
+- Any change to how the daemon resolves/spawns backends at runtime.

--- a/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/proposal.md
+++ b/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/proposal.md
@@ -1,0 +1,83 @@
+# Prompt for agent type (backend) in daemon add / login / install flows
+
+## Why
+
+The daemon can serve multiple agents from one process (`agents[]` in
+`~/.chorus/daemon.json`), and it already spawns a **per-agent backend**: each
+`agents[]` entry may carry its own `agentType`, and at runtime the daemon
+selects a spawner per entry (`cli/daemon-config.mjs` reads `entry.agentType`;
+`cli/daemon.mjs` injects a per-agent `selectSpawner`). Mixing backends in one
+daemon — e.g. one Claude Code + one Codex — is therefore fully functional.
+
+The gap is purely in the **credential-capture UX**: the commands that add or
+first-configure an agent only ever prompt for **Chorus URL** and **API key**,
+never for which backend the agent should use:
+
+- `chorus login` (single-agent first setup) — never asks, never persists a
+  backend, and ignores `--agent` entirely.
+- `chorus login --add` / `chorus daemon add` (append an agent) — prompts only
+  URL + key; writes `agentType` **only** when `--agent` was passed on the
+  command line, never interactively.
+- `chorus install`'s "Add another agent?" loop — calls `appendAgent({ url,
+  apiKey, agentUuid, agentName })` with **no** `agentType` at all, and does not
+  read `--agent`.
+
+Consequently every agent added through these flows silently falls back to the
+daemon's top-level default backend (claude-code unless a daemon-level `--agent`
+overrides). The multi-backend capability the daemon already has cannot be
+reached from the supported setup commands — which is exactly the scenario
+multi-agent mode is most useful for.
+
+## What Changes
+
+Capture the agent backend at credential-add / first-login time, reusing the
+**existing** interactive backend menu so the two paths never drift:
+
+- Extract the numbered backend menu (currently a private `AGENT_MENU` +
+  inline prompt inside `resolveInstallAgent`) into one shared prompt helper
+  that returns a chosen backend **or `undefined`** when the operator presses
+  Enter / declines. `resolveInstallAgent` is refactored to consume the shared
+  menu with no behavior change.
+- `chorus login` (single-agent) and `chorus login --add` / `chorus daemon add`
+  gain an interactive backend prompt on a TTY, and honor the existing
+  `--agent` flag for non-interactive use.
+- `chorus install`'s "Add another agent?" loop gains the same prompt (and
+  honors `--agent`).
+- Selection is persisted where the runtime already reads it: the single-agent
+  path writes the top-level `agent` field; the append paths write the entry's
+  `agentType`.
+
+**Default when the operator makes no choice** (plain Enter, no `--agent`, or a
+non-TTY run): write **nothing**. An empty `agentType` on an appended entry
+inherits the daemon's top-level default at resolve time; an empty top-level
+`agent` resolves to claude-code. This is the least-surprising behavior and
+matches the current outcome — the only change is that the operator is now
+*asked*.
+
+The interactive menu deliberately reuses the shared `AGENT_MENU` list, which
+today advertises **claude-code / codex / kiro** (the `dsh` backend is
+temporarily de-advertised); dsh reappears in every prompt automatically the day
+the menu re-advertises it — no second edit.
+
+## Capabilities
+
+- `daemon-add-agent-type` (new): the daemon credential-add / first-login /
+  install-add commands MUST offer an agent-backend selection (interactive menu
+  on a TTY, `--agent` flag otherwise), persist it to the location the runtime
+  reads, and inherit the daemon default when the operator makes no choice.
+
+## Impact
+
+- **Code:** `cli/login.mjs` (`runLogin` — both single and `--add` branches),
+  `cli/daemon-install-config.mjs` (extract `AGENT_MENU`; wire the add-loop),
+  and a new shared prompt module imported by both. `cli/daemon-agent.mjs`
+  (`KNOWN_AGENTS`, `DEFAULT_AGENT`) and `cli/daemon-config.mjs` (per-agent
+  `agentType` resolution) are unchanged — the runtime is already ready.
+- **Help text:** `cli/client-args.mjs` login/daemon usage notes that `--agent`
+  applies to the add flows too.
+- **Config format:** unchanged. Reads the existing top-level `agent` and
+  per-entry `agentType` fields; no migration.
+- **Back-compat:** the default (no selection → inherit) reproduces today's
+  behavior byte-for-byte, so existing scripts and non-TTY installs are
+  unaffected. No GUI is involved (CLI-only), so `docs/design.pen` is not
+  touched.

--- a/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/specs/daemon-add-agent-type/spec.md
+++ b/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/specs/daemon-add-agent-type/spec.md
@@ -1,0 +1,61 @@
+# daemon-add-agent-type
+
+## ADDED Requirements
+
+### Requirement: Add / first-login flows offer an agent-backend selection
+
+The daemon credential commands that add or first-configure an agent SHALL let the operator choose the agent backend (agent type) for that agent, in addition to the Chorus URL and API key. This covers `chorus login` (single-agent), `chorus login --add` / `chorus daemon add` (append), and the `chorus install` "Add another agent?" loop. The selection MUST be offered both interactively (a numbered menu on a TTY) and non-interactively (the existing `--agent` flag).
+
+#### Scenario: Interactive add prompts for a backend
+
+- **WHEN** an operator runs `chorus daemon add` (or `chorus login --add`) on a
+  TTY without passing `--agent`, and supplies a valid URL and API key
+- **THEN** a numbered agent-backend menu is displayed after the URL/key prompts
+- **AND** the chosen backend is persisted as the new `agents[]` entry's
+  `agentType`
+
+#### Scenario: `--agent` flag is honored non-interactively
+
+- **WHEN** an operator runs an add / login command with `--agent codex`
+- **THEN** no backend menu is shown for that agent
+- **AND** the agent is configured with the `codex` backend
+
+#### Scenario: Non-TTY add never blocks on the menu
+
+- **WHEN** an add / login command runs without a TTY (piped or scripted) and no
+  `--agent` flag
+- **THEN** no backend menu is shown and the command does not block waiting for
+  input
+- **AND** no backend value is written for that agent (it inherits the daemon
+  default at resolve time)
+
+### Requirement: No explicit backend choice inherits the daemon default
+
+The command SHALL write no backend value for an agent when the operator makes no explicit choice — pressing Enter at the menu, entering an unrecognized value, running without a TTY, and passing no `--agent` flag. An appended `agents[]` entry MUST omit `agentType` (so it inherits the daemon's top-level default at resolve time); a single-agent login MUST omit the top-level `agent` field (so it resolves to the default backend, claude-code). The command MUST NOT write a literal `claude-code` value on an empty selection.
+
+#### Scenario: Enter at the menu inherits the default
+
+- **WHEN** the operator presses Enter (empty input) at the backend menu during
+  an append flow
+- **THEN** the new `agents[]` entry is written without an `agentType` key
+- **AND** at daemon start that agent resolves to the daemon's top-level default
+  backend
+
+#### Scenario: Single-agent login without a choice omits the backend field
+
+- **WHEN** `chorus login` (single-agent) completes with no `--agent` flag and no
+  menu selection
+- **THEN** `~/.chorus/daemon.json` is written without a top-level `agent` key
+- **AND** the daemon resolves that agent to claude-code
+
+### Requirement: The backend menu is a single shared source of truth
+
+The interactive backend menu presented by the add / login / install-add flows SHALL be the same menu list used by the daemon-level install backend selection, so the advertised backends never diverge between entry points. Adding or removing an advertised backend MUST be a single edit that all prompts pick up.
+
+#### Scenario: Add-flow menu matches the install backend menu
+
+- **WHEN** the add / login backend menu is displayed
+- **THEN** it lists exactly the backends advertised by the install backend menu
+  (currently claude-code, codex, kiro; `dsh` de-advertised)
+- **AND** re-advertising a backend in the shared list makes it appear in every
+  prompt without a further code change

--- a/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/tasks.md
+++ b/openspec/changes/archive/2026-08-19-daemon-add-agent-type-prompt/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## 1. Shared backend-prompt module + install refactor
+- [ ] Create `cli/agent-backend-prompt.mjs` exporting `AGENT_MENU` (moved verbatim from `daemon-install-config.mjs`) and `promptAgentBackend({ ask, log, isTTY })`.
+- [ ] `promptAgentBackend` returns the chosen backend value, or `undefined` on Enter / unrecognized input / non-TTY.
+- [ ] Refactor `resolveInstallAgent` to import `AGENT_MENU` from the new module (delete the local copy); no behavior change.
+- [ ] Unit tests for the new module; existing `resolveInstallAgent` tests still pass.
+
+## 2. Wire the prompt into login / add / install-add
+- [ ] `runLogin` (single + `--add`): resolve backend from `--agent` else TTY menu; persist top-level `agent` (single) / entry `agentType` (`--add`) only when defined.
+- [ ] install "Add another agent?" loop: resolve backend from `--agent` else menu; set `agentType` on the appended entry only when defined.
+- [ ] Update `client-args.mjs` login/daemon usage help so `--agent` documents the add flows.
+- [ ] Tests across every call site (flag path, menu pick, Enter-inherit, non-TTY, duplicate/validation-fail unchanged).

--- a/openspec/specs/daemon-add-agent-type/spec.md
+++ b/openspec/specs/daemon-add-agent-type/spec.md
@@ -1,0 +1,63 @@
+# daemon-add-agent-type Specification
+
+## Purpose
+TBD - created by archiving change daemon-add-agent-type-prompt. Update Purpose after archive.
+## Requirements
+### Requirement: Add / first-login flows offer an agent-backend selection
+
+The daemon credential commands that add or first-configure an agent SHALL let the operator choose the agent backend (agent type) for that agent, in addition to the Chorus URL and API key. This covers `chorus login` (single-agent), `chorus login --add` / `chorus daemon add` (append), and the `chorus install` "Add another agent?" loop. The selection MUST be offered both interactively (a numbered menu on a TTY) and non-interactively (the existing `--agent` flag).
+
+#### Scenario: Interactive add prompts for a backend
+
+- **WHEN** an operator runs `chorus daemon add` (or `chorus login --add`) on a
+  TTY without passing `--agent`, and supplies a valid URL and API key
+- **THEN** a numbered agent-backend menu is displayed after the URL/key prompts
+- **AND** the chosen backend is persisted as the new `agents[]` entry's
+  `agentType`
+
+#### Scenario: `--agent` flag is honored non-interactively
+
+- **WHEN** an operator runs an add / login command with `--agent codex`
+- **THEN** no backend menu is shown for that agent
+- **AND** the agent is configured with the `codex` backend
+
+#### Scenario: Non-TTY add never blocks on the menu
+
+- **WHEN** an add / login command runs without a TTY (piped or scripted) and no
+  `--agent` flag
+- **THEN** no backend menu is shown and the command does not block waiting for
+  input
+- **AND** no backend value is written for that agent (it inherits the daemon
+  default at resolve time)
+
+### Requirement: No explicit backend choice inherits the daemon default
+
+The command SHALL write no backend value for an agent when the operator makes no explicit choice — pressing Enter at the menu, entering an unrecognized value, running without a TTY, and passing no `--agent` flag. An appended `agents[]` entry MUST omit `agentType` (so it inherits the daemon's top-level default at resolve time); a single-agent login MUST omit the top-level `agent` field (so it resolves to the default backend, claude-code). The command MUST NOT write a literal `claude-code` value on an empty selection.
+
+#### Scenario: Enter at the menu inherits the default
+
+- **WHEN** the operator presses Enter (empty input) at the backend menu during
+  an append flow
+- **THEN** the new `agents[]` entry is written without an `agentType` key
+- **AND** at daemon start that agent resolves to the daemon's top-level default
+  backend
+
+#### Scenario: Single-agent login without a choice omits the backend field
+
+- **WHEN** `chorus login` (single-agent) completes with no `--agent` flag and no
+  menu selection
+- **THEN** `~/.chorus/daemon.json` is written without a top-level `agent` key
+- **AND** the daemon resolves that agent to claude-code
+
+### Requirement: The backend menu is a single shared source of truth
+
+The interactive backend menu presented by the add / login / install-add flows SHALL be the same menu list used by the daemon-level install backend selection, so the advertised backends never diverge between entry points. Adding or removing an advertised backend MUST be a single edit that all prompts pick up.
+
+#### Scenario: Add-flow menu matches the install backend menu
+
+- **WHEN** the add / login backend menu is displayed
+- **THEN** it lists exactly the backends advertised by the install backend menu
+  (currently claude-code, codex, kiro; `dsh` de-advertised)
+- **AND** re-advertising a backend in the shared list makes it appear in every
+  prompt without a further code change
+


### PR DESCRIPTION
## Summary

The daemon already spawns a **per-agent backend** (each `agents[]` entry may carry its own `agentType`, resolved per-entry at spawn time), but the credential-capture commands only ever asked for URL + API key — so every agent added via `login` / `--add` / `install` silently fell back to the daemon default. This PR captures the backend at add/first-login time, reusing the existing install backend menu.

- **New `cli/agent-backend-prompt.mjs`** — shared `AGENT_MENU` (claude-code / codex / kiro; `dsh` de-advertised, still reachable by name) + `promptAgentBackend({ask, log, isTTY})` returning the chosen backend or `undefined` (Enter / unrecognized / non-TTY). Its own module to avoid an import cycle between `login.mjs` and `daemon-install-config.mjs`.
- **`resolveInstallAgent`** now imports `AGENT_MENU` (behavior unchanged).
- **`runLogin`** (single + `--add`) and the **`install` "Add another agent?" loop** capture the backend: explicit `--agent` wins, else the TTY menu. **No choice omits the field** (top-level `agent` for single-agent; per-entry `agentType` for appended) so it inherits the daemon default — **never a literal `claude-code`**.
- **`client-args`** help documents `--agent` for the add flows.

Runtime resolution/spawn (`daemon-config.mjs` / `daemon.mjs`) is intentionally unchanged.

Implements idea 44ecab6d (elaboration-resolved: scope = append + first-login; interaction = menu + `--agent`; default = inherit; edit-existing = out of scope). OpenSpec change `daemon-add-agent-type-prompt` (archived).

## Changed files
| File | Change |
|------|--------|
| `cli/agent-backend-prompt.mjs` | **new** — shared menu + `promptAgentBackend` |
| `cli/login.mjs` | `runLogin` captures backend (single + `--add`) |
| `cli/daemon-install-config.mjs` | `AGENT_MENU` moved to shared module; add-loop captures backend |
| `cli/client-args.mjs` | `--agent` help for the add flows |
| `cli/__tests__/agent-backend-prompt.test.mjs` | **new** — 12 tests |
| `cli/__tests__/login-add-agent.test.mjs` | +8 tests (backend capture + install loop) |
| `openspec/specs/daemon-add-agent-type/`, `openspec/changes/archive/...` | spec + archived change |

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `eslint` on all touched files — clean
- [x] Touched suites: `login`, `login-add-agent`, `agent-backend-prompt`, `daemon-install-config`, `client-args` = **81 passed**
- [x] Reviewed by proposal-reviewer, two task-reviewers, and the idea code-review gateway (all PASS / PASS WITH NOTES)

## ⚠️ Pre-existing CI note
A full `pnpm test` has **15 failures in 5 daemon `runDaemon` suites** (permission-wiring / credential-completion / integration / lifecycle-dispatch / claude-notfound-warning). These are **pre-existing on `develop` HEAD** (stash-verified on a clean tree) and unrelated to this change — none of those files are touched here. Root cause looks like `runDaemon` now building 2 connections where the stale tests assert on `calls[0]` expecting 1. Worth a separate fix; called out so a red CI on those suites is not mistaken for a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)